### PR TITLE
fix(daemon): report FTS ledger counts

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -815,6 +815,11 @@ def _mark_message_fts_ready_after_targeted_repair(conn: sqlite3.Connection) -> N
     from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_sync
 
     readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
+    freshness_columns = (
+        {str(row[1]) for row in conn.execute("PRAGMA table_info(fts_freshness_state)").fetchall()}
+        if _table_exists(conn, "fts_freshness_state")
+        else set()
+    )
     existing = (
         conn.execute(
             """
@@ -823,7 +828,7 @@ def _mark_message_fts_ready_after_targeted_repair(conn: sqlite3.Connection) -> N
             WHERE surface = 'messages_fts'
             """,
         ).fetchone()
-        if _table_exists(conn, "fts_freshness_state")
+        if {"source_rows", "indexed_rows", "missing_rows", "excess_rows", "duplicate_rows"} <= freshness_columns
         else None
     )
     counts = existing if existing is not None else (0, 0, 0, 0, 0)

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -815,10 +815,27 @@ def _mark_message_fts_ready_after_targeted_repair(conn: sqlite3.Connection) -> N
     from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_sync
 
     readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
+    existing = (
+        conn.execute(
+            """
+            SELECT source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows
+            FROM fts_freshness_state
+            WHERE surface = 'messages_fts'
+            """,
+        ).fetchone()
+        if _table_exists(conn, "fts_freshness_state")
+        else None
+    )
+    counts = existing if existing is not None else (0, 0, 0, 0, 0)
     record_fts_surface_state_sync(
         conn,
         surface="messages_fts",
         state=READY if bool(readiness["ready"]) else STALE,
+        source_rows=int(counts[0] or 0),
+        indexed_rows=int(counts[1] or 0),
+        missing_rows=0 if bool(readiness["ready"]) else int(counts[2] or 0),
+        excess_rows=0 if bool(readiness["ready"]) else int(counts[3] or 0),
+        duplicate_rows=0 if bool(readiness["ready"]) else int(counts[4] or 0),
         detail=(
             "targeted changed-conversation repair complete"
             if bool(readiness["ready"])

--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -91,11 +91,11 @@ def _freshness_rows(conn: sqlite3.Connection) -> dict[str, dict[str, int | str |
         record = dict(zip(selected, row, strict=True))
         records[str(record["surface"])] = {
             "state": str(record["state"]),
-            "source_rows": int(record.get("source_rows") or 0),
-            "indexed_rows": int(record.get("indexed_rows") or 0),
-            "missing_rows": int(record.get("missing_rows") or 0),
-            "excess_rows": int(record.get("excess_rows") or 0),
-            "duplicate_rows": int(record.get("duplicate_rows") or 0),
+            "source_rows": _int_or_zero(record.get("source_rows")),
+            "indexed_rows": _int_or_zero(record.get("indexed_rows")),
+            "missing_rows": _int_or_zero(record.get("missing_rows")),
+            "excess_rows": _int_or_zero(record.get("excess_rows")),
+            "duplicate_rows": _int_or_zero(record.get("duplicate_rows")),
             "detail": None if "detail" not in record or record["detail"] is None else str(record["detail"]),
         }
     return records
@@ -127,9 +127,27 @@ def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool | str
     }
 
 
+def _int_or_zero(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float | str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    if value is None:
+        return 0
+    try:
+        return int(str(value))
+    except ValueError:
+        return 0
+
+
 def _payload_int(surface: dict[str, int | bool | str | None], key: str) -> int:
     value = surface.get(key)
-    return int(value) if isinstance(value, int) and not isinstance(value, bool) else 0
+    return _int_or_zero(value)
 
 
 def _exact_readiness_payload(snapshot: FtsInvariantSnapshot) -> dict[str, object]:

--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -70,18 +70,46 @@ def _triggers_present(conn: sqlite3.Connection, trigger_names: tuple[str, ...]) 
     return all(name in present for name in trigger_names)
 
 
-def _freshness_states(conn: sqlite3.Connection) -> dict[str, str] | None:
+def _freshness_rows(conn: sqlite3.Connection) -> dict[str, dict[str, int | str | None]] | None:
     if not _table_exists(conn, "fts_freshness_state"):
         return None
-    rows = conn.execute("SELECT surface, state FROM fts_freshness_state").fetchall()
-    return {str(row[0]): str(row[1]) for row in rows}
+    columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(fts_freshness_state)").fetchall()}
+    numeric_columns = (
+        "source_rows",
+        "indexed_rows",
+        "missing_rows",
+        "excess_rows",
+        "duplicate_rows",
+    )
+    selected = ["surface", "state"]
+    selected.extend(name for name in numeric_columns if name in columns)
+    if "detail" in columns:
+        selected.append("detail")
+    rows = conn.execute(f"SELECT {', '.join(selected)} FROM fts_freshness_state").fetchall()
+    records: dict[str, dict[str, int | str | None]] = {}
+    for row in rows:
+        record = dict(zip(selected, row, strict=True))
+        records[str(record["surface"])] = {
+            "state": str(record["state"]),
+            "source_rows": int(record.get("source_rows") or 0),
+            "indexed_rows": int(record.get("indexed_rows") or 0),
+            "missing_rows": int(record.get("missing_rows") or 0),
+            "excess_rows": int(record.get("excess_rows") or 0),
+            "duplicate_rows": int(record.get("duplicate_rows") or 0),
+            "detail": None if "detail" not in record or record["detail"] is None else str(record["detail"]),
+        }
+    return records
 
 
-def _freshness_ready(freshness: dict[str, str] | None, surface: str) -> tuple[bool, str | None]:
+def _freshness_record(
+    freshness: dict[str, dict[str, int | str | None]] | None,
+    surface: str,
+) -> tuple[bool, dict[str, int | str | None] | None]:
     if freshness is None:
         return True, None
-    state = freshness.get(surface)
-    return state == "ready", state
+    record = freshness.get(surface)
+    state = None if record is None else record.get("state")
+    return state == "ready", record
 
 
 def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool | str | None]:
@@ -97,6 +125,11 @@ def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool | str
         "ready": surface.ready,
         "exact": True,
     }
+
+
+def _payload_int(surface: dict[str, int | bool | str | None], key: str) -> int:
+    value = surface.get(key)
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 def _exact_readiness_payload(snapshot: FtsInvariantSnapshot) -> dict[str, object]:
@@ -136,27 +169,28 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
         try:
             if exact:
                 return _exact_readiness_payload(fts_invariant_snapshot_sync(conn))
-            freshness = _freshness_states(conn)
+            freshness_records = _freshness_rows(conn)
             surfaces: dict[str, dict[str, int | bool | str | None]] = {}
             for name, source_table, fts_table, triggers in _FTS_SURFACES:
                 source_exists = _table_exists(conn, source_table)
                 exists = _table_exists(conn, fts_table)
                 triggers_present = exists and _triggers_present(conn, triggers)
-                freshness_ready, freshness_state = _freshness_ready(freshness, name)
+                freshness_ready, freshness = _freshness_record(freshness_records, name)
                 ready = (exists and triggers_present and freshness_ready) if source_exists else not exists
                 surfaces[name] = {
                     "source_exists": source_exists,
                     "exists": exists,
-                    "source_rows": 0,
-                    "indexed_rows": 0,
+                    "source_rows": 0 if freshness is None else int(freshness.get("source_rows") or 0),
+                    "indexed_rows": 0 if freshness is None else int(freshness.get("indexed_rows") or 0),
                     "triggers_present": triggers_present,
-                    "missing_rows": 0,
-                    "excess_rows": 0,
-                    "duplicate_rows": 0,
+                    "missing_rows": 0 if freshness is None else int(freshness.get("missing_rows") or 0),
+                    "excess_rows": 0 if freshness is None else int(freshness.get("excess_rows") or 0),
+                    "duplicate_rows": 0 if freshness is None else int(freshness.get("duplicate_rows") or 0),
                     "ready": ready,
                     "exact": False,
-                    "freshness_known": freshness is not None,
-                    "freshness_state": freshness_state,
+                    "freshness_known": freshness_records is not None,
+                    "freshness_state": None if freshness is None else str(freshness.get("state")),
+                    "freshness_detail": None if freshness is None else freshness.get("detail"),
                 }
         finally:
             conn.close()
@@ -176,17 +210,23 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
     session_work_events = surfaces["session_work_events_fts"]
     work_threads = surfaces["work_threads_fts"]
     invariant_ready = all(bool(surface["ready"]) for surface in surfaces.values())
+    message_source_rows = _payload_int(messages, "source_rows")
+    message_indexed_rows = _payload_int(messages, "indexed_rows")
     return {
         "messages_ready": messages["ready"],
         "action_events_ready": action_events["ready"],
         "session_work_events_ready": session_work_events["ready"],
         "work_threads_ready": work_threads["ready"],
         "invariant_ready": invariant_ready,
-        "message_indexed_count": 0,
-        "message_indexable_count": 0,
-        "action_event_indexed_count": 0,
-        "action_event_count": 0,
-        "coverage_pct": 100.0 if invariant_ready else 0.0,
+        "message_indexed_count": message_indexed_rows,
+        "message_indexable_count": message_source_rows,
+        "action_event_indexed_count": _payload_int(action_events, "indexed_rows"),
+        "action_event_count": _payload_int(action_events, "source_rows"),
+        "coverage_pct": (
+            round((message_indexed_rows / message_source_rows) * 100, 1)
+            if message_source_rows > 0
+            else (100.0 if invariant_ready else 0.0)
+        ),
         "coverage_exact": False,
         "surfaces": surfaces,
     }

--- a/polylogue/storage/fts/freshness.py
+++ b/polylogue/storage/fts/freshness.py
@@ -28,6 +28,15 @@ _CREATE_TABLE_SQL = f"""
     )
 """
 
+_COLUMN_UPGRADES: tuple[tuple[str, str], ...] = (
+    ("source_rows", "INTEGER NOT NULL DEFAULT 0"),
+    ("indexed_rows", "INTEGER NOT NULL DEFAULT 0"),
+    ("missing_rows", "INTEGER NOT NULL DEFAULT 0"),
+    ("excess_rows", "INTEGER NOT NULL DEFAULT 0"),
+    ("duplicate_rows", "INTEGER NOT NULL DEFAULT 0"),
+    ("detail", "TEXT"),
+)
+
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
@@ -53,10 +62,19 @@ async def _table_exists_async(conn: aiosqlite.Connection) -> bool:
 
 def ensure_fts_freshness_table_sync(conn: sqlite3.Connection) -> None:
     conn.execute(_CREATE_TABLE_SQL)
+    columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({FRESHNESS_TABLE})").fetchall()}
+    for name, definition in _COLUMN_UPGRADES:
+        if name not in columns:
+            conn.execute(f"ALTER TABLE {FRESHNESS_TABLE} ADD COLUMN {name} {definition}")
 
 
 async def ensure_fts_freshness_table_async(conn: aiosqlite.Connection) -> None:
     await conn.execute(_CREATE_TABLE_SQL)
+    rows = await (await conn.execute(f"PRAGMA table_info({FRESHNESS_TABLE})")).fetchall()
+    columns = {str(row[1]) for row in rows}
+    for name, definition in _COLUMN_UPGRADES:
+        if name not in columns:
+            await conn.execute(f"ALTER TABLE {FRESHNESS_TABLE} ADD COLUMN {name} {definition}")
 
 
 def record_fts_surface_state_sync(

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -327,6 +327,49 @@ def test_targeted_fts_ready_marker_preserves_ledger_counts(tmp_path: Path) -> No
     )
 
 
+def test_targeted_fts_ready_marker_handles_legacy_freshness_table(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.sqlite"
+    with open_connection(db_path) as conn:
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id, version) VALUES(?,?,?,1)",
+            ("conv-legacy-ledger", "codex", "provider-conv"),
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) VALUES(?,?,?,?,?,1)",
+            ("msg-legacy-ledger", "conv-legacy-ledger", "user", "indexed text", "codex"),
+        )
+        conn.execute("DROP TABLE IF EXISTS fts_freshness_state")
+        conn.execute(
+            """
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                checked_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute("INSERT INTO fts_freshness_state VALUES ('messages_fts', 'stale', '2026-05-24T00:00:00+00:00')")
+
+        stages._mark_message_fts_ready_after_targeted_repair(conn)
+        row = conn.execute(
+            """
+            SELECT state, source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows, detail
+            FROM fts_freshness_state
+            WHERE surface='messages_fts'
+            """,
+        ).fetchone()
+
+    assert tuple(row) == (
+        "ready",
+        0,
+        0,
+        0,
+        0,
+        0,
+        "targeted changed-conversation repair complete",
+    )
+
+
 def test_embed_stage_scopes_changed_conversations_without_asyncio_run(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -285,6 +285,48 @@ def test_fts_repair_needs_ignores_empty_text_messages(tmp_path: Path) -> None:
         assert stages._fts_repair_needs_for_conversations(conn, ["conv-empty-text"]) == stages._FtsRepairNeeds()
 
 
+def test_targeted_fts_ready_marker_preserves_ledger_counts(tmp_path: Path) -> None:
+    from polylogue.storage.fts.freshness import record_fts_surface_state_sync
+
+    db_path = tmp_path / "archive.sqlite"
+    with open_connection(db_path) as conn:
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id, version) VALUES(?,?,?,1)",
+            ("conv-ledger", "codex", "provider-conv"),
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) VALUES(?,?,?,?,?,1)",
+            ("msg-ledger", "conv-ledger", "user", "indexed text", "codex"),
+        )
+        record_fts_surface_state_sync(
+            conn,
+            surface="messages_fts",
+            state="stale",
+            source_rows=100,
+            indexed_rows=99,
+            missing_rows=1,
+            detail="pre-existing exact snapshot",
+        )
+        stages._mark_message_fts_ready_after_targeted_repair(conn)
+        row = conn.execute(
+            """
+            SELECT state, source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows, detail
+            FROM fts_freshness_state
+            WHERE surface='messages_fts'
+            """,
+        ).fetchone()
+
+    assert tuple(row) == (
+        "ready",
+        100,
+        99,
+        0,
+        0,
+        0,
+        "targeted changed-conversation repair complete",
+    )
+
+
 def test_embed_stage_scopes_changed_conversations_without_asyncio_run(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -444,6 +444,70 @@ def test_fts_readiness_requires_recorded_freshness_when_available(tmp_path: Path
     assert messages["ready"] is False
 
 
+def test_fts_readiness_reports_recorded_freshness_counts_without_exact_scan(tmp_path: Path) -> None:
+    from polylogue.daemon.fts_status import fts_readiness_info
+
+    db_path = tmp_path / "polylogue.db"
+    queries: list[str] = []
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE messages (message_id TEXT, text TEXT);
+            CREATE TABLE messages_fts (text TEXT);
+            CREATE TABLE messages_fts_docsize (id INTEGER PRIMARY KEY, sz BLOB);
+            CREATE TRIGGER messages_fts_ai AFTER INSERT ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_ad AFTER DELETE ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_au AFTER UPDATE ON messages BEGIN SELECT 1; END;
+            CREATE TABLE action_events (event_id TEXT);
+            CREATE TABLE action_events_fts (text TEXT);
+            CREATE TABLE action_events_fts_docsize (id INTEGER PRIMARY KEY, sz BLOB);
+            CREATE TRIGGER action_events_fts_ai AFTER INSERT ON action_events BEGIN SELECT 1; END;
+            CREATE TRIGGER action_events_fts_ad AFTER DELETE ON action_events BEGIN SELECT 1; END;
+            CREATE TRIGGER action_events_fts_au AFTER UPDATE ON action_events BEGIN SELECT 1; END;
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                checked_at TEXT NOT NULL,
+                source_rows INTEGER NOT NULL DEFAULT 0,
+                indexed_rows INTEGER NOT NULL DEFAULT 0,
+                missing_rows INTEGER NOT NULL DEFAULT 0,
+                excess_rows INTEGER NOT NULL DEFAULT 0,
+                duplicate_rows INTEGER NOT NULL DEFAULT 0,
+                detail TEXT
+            );
+            INSERT INTO fts_freshness_state
+                (surface, state, checked_at, source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows, detail)
+            VALUES
+                ('messages_fts', 'ready', '2026-05-24T00:00:00+00:00', 200, 199, 1, 0, 0, 'repair pending'),
+                ('action_events_fts', 'ready', '2026-05-24T00:00:00+00:00', 7, 7, 0, 0, 0, NULL);
+            """
+        )
+
+    original_connect = sqlite3.connect
+
+    def traced_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        conn = original_connect(*args, **kwargs)
+        conn.set_trace_callback(queries.append)
+        return cast(sqlite3.Connection, conn)
+
+    with patch("polylogue.storage.sqlite.connection_profile.sqlite3.connect", side_effect=traced_connect):
+        readiness = fts_readiness_info(db_path)
+
+    assert readiness["message_indexable_count"] == 200
+    assert readiness["message_indexed_count"] == 199
+    assert readiness["action_event_count"] == 7
+    assert readiness["action_event_indexed_count"] == 7
+    assert readiness["coverage_pct"] == 99.5
+    surfaces = readiness["surfaces"]
+    assert isinstance(surfaces, dict)
+    messages = surfaces["messages_fts"]
+    assert isinstance(messages, dict)
+    assert messages["missing_rows"] == 1
+    assert messages["freshness_detail"] == "repair pending"
+    assert all("COUNT(*) FROM messages" not in query for query in queries)
+    assert all("messages_fts_docsize" not in query for query in queries)
+
+
 def test_daemon_status_insight_freshness_uses_lightweight_counts(tmp_path: Path) -> None:
     db = tmp_path / "polylogue.db"
     with sqlite3.connect(db) as conn:

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -508,6 +508,45 @@ def test_fts_readiness_reports_recorded_freshness_counts_without_exact_scan(tmp_
     assert all("messages_fts_docsize" not in query for query in queries)
 
 
+def test_fts_readiness_tolerates_malformed_recorded_counts(tmp_path: Path) -> None:
+    from polylogue.daemon.fts_status import fts_readiness_info
+
+    db_path = tmp_path / "polylogue.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE messages (message_id TEXT, text TEXT);
+            CREATE TABLE messages_fts (text TEXT);
+            CREATE TRIGGER messages_fts_ai AFTER INSERT ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_ad AFTER DELETE ON messages BEGIN SELECT 1; END;
+            CREATE TRIGGER messages_fts_au AFTER UPDATE ON messages BEGIN SELECT 1; END;
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                checked_at TEXT NOT NULL,
+                source_rows TEXT,
+                indexed_rows TEXT,
+                missing_rows TEXT,
+                excess_rows TEXT,
+                duplicate_rows TEXT
+            );
+            INSERT INTO fts_freshness_state
+                (surface, state, checked_at, source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows)
+            VALUES
+                ('messages_fts', 'ready', '2026-05-24T00:00:00+00:00', 'not-int', NULL, 'bad', '0', 'bad');
+            """
+        )
+
+    readiness = fts_readiness_info(db_path)
+    surfaces = readiness["surfaces"]
+    assert isinstance(surfaces, dict)
+    messages = surfaces["messages_fts"]
+    assert isinstance(messages, dict)
+    assert messages["source_rows"] == 0
+    assert messages["missing_rows"] == 0
+    assert readiness["message_indexable_count"] == 0
+
+
 def test_daemon_status_insight_freshness_uses_lightweight_counts(tmp_path: Path) -> None:
     db = tmp_path / "polylogue.db"
     with sqlite3.connect(db) as conn:


### PR DESCRIPTION
## Summary
Fast daemon FTS status now reports row-count fields from the durable `fts_freshness_state` ledger instead of returning zeros, and targeted changed-conversation FTS repair no longer overwrites existing ledger counts with zeros.

## Problem
The live daemon status endpoint reported `message_indexed_count=0` and `message_indexable_count=0` while the archive was large. The request-safe status path intentionally avoids exact FTS scans, but it also discarded count fields that the freshness ledger can already store. A targeted repair path then made the symptom worse by marking `messages_fts` ready with default zero counts.

## Solution
`polylogue.daemon.fts_status` now reads optional ledger columns (`source_rows`, `indexed_rows`, missing/excess/duplicate counts, and detail) without touching FTS shadow-table counts. The targeted FTS repair marker in `polylogue.daemon.convergence_stages` preserves existing ledger counts while clearing resolved missing/excess/duplicate counters on a successful cheap readiness probe.

## Verification
- `pytest tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_convergence_stages.py -q` → 36 passed.
- `devtools verify --quick` → exit_code 0, total_duration_s 35.04.
- Push hook reran `devtools verify --quick` on `66924a29` → exit_code 0, total_duration_s 35.57.

Ref #1515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced full-text search status tracking to use recorded freshness metrics for more efficient readiness checks.
  * Improved status reporting to include detailed freshness information and row counts.
  * Made status reporting more robust with safer schema parsing and better edge-case handling.

* **Tests**
  * Added tests validating freshness state preservation during repair operations.
  * Added tests confirming efficient readiness reporting without full table scans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->