### PR TITLE
feat: record daemon embedding progress

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -17,6 +17,7 @@ import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from polylogue.config import load_polylogue_config
 from polylogue.daemon.convergence import ConvergenceStage
@@ -26,6 +27,9 @@ from polylogue.storage.source_conversations import (
     conversation_ids_for_source_path,
     conversation_ids_for_source_paths,
 )
+
+if TYPE_CHECKING:
+    from polylogue.storage.embeddings.materialization import PendingConversation
 
 logger = get_logger(__name__)
 
@@ -728,21 +732,28 @@ def _stored_dim_from_meta(conn: sqlite3.Connection) -> int:
     return int(row[0]) if row else 0
 
 
-def _pending_embedding_conversation_ids(
+def _pending_embedding_conversation_ids(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> list[str]:
+    return [item.conversation_id for item in _pending_embedding_conversation_window(conn, conversation_ids)]
+
+
+def _pending_embedding_conversation_window(
     conn: sqlite3.Connection,
     conversation_ids: Sequence[str],
-) -> list[str]:
-    if not conversation_ids:
+) -> list[PendingConversation]:
+    unique_ids = tuple(dict.fromkeys(conversation_ids))
+    if not unique_ids:
         return []
-    from polylogue.storage.embeddings.materialization import select_pending_conversation_window
+    from polylogue.storage.embeddings.materialization import PendingConversation, select_pending_conversation_window
 
-    pending = select_pending_conversation_window(
+    if not _table_exists(conn, "conversations"):
+        return [PendingConversation(conversation_id=conversation_id) for conversation_id in unique_ids]
+
+    return select_pending_conversation_window(
         conn,
-        conversation_ids=tuple(dict.fromkeys(conversation_ids)),
+        conversation_ids=unique_ids,
         max_conversations=_DAEMON_EMBED_MAX_CONVERSATIONS,
         max_messages=_DAEMON_EMBED_MAX_MESSAGES,
     )
-    return [item.conversation_id for item in pending]
 
 
 def _embedding_debt_remaining_for_conversations(db_path: Path, conversation_ids: Sequence[str]) -> bool:
@@ -770,6 +781,13 @@ def _embed_conversations_sync(
 ) -> bool:
     from polylogue.api.sync.bridge import run_coroutine_sync
     from polylogue.storage.embeddings.materialization import embed_conversation_sync
+    from polylogue.storage.embeddings.progress import (
+        CatchupRunDelta,
+        CatchupRunStart,
+        finish_embedding_catchup_run,
+        record_embedding_catchup_progress,
+        start_embedding_catchup_run,
+    )
     from polylogue.storage.repository import ConversationRepository
     from polylogue.storage.search_providers import create_vector_provider
     from polylogue.storage.search_providers.sqlite_vec_support import (
@@ -777,37 +795,59 @@ def _embed_conversations_sync(
         VOYAGE_4_COST_PER_1M_TOKENS,
     )
     from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
     cfg = load_polylogue_config()
     voyage_key = cfg.get("voyage_api_key")
     if not voyage_key:
         return True
 
+    with open_readonly_connection(db_path, timeout=5.0) as conn:
+        pending = _pending_embedding_conversation_window(conn, conversation_ids)
+    if not pending:
+        return True
+
     max_cost = float(str(cfg.get("embedding_max_cost_usd", 0.0)))
     model = cfg.embedding_model
     dimension = cfg.embedding_dimension
+    planned_messages = sum(item.message_count for item in pending)
+    run_id = start_embedding_catchup_run(
+        db_path,
+        CatchupRunStart(
+            rebuild=False,
+            max_conversations=_DAEMON_EMBED_MAX_CONVERSATIONS,
+            max_messages=_DAEMON_EMBED_MAX_MESSAGES,
+            stop_after_seconds=stop_after_seconds,
+            max_errors=max_errors,
+            planned_conversations=len(pending),
+            planned_messages=planned_messages,
+        ),
+    )
 
     vec_provider = create_vector_provider(
         voyage_api_key=str(voyage_key), db_path=db_path, model=model, dimension=dimension
     )
     if vec_provider is None:
         logger.warning("embed: vector provider unavailable")
+        finish_embedding_catchup_run(db_path, run_id, status="failed", stop_reason="vector provider unavailable")
         return False
 
     repo = ConversationRepository(backend=SQLiteBackend(db_path=db_path))
     errors = 0
     embedded = 0
     cumulative_cost = 0.0
+    stop_reason: str | None = None
     started_at = time.monotonic()
     try:
-        for conversation_id in dict.fromkeys(conversation_ids):
+        for item in pending:
+            conversation_id = item.conversation_id
             if stop_after_seconds is not None and time.monotonic() - started_at >= stop_after_seconds:
-                logger.info("embed: stop-after-seconds reached (%ds)", stop_after_seconds)
+                stop_reason = f"stop-after-seconds reached ({stop_after_seconds})"
+                logger.info("embed: %s", stop_reason)
                 break
             outcome = embed_conversation_sync(repo, vec_provider, conversation_id)
             if outcome.status == "embedded":
                 embedded += 1
-                # Estimate cost: messages * estimated_tokens_per_message * price_per_token
                 batch_cost = (
                     outcome.embedded_message_count
                     * ESTIMATED_TOKENS_PER_MESSAGE
@@ -815,23 +855,48 @@ def _embed_conversations_sync(
                     / 1_000_000
                 )
                 cumulative_cost += batch_cost
+                record_embedding_catchup_progress(
+                    db_path,
+                    run_id,
+                    CatchupRunDelta(
+                        conversation_id=outcome.conversation_id,
+                        embedded=True,
+                        embedded_messages=outcome.embedded_message_count,
+                        estimated_cost_usd=batch_cost,
+                    ),
+                )
                 if max_cost > 0.0 and cumulative_cost > max_cost:
+                    stop_reason = f"cost cap reached ({cumulative_cost:.4f} > {max_cost:.2f})"
                     logger.info(
-                        "embed: cost cap reached (%.4f > %.2f) — stopping after %d conversations",
-                        cumulative_cost,
-                        max_cost,
+                        "embed: %s — stopping after %d conversations",
+                        stop_reason,
                         embedded,
                     )
                     break
             elif outcome.status in {"no_messages", "no_embeddable_messages"}:
                 logger.info("embed: %s has no embeddable messages", conversation_id)
+                record_embedding_catchup_progress(
+                    db_path,
+                    run_id,
+                    CatchupRunDelta(conversation_id=outcome.conversation_id, skipped=True),
+                )
             elif outcome.status == "error":
                 errors += 1
                 logger.warning("embed: %s failed: %s", conversation_id, outcome.error)
+                record_embedding_catchup_progress(
+                    db_path,
+                    run_id,
+                    CatchupRunDelta(conversation_id=outcome.conversation_id, errored=True),
+                )
                 if max_errors is not None and errors >= max_errors:
-                    logger.info("embed: max errors reached (%d)", max_errors)
+                    stop_reason = f"max errors reached ({max_errors})"
+                    logger.info("embed: %s", stop_reason)
                     break
         logger.info("embed: %d done, %d errors, est. cost $%.4f", embedded, errors, cumulative_cost)
+        if stop_reason is not None:
+            finish_embedding_catchup_run(db_path, run_id, status="stopped", stop_reason=stop_reason)
+        else:
+            finish_embedding_catchup_run(db_path, run_id, status="completed", stop_reason=None)
         return errors == 0
     finally:
         run_coroutine_sync(repo.close())

--- a/polylogue/daemon/embedding_readiness.py
+++ b/polylogue/daemon/embedding_readiness.py
@@ -27,6 +27,7 @@ def _defaults(*, enabled: bool, config_enabled: bool, has_key: bool, model: str,
         "embedding_coverage_percent": 0.0,
         "embedding_failure_count": 0,
         "embedding_estimated_cost_usd": 0.0,
+        "embedding_latest_catchup_run": None,
     }
 
 
@@ -56,10 +57,15 @@ def embedding_readiness_info(db_file: Path, *, detail: bool = False) -> dict[str
 
     pending = pending_messages = stale = failure = total = total_messages = total_conv = embedded_conv = 0
     cost = 0.0
+    latest_catchup_run: object | None = None
     try:
         conn = open_readonly_connection(db_file)
         try:
+            from polylogue.storage.embeddings.progress import latest_embedding_catchup_run
+
             embedded_msg = embedded_message_count_sync(conn)
+            if table_exists_sync(conn, "embedding_catchup_runs"):
+                latest_catchup_run = latest_embedding_catchup_run(conn)
             if _column_exists(conn, "embedding_status", "error_message"):
                 failure = optional_count_sync(
                     conn, "SELECT COUNT(*) FROM embedding_status WHERE error_message IS NOT NULL"
@@ -132,6 +138,7 @@ def embedding_readiness_info(db_file: Path, *, detail: bool = False) -> dict[str
         "embedding_coverage_percent": round(coverage, 1),
         "embedding_failure_count": failure,
         "embedding_estimated_cost_usd": cost,
+        "embedding_latest_catchup_run": latest_catchup_run,
     }
 
 

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -83,6 +83,7 @@ class EmbeddingReadiness(BaseModel):
     embedding_coverage_percent: float = 0.0
     embedding_failure_count: int = 0
     embedding_estimated_cost_usd: float = 0.0
+    embedding_latest_catchup_run: dict[str, object] | None = None
 
 
 class LiveCursorFileState(BaseModel):
@@ -964,6 +965,10 @@ def build_daemon_status(
             embedding_coverage_percent=_safe_float(embedding_info.get("embedding_coverage_percent")),
             embedding_failure_count=_safe_int(embedding_info.get("embedding_failure_count", 0)),
             embedding_estimated_cost_usd=_safe_float(embedding_info.get("embedding_estimated_cost_usd")),
+            embedding_latest_catchup_run=cast(
+                dict[str, object] | None,
+                embedding_info.get("embedding_latest_catchup_run"),
+            ),
         ),
         health=health,
         browser_capture_active=browser_capture_spool_path is not None,
@@ -1262,6 +1267,15 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
                 model = str(embedding.get("embedding_model", ""))
                 dimension = _safe_int(embedding.get("embedding_dimension"))
                 lines.append(f"  model: {model} ({dimension}d), est. cost: ${cost:.2f}")
+            latest = embedding.get("embedding_latest_catchup_run")
+            if isinstance(latest, dict):
+                lines.append(
+                    "  latest catch-up: "
+                    f"{latest.get('status', 'unknown')}, "
+                    f"{_safe_int(latest.get('processed_conversations'))}/"
+                    f"{_safe_int(latest.get('planned_conversations'))} convs, "
+                    f"{_safe_int(latest.get('embedded_messages')):,} msgs embedded"
+                )
         else:
             pending = _safe_int(embedding.get("embedding_pending_count"))
             pending_messages = _safe_int(embedding.get("embedding_pending_message_count"))
@@ -1269,4 +1283,12 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
             lines.append(
                 f"Embeddings: disabled ({key_state}; {pending} pending convs, {pending_messages:,} pending msgs)"
             )
+            latest = embedding.get("embedding_latest_catchup_run")
+            if isinstance(latest, dict):
+                lines.append(
+                    "  latest catch-up: "
+                    f"{latest.get('status', 'unknown')}, "
+                    f"{_safe_int(latest.get('processed_conversations'))}/"
+                    f"{_safe_int(latest.get('planned_conversations'))} convs"
+                )
     return lines

--- a/tests/unit/daemon/test_embedding_convergence_progress.py
+++ b/tests/unit/daemon/test_embedding_convergence_progress.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from polylogue.daemon import convergence_stages
+from polylogue.daemon.status import format_daemon_status_lines
+from polylogue.storage.embeddings.materialization import EmbedConversationOutcome
+from polylogue.storage.embeddings.progress import latest_embedding_catchup_run
+
+
+class _EmbeddingConfig:
+    embedding_model = "voyage-4"
+    embedding_dimension = 1024
+
+    def get(self, key: str, default: object = None) -> object:
+        values: dict[str, object] = {
+            "voyage_api_key": "pa-test",
+            "embedding_max_cost_usd": 5.0,
+        }
+        return values.get(key, default)
+
+
+class _FakeRepository:
+    def __init__(self, *, backend: object) -> None:
+        self.backend = backend
+
+    async def close(self) -> None:
+        return None
+
+
+def _seed_embedding_db(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                title TEXT,
+                updated_at TEXT
+            );
+            CREATE TABLE messages (
+                message_id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                text TEXT
+            );
+            """
+        )
+        conn.execute("INSERT INTO conversations VALUES ('conv-a', 'A', '2026-01-01')")
+        conn.execute("INSERT INTO conversations VALUES ('conv-b', 'B', '2026-01-02')")
+        conn.execute("INSERT INTO messages VALUES ('msg-a-1', 'conv-a', 'alpha')")
+        conn.execute("INSERT INTO messages VALUES ('msg-a-2', 'conv-a', 'beta')")
+        conn.execute("INSERT INTO messages VALUES ('msg-b-1', 'conv-b', 'gamma')")
+        conn.commit()
+
+
+def test_daemon_embedding_batch_records_catchup_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "polylogue.db"
+    _seed_embedding_db(db_path)
+    outcomes = iter(
+        [
+            EmbedConversationOutcome(status="embedded", conversation_id="conv-a", embedded_message_count=2),
+            EmbedConversationOutcome(status="no_messages", conversation_id="conv-b"),
+        ]
+    )
+
+    monkeypatch.setattr(convergence_stages, "load_polylogue_config", lambda: _EmbeddingConfig())
+    monkeypatch.setattr("polylogue.storage.repository.ConversationRepository", _FakeRepository)
+    monkeypatch.setattr("polylogue.storage.search_providers.create_vector_provider", lambda **_: MagicMock())
+    monkeypatch.setattr(
+        "polylogue.storage.embeddings.materialization.embed_conversation_sync",
+        lambda *_args, **_kwargs: next(outcomes),
+    )
+
+    ok = convergence_stages._embed_conversations_sync(db_path, ("conv-a", "conv-b"))
+
+    assert ok is True
+    with sqlite3.connect(db_path) as conn:
+        payload = latest_embedding_catchup_run(conn)
+    assert payload is not None
+    assert payload["status"] == "completed"
+    assert payload["planned_conversations"] == 2
+    assert payload["planned_messages"] == 3
+    assert payload["processed_conversations"] == 2
+    assert payload["embedded_conversations"] == 1
+    assert payload["skipped_conversations"] == 1
+    assert payload["error_count"] == 0
+    assert payload["embedded_messages"] == 2
+
+
+def test_daemon_embedding_batch_marks_error_stop_reason(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "polylogue.db"
+    _seed_embedding_db(db_path)
+
+    monkeypatch.setattr(convergence_stages, "load_polylogue_config", lambda: _EmbeddingConfig())
+    monkeypatch.setattr("polylogue.storage.repository.ConversationRepository", _FakeRepository)
+    monkeypatch.setattr("polylogue.storage.search_providers.create_vector_provider", lambda **_: MagicMock())
+    monkeypatch.setattr(
+        "polylogue.storage.embeddings.materialization.embed_conversation_sync",
+        lambda *_args, **_kwargs: EmbedConversationOutcome(
+            status="error",
+            conversation_id="conv-a",
+            error="provider 429",
+        ),
+    )
+
+    ok = convergence_stages._embed_conversations_sync(db_path, ("conv-a", "conv-b"), max_errors=1)
+
+    assert ok is False
+    with sqlite3.connect(db_path) as conn:
+        payload = latest_embedding_catchup_run(conn)
+    assert payload is not None
+    assert payload["status"] == "stopped"
+    assert payload["stop_reason"] == "max errors reached (1)"
+    assert payload["processed_conversations"] == 1
+    assert payload["error_count"] == 1
+
+
+def test_daemon_status_lines_include_latest_embedding_catchup() -> None:
+    lines = format_daemon_status_lines(
+        {
+            "embedding_readiness": {
+                "embedding_enabled": True,
+                "embedding_coverage_percent": 12.5,
+                "embedding_pending_count": 10,
+                "embedding_pending_message_count": 200,
+                "embedding_stale_count": 0,
+                "embedding_failure_count": 0,
+                "embedding_estimated_cost_usd": 0.02,
+                "embedding_model": "voyage-4",
+                "embedding_dimension": 1024,
+                "embedding_latest_catchup_run": {
+                    "status": "running",
+                    "processed_conversations": 3,
+                    "planned_conversations": 10,
+                    "embedded_messages": 42,
+                },
+            }
+        }
+    )
+
+    assert "  latest catch-up: running, 3/10 convs, 42 msgs embedded" in lines


### PR DESCRIPTION
## Summary

Daemon embedding convergence now records the same durable `embedding_catchup_runs` progress ledger as manual `polylogue embed backfill`. Daemon status also carries and renders the latest embedding catch-up run, so operator surfaces can explain daemon-driven embedding work without relying only on Prometheus metrics.

## Problem

#1523 made manual embedding backfill resumability visible, and #1524 exposed that ledger in metrics. The daemon embed stage still ran bounded batches without starting/updating/finalizing a catch-up run. That made daemon-driven semantic-search catch-up opaque: a live daemon could be doing embedding work, but `embed status`, `/metrics`, and daemon status had no shared run record to explain the current or latest daemon batch.

## Solution

`_embed_conversations_sync` now selects the pending daemon batch up front, starts an `embedding_catchup_runs` row with planned conversation/message counts, records per-conversation embedded/skipped/error progress, and finalizes the run as completed, stopped, or failed with a stop reason. The legacy unit-test seam where the helper is called against an empty touched DB remains supported by treating the provided IDs as the pending window.

`embedding_readiness_info` now includes the latest catch-up run when present, and `polylogued status` plain output shows the latest embedding catch-up status/progress inline with the embedding readiness section.

## Verification

- `pytest -q tests/unit/daemon/test_embedding_readiness.py::test_embed_loop_counts_errors_and_returns_false tests/unit/daemon/test_embedding_readiness.py::test_embed_loop_halts_when_cost_cap_exceeded tests/unit/daemon/test_embedding_readiness.py::test_embed_loop_no_cost_cap_processes_all tests/unit/daemon/test_embedding_convergence_progress.py tests/unit/daemon/test_metrics_endpoint.py::TestFormatMetricsReadsArchiveState::test_embedding_backlog_and_latest_catchup_state --tb=short` — 7 passed.
- `pytest -q tests/unit/ui/test_tui.py::test_search_flow --tb=short` — passed when rerun individually after the first broad run exposed a transient UI failure.
- `pytest -q tests/unit/storage/test_scale.py::TestPerformanceBudget::test_get_many_performance_budget --tb=short` — passed when rerun individually after the first broad run exposed a transient setup/perf failure.
- `ruff check polylogue/daemon/convergence_stages.py polylogue/daemon/embedding_readiness.py polylogue/daemon/status.py tests/unit/daemon/test_embedding_convergence_progress.py tests/unit/daemon/test_embedding_readiness.py` — passed.
- `python -m mypy polylogue/daemon/convergence_stages.py polylogue/daemon/embedding_readiness.py polylogue/daemon/status.py tests/unit/daemon/test_embedding_convergence_progress.py tests/unit/daemon/test_embedding_readiness.py` — passed.
- `devtools verify --quick` — passed.
- `devtools verify` — passed: 9,454 passed, 2 xfailed under pytest-testmon.

Ref #1503
