### PR TITLE
docs: surface bounded embedding activation

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -215,6 +215,27 @@ Implementation: `polylogue/storage/search_providers/fts5.py`,
   retrieval-band accounting; the default status path stays cheap and reports
   the latest persisted catch-up run.
 
+### Embedding Activation And Catch-Up
+
+Semantic search stays unavailable until embeddings are both enabled and
+materialized. The activation path is deliberately bounded:
+
+1. `polylogue embed status` shows config state, key presence, coverage,
+   backlog, latest catch-up progress, and the next safe command.
+2. `polylogue embed preflight --max-conversations 10` estimates the next
+   bounded window without contacting Voyage.
+3. `polylogue embed enable --yes` enables the daemon stage when a Voyage key is
+   already configured, or `polylogue embed enable --voyage-api-key ...` records
+   the key and enables the stage.
+4. `polylogue embed backfill --max-conversations 10` runs an explicit bounded
+   catch-up batch; after enablement, `polylogued` also processes bounded daemon
+   batches for new or stale conversations.
+
+`--max-messages` is a hard message-count window and uses live message counts
+rather than potentially stale `conversation_stats`. `--max-conversations` may
+use materialized conversation stats so small first batches remain fast on large
+archives.
+
 ### Auto Elevation
 
 When `retrieval_lane=auto` (the default), the planner picks a concrete

--- a/polylogue/cli/shared/embed_stats.py
+++ b/polylogue/cli/shared/embed_stats.py
@@ -68,6 +68,23 @@ def _render_latest_catchup_run(payload: EmbeddingStatusPayload) -> None:
         click.echo(f"    reason: {latest['stop_reason']}")
 
 
+def _render_next_actions(payload: EmbeddingStatusPayload) -> None:
+    if payload["total_conversations"] <= 0:
+        return
+    if not payload["daemon_stage_enabled"]:
+        if payload["has_voyage_api_key"]:
+            click.echo("  Activation:            polylogue embed enable --yes")
+        else:
+            click.echo("  Activation:            polylogue embed enable --voyage-api-key ...")
+    if payload["pending_conversations"] > 0:
+        click.echo("  Next preflight:        polylogue embed preflight --max-conversations 10")
+        if payload["daemon_stage_enabled"]:
+            click.echo("  Catch-up:              polylogued will process bounded batches, or run:")
+        else:
+            click.echo("  Catch-up:              after enabling, run:")
+        click.echo("                         polylogue embed backfill --max-conversations 10")
+
+
 def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool = False) -> None:
     """Render an embedding statistics payload."""
     if json_output:
@@ -94,11 +111,7 @@ def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool
     click.echo(f"  Stale messages:        {payload['stale_messages']}")
     click.echo(f"  Missing provenance:    {payload['messages_missing_provenance']}")
     click.echo(f"  Estimated total cost:  ~${payload['total_estimated_cost_usd']:.2f}")
-    if payload["total_conversations"] > 0 and not payload["daemon_stage_enabled"]:
-        if payload["has_voyage_api_key"]:
-            click.echo("  Activation:            polylogue embed enable --yes")
-        else:
-            click.echo("  Activation:            polylogue embed enable --voyage-api-key ...")
+    _render_next_actions(payload)
     _render_embedding_window(payload)
     _render_named_counts("Models", payload["embedding_models"])
     _render_named_counts("Dimensions", payload["embedding_dimensions"])

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -69,6 +69,17 @@ def _run_status(db_path: Path, *args: str, cfg: _Cfg | None = None) -> dict[str,
     return _payload(result.output)
 
 
+def _run_status_text(db_path: Path, *, cfg: _Cfg | None = None) -> str:
+    runner = CliRunner(env={"POLYLOGUE_FORCE_PLAIN": "1"})
+    with patch(
+        "polylogue.config.load_polylogue_config",
+        return_value=cfg or _Cfg(embedding_enabled=False, voyage_api_key=None),
+    ):
+        result = runner.invoke(embed_command, ["status"], obj=_env(db_path), catch_exceptions=False)
+    assert result.exit_code == 0
+    return str(result.output)
+
+
 def test_status_json_fast_path_handles_absent_embedding_tables(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"
     _seed_archive_without_embedding_ledgers(db_path)
@@ -179,3 +190,25 @@ def test_status_json_includes_latest_catchup_run(tmp_path: Path) -> None:
     assert latest["stop_reason"] == "keyboard interrupt"
     assert latest["rebuild"] is True
     assert latest["planned_conversations"] == 2
+
+
+def test_status_text_prints_bounded_next_actions(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    _seed_archive_without_embedding_ledgers(db_path)
+
+    output = _run_status_text(db_path, cfg=_Cfg(embedding_enabled=False, voyage_api_key="vk-live"))
+
+    assert "Activation:            polylogue embed enable --yes" in output
+    assert "Next preflight:        polylogue embed preflight --max-conversations 10" in output
+    assert "Catch-up:              after enabling, run:" in output
+    assert "polylogue embed backfill --max-conversations 10" in output
+
+
+def test_status_text_prints_daemon_catchup_when_enabled(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    _seed_archive_without_embedding_ledgers(db_path)
+
+    output = _run_status_text(db_path, cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
+
+    assert "Activation:" not in output
+    assert "Catch-up:              polylogued will process bounded batches, or run:" in output


### PR DESCRIPTION
## Summary

`polylogue embed status` now prints explicit bounded next actions for semantic-search activation and first catch-up. `docs/search.md` documents the same activation flow, including the distinction between fast conversation-count windows and hard live-count message windows.

## Problem

After #1531/#1532, the mechanics for bounded embedding catch-up and daemon progress existed, but the operator still had to infer the safe first commands from status fields and docs spread across search/architecture. On the live archive this matters: embeddings are disabled, the key is present, and there are 7,951 pending conversations, so the next step must be obvious and bounded.

## Solution

Embedding status now prints:

- activation command when config is disabled,
- bounded preflight command,
- bounded backfill command,
- daemon-enabled wording when the daemon stage is already enabled.

Search docs now include the activation/catch-up sequence and explicitly state that `--max-messages` uses live counts because it is a hard cap, while `--max-conversations` may use materialized stats for speed.

## Verification

- `pytest -q tests/unit/cli/test_embed_status_fast.py --tb=short` — 8 passed.
- `ruff format --check polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py` — passed.
- `ruff check polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py` — passed.
- `python -m mypy polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py` — passed.
- `POLYLOGUE_FORCE_PLAIN=1 timeout 20 polylogue embed status` — live read-only smoke showed the new activation/preflight/backfill lines against the real archive.
- `devtools render-all --check` — passed after refreshing the docs site cache.
- `devtools verify --quick` — passed.

Ref #1503
