### PR TITLE
fix(search): repair FTS during live ingest

### DIFF
--- a/polylogue/archive/write_effects.py
+++ b/polylogue/archive/write_effects.py
@@ -22,16 +22,6 @@ from polylogue.archive.write_gateway import WriteOperation, WriteResult
 
 logger = logging.getLogger(__name__)
 
-_MESSAGE_FTS_TRIGGER_NAMES = (
-    "messages_fts_ai",
-    "messages_fts_ad",
-    "messages_fts_au",
-    "content_blocks_fts_ai",
-    "content_blocks_fts_ad",
-    "content_blocks_fts_au",
-)
-_ACTION_FTS_TRIGGER_NAMES = ("action_events_fts_ai", "action_events_fts_ad", "action_events_fts_au")
-
 
 def commit_archive_write_effects(
     conn: sqlite3.Connection,
@@ -87,19 +77,16 @@ def commit_archive_write_effects(
 
         acquire_blob_leases(db_path, blob_hashes, operation_id)
 
-    message_triggers_live = _all_triggers_present(conn, _MESSAGE_FTS_TRIGGER_NAMES)
-    action_triggers_live = _all_triggers_present(conn, _ACTION_FTS_TRIGGER_NAMES)
-
     t_trigger = time.perf_counter()
     ensure_fts_triggers_sync(conn)
     trigger_elapsed_s = time.perf_counter() - t_trigger
     message_fts_elapsed_s = 0.0
     action_fts_elapsed_s = 0.0
-    if sorted_ids and repair_message_fts and not message_triggers_live:
+    if sorted_ids and repair_message_fts:
         t_message = time.perf_counter()
         repair_message_fts_index_sync(conn, sorted_ids)
         message_fts_elapsed_s = time.perf_counter() - t_message
-    if sorted_ids and repair_action_fts and not action_triggers_live:
+    if sorted_ids and repair_action_fts:
         t_action = time.perf_counter()
         repair_action_fts_index_sync(conn, sorted_ids)
         action_fts_elapsed_s = time.perf_counter() - t_action
@@ -144,17 +131,6 @@ def _invalidate_search_cache() -> None:
     from polylogue.storage.search.cache import invalidate_search_cache
 
     invalidate_search_cache()
-
-
-def _all_triggers_present(conn: sqlite3.Connection, names: Sequence[str]) -> bool:
-    if not names:
-        return True
-    placeholders = ", ".join("?" for _ in names)
-    rows = conn.execute(
-        f"SELECT name FROM sqlite_master WHERE type = 'trigger' AND name IN ({placeholders})",
-        tuple(names),
-    ).fetchall()
-    return {str(row[0]) for row in rows} == set(names)
 
 
 __all__ = ["commit_archive_write_effects"]

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -188,6 +188,7 @@ async def _ensure_fts_startup_readiness() -> None:
         snapshot = fts_invariant_snapshot_sync(conn)
         if not snapshot.ready:
             logger.warning("daemon: FTS invariant failed on startup. Rebuilding before serving search.")
+            restore_fts_triggers_sync(conn)
             rebuild_fts_index_sync(conn)
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -63,8 +63,8 @@ def ingest_append_plans(owner: _AppendIngestOwner, plans: list[_AppendPlan]) -> 
             validation_mode=str(getattr(getattr(owner._polylogue, "config", None), "validation_mode", "advisory")),
             ingest_workers=1,
             measure_ingest_result_size=False,
-            repair_message_fts=False,
-            repair_action_fts=False,
+            repair_message_fts=True,
+            repair_action_fts=True,
             ingest_result_chunk_size=_INGEST_RESULT_CHUNK_SIZE,
         )
     except Exception as exc:

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -917,8 +917,8 @@ class LiveBatchProcessor:
                 validation_mode=str(getattr(getattr(self._polylogue, "config", None), "validation_mode", "advisory")),
                 ingest_workers=_full_ingest_worker_count(raw_records),
                 measure_ingest_result_size=False,
-                repair_message_fts=suspend_fts_triggers,
-                repair_action_fts=suspend_fts_triggers,
+                repair_message_fts=True,
+                repair_action_fts=True,
                 ingest_result_chunk_size=_INGEST_RESULT_CHUNK_SIZE,
                 suspend_fts_triggers=suspend_fts_triggers,
                 heartbeat=None

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -866,6 +866,26 @@ def _trigger_invariant_sync(
 
 
 def fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapshot:
+    """Return exact freshness status for every active FTS search surface.
+
+    The snapshot spans multiple aggregate queries. Start an explicit read
+    transaction when the caller has not already opened one so live ingest
+    commits cannot make source counts and FTS shadow counts describe
+    different moments in time.
+    """
+    if conn.in_transaction:
+        return _fts_invariant_snapshot_sync(conn)
+    conn.execute("BEGIN")
+    try:
+        snapshot = _fts_invariant_snapshot_sync(conn)
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    conn.execute("COMMIT")
+    return snapshot
+
+
+def _fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapshot:
     """Return exact freshness status for every active FTS search surface."""
     has_content_blocks = _table_exists_sync(conn, "content_blocks")
     message_source_sql = (

--- a/tests/unit/archive/test_write_gateway.py
+++ b/tests/unit/archive/test_write_gateway.py
@@ -88,19 +88,20 @@ def test_write_gateway_can_skip_fts_repairs_when_triggers_maintained_rows(
     assert repaired == []
 
 
-def test_write_gateway_skips_redundant_fts_repairs_when_live_triggers_exist(
+def test_write_gateway_repairs_fts_when_requested_even_if_live_triggers_exist(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_path = tmp_path / "archive.db"
+    repaired: list[str] = []
 
     monkeypatch.setattr(
         "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
-        lambda _conn, _ids: pytest.fail("message FTS repair should be handled by live triggers"),
+        lambda _conn, _ids: repaired.append("messages"),
     )
     monkeypatch.setattr(
         "polylogue.storage.fts.fts_lifecycle.repair_action_fts_index_sync",
-        lambda _conn, _ids: pytest.fail("action FTS repair should be handled by live triggers"),
+        lambda _conn, _ids: repaired.append("actions"),
     )
 
     with open_connection(db_path) as conn:
@@ -114,6 +115,7 @@ def test_write_gateway_skips_redundant_fts_repairs_when_live_triggers_exist(
         )
 
     assert result.status == "committed"
+    assert repaired == ["messages", "actions"]
 
 
 def test_write_gateway_repairs_fts_when_live_triggers_were_missing(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -413,6 +413,7 @@ def test_ensure_fts_startup_readiness_rebuilds_stale_invariant(
 
     conn = FakeConnection()
     rebuilds: list[FakeConnection] = []
+    restored: list[FakeConnection] = []
 
     def rebuild(fake_conn: FakeConnection) -> None:
         rebuilds.append(fake_conn)
@@ -427,11 +428,16 @@ def test_ensure_fts_startup_readiness_rebuilds_stale_invariant(
         "polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync",
         lambda fake_conn: FakeSnapshot(),
     )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.restore_fts_triggers_sync",
+        lambda fake_conn: restored.append(fake_conn),
+    )
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
+    assert restored == [conn]
     assert rebuilds == [conn]
     assert conn.committed is True
     assert conn.closed is True

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -523,8 +523,8 @@ def test_append_ingest_preserves_successes_when_other_plan_fails(
     assert result.succeeded == [plans[0]]
     assert result.failed == [plans[1]]
     assert result.worker_count == 1
-    assert captured_kwargs["repair_message_fts"] is False
-    assert captured_kwargs["repair_action_fts"] is False
+    assert captured_kwargs["repair_message_fts"] is True
+    assert captured_kwargs["repair_action_fts"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Make live ingest maintain FTS freshness as a hard write-side contract instead of relying on trigger timing alone.

## Problem

#1500 fixed daemon startup readiness, but live catch-up on the production archive still drifted while the daemon was running. With the daemon stopped, exact invariant evidence showed:

```text
messages_fts: source_rows=986362 indexed_rows=975948 missing_rows=10414
 action_events_fts: source_rows=354184 indexed_rows=350407 missing_rows=3777
```

The missing message rows were block-only messages whose searchable content lives in `content_blocks`; missing action rows were normal `action_events`. Live full/append ingest had been opting out of conversation-scoped repair unless triggers were explicitly suspended, and write effects ignored an explicit repair request when triggers were present.

Closes #1501.

## Solution

- `commit_archive_write_effects` now treats `repair_message_fts=True` and `repair_action_fts=True` literally: changed conversations are repaired even when triggers exist.
- Live full ingest and append ingest explicitly request message/action FTS repair for changed conversations.
- Daemon stale-startup recovery refreshes trigger definitions before rebuilding, so stale trigger bodies cannot survive a rebuild.
- Exact FTS invariant snapshots run inside one read transaction so source counts and shadow-table counts describe the same DB moment.

## Verification

- `pytest tests/unit/archive/test_write_gateway.py tests/unit/daemon/test_daemon_cli.py tests/unit/sources/test_live_batch_support.py tests/unit/storage/test_retrieval_readiness_laws.py tests/unit/storage/test_perf_rescue_1314.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py tests/unit/storage/test_fts_trigger_lifecycle.py -q`
  - `87 passed in 1.93s`
- `devtools verify --quick`
  - `exit_code: 0`, `total_duration_s: 35.97`
- Pre-push `devtools verify --quick`
  - `exit_code: 0`, `total_duration_s: 34.78`
- Live archive repair with the daemon stopped:
  - `missing_message_conversations=11 missing_action_conversations=10 union=11`
  - `ready=True`
  - `messages_fts 986362 986362 0 0 0 True`
  - `action_events_fts 354184 354184 0 0 0 True`
  - `session_work_events_fts 10192 10192 0 0 0 True`
  - `work_threads_fts 1922 1922 0 0 0 True`