### PR TITLE
perf(daemon): bound session insight convergence reads

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from polylogue.config import load_polylogue_config
 from polylogue.daemon.convergence import ConvergenceStage
 from polylogue.logging import get_logger
+from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.source_conversations import (
     conversation_ids_for_source_path,
     conversation_ids_for_source_paths,
@@ -346,8 +347,9 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
             try:
                 if not _table_exists(conn, "session_profiles"):
                     return False
-                if _conversation_ids_for_source_path(conn, path):
-                    return True
+                conversation_ids = _conversation_ids_for_source_path(conn, path)
+                if conversation_ids:
+                    return bool(_stale_session_profile_ids(conn, conversation_ids))
                 total_conv = int(conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0])
                 if total_conv == 0:
                     return False
@@ -397,7 +399,11 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
                 if not _table_exists(conn, "session_profiles"):
                     return set()
                 by_path = _conversation_ids_for_source_paths(conn, paths)
-                paths_with_conversations = {path for path, conversation_ids in by_path.items() if conversation_ids}
+                paths_with_conversations = {
+                    path
+                    for path, conversation_ids in by_path.items()
+                    if conversation_ids and _stale_session_profile_ids(conn, conversation_ids)
+                }
                 if paths_with_conversations:
                     return paths_with_conversations
                 if _conversation_ids_missing_profiles(conn):
@@ -450,8 +456,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
             try:
                 if not _table_exists(conn, "session_profiles"):
                     return set()
-                existing_ids = _existing_conversation_ids(conn, tuple(dict.fromkeys(conversation_ids)))
-                return set(existing_ids)
+                return set(_stale_session_profile_ids(conn, tuple(dict.fromkeys(conversation_ids))))
             finally:
                 conn.close()
         except Exception:
@@ -796,6 +801,29 @@ def _existing_conversation_ids(conn: sqlite3.Connection, conversation_ids: Seque
         ORDER BY conversation_id
         """,
         unique_ids,
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def _stale_session_profile_ids(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> list[str]:
+    unique_ids = tuple(dict.fromkeys(str(conversation_id) for conversation_id in conversation_ids if conversation_id))
+    if not unique_ids or not _table_exists(conn, "conversations") or not _table_exists(conn, "session_profiles"):
+        return []
+    placeholders = ", ".join("?" for _ in unique_ids)
+    rows = conn.execute(
+        f"""
+        SELECT c.conversation_id
+        FROM conversations AS c
+        LEFT JOIN session_profiles AS sp ON sp.conversation_id = c.conversation_id
+        WHERE c.conversation_id IN ({placeholders})
+          AND (
+              sp.conversation_id IS NULL
+              OR sp.materializer_version != ?
+              OR COALESCE(sp.source_updated_at, '') != COALESCE(c.updated_at, '')
+          )
+        ORDER BY c.conversation_id
+        """,
+        unique_ids + (SESSION_INSIGHT_MATERIALIZER_VERSION,),
     ).fetchall()
     return [str(row[0]) for row in rows]
 

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -96,6 +96,8 @@ ORDER BY COALESCE(source_sort_key, 0) DESC, conversation_id
 _SESSION_INSIGHT_REBUILD_PAGE_SIZE = 50
 _SESSION_INSIGHT_REBUILD_MESSAGE_BUDGET = 5_000
 _SESSION_INSIGHT_RELEASE_MESSAGE_THRESHOLD = 1_000
+_SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS = 16_384
+_SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS = 4_096
 _SESSION_INSIGHT_CONVERSATION_SQL_TEMPLATE = """
 SELECT
     conversation_id,
@@ -116,6 +118,66 @@ SELECT
     json_extract(provider_meta, '$.git') AS provider_meta_git
 FROM conversations
 WHERE conversation_id IN ({placeholders})
+"""
+_SESSION_INSIGHT_MESSAGE_SQL_TEMPLATE = """
+SELECT
+    message_id,
+    conversation_id,
+    provider_message_id,
+    role,
+    CASE
+        WHEN text IS NULL THEN NULL
+        ELSE substr(text, 1, {text_preview_chars})
+    END AS text,
+    sort_key,
+    content_hash,
+    version,
+    parent_message_id,
+    branch_index,
+    provider_name,
+    word_count,
+    has_tool_use,
+    has_thinking,
+    has_paste,
+    input_tokens,
+    output_tokens,
+    cache_read_tokens,
+    cache_write_tokens,
+    model_name,
+    message_type
+FROM messages
+WHERE conversation_id IN ({placeholders})
+ORDER BY conversation_id, sort_key, message_id
+"""
+_SESSION_INSIGHT_BLOCK_SQL_TEMPLATE = """
+SELECT
+    block_id,
+    message_id,
+    conversation_id,
+    block_index,
+    type,
+    CASE
+        WHEN text IS NULL THEN NULL
+        ELSE substr(text, 1, {text_preview_chars})
+    END AS text,
+    tool_name,
+    tool_id,
+    tool_input,
+    metadata,
+    semantic_type
+FROM content_blocks
+WHERE conversation_id IN ({placeholders})
+  AND message_id IN (
+      SELECT message_id
+      FROM messages
+      WHERE conversation_id IN ({placeholders})
+        AND (
+            has_tool_use != 0
+            OR has_thinking != 0
+            OR message_type IN ('tool_use', 'tool_result', 'thinking')
+        )
+  )
+ORDER BY conversation_id, message_id, block_index
 """
 
 
@@ -344,34 +406,20 @@ def load_sync_batch(
     messages = [
         _row_to_message(row)
         for row in conn.execute(
-            f"""
-            SELECT *
-            FROM messages
-            WHERE conversation_id IN ({placeholders})
-            ORDER BY conversation_id, sort_key, message_id
-            """,
+            _SESSION_INSIGHT_MESSAGE_SQL_TEMPLATE.format(
+                placeholders=placeholders,
+                text_preview_chars=_SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS,
+            ),
             tuple(conversation_ids),
         ).fetchall()
     ]
     blocks = [
         _row_to_content_block(row)
         for row in conn.execute(
-            f"""
-            SELECT *
-            FROM content_blocks
-            WHERE conversation_id IN ({placeholders})
-              AND message_id IN (
-                  SELECT message_id
-                  FROM messages
-                  WHERE conversation_id IN ({placeholders})
-                    AND (
-                        has_tool_use != 0
-                        OR has_thinking != 0
-                        OR message_type IN ('tool_use', 'tool_result', 'thinking')
-                    )
-              )
-            ORDER BY conversation_id, message_id, block_index
-            """,
+            _SESSION_INSIGHT_BLOCK_SQL_TEMPLATE.format(
+                placeholders=placeholders,
+                text_preview_chars=_SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS,
+            ),
             tuple(conversation_ids) + tuple(conversation_ids),
         ).fetchall()
     ]
@@ -403,12 +451,10 @@ async def load_async_batch(
         _row_to_message(row)
         for row in await (
             await conn.execute(
-                f"""
-                SELECT *
-                FROM messages
-                WHERE conversation_id IN ({placeholders})
-                ORDER BY conversation_id, sort_key, message_id
-                """,
+                _SESSION_INSIGHT_MESSAGE_SQL_TEMPLATE.format(
+                    placeholders=placeholders,
+                    text_preview_chars=_SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS,
+                ),
                 tuple(conversation_ids),
             )
         ).fetchall()
@@ -417,22 +463,10 @@ async def load_async_batch(
         _row_to_content_block(row)
         for row in await (
             await conn.execute(
-                f"""
-                SELECT *
-                FROM content_blocks
-                WHERE conversation_id IN ({placeholders})
-                  AND message_id IN (
-                      SELECT message_id
-                      FROM messages
-                      WHERE conversation_id IN ({placeholders})
-                        AND (
-                            has_tool_use != 0
-                            OR has_thinking != 0
-                            OR message_type IN ('tool_use', 'tool_result', 'thinking')
-                        )
-                  )
-                ORDER BY conversation_id, message_id, block_index
-                """,
+                _SESSION_INSIGHT_BLOCK_SQL_TEMPLATE.format(
+                    placeholders=placeholders,
+                    text_preview_chars=_SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS,
+                ),
                 tuple(conversation_ids) + tuple(conversation_ids),
             )
         ).fetchall()

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -16,7 +16,11 @@ from polylogue.daemon.convergence_stages import (
     make_fts_stage,
     make_insights_stage,
 )
+from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
+from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.storage_records import make_conversation, make_message, store_records
 
 
 def test_insights_stage_rebuilds_sync_against_configured_db(
@@ -332,6 +336,67 @@ def test_insights_stage_batches_sync_rebuild_chunks(
     assert stage.execute_many is not None
     assert stage.execute_many([tmp_path / "a.jsonl", tmp_path / "b.jsonl"]) is True
     assert rebuild_calls == [(["conv-a", "conv-b"], 10)]
+
+
+def test_insights_stage_scopes_conversation_debt_to_stale_profiles(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    conversations = {
+        "conv-fresh": "2026-05-24T01:00:00+00:00",
+        "conv-missing-profile": "2026-05-24T01:01:00+00:00",
+        "conv-stale-source": "2026-05-24T01:02:00+00:00",
+        "conv-stale-version": "2026-05-24T01:03:00+00:00",
+    }
+    with open_connection(db_path) as conn:
+        for conversation_id, updated_at in conversations.items():
+            store_records(
+                conversation=make_conversation(
+                    conversation_id,
+                    provider_name="codex",
+                    title=conversation_id,
+                    created_at=updated_at,
+                    updated_at=updated_at,
+                ),
+                messages=[
+                    make_message(
+                        f"{conversation_id}:msg-1",
+                        conversation_id,
+                        text=f"Message for {conversation_id}",
+                    )
+                ],
+                attachments=[],
+                conn=conn,
+            )
+        rebuild_session_insights_sync(
+            conn,
+            conversation_ids=list(conversations),
+            page_size=10,
+        )
+        conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", ("conv-missing-profile",))
+        conn.execute(
+            "UPDATE conversations SET updated_at = ? WHERE conversation_id = ?",
+            ("2026-05-24T02:02:00+00:00", "conv-stale-source"),
+        )
+        conn.execute(
+            "UPDATE session_profiles SET materializer_version = ? WHERE conversation_id = ?",
+            (SESSION_INSIGHT_MATERIALIZER_VERSION - 1, "conv-stale-version"),
+        )
+        conn.commit()
+
+    stage = make_insights_stage(db_path)
+    assert stage.check_conversations is not None
+    assert stage.check_conversations(
+        [
+            "conv-fresh",
+            "conv-missing-profile",
+            "conv-stale-source",
+            "conv-stale-version",
+            "conv-unknown",
+        ]
+    ) == {
+        "conv-missing-profile",
+        "conv-stale-source",
+        "conv-stale-version",
+    }
 
 
 def test_embedding_config_enabled_with_key() -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import pytest
 
 from polylogue.storage.insights.session.aggregates import refresh_async_provider_day_aggregates
-from polylogue.storage.insights.session.rebuild import load_sync_batch, rebuild_session_insights_sync
+from polylogue.storage.insights.session.rebuild import (
+    _SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS,
+    _SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS,
+    load_sync_batch,
+    rebuild_session_insights_sync,
+)
 from polylogue.storage.insights.session.refresh import (
     _apply_session_insight_conversation_updates_async,
     _refresh_thread_roots_async,
@@ -255,6 +260,37 @@ def test_session_insight_load_skips_plain_text_blocks(tmp_path: Path) -> None:
         batch = load_sync_batch(conn, ["conv-blocks"])
 
     assert [str(block.message_id) for block in batch.blocks] == ["conv-blocks:msg-2"]
+
+
+def test_session_insight_load_bounds_large_text_payloads(tmp_path: Path) -> None:
+    db_path = tmp_path / "refresh-text-bound.db"
+    large_message = "m" * (_SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS + 100)
+    large_tool_output = "o" * (_SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS + 100)
+    with open_connection(db_path) as conn:
+        store_records(
+            conversation=make_conversation("conv-large-text", provider_name="codex", title="Large Text"),
+            messages=[
+                make_message(
+                    "conv-large-text:msg-1",
+                    "conv-large-text",
+                    role="assistant",
+                    text=large_message,
+                    content_blocks=[
+                        {
+                            "type": "tool_result",
+                            "tool_id": "call-1",
+                            "text": large_tool_output,
+                        }
+                    ],
+                )
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        batch = load_sync_batch(conn, ["conv-large-text"])
+
+    assert batch.messages[0].text == large_message[:_SESSION_INSIGHT_MESSAGE_TEXT_PREVIEW_CHARS]
+    assert batch.blocks[0].text == large_tool_output[:_SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS]
 
 
 def test_targeted_session_insight_rebuild_splits_large_message_batches(


### PR DESCRIPTION
## Summary

Bounds daemon session-insight convergence for large conversations by loading only the columns and bounded text previews that the insight materializer needs, then scopes daemon insight debt checks to profiles that are actually missing or stale.

## Problem

The deployed #1462 fix removed the remaining source parse/write amplification, but the live daemon still entered unsafe IO pressure during the convergence phase for a 236 MB Codex session. The latest `live_ingest_attempt` row showed only ~1.17 MB of source payload reads but ~1.19 GB of physical reads over a five-second sample, with cgroup memory dominated by file cache rather than Python heap. The expensive work had moved to session-insight convergence hydrating a 33,150-message session.

## Solution

`load_sync_batch` and `load_async_batch` now use explicit projections instead of `SELECT *`, truncating message text to 16 KiB and selected tool/thinking block text to 4 KiB. The archive rows remain exact; this only bounds the heuristic insight-refresh input.

The daemon insights stage now checks freshness before queueing work: missing profile rows, materializer-version mismatch, or `session_profiles.source_updated_at != conversations.updated_at`. Already-converged source paths/conversation IDs no longer re-trigger full insight rebuilds.

## Verification

- `pytest tests/unit/daemon/test_convergence_stages.py tests/unit/storage/test_session_insight_refresh.py -q` → `24 passed in 0.68s`
- `ruff check polylogue/storage/insights/session/rebuild.py polylogue/daemon/convergence_stages.py tests/unit/storage/test_session_insight_refresh.py tests/unit/daemon/test_convergence_stages.py` → `All checks passed!`
- `mypy polylogue/storage/insights/session/rebuild.py polylogue/daemon/convergence_stages.py tests/unit/storage/test_session_insight_refresh.py tests/unit/daemon/test_convergence_stages.py` → `Success: no issues found in 4 source files`
- `devtools verify --quick` → passed locally in `41.31s`
- pre-push `devtools verify --quick` → passed in `35.07s`
- Real archive probe with `polylogued.service` stopped: rebuilt `codex:019e309f-7614-7381-a8ac-f9080f304ee6` (33,150 messages) in `13.095s`, physical read delta `434,913,280` bytes, max RSS `761 MB`. After rebuild, the new daemon freshness predicate returned `[]` for the known large recent Codex sessions.

Ref #1447