### PR TITLE
fix(daemon): restore all active FTS triggers

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from polylogue.paths import db_path as default_db_path
+from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
@@ -46,17 +47,6 @@ _BOUNDARY_TABLES: tuple[str, ...] = (
     "topology_edges",
     "repo_identities",
     "conversation_repo_observations",
-)
-
-# Expected FTS-sync triggers.  A missing trigger means the FTS index can drift
-# silently (suspended for bulk operations and never restored, for example).
-_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
-    "messages_fts_ai",
-    "messages_fts_ad",
-    "messages_fts_au",
-    "action_events_fts_ai",
-    "action_events_fts_ad",
-    "action_events_fts_au",
 )
 
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -34,6 +34,7 @@ from polylogue.daemon.status import daemon_status_payload, format_daemon_status_
 from polylogue.logging import configure_logging, get_logger
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.watcher import default_sources
+from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 
 logger = get_logger(__name__)
 
@@ -73,30 +74,17 @@ def _verify_pidfile(pidfile: Path) -> bool:
         return False
 
 
-_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
-    "messages_fts_ai",
-    "messages_fts_ad",
-    "messages_fts_au",
-    "action_events_fts_ai",
-    "action_events_fts_ad",
-    "action_events_fts_au",
-)
-"""Canonical FTS sync triggers (#1242).
-
-Mirrors ``polylogue.daemon.health._EXPECTED_FTS_TRIGGERS``. Defined
-here to keep the daemon startup path independent of the health-check
-module's import surface.
-"""
-
-
 def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
-    placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
+    expected = _active_fts_triggers_sync(conn)
+    if not expected:
+        return []
+    placeholders = ",".join("?" for _ in expected)
     rows = conn.execute(
         f"SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
-        _EXPECTED_FTS_TRIGGERS,
+        expected,
     ).fetchall()
     present = {row[0] for row in rows}
-    return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
+    return [name for name in expected if name not in present]
 
 
 def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
@@ -105,6 +93,20 @@ def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
         (table_name,),
     ).fetchone()
     return row is not None
+
+
+def _active_fts_triggers_sync(conn: sqlite3.Connection) -> tuple[str, ...]:
+    surfaces = (
+        (("messages", "messages_fts"), _EXPECTED_FTS_TRIGGERS[0:3]),
+        (("action_events", "action_events_fts"), _EXPECTED_FTS_TRIGGERS[3:6]),
+        (("session_work_events", "session_work_events_fts"), _EXPECTED_FTS_TRIGGERS[6:9]),
+        (("work_threads", "work_threads_fts"), _EXPECTED_FTS_TRIGGERS[9:12]),
+    )
+    expected: list[str] = []
+    for table_names, trigger_names in surfaces:
+        if all(_table_exists_sync(conn, table_name) for table_name in table_names):
+            expected.extend(trigger_names)
+    return tuple(expected)
 
 
 def _enable_faulthandler_if_supported() -> None:

--- a/polylogue/daemon/cursor_lag_baseline.py
+++ b/polylogue/daemon/cursor_lag_baseline.py
@@ -149,17 +149,22 @@ def record_cursor_lag_sample(
     if not rows:
         return 0
     dbf.parent.mkdir(parents=True, exist_ok=True)
-    with open_connection(dbf, timeout=5.0) as conn:
-        ensure_lag_sample_table(conn)
-        conn.executemany(
-            """
-            INSERT INTO live_cursor_lag_sample (
-                family, observed_at, max_lag_s, stuck_file_count, p50_lag_s, p95_lag_s
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            rows,
-        )
-        conn.commit()
+    try:
+        with open_connection(dbf, timeout=0.1) as conn:
+            ensure_lag_sample_table(conn)
+            conn.executemany(
+                """
+                INSERT INTO live_cursor_lag_sample (
+                    family, observed_at, max_lag_s, stuck_file_count, p50_lag_s, p95_lag_s
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+            conn.commit()
+    except sqlite3.OperationalError as exc:
+        if _database_is_locked(exc):
+            return 0
+        raise
     return len(rows)
 
 
@@ -180,14 +185,19 @@ def gc_cursor_lag_samples(
     if not dbf.exists():
         return 0
     cutoff = ((now or datetime.now(UTC)) - timedelta(days=retention_days)).isoformat()
-    with open_connection(dbf, timeout=5.0) as conn:
-        ensure_lag_sample_table(conn)
-        cur = conn.execute(
-            "DELETE FROM live_cursor_lag_sample WHERE observed_at < ?",
-            (cutoff,),
-        )
-        conn.commit()
-        return cur.rowcount or 0
+    try:
+        with open_connection(dbf, timeout=0.1) as conn:
+            ensure_lag_sample_table(conn)
+            cur = conn.execute(
+                "DELETE FROM live_cursor_lag_sample WHERE observed_at < ?",
+                (cutoff,),
+            )
+            conn.commit()
+            return cur.rowcount or 0
+    except sqlite3.OperationalError as exc:
+        if _database_is_locked(exc):
+            return 0
+        raise
 
 
 def load_family_baseline(
@@ -293,6 +303,10 @@ def _bucket_stuck_lags_by_family(stuck: list[CursorLagItem]) -> dict[str, list[f
     for lags in out.values():
         lags.sort()
     return out
+
+
+def _database_is_locked(exc: sqlite3.OperationalError) -> bool:
+    return "database is locked" in str(exc).lower()
 
 
 def _percentile(sorted_values: list[float], q: float) -> float:

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from polylogue.config import PolylogueConfig
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root, db_path
+from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 
 logger = get_logger(__name__)
 
@@ -272,33 +273,45 @@ def _check_source_availability_fast() -> HealthAlert:
         )
 
 
-_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
-    "messages_fts_ai",
-    "messages_fts_ad",
-    "messages_fts_au",
-    "action_events_fts_ai",
-    "action_events_fts_ad",
-    "action_events_fts_au",
-)
-"""Six canonical FTS sync triggers (#1229).
-
-Three for ``messages_fts`` + three for ``action_events_fts``. These are
-restored after every bulk-write window by
-``polylogue/storage/fts/fts_lifecycle.py::restore_fts_triggers_sync``;
-their absence after a SIGKILL during a suspension window leaves the FTS
-indexes silently out of sync with the source tables.
-"""
+"""Canonical FTS sync triggers for archive and insight search surfaces."""
 
 
 def _find_missing_fts_triggers(conn: sqlite3.Connection) -> list[str]:
     """Return the names of expected FTS triggers that do not exist."""
-    placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
+    expected = _active_fts_triggers(conn)
+    if not expected:
+        return []
+    placeholders = ",".join("?" for _ in expected)
     rows = conn.execute(
         f"SELECT name FROM sqlite_schema WHERE type='trigger' AND name IN ({placeholders})",
-        _EXPECTED_FTS_TRIGGERS,
+        expected,
     ).fetchall()
     present = {row[0] for row in rows}
-    return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
+    return [name for name in expected if name not in present]
+
+
+def _table_exists_for_fts_trigger(conn: sqlite3.Connection, table_name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _active_fts_triggers(conn: sqlite3.Connection) -> tuple[str, ...]:
+    surfaces = (
+        (("messages", "messages_fts"), _EXPECTED_FTS_TRIGGERS[0:3]),
+        (("action_events", "action_events_fts"), _EXPECTED_FTS_TRIGGERS[3:6]),
+        (("session_work_events", "session_work_events_fts"), _EXPECTED_FTS_TRIGGERS[6:9]),
+        (("work_threads", "work_threads_fts"), _EXPECTED_FTS_TRIGGERS[9:12]),
+    )
+    expected: list[str] = []
+    for table_names, trigger_names in surfaces:
+        if all(_table_exists_for_fts_trigger(conn, table_name) for table_name in table_names):
+            expected.extend(trigger_names)
+    return tuple(expected)
 
 
 def _auto_restore_fts_triggers(dbf: object) -> tuple[list[str], bool, str]:
@@ -386,6 +399,7 @@ def _check_fts_trigger_drift_fast() -> HealthAlert:
         # opens a writable connection.
         conn = sqlite3.connect(f"file:{dbf}?mode=ro", uri=True, timeout=2.0)
         try:
+            active_trigger_count = len(_active_fts_triggers(conn))
             missing = _find_missing_fts_triggers(conn)
         finally:
             conn.close()
@@ -395,7 +409,7 @@ def _check_fts_trigger_drift_fast() -> HealthAlert:
                 check_name="fts_trigger_drift",
                 tier=HealthTier.FAST,
                 severity=HealthSeverity.OK,
-                message=f"all {len(_EXPECTED_FTS_TRIGGERS)} FTS triggers present",
+                message=f"all {active_trigger_count} active FTS triggers present",
                 checked_at=now,
                 consecutive_failures=_record_failure("fts_trigger_drift", True),
             )
@@ -410,7 +424,7 @@ def _check_fts_trigger_drift_fast() -> HealthAlert:
 
         if not auto_restore:
             message = (
-                f"FTS trigger drift: {len(missing)}/{len(_EXPECTED_FTS_TRIGGERS)} missing "
+                f"FTS trigger drift: {len(missing)}/{active_trigger_count} missing "
                 f"({missing_text}); restore with `{restore_cmd}` "
                 "(rebuild ~O(messages))"
             )

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from typing import Protocol
 
 from polylogue.logging import get_logger
+from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 
 logger = get_logger(__name__)
 
@@ -154,18 +155,6 @@ def _scalar_int(conn: sqlite3.Connection, sql: str) -> int:
     if row is None or row[0] is None:
         return 0
     return int(row[0])
-
-
-# Same expected FTS triggers as devtools/daemon_workload_probe.py — kept
-# inline so the metrics module does not depend on the probe.
-_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
-    "messages_fts_ai",
-    "messages_fts_ad",
-    "messages_fts_au",
-    "action_events_fts_ai",
-    "action_events_fts_ad",
-    "action_events_fts_au",
-)
 
 
 def _attempt_counts(conn: sqlite3.Connection) -> dict[str, int]:

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -99,6 +99,9 @@ _FTS_TRIGGER_NAMES = (
     + _WORK_THREAD_FTS_TRIGGER_NAMES
 )
 
+FTS_TRIGGER_NAMES = _FTS_TRIGGER_NAMES
+"""Canonical FTS trigger set for all archive and insight search surfaces."""
+
 
 @dataclass(frozen=True, slots=True)
 class FtsSurfaceInvariant:
@@ -182,7 +185,7 @@ async def suspend_fts_triggers_async(conn: aiosqlite.Connection, *, mark_stale: 
 async def restore_fts_triggers_async(conn: aiosqlite.Connection) -> None:
     """Re-create FTS triggers after bulk insert."""
     await suspend_fts_triggers_async(conn)
-    for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
+    for ddl in await _fts_trigger_ddl_for_existing_surfaces_async(conn):
         await conn.execute(ddl)
 
 
@@ -229,6 +232,49 @@ _ACTION_FTS_TRIGGER_DDL = [
        END""",
 ]
 
+_SESSION_WORK_EVENT_FTS_TRIGGER_DDL = [
+    """CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ai
+       AFTER INSERT ON session_work_events BEGIN
+           INSERT INTO session_work_events_fts (event_id, conversation_id, provider_name, kind, text)
+           VALUES (new.event_id, new.conversation_id, new.provider_name, new.kind, new.search_text);
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ad
+       AFTER DELETE ON session_work_events BEGIN
+           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS session_work_events_fts_au
+       AFTER UPDATE ON session_work_events BEGIN
+           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
+           INSERT INTO session_work_events_fts (event_id, conversation_id, provider_name, kind, text)
+           VALUES (new.event_id, new.conversation_id, new.provider_name, new.kind, new.search_text);
+       END""",
+]
+
+_WORK_THREAD_FTS_TRIGGER_DDL = [
+    """CREATE TRIGGER IF NOT EXISTS work_threads_fts_ai
+       AFTER INSERT ON work_threads BEGIN
+           INSERT INTO work_threads_fts (thread_id, root_id, text)
+           VALUES (new.thread_id, new.root_id, new.search_text);
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS work_threads_fts_ad
+       AFTER DELETE ON work_threads BEGIN
+           DELETE FROM work_threads_fts WHERE thread_id = old.thread_id;
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS work_threads_fts_au
+       AFTER UPDATE ON work_threads BEGIN
+           DELETE FROM work_threads_fts WHERE thread_id = old.thread_id;
+           INSERT INTO work_threads_fts (thread_id, root_id, text)
+           VALUES (new.thread_id, new.root_id, new.search_text);
+       END""",
+]
+
+_FTS_TRIGGER_DDL = (
+    _MESSAGE_FTS_TRIGGER_DDL
+    + _ACTION_FTS_TRIGGER_DDL
+    + _SESSION_WORK_EVENT_FTS_TRIGGER_DDL
+    + _WORK_THREAD_FTS_TRIGGER_DDL
+)
+
 
 def suspend_fts_triggers_sync(conn: sqlite3.Connection, *, mark_stale: bool = True) -> None:
     """Drop FTS triggers for bulk sync operations."""
@@ -243,7 +289,7 @@ def suspend_fts_triggers_sync(conn: sqlite3.Connection, *, mark_stale: bool = Tr
 def restore_fts_triggers_sync(conn: sqlite3.Connection) -> None:
     """Re-create FTS triggers after bulk insert."""
     suspend_fts_triggers_sync(conn)
-    for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
+    for ddl in _fts_trigger_ddl_for_existing_surfaces_sync(conn):
         conn.execute(ddl)
 
 
@@ -254,7 +300,7 @@ def ensure_fts_triggers_sync(conn: sqlite3.Connection) -> None:
     ``restore_fts_triggers_sync`` remains the explicit recovery/rebuild path
     for replacing trigger definitions and repairing global FTS state.
     """
-    for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
+    for ddl in _fts_trigger_ddl_for_existing_surfaces_sync(conn):
         conn.execute(ddl)
 
 
@@ -269,8 +315,45 @@ async def ensure_fts_index_async(conn: aiosqlite.Connection) -> None:
     """Ensure the FTS5 tables and triggers exist on an async SQLite connection."""
     await conn.execute(FTS_MESSAGES_TABLE_SQL)
     await conn.execute(FTS_ACTIONS_TABLE_SQL)
-    for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
+    for ddl in await _fts_trigger_ddl_for_existing_surfaces_async(conn):
         await conn.execute(ddl)
+
+
+def _fts_trigger_ddl_for_existing_surfaces_sync(conn: sqlite3.Connection) -> tuple[str, ...]:
+    ddl: list[str] = []
+    if _table_exists_sync(conn, "messages") and _table_exists_sync(conn, "messages_fts"):
+        ddl.extend(_MESSAGE_FTS_TRIGGER_DDL)
+    if _table_exists_sync(conn, "action_events") and _table_exists_sync(conn, "action_events_fts"):
+        ddl.extend(_ACTION_FTS_TRIGGER_DDL)
+    if _table_exists_sync(conn, "session_work_events") and _table_exists_sync(conn, "session_work_events_fts"):
+        ddl.extend(_SESSION_WORK_EVENT_FTS_TRIGGER_DDL)
+    if _table_exists_sync(conn, "work_threads") and _table_exists_sync(conn, "work_threads_fts"):
+        ddl.extend(_WORK_THREAD_FTS_TRIGGER_DDL)
+    return tuple(ddl)
+
+
+async def _table_exists_async(conn: aiosqlite.Connection, table_name: str) -> bool:
+    cursor = await conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+        (table_name,),
+    )
+    row = await cursor.fetchone()
+    return row is not None
+
+
+async def _fts_trigger_ddl_for_existing_surfaces_async(conn: aiosqlite.Connection) -> tuple[str, ...]:
+    ddl: list[str] = []
+    if await _table_exists_async(conn, "messages") and await _table_exists_async(conn, "messages_fts"):
+        ddl.extend(_MESSAGE_FTS_TRIGGER_DDL)
+    if await _table_exists_async(conn, "action_events") and await _table_exists_async(conn, "action_events_fts"):
+        ddl.extend(_ACTION_FTS_TRIGGER_DDL)
+    if await _table_exists_async(conn, "session_work_events") and await _table_exists_async(
+        conn, "session_work_events_fts"
+    ):
+        ddl.extend(_SESSION_WORK_EVENT_FTS_TRIGGER_DDL)
+    if await _table_exists_async(conn, "work_threads") and await _table_exists_async(conn, "work_threads_fts"):
+        ddl.extend(_WORK_THREAD_FTS_TRIGGER_DDL)
+    return tuple(ddl)
 
 
 def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
@@ -284,9 +367,37 @@ def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
     ensure_fts_index_sync(conn)
     conn.execute(FTS_REBUILD_SQL)
     conn.execute(ACTION_FTS_REBUILD_SQL)
+    _rebuild_session_work_events_fts_sync(conn)
+    _rebuild_work_threads_fts_sync(conn)
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
 
     record_fts_invariant_snapshot_sync(conn, fts_invariant_snapshot_sync(conn))
+
+
+def _rebuild_session_work_events_fts_sync(conn: sqlite3.Connection) -> None:
+    if not (_table_exists_sync(conn, "session_work_events") and _table_exists_sync(conn, "session_work_events_fts")):
+        return
+    conn.execute("DELETE FROM session_work_events_fts")
+    conn.execute(
+        """
+        INSERT INTO session_work_events_fts (event_id, conversation_id, provider_name, kind, text)
+        SELECT event_id, conversation_id, provider_name, kind, search_text
+        FROM session_work_events
+        """
+    )
+
+
+def _rebuild_work_threads_fts_sync(conn: sqlite3.Connection) -> None:
+    if not (_table_exists_sync(conn, "work_threads") and _table_exists_sync(conn, "work_threads_fts")):
+        return
+    conn.execute("DELETE FROM work_threads_fts")
+    conn.execute(
+        """
+        INSERT INTO work_threads_fts (thread_id, root_id, text)
+        SELECT thread_id, root_id, search_text
+        FROM work_threads
+        """
+    )
 
 
 async def rebuild_fts_index_async(
@@ -776,6 +887,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
 __all__ = [
     "FtsInvariantSnapshot",
     "FtsSurfaceInvariant",
+    "FTS_TRIGGER_NAMES",
     "_MESSAGE_FTS_TRIGGER_DDL",
     "_chunked",
     "check_fts_readiness",

--- a/tests/unit/daemon/test_cursor_lag_integration.py
+++ b/tests/unit/daemon/test_cursor_lag_integration.py
@@ -19,7 +19,7 @@ from polylogue.daemon.cursor_lag_alert import reset_default_dedup_state as reset
 from polylogue.daemon.cursor_lag_anomaly import (
     reset_default_dedup_state as reset_anomaly_dedup,
 )
-from polylogue.daemon.cursor_lag_baseline import record_cursor_lag_sample
+from polylogue.daemon.cursor_lag_baseline import gc_cursor_lag_samples, record_cursor_lag_sample
 from polylogue.daemon.cursor_lag_status import (
     CursorLagFamilySummary,
     CursorLagSummary,
@@ -136,6 +136,30 @@ def _sample_history(
     )
     for i in range(samples):
         record_cursor_lag_sample(db, summary, now=now - spacing * (i + 1))
+
+
+def test_lag_sample_writes_do_not_block_health_loop_on_database_lock(
+    tmp_path: Path,
+    frozen_clock: FrozenClock,
+) -> None:
+    db = tmp_path / "locked.db"
+    summary = CursorLagSummary(
+        tracked_file_count=1,
+        stuck_file_count=1,
+        idle_file_count=0,
+        max_lag_s=120,
+        family_summaries=[CursorLagFamilySummary(family="codex-session", stuck_file_count=1, max_lag_s=120)],
+    )
+    blocker = sqlite3.connect(str(db))
+    try:
+        blocker.execute("CREATE TABLE lock_holder (id INTEGER PRIMARY KEY)")
+        blocker.execute("BEGIN EXCLUSIVE")
+
+        assert record_cursor_lag_sample(db, summary, now=frozen_clock.now()) == 0
+        assert gc_cursor_lag_samples(db, retention_days=14, now=frozen_clock.now()) == 0
+    finally:
+        blocker.rollback()
+        blocker.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_fts_trigger_drift.py
+++ b/tests/unit/daemon/test_fts_trigger_drift.py
@@ -1,7 +1,7 @@
 """FTS sync-trigger drift detection and auto-restore (#1229).
 
-The daemon's FAST tier inspects the six canonical FTS triggers
-(``messages_fts_a{i,d,u}`` + ``action_events_fts_a{i,d,u}``) every health
+The daemon's FAST tier inspects the canonical FTS triggers for active
+archive and insight search surfaces every health
 cycle. A SIGKILL during the bulk-write suspension window (see
 ``docs/internals.md`` "FTS5 Model") leaves these triggers dropped and
 silently corrupts search.
@@ -62,6 +62,44 @@ CREATE TABLE IF NOT EXISTS action_events (
 )
 """
 
+_SESSION_WORK_EVENTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS session_work_events (
+    event_id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    provider_name TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    search_text TEXT NOT NULL
+)
+"""
+
+_SESSION_WORK_EVENTS_FTS_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS session_work_events_fts USING fts5(
+    event_id UNINDEXED,
+    conversation_id UNINDEXED,
+    provider_name UNINDEXED,
+    kind UNINDEXED,
+    text,
+    tokenize='unicode61'
+)
+"""
+
+_WORK_THREADS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS work_threads (
+    thread_id TEXT PRIMARY KEY,
+    root_id TEXT NOT NULL,
+    search_text TEXT NOT NULL
+)
+"""
+
+_WORK_THREADS_FTS_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS work_threads_fts USING fts5(
+    thread_id UNINDEXED,
+    root_id UNINDEXED,
+    text,
+    tokenize='unicode61'
+)
+"""
+
 
 @pytest.fixture(autouse=True)
 def _reset_failure_counts() -> Iterator[None]:
@@ -75,14 +113,18 @@ def _seed_archive_with_triggers(path: Path) -> None:
     """Bootstrap the minimal table set + the canonical FTS triggers.
 
     The check is schema-agnostic — it only reads ``sqlite_schema`` — but
-    the auto-restore path needs ``messages`` and ``action_events`` to
-    exist (because the FTS5 ``rebuild`` command reads from them).
+    the auto-restore path needs the active source and FTS tables to
+    exist because repair recreates triggers and rebuilds the indexes.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path))
     try:
         conn.execute(_MESSAGES_TABLE_SQL)
         conn.execute(_ACTION_EVENTS_TABLE_SQL)
+        conn.execute(_SESSION_WORK_EVENTS_TABLE_SQL)
+        conn.execute(_SESSION_WORK_EVENTS_FTS_SQL)
+        conn.execute(_WORK_THREADS_TABLE_SQL)
+        conn.execute(_WORK_THREADS_FTS_SQL)
         ensure_fts_index_sync(conn)
         conn.commit()
     finally:
@@ -103,9 +145,9 @@ def _drop_trigger(path: Path, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_expected_fts_trigger_inventory_is_six_canonical_names() -> None:
-    """The contract is six triggers — three per FTS table."""
-    assert len(_EXPECTED_FTS_TRIGGERS) == 6
+def test_expected_fts_trigger_inventory_covers_archive_and_insight_search() -> None:
+    """The contract is twelve triggers — three per active FTS table."""
+    assert len(_EXPECTED_FTS_TRIGGERS) == 12
     assert set(_EXPECTED_FTS_TRIGGERS) == {
         "messages_fts_ai",
         "messages_fts_ad",
@@ -113,6 +155,12 @@ def test_expected_fts_trigger_inventory_is_six_canonical_names() -> None:
         "action_events_fts_ai",
         "action_events_fts_ad",
         "action_events_fts_au",
+        "session_work_events_fts_ai",
+        "session_work_events_fts_ad",
+        "session_work_events_fts_au",
+        "work_threads_fts_ai",
+        "work_threads_fts_ad",
+        "work_threads_fts_au",
     }
 
 
@@ -135,7 +183,7 @@ def test_check_returns_ok_when_all_triggers_present(
     alert = _check_fts_trigger_drift_fast()
     assert alert.severity == HealthSeverity.OK
     assert alert.tier == HealthTier.FAST
-    assert "all 6 FTS triggers present" in alert.message
+    assert "all 12 active FTS triggers present" in alert.message
     assert alert.consecutive_failures == 0
 
 
@@ -149,7 +197,7 @@ def test_check_detects_any_missing_trigger(
     workspace_env: dict[str, Path],
     dropped: str,
 ) -> None:
-    """Dropping any of the six canonical triggers must surface as CRITICAL."""
+    """Dropping any active canonical trigger must surface as CRITICAL."""
     dbf = db_path()
     _seed_archive_with_triggers(dbf)
     _drop_trigger(dbf, dropped)
@@ -173,7 +221,7 @@ def test_check_lists_all_missing_triggers_when_several_drop(
 
     alert = _check_fts_trigger_drift_fast()
     assert alert.severity == HealthSeverity.CRITICAL
-    assert "2/6 missing" in alert.message
+    assert "2/12 missing" in alert.message
     assert "messages_fts_ai" in alert.message
     assert "action_events_fts_ad" in alert.message
 
@@ -243,7 +291,7 @@ def test_auto_restore_repairs_missing_triggers_and_warns(
     # The next health cycle returns to OK.
     next_alert = _check_fts_trigger_drift_fast()
     assert next_alert.severity == HealthSeverity.OK
-    assert "all 6 FTS triggers present" in next_alert.message
+    assert "all 12 active FTS triggers present" in next_alert.message
 
 
 def test_auto_restore_disabled_by_default_keeps_alert_critical(

--- a/tests/unit/storage/test_fts_trigger_lifecycle.py
+++ b/tests/unit/storage/test_fts_trigger_lifecycle.py
@@ -3,14 +3,14 @@
 Pins the contract documented in ``docs/internals.md`` ("FTS5 Model →
 Trigger suspension"):
 
-- ``suspend_fts_triggers_sync`` drops the six expected FTS triggers.
+- ``suspend_fts_triggers_sync`` drops every expected FTS trigger.
 - ``restore_fts_triggers_sync`` is idempotent and re-creates the full
   set even if invoked twice in a row.
 - A SIGKILL-like interruption between ``suspend`` and ``restore`` leaves
   the database in a detectable drift state (no triggers present); the
   recovery path is ``restore_fts_triggers_sync`` itself.
 - Multiple threads racing on suspend + restore on independent
-  connections converge on the "all six present" state.
+  connections converge on the "all present" state.
 """
 
 from __future__ import annotations
@@ -36,6 +36,12 @@ _EXPECTED_TRIGGERS = (
     "action_events_fts_ai",
     "action_events_fts_ad",
     "action_events_fts_au",
+    "session_work_events_fts_ai",
+    "session_work_events_fts_ad",
+    "session_work_events_fts_au",
+    "work_threads_fts_ai",
+    "work_threads_fts_ad",
+    "work_threads_fts_au",
 )
 
 
@@ -67,12 +73,46 @@ def _bootstrap_fts_db(path: Path) -> sqlite3.Connection:
             search_text TEXT
         )"""
     )
+    conn.execute(
+        """CREATE TABLE session_work_events (
+            event_id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            provider_name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            search_text TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE VIRTUAL TABLE session_work_events_fts USING fts5(
+            event_id UNINDEXED,
+            conversation_id UNINDEXED,
+            provider_name UNINDEXED,
+            kind UNINDEXED,
+            text,
+            tokenize='unicode61'
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE work_threads (
+            thread_id TEXT PRIMARY KEY,
+            root_id TEXT NOT NULL,
+            search_text TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE VIRTUAL TABLE work_threads_fts USING fts5(
+            thread_id UNINDEXED,
+            root_id UNINDEXED,
+            text,
+            tokenize='unicode61'
+        )"""
+    )
     ensure_fts_index_sync(conn)
     conn.commit()
     return conn
 
 
-def test_suspend_drops_all_six_triggers(tmp_path: Path) -> None:
+def test_suspend_drops_all_fts_triggers(tmp_path: Path) -> None:
     conn = _bootstrap_fts_db(tmp_path / "fts.db")
     try:
         present = _trigger_names(conn)
@@ -126,8 +166,43 @@ def test_restore_is_idempotent(tmp_path: Path) -> None:
         conn.close()
 
 
+def test_rebuild_restores_insight_fts_surfaces(tmp_path: Path) -> None:
+    from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync, rebuild_fts_index_sync
+
+    conn = _bootstrap_fts_db(tmp_path / "fts.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO session_work_events (
+                event_id, conversation_id, provider_name, kind, search_text
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            ("event-1", "conversation-1", "codex", "implementation", "fixed daemon locks"),
+        )
+        conn.execute(
+            "INSERT INTO work_threads (thread_id, root_id, search_text) VALUES (?, ?, ?)",
+            ("thread-1", "conversation-1", "daemon convergence"),
+        )
+        conn.execute("DELETE FROM session_work_events_fts")
+        conn.execute("DELETE FROM work_threads_fts")
+        conn.commit()
+
+        snapshot = fts_invariant_snapshot_sync(conn)
+        assert snapshot.session_work_events.ready is False
+        assert snapshot.work_threads.ready is False
+
+        rebuild_fts_index_sync(conn)
+        conn.commit()
+
+        snapshot = fts_invariant_snapshot_sync(conn)
+        assert snapshot.session_work_events.ready is True
+        assert snapshot.work_threads.ready is True
+    finally:
+        conn.close()
+
+
 def test_concurrent_suspend_restore_threads_converge(tmp_path: Path) -> None:
-    """Two threads alternating suspend/restore on independent connections must end with all six triggers present."""
+    """Two threads alternating suspend/restore on independent connections must end with all triggers present."""
     db_file = tmp_path / "fts.db"
     conn = _bootstrap_fts_db(db_file)
     conn.close()
@@ -209,7 +284,12 @@ def test_hypothesis_arbitrary_lifecycle_recoverable(
         unexpected = {
             name
             for name in present
-            if (name.startswith("messages_fts_") or name.startswith("action_events_fts_"))
+            if (
+                name.startswith("messages_fts_")
+                or name.startswith("action_events_fts_")
+                or name.startswith("session_work_events_fts_")
+                or name.startswith("work_threads_fts_")
+            )
             and name not in _EXPECTED_TRIGGERS
         }
         assert not unexpected, f"unexpected FTS triggers leaked: {unexpected}"


### PR DESCRIPTION
## Summary

Restore and monitor the full active FTS trigger set during daemon startup, recovery, health checks, metrics, and workload probes. The patch also makes cursor-lag sample writes best-effort under SQLite write contention so observability does not add more pressure during catch-up.

## Problem

Live deployment showed `fts_readiness` errors for `session_work_events_fts` and `work_threads_fts` missing triggers while the daemon was also hitting SQLite lock contention. The lifecycle module knew about twelve trigger names, but restore paths recreated only the message and action-event triggers. A catch-up recovery window could therefore leave insight search surfaces stale even after the daemon believed trigger recovery had run.

This is related to #1447 but does not close it: WAL growth, bounded checkpoints, and large-session memory release remain open there.

## Solution

- Export the canonical FTS trigger inventory from `polylogue.storage.fts.fts_lifecycle`.
- Recreate triggers for every active FTS surface: messages, action events, session work events, and work threads.
- Rebuild the insight FTS tables during full FTS recovery so repair covers the indexed surfaces it now owns.
- Teach daemon startup, health, metrics, and `devtools daemon-workload-probe` to use the same inventory.
- Scope startup/health checks to active surfaces so partial/minimal databases do not report irrelevant missing triggers.
- Make cursor-lag sample and GC writes return immediately when SQLite is locked.

Ref #1447

## Verification

- `pytest tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/daemon/test_cursor_lag_integration.py tests/unit/daemon/test_fts_trigger_drift.py tests/unit/daemon/test_metrics_endpoint.py tests/unit/devtools/test_daemon_workload_probe.py -q` → `60 passed`
- `python -m mypy polylogue/storage/fts/fts_lifecycle.py polylogue/daemon/cursor_lag_baseline.py polylogue/daemon/health.py polylogue/daemon/metrics.py polylogue/daemon/cli.py devtools/daemon_workload_probe.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/daemon/test_cursor_lag_integration.py tests/unit/daemon/test_fts_trigger_drift.py` → `Success: no issues found in 9 source files`
- `devtools verify --quick` → exit `0`
- pre-push `devtools verify --quick` → exit `0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended full-text search capability to cover session work events and work threads in addition to existing message and action event search surfaces.

* **Bug Fixes**
  * Improved database lock handling in health monitoring to prevent blocking operations during concurrent database access.

* **Improvements**
  * Enhanced search health checks with more reliable trigger monitoring and drift detection across all search surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->