### PR TITLE
fix(maintenance): support tuple repair candidate rows

### DIFF
--- a/polylogue/storage/insights/session/status.py
+++ b/polylogue/storage/insights/session/status.py
@@ -716,7 +716,7 @@ def session_profile_repair_candidate_ids_sync(conn: sqlite3.Connection) -> list[
         SESSION_PROFILE_REPAIR_CANDIDATES_SQL,
         (SESSION_INSIGHT_MATERIALIZER_VERSION,),
     ).fetchall()
-    return [str(row["conversation_id"]) for row in rows]
+    return [str(row["conversation_id"] if isinstance(row, sqlite3.Row) else row[0]) for row in rows]
 
 
 async def session_profile_repair_candidate_ids_async(conn: aiosqlite.Connection) -> list[str]:

--- a/tests/unit/storage/test_session_insight_status_descriptors.py
+++ b/tests/unit/storage/test_session_insight_status_descriptors.py
@@ -171,6 +171,32 @@ def test_profile_repair_candidates_match_sort_key_freshness() -> None:
     assert candidates == ["missing-profile", "stale-sort-key"]
 
 
+def test_profile_repair_candidates_do_not_require_row_factory() -> None:
+    with sqlite3.connect(":memory:") as conn:
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                sort_key REAL,
+                updated_at TEXT
+            );
+            CREATE TABLE session_profiles (
+                conversation_id TEXT PRIMARY KEY,
+                materializer_version INTEGER NOT NULL,
+                source_sort_key REAL,
+                source_updated_at TEXT
+            );
+
+            INSERT INTO conversations (conversation_id, sort_key, updated_at)
+            VALUES ('missing-profile', 3.0, '2026-05-01T12:00:00Z');
+            """
+        )
+
+        candidates = session_profile_repair_candidate_ids_sync(conn)
+
+    assert candidates == ["missing-profile"]
+
+
 async def test_status_sync_and_async_match_when_product_tables_are_absent(tmp_path: Path) -> None:
     db_path = tmp_path / "status.db"
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Summary

Allows session-profile repair candidate extraction to work with both `sqlite3.Row` mapping rows and ordinary tuple rows.

## Problem

The narrow session insight repair helper can be called with a direct `sqlite3.Connection` that has no row factory. In that case `fetchall()` returns tuples, but `session_profile_repair_candidate_ids_sync()` assumed mapping access and failed before returning the actual stale/missing candidate IDs.

## Solution

The sync helper now reads `conversation_id` from either a `sqlite3.Row` or the first tuple column. A focused test covers the no-row-factory path while preserving the sort-key freshness repair contract.

## Verification

- `pytest -q tests/unit/storage/test_session_insight_status_descriptors.py::test_profile_repair_candidates_do_not_require_row_factory tests/unit/storage/test_session_insight_status_descriptors.py::test_profile_repair_candidates_match_sort_key_freshness tests/unit/storage/test_repair.py::test_repair_session_insights_uses_stale_profile_candidates` -> `3 passed in 0.04s`
- `python -m mypy polylogue/storage/insights/session/status.py tests/unit/storage/test_session_insight_status_descriptors.py` -> `Success: no issues found in 2 source files`
- pre-push `devtools verify --quick` -> pass, `total_duration_s: 36.78`
