### PR TITLE
fix(daemon): keep Codex append identity hot

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1060,7 +1060,6 @@ class LiveBatchProcessor:
                 FROM conversations AS c
                 JOIN raw_conversations AS r ON r.raw_id = c.raw_id
                 WHERE r.source_path = ?
-                  AND COALESCE(r.source_index, 0) >= 0
                 ORDER BY c.updated_at DESC, c.created_at DESC, c.conversation_id DESC
                 LIMIT 1
                 """,

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -322,6 +322,97 @@ def test_incomplete_append_is_requeued_not_full_ingested(tmp_path: Path) -> None
     assert metrics.failed_paths == [str(path)]
 
 
+def test_codex_append_plan_uses_append_only_conversation_identity(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.schema import _ensure_schema
+
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "rollout-2026-05-16T13-50-17-019e309f-7614-7381-a8ac-f9080f304ee6.jsonl"
+    original = b'{"type":"session_meta","payload":{"id":"019e309f-7614-7381-a8ac-f9080f304ee6"}}\n'
+    appended = b'{"type":"event_msg","payload":{"message":"new"}}\n'
+    path.write_bytes(original + appended)
+    db_path = tmp_path / "archive.sqlite"
+    cursor = CursorStore(db_path)
+    with cursor._connect() as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO raw_conversations (
+                raw_id, provider_name, payload_provider, source_name, source_path,
+                source_index, blob_size, acquired_at, file_mtime
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "append-raw",
+                "codex",
+                "codex",
+                "codex",
+                str(path),
+                -1,
+                len(original),
+                "2026-05-24T00:00:00+00:00",
+                "2026-05-24T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO conversations (
+                conversation_id, provider_name, provider_conversation_id, title,
+                created_at, updated_at, sort_key, content_hash, provider_meta,
+                metadata, source_name, working_directories_json, git_branch,
+                git_repository_url, version, parent_conversation_id, branch_type, raw_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex:019e309f-7614-7381-a8ac-f9080f304ee6",
+                "codex",
+                "019e309f-7614-7381-a8ac-f9080f304ee6",
+                "hot session",
+                "2026-05-24T00:00:00+00:00",
+                "2026-05-24T00:00:00+00:00",
+                0.0,
+                "base-hash",
+                '{"source":"codex"}',
+                "{}",
+                "codex",
+                None,
+                None,
+                None,
+                1,
+                None,
+                None,
+                "append-raw",
+            ),
+        )
+        conn.commit()
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+        parser_fingerprint="test-parser",
+    )
+    stat = path.stat()
+    cursor.set(
+        path,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint="test-parser",
+        content_fingerprint="base-cursor",
+        source_name="codex",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+    plan = processor._append_plan(path)
+
+    assert isinstance(plan, _AppendPlan)
+    assert plan.start_offset == len(original)
+    assert plan.payload.startswith(b'{"type":"session_meta","payload":{"id":"019e309f-7614-7381-a8ac-f9080f304ee6"}}\n')
+    assert plan.payload.endswith(appended)
+
+
 def test_append_ingest_preserves_successes_when_other_plan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Codex live append planning now accepts an existing conversation identity even when that conversation is currently linked through an append-only raw record. This prevents hot long-running sessions from falling back to full-file replay when the archive has already converged through append ingest.

## Problem

Live deployment of #1460 through Sinnix still showed unsafe catch-up behavior under #1447. The daemon replayed an 81 MB Codex file as ~10.5k changed messages and then started a 234 MB full replay. Inspection of the 234 MB source showed the append planner returned `None` because `_existing_provider_conversation_id()` filtered out `raw_conversations.source_index = -1`; the only linked conversation identity for that path came from an append raw record, so the planner treated the next tail as requiring full ingest.

## Solution

Remove the full-raw-only filter from Codex conversation identity lookup. Append-only raw records are valid convergence state for source identity, and using them preserves full daemon scope while keeping hot-session catch-up on the bounded append path. A regression seeds the exact archive shape and asserts `_append_plan()` produces a bounded Codex append payload with the session metadata prefix.

## Verification

- `pytest tests/unit/sources/test_live_batch_support.py -q` -> 13 passed
- `pytest tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_hot_session_convergence.py -q` -> 81 passed
- `ruff check polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py` -> passed
- `mypy polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py` -> passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 37.29
- pre-push `devtools verify --quick` -> exit_code 0, total_duration_s 34.94
- Manual live-archive planner probe for `/home/sinity/.codex/sessions/2026/05/16/rollout-2026-05-16T13-50-17-019e309f-7614-7381-a8ac-f9080f304ee6.jsonl`: before fix `_append_plan()` returned `None`; after fix it returns `_AppendPlan` with `start=232985578`, `last=234554166`, `bytes_read=1568588`, `payload_len=1568668`.

Ref #1447