### PR TITLE
fix(daemon): defer hot insight rebuilds

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -37,6 +37,7 @@ from polylogue.sources.live.watcher import default_sources
 from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 
 logger = get_logger(__name__)
+_CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
 
 # Track the pidfile path for atexit cleanup.
 _pidfile_path: Path | None = None
@@ -321,7 +322,7 @@ async def _periodic_convergence_check(
 
     db = db_path()
     while True:
-        await asyncio.sleep(600)  # 10 minutes
+        await asyncio.sleep(_CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS)
         if not db.exists():
             continue
         try:

--- a/polylogue/daemon/convergence.py
+++ b/polylogue/daemon/convergence.py
@@ -25,6 +25,13 @@ from polylogue.logging import get_logger
 from polylogue.pipeline.services.process_pool import process_pool_executor
 
 logger = get_logger(__name__)
+_INSIGHT_DEFERRED_UNTIL_QUIET = "insights deferred until source quiet"
+
+
+def _stage_false_error(stage_name: str, *, scope: str) -> str:
+    if stage_name == "insights":
+        return _INSIGHT_DEFERRED_UNTIL_QUIET
+    return f"{scope} stage {stage_name} returned False"
 
 
 class StageState(Enum):
@@ -201,7 +208,7 @@ class DaemonConverger:
             state.stages[stage_name] = StageState.DONE if success else StageState.FAILED
             if not success:
                 state.error_count += 1
-                state.last_error = f"stage {stage_name} returned False"
+                state.last_error = _stage_false_error(stage_name, scope="stage")
 
         return state
 
@@ -283,7 +290,7 @@ class DaemonConverger:
                     state.stages[stage_name] = StageState.DONE if success else StageState.FAILED
                     if not success:
                         state.error_count += 1
-                        state.last_error = f"stage {stage_name} returned False"
+                        state.last_error = _stage_false_error(stage_name, scope="stage")
                 continue
 
             try:
@@ -322,7 +329,7 @@ class DaemonConverger:
                 state.stages[stage_name] = StageState.DONE if success else StageState.FAILED
                 if not success:
                     state.error_count += 1
-                    state.last_error = f"batch stage {stage_name} returned False"
+                    state.last_error = _stage_false_error(stage_name, scope="batch")
 
         results = {path: self._file_states[path] for path in paths}
         self._evict_converged_files(paths)
@@ -388,7 +395,7 @@ class DaemonConverger:
                 state.stages[stage_name] = StageState.DONE if success else StageState.FAILED
                 if not success:
                     state.error_count += 1
-                    state.last_error = f"conversation stage {stage_name} returned False"
+                    state.last_error = _stage_false_error(stage_name, scope="conversation")
 
         results = {conversation_id: self._conversation_states[conversation_id] for conversation_id in ids}
         self._evict_converged_conversations(ids)

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -13,6 +13,7 @@ repair and refresh post-ingest archive state.
 from __future__ import annotations
 
 import sqlite3
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,8 @@ from polylogue.storage.source_conversations import (
 logger = get_logger(__name__)
 
 _DAEMON_INSIGHT_REBUILD_PAGE_SIZE = 10
+_HOT_INSIGHT_SOURCE_BYTES = 64 * 1024 * 1024
+_HOT_INSIGHT_QUIET_SECONDS = 60.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -372,6 +375,14 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
                 conversation_ids = _conversation_ids_for_source_path(conn, path) or _conversation_ids_missing_profiles(
                     conn
                 )
+                hot_ids = _hot_insight_conversation_ids(conn, conversation_ids)
+                if hot_ids:
+                    logger.info(
+                        "insights: deferring hot source rebuild conversations=%d quiet_s=%.0f",
+                        len(hot_ids),
+                        _HOT_INSIGHT_QUIET_SECONDS,
+                    )
+                    return False
                 counts = rebuild_session_insights_sync(
                     conn,
                     conversation_ids=conversation_ids,
@@ -429,6 +440,14 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
                 )
                 if not conversation_ids:
                     conversation_ids = _conversation_ids_missing_profiles(conn)
+                hot_ids = _hot_insight_conversation_ids(conn, conversation_ids)
+                if hot_ids:
+                    logger.info(
+                        "insights: deferring hot source batch rebuild conversations=%d quiet_s=%.0f",
+                        len(hot_ids),
+                        _HOT_INSIGHT_QUIET_SECONDS,
+                    )
+                    return False
                 counts = rebuild_session_insights_sync(
                     conn,
                     conversation_ids=conversation_ids,
@@ -474,6 +493,14 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
                 ids = _existing_conversation_ids(conn, tuple(dict.fromkeys(conversation_ids)))
                 if not ids:
                     return True
+                hot_ids = _hot_insight_conversation_ids(conn, ids)
+                if hot_ids:
+                    logger.info(
+                        "insights: deferring hot source conversation rebuild conversations=%d quiet_s=%.0f",
+                        len(hot_ids),
+                        _HOT_INSIGHT_QUIET_SECONDS,
+                    )
+                    return False
                 counts = rebuild_session_insights_sync(
                     conn,
                     conversation_ids=ids,
@@ -823,6 +850,56 @@ def _existing_conversation_ids(conn: sqlite3.Connection, conversation_ids: Seque
         unique_ids,
     ).fetchall()
     return [str(row[0]) for row in rows]
+
+
+def _hot_insight_conversation_ids(
+    conn: sqlite3.Connection,
+    conversation_ids: Sequence[str],
+    *,
+    now: float | None = None,
+) -> set[str]:
+    """Return stale conversations whose source file is too hot for full insight rebuild.
+
+    Live archive writes and targeted FTS repair must stay immediate. Session
+    insight rebuilds can require rehydrating an entire conversation; for huge
+    actively-appending agent sessions that turns every small append into a
+    multi-GB read cycle. Returning False from the stage records durable
+    convergence debt, so this is a quiet-window deferral, not a scope reduction.
+    """
+
+    unique_ids = tuple(dict.fromkeys(str(conversation_id) for conversation_id in conversation_ids if conversation_id))
+    if not unique_ids or not _table_exists(conn, "conversations") or not _table_exists(conn, "raw_conversations"):
+        return set()
+    placeholders = ", ".join("?" for _ in unique_ids)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT c.conversation_id, r.source_path
+        FROM conversations AS c
+        JOIN raw_conversations AS r ON r.raw_id = c.raw_id
+        WHERE c.conversation_id IN ({placeholders})
+          AND r.source_path IS NOT NULL
+          AND r.source_path != ''
+        ORDER BY c.conversation_id
+        """,
+        unique_ids,
+    ).fetchall()
+    current = time.time() if now is None else now
+    hot: set[str] = set()
+    for conversation_id, source_path in rows:
+        if _source_path_is_hot_for_insights(Path(str(source_path)), now=current):
+            hot.add(str(conversation_id))
+    return hot
+
+
+def _source_path_is_hot_for_insights(path: Path, *, now: float | None = None) -> bool:
+    try:
+        stat = path.stat()
+    except OSError:
+        return False
+    if stat.st_size < _HOT_INSIGHT_SOURCE_BYTES:
+        return False
+    current = time.time() if now is None else now
+    return current - stat.st_mtime < _HOT_INSIGHT_QUIET_SECONDS
 
 
 def _stale_session_profile_ids(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> list[str]:

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1064,7 +1064,7 @@ class CursorStore:
                 (stage, subject_type, subject_id),
             ).fetchone()
             failure_count = int(row[0]) + 1 if row is not None else 1
-            delay_s = min(60 * (2 ** (failure_count - 1)), 3600)
+            delay_s = _convergence_debt_retry_delay_s(failure_count, error=error)
             retry_at = datetime.fromtimestamp(datetime.now(UTC).timestamp() + delay_s, tz=UTC).isoformat()
             conn.execute(
                 """
@@ -1171,3 +1171,9 @@ __all__ = [
     "LiveConvergenceDebt",
     "LiveIngestAttempt",
 ]
+
+
+def _convergence_debt_retry_delay_s(failure_count: int, *, error: str | None) -> int:
+    if error == "insights deferred until source quiet":
+        return 60
+    return int(min(60 * (2 ** (failure_count - 1)), 3600))

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -20,7 +21,54 @@ from polylogue.storage.insights.session.rebuild import rebuild_session_insights_
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
 from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.frozen_clock import FrozenClock
 from tests.infra.storage_records import make_conversation, make_message, store_records
+
+
+def _seed_raw_source_conversation(conn: sqlite3.Connection, *, conversation_id: str, source_path: Path) -> None:
+    conn.execute(
+        """
+        INSERT INTO raw_conversations (
+            raw_id,
+            provider_name,
+            source_path,
+            blob_size,
+            acquired_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            f"raw-{conversation_id}",
+            "codex",
+            str(source_path),
+            source_path.stat().st_size,
+            "2026-05-24T01:00:00+00:00",
+        ),
+    )
+    store_records(
+        conversation=make_conversation(
+            conversation_id,
+            provider_name="codex",
+            title=conversation_id,
+            created_at="2026-05-24T01:00:00+00:00",
+            updated_at="2026-05-24T01:00:00+00:00",
+            raw_id=f"raw-{conversation_id}",
+        ),
+        messages=[
+            make_message(
+                f"{conversation_id}:msg-1",
+                conversation_id,
+                text=f"Message for {conversation_id}",
+            )
+        ],
+        attachments=[],
+        conn=conn,
+    )
+
+
+def _truncate(path: Path, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as handle:
+        handle.truncate(size)
 
 
 def test_insights_stage_rebuilds_sync_against_configured_db(
@@ -334,11 +382,96 @@ def test_insights_stage_batches_sync_rebuild_chunks(
         "_conversation_ids_for_source_paths",
         lambda _conn, paths: {Path(paths[0]): ["conv-a"], Path(paths[1]): ["conv-b"]},
     )
+    monkeypatch.setattr(stages, "_hot_insight_conversation_ids", lambda _conn, _ids: set())
 
     stage = make_insights_stage(db_path)
     assert stage.execute_many is not None
     assert stage.execute_many([tmp_path / "a.jsonl", tmp_path / "b.jsonl"]) is True
     assert rebuild_calls == [(["conv-a", "conv-b"], 10)]
+
+
+def test_insights_stage_defers_hot_large_conversation_debt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    source_path = tmp_path / "active-codex.jsonl"
+    _truncate(source_path, stages._HOT_INSIGHT_SOURCE_BYTES + 1)
+    with open_connection(db_path) as conn:
+        _seed_raw_source_conversation(conn, conversation_id="conv-hot", source_path=source_path)
+        conn.commit()
+
+    def fail_rebuild(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("hot active sources should wait for convergence debt retry")
+
+    monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fail_rebuild)
+
+    stage = make_insights_stage(db_path)
+    assert stage.execute_conversations is not None
+    assert stage.execute_conversations(["conv-hot"]) is False
+
+
+def test_insights_stage_rebuilds_large_conversation_after_quiet_window(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    frozen_clock: FrozenClock,
+) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    source_path = tmp_path / "quiet-codex.jsonl"
+    _truncate(source_path, stages._HOT_INSIGHT_SOURCE_BYTES + 1)
+    quiet_mtime = frozen_clock.now().timestamp() - stages._HOT_INSIGHT_QUIET_SECONDS - 5
+    os.utime(source_path, (quiet_mtime, quiet_mtime))
+    rebuild_calls: list[tuple[list[str], int]] = []
+    with open_connection(db_path) as conn:
+        _seed_raw_source_conversation(conn, conversation_id="conv-quiet", source_path=source_path)
+        conn.commit()
+
+    def fake_rebuild(
+        conn: sqlite3.Connection,
+        *,
+        conversation_ids: list[str],
+        page_size: int,
+    ) -> SessionInsightCounts:
+        del conn
+        rebuild_calls.append((conversation_ids, page_size))
+        return SessionInsightCounts(profiles=1, work_events=0, phases=0, threads=0, tag_rollups=0, day_summaries=0)
+
+    monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fake_rebuild)
+
+    stage = make_insights_stage(db_path)
+    assert stage.execute_conversations is not None
+    assert stage.execute_conversations(["conv-quiet"]) is True
+    assert rebuild_calls == [(["conv-quiet"], 10)]
+
+
+def test_insights_stage_rebuilds_small_active_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    source_path = tmp_path / "small-active-codex.jsonl"
+    _truncate(source_path, 1024)
+    rebuild_calls: list[tuple[list[str], int]] = []
+    with open_connection(db_path) as conn:
+        _seed_raw_source_conversation(conn, conversation_id="conv-small", source_path=source_path)
+        conn.commit()
+
+    def fake_rebuild(
+        conn: sqlite3.Connection,
+        *,
+        conversation_ids: list[str],
+        page_size: int,
+    ) -> SessionInsightCounts:
+        del conn
+        rebuild_calls.append((conversation_ids, page_size))
+        return SessionInsightCounts(profiles=1, work_events=0, phases=0, threads=0, tag_rollups=0, day_summaries=0)
+
+    monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fake_rebuild)
+
+    stage = make_insights_stage(db_path)
+    assert stage.execute_conversations is not None
+    assert stage.execute_conversations(["conv-small"]) is True
+    assert rebuild_calls == [(["conv-small"], 10)]
 
 
 def test_insights_stage_scopes_conversation_debt_to_stale_profiles(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -169,3 +169,30 @@ def test_failed_retry_scan_requeues_only_due_failures(tmp_path: Path, frozen_clo
     asyncio.run(run_scan())
 
     assert watcher._pending_paths == {due}
+
+
+@pytest.mark.frozen_clock_modules("polylogue.sources.live.cursor")
+def test_hot_insight_convergence_debt_uses_quiet_window_retry(
+    tmp_path: Path,
+    frozen_clock: FrozenClock,
+) -> None:
+    cursor = CursorStore(tmp_path / "cursor.sqlite")
+    cursor.record_convergence_debt(
+        stage="insights",
+        subject_type="conversation_id",
+        subject_id="conv-hot",
+        error="insights deferred until source quiet",
+    )
+    frozen_clock.advance(1)
+    cursor.record_convergence_debt(
+        stage="insights",
+        subject_type="conversation_id",
+        subject_id="conv-hot",
+        error="insights deferred until source quiet",
+    )
+
+    debt = cursor.list_convergence_debt(limit=1)[0]
+    retry_at = datetime.fromisoformat(debt.next_retry_at or "")
+    failed_at = datetime.fromisoformat(debt.last_failed_at)
+    assert debt.failure_count == 2
+    assert retry_at - failed_at == timedelta(seconds=60)


### PR DESCRIPTION
## Summary

Defers expensive session-insight rebuilds for very large source files while they are still actively appending, without reducing daemon convergence scope. Archive writes and targeted FTS repair still run immediately; insight convergence becomes durable debt until the source is quiet.

## Problem

After #1467 was deployed, the failed-file hot requeue loop stopped, but live monitoring still showed severe physical reads on tiny appends to huge active Codex sessions. `source_payload_read_bytes` was only a few KB per attempt while `/proc/$pid/io` showed roughly 2.36 GB of reads over 10s, pointing at derived session insight rebuilds rehydrating whole conversations on every append.

## Solution

- Add a 64 MiB / 60s quiet-window guard to the daemon insights stage.
- Return convergence debt, not success, when a huge source is still hot so the daemon must still converge once the file quiets.
- Mark this expected deferral with a fixed 60s retry cadence instead of exponential failure backoff.
- Shorten the daemon's convergence-debt retry loop from 10 minutes to 60 seconds.
- Add focused coverage for hot large deferral, quiet large rebuild, small active rebuild, and fixed retry scheduling.

Ref #1447

## Verification

- `pytest -q tests/unit/daemon/test_convergence_stages.py tests/unit/daemon/test_daemon_convergence.py tests/unit/daemon/test_daemon_cli.py tests/unit/sources/test_live_catchup_planning.py` -> 45 passed
- `pytest -q tests/unit/sources/test_live_watcher.py` -> 60 passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 34.58
- pre-push `devtools verify --quick` -> exit_code 0, total_duration_s 34.61
