### PR TITLE
fix(daemon): back off failed live ingest paths

### DIFF
--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1012,6 +1012,37 @@ class CursorStore:
             ).fetchall()
         return [str(row[0]) for row in rows]
 
+    def list_failed_records(self) -> list[CursorRecord]:
+        """Return all failed, non-excluded cursor records."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    source_path,
+                    byte_size,
+                    byte_offset,
+                    last_complete_newline,
+                    record_count,
+                    updated_at,
+                    last_record_ts,
+                    parser_fingerprint,
+                    content_fingerprint,
+                    tail_hash,
+                    source_name,
+                    st_dev,
+                    st_ino,
+                    mtime_ns,
+                    source_generation,
+                    failure_count,
+                    next_retry_at,
+                    excluded
+                FROM live_cursor
+                WHERE failure_count > 0 AND excluded = 0
+                ORDER BY next_retry_at IS NULL DESC, next_retry_at ASC, source_path ASC
+                """
+            ).fetchall()
+        return [_cursor_record_from_row(row) for row in rows]
+
     def record_convergence_debt(
         self,
         *,

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -102,6 +102,8 @@ class LiveWatcher:
         self._pending_paths: set[Path] = set()
         self._pending_scheduled = False
         self._drain_task: asyncio.Task[None] | None = None
+        self._failed_retry_task: asyncio.Task[None] | None = None
+        self._failed_retry_deadline: float | None = None
         self._last_batch_at: float = 0.0
         self._batch_lock = asyncio.Lock()
         self._ingest_lock = asyncio.Lock()
@@ -125,6 +127,7 @@ class LiveWatcher:
             return
 
         await self._catch_up(roots)
+        self._schedule_failed_retry_scan()
         self._ensure_pending_scheduled()
 
         logger.info("live.watcher: watching %s", ", ".join(str(r) for r in roots))
@@ -139,6 +142,7 @@ class LiveWatcher:
 
     def stop(self) -> None:
         self._stop.set()
+        self._cancel_failed_retry_task()
 
     def cancel_pending(self) -> None:
         task = self._drain_task
@@ -146,6 +150,7 @@ class LiveWatcher:
             task.cancel()
         self._drain_task = None
         self._pending_scheduled = False
+        self._cancel_failed_retry_task()
 
     # ------------------------------------------------------------------
     # Catch-up: batch all changed files
@@ -179,12 +184,12 @@ class LiveWatcher:
                     len(chunk),
                     chunk_bytes / 1e6,
                 )
-                metrics = await self._ingest_files(
+                await self._ingest_files(
                     list(chunk),
                     queued_file_count=len(plan.candidates) if index == 1 else len(chunk),
                     skipped_file_count=plan.skipped_file_count if index == 1 else 0,
                 )
-                await self._requeue_failed_paths(metrics)
+                self._schedule_failed_retry_scan()
 
     def _scan_catch_up_candidates(self, roots: list[Path]) -> tuple[CandidateSourceFile, ...]:
         root_set = {root.resolve() for root in roots}
@@ -274,19 +279,61 @@ class LiveWatcher:
             self._pending_scheduled = True
             self._drain_task = asyncio.create_task(self._debounced_batch())
 
-    async def _requeue_failed_paths(self, metrics: object) -> None:
-        failed_paths = getattr(metrics, "failed_paths", ())
-        if not failed_paths:
+    def _schedule_failed_retry_scan(self) -> None:
+        if self._stop.is_set():
             return
-        paths = [Path(path) for path in failed_paths if isinstance(path, str) and path]
-        if not paths:
+        due_paths: list[Path] = []
+        next_retry_at: datetime | None = None
+        for record in self._cursor.list_failed_records():
+            path = Path(record.source_path)
+            if not self._source_accepts(path):
+                continue
+            if _retry_due(record.next_retry_at):
+                due_paths.append(path)
+                continue
+            retry_at = _parse_retry_at(record.next_retry_at)
+            if retry_at is not None and (next_retry_at is None or retry_at < next_retry_at):
+                next_retry_at = retry_at
+        if due_paths:
+            logger.info("live.watcher: scheduling %d failed file(s) whose retry is due", len(due_paths))
+            self._pending_paths.update(due_paths)
+            self._ensure_pending_scheduled()
+        if next_retry_at is not None:
+            self._schedule_failed_retry_wakeup(next_retry_at)
+
+    def _schedule_failed_retry_wakeup(self, retry_at: datetime) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
             return
-        logger.warning(
-            "live.watcher: requeued %d failed file(s) for live retry",
-            len(paths),
-        )
-        async with self._batch_lock:
-            self._pending_paths.update(paths)
+        delay_s = max(0.0, (retry_at - datetime.now(UTC)).total_seconds())
+        deadline = loop.time() + delay_s
+        if (
+            self._failed_retry_task is not None
+            and not self._failed_retry_task.done()
+            and self._failed_retry_deadline is not None
+            and self._failed_retry_deadline <= deadline
+        ):
+            return
+        self._cancel_failed_retry_task()
+        self._failed_retry_deadline = deadline
+        self._failed_retry_task = asyncio.create_task(self._wake_failed_retries(delay_s))
+
+    async def _wake_failed_retries(self, delay_s: float) -> None:
+        try:
+            await asyncio.sleep(delay_s)
+            self._failed_retry_deadline = None
+            self._failed_retry_task = None
+            self._schedule_failed_retry_scan()
+        except asyncio.CancelledError:
+            raise
+
+    def _cancel_failed_retry_task(self) -> None:
+        task = self._failed_retry_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._failed_retry_task = None
+        self._failed_retry_deadline = None
 
     async def _debounced_batch(self) -> None:
         """Wait for the debounce window, then drain pending paths serially."""
@@ -335,12 +382,12 @@ class LiveWatcher:
                 return bool(paths)
 
             logger.info("live.watcher: batching %d changed file(s)", len(needed))
-            metrics = await self._ingest_files(
+            await self._ingest_files(
                 needed,
                 queued_file_count=len(paths),
                 skipped_file_count=len(paths) - len(needed),
             )
-            await self._requeue_failed_paths(metrics)
+            self._schedule_failed_retry_scan()
         except sqlite3.OperationalError as exc:
             if not _is_database_locked(exc):
                 raise
@@ -477,13 +524,22 @@ def _is_database_locked(exc: sqlite3.OperationalError) -> bool:
 def _retry_due(next_retry_at: str | None) -> bool:
     if not next_retry_at:
         return True
+    retry_at = _parse_retry_at(next_retry_at)
+    if retry_at is None:
+        return True
+    return retry_at <= datetime.now(UTC)
+
+
+def _parse_retry_at(next_retry_at: str | None) -> datetime | None:
+    if not next_retry_at:
+        return None
     try:
         retry_at = datetime.fromisoformat(next_retry_at)
     except ValueError:
-        return True
+        return None
     if retry_at.tzinfo is None:
         retry_at = retry_at.replace(tzinfo=UTC)
-    return retry_at <= datetime.now(UTC)
+    return retry_at
 
 
 __all__ = ["LiveWatcher", "WatchSource", "default_sources"]

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
+from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -10,6 +12,7 @@ import pytest
 import polylogue.sources.live.watcher as live_watcher
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.cursor import CursorStore
+from tests.infra.frozen_clock import FrozenClock
 
 
 def test_catch_up_plan_carries_statted_candidates_without_payload_reads(
@@ -86,7 +89,7 @@ def test_catch_up_ingests_needed_files_in_bounded_chunks(
     assert calls[2][1:] == (1, 0)
 
 
-def test_catch_up_requeues_failed_paths_for_live_retry(tmp_path: Path) -> None:
+def test_catch_up_does_not_immediately_requeue_failed_paths(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()
     files = [root / f"session-{index}.jsonl" for index in range(3)]
@@ -107,4 +110,62 @@ def test_catch_up_requeues_failed_paths_for_live_retry(tmp_path: Path) -> None:
 
     asyncio.run(watcher._catch_up([root]))
 
-    assert watcher._pending_paths == {files[1]}
+    assert watcher._pending_paths == set()
+
+
+def test_flush_pending_does_not_hot_requeue_backed_off_failure(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"role":"user","content":"a"}\n')
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),))
+
+    async def fake_ingest_files(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> SimpleNamespace:
+        del queued_file_count, skipped_file_count
+        watcher._cursor.mark_failed(paths[0])
+        return SimpleNamespace(failed_paths=[str(paths[0])])
+
+    watcher._ingest_files = fake_ingest_files  # type: ignore[assignment,method-assign]
+    watcher._pending_paths.add(f)
+
+    asyncio.run(watcher._flush_pending())
+
+    assert watcher._pending_paths == set()
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.failure_count == 1
+    assert record.next_retry_at is not None
+
+
+@pytest.mark.frozen_clock_modules("polylogue.sources.live.watcher", "polylogue.sources.live.cursor")
+def test_failed_retry_scan_requeues_only_due_failures(tmp_path: Path, frozen_clock: FrozenClock) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    due = root / "due.jsonl"
+    waiting = root / "waiting.jsonl"
+    due.write_text('{"role":"user","content":"due"}\n')
+    waiting.write_text('{"role":"user","content":"waiting"}\n')
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),))
+    watcher._cursor.mark_failed(due)
+    watcher._cursor.mark_failed(waiting)
+    past = (frozen_clock.now() - timedelta(seconds=1)).isoformat()
+    future = (frozen_clock.now() + timedelta(seconds=60)).isoformat()
+    with sqlite3.connect(tmp_path / "polylogue.db") as conn:
+        conn.execute("UPDATE live_cursor SET next_retry_at = ? WHERE source_path = ?", (past, str(due)))
+        conn.execute("UPDATE live_cursor SET next_retry_at = ? WHERE source_path = ?", (future, str(waiting)))
+        conn.commit()
+
+    async def run_scan() -> None:
+        watcher._schedule_failed_retry_scan()
+        watcher.cancel_pending()
+
+    asyncio.run(run_scan())
+
+    assert watcher._pending_paths == {due}


### PR DESCRIPTION
## Summary

Failed live-ingest paths now retry through `live_cursor` backoff instead of being immediately requeued from batch metrics. The daemon can still converge every source file, but a failing catch-up group no longer turns into a half-second disk hot loop.

## Problem

After the #1466 deploy, `polylogued` reached real catch-up and processed the large Codex chunks, then repeatedly logged `batching 305 changed file(s)` and `requeued 305 failed file(s) for live retry`. `/proc/$pid/io` reached ~23 GB of reads and IO PSI full avg10 hit ~24%, while `live_cursor` had zero failed rows. That means retry state was bypassing the durable cursor/backoff mechanism.

The sampled failed paths were valid-ish Antigravity/Hermes inputs and parsed successfully in a fresh temp archive, so the correct fix is not scope reduction or quarantine.

Ref #1447

## Solution

- Add `CursorStore.list_failed_records()` so the watcher can inspect failed cursor rows with their retry timestamps.
- Replace direct metrics `failed_paths` requeueing with cursor-owned retry scheduling.
- Schedule due failed paths back into pending work, and create one delayed wake-up for the next `next_retry_at` so convergence continues without hot polling.
- Cancel the failed-retry wake-up with pending watcher tasks on stop/cancel.
- Update catch-up/live watcher tests to assert backed-off failures are not immediately requeued and only due failures re-enter pending work.

## Verification

- `pytest -q tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py` -> 65 passed
- `ruff check polylogue/sources/live/watcher.py polylogue/sources/live/cursor.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py` -> pass
- `mypy polylogue/sources/live/watcher.py polylogue/sources/live/cursor.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_watcher.py` -> pass
- `devtools verify --quick` -> exit_code 0, total_duration_s 37.93
- pre-push `devtools verify --quick` -> exit_code 0, total_duration_s 35.40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry scheduling for failed files with deadline-aware retry timing. Failed files are now queued only when their retry deadline is reached, preventing immediate requeue bursts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->