### PR TITLE
fix(daemon): bound startup FTS and isolate live ingest

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -117,6 +117,11 @@ def _enable_faulthandler_if_supported() -> None:
 
 
 async def _ensure_fts_startup_readiness() -> None:
+    """Run daemon startup FTS maintenance without blocking the event loop."""
+    await asyncio.to_thread(_ensure_fts_startup_readiness_sync)
+
+
+def _ensure_fts_startup_readiness_sync() -> None:
     """Ensure FTS triggers and index are healthy on daemon startup.
 
     Three failure modes are recovered here:
@@ -132,11 +137,10 @@ async def _ensure_fts_startup_readiness() -> None:
        death, and subsequent writes silently bypass the FTS index. See
        #1242.
 
-    This path restores obvious broken structure first and records a durable
+    This path restores obvious broken structure first and records durable
     freshness state for search request handlers. It deliberately avoids exact
-    full-archive invariant scans during ordinary startup. If triggers are
-    missing, however, writes may already have bypassed FTS; the only correct
-    recovery is a one-time rebuild before search is served.
+    full-archive invariant scans during ordinary startup; bounded missing-row
+    repair is enough for the normal SIGKILL-after-trigger-suspend failure mode.
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -151,17 +155,21 @@ async def _ensure_fts_startup_readiness() -> None:
         row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
         has_fts_table = row is not None
 
+        from polylogue.storage.fts.dangling_repair import (
+            configure_bounded_repair_connection,
+            repair_missing_fts_rows,
+            repair_stale_fts_rows,
+        )
         from polylogue.storage.fts.freshness import (
             ensure_fts_freshness_table_sync,
-            record_fts_invariant_snapshot_sync,
         )
         from polylogue.storage.fts.fts_lifecycle import (
             ensure_fts_index_sync,
-            fts_invariant_snapshot_sync,
             rebuild_fts_index_sync,
             restore_fts_triggers_sync,
         )
 
+        configure_bounded_repair_connection(conn)
         ensure_fts_freshness_table_sync(conn)
 
         if not has_fts_table:
@@ -179,22 +187,24 @@ async def _ensure_fts_startup_readiness() -> None:
                 ", ".join(missing_triggers),
             )
             restore_fts_triggers_sync(conn)
-            rebuild_fts_index_sync(conn)
+            outcome = repair_missing_fts_rows(conn)
+            if not outcome.success:
+                logger.warning("daemon: bounded FTS repair failed after trigger restore: %s", outcome.detail)
+                rebuild_fts_index_sync(conn)
             conn.commit()
-            logger.info("daemon: FTS rebuild complete after trigger recovery.")
+            logger.info("daemon: FTS trigger recovery complete.")
             return
 
         ensure_fts_index_sync(conn)
-        snapshot = fts_invariant_snapshot_sync(conn)
-        if not snapshot.ready:
-            logger.warning("daemon: FTS invariant failed on startup. Rebuilding before serving search.")
+        outcome = repair_stale_fts_rows(conn)
+        if not outcome.success:
+            logger.warning("daemon: bounded FTS startup repair failed: %s. Rebuilding.", outcome.detail)
             restore_fts_triggers_sync(conn)
             rebuild_fts_index_sync(conn)
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
             return
 
-        record_fts_invariant_snapshot_sync(conn, snapshot)
         conn.commit()
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)
@@ -596,13 +606,6 @@ async def run_daemon_services(
     # daemon's pidfile.
     _pidfile_path = pidfile
 
-    # Ensure FTS structure is usable on startup. Keep this after pidfile
-    # acquisition so operator status sees the live daemon even if SQLite is
-    # busy, and keep the check bounded so daemon restart is not a full-table
-    # maintenance operation.
-    if not watcher_blocked:
-        await _ensure_fts_startup_readiness()
-
     # Periodic maintenance tasks. If schema preflight blocks the watcher, do
     # not start any background loop that opens the archive: a mismatched
     # runtime/database pair must remain observable without doing catch-up,
@@ -678,6 +681,11 @@ async def run_daemon_services(
             )
             api_server_task = asyncio.create_task(asyncio.to_thread(api_server.serve_forever, 0.5))
             tasks.append(api_server_task)
+
+        # Ensure FTS structure after HTTP surfaces are bound. On multi-GB
+        # archives, bounded SQLite maintenance can fault substantial file cache.
+        if not watcher_blocked:
+            maintenance_tasks.append(asyncio.create_task(_ensure_fts_startup_readiness()))
 
         # Preflight already ran at the top of run_daemon_services (see
         # ``watcher_blocked`` above); reuse that result.

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -759,15 +759,9 @@ def _iter_ingest_results_sync(
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
     chunk_size: int = 0,
+    force_process_pool: bool = False,
 ) -> Iterable[IngestRecordResult]:
-    """Yield ingest results for raw_artifacts, optionally in bounded chunks.
-
-    When *chunk_size* > 0 and *total* > *chunk_size*, the raw_artifacts are
-    split into sub-lists of at most *chunk_size* records. Each chunk is
-    submitted and drained before the next begins, so the process pool and
-    the drain loop never hold parsed results for more than one chunk in
-    memory at once.
-    """
+    """Yield ingest results, optionally chunked to bound parsed-result memory."""
     total = len(raw_artifacts)
     if progress is not None:
         progress.total_raw_count = total
@@ -781,6 +775,7 @@ def _iter_ingest_results_sync(
             worker_count=worker_count,
             heartbeat=heartbeat,
             progress=progress,
+            force_process_pool=force_process_pool,
         )
         return
 
@@ -792,6 +787,7 @@ def _iter_ingest_results_sync(
             worker_count=worker_count,
             heartbeat=heartbeat,
             progress=progress,
+            force_process_pool=force_process_pool,
         )
 
 
@@ -802,9 +798,10 @@ def _iter_ingest_results_chunk(
     worker_count: int,
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
+    force_process_pool: bool = False,
 ) -> Iterable[IngestRecordResult]:
     """Process one chunk of raw_artifacts through the process pool."""
-    if worker_count <= 1:
+    if worker_count <= 1 and not force_process_pool:
         for raw_record in raw_artifacts:
             if progress is not None:
                 progress.in_flight_raw_ids[:] = [raw_record.raw_id]
@@ -816,7 +813,7 @@ def _iter_ingest_results_chunk(
                 progress.in_flight_raw_ids.clear()
         return
     try:
-        with process_pool_executor(max_workers=worker_count) as executor:
+        with process_pool_executor(max_workers=max(1, worker_count)) as executor:
             raw_iter = iter(raw_artifacts)
             futures: dict[Future[IngestRecordResult], str] = {}
             max_in_flight = max(1, worker_count)
@@ -971,7 +968,9 @@ def _consume_ingest_results(
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
     ingest_result_chunk_size: int = 0,
-) -> None:
+    suspend_fts_triggers: bool = False,
+    force_process_pool: bool = False,
+) -> bool:
     result_iterator = iter(
         _iter_ingest_results_sync(
             raw_artifacts,
@@ -980,8 +979,10 @@ def _consume_ingest_results(
             heartbeat=heartbeat,
             progress=progress,
             chunk_size=ingest_result_chunk_size,
+            force_process_pool=force_process_pool,
         )
     )
+    transaction_started = False
     while True:
         wait_started = time.perf_counter()
         try:
@@ -990,6 +991,13 @@ def _consume_ingest_results(
             summary.teardown_elapsed_s = time.perf_counter() - wait_started
             break
         summary.result_wait_s += time.perf_counter() - wait_started
+        if not transaction_started:
+            conn.execute("BEGIN IMMEDIATE")
+            if suspend_fts_triggers:
+                from polylogue.storage.fts.fts_lifecycle import suspend_fts_triggers_sync
+
+                suspend_fts_triggers_sync(conn, mark_stale=False)
+            transaction_started = True
         _drain_ingest_result(
             conn,
             ir,
@@ -998,6 +1006,7 @@ def _consume_ingest_results(
             pending_by_parent=pending_by_parent,
             force_write=force_write,
         )
+    return transaction_started
 
 
 def _flush_ingest_results(
@@ -1063,6 +1072,7 @@ def _process_ingest_batch_sync(
     progress: _WorkerProgress | None = None,
     ingest_result_chunk_size: int = 0,
     suspend_fts_triggers: bool = False,
+    force_process_pool: bool = False,
 ) -> _IngestBatchSummary:
     if progress is None:
         progress = _WorkerProgress()
@@ -1080,13 +1090,9 @@ def _process_ingest_batch_sync(
     materialized_ids: set[str] = set()
     pending_by_parent: dict[str, list[_ConversationEntry]] = {}
     _observe_current_rss(summary)
+    transaction_started = False
     try:
-        conn.execute("BEGIN IMMEDIATE")
-        if suspend_fts_triggers:
-            from polylogue.storage.fts.fts_lifecycle import suspend_fts_triggers_sync
-
-            suspend_fts_triggers_sync(conn, mark_stale=False)
-        _consume_ingest_results(
+        transaction_started = _consume_ingest_results(
             conn,
             raw_artifacts,
             worker_request=worker_request,
@@ -1097,6 +1103,8 @@ def _process_ingest_batch_sync(
             heartbeat=heartbeat,
             progress=progress,
             ingest_result_chunk_size=ingest_result_chunk_size,
+            suspend_fts_triggers=suspend_fts_triggers,
+            force_process_pool=force_process_pool,
         )
         _flush_ingest_results(
             conn,
@@ -1104,43 +1112,43 @@ def _process_ingest_batch_sync(
             materialized_ids=materialized_ids,
             pending_by_parent=pending_by_parent,
         )
-        fts_repair_ids = set(summary.fts_repair_conversation_ids)
-        # Side effects (FTS trigger restore + FTS repair + commit) run
-        # BEFORE we release the connection so the data write and post-
-        # write effects share one transaction. The previous arrangement
-        # ran side effects in a `finally` block — they fired even after
-        # a rollback (silently restoring triggers on top of nothing) and
-        # ran AFTER the row commit, so a failure between commit and FTS
-        # repair would leave the index drifted. See #1242.
-        commit_started = time.perf_counter()
-        _commit_sync_ingest_side_effects(
-            conn,
-            db_path=db_path,
-            changed_conversation_ids=tuple(fts_repair_ids),
-            repair_message_fts=repair_message_fts or suspend_fts_triggers,
-            repair_action_fts=repair_action_fts or suspend_fts_triggers,
-        )
-        summary.commit_elapsed_s = time.perf_counter() - commit_started
-        from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_wal
-
-        wal_observation = maybe_checkpoint_wal(db_path, reason="ingest_batch_commit")
-        summary.wal_checkpoint_mode = wal_observation.mode
-        summary.wal_bytes_before_checkpoint = wal_observation.wal_bytes_before
-        summary.wal_bytes_after_checkpoint = wal_observation.wal_bytes_after
-        summary.wal_checkpointed_pages = wal_observation.checkpointed_pages
-        summary.wal_busy_pages = wal_observation.busy_pages
-        summary.wal_checkpoint_elapsed_s = wal_observation.elapsed_s
-        summary.wal_checkpoint_error = wal_observation.error
-        if wal_observation.blocking_processes:
-            logger.warning(
-                "wal_checkpoint_blocked",
-                reason=wal_observation.reason,
-                mode=wal_observation.mode,
-                wal_bytes_before=wal_observation.wal_bytes_before,
-                wal_bytes_after=wal_observation.wal_bytes_after,
-                busy_pages=wal_observation.busy_pages,
-                blocking_processes=wal_observation.blocking_processes[:5],
+        if transaction_started:
+            fts_repair_ids = set(summary.fts_repair_conversation_ids)
+            # Side effects run before releasing the connection so data and post-
+            # write effects share one transaction. The previous arrangement
+            # ran side effects in a `finally` block — they fired even after
+            # a rollback (silently restoring triggers on top of nothing) and
+            # ran AFTER the row commit, so a failure between commit and FTS
+            # repair would leave the index drifted. See #1242.
+            commit_started = time.perf_counter()
+            _commit_sync_ingest_side_effects(
+                conn,
+                db_path=db_path,
+                changed_conversation_ids=tuple(fts_repair_ids),
+                repair_message_fts=repair_message_fts or suspend_fts_triggers,
+                repair_action_fts=repair_action_fts or suspend_fts_triggers,
             )
+            summary.commit_elapsed_s = time.perf_counter() - commit_started
+            from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_wal
+
+            wal_observation = maybe_checkpoint_wal(db_path, reason="ingest_batch_commit")
+            summary.wal_checkpoint_mode = wal_observation.mode
+            summary.wal_bytes_before_checkpoint = wal_observation.wal_bytes_before
+            summary.wal_bytes_after_checkpoint = wal_observation.wal_bytes_after
+            summary.wal_checkpointed_pages = wal_observation.checkpointed_pages
+            summary.wal_busy_pages = wal_observation.busy_pages
+            summary.wal_checkpoint_elapsed_s = wal_observation.elapsed_s
+            summary.wal_checkpoint_error = wal_observation.error
+            if wal_observation.blocking_processes:
+                logger.warning(
+                    "wal_checkpoint_blocked",
+                    reason=wal_observation.reason,
+                    mode=wal_observation.mode,
+                    wal_bytes_before=wal_observation.wal_bytes_before,
+                    wal_bytes_after=wal_observation.wal_bytes_after,
+                    busy_pages=wal_observation.busy_pages,
+                    blocking_processes=wal_observation.blocking_processes[:5],
+                )
     except Exception:
         # Roll back the row writes.  If a caller explicitly opted into
         # dropped-trigger bulk mode, restore triggers before propagating

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -921,6 +921,7 @@ class LiveBatchProcessor:
                 repair_action_fts=True,
                 ingest_result_chunk_size=_INGEST_RESULT_CHUNK_SIZE,
                 suspend_fts_triggers=suspend_fts_triggers,
+                force_process_pool=True,
                 heartbeat=None
                 if heartbeat is None
                 else lambda: heartbeat(

--- a/polylogue/storage/fts/dangling_repair.py
+++ b/polylogue/storage/fts/dangling_repair.py
@@ -94,10 +94,153 @@ def insert_missing_action_fts_rows_sync(conn: sqlite3.Connection) -> int:
     return max(0, after - before)
 
 
+def _count_table(conn: sqlite3.Connection, table_name: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0] or 0)
+
+
+def _repair_keyed_content_fts_sync(
+    conn: sqlite3.Connection,
+    *,
+    source_table: str,
+    fts_table: str,
+    key_column: str,
+    insert_sql: str,
+) -> tuple[int, int, int, int]:
+    if not (_table_exists(conn, source_table) and _table_exists(conn, fts_table)):
+        return (0, 0, 0, 0)
+    before = _count_table(conn, f"{fts_table}_docsize")
+    source = _count_table(conn, source_table)
+    if before == source:
+        return (0, source, before, 0)
+    conn.execute(
+        f"""
+        DELETE FROM {fts_table}
+        WHERE {key_column} NOT IN (SELECT {key_column} FROM {source_table})
+        """
+    )
+    after_delete = _count_table(conn, f"{fts_table}_docsize")
+    conn.execute(insert_sql)
+    after = _count_table(conn, f"{fts_table}_docsize")
+    return (max(0, after - after_delete), source, after, max(0, before - source))
+
+
+def _repair_session_work_events_fts_rows_sync(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
+    return _repair_keyed_content_fts_sync(
+        conn,
+        source_table="session_work_events",
+        fts_table="session_work_events_fts",
+        key_column="event_id",
+        insert_sql="""
+            INSERT INTO session_work_events_fts (event_id, conversation_id, provider_name, kind, text)
+            SELECT swe.event_id, swe.conversation_id, swe.provider_name, swe.kind, swe.search_text
+            FROM session_work_events AS swe
+            LEFT JOIN session_work_events_fts AS fts ON fts.event_id = swe.event_id
+            WHERE fts.event_id IS NULL
+        """,
+    )
+
+
+def _repair_work_threads_fts_rows_sync(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
+    return _repair_keyed_content_fts_sync(
+        conn,
+        source_table="work_threads",
+        fts_table="work_threads_fts",
+        key_column="thread_id",
+        insert_sql="""
+            INSERT INTO work_threads_fts (thread_id, root_id, text)
+            SELECT wt.thread_id, wt.root_id, wt.search_text
+            FROM work_threads AS wt
+            LEFT JOIN work_threads_fts AS fts ON fts.thread_id = wt.thread_id
+            WHERE fts.thread_id IS NULL
+        """,
+    )
+
+
+def _record_optional_derived_surface(
+    conn: sqlite3.Connection,
+    *,
+    surface: str,
+    source_rows: int,
+    indexed_rows: int,
+    triggers: tuple[str, ...],
+) -> bool:
+    if not _table_exists(conn, surface):
+        return True
+    ready = source_rows == indexed_rows and _triggers_present_sync(conn, triggers)
+    record_fts_surface_state_sync(
+        conn,
+        surface=surface,
+        state=READY if ready else STALE,
+        source_rows=source_rows,
+        indexed_rows=indexed_rows,
+        detail=None if ready else f"{surface} count/trigger check failed after repair",
+    )
+    return ready
+
+
+def _freshness_state(conn: sqlite3.Connection, surface: str) -> str | None:
+    if not _table_exists(conn, "fts_freshness_state"):
+        return None
+    row = conn.execute("SELECT state FROM fts_freshness_state WHERE surface=?", (surface,)).fetchone()
+    return None if row is None else str(row[0])
+
+
+def _ready_freshness_marker(conn: sqlite3.Connection, surface: str, triggers: tuple[str, ...]) -> bool:
+    return _freshness_state(conn, surface) == READY and _triggers_present_sync(conn, triggers)
+
+
+def repair_stale_fts_rows(conn: sqlite3.Connection) -> DanglingFtsRepairOutcome:
+    """Repair only stale/unknown FTS surfaces when durable freshness is usable."""
+    message_ready = _ready_freshness_marker(
+        conn,
+        "messages_fts",
+        _message_trigger_names(content_blocks_exists=_table_exists(conn, "content_blocks")),
+    )
+    action_ready = not _table_exists(conn, "action_events") or _ready_freshness_marker(
+        conn,
+        "action_events_fts",
+        ("action_events_fts_ai", "action_events_fts_ad", "action_events_fts_au"),
+    )
+    if not (message_ready and action_ready):
+        return repair_missing_fts_rows(conn)
+
+    inserted_work_events, source_work_events, after_work_events, _excess_work_events = (
+        _repair_session_work_events_fts_rows_sync(conn)
+    )
+    inserted_threads, source_threads, after_threads, _excess_threads = _repair_work_threads_fts_rows_sync(conn)
+    work_event_ready = _record_optional_derived_surface(
+        conn,
+        surface="session_work_events_fts",
+        source_rows=source_work_events,
+        indexed_rows=after_work_events,
+        triggers=("session_work_events_fts_ai", "session_work_events_fts_ad", "session_work_events_fts_au"),
+    )
+    thread_ready = _record_optional_derived_surface(
+        conn,
+        surface="work_threads_fts",
+        source_rows=source_threads,
+        indexed_rows=after_threads,
+        triggers=("work_threads_fts_ai", "work_threads_fts_ad", "work_threads_fts_au"),
+    )
+    return DanglingFtsRepairOutcome(
+        repaired_count=inserted_work_events + inserted_threads,
+        success=work_event_ready and thread_ready,
+        detail=(
+            "FTS sync: repaired stale derived surfaces "
+            f"({after_work_events:,}/{source_work_events:,} work events, {after_threads:,}/{source_threads:,} threads)"
+        ),
+    )
+
+
 def repair_missing_fts_rows(conn: sqlite3.Connection) -> DanglingFtsRepairOutcome:
     """Repair missing message/action FTS rows without full invariant snapshots."""
     before_messages = int(conn.execute(FTS_INDEX_DOC_COUNT_SQL).fetchone()[0] or 0)
-    source_messages = int(conn.execute(FTS_INDEXABLE_MESSAGE_COUNT_SQL).fetchone()[0] or 0)
+    source_messages_sql = (
+        FTS_INDEXABLE_MESSAGE_COUNT_SQL
+        if _table_exists(conn, "content_blocks")
+        else "SELECT COUNT(*) FROM messages WHERE NULLIF(text, '') IS NOT NULL"
+    )
+    source_messages = int(conn.execute(source_messages_sql).fetchone()[0] or 0)
     action_table_exists = _table_exists(conn, "action_events")
     before_actions = int(conn.execute(ACTION_FTS_INDEX_DOC_COUNT_SQL).fetchone()[0] or 0) if action_table_exists else 0
     source_actions = (
@@ -118,6 +261,10 @@ def repair_missing_fts_rows(conn: sqlite3.Connection) -> DanglingFtsRepairOutcom
 
     inserted_messages = insert_missing_message_fts_rows_sync(conn)
     inserted_actions = insert_missing_action_fts_rows_sync(conn)
+    inserted_work_events, source_work_events, after_work_events, _excess_work_events = (
+        _repair_session_work_events_fts_rows_sync(conn)
+    )
+    inserted_threads, source_threads, after_threads, _excess_threads = _repair_work_threads_fts_rows_sync(conn)
     after_messages = int(conn.execute(FTS_INDEX_DOC_COUNT_SQL).fetchone()[0] or 0)
     after_actions = int(conn.execute(ACTION_FTS_INDEX_DOC_COUNT_SQL).fetchone()[0] or 0) if action_table_exists else 0
     message_ready = after_messages == source_messages and _triggers_present_sync(
@@ -146,13 +293,28 @@ def repair_missing_fts_rows(conn: sqlite3.Connection) -> DanglingFtsRepairOutcom
             indexed_rows=after_actions,
             detail=None if action_ready else "action-event FTS count/trigger check failed after repair",
         )
+    work_event_ready = _record_optional_derived_surface(
+        conn,
+        surface="session_work_events_fts",
+        source_rows=source_work_events,
+        indexed_rows=after_work_events,
+        triggers=("session_work_events_fts_ai", "session_work_events_fts_ad", "session_work_events_fts_au"),
+    )
+    thread_ready = _record_optional_derived_surface(
+        conn,
+        surface="work_threads_fts",
+        source_rows=source_threads,
+        indexed_rows=after_threads,
+        triggers=("work_threads_fts_ai", "work_threads_fts_ad", "work_threads_fts_au"),
+    )
 
     return DanglingFtsRepairOutcome(
-        repaired_count=inserted_messages + inserted_actions,
-        success=message_ready and action_ready,
+        repaired_count=inserted_messages + inserted_actions + inserted_work_events + inserted_threads,
+        success=message_ready and action_ready and work_event_ready and thread_ready,
         detail=(
             "FTS sync: repaired index "
-            f"({after_messages:,}/{source_messages:,} messages, {after_actions:,}/{source_actions:,} actions)"
+            f"({after_messages:,}/{source_messages:,} messages, {after_actions:,}/{source_actions:,} actions, "
+            f"{after_work_events:,}/{source_work_events:,} work events, {after_threads:,}/{source_threads:,} threads)"
         ),
     )
 
@@ -165,4 +327,5 @@ __all__ = [
     "insert_missing_action_fts_rows_sync",
     "insert_missing_message_fts_rows_sync",
     "repair_missing_fts_rows",
+    "repair_stale_fts_rows",
 ]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -6,7 +6,8 @@ import sqlite3
 import threading
 from datetime import timedelta
 from pathlib import Path
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,11 @@ from polylogue.daemon.convergence import ConvergenceStage
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.cursor import CursorStore
 from tests.infra.frozen_clock import FrozenClock
+
+
+def _record_successful_repair(fake_conn: object, repairs: list[Any]) -> SimpleNamespace:
+    repairs.append(fake_conn)
+    return SimpleNamespace(success=True, repaired_count=0, detail="FTS index in sync")
 
 
 def test_polylogued_help_lists_watch_command() -> None:
@@ -262,7 +268,7 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
-def test_ensure_fts_startup_readiness_records_exact_invariant(
+def test_ensure_fts_startup_readiness_runs_bounded_repair(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -329,33 +335,32 @@ def test_ensure_fts_startup_readiness_records_exact_invariant(
     def ensure(fake_conn: FakeConnection) -> None:
         ensured.append(fake_conn)
 
-    class FakeSnapshot:
-        ready = True
-
-    snapshot = FakeSnapshot()
-    recorded: list[FakeSnapshot] = []
+    repairs: list[FakeConnection] = []
 
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", ensure)
-    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync", lambda fake_conn: snapshot)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
     monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync",
-        lambda fake_conn, fake_snapshot: recorded.append(fake_snapshot),
+        "polylogue.storage.fts.dangling_repair.configure_bounded_repair_connection",
+        lambda fake_conn: None,
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair.repair_stale_fts_rows",
+        lambda fake_conn: _record_successful_repair(fake_conn, repairs),
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
     assert ensured == [conn]
     assert rebuilds == []
-    assert recorded == [snapshot]
+    assert repairs == [conn]
     assert conn.committed is True
     assert conn.closed is True
 
 
-def test_ensure_fts_startup_readiness_rebuilds_stale_invariant(
+def test_ensure_fts_startup_readiness_rebuilds_when_bounded_repair_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -418,22 +423,23 @@ def test_ensure_fts_startup_readiness_rebuilds_stale_invariant(
     def rebuild(fake_conn: FakeConnection) -> None:
         rebuilds.append(fake_conn)
 
-    class FakeSnapshot:
-        ready = False
-
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
-    monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync",
-        lambda fake_conn: FakeSnapshot(),
-    )
     monkeypatch.setattr(
         "polylogue.storage.fts.fts_lifecycle.restore_fts_triggers_sync",
         lambda fake_conn: restored.append(fake_conn),
     )
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair.configure_bounded_repair_connection",
+        lambda fake_conn: None,
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair.repair_stale_fts_rows",
+        lambda fake_conn: SimpleNamespace(success=False, repaired_count=1, detail="excess rows"),
+    )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
@@ -482,8 +488,8 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
                     else FakeCursor(None)
                 )
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
-                # One missing trigger must send startup through restore+rebuild
-                # before ensure_fts_index_sync can hide the drift evidence.
+                # One missing trigger must send startup through trigger restore
+                # before bounded repair can mark the FTS surfaces fresh.
                 triggers: list[tuple[object, ...]] = [
                     ("messages_fts_ai",),
                     ("messages_fts_ad",),
@@ -522,13 +528,18 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
 
     monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
     monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync", lambda fake_conn, fake_snapshot: None
+        "polylogue.storage.fts.dangling_repair.configure_bounded_repair_connection",
+        lambda fake_conn: None,
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair.repair_missing_fts_rows",
+        lambda fake_conn: SimpleNamespace(success=True, repaired_count=3, detail="repaired"),
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
     assert restored == [conn]
-    assert rebuilds == [conn]
+    assert rebuilds == []
     assert conn.committed is True
     assert conn.closed is True
 

--- a/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
+++ b/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
@@ -1,0 +1,113 @@
+"""Resource-boundary tests for ingest worker handoff."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+import pytest
+
+import polylogue.pipeline.services.ingest_batch._core as ingest_batch_core
+from polylogue.pipeline.services.ingest_batch import _IngestWorkerRequest, _iter_ingest_results_sync
+from polylogue.pipeline.services.ingest_worker import IngestRecordResult
+from polylogue.storage.runtime import RawConversationRecord
+
+
+def _large_raw_record() -> RawConversationRecord:
+    return RawConversationRecord(
+        raw_id="raw-large",
+        provider_name="codex",
+        source_path="/tmp/raw-large.jsonl",
+        blob_size=150 * 1024 * 1024,
+        acquired_at="2026-04-02T00:00:00Z",
+    )
+
+
+def _worker_request() -> _IngestWorkerRequest:
+    return _IngestWorkerRequest(
+        archive_root_str="/tmp/archive",
+        blob_root_str="/tmp/blob-store",
+        validation_mode="strict",
+        measure_ingest_result_size=False,
+    )
+
+
+def test_iter_ingest_results_sync_can_isolate_single_worker_in_process_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_artifacts = [_large_raw_record()]
+    submitted: list[str] = []
+
+    class FakeExecutor:
+        def __enter__(self) -> FakeExecutor:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def submit(
+            self,
+            fn: object,
+            raw_record: RawConversationRecord,
+            request: _IngestWorkerRequest,
+        ) -> Future[IngestRecordResult]:
+            del fn, request
+            submitted.append(raw_record.raw_id)
+            future: Future[IngestRecordResult] = Future()
+            future.set_result(IngestRecordResult(raw_id=raw_record.raw_id))
+            return future
+
+    def fake_process_pool_executor(*, max_workers: int) -> FakeExecutor:
+        assert max_workers == 1
+        return FakeExecutor()
+
+    monkeypatch.setattr(ingest_batch_core, "process_pool_executor", fake_process_pool_executor)
+
+    results = list(
+        _iter_ingest_results_sync(
+            raw_artifacts,
+            request=_worker_request(),
+            worker_count=1,
+            force_process_pool=True,
+        )
+    )
+
+    assert submitted == ["raw-large"]
+    assert [result.raw_id for result in results] == ["raw-large"]
+
+
+def test_consume_ingest_results_delays_write_transaction_until_parse_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql: str) -> object:
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return None
+
+    def fake_iter(*args: object, **kwargs: object) -> list[IngestRecordResult]:
+        del args, kwargs
+        events.append("parse-drained")
+        return [IngestRecordResult(raw_id="raw-large")]
+
+    def fake_drain(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        events.append("drain")
+
+    monkeypatch.setattr(ingest_batch_core, "_iter_ingest_results_sync", fake_iter)
+    monkeypatch.setattr(ingest_batch_core, "_drain_ingest_result", fake_drain)
+
+    summary = SimpleNamespace(result_wait_s=0.0, teardown_elapsed_s=0.0, worker_count=1)
+    transaction_started = ingest_batch_core._consume_ingest_results(
+        FakeConnection(),  # type: ignore[arg-type]
+        [_large_raw_record()],
+        worker_request=_worker_request(),
+        summary=summary,  # type: ignore[arg-type]
+        materialized_ids=set(),
+        pending_by_parent={},
+    )
+
+    assert transaction_started is True
+    assert events == ["parse-drained", "begin", "drain"]

--- a/tests/unit/storage/test_dangling_fts_derived_surfaces.py
+++ b/tests/unit/storage/test_dangling_fts_derived_surfaces.py
@@ -1,0 +1,100 @@
+"""Bounded FTS repair covers derived insight search surfaces."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.fts.dangling_repair import repair_missing_fts_rows, repair_stale_fts_rows
+from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
+
+
+def test_repair_missing_fts_rows_marks_derived_surfaces_ready(tmp_path: Path) -> None:
+    db = tmp_path / "archive.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE messages (message_id TEXT, conversation_id TEXT, text TEXT);
+            CREATE VIRTUAL TABLE messages_fts USING fts5(message_id UNINDEXED, conversation_id UNINDEXED, text);
+            CREATE TABLE action_events (event_id TEXT, message_id TEXT, conversation_id TEXT, action_kind TEXT,
+                normalized_tool_name TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE action_events_fts USING fts5(event_id UNINDEXED, message_id UNINDEXED,
+                conversation_id UNINDEXED, action_kind UNINDEXED, normalized_tool_name UNINDEXED, search_text);
+            CREATE TABLE session_work_events (event_id TEXT PRIMARY KEY, conversation_id TEXT, provider_name TEXT,
+                kind TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE session_work_events_fts USING fts5(event_id UNINDEXED, conversation_id UNINDEXED,
+                provider_name UNINDEXED, kind UNINDEXED, text);
+            CREATE TABLE work_threads (thread_id TEXT PRIMARY KEY, root_id TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE work_threads_fts USING fts5(thread_id UNINDEXED, root_id UNINDEXED, text);
+            INSERT INTO session_work_events VALUES ('event-1', 'conv-1', 'codex', 'decision', 'ship it');
+            INSERT INTO work_threads VALUES ('thread-1', 'conv-1', 'startup fts repair');
+            """
+        )
+        restore_fts_triggers_sync(conn)
+        outcome = repair_missing_fts_rows(conn)
+        states = dict(conn.execute("SELECT surface, state FROM fts_freshness_state").fetchall())
+        work_events = conn.execute("SELECT COUNT(*) FROM session_work_events_fts_docsize").fetchone()[0]
+        threads = conn.execute("SELECT COUNT(*) FROM work_threads_fts_docsize").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert outcome.success is True
+    assert work_events == 1
+    assert threads == 1
+    assert states["session_work_events_fts"] == "ready"
+    assert states["work_threads_fts"] == "ready"
+
+
+def test_repair_stale_fts_rows_skips_ready_archive_surfaces(tmp_path: Path) -> None:
+    db = tmp_path / "archive.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE messages (message_id TEXT, conversation_id TEXT, text TEXT);
+            CREATE VIRTUAL TABLE messages_fts USING fts5(message_id UNINDEXED, conversation_id UNINDEXED, text);
+            CREATE TABLE action_events (event_id TEXT, message_id TEXT, conversation_id TEXT, action_kind TEXT,
+                normalized_tool_name TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE action_events_fts USING fts5(event_id UNINDEXED, message_id UNINDEXED,
+                conversation_id UNINDEXED, action_kind UNINDEXED, normalized_tool_name UNINDEXED, search_text);
+            CREATE TABLE session_work_events (event_id TEXT PRIMARY KEY, conversation_id TEXT, provider_name TEXT,
+                kind TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE session_work_events_fts USING fts5(event_id UNINDEXED, conversation_id UNINDEXED,
+                provider_name UNINDEXED, kind UNINDEXED, text);
+            CREATE TABLE work_threads (thread_id TEXT PRIMARY KEY, root_id TEXT, search_text TEXT);
+            CREATE VIRTUAL TABLE work_threads_fts USING fts5(thread_id UNINDEXED, root_id UNINDEXED, text);
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY, state TEXT NOT NULL, checked_at TEXT NOT NULL,
+                source_rows INTEGER NOT NULL DEFAULT 0, indexed_rows INTEGER NOT NULL DEFAULT 0,
+                missing_rows INTEGER NOT NULL DEFAULT 0, excess_rows INTEGER NOT NULL DEFAULT 0,
+                duplicate_rows INTEGER NOT NULL DEFAULT 0, detail TEXT
+            );
+            INSERT INTO fts_freshness_state (surface, state, checked_at, source_rows, indexed_rows, detail)
+            VALUES ('messages_fts', 'ready', 'now', 0, 0, NULL);
+            INSERT INTO fts_freshness_state (surface, state, checked_at, source_rows, indexed_rows, detail)
+            VALUES ('action_events_fts', 'ready', 'now', 0, 0, NULL);
+            INSERT INTO fts_freshness_state (surface, state, checked_at, source_rows, indexed_rows, detail)
+            VALUES ('session_work_events_fts', 'stale', 'now', 0, 0, 'old');
+            INSERT INTO fts_freshness_state (surface, state, checked_at, source_rows, indexed_rows, detail)
+            VALUES ('work_threads_fts', 'stale', 'now', 0, 0, 'old');
+            INSERT INTO session_work_events VALUES ('event-1', 'conv-1', 'codex', 'decision', 'ship it');
+            INSERT INTO work_threads VALUES ('thread-1', 'conv-1', 'startup fts repair');
+            """
+        )
+        restore_fts_triggers_sync(conn)
+        conn.execute(
+            "UPDATE fts_freshness_state SET state='ready' WHERE surface IN ('messages_fts', 'action_events_fts')"
+        )
+        outcome = repair_stale_fts_rows(conn)
+        states = dict(conn.execute("SELECT surface, state FROM fts_freshness_state").fetchall())
+    finally:
+        conn.close()
+
+    assert outcome.success is True
+    assert states == {
+        "messages_fts": "ready",
+        "action_events_fts": "ready",
+        "session_work_events_fts": "ready",
+        "work_threads_fts": "ready",
+    }

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -371,6 +371,18 @@ def test_repair_dangling_fts_uses_targeted_missing_row_repair(monkeypatch: pytes
         "polylogue.storage.fts.dangling_repair.insert_missing_action_fts_rows_sync",
         repair_actions,
     )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair._repair_session_work_events_fts_rows_sync",
+        lambda _conn: (0, 0, 0, 0),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair._repair_work_threads_fts_rows_sync",
+        lambda _conn: (0, 0, 0, 0),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.dangling_repair._record_optional_derived_surface",
+        lambda _conn, **_kwargs: True,
+    )
     monkeypatch.setattr("polylogue.storage.fts.dangling_repair._triggers_present_sync", lambda _conn, _names: True)
     monkeypatch.setattr(
         "polylogue.storage.fts.dangling_repair.record_fts_surface_state_sync",


### PR DESCRIPTION
## Summary

Bounds daemon startup FTS maintenance and live ingest memory pressure without reducing convergence scope. HTTP/API surfaces now bind before startup FTS repair runs, startup repair uses freshness-aware bounded repair where possible, derived insight FTS surfaces participate in readiness, and full live ingest parse work is isolated in a worker process even with a single worker.

## Problem

A live `polylogued.service` restart after #1504 produced severe host pressure: systemd reported a 6.4 GB service memory peak, but `/proc/<pid>/status` and cgroup `memory.stat` showed the current process RSS was much smaller and the excess was largely file-backed/inactive SQLite cache. That does not prove a Python heap leak, but it does show the daemon can make the host unfriendly by faulting multi-GB archive pages during startup/catch-up. The same live pass exposed an old stale `live_ingest_attempt` stuck in `running/full_worker_wait`, daemon HTTP ports not binding while startup SQLite maintenance ran, and stale derived FTS surfaces despite archive message/action FTS being marked ready.

Closes #1505.

## Solution

- Move daemon startup FTS readiness into a background maintenance task after HTTP/API surfaces are bound, and run the synchronous SQLite work via `asyncio.to_thread`.
- Replace normal startup exact archive invariant scans with bounded freshness-aware repair. Trigger recovery still restores triggers and repairs missing rows, escalating to a full rebuild only when bounded repair cannot establish readiness.
- Extend FTS repair/readiness to `session_work_events_fts` and `work_threads_fts`, while preserving the existing message/action archive freshness markers.
- Force live full ingest to use a process pool even when `worker_count=1`, so large parse heaps die with the worker process instead of accumulating in the long-lived daemon.
- Delay `BEGIN IMMEDIATE` until the first parsed ingest result is ready, so CPU parse waits no longer hold SQLite's write lock.

## Verification

- `pytest tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_batch_resource_bounds.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_watcher.py tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_dangling_fts_derived_surfaces.py tests/unit/storage/test_repair.py::test_repair_dangling_fts_uses_targeted_missing_row_repair -q` → `133 passed in 14.33s`
- `devtools verify --quick` → `exit_code: 0`, `total_duration_s: 34.57`
- push hook `devtools verify --quick` → `exit_code: 0`, `total_duration_s: 40.74`
- live patched-daemon smoke before this PR: daemon bound `/metrics`, `/healthz/live`, and `/api/status` promptly, marked the stale `full_worker_wait` attempt abandoned, and reported live RSS around 284 MiB while catch-up discovered remaining work
- live archive repair after this change: `repair_stale_fts_rows` marked `messages_fts`, `action_events_fts`, `session_work_events_fts`, and `work_threads_fts` ready with matching source/indexed counts
