### PR TITLE
fix(daemon): treat convergence locks as archive busy

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -33,6 +33,7 @@ from polylogue.daemon.health import (
 from polylogue.daemon.status import daemon_status_payload, format_daemon_status_lines
 from polylogue.logging import configure_logging, get_logger
 from polylogue.sources.live import LiveWatcher, WatchSource
+from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
 from polylogue.sources.live.watcher import default_sources
 from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES as _EXPECTED_FTS_TRIGGERS
 
@@ -312,15 +313,8 @@ async def _periodic_db_optimize() -> None:
             logger.warning("daemon: DB optimize failed", exc_info=True)
 
 
-async def _periodic_convergence_check(
-    sources: tuple[WatchSource, ...],
-) -> None:
-    """Periodically retry derived convergence debt.
-
-    The live ingest path schedules per-source/per-conversation convergence
-    work. This safety net retries recorded debt without doing full-archive
-    scans or global FTS rebuilds from the daemon's idle loop.
-    """
+async def _periodic_convergence_check(sources: tuple[WatchSource, ...]) -> None:
+    """Periodically retry recorded derived convergence debt."""
     from polylogue.paths import db_path
 
     db = db_path()
@@ -332,6 +326,11 @@ async def _periodic_convergence_check(
             repaired = await asyncio.to_thread(_drain_convergence_debt_once, db)
             if repaired:
                 logger.info("convergence: retried %d derived debt item(s)", repaired)
+        except sqlite3.OperationalError as exc:
+            if is_transient_sqlite_lock(exc):
+                logger.info("convergence: archive busy; retrying derived debt on next tick: %s", exc)
+                continue
+            logger.warning("convergence: check failed", exc_info=True)
         except Exception:
             logger.warning("convergence: check failed", exc_info=True)
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -157,6 +157,69 @@ def test_drain_convergence_debt_retries_conversation_subjects_without_source_loo
     assert debt_after == []
 
 
+def test_periodic_convergence_check_treats_sqlite_lock_as_archive_busy(tmp_path: Path) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.touch()
+    sleep_calls = 0
+
+    async def fake_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls > 1:
+            raise asyncio.CancelledError
+
+    async def fake_to_thread(_func: object, *_args: object, **_kwargs: object) -> object:
+        raise sqlite3.OperationalError("database is locked")
+
+    with (
+        patch("polylogue.paths.db_path", return_value=db),
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch.object(daemon_cli.logger, "info") as info,
+        patch.object(daemon_cli.logger, "warning") as warning,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        asyncio.run(daemon_cli._periodic_convergence_check(()))
+
+    info.assert_called_once()
+    assert info.call_args.args[0] == "convergence: archive busy; retrying derived debt on next tick: %s"
+    warning.assert_not_called()
+
+
+def test_periodic_convergence_check_warns_on_non_lock_failures(tmp_path: Path) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.touch()
+    sleep_calls = 0
+
+    async def fake_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls > 1:
+            raise asyncio.CancelledError
+
+    async def fake_to_thread(_func: object, *_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("unexpected convergence retry failure")
+
+    with (
+        patch("polylogue.paths.db_path", return_value=db),
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+        patch.object(daemon_cli.logger, "info") as info,
+        patch.object(daemon_cli.logger, "warning") as warning,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        asyncio.run(daemon_cli._periodic_convergence_check(()))
+
+    info.assert_not_called()
+    warning.assert_called_once()
+    assert warning.call_args.args[0] == "convergence: check failed"
+    assert warning.call_args.kwargs == {"exc_info": True}
+
+
 def test_polylogued_browser_capture_help_lists_service_commands() -> None:
     result = CliRunner().invoke(main, ["browser-capture", "--help"])
 


### PR DESCRIPTION
## Summary

Treat transient SQLite lock/busy errors in the periodic convergence-debt retry loop as an archive-busy tick instead of a failed convergence check.

## Problem

During live catch-up the main ingest path can hold SQLite write locks while processing large Codex sessions. The periodic convergence retry safety net races with that work and has been logging full `convergence: check failed` tracebacks when `CursorStore` setup or convergence-debt bookkeeping hits `sqlite3.OperationalError: database is locked`.

That retry loop is not the primary convergence executor. A transient lock means "try again on the next tick", not "convergence failed".

## Solution

- Reuse the live SQLite lock classifier in `polylogue.daemon.cli`.
- Convert transient periodic convergence lock failures into a concise archive-busy info log.
- Keep non-lock exceptions on the existing warning traceback path.
- Add daemon CLI tests for both branches.

Closes #1517

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py -q` → `21 passed in 0.30s`
- `ruff check polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` → `All checks passed!`
- `mypy polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` → `Success: no issues found in 2 source files`
- `devtools render-all --check` → `OK: /realm/project/polylogue/.cache/site matches sources.`
- `devtools verify --quick` → `exit_code: 0`, `total_duration_s: 34.39`
