### PR TITLE
fix(daemon): report WAL checkpoint blockers

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -219,7 +219,7 @@ async def _periodic_wal_checkpoint() -> None:
 
     db = db_path()
     while True:
-        await asyncio.sleep(300)  # 5 minutes
+        await asyncio.sleep(300)
         if not db.exists():
             continue
         try:
@@ -227,17 +227,17 @@ async def _periodic_wal_checkpoint() -> None:
                 maybe_checkpoint_wal,
                 db,
                 reason="periodic",
-                timeout_s=5.0,
             )
             if observation.ran:
                 logger.info(
-                    "daemon: WAL checkpoint %s before=%d after=%d busy=%d checkpointed=%d error=%s",
+                    "daemon: WAL checkpoint %s before=%d after=%d busy=%d checkpointed=%d error=%s blockers=%s",
                     observation.mode,
                     observation.wal_bytes_before,
                     observation.wal_bytes_after,
                     observation.busy_pages,
                     observation.checkpointed_pages,
                     observation.error,
+                    ",".join(observation.blocking_processes[:5]),
                 )
         except Exception:
             logger.warning("daemon: WAL checkpoint failed", exc_info=True)

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -1081,6 +1081,16 @@ def _process_ingest_batch_sync(
         summary.wal_busy_pages = wal_observation.busy_pages
         summary.wal_checkpoint_elapsed_s = wal_observation.elapsed_s
         summary.wal_checkpoint_error = wal_observation.error
+        if wal_observation.blocking_processes:
+            logger.warning(
+                "wal_checkpoint_blocked",
+                reason=wal_observation.reason,
+                mode=wal_observation.mode,
+                wal_bytes_before=wal_observation.wal_bytes_before,
+                wal_bytes_after=wal_observation.wal_bytes_after,
+                busy_pages=wal_observation.busy_pages,
+                blocking_processes=wal_observation.blocking_processes[:5],
+            )
     except Exception:
         # Roll back the row writes.  If a caller explicitly opted into
         # dropped-trigger bulk mode, restore triggers before propagating

--- a/polylogue/storage/sqlite/wal_checkpoint.py
+++ b/polylogue/storage/sqlite/wal_checkpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -26,6 +27,7 @@ class WalCheckpointObservation:
     checkpointed_pages: int = 0
     elapsed_s: float = 0.0
     error: str | None = None
+    blocking_processes: tuple[str, ...] = ()
 
     @property
     def ran(self) -> bool:
@@ -82,6 +84,11 @@ def maybe_checkpoint_wal(
     except sqlite3.Error as exc:
         error = str(exc)
     after = _wal_size(db)
+    blocking_processes = (
+        _sqlite_file_holders(db)
+        if busy > 0 or after >= truncate_bytes or (error is not None and "locked" in error.lower())
+        else ()
+    )
     return WalCheckpointObservation(
         reason=reason,
         mode=mode,
@@ -92,7 +99,50 @@ def maybe_checkpoint_wal(
         checkpointed_pages=checkpointed,
         elapsed_s=round(time.perf_counter() - started, 6),
         error=error,
+        blocking_processes=blocking_processes,
     )
+
+
+def _sqlite_file_holders(db: Path) -> tuple[str, ...]:
+    """Return processes currently holding the SQLite db/wal/shm files."""
+    targets = {db.resolve(), db.with_suffix(".db-wal").resolve(), db.with_suffix(".db-shm").resolve()}
+    holders: list[str] = []
+    proc_root = Path("/proc")
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        pid = entry.name
+        fd_dir = entry / "fd"
+        try:
+            fd_paths = tuple(fd_dir.iterdir())
+        except OSError:
+            continue
+        matched = False
+        for fd in fd_paths:
+            try:
+                if Path(os.readlink(fd)).resolve() in targets:
+                    matched = True
+                    break
+            except OSError:
+                continue
+        if not matched:
+            continue
+        holders.append(f"{pid}:{_process_command(entry)}")
+    return tuple(sorted(holders))
+
+
+def _process_command(proc_entry: Path) -> str:
+    try:
+        comm = (proc_entry / "comm").read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        comm = "unknown"
+    try:
+        cmdline = (proc_entry / "cmdline").read_bytes().replace(b"\0", b" ").decode("utf-8", errors="replace").strip()
+    except OSError:
+        cmdline = ""
+    if not cmdline:
+        return comm
+    return cmdline[:240]
 
 
 __all__ = [

--- a/tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py
+++ b/tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py
@@ -11,7 +11,7 @@ from polylogue.pipeline.services.ingest_batch import _process_ingest_batch_sync
 from polylogue.pipeline.services.ingest_worker import IngestRecordResult
 from polylogue.storage.runtime import RawConversationRecord
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.storage.sqlite.wal_checkpoint import WalCheckpointObservation
+from polylogue.storage.sqlite.wal_checkpoint import WalCheckpointObservation, maybe_checkpoint_wal
 
 
 def test_process_ingest_batch_sync_records_wal_checkpoint_observation(
@@ -93,3 +93,35 @@ def test_process_ingest_batch_sync_records_wal_checkpoint_observation(
     assert summary.wal_bytes_after_checkpoint == 0
     assert summary.wal_checkpointed_pages == 7
     assert summary.wal_checkpoint_elapsed_s == 0.25
+
+
+def test_maybe_checkpoint_wal_reports_blocking_processes_when_busy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "polylogue.db"
+
+    class FakeConnection:
+        def execute(self, sql: str) -> object:
+            assert sql == "PRAGMA wal_checkpoint(PASSIVE)"
+            return self
+
+        def fetchone(self) -> tuple[int, int, int]:
+            return (1, 25, 12)
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("polylogue.storage.sqlite.wal_checkpoint._wal_size", lambda db: 1024)
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.wal_checkpoint.open_connection", lambda *_args, **_kwargs: FakeConnection()
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.wal_checkpoint._sqlite_file_holders",
+        lambda db: ("1234:polylogue-mcp",) if db == db_path else (),
+    )
+
+    observation = maybe_checkpoint_wal(db_path, reason="test", warn_bytes=0, truncate_bytes=0)
+
+    assert observation.busy_pages == 1
+    assert observation.blocking_processes == ("1234:polylogue-mcp",)


### PR DESCRIPTION
## Summary

Adds process-holder diagnostics to WAL checkpoint observations so live ingest and daemon checkpoint logs can explain when SQLite checkpointing is blocked by another reader instead of silently leaving a large WAL behind.

## Problem

While deploying the FTS trigger repair work from #1455, `polylogued` generated a growing WAL during catch-up and checkpointing stayed busy. The live blocker was an unrelated long-running `lynchpin.cli.current_state` process holding Polylogue database files open, but Polylogue only reported checkpoint mode/page counts. That left the operator to manually correlate `/proc`, `fuser`, and service logs.

## Solution

`WalCheckpointObservation` now carries bounded `/proc` process-holder details when a checkpoint is busy, locked, or leaves the WAL above the truncate threshold. Batch ingest logs `wal_checkpoint_blocked` with the checkpoint reason, WAL sizes, busy pages, and first blockers; the daemon periodic checkpoint log includes the same blocker list. The `/proc` scan is Linux-only, bounded to active file descriptors for `polylogue.db`, `.db-wal`, and `.db-shm`, and degrades quietly when `/proc` entries vanish during iteration.

Ref #1447.

## Verification

- `pytest tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py -q` → `2 passed in 0.08s`
- `python -m mypy polylogue/storage/sqlite/wal_checkpoint.py polylogue/pipeline/services/ingest_batch/_core.py polylogue/daemon/cli.py tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py` → `Success: no issues found in 4 source files`
- `devtools verify --quick` → exit 0, total `38.78s`