### PR TITLE
fix(daemon): stop schema-blocked background work

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -607,21 +607,28 @@ async def run_daemon_services(
     if not watcher_blocked:
         await _ensure_fts_startup_readiness()
 
-    # Periodic maintenance tasks.
-    wal_task = asyncio.create_task(_periodic_wal_checkpoint())
-    heartbeat_task = asyncio.create_task(_periodic_heartbeat())
-    convergence_task = asyncio.create_task(_periodic_convergence_check(sources))
-    health_task = asyncio.create_task(_periodic_health_check())
-    db_optimize_task = asyncio.create_task(_periodic_db_optimize())
-    status_snapshot_task = asyncio.create_task(_periodic_status_snapshot_refresh())
-    maintenance_tasks = [
-        wal_task,
-        heartbeat_task,
-        convergence_task,
-        health_task,
-        db_optimize_task,
-        status_snapshot_task,
-    ]
+    # Periodic maintenance tasks. If schema preflight blocks the watcher, do
+    # not start any background loop that opens the archive: a mismatched
+    # runtime/database pair must remain observable without doing catch-up,
+    # FTS repair, status snapshots, WAL checkpointing, or convergence work.
+    maintenance_tasks: list[asyncio.Task[None]] = []
+    if not watcher_blocked:
+        wal_task = asyncio.create_task(_periodic_wal_checkpoint())
+        heartbeat_task = asyncio.create_task(_periodic_heartbeat())
+        convergence_task = asyncio.create_task(_periodic_convergence_check(sources))
+        health_task = asyncio.create_task(_periodic_health_check())
+        db_optimize_task = asyncio.create_task(_periodic_db_optimize())
+        status_snapshot_task = asyncio.create_task(_periodic_status_snapshot_refresh())
+        maintenance_tasks.extend(
+            [
+                wal_task,
+                heartbeat_task,
+                convergence_task,
+                health_task,
+                db_optimize_task,
+                status_snapshot_task,
+            ]
+        )
 
     api_server: ThreadingHTTPServer | None = None
     api_server_task: asyncio.Task[None] | None = None
@@ -642,11 +649,12 @@ async def run_daemon_services(
 
         _db = db_path()
 
-        converger = DaemonConverger(
-            stages=make_default_convergence_stages(_db),
-            max_workers=2,
-        )
-        await converger.start()
+        if not watcher_blocked:
+            converger = DaemonConverger(
+                stages=make_default_convergence_stages(_db),
+                max_workers=2,
+            )
+            await converger.start()
 
         if enable_browser_capture:
             server = make_server(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -639,3 +639,60 @@ def test_run_daemon_services_closes_browser_capture_server_on_failure() -> None:
 
     assert server.shutdown_called is True
     assert server.close_called is True
+
+
+def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+
+    class FakeServer:
+        shutdown_called = False
+        close_called = False
+
+        def serve_forever(self, poll_interval: float = 0.5) -> None:
+            assert poll_interval == 0.5
+            raise RuntimeError("server stopped")
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+        def server_close(self) -> None:
+            self.close_called = True
+
+    def fail_background_work(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("schema-blocked daemon must not start DB background work")
+
+    server = FakeServer()
+    critical = HealthAlert(
+        check_name="schema_version",
+        tier=HealthTier.FAST,
+        severity=HealthSeverity.CRITICAL,
+        message="schema v12 incompatible with runtime v8",
+        checked_at="2026-05-24T00:00:00+00:00",
+    )
+    with (
+        patch.object(daemon_cli, "_check_schema_version_fast", return_value=critical),
+        patch.object(daemon_cli, "_periodic_wal_checkpoint", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_heartbeat", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_convergence_check", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_health_check", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_db_optimize", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_status_snapshot_refresh", side_effect=fail_background_work),
+        patch("polylogue.daemon.convergence.DaemonConverger", side_effect=fail_background_work),
+        patch.object(daemon_cli, "make_server", return_value=server),
+        pytest.raises(RuntimeError, match="server stopped"),
+    ):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(WatchSource(name="codex", root=Path("/tmp/codex")),),
+                debounce_s=1.0,
+                enable_watch=True,
+                enable_browser_capture=True,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
+    assert server.shutdown_called is True
+    assert server.close_called is True


### PR DESCRIPTION
## Summary

Stops schema-blocked daemon startup from launching any DB-opening background work. The daemon can still expose degraded browser/API surfaces, but a critical schema preflight now blocks the watcher, periodic archive tasks, and the post-ingest converger.

## Problem

After deploying #1465, the live service correctly refused live ingest because the archive metadata reported schema v12 against runtime v8, but it still started the convergence engine and periodic loops. On the real archive, `read_bytes` rose by about 1.17 GB in 5 seconds even though the watcher was blocked. That defeats the schema preflight's purpose and can keep the host under IO pressure.

## Solution

- Keep `run_daemon_services` from creating WAL, heartbeat, convergence-debt, health, DB optimize, or status-snapshot tasks when `watcher_blocked` is true.
- Keep the post-ingest `DaemonConverger` unconstructed under the same schema-blocked state.
- Add a regression test proving the schema-blocked browser/API path closes cleanly without starting DB background work.

Ref #1447

## Verification

- `pytest -q tests/unit/daemon/test_daemon_cli.py -q` -> `18 passed`
- `ruff check polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` -> `All checks passed!`
- `mypy polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` -> `Success: no issues found in 2 source files`
- `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 35.03`
- pre-push `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 33.62`