### PR TITLE
fix(ingest): bound targeted FTS repair memory

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -288,17 +288,6 @@ def _resolved_conversation_tuple(
     )
 
 
-def _parent_ready(
-    conn: sqlite3.Connection,
-    cdata: ConversationData,
-    materialized_ids: set[str],
-) -> bool:
-    parent_id = _conversation_parent_id(cdata)
-    if parent_id is None or parent_id == cdata.conversation_id:
-        return True
-    return parent_id in materialized_ids or _conversation_exists(conn, parent_id)
-
-
 def _conversation_tuple_with_hash(conversation: ConversationTuple, content_hash: str) -> ConversationTuple:
     return (
         conversation[0],
@@ -712,43 +701,14 @@ def _drain_ready_conversation_entries(
     *,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
-    pending_by_parent: dict[str, list[_ConversationEntry]],
     force_write: bool = False,
 ) -> None:
-    stack = list(reversed(ready_entries))
-    while stack:
-        raw_id, cdata = stack.pop()
-        if not _parent_ready(conn, cdata, materialized_ids):
-            parent_id = _conversation_parent_id(cdata)
-            if parent_id is not None:
-                pending_by_parent.setdefault(parent_id, []).append((raw_id, cdata))
-            continue
+    for raw_id, cdata in _topo_sort_conversation_entries(ready_entries):
         wrote = _write_conversation_entry(conn, raw_id, cdata, summary=summary, force_write=force_write)
         discard_conversation_data_payload(cdata)
         if not wrote:
             continue
         materialized_ids.add(cdata.conversation_id)
-        children = pending_by_parent.pop(cdata.conversation_id, [])
-        if children:
-            stack.extend(reversed(children))
-
-
-def _flush_pending_conversation_entries(
-    conn: sqlite3.Connection,
-    pending_by_parent: dict[str, list[_ConversationEntry]],
-    *,
-    summary: _IngestBatchSummary,
-    materialized_ids: set[str],
-) -> None:
-    remaining = [entry for entries in pending_by_parent.values() for entry in entries]
-    if not remaining:
-        return
-    pending_by_parent.clear()
-    for raw_id, cdata in _topo_sort_conversation_entries(remaining):
-        wrote = _write_conversation_entry(conn, raw_id, cdata, summary=summary)
-        discard_conversation_data_payload(cdata)
-        if wrote:
-            materialized_ids.add(cdata.conversation_id)
 
 
 def _run_ingest_record(
@@ -941,7 +901,6 @@ def _drain_ingest_result(
     *,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
-    pending_by_parent: dict[str, list[_ConversationEntry]],
     force_write: bool = False,
 ) -> None:
     _record_outcome(summary, ir)
@@ -955,18 +914,16 @@ def _drain_ingest_result(
         summary.skipped_raw_ids.add(ir.raw_id)
         return
 
-    for cdata in ir.conversations:
-        drain_started = time.perf_counter()
-        _drain_ready_conversation_entries(
-            conn,
-            [(ir.raw_id, cdata)],
-            summary=summary,
-            materialized_ids=materialized_ids,
-            pending_by_parent=pending_by_parent,
-            force_write=force_write,
-        )
-        summary.drain_elapsed_s += time.perf_counter() - drain_started
-        _observe_current_rss(summary)
+    drain_started = time.perf_counter()
+    _drain_ready_conversation_entries(
+        conn,
+        [(ir.raw_id, cdata) for cdata in ir.conversations],
+        summary=summary,
+        materialized_ids=materialized_ids,
+        force_write=force_write,
+    )
+    summary.drain_elapsed_s += time.perf_counter() - drain_started
+    _observe_current_rss(summary)
 
 
 def _consume_ingest_results(
@@ -976,7 +933,6 @@ def _consume_ingest_results(
     worker_request: _IngestWorkerRequest,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
-    pending_by_parent: dict[str, list[_ConversationEntry]],
     force_write: bool = False,
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
@@ -1018,7 +974,6 @@ def _consume_ingest_results(
                 ir,
                 summary=summary,
                 materialized_ids=materialized_ids,
-                pending_by_parent=pending_by_parent,
                 force_write=force_write,
             )
         finally:
@@ -1033,10 +988,8 @@ def _flush_ingest_results(
     conn: sqlite3.Connection,
     *,
     summary: _IngestBatchSummary,
-    materialized_ids: set[str],
-    pending_by_parent: dict[str, list[_ConversationEntry]],
 ) -> None:
-    """Flush pending conversation entries without committing.
+    """Record final drain timing before committing.
 
     The commit + FTS trigger restore + FTS repair are deliberately
     deferred to ``_commit_sync_ingest_side_effects`` so they land as a
@@ -1046,12 +999,6 @@ def _flush_ingest_results(
     committed and the FTS index drifted silently.
     """
     flush_started = time.perf_counter()
-    _flush_pending_conversation_entries(
-        conn,
-        pending_by_parent,
-        summary=summary,
-        materialized_ids=materialized_ids,
-    )
     summary.flush_elapsed_s = time.perf_counter() - flush_started
     _observe_current_rss(summary)
 
@@ -1109,7 +1056,6 @@ def _process_ingest_batch_sync(
     summary.setup_elapsed_s = time.perf_counter() - setup_started
     heavy_batch = summary.total_blob_mb >= INGEST_RELEASE_BLOB_MB_THRESHOLD
     materialized_ids: set[str] = set()
-    pending_by_parent: dict[str, list[_ConversationEntry]] = {}
     _observe_current_rss(summary)
     transaction_started = False
     try:
@@ -1119,7 +1065,6 @@ def _process_ingest_batch_sync(
             worker_request=worker_request,
             summary=summary,
             materialized_ids=materialized_ids,
-            pending_by_parent=pending_by_parent,
             force_write=force_write,
             heartbeat=heartbeat,
             progress=progress,
@@ -1130,8 +1075,6 @@ def _process_ingest_batch_sync(
         _flush_ingest_results(
             conn,
             summary=summary,
-            materialized_ids=materialized_ids,
-            pending_by_parent=pending_by_parent,
         )
         if transaction_started:
             fts_repair_ids = set(summary.fts_repair_conversation_ids)

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -83,36 +83,53 @@ def delete_conversation_rows_sql(chunk_size: int) -> str:
 
 
 def insert_conversation_rows_sql(chunk_size: int) -> str:
-    placeholders = ", ".join("?" for _ in range(chunk_size))
+    values = ", ".join("(?)" for _ in range(chunk_size))
     return f"""
-        INSERT INTO messages_fts (rowid, message_id, conversation_id, text)
-        SELECT m.rowid, m.message_id, m.conversation_id, parts.search_text
-        FROM messages AS m
-        JOIN (
+        WITH target_conversations(conversation_id) AS (
+            VALUES {values}
+        ),
+        message_parts AS (
+            SELECT m.message_id, m.text AS part, -1 AS block_index, 0 AS part_index
+            FROM messages AS m
+            JOIN target_conversations AS target
+              ON target.conversation_id = m.conversation_id
+            WHERE m.text IS NOT NULL AND m.text != ''
+            UNION ALL
+            SELECT cb.message_id, cb.text AS part, cb.block_index, 1 AS part_index
+            FROM content_blocks AS cb
+            JOIN target_conversations AS target
+              ON target.conversation_id = cb.conversation_id
+            WHERE cb.text IS NOT NULL AND cb.text != ''
+            UNION ALL
+            SELECT cb.message_id, cb.tool_input AS part, cb.block_index, 2 AS part_index
+            FROM content_blocks AS cb
+            JOIN target_conversations AS target
+              ON target.conversation_id = cb.conversation_id
+            WHERE cb.tool_input IS NOT NULL AND cb.tool_input != ''
+            UNION ALL
+            SELECT cb.message_id, cb.metadata AS part, cb.block_index, 3 AS part_index
+            FROM content_blocks AS cb
+            JOIN target_conversations AS target
+              ON target.conversation_id = cb.conversation_id
+            WHERE cb.metadata IS NOT NULL AND cb.metadata != ''
+        ),
+        grouped_parts AS (
             SELECT
-                source.message_id,
-                group_concat(source.part, char(10)) AS search_text
+                message_parts.message_id,
+                group_concat(message_parts.part, char(10)) AS search_text
             FROM (
-                SELECT message_id, text AS part, -1 AS block_index, 0 AS part_index
-                FROM messages
-                WHERE text IS NOT NULL AND text != ''
-                UNION ALL
-                SELECT message_id, text AS part, block_index, 1 AS part_index
-                FROM content_blocks
-                WHERE text IS NOT NULL AND text != ''
-                UNION ALL
-                SELECT message_id, tool_input AS part, block_index, 2 AS part_index
-                FROM content_blocks
-                WHERE tool_input IS NOT NULL AND tool_input != ''
-                UNION ALL
-                SELECT message_id, metadata AS part, block_index, 3 AS part_index
-                FROM content_blocks
-                WHERE metadata IS NOT NULL AND metadata != ''
-                ORDER BY 1, 3, 4
-            ) AS source
-            GROUP BY source.message_id
-        ) AS parts ON parts.message_id = m.message_id
-        WHERE m.conversation_id IN ({placeholders})
+                SELECT message_id, part, block_index, part_index
+                FROM message_parts
+                ORDER BY message_id, block_index, part_index
+            ) AS message_parts
+            GROUP BY message_parts.message_id
+        )
+        INSERT INTO messages_fts (rowid, message_id, conversation_id, text)
+        SELECT m.rowid, m.message_id, m.conversation_id, grouped_parts.search_text
+        FROM messages AS m
+        JOIN target_conversations AS target
+          ON target.conversation_id = m.conversation_id
+        JOIN grouped_parts ON grouped_parts.message_id = m.message_id
     """
 
 

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1099,7 +1099,44 @@ def test_select_ingest_worker_count_respects_limit(monkeypatch: pytest.MonkeyPat
     assert worker_count == 4
 
 
-def test_drain_ready_conversation_entries_preserves_late_parent_fk(tmp_path: Path) -> None:
+def test_drain_ready_conversation_entries_writes_missing_parent_without_buffering(tmp_path: Path) -> None:
+    with open_connection(tmp_path / "ingest.db") as conn:
+        c_msg = _message_tuple(
+            "msg-c",
+            "codex:child",
+            role="user",
+            text="child",
+            content_hash="hash-c",
+            sort_key=1.0,
+        )
+        child = _conversation_data(
+            "codex:child",
+            content_hash="hash-child",
+            parent_conversation_id="codex:parent",
+            message_tuples=[c_msg],
+        )
+
+        summary = _IngestBatchSummary()
+        materialized_ids: set[str] = set()
+
+        _drain_ready_conversation_entries(
+            conn,
+            [("raw-child", child)],
+            summary=summary,
+            materialized_ids=materialized_ids,
+        )
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT parent_conversation_id FROM conversations WHERE conversation_id = ?",
+            ("codex:child",),
+        ).fetchone()
+        assert row is not None
+        assert row["parent_conversation_id"] is None
+        assert child.message_tuples == []
+
+
+def test_drain_ready_conversation_entries_preserves_same_result_parent_fk(tmp_path: Path) -> None:
     with open_connection(tmp_path / "ingest.db") as conn:
         p_msg = _message_tuple(
             "msg-p",
@@ -1129,25 +1166,11 @@ def test_drain_ready_conversation_entries_preserves_late_parent_fk(tmp_path: Pat
             message_tuples=[c_msg],
         )
 
-        summary = _IngestBatchSummary()
-        materialized_ids: set[str] = set()
-        pending_by_parent: dict[str, list[tuple[str, ConversationData]]] = {}
-
         _drain_ready_conversation_entries(
             conn,
-            [("raw-child", child)],
-            summary=summary,
-            materialized_ids=materialized_ids,
-            pending_by_parent=pending_by_parent,
-        )
-        assert list(pending_by_parent) == ["codex:parent"]
-
-        _drain_ready_conversation_entries(
-            conn,
-            [("raw-parent", parent)],
-            summary=summary,
-            materialized_ids=materialized_ids,
-            pending_by_parent=pending_by_parent,
+            [("raw-child", child), ("raw-parent", parent)],
+            summary=_IngestBatchSummary(),
+            materialized_ids=set(),
         )
         conn.commit()
 

--- a/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
+++ b/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
@@ -38,6 +38,26 @@ def _conversation_data_with_rows(*, conversation_id: str = "conv-large", message
         ConversationData,
         SimpleNamespace(
             conversation_id=conversation_id,
+            conversation_tuple=(
+                conversation_id,
+                "codex",
+                conversation_id,
+                "Large",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                "[]",
+                None,
+                "hash-large",
+                "raw-large",
+                "codex",
+                None,
+                None,
+                None,
+            ),
             message_tuples=[object()] * messages,
             block_tuples=[],
             action_event_tuples=[],
@@ -122,7 +142,6 @@ def test_consume_ingest_results_delays_write_transaction_until_parse_result(
         worker_request=_worker_request(),
         summary=summary,  # type: ignore[arg-type]
         materialized_ids=set(),
-        pending_by_parent={},
     )
 
     assert transaction_started is True
@@ -158,7 +177,6 @@ def test_consume_ingest_results_releases_large_result_payload(
         worker_request=_worker_request(),
         summary=summary,  # type: ignore[arg-type]
         materialized_ids=set(),
-        pending_by_parent={},
     )
 
     assert transaction_started is True
@@ -173,8 +191,6 @@ def test_drain_ready_conversation_entries_drops_written_payload(
     cdata = _conversation_data_with_rows(messages=3)
     writes: list[int] = []
 
-    monkeypatch.setattr(ingest_batch_core, "_parent_ready", lambda *args, **kwargs: True)
-
     def fake_write(*args: object, **kwargs: object) -> bool:
         del args, kwargs
         writes.append(len(cdata.message_tuples))
@@ -187,7 +203,6 @@ def test_drain_ready_conversation_entries_drops_written_payload(
         [("raw-large", cdata)],
         summary=SimpleNamespace(),  # type: ignore[arg-type]
         materialized_ids=set(),
-        pending_by_parent={},
     )
 
     assert writes == [3]


### PR DESCRIPTION
## Summary

Bounds live ingest memory in the remaining spike path by making targeted message FTS repair actually target only the changed conversations, and by removing the obsolete unresolved-parent ingest buffer that retained full parsed payloads until batch flush.

## Problem

After #1508, deployed `polylogued` still reached about 4.0 GiB RSS / 3.0 GiB anonymous memory during the first live catch-up chunk. A branch smoke showed the parent still climbing past 3 GiB RSS / 2 GiB anonymous by roughly 60 seconds. `py-spy` caught the main loop idle while an executor thread was inside `_repair_changed_conversation_fts -> repair_message_fts_index_sync`.

The root SQL problem was `insert_conversation_rows_sql()`: it grouped message/content-block FTS text across the whole archive before applying the target `conversation_id` filter. Every targeted repair could therefore materialize archive-scale text state.

There was also a now-obsolete ingest retention path: `_drain_ready_conversation_entries` buffered missing-parent conversations in `pending_by_parent` even though #1258 topology edges are the durable unresolved-parent record and `_write_conversation` already writes missing external parents with a NULL fast-path FK.

## Solution

`polylogue/storage/fts/sql.py` now builds targeted message FTS repair from a `target_conversations` CTE and joins that CTE before reading `messages` and `content_blocks`.

`polylogue/pipeline/services/ingest_batch/_core.py` no longer retains full `ConversationData` payloads for missing external parents. It topologically sorts conversations present in the same worker result, writes them immediately, and leaves genuinely absent parents to the existing unresolved topology-edge repair model.

## Verification

```text
pytest tests/unit/storage/test_fts*.py tests/unit/storage/test_topology_edges.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_batch_resource_bounds.py -q
147 passed in 3.61s

ruff check polylogue/storage/fts/sql.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_batch_resource_bounds.py
All checks passed!

mypy polylogue/storage/fts/sql.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_ingest_batch_resource_bounds.py
Success: no issues found in 4 source files

devtools verify --quick
exit_code: 0, total_duration_s: 34.75

pre-push devtools verify --quick
exit_code: 0, total_duration_s: 35.84
```

Live smoke against the real archive:

```text
Before SQL fix: parent reached ~3.1 GiB RSS / ~2.1 GiB RssAnon by ~60s in chunk 1.
After SQL fix: parent plateaued around ~786 MiB RSS / ~232 MiB RssAnon through chunk 1, then after chunk 1 completed dropped to ~260 MiB RSS / ~164 MiB RssAnon and progressed into 151 MiB Codex chunks.
```

Closes #1509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized conversation ingestion pipeline processing for improved efficiency.
  * Enhanced full-text search indexing for conversations with streamlined query structure.
  * Updated internal test coverage to reflect refined conversation handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->