### PR TITLE
fix(daemon): reduce catch-up replay amplification

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -323,18 +323,44 @@ def _conversation_tuple_with_hash(conversation: ConversationTuple, content_hash:
 def _existing_message_hashes(conn: sqlite3.Connection, message_ids: Sequence[str]) -> dict[str, str]:
     if not message_ids:
         return {}
-    placeholders = ", ".join("?" for _ in message_ids)
-    rows = conn.execute(
-        f"SELECT message_id, content_hash FROM messages WHERE message_id IN ({placeholders})",
-        tuple(message_ids),
-    ).fetchall()
-    return {str(row["message_id"]): str(row["content_hash"]) for row in rows}
+    hashes: dict[str, str] = {}
+    for offset in range(0, len(message_ids), _WRITE_SELECT_CHUNK_SIZE):
+        chunk = message_ids[offset : offset + _WRITE_SELECT_CHUNK_SIZE]
+        placeholders = ", ".join("?" for _ in chunk)
+        rows = conn.execute(
+            f"SELECT message_id, content_hash FROM messages WHERE message_id IN ({placeholders})",
+            tuple(chunk),
+        ).fetchall()
+        hashes.update({str(row["message_id"]): str(row["content_hash"]) for row in rows})
+    return hashes
+
+
+def _existing_provider_event_ids(conn: sqlite3.Connection, event_ids: Sequence[str]) -> set[str]:
+    if not event_ids:
+        return set()
+    existing: set[str] = set()
+    for offset in range(0, len(event_ids), _WRITE_SELECT_CHUNK_SIZE):
+        chunk = event_ids[offset : offset + _WRITE_SELECT_CHUNK_SIZE]
+        placeholders = ", ".join("?" for _ in chunk)
+        rows = conn.execute(
+            f"SELECT event_id FROM provider_events WHERE event_id IN ({placeholders})",
+            tuple(chunk),
+        ).fetchall()
+        existing.update(str(row["event_id"]) for row in rows)
+    return existing
 
 
 def _append_content_hash(existing_hash: str | None, tail_hash: str) -> str:
     if not existing_hash:
         return tail_hash
     return sha256(f"{existing_hash}\0{tail_hash}".encode()).hexdigest()
+
+
+def _tail_content_hash(changed_messages: Sequence[MessageTuple], fallback_hash: str) -> str:
+    if not changed_messages:
+        return fallback_hash
+    joined_hashes = "\0".join(str(message[6]) for message in changed_messages)
+    return sha256(joined_hashes.encode()).hexdigest()
 
 
 def _upsert_stats_from_messages(conn: sqlite3.Connection, conversation_id: str, provider_name: str) -> None:
@@ -367,6 +393,7 @@ def _upsert_stats_from_messages(conn: sqlite3.Connection, conversation_id: str, 
 
 _ACTION_EVENT_INSERT_OR_IGNORE_SQL = _ACTION_EVENT_INSERT_SQL.replace("INSERT INTO", "INSERT OR IGNORE INTO", 1)
 _PROVIDER_EVENT_INSERT_OR_IGNORE_SQL = _PROVIDER_EVENT_INSERT_SQL.replace("INSERT INTO", "INSERT OR IGNORE INTO", 1)
+_WRITE_SELECT_CHUNK_SIZE = 900
 _WRITE_EXECUTEMANY_CHUNK_SIZE = 1_000
 
 
@@ -399,14 +426,23 @@ def _append_conversation(
     changed_messages = [
         message for message in cdata.message_tuples if existing_messages.get(str(message[0])) != str(message[6])
     ]
-    if not changed_messages and not cdata.attachment_tuples:
+    changed_message_ids = {str(message[0]) for message in changed_messages}
+    event_ids = [str(event[0]) for event in cdata.provider_event_tuples]
+    existing_provider_events = _existing_provider_event_ids(conn, event_ids)
+    changed_provider_events = [
+        event for event in cdata.provider_event_tuples if str(event[0]) not in existing_provider_events
+    ]
+    if not changed_messages and not cdata.attachment_tuples and not changed_provider_events:
         counts["skipped_conversations"] = 1
         counts["skipped_messages"] = len(cdata.message_tuples)
         counts["skipped_attachments"] = len(cdata.attachment_tuples)
         counts["skipped_provider_events"] = len(cdata.provider_event_tuples)
         return False, counts
 
-    merged_hash = _append_content_hash(existing_hash, cdata.content_hash)
+    counts["skipped_messages"] = len(cdata.message_tuples) - len(changed_messages)
+    counts["skipped_provider_events"] = len(cdata.provider_event_tuples) - len(changed_provider_events)
+
+    merged_hash = _append_content_hash(existing_hash, _tail_content_hash(changed_messages, cdata.content_hash))
     resolved_tuple = _resolved_conversation_tuple(conn, cdata)
     conn.execute(_CONVERSATION_UPSERT_SQL, _conversation_tuple_with_hash(resolved_tuple, merged_hash))
     # Record the identity mapping so re-ingest after reset preserves conversation_id.
@@ -423,20 +459,32 @@ def _append_conversation(
         ),
     )
 
-    if cdata.message_tuples:
-        sorted_msgs = _topo_sort_message_tuples(cdata.message_tuples)
+    if changed_messages:
+        sorted_msgs = _topo_sort_message_tuples(changed_messages)
         _executemany_chunked(conn, _MESSAGE_UPSERT_SQL, sorted_msgs)
         counts["messages"] = len(changed_messages)
 
-    if cdata.block_tuples:
-        _executemany_chunked(conn, _CONTENT_BLOCK_UPSERT_SQL, cdata.block_tuples)
+    changed_blocks = [block for block in cdata.block_tuples if str(block[1]) in changed_message_ids]
+    if changed_blocks:
+        changed_block_message_ids = sorted({str(block[1]) for block in changed_blocks})
+        placeholders = ", ".join("?" for _ in changed_block_message_ids)
+        conn.execute(
+            f"DELETE FROM content_blocks WHERE message_id IN ({placeholders})", tuple(changed_block_message_ids)
+        )
+        _executemany_chunked(conn, _CONTENT_BLOCK_UPSERT_SQL, changed_blocks)
 
-    if cdata.action_event_tuples:
-        _executemany_chunked(conn, _ACTION_EVENT_INSERT_OR_IGNORE_SQL, cdata.action_event_tuples)
+    changed_action_events = [event for event in cdata.action_event_tuples if str(event[2]) in changed_message_ids]
+    if changed_action_events:
+        changed_action_message_ids = sorted({str(event[2]) for event in changed_action_events})
+        placeholders = ", ".join("?" for _ in changed_action_message_ids)
+        conn.execute(
+            f"DELETE FROM action_events WHERE message_id IN ({placeholders})", tuple(changed_action_message_ids)
+        )
+        _executemany_chunked(conn, _ACTION_EVENT_INSERT_OR_IGNORE_SQL, changed_action_events)
 
-    if cdata.provider_event_tuples:
-        _executemany_chunked(conn, _PROVIDER_EVENT_INSERT_OR_IGNORE_SQL, cdata.provider_event_tuples)
-        counts["provider_events"] = len(cdata.provider_event_tuples)
+    if changed_provider_events:
+        _executemany_chunked(conn, _PROVIDER_EVENT_INSERT_OR_IGNORE_SQL, changed_provider_events)
+        counts["provider_events"] = len(changed_provider_events)
 
     affected_attachment_ids = {str(attachment_id) for attachment_id, *_rest in cdata.attachment_tuples}
     if cdata.attachment_tuples:
@@ -637,6 +685,13 @@ def _write_conversation_entry(
                 cid=cdata.conversation_id[:20],
                 elapsed_s=round(write_elapsed, 2),
                 msgs=len(cdata.message_tuples),
+                changed_messages=counts["messages"],
+                skipped_messages=counts["skipped_messages"],
+                blocks=len(cdata.block_tuples),
+                actions=len(cdata.action_event_tuples),
+                provider_events=len(cdata.provider_event_tuples),
+                changed_provider_events=counts["provider_events"],
+                attachments=len(cdata.attachment_tuples),
             )
         return True
     except Exception as exc:
@@ -1212,7 +1267,12 @@ async def process_ingest_batch(
             messages=batch_summary.total_msgs,
             workers=batch_summary.worker_count,
             changed=len(batch_summary.changed_conversation_ids),
+            result_mb=round(batch_summary.total_result_bytes / (1024 * 1024), 1),
+            max_result_mb=round(batch_summary.max_result_bytes / (1024 * 1024), 1),
+            max_result_raw_id=batch_summary.max_result_raw_id,
+            max_current_rss_mb=batch_summary.max_current_rss_mb,
             write_s=round(batch_summary.write_elapsed_s, 2),
+            max_write_s=round(batch_summary.max_write_elapsed_s, 2),
             commit_s=round(batch_summary.commit_elapsed_s, 2),
             wal_mode=batch_summary.wal_checkpoint_mode,
             wal_before=batch_summary.wal_bytes_before_checkpoint,

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -161,6 +161,31 @@ def _record_payload(record: dict[str, object]) -> dict[str, object]:
     return {str(key): value for key, value in record.items() if value is not None}
 
 
+def _compact_response_payload(payload: dict[str, object], *, index: int) -> dict[str, object]:
+    compact: dict[str, object] = {"source_index": index}
+    for key in ("type", "id", "call_id", "name", "status"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            compact[key] = value
+    timestamp = _record_timestamp(payload)
+    if timestamp is not None:
+        compact["timestamp"] = timestamp
+    output = payload.get("output")
+    if isinstance(output, str):
+        compact["output_chars"] = len(output)
+    elif output is not None:
+        compact["has_output"] = True
+    arguments = payload.get("arguments")
+    if isinstance(arguments, str):
+        compact["argument_chars"] = len(arguments)
+    elif arguments is not None:
+        compact["has_arguments"] = True
+    cwd = _extract_cwd(payload)
+    if cwd:
+        compact["cwd"] = cwd
+    return compact
+
+
 def _extract_cwd(payload: dict[str, object] | None) -> str | None:
     if not payload:
         return None
@@ -319,11 +344,10 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
             payload = _payload_record(record) or {}
             history = payload.get("replacement_history")
             event_payload: dict[str, object] = {
+                "source_index": idx,
                 "summary": str(payload.get("message", "") or ""),
-                "has_replacement_history": isinstance(history, list) and bool(history),
+                "replacement_history_count": len(history) if isinstance(history, list) else 0,
             }
-            if payload:
-                event_payload["raw"] = payload
             provider_events.append(
                 ParsedProviderEvent(
                     event_type="compaction",
@@ -339,7 +363,7 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
             tc_payload: dict[str, object] = {}
             turn_payload = _payload_record(record)
             if turn_payload:
-                tc_payload["raw"] = turn_payload
+                tc_payload["source_index"] = idx
                 cwd = _extract_cwd(turn_payload)
                 if cwd:
                     tc_payload["cwd"] = cwd
@@ -356,12 +380,12 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
         if _record_type(record) == "response_item":
             inner = _payload_record(record)
             if inner is not None and not _is_message(inner):
-                event_payload = _record_payload(inner)
+                event_payload = _compact_response_payload(inner, index=idx)
                 provider_events.append(
                     ParsedProviderEvent(
                         event_type=_record_type(inner) or "response_item",
                         timestamp=_iso_or_none(_record_timestamp(inner) or _record_timestamp(record)),
-                        payload={"raw": event_payload},
+                        payload=event_payload,
                     )
                 )
                 tool_message = _codex_tool_message(inner, index=idx)

--- a/tests/unit/pipeline/test_ingest_append_replay.py
+++ b/tests/unit/pipeline/test_ingest_append_replay.py
@@ -1,0 +1,107 @@
+"""Append-only ingest replay regression tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue.pipeline.services.ingest_batch import _write_conversation
+from polylogue.storage.sqlite.connection import open_connection
+from polylogue.types import ConversationId
+from tests.unit.pipeline.test_ingest_batch import (
+    _block_tuple,
+    _conversation_data,
+    _message_tuple,
+)
+
+
+def test_append_mode_filters_unchanged_replayed_rows(tmp_path: Path) -> None:
+    with open_connection(tmp_path / "ingest.db") as conn:
+        initial = _conversation_data(
+            "codex:append-replay",
+            content_hash="hash-v1",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex:append-replay",
+                    role="user",
+                    text="first",
+                    content_hash="msg-v1-1",
+                    sort_key=1.0,
+                )
+            ],
+            block_tuples=[
+                _block_tuple(
+                    block_id="blk-msg-1-0",
+                    message_id="msg-1",
+                    conversation_id="codex:append-replay",
+                    block_index=0,
+                    text="first block",
+                )
+            ],
+            stats_tuple=(ConversationId("codex:append-replay"), "codex", 1, 1, 0, 0, 0),
+        )
+        replay = _conversation_data(
+            "codex:append-replay",
+            content_hash="hash-replayed-full-file",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex:append-replay",
+                    role="user",
+                    text="first should not be rewritten",
+                    content_hash="msg-v1-1",
+                    sort_key=1.0,
+                ),
+                _message_tuple(
+                    "msg-2",
+                    "codex:append-replay",
+                    role="assistant",
+                    text="second",
+                    content_hash="msg-v2-2",
+                    sort_key=2.0,
+                ),
+            ],
+            block_tuples=[
+                _block_tuple(
+                    block_id="blk-msg-1-0",
+                    message_id="msg-1",
+                    conversation_id="codex:append-replay",
+                    block_index=0,
+                    text="rewritten block should be ignored",
+                ),
+                _block_tuple(
+                    block_id="blk-msg-2-0",
+                    message_id="msg-2",
+                    conversation_id="codex:append-replay",
+                    block_index=0,
+                    text="second block",
+                ),
+            ],
+            append_only=True,
+        )
+
+        changed_initial, _initial_counts = _write_conversation(conn, initial)
+        changed_tail, tail_counts = _write_conversation(conn, replay)
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT message_id, text FROM messages WHERE conversation_id = ? ORDER BY sort_key",
+            ("codex:append-replay",),
+        ).fetchall()
+        block_rows = conn.execute(
+            "SELECT message_id, text FROM content_blocks WHERE conversation_id = ? ORDER BY message_id",
+            ("codex:append-replay",),
+        ).fetchall()
+
+    assert changed_initial is True
+    assert changed_tail is True
+    assert tail_counts["messages"] == 1
+    assert tail_counts["skipped_messages"] == 1
+    assert [(row["message_id"], row["text"]) for row in rows] == [
+        ("msg-1", "first"),
+        ("msg-2", "second"),
+    ]
+    assert [(row["message_id"], row["text"]) for row in block_rows] == [
+        ("msg-1", "first block"),
+        ("msg-2", "second block"),
+    ]

--- a/tests/unit/sources/test_codex_event_stream_contract.py
+++ b/tests/unit/sources/test_codex_event_stream_contract.py
@@ -451,5 +451,5 @@ class TestCrossMessageReferences:
         conversation = _parse(records, "interleaved_stream")
         compactions = [e for e in conversation.provider_events if e.event_type == "compaction"]
         assert len(compactions) == 1
-        assert compactions[0].payload["has_replacement_history"] is True
+        assert compactions[0].payload["replacement_history_count"] == 1
         assert compactions[0].payload["summary"] == "Conversation compacted"

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -445,6 +445,52 @@ class TestGitContextAndInstructions:
         assert _provider_meta(result)["working_directories"] == ["/repo/other", "/repo/polylogue"]
         assert result.provider_events[0].payload["cwd"] == "/repo/polylogue"
 
+    def test_provider_events_keep_compact_provenance_not_raw_payloads(self) -> None:
+        payload = [
+            {
+                "type": "compacted",
+                "payload": {
+                    "message": "summary",
+                    "replacement_history": [{"role": "user", "content": "large prior text"}],
+                },
+            },
+            {"type": "turn_context", "payload": {"cwd": "/repo/polylogue", "large": "x" * 1024}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "id": "evt-1",
+                    "call_id": "call-1",
+                    "output": "large command output" * 1024,
+                },
+            },
+        ]
+
+        result = parse(payload, "fallback")
+
+        assert [event.event_type for event in result.provider_events] == [
+            "compaction",
+            "turn_context",
+            "function_call_output",
+        ]
+        assert result.provider_events[0].payload == {
+            "source_index": 1,
+            "summary": "summary",
+            "replacement_history_count": 1,
+        }
+        assert result.provider_events[1].payload == {
+            "source_index": 2,
+            "cwd": "/repo/polylogue",
+        }
+        assert result.provider_events[2].payload == {
+            "source_index": 3,
+            "type": "function_call_output",
+            "id": "evt-1",
+            "call_id": "call-1",
+            "output_chars": len("large command output" * 1024),
+        }
+        assert all("raw" not in event.payload for event in result.provider_events)
+
 
 # =============================================================================
 # Edge Cases


### PR DESCRIPTION
## Summary

Reduce daemon catch-up amplification for large Codex sessions by making append-only replay write only changed rows, compacting Codex provider-event payloads, and expanding ingest logs with row/result/RSS attribution fields.

## Problem

Live #1447 deployment evidence showed `polylogued` reaching the 6G memory high mark and severe host IO PSI while processing a single 232MB Codex session. Inspection found a concrete append-only bug: the writer computed changed messages but still upserted every replayed message/block/action/provider-event tuple from the full parsed session. Codex provider events also duplicated raw command output and compaction history already retained in the raw blob and normalized message/action rows.

## Solution

- Chunk large existing-message/provider-event lookups so replay checks do not exceed SQLite variable limits.
- In append-only mode, write only changed messages, changed blocks/actions, and new provider events; unchanged replayed rows are counted as skipped and left untouched.
- Preserve append-only content hash progression from the changed tail rather than the whole replayed file hash.
- Compact Codex compaction, turn-context, and response-item provider-event payloads into source index/type/id/shape metadata instead of storing raw duplicated payloads.
- Add slow-write and ingest-batch log fields for changed/skipped rows, provider events, serialized result size, max write duration, and observed RSS.

Ref #1447. This does not close #1447: live catch-up still needs to prove whether first-time huge-session ingest requires chunked materialization beyond these amplification fixes.

## Verification

- `pytest tests/unit/pipeline/test_ingest_append_replay.py tests/unit/pipeline/test_ingest_batch.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_codex_event_stream_contract.py -q` → `90 passed in 0.32s`
- `ruff check polylogue/sources/parsers/codex.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_codex_event_stream_contract.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_append_replay.py` → `All checks passed!`
- `mypy polylogue/sources/parsers/codex.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_codex_event_stream_contract.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_append_replay.py` → `Success: no issues found in 6 source files`
- `devtools verify-file-budgets` → `file-size budgets: clean`
- `devtools verify --quick` → exit 0, `total_duration_s: 37.33`
- pre-push `devtools verify --quick` → exit 0, `total_duration_s: 34.68`