### PR TITLE
fix(devtools): run testmon verify with workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,9 +420,10 @@ the default command fails with setup guidance instead of silently running the
 whole suite.
 
 Plain focused `pytest` runs are single-process by default so small inner-loop
-checks do not spawn a worker pool. Broad gates that benefit from parallelism
-opt into workers explicitly through `devtools verify --all`,
-`devtools verify --seed-testmon`, or an explicit `pytest -n <workers>`.
+checks do not spawn a worker pool. `devtools verify` keeps pytest-testmon as
+the affected-test selector and runs the selected tests with xdist workers
+(`-n 8` by default, override with `POLYLOGUE_PYTEST_WORKERS`). Full diagnostic
+and seed runs use the same worker override and default to `-n 16`.
 
 The default path does not replay cached verify results. Every invocation runs
 the static gates and lets pytest-testmon evaluate current source, package, and

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,9 +33,10 @@ the default command fails with setup guidance instead of silently running the
 whole suite.
 
 Plain focused `pytest` runs are single-process by default so small inner-loop
-checks do not spawn a worker pool. Broad gates that benefit from parallelism
-opt into workers explicitly through `devtools verify --all`,
-`devtools verify --seed-testmon`, or an explicit `pytest -n <workers>`.
+checks do not spawn a worker pool. `devtools verify` keeps pytest-testmon as
+the affected-test selector and runs the selected tests with xdist workers
+(`-n 8` by default, override with `POLYLOGUE_PYTEST_WORKERS`). Full diagnostic
+and seed runs use the same worker override and default to `-n 16`.
 
 The default path does not replay cached verify results. Every invocation runs
 the static gates and lets pytest-testmon evaluate current source, package, and

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -236,6 +236,22 @@ def _pytest_metadata_from_report(report: dict[str, Any]) -> dict[str, Any]:
     return metadata
 
 
+def _pytest_command_metadata(cmd: list[str]) -> dict[str, Any]:
+    """Return verify metadata that explains the pytest worker policy."""
+    metadata: dict[str, Any] = {}
+    if "-n" in cmd:
+        index = cmd.index("-n")
+        if index + 1 < len(cmd):
+            metadata["pytest_workers"] = cmd[index + 1]
+    else:
+        metadata["pytest_workers"] = "unset"
+    if "--testmon" in cmd:
+        metadata["pytest_selection"] = "testmon-noselect" if "--testmon-noselect" in cmd else "testmon"
+    else:
+        metadata["pytest_selection"] = "full"
+    return metadata
+
+
 def _clear_pytest_report() -> None:
     """Remove a stale report before a pytest step runs."""
     with contextlib.suppress(FileNotFoundError):
@@ -253,6 +269,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
     elapsed = time.monotonic() - t0
     metadata: dict[str, Any] = {}
     if label.startswith("pytest"):
+        metadata.update(_pytest_command_metadata(cmd))
         report = _read_pytest_report()
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report))
@@ -379,7 +396,7 @@ def build_verify_steps(
             pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")])
             steps.append(("pytest testmon-global", pytest_cmd))
         else:
-            pytest_cmd.extend(["--testmon", "-n", "0"])
+            pytest_cmd.extend(["--testmon", *_pytest_worker_args(default="8")])
             if skip_slow:
                 pytest_cmd.append("--testmon-forceselect")
             steps.append(("pytest testmon", pytest_cmd))

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -790,11 +790,7 @@ def repair_session_insights(
                 conn.commit()
                 rebuilt_count = rebuilt.total()
             refreshed = session_insight_status_sync(conn)
-            if (
-                conversation_ids is None
-                and not session_insight_status_ready(refreshed)
-                and assess_session_insight_repairs(refreshed).row_debt > 0
-            ):
+            if conversation_ids is None and not session_insight_status_ready(refreshed):
                 rebuilt = rebuild_session_insights_sync(
                     conn,
                     conversation_ids=None,

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -151,11 +151,13 @@ def test_check_records_scoped_maintenance_preview(cli_workspace: WorkspacePaths,
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
     db_path = cli_workspace["db_path"]
+    old_timestamp = "2020-01-01T00:00:00+00:00"
     (
         ConversationBuilder(db_path, "conv-check-insights")
         .provider("claude-code")
         .title("Scoped Check Repair")
-        .add_message("u1", role="user", text="Plan the cleanup")
+        .updated_at(old_timestamp)
+        .add_message("u1", role="user", text="Plan the cleanup", timestamp=old_timestamp)
         .save()
     )
     with open_connection(db_path) as conn:
@@ -192,11 +194,13 @@ def test_check_records_scoped_maintenance_apply(cli_workspace: WorkspacePaths, c
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
     db_path = cli_workspace["db_path"]
+    old_timestamp = "2020-01-01T00:00:00+00:00"
     (
         ConversationBuilder(db_path, "conv-check-insights-apply")
         .provider("claude-code")
         .title("Scoped Check Repair Apply")
-        .add_message("u1", role="user", text="Repair the durable insights")
+        .updated_at(old_timestamp)
+        .add_message("u1", role="user", text="Repair the durable insights", timestamp=old_timestamp)
         .save()
     )
     with open_connection(db_path) as conn:
@@ -209,6 +213,7 @@ def test_check_records_scoped_maintenance_apply(cli_workspace: WorkspacePaths, c
         [
             "--plain",
             "doctor",
+            "--deep",
             "--format",
             "json",
             "--repair",
@@ -276,11 +281,13 @@ def test_check_plain_preview_summarizes_changes_not_issues(
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
     db_path = cli_workspace["db_path"]
+    old_timestamp = "2020-01-01T00:00:00+00:00"
     (
         ConversationBuilder(db_path, "conv-check-insights-preview-plain")
         .provider("claude-code")
         .title("Scoped Check Repair Preview Plain")
-        .add_message("u1", role="user", text="Preview the repair output")
+        .updated_at(old_timestamp)
+        .add_message("u1", role="user", text="Preview the repair output", timestamp=old_timestamp)
         .save()
     )
     with open_connection(db_path) as conn:
@@ -293,6 +300,7 @@ def test_check_plain_preview_summarizes_changes_not_issues(
         [
             "--plain",
             "doctor",
+            "--deep",
             "--repair",
             "--preview",
             "--target",

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -13,6 +13,7 @@ from devtools.verify import (
     _format_completion_notification,
     _is_testmon_global_invalidator,
     _parse_pytest_test_count,
+    _pytest_command_metadata,
     _pytest_metadata_from_report,
     _read_pytest_report,
     _run,
@@ -60,7 +61,7 @@ def test_default_verify_uses_pytest_testmon() -> None:
     assert "--testmon" in command
     assert "--testmon-noselect" not in command
     assert "-n" in command
-    assert "0" in command
+    assert command[command.index("-n") + 1] == "8"
 
 
 def test_pytest_step_requests_structured_json_report() -> None:
@@ -111,6 +112,16 @@ def test_seed_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyP
     label, command = steps[-1]
     assert label == "pytest seed-testmon"
     assert command[command.index("-n") + 1] == "4"
+
+
+def test_default_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_WORKERS", "3")
+
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False)
+
+    label, command = steps[-1]
+    assert label == "pytest testmon"
+    assert command[command.index("-n") + 1] == "3"
 
 
 def test_global_testmon_invalidator_runs_full_collection(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -254,6 +265,8 @@ def test_run_records_pytest_count_metadata_from_terminal_fallback() -> None:
     assert rc == 0
     assert metadata["count"] == 4
     assert metadata["report_path"] is None
+    assert metadata["pytest_workers"] == "unset"
+    assert metadata["pytest_selection"] == "full"
 
 
 def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -289,7 +302,7 @@ def test_run_reads_structured_pytest_report() -> None:
         patch("devtools.verify.subprocess.run", return_value=completed),
         patch("devtools.verify._read_pytest_report", return_value=report),
     ):
-        rc, _elapsed, metadata = _run("pytest testmon", ["pytest"])
+        rc, _elapsed, metadata = _run("pytest testmon", ["pytest", "--testmon", "-n", "8"])
 
     assert rc == 0
     assert metadata["count"] == 13  # passed+failed+skipped
@@ -299,6 +312,23 @@ def test_run_reads_structured_pytest_report() -> None:
     assert metadata["total"] == 13
     assert metadata["pytest_duration_s"] == 4.56
     assert metadata["report_path"] == str(PYTEST_REPORT_PATH)
+    assert metadata["pytest_workers"] == "8"
+    assert metadata["pytest_selection"] == "testmon"
+
+
+def test_pytest_command_metadata_reports_worker_and_selection_policy() -> None:
+    assert _pytest_command_metadata(["pytest", "--testmon", "-n", "8"]) == {
+        "pytest_workers": "8",
+        "pytest_selection": "testmon",
+    }
+    assert _pytest_command_metadata(["pytest", "--testmon", "--testmon-noselect", "-n", "16"]) == {
+        "pytest_workers": "16",
+        "pytest_selection": "testmon-noselect",
+    }
+    assert _pytest_command_metadata(["pytest", "-n", "16"]) == {
+        "pytest_workers": "16",
+        "pytest_selection": "full",
+    }
 
 
 def test_pytest_metadata_handles_empty_summary() -> None:

--- a/tests/unit/storage/test_perf_rescue_1314.py
+++ b/tests/unit/storage/test_perf_rescue_1314.py
@@ -100,14 +100,12 @@ def test_search_conversation_hits_uses_freshness_ledger_before_match(tier_small_
 @pytest.mark.scale_small
 def test_search_conversation_hits_falls_back_to_exact_freshness(tier_small_db: Path) -> None:
     """Absent ledger rows fall back to exact FTS verification before MATCH."""
-    from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_async
-
     with open_bench_store(tier_small_db) as store:
         backend = store.backend
 
         async def _run(statements: list[str]) -> None:
             async with backend.connection() as conn:
-                await record_fts_surface_state_async(conn, surface="messages_fts", state=STALE)
+                await conn.execute("DELETE FROM fts_freshness_state WHERE surface = 'messages_fts'")
                 await conn.commit()
                 await search_conversation_hits(conn, "analysis", limit=5)
 


### PR DESCRIPTION
## Summary

`devtools verify` now keeps pytest-testmon as the default affected-test selector while running the selected tests through xdist workers. The pytest step records worker and selection metadata in verify JSON so local notifications and PR evidence explain whether a run was testmon-selected, globally refreshed, or full.

## Problem

The default affected-test path had regressed to single-process pytest by forcing `-n 0`, so a correct testmon selection could still waste wallclock and host resources on large affected sets. The verify report also showed the selected test count without making the worker/selection policy explicit, which made notifications harder to interpret.

## Solution

- Change the default `pytest testmon` step to use `-n 8`, with `POLYLOGUE_PYTEST_WORKERS` overriding the count consistently across default, seed, global-refresh, and full pytest steps.
- Add `pytest_workers` and `pytest_selection` metadata to pytest verify steps.
- Update the testing docs and generated agent memory to describe the new default.
- Refresh stale selected tests to match current FTS freshness and hot-source insight repair contracts.
- Ensure global session-insight repair performs one full rebuild when targeted repair still leaves readiness false.

Closes #1449

## Verification

- `pytest -q tests/unit/devtools/test_verify.py` -> 33 passed in 5.68s
- `pytest -q tests/unit/devtools/test_verify.py tests/unit/storage/test_perf_rescue_1314.py tests/unit/cli/test_check.py::test_check_records_scoped_maintenance_apply tests/unit/cli/test_check.py::test_check_records_scoped_maintenance_preview tests/unit/cli/test_check.py::test_check_plain_preview_summarizes_changes_not_issues --tb=short` -> 41 passed in 7.66s
- `pytest -q -n 8 tests/unit/cli/test_check.py::test_check_records_scoped_maintenance_apply tests/unit/cli/test_check.py::test_check_records_scoped_maintenance_preview tests/unit/cli/test_check.py::test_check_plain_preview_summarizes_changes_not_issues tests/unit/sources/test_live_batch_support.py::test_incomplete_append_is_requeued_not_full_ingested tests/unit/storage/test_perf_rescue_1314.py::test_search_conversation_hits_falls_back_to_exact_freshness tests/benchmarks/test_daemon_convergence.py::test_convergence_scale_tier --tb=short` -> 11 passed in 18.75s
- `python -m mypy devtools/verify.py polylogue/storage/repair.py tests/unit/devtools/test_verify.py tests/unit/cli/test_check.py tests/unit/storage/test_perf_rescue_1314.py` -> passed
- `ruff check devtools/verify.py polylogue/storage/repair.py tests/unit/devtools/test_verify.py tests/unit/cli/test_check.py tests/unit/storage/test_perf_rescue_1314.py` -> passed
- `ruff format --check devtools/verify.py polylogue/storage/repair.py tests/unit/devtools/test_verify.py tests/unit/cli/test_check.py tests/unit/storage/test_perf_rescue_1314.py` -> passed
- `devtools render-all --check` -> passed
- `devtools verify --json --skip-slow` -> passed in 56.43s; pytest step: `pytest testmon`, `pytest_workers=8`, `pytest_selection=testmon`, `count=8`, `passed=8`, `pytest_duration_s=6.35`
- pre-push `devtools verify --quick` -> passed in 33.83s