### PR TITLE
fix(daemon): defer incomplete live appends

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -39,9 +39,7 @@ from polylogue.sources.live.batch_observability import (
     record_attempt_progress,
 )
 from polylogue.sources.live.batch_support import (
-    _LARGE_FULL_PARSE_PROGRESS_BYTES as _LARGE_FULL_PARSE_PROGRESS_BYTES,
-)
-from polylogue.sources.live.batch_support import (
+    _DEFER_APPEND,
     _MAX_APPEND_PLAN_PAYLOAD_BYTES,
     _STREAMING_FULL_INGEST_BYTES,
     _accumulate_stage_timings,
@@ -49,6 +47,7 @@ from polylogue.sources.live.batch_support import (
     _AppendPlan,
     _AppendResult,
     _blob_copy_heartbeat,
+    _DeferredAppend,
     _detect_provider_from_path_sample,
     _full_ingest_result_from_summary,
     _full_ingest_worker_count,
@@ -64,6 +63,9 @@ from polylogue.sources.live.batch_support import (
     fingerprint_file,
     last_complete_newline_from_tail,
     tail_hash_from_path,
+)
+from polylogue.sources.live.batch_support import (
+    _LARGE_FULL_PARSE_PROGRESS_BYTES as _LARGE_FULL_PARSE_PROGRESS_BYTES,
 )
 from polylogue.sources.live.batch_support import (
     _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES as _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES,
@@ -166,10 +168,10 @@ class LiveBatchProcessor:
         ingest_worker_count_max = 0
         full_ingest_aggregate = LiveFullIngestAggregate()
         cursor_records = self._cursor.get_records(paths)
-
         append_file_count = 0
         pending_append_plans: list[_AppendPlan] = []
         full_paths: list[Path] = []
+        deferred_paths: list[Path] = []
 
         async def flush_append_plans() -> None:
             nonlocal convergence_time_s
@@ -248,7 +250,9 @@ class LiveBatchProcessor:
                 if self._can_ingest_appends_directly()
                 else None
             )
-            if append_plan is None:
+            if isinstance(append_plan, _DeferredAppend):
+                deferred_paths.append(path)
+            elif append_plan is None:
                 full_paths.append(path)
             else:
                 pending_append_plans.append(append_plan)
@@ -412,7 +416,7 @@ class LiveBatchProcessor:
             attempt_id,
             phase="cursor_update",
             succeeded_file_count=len(succeeded_paths),
-            failed_file_count=len(failed_paths),
+            failed_file_count=len(failed_paths) + len(deferred_paths),
             source_payload_read_bytes=source_payload_read_bytes,
             cursor_fingerprint_read_bytes=cursor_fingerprint_read_bytes,
             parse_time_s=parse_time_s,
@@ -420,6 +424,7 @@ class LiveBatchProcessor:
             stale_cursor_write_count=stale_cursor_write_count,
         )
 
+        retry_paths = failed_paths + [str(path) for path in deferred_paths]
         db_bytes_after = _path_size(self._cursor._db_path) + _path_size(self._cursor._db_path.with_suffix(".db-wal"))
         metrics = LiveBatchMetrics(
             queued_file_count=queued_file_count if queued_file_count is not None else len(paths),
@@ -450,7 +455,7 @@ class LiveBatchProcessor:
             cgroup_memory_swap_current_mb=read_cgroup_memory_swap_current_mb(),
             stale_cursor_write_count=stale_cursor_write_count,
             stage_timings_s={name: round(elapsed, 6) for name, elapsed in stage_timings.items()},
-            failed_paths=failed_paths,
+            failed_paths=retry_paths,
         )
         if emit_event and self._event_emitter is not None:
             self._event_emitter("ingestion_batch", metrics.to_payload())
@@ -462,7 +467,7 @@ class LiveBatchProcessor:
             needed_file_count=metrics.needed_file_count,
             skipped_file_count=metrics.skipped_file_count,
             succeeded_file_count=len(succeeded_paths),
-            failed_file_count=len(failed_paths),
+            failed_file_count=len(failed_paths) + len(deferred_paths),
             input_bytes=input_bytes,
             source_payload_read_bytes=source_payload_read_bytes,
             cursor_fingerprint_read_bytes=cursor_fingerprint_read_bytes,
@@ -475,9 +480,9 @@ class LiveBatchProcessor:
         )
         self._cursor.finish_ingest_attempt(
             attempt_id,
-            status="completed" if not failed_paths else "completed_with_failures",
+            status="completed" if not retry_paths else "completed_with_failures",
             phase="completed",
-            error="; ".join(failed_paths[:3]) if failed_paths else None,
+            error="; ".join(retry_paths[:3]) if retry_paths else None,
         )
         return metrics
 
@@ -987,7 +992,7 @@ class LiveBatchProcessor:
             excluded=True,
         )
 
-    def _append_plan(self, path: Path, *, cursor: CursorRecord | None = None) -> _AppendPlan | None:
+    def _append_plan(self, path: Path, *, cursor: CursorRecord | None = None) -> _AppendPlan | _DeferredAppend | None:
         cursor = cursor or self._cursor.get_record(path)
         if cursor is None or cursor.parser_fingerprint != self._current_parser_fingerprint():
             return None
@@ -1009,10 +1014,10 @@ class LiveBatchProcessor:
             payload = handle.read(append_window)
         newline_at = payload.rfind(b"\n")
         if newline_at < 0:
-            return None
+            return _DEFER_APPEND
         complete_payload = payload[: newline_at + 1]
         if not complete_payload:
-            return None
+            return _DEFER_APPEND
         append_payload = self._append_payload_for_provider(path, self._source_name_for(path), complete_payload)
         if append_payload is None:
             return None

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -74,6 +74,13 @@ class _AppendResult:
     worker_count: int = 0
 
 
+class _DeferredAppend:
+    pass
+
+
+_DEFER_APPEND = _DeferredAppend()
+
+
 @dataclass(frozen=True, slots=True)
 class _FullIngestResult:
     succeeded: list[Path]

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -26,6 +26,7 @@ from polylogue.logging import get_logger
 from polylogue.sources.live.batch import LiveBatchEventEmitter, LiveBatchProcessor, fingerprint_file
 from polylogue.sources.live.batch_support import tail_hash_from_path
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
+from polylogue.sources.live.metrics import LiveBatchMetrics
 
 if TYPE_CHECKING:
     from polylogue.api import Polylogue
@@ -124,6 +125,7 @@ class LiveWatcher:
             return
 
         await self._catch_up(roots)
+        self._ensure_pending_scheduled()
 
         logger.info("live.watcher: watching %s", ", ".join(str(r) for r in roots))
         async for changes in awatch(*roots, stop_event=self._stop, recursive=True):
@@ -177,11 +179,12 @@ class LiveWatcher:
                     len(chunk),
                     chunk_bytes / 1e6,
                 )
-                await self._ingest_files(
+                metrics = await self._ingest_files(
                     list(chunk),
                     queued_file_count=len(plan.candidates) if index == 1 else len(chunk),
                     skipped_file_count=plan.skipped_file_count if index == 1 else 0,
                 )
+                await self._requeue_failed_paths(metrics)
 
     def _scan_catch_up_candidates(self, roots: list[Path]) -> tuple[CandidateSourceFile, ...]:
         root_set = {root.resolve() for root in roots}
@@ -262,9 +265,28 @@ class LiveWatcher:
     def _enqueue(self, path: Path) -> None:
         """Enqueue a path for batched ingestion after debounce."""
         self._pending_paths.add(path)
+        self._ensure_pending_scheduled()
+
+    def _ensure_pending_scheduled(self) -> None:
+        if not self._pending_paths or self._stop.is_set():
+            return
         if self._drain_task is None or self._drain_task.done():
             self._pending_scheduled = True
             self._drain_task = asyncio.create_task(self._debounced_batch())
+
+    async def _requeue_failed_paths(self, metrics: object) -> None:
+        failed_paths = getattr(metrics, "failed_paths", ())
+        if not failed_paths:
+            return
+        paths = [Path(path) for path in failed_paths if isinstance(path, str) and path]
+        if not paths:
+            return
+        logger.warning(
+            "live.watcher: requeued %d failed file(s) for live retry",
+            len(paths),
+        )
+        async with self._batch_lock:
+            self._pending_paths.update(paths)
 
     async def _debounced_batch(self) -> None:
         """Wait for the debounce window, then drain pending paths serially."""
@@ -313,11 +335,12 @@ class LiveWatcher:
                 return bool(paths)
 
             logger.info("live.watcher: batching %d changed file(s)", len(needed))
-            await self._ingest_files(
+            metrics = await self._ingest_files(
                 needed,
                 queued_file_count=len(paths),
                 skipped_file_count=len(paths) - len(needed),
             )
+            await self._requeue_failed_paths(metrics)
         except sqlite3.OperationalError as exc:
             if not _is_database_locked(exc):
                 raise
@@ -379,14 +402,15 @@ class LiveWatcher:
         *,
         queued_file_count: int | None = None,
         skipped_file_count: int = 0,
-    ) -> None:
+    ) -> LiveBatchMetrics:
         """Ingest files through the reusable daemon live batch processor."""
         async with self._ingest_lock:
-            await self._batch_processor.ingest_files(
+            metrics = await self._batch_processor.ingest_files(
                 paths,
                 queued_file_count=queued_file_count,
                 skipped_file_count=skipped_file_count,
             )
+        return metrics
 
     def _source_name_for(self, path: Path) -> str:
         resolved = path.resolve()

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -10,6 +11,7 @@ from polylogue.sources.live import WatchSource
 from polylogue.sources.live.append_ingest import ingest_append_plans
 from polylogue.sources.live.batch import _MAX_APPEND_PLAN_PAYLOAD_BYTES, LiveBatchProcessor
 from polylogue.sources.live.batch_support import (
+    _DEFER_APPEND,
     _AppendPlan,
     _AppendResult,
     _detect_provider_from_path_sample,
@@ -242,7 +244,7 @@ def test_append_plan_chunks_large_tail_without_full_ingest(tmp_path: Path) -> No
 
     plan = processor._append_plan(path)
 
-    assert plan is not None
+    assert isinstance(plan, _AppendPlan)
     assert plan.start_offset == len(original)
     assert plan.last_complete_newline == len(original) + len(first_chunk)
     assert plan.stat_size == len(original) + len(appended)
@@ -251,10 +253,73 @@ def test_append_plan_chunks_large_tail_without_full_ingest(tmp_path: Path) -> No
 
     assert processor._record_append_cursor(plan) is True
     next_plan = processor._append_plan(path)
-    assert next_plan is not None
+    assert isinstance(next_plan, _AppendPlan)
     assert next_plan.start_offset == len(original) + len(first_chunk)
     assert next_plan.last_complete_newline == len(original) + len(appended)
     assert next_plan.payload == second_chunk
+
+
+def test_append_plan_defers_when_tail_has_no_complete_line(tmp_path: Path) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "session.jsonl"
+    original = b'{"a":1}\n'
+    path.write_bytes(original + b'{"b":')
+    db_path = tmp_path / "archive.sqlite"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
+        (WatchSource(name="chatgpt", root=root),),
+        cursor=CursorStore(db_path),
+        parser_fingerprint="test-parser",
+    )
+    stat = path.stat()
+    processor._cursor.set(
+        path,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint="test-parser",
+        content_fingerprint="base",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+    assert processor._append_plan(path) is _DEFER_APPEND
+
+
+def test_incomplete_append_is_requeued_not_full_ingested(tmp_path: Path) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "session.jsonl"
+    original = b'{"a":1}\n'
+    path.write_bytes(original + b'{"b":')
+    db_path = tmp_path / "archive.sqlite"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
+        (WatchSource(name="chatgpt", root=root),),
+        cursor=CursorStore(db_path),
+        parser_fingerprint="test-parser",
+    )
+    stat = path.stat()
+    processor._cursor.set(
+        path,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint="test-parser",
+        content_fingerprint="base",
+        source_name="chatgpt",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+    metrics = asyncio.run(processor.ingest_files([path], emit_event=False))
+
+    assert metrics.full_file_count == 0
+    assert metrics.append_file_count == 0
+    assert metrics.failed_paths == [str(path)]
 
 
 def test_append_ingest_preserves_successes_when_other_plan_fails(

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -76,7 +76,7 @@ def test_catch_up_ingests_needed_files_in_bounded_chunks(
     ) -> None:
         calls.append((paths, queued_file_count, skipped_file_count))
 
-    watcher._ingest_files = fake_ingest_files  # type: ignore[method-assign]
+    watcher._ingest_files = fake_ingest_files  # type: ignore[assignment,method-assign]
 
     asyncio.run(watcher._catch_up([root]))
 
@@ -84,3 +84,27 @@ def test_catch_up_ingests_needed_files_in_bounded_chunks(
     assert calls[0][1:] == (5, 0)
     assert calls[1][1:] == (2, 0)
     assert calls[2][1:] == (1, 0)
+
+
+def test_catch_up_requeues_failed_paths_for_live_retry(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    files = [root / f"session-{index}.jsonl" for index in range(3)]
+    for path in files:
+        path.write_text('{"role":"user","content":"x"}\n')
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),))
+
+    async def fake_ingest_files(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(failed_paths=[str(paths[1])])
+
+    watcher._ingest_files = fake_ingest_files  # type: ignore[assignment,method-assign]
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert watcher._pending_paths == {files[1]}

--- a/tests/unit/sources/test_live_hot_session_convergence.py
+++ b/tests/unit/sources/test_live_hot_session_convergence.py
@@ -118,7 +118,7 @@ def test_debounce_drains_live_events_serially_while_ingest_is_active(tmp_path: P
         active -= 1
 
     async def _drive() -> None:
-        watcher._ingest_files = fake_ingest  # type: ignore[method-assign]
+        watcher._ingest_files = fake_ingest  # type: ignore[assignment,method-assign]
         watcher._enqueue(first)
         await asyncio.wait_for(entered_first_batch.wait(), timeout=2.0)
         watcher._enqueue(second)

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -497,7 +497,7 @@ def test_catch_up_uses_bulk_cursor_records(tmp_path: Path, monkeypatch: pytest.M
 
     monkeypatch.setattr(watcher._cursor, "get_records", counted_get_records)
     monkeypatch.setattr(watcher._cursor, "get_record", fail_get_record)
-    watcher._ingest_files = fake_ingest_files  # type: ignore[method-assign]
+    watcher._ingest_files = fake_ingest_files  # type: ignore[assignment,method-assign]
 
     asyncio.run(watcher._catch_up([root]))
 
@@ -688,10 +688,11 @@ def test_append_plan_reads_only_completed_tail(tmp_path: Path) -> None:
     plan = watcher._batch_processor._append_plan(f)
 
     assert plan is not None
-    assert plan.start_offset == len(original)
-    assert plan.payload == b'{"b":2}\n'
-    assert plan.bytes_read == len(appended)
-    assert plan.last_complete_newline == len(original) + len(b'{"b":2}\n')
+    append_plan = cast(Any, plan)
+    assert append_plan.start_offset == len(original)
+    assert append_plan.payload == b'{"b":2}\n'
+    assert append_plan.bytes_read == len(appended)
+    assert append_plan.last_complete_newline == len(original) + len(b'{"b":2}\n')
 
 
 def test_last_complete_newline_from_tail_reads_only_final_chunk(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Prevents hot JSONL session files from falling back to full ingest when the watcher observes a partial trailing line, and requeues failed live/catch-up paths for the normal retry loop.

## Problem

Live deployment of #1459 proved #1447 is still open: catch-up reached watching, but a Codex file then triggered `slow_write ... changed_messages=10309 ... elapsed_s=81.76`, drove IO PSI full avg10 to ~55%, and left the daemon in D-state. The append planner was treating a grown tail with no complete newline as "not appendable", which sent an actively-written JSONL file into full ingest instead of waiting for the writer to finish the line.

## Solution

- Add an explicit deferred-append sentinel for incomplete JSONL tails.
- Keep deferred paths out of full ingest and report them as retryable failed paths.
- Requeue failed catch-up and live-drain paths into the existing pending watcher loop.
- Return `LiveBatchMetrics` from `LiveWatcher._ingest_files` so callers can act on retryable failures.
- Add regression coverage for incomplete append deferral and failed catch-up requeue.

Ref #1447

## Verification

- `pytest tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_watcher_locking.py tests/unit/sources/test_live_hot_session_convergence.py -q` → 83 passed
- `ruff check polylogue/sources/live/batch.py polylogue/sources/live/batch_support.py polylogue/sources/live/watcher.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_hot_session_convergence.py` → passed
- `mypy polylogue/sources/live/batch.py polylogue/sources/live/batch_support.py polylogue/sources/live/watcher.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_hot_session_convergence.py` → passed
- `devtools verify-file-budgets` → clean
- `devtools verify --quick` → exit_code 0, total_duration_s 37.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File ingestion now automatically retries failed paths during live processing, improving reliability.

* **Refactor**
  * Improved batch processing to better handle incomplete file appends and optimized scheduling logic for pending files.

* **Tests**
  * Added comprehensive test coverage for deferred append behavior and failed file retry mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->