### PR TITLE
fix(storage): index raw cleanup on existing archives

### DIFF
--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -43,6 +43,12 @@ ORDER BY r.blob_size DESC, r.acquired_at ASC, r.raw_id ASC
 LIMIT ?
 """
 
+_PROVIDER_EVENT_RAW_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_provider_events_raw_id
+ON provider_events(raw_id)
+WHERE raw_id IS NOT NULL
+"""
+
 
 @dataclass(frozen=True)
 class RawSnapshotCleanupCandidate:
@@ -62,6 +68,11 @@ class RawSnapshotCleanupResult:
     provider_event_links_cleared: int
     skipped_missing_source_count: int
     errors: tuple[str, ...] = ()
+
+
+def ensure_provider_event_raw_index(conn: sqlite3.Connection) -> None:
+    """Ensure parent raw deletes do not scan provider_events repeatedly."""
+    conn.execute(_PROVIDER_EVENT_RAW_INDEX_SQL)
 
 
 def superseded_raw_snapshot_candidates(
@@ -153,6 +164,7 @@ def cleanup_superseded_raw_snapshots(
             skipped_missing_source_count=0,
         )
 
+    ensure_provider_event_raw_index(conn)
     placeholders = ", ".join("?" for _ in raw_ids)
     provider_links = conn.execute(
         f"UPDATE provider_events SET raw_id = NULL WHERE raw_id IN ({placeholders})",
@@ -239,5 +251,6 @@ __all__ = [
     "RawSnapshotCleanupResult",
     "cleanup_superseded_raw_snapshots",
     "compact_paths_superseded_raw_snapshots",
+    "ensure_provider_event_raw_index",
     "superseded_raw_snapshot_candidates",
 ]

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -172,3 +172,67 @@ def test_provider_event_raw_index_is_ensured_on_existing_archive(tmp_path: Path)
 
     indexes = {str(row[1]) for row in conn.execute("PRAGMA index_list(provider_events)").fetchall()}
     assert "idx_provider_events_raw_id" in indexes
+
+
+def test_destructive_cleanup_adds_provider_event_raw_index_when_missing(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    source = tmp_path / "rollout.jsonl"
+    source.write_text('{"type":"message"}\n', encoding="utf-8")
+    blob_store = BlobStore(tmp_path / "blob")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    _ensure_schema(conn)
+    conn.execute("DROP INDEX idx_provider_events_raw_id")
+
+    old_raw, old_size = _write_blob(blob_store, b"old")
+    current_raw, current_size = _write_blob(blob_store, b"current")
+    _insert_raw(
+        conn,
+        raw_id=old_raw,
+        source_path=source,
+        source_index=-1,
+        blob_size=old_size,
+        acquired_at="2026-05-24T00:00:00+00:00",
+    )
+    _insert_raw(
+        conn,
+        raw_id=current_raw,
+        source_path=source,
+        source_index=-1,
+        blob_size=current_size,
+        acquired_at="2026-05-24T00:01:00+00:00",
+    )
+    conn.execute(
+        """
+        INSERT INTO conversations (
+            conversation_id, provider_name, provider_conversation_id,
+            content_hash, source_name, version, raw_id
+        ) VALUES ('conv-1', 'codex', 'conv-1', 'hash', 'codex-session', 1, ?)
+        """,
+        (current_raw,),
+    )
+    conn.execute(
+        """
+        INSERT INTO provider_events (
+            event_id, conversation_id, provider_name, event_index,
+            event_type, payload_json, raw_id
+        ) VALUES ('event-1', 'conv-1', 'codex', 1, 'message', '{}', ?)
+        """,
+        (old_raw,),
+    )
+    conn.commit()
+
+    dry_run = cleanup_superseded_raw_snapshots(conn, dry_run=True, blob_store=blob_store)
+    assert dry_run.candidate_count == 1
+    indexes_after_dry_run = {str(row[1]) for row in conn.execute("PRAGMA index_list(provider_events)").fetchall()}
+    assert "idx_provider_events_raw_id" not in indexes_after_dry_run
+
+    result = cleanup_superseded_raw_snapshots(conn, dry_run=False, blob_store=blob_store)
+    assert result.deleted_raw_count == 1
+    assert result.provider_event_links_cleared == 1
+    assert conn.execute("SELECT raw_id FROM provider_events WHERE event_id = 'event-1'").fetchone()[0] is None
+
+    indexes_after_cleanup = {str(row[1]) for row in conn.execute("PRAGMA index_list(provider_events)").fetchall()}
+    assert "idx_provider_events_raw_id" in indexes_after_cleanup


### PR DESCRIPTION
## Summary

Make the destructive `superseded_raw_snapshots` cleanup target index-aware for existing archives that predate the new `provider_events(raw_id)` schema index.

## Problem

PR #1483 added raw snapshot compaction and put `idx_provider_events_raw_id` in the fresh schema, but the live archive was created before that index existed. Running the cleanup target there was not acceptable: it read roughly 50 GB in under two minutes while clearing/deleting about 4k candidate raw rows, because `provider_events.raw_id` updates and parent-row delete checks had no child-key index.

## Solution

`cleanup_superseded_raw_snapshots(..., dry_run=False)` now creates `idx_provider_events_raw_id` if missing before clearing provider-event links and deleting raw rows. Preview/dry-run remains cheap and does not build the index, so daemon startup and ordinary status checks do not perform heavyweight schema work.

A focused regression test simulates an older archive by dropping the index, verifies dry-run leaves it absent, then verifies destructive cleanup creates it and clears the provider-event raw link.

Closes #1484

## Verification

- `pytest -q tests/unit/storage/test_raw_retention.py --tb=short` -> 3 passed
- `pytest -q tests/unit/storage/test_raw_retention.py tests/unit/cli/test_check.py --tb=short` -> 48 passed
- `ruff format --check polylogue/storage/raw_retention.py tests/unit/storage/test_raw_retention.py && ruff check polylogue/storage/raw_retention.py tests/unit/storage/test_raw_retention.py` -> passed
- `mypy polylogue/storage/raw_retention.py tests/unit/storage/test_raw_retention.py` -> passed
- `devtools verify --quick` -> exit_code 0, 39.69s
- pre-push `devtools verify --quick` -> exit_code 0, 35.60s
