### PR TITLE
fix(daemon): expose live batch WAL metrics

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -50,6 +50,7 @@ from polylogue.sources.live.batch_support import (
     _AppendResult,
     _blob_copy_heartbeat,
     _detect_provider_from_path_sample,
+    _full_ingest_result_from_summary,
     _full_ingest_worker_count,
     _full_parse_progress_groups,
     _FullIngestHeartbeat,
@@ -79,7 +80,7 @@ from polylogue.sources.live.convergence_debt import (
 from polylogue.sources.live.conversation_convergence import converge_known_conversations
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
 from polylogue.sources.live.dedup import handle_schema_incompatible, handle_structural_database_error
-from polylogue.sources.live.metrics import LiveBatchMetrics
+from polylogue.sources.live.metrics import LiveBatchMetrics, LiveFullIngestAggregate
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawConversationRecord
 from polylogue.types import Provider
@@ -163,6 +164,7 @@ class LiveBatchProcessor:
         failed_paths: list[str] = []
         succeeded_paths: set[Path] = set()
         ingest_worker_count_max = 0
+        full_ingest_aggregate = LiveFullIngestAggregate()
         cursor_records = self._cursor.get_records(paths)
 
         append_file_count = 0
@@ -303,6 +305,7 @@ class LiveBatchProcessor:
                         ),
                     )
                     ingest_worker_count_max = max(ingest_worker_count_max, full_result.worker_count)
+                    full_ingest_aggregate.add(full_result)
                 except SchemaIncompatibleError as exc:
                     handle_schema_incompatible(source_name, exc)
                     # Account for every queued path in this source group, not
@@ -437,6 +440,7 @@ class LiveBatchProcessor:
             parse_time_s=round(parse_time_s, 6),
             convergence_time_s=round(convergence_time_s, 6),
             total_time_s=round(time.perf_counter() - batch_started, 6),
+            **full_ingest_aggregate.to_metric_kwargs(),
             rss_current_mb=read_current_rss_mb(),
             rss_peak_self_mb=read_peak_rss_self_mb(),
             rss_peak_children_mb=read_peak_rss_children_mb(),
@@ -948,17 +952,17 @@ class LiveBatchProcessor:
 
         failed_set = set(failed)
         raw_fingerprints = {path: raw_id for raw_id, path in raw_by_id.items()}
-        worker_count = int(getattr(summary, "worker_count", 0)) if raw_records else 0
-        raw_records.clear()
-        raw_by_id.clear()
-        return _FullIngestResult(
+        result = _full_ingest_result_from_summary(
             succeeded=[path for path in ingested if path not in failed_set],
             failed=failed,
             source_payload_read_bytes=source_payload_read_bytes,
             raw_fingerprints=raw_fingerprints,
             raw_byte_sizes=raw_byte_sizes,
-            worker_count=worker_count,
+            summary=summary,
         )
+        raw_records.clear()
+        raw_by_id.clear()
+        return result
 
     def _assert_writable_archive_layout(self) -> None:
         from polylogue.storage.sqlite.connection_profile import open_connection

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -82,6 +82,50 @@ class _FullIngestResult:
     raw_fingerprints: dict[Path, str] = field(default_factory=dict)
     raw_byte_sizes: dict[Path, int] = field(default_factory=dict)
     worker_count: int = 0
+    ingested_conversation_count: int = 0
+    ingested_message_count: int = 0
+    changed_conversation_count: int = 0
+    wal_bytes_before_checkpoint: int = 0
+    wal_bytes_after_checkpoint: int = 0
+    wal_checkpointed_pages: int = 0
+    wal_busy_pages: int = 0
+    wal_checkpoint_elapsed_s: float = 0.0
+    wal_checkpoint_mode: str = "none"
+    wal_checkpoint_error: str | None = None
+
+
+def _full_ingest_result_from_summary(
+    *,
+    succeeded: list[Path],
+    failed: list[Path],
+    source_payload_read_bytes: int,
+    raw_fingerprints: dict[Path, str],
+    raw_byte_sizes: dict[Path, int],
+    summary: object | None,
+) -> _FullIngestResult:
+    error = getattr(summary, "wal_checkpoint_error", None) if summary is not None else None
+    return _FullIngestResult(
+        succeeded=succeeded,
+        failed=failed,
+        source_payload_read_bytes=source_payload_read_bytes,
+        raw_fingerprints=raw_fingerprints,
+        raw_byte_sizes=raw_byte_sizes,
+        worker_count=int(getattr(summary, "worker_count", 0)) if summary is not None else 0,
+        ingested_conversation_count=int(getattr(summary, "total_convos", 0)) if summary is not None else 0,
+        ingested_message_count=int(getattr(summary, "total_msgs", 0)) if summary is not None else 0,
+        changed_conversation_count=len(getattr(summary, "changed_conversation_ids", ())) if summary is not None else 0,
+        wal_bytes_before_checkpoint=int(getattr(summary, "wal_bytes_before_checkpoint", 0))
+        if summary is not None
+        else 0,
+        wal_bytes_after_checkpoint=int(getattr(summary, "wal_bytes_after_checkpoint", 0)) if summary is not None else 0,
+        wal_checkpointed_pages=int(getattr(summary, "wal_checkpointed_pages", 0)) if summary is not None else 0,
+        wal_busy_pages=int(getattr(summary, "wal_busy_pages", 0)) if summary is not None else 0,
+        wal_checkpoint_elapsed_s=float(getattr(summary, "wal_checkpoint_elapsed_s", 0.0))
+        if summary is not None
+        else 0.0,
+        wal_checkpoint_mode=str(getattr(summary, "wal_checkpoint_mode", "none")) if summary is not None else "none",
+        wal_checkpoint_error=str(error) if error is not None else None,
+    )
 
 
 _FINGERPRINT_STREAM_CHUNK = 1 << 20  # 1 MiB

--- a/polylogue/sources/live/metrics.py
+++ b/polylogue/sources/live/metrics.py
@@ -3,6 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TypedDict
+
+
+class LiveFullIngestMetricKwargs(TypedDict):
+    ingested_conversation_count: int
+    ingested_message_count: int
+    changed_conversation_count: int
+    wal_bytes_before_checkpoint_max: int
+    wal_bytes_after_checkpoint_max: int
+    wal_checkpointed_pages_total: int
+    wal_busy_pages_total: int
+    wal_checkpoint_elapsed_s: float
+    wal_checkpoint_modes: dict[str, int]
+    wal_checkpoint_errors: list[str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +41,16 @@ class LiveBatchMetrics:
     parse_time_s: float
     convergence_time_s: float
     total_time_s: float
+    ingested_conversation_count: int = 0
+    ingested_message_count: int = 0
+    changed_conversation_count: int = 0
+    wal_bytes_before_checkpoint_max: int = 0
+    wal_bytes_after_checkpoint_max: int = 0
+    wal_checkpointed_pages_total: int = 0
+    wal_busy_pages_total: int = 0
+    wal_checkpoint_elapsed_s: float = 0.0
+    wal_checkpoint_modes: dict[str, int] = field(default_factory=dict)
+    wal_checkpoint_errors: list[str] = field(default_factory=list)
     rss_current_mb: float | None = None
     rss_peak_self_mb: float | None = None
     rss_peak_children_mb: float | None = None
@@ -65,6 +89,16 @@ class LiveBatchMetrics:
             "archive_bytes_before": self.archive_bytes_before,
             "archive_bytes_after": self.archive_bytes_after,
             "archive_write_bytes_delta": self.archive_write_bytes_delta,
+            "ingested_conversation_count": self.ingested_conversation_count,
+            "ingested_message_count": self.ingested_message_count,
+            "changed_conversation_count": self.changed_conversation_count,
+            "wal_bytes_before_checkpoint_max": self.wal_bytes_before_checkpoint_max,
+            "wal_bytes_after_checkpoint_max": self.wal_bytes_after_checkpoint_max,
+            "wal_checkpointed_pages_total": self.wal_checkpointed_pages_total,
+            "wal_busy_pages_total": self.wal_busy_pages_total,
+            "wal_checkpoint_elapsed_s": self.wal_checkpoint_elapsed_s,
+            "wal_checkpoint_modes": self.wal_checkpoint_modes,
+            "wal_checkpoint_errors": self.wal_checkpoint_errors,
             "parse_time_s": self.parse_time_s,
             "convergence_time_s": self.convergence_time_s,
             "total_time_s": self.total_time_s,
@@ -81,4 +115,55 @@ class LiveBatchMetrics:
         }
 
 
-__all__ = ["LiveBatchMetrics"]
+@dataclass(slots=True)
+class LiveFullIngestAggregate:
+    """Aggregated full-ingest counters folded into one live batch."""
+
+    ingested_conversation_count: int = 0
+    ingested_message_count: int = 0
+    changed_conversation_count: int = 0
+    wal_bytes_before_checkpoint_max: int = 0
+    wal_bytes_after_checkpoint_max: int = 0
+    wal_checkpointed_pages_total: int = 0
+    wal_busy_pages_total: int = 0
+    wal_checkpoint_elapsed_s: float = 0.0
+    wal_checkpoint_modes: dict[str, int] = field(default_factory=dict)
+    wal_checkpoint_errors: list[str] = field(default_factory=list)
+
+    def add(self, result: object) -> None:
+        self.ingested_conversation_count += int(getattr(result, "ingested_conversation_count", 0))
+        self.ingested_message_count += int(getattr(result, "ingested_message_count", 0))
+        self.changed_conversation_count += int(getattr(result, "changed_conversation_count", 0))
+        self.wal_bytes_before_checkpoint_max = max(
+            self.wal_bytes_before_checkpoint_max,
+            int(getattr(result, "wal_bytes_before_checkpoint", 0)),
+        )
+        self.wal_bytes_after_checkpoint_max = max(
+            self.wal_bytes_after_checkpoint_max,
+            int(getattr(result, "wal_bytes_after_checkpoint", 0)),
+        )
+        self.wal_checkpointed_pages_total += int(getattr(result, "wal_checkpointed_pages", 0))
+        self.wal_busy_pages_total += int(getattr(result, "wal_busy_pages", 0))
+        self.wal_checkpoint_elapsed_s += float(getattr(result, "wal_checkpoint_elapsed_s", 0.0))
+        mode = str(getattr(result, "wal_checkpoint_mode", "none"))
+        self.wal_checkpoint_modes[mode] = self.wal_checkpoint_modes.get(mode, 0) + 1
+        error = getattr(result, "wal_checkpoint_error", None)
+        if error is not None:
+            self.wal_checkpoint_errors.append(str(error))
+
+    def to_metric_kwargs(self) -> LiveFullIngestMetricKwargs:
+        return {
+            "ingested_conversation_count": self.ingested_conversation_count,
+            "ingested_message_count": self.ingested_message_count,
+            "changed_conversation_count": self.changed_conversation_count,
+            "wal_bytes_before_checkpoint_max": self.wal_bytes_before_checkpoint_max,
+            "wal_bytes_after_checkpoint_max": self.wal_bytes_after_checkpoint_max,
+            "wal_checkpointed_pages_total": self.wal_checkpointed_pages_total,
+            "wal_busy_pages_total": self.wal_busy_pages_total,
+            "wal_checkpoint_elapsed_s": round(self.wal_checkpoint_elapsed_s, 6),
+            "wal_checkpoint_modes": self.wal_checkpoint_modes,
+            "wal_checkpoint_errors": self.wal_checkpoint_errors,
+        }
+
+
+__all__ = ["LiveBatchMetrics", "LiveFullIngestAggregate"]

--- a/tests/unit/sources/test_live_metrics.py
+++ b/tests/unit/sources/test_live_metrics.py
@@ -23,6 +23,16 @@ def test_live_batch_metrics_payload_includes_memory_pressure_fields() -> None:
         parse_time_s=0.1,
         convergence_time_s=0.2,
         total_time_s=0.3,
+        ingested_conversation_count=2,
+        ingested_message_count=12,
+        changed_conversation_count=1,
+        wal_bytes_before_checkpoint_max=4096,
+        wal_bytes_after_checkpoint_max=1024,
+        wal_checkpointed_pages_total=3,
+        wal_busy_pages_total=1,
+        wal_checkpoint_elapsed_s=0.04,
+        wal_checkpoint_modes={"passive": 1},
+        wal_checkpoint_errors=["database is locked"],
         cgroup_path="/user.slice/test.scope",
         cgroup_memory_peak_mb=128.0,
     )
@@ -31,3 +41,13 @@ def test_live_batch_metrics_payload_includes_memory_pressure_fields() -> None:
 
     assert payload["cgroup_path"] == "/user.slice/test.scope"
     assert payload["cgroup_memory_peak_mb"] == 128.0
+    assert payload["ingested_conversation_count"] == 2
+    assert payload["ingested_message_count"] == 12
+    assert payload["changed_conversation_count"] == 1
+    assert payload["wal_bytes_before_checkpoint_max"] == 4096
+    assert payload["wal_bytes_after_checkpoint_max"] == 1024
+    assert payload["wal_checkpointed_pages_total"] == 3
+    assert payload["wal_busy_pages_total"] == 1
+    assert payload["wal_checkpoint_elapsed_s"] == 0.04
+    assert payload["wal_checkpoint_modes"] == {"passive": 1}
+    assert payload["wal_checkpoint_errors"] == ["database is locked"]

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -56,6 +56,16 @@ class _FullIngestMock:
             succeeded=list(paths),
             failed=[],
             source_payload_read_bytes=sum(path.stat().st_size for path in paths),
+            raw_fingerprints={path: f"raw:{path.name}" for path in paths},
+            ingested_conversation_count=1,
+            ingested_message_count=7,
+            changed_conversation_count=1,
+            wal_bytes_before_checkpoint=8192,
+            wal_bytes_after_checkpoint=1024,
+            wal_checkpointed_pages=4,
+            wal_busy_pages=2,
+            wal_checkpoint_elapsed_s=0.125,
+            wal_checkpoint_mode="truncate",
         )
 
 
@@ -1310,6 +1320,16 @@ def test_ingest_files_emits_observable_batch_metrics(tmp_path: Path) -> None:
     assert payload["append_file_count"] == 0
     assert payload["full_file_count"] == 1
     assert payload["archive_write_bytes_delta"] >= 0
+    assert payload["ingested_conversation_count"] == 1
+    assert payload["ingested_message_count"] == 7
+    assert payload["changed_conversation_count"] == 1
+    assert payload["wal_bytes_before_checkpoint_max"] == 8192
+    assert payload["wal_bytes_after_checkpoint_max"] == 1024
+    assert payload["wal_checkpointed_pages_total"] == 4
+    assert payload["wal_busy_pages_total"] == 2
+    assert payload["wal_checkpoint_elapsed_s"] == 0.125
+    assert payload["wal_checkpoint_modes"] == {"truncate": 1}
+    assert payload["wal_checkpoint_errors"] == []
     assert payload["parse_time_s"] >= 0
     assert payload["total_time_s"] >= 0
     assert payload["stage_timings_s"] == {}


### PR DESCRIPTION
## Summary

Carries sync ingest materialization and WAL checkpoint details up into the live daemon `ingestion_batch` payload so catch-up pressure can be diagnosed from normal daemon events/status rather than manual probes.

## Problem

#1447 requires per-batch visibility into message count, source bytes, memory, and WAL checkpoint behavior. The sync ingest layer already produced much of that data, but live catch-up collapsed it to file/byte counters before emitting the daemon batch event. That made the high-pressure live cases hard to attribute to a specific batch or large session.

## Solution

`_FullIngestResult` now carries the sync ingest summary fields needed by live telemetry: conversation/message counts, changed conversation count, checkpoint mode, WAL bytes before/after checkpoint, checkpointed pages, busy pages, elapsed checkpoint time, and checkpoint errors. `LiveBatchMetrics` aggregates those across full-ingest chunks and includes them in `to_payload()`, which is the daemon event/status surface. The focused tests assert both the metric payload contract and the live watcher event propagation.

Ref #1447.

## Verification

- `pytest tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_metrics.py -q` → `71 passed in 7.12s`
- `python -m mypy polylogue/sources/live/metrics.py polylogue/sources/live/batch_support.py polylogue/sources/live/batch.py tests/unit/sources/test_live_metrics.py tests/unit/sources/test_live_watcher.py` → `Success: no issues found in 5 source files`
- `ruff check polylogue/sources/live/metrics.py polylogue/sources/live/batch_support.py polylogue/sources/live/batch.py tests/unit/sources/test_live_metrics.py tests/unit/sources/test_live_watcher.py` → `All checks passed!`
- `devtools verify-file-budgets` → `file-size budgets: clean`
- `devtools verify --quick` → exit 0, total `37.74s`