### PR TITLE
fix(daemon): remove broad startup maintenance scans

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -131,10 +131,11 @@ async def _ensure_fts_startup_readiness() -> None:
        death, and subsequent writes silently bypass the FTS index. See
        #1242.
 
-    This path restores obvious broken structure first and records a
-    durable freshness state for search request handlers. It deliberately
-    avoids exact full-archive invariant scans: those run from the
-    ambient repair task, after HTTP/status surfaces have bound.
+    This path restores obvious broken structure first and records a durable
+    freshness state for search request handlers. It deliberately avoids exact
+    full-archive invariant scans during ordinary startup. If triggers are
+    missing, however, writes may already have bypassed FTS; the only correct
+    recovery is a one-time rebuild before search is served.
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -150,8 +151,7 @@ async def _ensure_fts_startup_readiness() -> None:
         has_fts_table = row is not None
 
         from polylogue.storage.fts.freshness import (
-            STALE,
-            UNKNOWN,
+            READY,
             ensure_fts_freshness_table_sync,
             message_fts_marked_ready_sync,
             record_fts_surface_state_sync,
@@ -175,16 +175,14 @@ async def _ensure_fts_startup_readiness() -> None:
         if missing_triggers:
             logger.warning(
                 "daemon: FTS triggers missing on startup (%s). "
-                "SIGKILL-during-bulk-suspend signature; restoring triggers before freshness repair.",
+                "SIGKILL-during-bulk-suspend signature; rebuilding before serving search.",
                 ", ".join(missing_triggers),
             )
             restore_fts_triggers_sync(conn)
-            record_fts_surface_state_sync(
-                conn,
-                surface="messages_fts",
-                state=STALE,
-                detail=f"startup restored missing triggers: {', '.join(missing_triggers)}",
-            )
+            rebuild_fts_index_sync(conn)
+            conn.commit()
+            logger.info("daemon: FTS rebuild complete after trigger recovery.")
+            return
 
         ensure_fts_index_sync(conn)
         has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
@@ -200,8 +198,8 @@ async def _ensure_fts_startup_readiness() -> None:
             record_fts_surface_state_sync(
                 conn,
                 surface="messages_fts",
-                state=STALE if missing_triggers else UNKNOWN,
-                detail="startup structural check passed; exact repair pending",
+                state=READY,
+                detail="startup structural check passed",
             )
         conn.commit()
     except Exception:

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -286,17 +286,18 @@ async def _periodic_db_optimize() -> None:
 
     On a 60 GB archive with millions of rows, the query planner's
     internal statistics drift as the table sizes change.  PRAGMA optimize
-    is a lightweight maintenance pass — it only runs ANALYZE on tables
-    that need it and never blocks reads.  It is NOT a VACUUM and does
-    not rewrite the file.
+    is an explicit background maintenance pass, not startup readiness.
+    The daemon must bind, catch up, and converge changed files before it
+    considers planner-stat maintenance; otherwise a large archive can pay
+    broad read IO at the exact moment live catch-up already needs the disk.
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
     db = db_path()
     while True:
+        await asyncio.sleep(86_400)  # 24 hours; no startup optimize.
         if not db.exists():
-            await asyncio.sleep(86_400)  # 24 hours
             continue
         try:
             conn = open_connection(db, timeout=30.0)
@@ -307,60 +308,6 @@ async def _periodic_db_optimize() -> None:
                 conn.close()
         except Exception:
             logger.warning("daemon: DB optimize failed", exc_info=True)
-        await asyncio.sleep(86_400)  # 24 hours
-
-
-async def _periodic_fts_repair() -> None:
-    """Keep FTS ambiently fresh without waiting for a search request to fail."""
-    from polylogue.paths import db_path
-
-    db = db_path()
-    delay_s = 30
-    while True:
-        await asyncio.sleep(delay_s)
-        delay_s = 600  # 10 minutes
-        if not db.exists():
-            continue
-        try:
-            repaired = await asyncio.to_thread(_repair_fts_if_stale_once, db)
-            if repaired:
-                logger.info("daemon: exact FTS invariant repaired")
-        except Exception:
-            logger.warning("daemon: exact FTS repair check failed", exc_info=True)
-
-
-def _repair_fts_if_stale_once(db: Path) -> bool:
-    """Rebuild FTS once when exact invariants show drift."""
-    from polylogue.storage.fts.freshness import message_fts_marked_ready_sync, record_fts_invariant_snapshot_sync
-    from polylogue.storage.fts.fts_lifecycle import (
-        fts_invariant_snapshot_sync,
-        message_fts_readiness_sync,
-        rebuild_fts_index_sync,
-    )
-    from polylogue.storage.search.cache import invalidate_search_cache
-    from polylogue.storage.sqlite.connection_profile import open_connection
-
-    conn = open_connection(db, timeout=30.0)
-    try:
-        conn.execute("PRAGMA cache_size = -8192")
-        conn.execute("PRAGMA mmap_size = 0")
-        if message_fts_marked_ready_sync(conn):
-            readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
-            if bool(readiness["ready"]):
-                return False
-        snapshot = fts_invariant_snapshot_sync(conn)
-        record_fts_invariant_snapshot_sync(conn, snapshot)
-        if snapshot.ready:
-            conn.commit()
-            return False
-        stale_surfaces = ", ".join(surface.name for surface in snapshot.surfaces if not surface.ready)
-        logger.warning("daemon: exact FTS invariant stale (%s). Rebuilding.", stale_surfaces)
-        rebuild_fts_index_sync(conn)
-        conn.commit()
-        invalidate_search_cache()
-        return True
-    finally:
-        conn.close()
 
 
 async def _periodic_convergence_check(
@@ -668,7 +615,6 @@ async def run_daemon_services(
     convergence_task = asyncio.create_task(_periodic_convergence_check(sources))
     health_task = asyncio.create_task(_periodic_health_check())
     db_optimize_task = asyncio.create_task(_periodic_db_optimize())
-    fts_repair_task = asyncio.create_task(_periodic_fts_repair())
     status_snapshot_task = asyncio.create_task(_periodic_status_snapshot_refresh())
     maintenance_tasks = [
         wal_task,
@@ -676,7 +622,6 @@ async def run_daemon_services(
         convergence_task,
         health_task,
         db_optimize_task,
-        fts_repair_task,
         status_snapshot_task,
     ]
 

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -85,6 +85,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
                 if conversation_ids:
                     needs = _fts_repair_needs_for_conversations(conn, conversation_ids)
                     _repair_changed_conversation_fts(conn, conversation_ids, needs=needs)
+                    _mark_message_fts_ready_after_targeted_repair(conn)
                     conn.commit()
                     logger.info("fts: repaired conversations=%d", len(conversation_ids))
                     return not _fts_needs_repair_for_conversations(conn, conversation_ids)
@@ -137,6 +138,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
                     return execute(Path(paths[0]))
                 needs = _fts_repair_needs_for_conversations(conn, conversation_ids)
                 _repair_changed_conversation_fts(conn, conversation_ids, needs=needs)
+                _mark_message_fts_ready_after_targeted_repair(conn)
                 conn.commit()
                 logger.info("fts: batch repaired paths=%d conversations=%d", len(paths), len(conversation_ids))
                 return not _fts_needs_repair_for_conversations(conn, conversation_ids)
@@ -175,6 +177,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
                 ids = tuple(dict.fromkeys(conversation_ids))
                 needs = _fts_repair_needs_for_conversations(conn, ids)
                 _repair_changed_conversation_fts(conn, ids, needs=needs)
+                _mark_message_fts_ready_after_targeted_repair(conn)
                 conn.commit()
                 logger.info("fts: repaired conversation debt conversations=%d", len(ids))
                 return not _fts_needs_repair_for_conversations(conn, ids)
@@ -757,6 +760,23 @@ def _repair_changed_conversation_fts(
             repair_action_fts_index_sync(conn, conversation_ids)
         else:
             insert_missing_action_fts_index_sync(conn, conversation_ids)
+
+
+def _mark_message_fts_ready_after_targeted_repair(conn: sqlite3.Connection) -> None:
+    from polylogue.storage.fts.freshness import READY, STALE, record_fts_surface_state_sync
+    from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_sync
+
+    readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
+    record_fts_surface_state_sync(
+        conn,
+        surface="messages_fts",
+        state=READY if bool(readiness["ready"]) else STALE,
+        detail=(
+            "targeted changed-conversation repair complete"
+            if bool(readiness["ready"])
+            else "targeted changed-conversation repair left structural FTS readiness false"
+        ),
+    )
 
 
 def _action_events_exist_for_conversations(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> bool:

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -128,6 +128,7 @@ def test_fts_stage_repairs_only_missing_action_index_when_messages_current(
         rebuilt = True
 
     needs_calls: list[list[str]] = []
+    marked_ready: list[FakeConnection] = []
 
     def fake_repair_needs(_conn: FakeConnection, conversation_ids: list[str]) -> stages._FtsRepairNeeds:
         needs_calls.append(conversation_ids)
@@ -147,6 +148,7 @@ def test_fts_stage_repairs_only_missing_action_index_when_messages_current(
     )
     monkeypatch.setattr(stages, "_fts_repair_needs_for_conversations", fake_repair_needs)
     monkeypatch.setattr(stages, "_action_events_exist_for_conversations", lambda _conn, _ids: False)
+    monkeypatch.setattr(stages, "_mark_message_fts_ready_after_targeted_repair", lambda conn: marked_ready.append(conn))
 
     stage = make_fts_stage(db_path)
     assert stage.execute_many is not None
@@ -154,6 +156,7 @@ def test_fts_stage_repairs_only_missing_action_index_when_messages_current(
     assert repaired_messages == []
     assert inserted_actions == [["conv-a", "conv-b"]]
     assert needs_calls == [["conv-a", "conv-b"], ["conv-a", "conv-b"]]
+    assert len(marked_ready) == 1
     assert committed is True
     assert rebuilt is False
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -292,6 +292,13 @@ def test_ensure_fts_startup_readiness_marks_unknown_without_exact_scan(
             self.queries.append(query)
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                name = str(_params[0]) if isinstance(_params, tuple) and _params else ""
+                return (
+                    FakeCursor((1,))
+                    if name in {"messages", "messages_fts", "action_events", "action_events_fts"}
+                    else FakeCursor(None)
+                )
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 # All six FTS triggers present — no SIGKILL-drift recovery.
                 triggers: list[tuple[object, ...]] = [
@@ -385,6 +392,13 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
             self.queries.append(query)
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                name = str(_params[0]) if isinstance(_params, tuple) and _params else ""
+                return (
+                    FakeCursor((1,))
+                    if name in {"messages", "messages_fts", "action_events", "action_events_fts"}
+                    else FakeCursor(None)
+                )
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 triggers: list[tuple[object, ...]] = [
                     ("messages_fts_ai",),
@@ -461,6 +475,13 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
             self.queries.append(query)
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                name = str(_params[0]) if isinstance(_params, tuple) and _params else ""
+                return (
+                    FakeCursor((1,))
+                    if name in {"messages", "messages_fts", "action_events", "action_events_fts"}
+                    else FakeCursor(None)
+                )
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 # One missing trigger must send startup through restore+rebuild
                 # before ensure_fts_index_sync can hide the drift evidence.
@@ -516,6 +537,32 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
     assert rebuilds == []
     assert conn.committed is True
     assert conn.closed is True
+
+
+def test_periodic_db_optimize_does_not_run_on_startup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    class SleepBeforeOptimizeError(Exception):
+        pass
+
+    opened: list[Path] = []
+
+    async def fake_sleep(_seconds: float) -> None:
+        raise SleepBeforeOptimizeError
+
+    def fake_open_connection(path: Path, *, timeout: float) -> object:
+        del timeout
+        opened.append(path)
+        raise AssertionError("PRAGMA optimize must not run at daemon startup")
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: tmp_path / "polylogue.db")
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", fake_open_connection)
+
+    with pytest.raises(SleepBeforeOptimizeError):
+        asyncio.run(daemon_cli._periodic_db_optimize())
+
+    assert opened == []
 
 
 def test_run_daemon_services_stops_live_watcher_on_failure() -> None:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -261,7 +261,7 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
-def test_ensure_fts_startup_readiness_marks_unknown_without_exact_scan(
+def test_ensure_fts_startup_readiness_marks_ready_without_exact_scan(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -352,8 +352,8 @@ def test_ensure_fts_startup_readiness_marks_unknown_without_exact_scan(
     assert recorded == [
         {
             "surface": "messages_fts",
-            "state": "unknown",
-            "detail": "startup structural check passed; exact repair pending",
+            "state": "ready",
+            "detail": "startup structural check passed",
         }
     ]
     assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
@@ -506,15 +506,12 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
             self.closed = True
 
     conn = FakeConnection()
-    ensured: list[FakeConnection] = []
     restored: list[FakeConnection] = []
     rebuilds: list[FakeConnection] = []
 
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
-    monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda fake_conn: ensured.append(fake_conn)
-    )
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda fake_conn: None)
     monkeypatch.setattr(
         "polylogue.storage.fts.fts_lifecycle.restore_fts_triggers_sync",
         lambda fake_conn: restored.append(fake_conn),
@@ -532,9 +529,8 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
-    assert ensured == [conn]
     assert restored == [conn]
-    assert rebuilds == []
+    assert rebuilds == [conn]
     assert conn.committed is True
     assert conn.closed is True
 


### PR DESCRIPTION
## Summary

Removes broad automatic maintenance scans from the daemon startup/catch-up path. `PRAGMA optimize` now waits for the daily maintenance interval before first execution, and the daemon no longer starts an exact FTS invariant repair loop 30 seconds after launch.

## Problem

Live validation of deployed Polylogue `cc0bf5ba` still showed unsafe host IO during catch-up:

- `polylogued.service` started from `/nix/store/10lqh6vbj0b5grkww4iqkvhlipjx2wj7-python3.13-polylogue-0.1.0/bin/polylogued`.
- Chunk 1 and chunk 2 writes were bounded (`changed_messages=208` and `368`, both under 5s), so source parse/write was no longer the primary issue.
- IO PSI still climbed to `full avg10=31.72%`, with process `read_bytes=12,176,195,584` and only ~341 MB RSS.
- The daemon starts `PRAGMA optimize` immediately and also schedules exact FTS invariant checking after 30 seconds. On this archive the DB file is 46G, so these broad reads run concurrently with catch-up and dominate host IO.

## Solution

The always-on daemon now avoids broad maintenance reads during startup/catch-up:

- `PRAGMA optimize` sleeps for its 24h maintenance interval before the first pass.
- The exact FTS invariant repair loop is removed from daemon startup. FTS freshness for live writes still comes from startup structural readiness plus targeted changed-conversation convergence repair.
- Startup now handles the missing-trigger crash signature by doing the correctness-preserving one-time rebuild before serving search, and targeted daemon FTS repair clears the durable message-search freshness ledger after changed conversations have been repaired.

Full exact FTS invariant audits remain explicit maintenance/lab work rather than a background daemon loop. This does not reduce daemon convergence scope: valid changed source files still ingest and converge; the change only removes unrelated broad maintenance scans from the runtime path.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_convergence_stages.py -q` -> `29 passed in 0.32s`
- `ruff check polylogue/daemon/cli.py polylogue/daemon/convergence_stages.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_convergence_stages.py` -> `All checks passed!`
- `mypy polylogue/daemon/cli.py polylogue/daemon/convergence_stages.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_convergence_stages.py` -> `Success: no issues found in 4 source files`
- `devtools verify --quick` -> passed in `36.05s` before push
- pre-push `devtools verify --quick` -> passed in `33.85s`
- PR checks: Analyze, CodeQL, GitGuardian, runtime container, and distroless container passed

Ref #1447
