### PR TITLE
fix(fts): ignore empty text in repair predicate

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -599,7 +599,7 @@ def _fts_repair_needs_for_conversations(
             WHERE m.conversation_id IN ({placeholders})
               AND d.id IS NULL
               AND (
-                  m.text IS NOT NULL
+                  NULLIF(m.text, '') IS NOT NULL
                   OR EXISTS (
                       SELECT 1
                       FROM content_blocks AS cb

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -17,6 +17,7 @@ from polylogue.daemon.convergence_stages import (
     make_fts_stage,
     make_insights_stage,
 )
+from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
 from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
 from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
@@ -267,6 +268,21 @@ def test_fts_repair_needs_probe_uses_docsize_shadow_tables() -> None:
     assert "LEFT JOIN action_events_fts_docsize" in probe_sql
     assert "LEFT JOIN messages_fts AS" not in probe_sql
     assert "LEFT JOIN action_events_fts AS" not in probe_sql
+
+
+def test_fts_repair_needs_ignores_empty_text_messages(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    with open_connection(db_path) as conn:
+        restore_fts_triggers_sync(conn)
+        store_records(
+            conversation=make_conversation("conv-empty-text", provider_name="codex"),
+            messages=[make_message("msg-empty-text", "conv-empty-text", text="")],
+            attachments=[],
+            conn=conn,
+        )
+        conn.commit()
+
+        assert stages._fts_repair_needs_for_conversations(conn, ["conv-empty-text"]) == stages._FtsRepairNeeds()
 
 
 def test_embed_stage_scopes_changed_conversations_without_asyncio_run(


### PR DESCRIPTION
## Summary

Aligns the daemon FTS convergence repair predicate with the actual FTS indexable-message contract so empty-string messages do not create permanent false-positive repair debt.

## Problem

Live deployment after #1510/#1512 still recorded two retrying FTS convergence debt rows even though direct DB checks showed the affected conversations had zero missing message rows and zero missing action rows. The daemon predicate treated `m.text IS NOT NULL` as indexable, while the FTS insert/readiness contract indexes only non-empty message text or non-empty content-block material.

## Solution

- Change `_fts_repair_needs_for_conversations` to use `NULLIF(m.text, '') IS NOT NULL`.
- Add a regression in `tests/unit/daemon/test_convergence_stages.py` for an empty-string message with no content blocks.

Closes #1513.

## Verification

- `pytest tests/unit/daemon/test_convergence_stages.py::test_fts_repair_needs_ignores_empty_text_messages tests/unit/daemon/test_convergence_stages.py::test_fts_repair_needs_probe_uses_docsize_shadow_tables tests/unit/storage/test_fts_repair_sql.py -q` -> `5 passed in 0.30s`
- `ruff check polylogue/daemon/convergence_stages.py tests/unit/daemon/test_convergence_stages.py` -> `All checks passed!`
- `mypy polylogue/daemon/convergence_stages.py tests/unit/daemon/test_convergence_stages.py` -> `Success: no issues found in 2 source files`
- `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 35.25`
- pre-push `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 34.37`
