### PR TITLE
fix(daemon): bound status and readiness probes

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -49,7 +49,7 @@ class FTSReadiness(BaseModel):
     action_event_indexed_count: int = 0
     action_event_count: int = 0
     coverage_pct: float = 0.0
-    surfaces: dict[str, dict[str, int | bool]] = Field(default_factory=dict)
+    surfaces: dict[str, dict[str, int | bool | str | None]] = Field(default_factory=dict)
 
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
@@ -70,7 +70,21 @@ def _triggers_present(conn: sqlite3.Connection, trigger_names: tuple[str, ...]) 
     return all(name in present for name in trigger_names)
 
 
-def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool]:
+def _freshness_states(conn: sqlite3.Connection) -> dict[str, str] | None:
+    if not _table_exists(conn, "fts_freshness_state"):
+        return None
+    rows = conn.execute("SELECT surface, state FROM fts_freshness_state").fetchall()
+    return {str(row[0]): str(row[1]) for row in rows}
+
+
+def _freshness_ready(freshness: dict[str, str] | None, surface: str) -> tuple[bool, str | None]:
+    if freshness is None:
+        return True, None
+    state = freshness.get(surface)
+    return state == "ready", state
+
+
+def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool | str | None]:
     return {
         "source_exists": surface.source_exists,
         "exists": surface.exists,
@@ -109,9 +123,11 @@ def _exact_readiness_payload(snapshot: FtsInvariantSnapshot) -> dict[str, object
 def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
     """Return FTS readiness for health/status probes.
 
-    The default is request-safe and structural: it proves tables/triggers
-    exist without scanning FTS shadow tables. Use ``exact=True`` for hard
-    readiness/search decisions where stale search must never be served.
+    The default is request-safe: it proves tables/triggers exist and, when
+    the durable freshness table exists, requires each live surface to be
+    marked ready. It never scans source or FTS shadow tables. Use
+    ``exact=True`` for explicit diagnostics/repair jobs that can afford a
+    full invariant scan.
     """
     if not dbf.exists():
         return {"messages_ready": False, "action_events_ready": False, "coverage_pct": 0.0}
@@ -120,12 +136,14 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
         try:
             if exact:
                 return _exact_readiness_payload(fts_invariant_snapshot_sync(conn))
-            surfaces: dict[str, dict[str, int | bool]] = {}
+            freshness = _freshness_states(conn)
+            surfaces: dict[str, dict[str, int | bool | str | None]] = {}
             for name, source_table, fts_table, triggers in _FTS_SURFACES:
                 source_exists = _table_exists(conn, source_table)
                 exists = _table_exists(conn, fts_table)
                 triggers_present = exists and _triggers_present(conn, triggers)
-                ready = (exists and triggers_present) if source_exists else not exists
+                freshness_ready, freshness_state = _freshness_ready(freshness, name)
+                ready = (exists and triggers_present and freshness_ready) if source_exists else not exists
                 surfaces[name] = {
                     "source_exists": source_exists,
                     "exists": exists,
@@ -137,6 +155,8 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
                     "duplicate_rows": 0,
                     "ready": ready,
                     "exact": False,
+                    "freshness_known": freshness is not None,
+                    "freshness_state": freshness_state,
                 }
         finally:
             conn.close()

--- a/polylogue/daemon/healthz.py
+++ b/polylogue/daemon/healthz.py
@@ -133,7 +133,7 @@ def handle_healthz_ready(responder: ProbeResponder) -> None:
         fts_ready = True
         fts_payload: dict[str, object] | None = None
         if dbf.exists():
-            fts_payload = fts_readiness_info(dbf, exact=True)
+            fts_payload = fts_readiness_info(dbf)
             fts_ready = bool(fts_payload.get("invariant_ready", False))
 
         if schema_ok and not critical and fts_ready:

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -128,9 +128,7 @@ def refresh_status_snapshot(*, payload: JSONDocument | None = None) -> StatusSna
         refresh_error: str | None = None
         try:
             if payload is None:
-                from polylogue.daemon.status import daemon_status_payload
-
-                payload = daemon_status_payload()
+                payload = _minimal_status_payload()
         except Exception as exc:
             refresh_error = str(exc)
             payload = _minimal_status_payload(refresh_error=refresh_error)

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -33,6 +33,26 @@ def test_status_snapshot_serves_cached_payload_without_rebuilding_status(monkeyp
     assert snapshot["state"] == "fresh"
 
 
+def test_status_snapshot_refresh_default_stays_request_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "polylogue.db"
+    db.touch()
+    monkeypatch.setattr("polylogue.daemon.status_snapshot.db_path", lambda: db)
+    monkeypatch.setattr(
+        "polylogue.daemon.status.daemon_status_payload",
+        lambda: (_ for _ in ()).throw(AssertionError("periodic snapshot must not build rich status")),
+    )
+
+    snapshot = refresh_status_snapshot()
+
+    status_snapshot = snapshot.payload["status_snapshot"]
+    assert isinstance(status_snapshot, dict)
+    assert status_snapshot["state"] == "minimal"
+    assert snapshot.payload["db_path"] == str(db)
+
+
 def test_build_daemon_status_reports_failed_live_cursor_files(tmp_path: Path) -> None:
     db = tmp_path / "polylogue.db"
     failed = tmp_path / "failed.jsonl"
@@ -387,6 +407,40 @@ def test_fts_readiness_exact_detects_missing_docsize_row(tmp_path: Path) -> None
     messages = surfaces["messages_fts"]
     assert isinstance(messages, dict)
     assert messages["missing_rows"] == 1
+    assert messages["ready"] is False
+
+
+def test_fts_readiness_requires_recorded_freshness_when_available(tmp_path: Path) -> None:
+    from polylogue.daemon.fts_status import fts_readiness_info
+
+    db_path = tmp_path / "polylogue.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE messages (message_id TEXT, text TEXT);
+            CREATE TABLE messages_fts (text TEXT);
+            CREATE TRIGGER messages_fts_ai AFTER INSERT ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_ad AFTER DELETE ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_au AFTER UPDATE ON messages BEGIN SELECT 1; END;
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                checked_at TEXT NOT NULL
+            );
+            INSERT INTO fts_freshness_state VALUES ('messages_fts', 'stale', '2026-05-24T00:00:00+00:00');
+            """
+        )
+
+    readiness = fts_readiness_info(db_path)
+
+    assert readiness["messages_ready"] is False
+    assert readiness["invariant_ready"] is False
+    surfaces = readiness["surfaces"]
+    assert isinstance(surfaces, dict)
+    messages = surfaces["messages_fts"]
+    assert isinstance(messages, dict)
+    assert messages["freshness_known"] is True
+    assert messages["freshness_state"] == "stale"
     assert messages["ready"] is False
 
 

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -397,6 +397,47 @@ class TestReadinessProbeContract:
         names = {check["name"] for check in payload["checks"]}
         assert names == EXPECTED_FAST_CHECKS
 
+    def test_readiness_uses_bounded_fts_freshness_not_exact_scan(
+        self,
+        workspace_env: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import sqlite3
+
+        from polylogue.paths import db_path
+
+        self._patch_healthy_fast(monkeypatch)
+        dbf = db_path()
+        dbf.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(dbf) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE messages (message_id TEXT, text TEXT);
+                CREATE TABLE messages_fts (text TEXT);
+                CREATE TRIGGER messages_fts_ai AFTER INSERT ON messages BEGIN SELECT 1; END;
+                CREATE TRIGGER messages_fts_ad AFTER DELETE ON messages BEGIN SELECT 1; END;
+                CREATE TRIGGER messages_fts_au AFTER UPDATE ON messages BEGIN SELECT 1; END;
+                CREATE TABLE fts_freshness_state (
+                    surface TEXT PRIMARY KEY,
+                    state TEXT NOT NULL,
+                    checked_at TEXT NOT NULL
+                );
+                INSERT INTO fts_freshness_state VALUES ('messages_fts', 'ready', '2026-05-24T00:00:00+00:00');
+                """
+            )
+        monkeypatch.setattr(
+            "polylogue.daemon.fts_status.fts_invariant_snapshot_sync",
+            lambda _conn: (_ for _ in ()).throw(AssertionError("readiness must not run exact FTS scans")),
+        )
+
+        handler = _make_handler("GET", "/healthz/ready")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["status"] == "ready"
+        assert payload["fts"]["coverage_exact"] is False
+
     def test_readiness_returns_503_on_critical_check(
         self,
         workspace_env: dict[str, Path],


### PR DESCRIPTION
## Summary

Bounds daemon status and readiness probes so ordinary request-time surfaces do not perform archive-scale scans during catch-up.

## Problem

Live validation after #1473 still showed severe IO pressure: the daemon RSS stayed around 245-249 MiB, but the service cgroup accumulated about 5.9 GiB of file cache and `/proc/$pid/io` showed about 2.1 GiB of physical reads over 10 seconds. With the service stopped, `refresh_status_snapshot()` reproduced the issue by running longer than 40 seconds. `/healthz/ready` also timed out because it used exact FTS invariant scans.

## Solution

`refresh_status_snapshot()` now defaults to the existing minimal bounded payload instead of building the rich daemon status payload. Bounded FTS readiness now combines live FTS table/trigger checks with the durable `fts_freshness_state` rows when that table exists, so stale or unknown recorded freshness blocks readiness without scanning source or FTS shadow tables. `/healthz/ready` uses that bounded readiness path; exact FTS invariant scans remain available for explicit diagnostics and repair jobs.

## Verification

- `pytest -q tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py` -> `35 passed in 0.48s`
- `python -m mypy polylogue/daemon/status_snapshot.py polylogue/daemon/fts_status.py polylogue/daemon/healthz.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py` -> `Success: no issues found in 5 source files`
- direct `refresh_status_snapshot()` IO probe -> `elapsed_s 0.001534`, `read_bytes 0`, `write_bytes 0`, `snapshot_state minimal`, `fts_ready True`
- `devtools verify --quick` -> pass, `total_duration_s: 36.3`
- pre-push `devtools verify --quick` -> pass, `total_duration_s: 38.05`
