### PR TITLE
perf(maintenance): target stale session insight repairs

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -737,7 +737,10 @@ def repair_session_insights(
     """
     from polylogue.storage.fts.fts_lifecycle import rebuild_session_insight_fts_sync
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
-    from polylogue.storage.insights.session.status import session_insight_status_sync
+    from polylogue.storage.insights.session.status import (
+        session_insight_status_sync,
+        session_profile_repair_candidate_ids_sync,
+    )
     from polylogue.storage.sqlite.connection import connection_context
 
     try:
@@ -773,15 +776,34 @@ def repair_session_insights(
                 conn.commit()
                 rebuilt_count = assessment.fts_debt
             else:
+                rebuild_conversation_ids = conversation_ids
+                if conversation_ids is None and assessment.row_debt > 0:
+                    candidates = tuple(session_profile_repair_candidate_ids_sync(conn))
+                    if candidates:
+                        rebuild_conversation_ids = candidates
                 rebuilt = rebuild_session_insights_sync(
                     conn,
-                    conversation_ids=conversation_ids,
+                    conversation_ids=rebuild_conversation_ids,
                     progress_callback=progress_callback,
                     progress_total=progress_total,
                 )
                 conn.commit()
                 rebuilt_count = rebuilt.total()
             refreshed = session_insight_status_sync(conn)
+            if (
+                conversation_ids is None
+                and not session_insight_status_ready(refreshed)
+                and assess_session_insight_repairs(refreshed).row_debt > 0
+            ):
+                rebuilt = rebuild_session_insights_sync(
+                    conn,
+                    conversation_ids=None,
+                    progress_callback=progress_callback,
+                    progress_total=progress_total,
+                )
+                conn.commit()
+                rebuilt_count += rebuilt.total()
+                refreshed = session_insight_status_sync(conn)
             if conversation_ids is None and not session_insight_fts_ready(refreshed):
                 fts_debt = assess_session_insight_repairs(refreshed).fts_debt
                 rebuild_session_insight_fts_sync(conn)

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -10,7 +10,7 @@ import pytest
 from polylogue.config import Config
 from polylogue.maintenance.models import DerivedModelStatus
 from polylogue.storage import repair as repair_mod
-from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
+from polylogue.storage.insights.session.runtime import SessionInsightCounts, SessionInsightStatusSnapshot
 
 
 def _config(tmp_path: Path) -> Config:
@@ -187,6 +187,62 @@ def test_repair_session_insights_noops_when_ready(monkeypatch: pytest.MonkeyPatc
     assert result.success is True
     assert result.repaired_count == 0
     assert result.detail == "Session insights already ready"
+
+
+def test_repair_session_insights_uses_stale_profile_candidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, tuple[str, ...] | None]] = []
+
+    class FakeConn:
+        def commit(self) -> None:
+            calls.append(("commit", None))
+
+    @contextmanager
+    def fake_connection_context(_path: Path) -> Iterator[FakeConn]:
+        yield FakeConn()
+
+    stale_status = SessionInsightStatusSnapshot(
+        profile_rows_ready=False,
+        work_event_inference_rows_ready=False,
+        work_event_inference_fts_ready=True,
+        phase_inference_rows_ready=True,
+        threads_ready=True,
+        threads_fts_ready=True,
+        tag_rollups_ready=True,
+        day_summaries_ready=True,
+        week_summaries_ready=True,
+        stale_profile_row_count=2,
+        stale_work_event_inference_count=2,
+        work_event_inference_fts_count=4,
+        work_event_inference_count=4,
+        thread_fts_count=1,
+        thread_count=1,
+    )
+    statuses = iter((stale_status, _ready_session_insight_status()))
+
+    def fake_rebuild(_conn: FakeConn, *, conversation_ids: tuple[str, ...] | None, **_kwargs: object) -> Any:
+        calls.append(("rebuild", conversation_ids))
+        return SessionInsightCounts(profiles=2, work_events=2)
+
+    monkeypatch.setattr("polylogue.storage.sqlite.connection.connection_context", fake_connection_context)
+    monkeypatch.setattr(
+        "polylogue.storage.insights.session.status.session_insight_status_sync",
+        lambda _conn: next(statuses),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.insights.session.status.session_profile_repair_candidate_ids_sync",
+        lambda _conn: ["conv-a", "conv-b"],
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync",
+        fake_rebuild,
+    )
+
+    result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
+
+    assert result.success is True
+    assert result.repaired_count == 4
+    assert ("rebuild", ("conv-a", "conv-b")) in calls
+    assert ("rebuild", None) not in calls
 
 
 def test_offline_maintenance_refuses_live_daemon(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Use stale session-profile candidate IDs for session-insight repair before escalating to a whole-archive session insight rebuild.

## Problem

Live daemon catch-up work has repeatedly shown that full session insight rebuilds are one of the largest remaining IO/RAM risks. The status layer already exposes stale profile candidates, but `repair_session_insights` ignored that bounded set and called `rebuild_session_insights_sync(..., conversation_ids=None)` whenever no explicit IDs were supplied.

## Solution

- Import `session_profile_repair_candidate_ids_sync` into the repair path.
- When row debt exists and the caller did not supply explicit IDs, rebuild stale profile candidates first.
- Refresh status after the targeted pass.
- Preserve correctness by falling back to the broad rebuild if the targeted pass does not restore readiness.
- Cover the candidate path with a focused repair unit test.

Ref #1447

## Verification

- `pytest -q tests/unit/storage/test_repair.py tests/integration/test_health.py::TestMaintenanceSelection::test_session_insight_repair_cleans_duplicate_fts_rows` -> `11 passed in 0.18s`
- `mypy polylogue/storage/repair.py tests/unit/storage/test_repair.py` -> `Success: no issues found in 2 source files`
- pre-push `devtools verify --quick` -> `exit_code 0`, `total_duration_s 37.23`