### PR TITLE
fix(daemon): bulk repair streaming full-ingest FTS

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -93,7 +93,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 LiveBatchEventEmitter = Callable[[str, dict[str, object]], None]
-_FULL_INGEST_SUSPEND_FTS_TRIGGER_BYTES = 32 * 1024 * 1024
+_FULL_INGEST_SUSPEND_FTS_TRIGGER_BYTES = _STREAMING_FULL_INGEST_BYTES
 
 
 class LiveBatchProcessor:

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -117,6 +117,47 @@ def test_large_full_ingest_suspends_fts_triggers_and_repairs_once(
     assert captured_kwargs["repair_action_fts"] is True
 
 
+def test_streaming_sized_full_ingest_suspends_fts_triggers_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    source = root / "large.jsonl"
+    source.write_bytes(b'{"type":"session_meta","payload":{"id":"large"}}\n' + (b" " * (9 * 1024 * 1024)))
+    db_path = tmp_path / "archive.sqlite"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(db_path),
+        parser_fingerprint="test-parser",
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_conversation_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.BlobStore.write_from_path",
+        lambda _store, path, heartbeat=None: ("a" * 64, path.stat().st_size),
+    )
+
+    def fake_process_ingest_batch_sync(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(failed_raw_ids=set(), parse_failures=0, worker_count=1)
+
+    monkeypatch.setattr("polylogue.sources.live.batch._process_ingest_batch_sync", fake_process_ingest_batch_sync)
+
+    result = processor._ingest_full_paths_sync([source], source_name="codex")
+
+    assert result.succeeded == [source]
+    assert captured_kwargs["suspend_fts_triggers"] is True
+    assert captured_kwargs["repair_message_fts"] is True
+    assert captured_kwargs["repair_action_fts"] is True
+
+
 def test_fingerprint_file_streams_in_bounded_memory(tmp_path: Path) -> None:
     """``fingerprint_file`` must not load the whole file into memory.
 


### PR DESCRIPTION
## Summary

Live full ingest now switches to suspended FTS triggers at the same size threshold where it already switches to streaming blob ingestion. This targets large same-size source rewrites that cannot use append planning but should not pay thousands of per-row FTS trigger updates.

## Problem

After #1461 was deployed, the two hot Codex append cases were fixed in live monitoring:

- 82 MB source: `changed_messages=89`, `elapsed_s=1.65`, `source_payload_read_bytes=598770`
- 235 MB source: `changed_messages=278`, `elapsed_s=4.08`, `source_payload_read_bytes=2051406`

The next catch-up chunk still exposed a separate unsafe path. A 37.8 MB chunk containing same-size changed Codex sessions produced:

```text
slow_write actions=2000 blocks=2374 changed_messages=2369 changed_provider_events=5471 cid=codex:019e548a-67af- elapsed_s=25.97
read_bytes ~= 24.8 GB
IO PSI full avg10 ~= 30.7%
database is locked
```

Those files were too large for cheap per-row FTS trigger churn but below the old 32 MiB trigger-suspension threshold.

## Solution

Use the existing `_STREAMING_FULL_INGEST_BYTES` threshold for full-ingest FTS trigger suspension. Files large enough to stream through the blob path now also get bulk FTS repair at commit. This preserves daemon convergence scope; it only changes the write mechanics for large full replays.

A regression verifies that a 9 MiB JSONL full-ingest source now calls `_process_ingest_batch_sync` with `suspend_fts_triggers=True`, `repair_message_fts=True`, and `repair_action_fts=True` by default.

## Verification

- `pytest tests/unit/sources/test_live_batch_support.py -q` -> 14 passed
- `ruff check polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py` -> passed
- `mypy polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py` -> passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 38.38

Ref #1447