### PR TITLE
fix(maintenance): filter replay sources lexically

### DIFF
--- a/polylogue/maintenance/source_replay.py
+++ b/polylogue/maintenance/source_replay.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.config import Config, Source
@@ -98,11 +99,8 @@ def _source_matches_filter(source: Source, scope_filter: MaintenanceScopeFilter)
     if scope_filter.source_root is not None:
         if source.path is None:
             return False
-        try:
-            source_path_resolved = source.path.expanduser().resolve()
-            filter_path_resolved = scope_filter.source_root.expanduser().resolve()
-        except (OSError, RuntimeError):
-            return False
+        source_path_resolved = _lexical_absolute_path(source.path)
+        filter_path_resolved = _lexical_absolute_path(scope_filter.source_root)
         # Honor either equality or "this source is rooted under the
         # filter root" — operators frequently pass a parent directory.
         if source_path_resolved != filter_path_resolved:
@@ -121,6 +119,22 @@ def _source_matches_filter(source: Source, scope_filter: MaintenanceScopeFilter)
     # the same way ``provider`` does. When the family rename lands the
     # comparison should switch to ``source.family.value``.
     return not (scope_filter.source_family is not None and source.name != scope_filter.source_family)
+
+
+def _lexical_absolute_path(path: Path) -> Path:
+    """Normalize a path without touching the filesystem.
+
+    Maintenance filters are applied to archived source paths. Some of those
+    paths point at old removable mounts or disk-image locations; resolving them
+    live can trigger autofs or block on unavailable media. For replay scoping,
+    lexical absolute normalization is enough: comparisons only need stable path
+    ancestry, not symlink truth in the current host namespace.
+    """
+
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        expanded = Path.cwd() / expanded
+    return Path(str(expanded))
 
 
 def resolve_source_replay_sources(

--- a/tests/unit/maintenance/test_source_replay.py
+++ b/tests/unit/maintenance/test_source_replay.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from polylogue.config import Config, Source
 from polylogue.maintenance.planner import BackfillKind, BackfillStatus
 from polylogue.maintenance.replay import (
@@ -139,6 +141,21 @@ def test_resolve_sources_filters_by_source_root(tmp_path: Path) -> None:
     config = _make_config(tmp_path, sources=[src_a, src_b])
     filter_a = MaintenanceScopeFilter(source_root=root_a)
     assert resolve_source_replay_sources(config, filter_a) == [src_a]
+
+
+def test_resolve_sources_filters_archived_paths_lexically(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    archived_root = Path("/mnt/pendrv/archive/chatgpt")
+    src = Source(name="chatgpt", path=archived_root / "exports")
+    config = _make_config(tmp_path, sources=[src])
+
+    def fail_resolve(self: Path, *args: object, **kwargs: object) -> Path:
+        raise AssertionError("source replay must not resolve archived paths")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    resolved = resolve_source_replay_sources(config, MaintenanceScopeFilter(source_root=archived_root))
+
+    assert resolved == [src]
 
 
 def test_resolve_sources_filters_by_provider(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Source replay source-root filtering now normalizes archived paths lexically instead of resolving them against the live filesystem.

## Problem

Maintenance replay scopes operate on source paths stored in configuration/archive context. Those paths can point at old removable mounts, disk-image paths, or otherwise unavailable locations. Calling `Path.resolve()` while deciding whether a source is in scope can touch the host filesystem and fail before the replay operation has a chance to run.

## Solution

Replace live filesystem resolution with a lexical absolute-path normalization helper for source replay filtering. Equality and parent-root matching are preserved, but filtering no longer depends on mount availability or symlink resolution. The regression test makes `Path.resolve()` raise and proves archived path filtering still includes the source.

## Verification

- `pytest tests/unit/maintenance/test_source_replay.py -q` → `19 passed in 0.18s`
- `python -m mypy polylogue/maintenance/source_replay.py tests/unit/maintenance/test_source_replay.py` → `Success: no issues found in 2 source files`
- `ruff check polylogue/maintenance/source_replay.py tests/unit/maintenance/test_source_replay.py` → `All checks passed!`
- pre-push `devtools verify --quick` → exit 0, total `38.28s`