### PR TITLE
fix(daemon): skip redundant write FTS repairs

### DIFF
--- a/polylogue/archive/write_effects.py
+++ b/polylogue/archive/write_effects.py
@@ -22,6 +22,9 @@ from polylogue.archive.write_gateway import WriteOperation, WriteResult
 
 logger = logging.getLogger(__name__)
 
+_MESSAGE_FTS_TRIGGER_NAMES = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
+_ACTION_FTS_TRIGGER_NAMES = ("action_events_fts_ai", "action_events_fts_ad", "action_events_fts_au")
+
 
 def commit_archive_write_effects(
     conn: sqlite3.Connection,
@@ -77,16 +80,19 @@ def commit_archive_write_effects(
 
         acquire_blob_leases(db_path, blob_hashes, operation_id)
 
+    message_triggers_live = _all_triggers_present(conn, _MESSAGE_FTS_TRIGGER_NAMES)
+    action_triggers_live = _all_triggers_present(conn, _ACTION_FTS_TRIGGER_NAMES)
+
     t_trigger = time.perf_counter()
     ensure_fts_triggers_sync(conn)
     trigger_elapsed_s = time.perf_counter() - t_trigger
     message_fts_elapsed_s = 0.0
     action_fts_elapsed_s = 0.0
-    if sorted_ids and repair_message_fts:
+    if sorted_ids and repair_message_fts and not message_triggers_live:
         t_message = time.perf_counter()
         repair_message_fts_index_sync(conn, sorted_ids)
         message_fts_elapsed_s = time.perf_counter() - t_message
-    if sorted_ids and repair_action_fts:
+    if sorted_ids and repair_action_fts and not action_triggers_live:
         t_action = time.perf_counter()
         repair_action_fts_index_sync(conn, sorted_ids)
         action_fts_elapsed_s = time.perf_counter() - t_action
@@ -131,6 +137,17 @@ def _invalidate_search_cache() -> None:
     from polylogue.storage.search.cache import invalidate_search_cache
 
     invalidate_search_cache()
+
+
+def _all_triggers_present(conn: sqlite3.Connection, names: Sequence[str]) -> bool:
+    if not names:
+        return True
+    placeholders = ", ".join("?" for _ in names)
+    rows = conn.execute(
+        f"SELECT name FROM sqlite_master WHERE type = 'trigger' AND name IN ({placeholders})",
+        tuple(names),
+    ).fetchall()
+    return {str(row[0]) for row in rows} == set(names)
 
 
 __all__ = ["commit_archive_write_effects"]

--- a/tests/unit/archive/test_write_gateway.py
+++ b/tests/unit/archive/test_write_gateway.py
@@ -88,6 +88,67 @@ def test_write_gateway_can_skip_fts_repairs_when_triggers_maintained_rows(
     assert repaired == []
 
 
+def test_write_gateway_skips_redundant_fts_repairs_when_live_triggers_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "archive.db"
+
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
+        lambda _conn, _ids: pytest.fail("message FTS repair should be handled by live triggers"),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_action_fts_index_sync",
+        lambda _conn, _ids: pytest.fail("action FTS repair should be handled by live triggers"),
+    )
+
+    with open_connection(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        result = ArchiveWriteGateway(db_path).commit_write_sync(
+            WriteOperation.INGEST,
+            {
+                "_connection": conn,
+                "changed_conversation_ids": ("c1",),
+            },
+        )
+
+    assert result.status == "committed"
+
+
+def test_write_gateway_repairs_fts_when_live_triggers_were_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "archive.db"
+    repaired: list[str] = []
+
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
+        lambda _conn, _ids: repaired.append("messages"),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_action_fts_index_sync",
+        lambda _conn, _ids: repaired.append("actions"),
+    )
+
+    with open_connection(db_path) as conn:
+        conn.execute("DROP TRIGGER messages_fts_ai")
+        conn.execute("DROP TRIGGER action_events_fts_ai")
+        conn.commit()
+        conn.execute("BEGIN IMMEDIATE")
+        result = ArchiveWriteGateway(db_path).commit_write_sync(
+            WriteOperation.INGEST,
+            {
+                "_connection": conn,
+                "changed_conversation_ids": ("c1",),
+            },
+        )
+
+    assert result.status == "committed"
+    assert repaired == ["messages", "actions"]
+
+
 @pytest.mark.asyncio
 async def test_write_gateway_async_commit_uses_same_local_effects_path(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"


### PR DESCRIPTION
## Summary

Skip post-write message/action FTS repair when live FTS triggers were already present for the write.

## Problem

After #1470 and #1471 were deployed, live validation still showed `polylogued` reading about `2.34 GB` over 10 seconds with IO full avg10 around `20%`, while logs showed hot insight rebuilds were deferred and append writes were small.

The remaining broad path was `commit_archive_write_effects`: it always called `repair_message_fts_index_sync` and `repair_action_fts_index_sync` for changed conversations. On normal live writes the FTS triggers already maintain those rows, so the repair did a redundant delete/reinsert of the whole conversation FTS surface after every append.

## Solution

- Record whether message/action FTS triggers were present before write side effects run.
- Always call `ensure_fts_triggers_sync` to restore missing triggers.
- If triggers were already live, trust them and skip the redundant repair.
- If triggers were missing or suspended, keep the existing targeted repair path after trigger restoration.
- Add tests for both paths.

This keeps the hard FTS freshness contract: live-triggered writes stay fresh immediately, and missing/suspended triggers still force repair.

Ref #1447

## Verification

- `pytest -q tests/unit/archive/test_write_gateway.py tests/unit/pipeline/test_ingest_append_replay.py` -> `9 passed in 0.20s`
- `mypy polylogue/archive/write_effects.py tests/unit/archive/test_write_gateway.py` -> `Success: no issues found in 2 source files`
- `devtools verify --quick` -> `exit_code 0`, `total_duration_s 39.71`
- pre-push `devtools verify --quick` -> `exit_code 0`, `total_duration_s 34.62`