### PR TITLE
fix(search): ground FTS freshness in invariants

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -35,7 +35,6 @@ from polylogue.logging import configure_logging, get_logger
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.watcher import default_sources
 from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
-from polylogue.storage.fts.sql import FTS_INDEXABLE_MESSAGE_COUNT_SQL
 
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
@@ -153,13 +152,12 @@ async def _ensure_fts_startup_readiness() -> None:
         has_fts_table = row is not None
 
         from polylogue.storage.fts.freshness import (
-            READY,
             ensure_fts_freshness_table_sync,
-            message_fts_marked_ready_sync,
-            record_fts_surface_state_sync,
+            record_fts_invariant_snapshot_sync,
         )
         from polylogue.storage.fts.fts_lifecycle import (
             ensure_fts_index_sync,
+            fts_invariant_snapshot_sync,
             rebuild_fts_index_sync,
             restore_fts_triggers_sync,
         )
@@ -187,22 +185,15 @@ async def _ensure_fts_startup_readiness() -> None:
             return
 
         ensure_fts_index_sync(conn)
-        has_indexable_messages = bool(conn.execute(FTS_INDEXABLE_MESSAGE_COUNT_SQL).fetchone()[0])
-        has_indexed_messages = bool(conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone())
-        if has_indexable_messages and not has_indexed_messages:
-            logger.warning("daemon: message FTS is empty on startup while messages exist. Rebuilding once.")
+        snapshot = fts_invariant_snapshot_sync(conn)
+        if not snapshot.ready:
+            logger.warning("daemon: FTS invariant failed on startup. Rebuilding before serving search.")
             rebuild_fts_index_sync(conn)
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
             return
 
-        if not message_fts_marked_ready_sync(conn):
-            record_fts_surface_state_sync(
-                conn,
-                surface="messages_fts",
-                state=READY,
-                detail="startup structural check passed",
-            )
+        record_fts_invariant_snapshot_sync(conn, snapshot)
         conn.commit()
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -225,7 +225,7 @@ def _message_fts_trigger_ddl(*, include_content_blocks: bool) -> tuple[str, ...]
         AFTER INSERT ON messages BEGIN
             INSERT INTO messages_fts(rowid, message_id, conversation_id, text)
             SELECT new.rowid, new.message_id, new.conversation_id, new.text
-            WHERE new.text IS NOT NULL;
+            WHERE new.text IS NOT NULL AND new.text != '';
         END;
 
         CREATE TRIGGER IF NOT EXISTS messages_fts_ad
@@ -238,7 +238,7 @@ def _message_fts_trigger_ddl(*, include_content_blocks: bool) -> tuple[str, ...]
             DELETE FROM messages_fts WHERE rowid = old.rowid;
             INSERT INTO messages_fts(rowid, message_id, conversation_id, text)
             SELECT new.rowid, new.message_id, new.conversation_id, new.text
-            WHERE new.text IS NOT NULL;
+            WHERE new.text IS NOT NULL AND new.text != '';
         END;
         """,
     )
@@ -409,7 +409,7 @@ def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
             INSERT INTO messages_fts (rowid, message_id, conversation_id, text)
             SELECT rowid, message_id, conversation_id, text
             FROM messages
-            WHERE text IS NOT NULL
+            WHERE NULLIF(text, '') IS NOT NULL
             """
         )
     conn.execute(ACTION_FTS_REBUILD_SQL)
@@ -482,7 +482,7 @@ async def rebuild_fts_index_async(
             INSERT INTO messages_fts (rowid, message_id, conversation_id, text)
             SELECT rowid, message_id, conversation_id, text
             FROM messages
-            WHERE text IS NOT NULL
+            WHERE NULLIF(text, '') IS NOT NULL
             """
         )
     await conn.execute(ACTION_FTS_REBUILD_SQL)
@@ -670,7 +670,9 @@ def message_fts_readiness_sync(
         # so the cheap path can still see the "FTS exists but empty"
         # state without paying for a full COUNT(*) (#1314).
         has_indexed_rows = exists and bool(conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone())
-        has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
+        has_indexable_messages = bool(
+            conn.execute("SELECT 1 FROM messages WHERE NULLIF(text, '') IS NOT NULL LIMIT 1").fetchone()
+        )
         triggers_present = exists and _triggers_present_sync(conn, _message_trigger_names_for_sync(conn))
         indexed_rows = 0
         total_messages = 0
@@ -750,7 +752,7 @@ async def message_fts_readiness_async(
             await (await conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1")).fetchone()
         )
         has_indexable_messages = bool(
-            await (await conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1")).fetchone()
+            await (await conn.execute("SELECT 1 FROM messages WHERE NULLIF(text, '') IS NOT NULL LIMIT 1")).fetchone()
         )
         triggers_present = exists and await _triggers_present_async(conn, await _message_trigger_names_for_async(conn))
         indexed_rows = 0
@@ -869,7 +871,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
     message_source_sql = (
         FTS_INDEXABLE_MESSAGE_COUNT_SQL
         if has_content_blocks
-        else "SELECT COUNT(*) FROM messages WHERE text IS NOT NULL"
+        else "SELECT COUNT(*) FROM messages WHERE NULLIF(text, '') IS NOT NULL"
     )
     message_trigger_names = (
         _MESSAGE_FTS_TRIGGER_NAMES if has_content_blocks else ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
@@ -881,7 +883,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
             LEFT JOIN messages_fts_docsize AS d ON d.id = m.rowid
             WHERE d.id IS NULL
               AND (
-                  m.text IS NOT NULL
+                  NULLIF(m.text, '') IS NOT NULL
                   OR EXISTS (
                       SELECT 1
                       FROM content_blocks AS cb
@@ -899,7 +901,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
             SELECT COUNT(*)
             FROM messages AS m
             LEFT JOIN messages_fts_docsize AS d ON d.id = m.rowid
-            WHERE m.text IS NOT NULL AND d.id IS NULL
+            WHERE NULLIF(m.text, '') IS NOT NULL AND d.id IS NULL
         """
     )
     message_excess_sql = (
@@ -909,7 +911,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
             LEFT JOIN messages AS m ON m.rowid = d.id
             WHERE m.rowid IS NULL
                OR (
-                   m.text IS NULL
+                   NULLIF(m.text, '') IS NULL
                    AND NOT EXISTS (
                        SELECT 1
                        FROM content_blocks AS cb
@@ -926,7 +928,7 @@ def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsho
         else """
             SELECT COUNT(*)
             FROM messages_fts_docsize AS d
-            LEFT JOIN messages AS m ON m.rowid = d.id AND m.text IS NOT NULL
+            LEFT JOIN messages AS m ON m.rowid = d.id AND NULLIF(m.text, '') IS NOT NULL
             WHERE m.rowid IS NULL
         """
     )

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -37,7 +37,7 @@ FTS_INDEX_DOC_COUNT_SQL = "SELECT COUNT(*) FROM messages_fts_docsize"
 FTS_INDEXABLE_MESSAGE_COUNT_SQL = """
     SELECT COUNT(*)
     FROM messages AS m
-    WHERE m.text IS NOT NULL
+    WHERE NULLIF(m.text, '') IS NOT NULL
        OR EXISTS (
            SELECT 1
            FROM content_blocks AS cb

--- a/polylogue/storage/sqlite/schema_ddl_archive.py
+++ b/polylogue/storage/sqlite/schema_ddl_archive.py
@@ -261,7 +261,7 @@ MESSAGE_FTS_DDL = """
         AFTER INSERT ON messages BEGIN
             INSERT INTO messages_fts(rowid, message_id, conversation_id, text)
             SELECT new.rowid, new.message_id, new.conversation_id, new.text
-            WHERE new.text IS NOT NULL;
+            WHERE new.text IS NOT NULL AND new.text != '';
         END;
 
         CREATE TRIGGER IF NOT EXISTS messages_fts_ad

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -262,7 +262,7 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
-def test_ensure_fts_startup_readiness_marks_ready_without_exact_scan(
+def test_ensure_fts_startup_readiness_records_exact_invariant(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -311,12 +311,6 @@ def test_ensure_fts_startup_readiness_marks_ready_without_exact_scan(
                     ("action_events_fts_au",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
-                return FakeCursor((1,))
-            if "COUNT(*)" in query and "FROM messages AS m" in query:
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
-                return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -335,36 +329,33 @@ def test_ensure_fts_startup_readiness_marks_ready_without_exact_scan(
     def ensure(fake_conn: FakeConnection) -> None:
         ensured.append(fake_conn)
 
-    recorded: list[dict[str, object]] = []
+    class FakeSnapshot:
+        ready = True
+
+    snapshot = FakeSnapshot()
+    recorded: list[FakeSnapshot] = []
 
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", ensure)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync", lambda fake_conn: snapshot)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
-    monkeypatch.setattr("polylogue.storage.fts.freshness.message_fts_marked_ready_sync", lambda fake_conn: False)
     monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_surface_state_sync",
-        lambda fake_conn, **kwargs: recorded.append(kwargs),
+        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync",
+        lambda fake_conn, fake_snapshot: recorded.append(fake_snapshot),
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
     assert ensured == [conn]
     assert rebuilds == []
-    assert recorded == [
-        {
-            "surface": "messages_fts",
-            "state": "ready",
-            "detail": "startup structural check passed",
-        }
-    ]
-    assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
+    assert recorded == [snapshot]
     assert conn.committed is True
     assert conn.closed is True
 
 
-def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
+def test_ensure_fts_startup_readiness_rebuilds_stale_invariant(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -412,12 +403,6 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
                     ("action_events_fts_au",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
-                return FakeCursor((1,))
-            if "COUNT(*)" in query and "FROM messages AS m" in query:
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
-                return FakeCursor(None)
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -432,9 +417,16 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     def rebuild(fake_conn: FakeConnection) -> None:
         rebuilds.append(fake_conn)
 
+    class FakeSnapshot:
+        ready = False
+
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync",
+        lambda fake_conn: FakeSnapshot(),
+    )
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
 
@@ -443,10 +435,6 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     assert rebuilds == [conn]
     assert conn.committed is True
     assert conn.closed is True
-    assert all("COUNT(*) FROM messages_fts" not in query for query in conn.queries)
-    assert all("COUNT(*) FROM messages_fts_docsize" not in query for query in conn.queries)
-    assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
-    assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
 
 
 def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
@@ -527,9 +515,8 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
     )
 
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
-    monkeypatch.setattr("polylogue.storage.fts.freshness.message_fts_marked_ready_sync", lambda fake_conn: False)
     monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_surface_state_sync", lambda fake_conn, **kwargs: None
+        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync", lambda fake_conn, fake_snapshot: None
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())

--- a/tests/unit/storage/test_retrieval_readiness_laws.py
+++ b/tests/unit/storage/test_retrieval_readiness_laws.py
@@ -210,7 +210,7 @@ class TestRetrievalIndexInvariants:
                     """
                     SELECT DISTINCT m.message_id
                     FROM messages AS m
-                    WHERE m.text IS NOT NULL
+                    WHERE NULLIF(m.text, '') IS NOT NULL
                        OR EXISTS (
                            SELECT 1
                            FROM content_blocks AS cb


### PR DESCRIPTION
## Summary

Daemon startup now grounds the durable FTS freshness ledger in exact executable invariants instead of structural table/trigger checks. If startup observes a stale FTS surface, it rebuilds before search is served. The message indexable-row definition now matches the actual FTS projection by excluding empty `messages.text` unless content blocks/tool input/metadata contribute searchable content.

## Problem

During the schema-v9 live re-ingest, the daemon recorded `messages_fts=ready` with `source_rows=0,indexed_rows=0` on a fresh DB. Catch-up then inserted over a million messages while the readiness ledger still said ready, so search readiness could trust a stale durable row. Direct live evidence before repair showed 1,313,271 indexable message rows versus 818,824 `messages_fts_docsize` rows.

## Solution

`_ensure_fts_startup_readiness()` now records `fts_freshness_state` from `fts_invariant_snapshot_sync()` and rebuilds when the invariant is stale. The startup path still restores missing triggers and rebuilds for the SIGKILL/bulk-suspend failure mode.

The invariant and trigger projection now agree that empty message text is not searchable content. This fixed the live false-stale result after rebuild: with the corrected definition, the partial live DB reported `messages_fts|ready|...|743090|743090|0|0|0|`.

Closes #1499

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py -q` → 19 passed
- `pytest tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py tests/unit/storage/test_perf_rescue_1314.py -q` → 41 passed
- `pytest tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_retrieval_readiness_laws.py -q` → 25 passed
- `python - <<'PY' ... _ensure_fts_startup_readiness() ... PY` against the live partial DB → first run rebuilt in 186.188s; after the empty-text fix, exact startup readiness completed in 21.788s and recorded all FTS surfaces ready.
- `devtools verify --quick` → pass, 34.42s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Full-Text Search (FTS) initialization to use invariant snapshot verification for more reliable startup readiness detection.
  * Messages with empty text are no longer indexed in Full-Text Search, ensuring only meaningful content is searchable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->