### PR TITLE
fix(daemon): keep live convergence responsive

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -686,35 +686,39 @@ async def run_daemon_services(
 
         # Preflight already ran at the top of run_daemon_services (see
         # ``watcher_blocked`` above); reuse that result.
-        if enable_watch and not watcher_blocked:
-            async with Polylogue() as polylogue:
-                watcher = LiveWatcher(
-                    polylogue,
-                    sources,
-                    debounce_s=debounce_s,
-                    converger=converger,
-                    event_emitter=_emit_live_batch_event,
-                )
-                watcher_task = asyncio.create_task(watcher.run())
-                tasks.append(watcher_task)
+        try:
+            if enable_watch and not watcher_blocked:
+                async with Polylogue() as polylogue:
+                    watcher = LiveWatcher(
+                        polylogue,
+                        sources,
+                        debounce_s=debounce_s,
+                        converger=converger,
+                        event_emitter=_emit_live_batch_event,
+                    )
+                    watcher_task = asyncio.create_task(watcher.run())
+                    tasks.append(watcher_task)
+                    all_tasks = tasks + maintenance_tasks
+                    await asyncio.gather(*all_tasks)
+            elif tasks:
+                # Watcher disabled or preflight-blocked: keep HTTP/health and
+                # other components serving so operators see the degraded state.
                 all_tasks = tasks + maintenance_tasks
                 await asyncio.gather(*all_tasks)
-        elif tasks:
-            # Watcher disabled or preflight-blocked: keep HTTP/health and
-            # other components serving so operators see the degraded state.
-            all_tasks = tasks + maintenance_tasks
-            await asyncio.gather(*all_tasks)
-        else:
-            await asyncio.gather(*maintenance_tasks)
+            else:
+                await asyncio.gather(*maintenance_tasks)
+        except BaseException:
+            _log_completed_daemon_tasks(tasks + maintenance_tasks)
+            raise
     finally:
         if watcher is not None:
             watcher.stop()
         if converger is not None:
             await converger.stop()
         if server is not None:
-            server.shutdown()
+            _shutdown_server_if_serving(server, server_task, label="browser-capture")
         if api_server is not None:
-            api_server.shutdown()
+            _shutdown_server_if_serving(api_server, api_server_task, label="api")
 
         # Cancel all component tasks.
         for task in tasks:
@@ -759,10 +763,14 @@ async def _drain_tasks(tasks: list[asyncio.Task[None]], *, timeout: float = 5.0)
     """
     if not tasks:
         return []
-    results = await asyncio.wait_for(
-        asyncio.gather(*tasks, return_exceptions=True),
-        timeout=timeout,
-    )
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=timeout,
+        )
+    except TimeoutError as exc:
+        logger.warning("daemon: timed out draining %d task(s) during shutdown", len(tasks))
+        return [exc]
     return [r if isinstance(r, BaseException) else None for r in results]
 
 
@@ -771,6 +779,43 @@ def _report_drain_exceptions(results: list[BaseException | None]) -> None:
     for exc in results:
         if exc is not None:
             logger.warning("daemon: task raised during shutdown: %s", exc)
+
+
+def _log_completed_daemon_tasks(tasks: list[asyncio.Task[None]]) -> None:
+    for task in tasks:
+        if not task.done():
+            continue
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            logger.warning("daemon: component task cancelled unexpectedly")
+            continue
+        if exc is None:
+            logger.warning("daemon: component task exited unexpectedly")
+        else:
+            logger.warning("daemon: component task failed unexpectedly: %s", exc)
+
+
+def _shutdown_server_if_serving(
+    server: BrowserCaptureHTTPServer | ThreadingHTTPServer,
+    task: asyncio.Task[None] | None,
+    *,
+    label: str,
+) -> None:
+    if task is None:
+        return
+    if task.done():
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            logger.warning("daemon: %s server task was cancelled before shutdown", label)
+            return
+        if exc is None:
+            logger.warning("daemon: %s server task exited before shutdown", label)
+        else:
+            logger.warning("daemon: %s server task failed before shutdown: %s", label, exc)
+        return
+    server.shutdown()
 
 
 @click.group(help="Run long-lived Polylogue local services.")

--- a/polylogue/storage/insights/session/status.py
+++ b/polylogue/storage/insights/session/status.py
@@ -349,7 +349,7 @@ SESSION_PROFILE_REPAIR_CANDIDATES_SQL = """
     LEFT JOIN session_profiles sp ON sp.conversation_id = c.conversation_id
     WHERE sp.conversation_id IS NULL
        OR sp.materializer_version != ?
-       OR COALESCE(sp.source_updated_at, '') != COALESCE(c.updated_at, '')
+       OR ABS(COALESCE(sp.source_sort_key, 0.0) - COALESCE(c.sort_key, 0.0)) > 0.000001
     ORDER BY c.conversation_id
 """
 
@@ -571,7 +571,7 @@ def _to_int(row: tuple[object, ...] | sqlite3.Row | None) -> int:
     if not row:
         return 0
     value = row[0]
-    if isinstance(value, (int, float, str)):
+    if isinstance(value, int | float | str):
         return int(value)
     return 0
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import sqlite3
+import threading
 from datetime import timedelta
 from pathlib import Path
 from typing import cast
@@ -637,6 +638,67 @@ def test_run_daemon_services_closes_browser_capture_server_on_failure() -> None:
             )
         )
 
+    assert server.shutdown_called is False
+    assert server.close_called is True
+
+
+def test_run_daemon_services_shutdowns_running_server_on_watcher_failure() -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    class FakePolylogue:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+    class FakeWatcher:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def run(self) -> None:
+            raise RuntimeError("watch stopped")
+
+        def stop(self) -> None:
+            return None
+
+    class BlockingServer:
+        shutdown_called = False
+        close_called = False
+
+        def __init__(self) -> None:
+            self._stopped = threading.Event()
+
+        def serve_forever(self, poll_interval: float = 0.5) -> None:
+            assert poll_interval == 0.5
+            self._stopped.wait(timeout=5)
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+            self._stopped.set()
+
+        def server_close(self) -> None:
+            self.close_called = True
+
+    server = BlockingServer()
+    with (
+        patch.object(daemon_cli, "Polylogue", FakePolylogue),
+        patch.object(daemon_cli, "LiveWatcher", FakeWatcher),
+        patch.object(daemon_cli, "make_server", return_value=server),
+        pytest.raises(RuntimeError, match="watch stopped"),
+    ):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(WatchSource(name="codex", root=Path("/tmp/codex")),),
+                debounce_s=1.0,
+                enable_watch=True,
+                enable_browser_capture=True,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
     assert server.shutdown_called is True
     assert server.close_called is True
 
@@ -694,5 +756,5 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
             )
         )
 
-    assert server.shutdown_called is True
+    assert server.shutdown_called is False
     assert server.close_called is True

--- a/tests/unit/storage/test_session_insight_status_descriptors.py
+++ b/tests/unit/storage/test_session_insight_status_descriptors.py
@@ -14,7 +14,9 @@ from polylogue.storage.insights.session.status import (
     SessionInsightReadyDescriptor,
     session_insight_status_async,
     session_insight_status_sync,
+    session_profile_repair_candidate_ids_sync,
 )
+from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
 
 
 def test_fts_descriptor_marks_duplicates_unready() -> None:
@@ -109,6 +111,64 @@ def test_ready_descriptor_combines_table_equalities_and_zero_counts() -> None:
         {"work_threads": True},
         {"thread_count": 3, "root_threads": 3, "stale_thread_count": 1, "orphan_thread_count": 0},
     )
+
+
+def test_profile_repair_candidates_match_sort_key_freshness() -> None:
+    with sqlite3.connect(":memory:") as conn:
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                sort_key REAL,
+                updated_at TEXT
+            );
+            CREATE TABLE session_profiles (
+                conversation_id TEXT PRIMARY KEY,
+                materializer_version INTEGER NOT NULL,
+                source_sort_key REAL,
+                source_updated_at TEXT
+            );
+
+            INSERT INTO conversations (conversation_id, sort_key, updated_at)
+            VALUES ('ready-even-if-updated-at-differs', 1.0, '2026-05-01T12:00:00Z');
+
+            INSERT INTO conversations (conversation_id, sort_key, updated_at)
+            VALUES ('stale-sort-key', 2.0, '2026-05-01T12:00:00Z');
+            INSERT INTO conversations (conversation_id, sort_key, updated_at)
+            VALUES ('missing-profile', 3.0, '2026-05-01T12:00:00Z');
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO session_profiles (
+                conversation_id, materializer_version, source_sort_key, source_updated_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                "ready-even-if-updated-at-differs",
+                SESSION_INSIGHT_MATERIALIZER_VERSION,
+                1.0,
+                "2026-04-30T12:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_profiles (
+                conversation_id, materializer_version, source_sort_key, source_updated_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                "stale-sort-key",
+                SESSION_INSIGHT_MATERIALIZER_VERSION,
+                1.5,
+                "2026-05-01T12:00:00Z",
+            ),
+        )
+
+        candidates = session_profile_repair_candidate_ids_sync(conn)
+
+    assert candidates == ["missing-profile", "stale-sort-key"]
 
 
 async def test_status_sync_and_async_match_when_product_tables_are_absent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes two live-convergence failure modes observed during the production daemon deployment: session-insight targeted repair could still select stale candidates far beyond the readiness predicate, and daemon teardown could deadlock into a half-dead process that kept sockets open while health, metrics, and convergence no longer responded.

## Problem

After #1472 deployed, `polylogued.service` stayed active with low RSS and zero IO, but logs showed `converger: stopped`; both daemon ports accepted TCP and timed out on HTTP; and two due `live_convergence_debt` rows remained undrained. That left the operator with a process that looked alive to systemd but was not doing daemon work. Separately, local dirt showed targeted session-insight repair still comparing `source_updated_at`, which could select unrelated historical rows and turn a targeted repair into a near-full archive rebuild.

Ref #1447.

## Solution

- Align session-profile repair candidates with the readiness predicate by comparing `source_sort_key` to `conversations.sort_key`, while ignoring harmless `updated_at` string drift.
- Log completed daemon component tasks before teardown so the next unexpected component exit names the failed surface.
- Call `BaseServer.shutdown()` only when the corresponding `serve_forever` task is still running; otherwise log the already-failed/exited task and proceed to `server_close()`.
- Bound shutdown task-drain timeouts so cleanup continues instead of leaving sockets/pidfiles behind.

## Verification

- `pytest -q tests/unit/storage/test_session_insight_status_descriptors.py::test_profile_repair_candidates_match_sort_key_freshness tests/unit/daemon/test_daemon_cli.py` -> `20 passed`
- `python -m mypy polylogue/daemon/cli.py polylogue/storage/insights/session/status.py tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_session_insight_status_descriptors.py` -> success
- `devtools verify --quick` -> `exit_code 0`, `total_duration_s 36.54`
- pre-push `devtools verify --quick` -> `exit_code 0`, `total_duration_s 39.36`