### PR TITLE
feat(insights): materialize logical session identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -773,6 +773,7 @@ back to the existing brain-artifact metadata walk. Both paths emit normalized
 | `Provider` enum | `types.py` | Legacy source identifier — 9 known providers + UNKNOWN. Public surfaces still flow through this enum during the dual-vocabulary period. |
 | `Source` dataclass | `core/sources.py` | Source-centered identity (`family`, `runtime_root`, `originating_lab`). Parallel to `Provider`; see "Dual Vocabulary Period" above. |
 | `TopologyEdgeRecord` | `archive/topology/edge.py` | Typed cross-conversation parent reference. Persisted in `topology_edges` even when the parent has not yet been ingested (#1258) so out-of-order ingest and sidechain/subagent edges are durable. Closed `TopologyEdgeType` / `TopologyEdgeStatus` enums centralize the vocabulary. |
+| Logical Session ID | `session_profiles.logical_conversation_id` | Materialized root conversation for continuation/fork/subagent lineages. Rollups expose `logical_session_count` alongside physical `conversation_count`, and `get_logical_session()` returns the compact read-pull lineage envelope. |
 
 ## Artifact Taxonomy
 
@@ -1056,6 +1057,20 @@ record that always carries the original provider-native parent id.
 - **Hash boundary:** topology edges are derived per ingest and are NOT part
   of `conversations.content_hash` — mirrors the same boundary as
   `user_corrections` (#1131) and the blob lease tables.
+
+## Logical Session Identity (#866)
+
+`session_profiles.logical_conversation_id` materializes the resolved root of a
+conversation's parent chain. For a root conversation it equals
+`conversation_id`; for continuations, forks, sidechains, and subagents it points
+at the root conversation that represents the logical work session.
+
+Day summaries and tag rollups retain `conversation_count` as the physical
+conversation count and add `logical_session_count` plus
+`logical_conversation_ids_json` so weekly and cross-provider reducers can count
+logical sessions without re-walking parent pointers. The Python API exposes
+`get_logical_session(conversation_id)` as the compact read-pull envelope for
+agents and MCP callers; `get_session_topology` remains the full graph view.
 
 ## Learning Corrections (Feedback Loop)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,7 @@ back to the existing brain-artifact metadata walk. Both paths emit normalized
 | `Provider` enum | `types.py` | Legacy source identifier — 9 known providers + UNKNOWN. Public surfaces still flow through this enum during the dual-vocabulary period. |
 | `Source` dataclass | `core/sources.py` | Source-centered identity (`family`, `runtime_root`, `originating_lab`). Parallel to `Provider`; see "Dual Vocabulary Period" above. |
 | `TopologyEdgeRecord` | `archive/topology/edge.py` | Typed cross-conversation parent reference. Persisted in `topology_edges` even when the parent has not yet been ingested (#1258) so out-of-order ingest and sidechain/subagent edges are durable. Closed `TopologyEdgeType` / `TopologyEdgeStatus` enums centralize the vocabulary. |
+| Logical Session ID | `session_profiles.logical_conversation_id` | Materialized root conversation for continuation/fork/subagent lineages. Rollups expose `logical_session_count` alongside physical `conversation_count`, and `get_logical_session()` returns the compact read-pull lineage envelope. |
 
 ## Artifact Taxonomy
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -136,6 +136,20 @@ record that always carries the original provider-native parent id.
   of `conversations.content_hash` — mirrors the same boundary as
   `user_corrections` (#1131) and the blob lease tables.
 
+## Logical Session Identity (#866)
+
+`session_profiles.logical_conversation_id` materializes the resolved root of a
+conversation's parent chain. For a root conversation it equals
+`conversation_id`; for continuations, forks, sidechains, and subagents it points
+at the root conversation that represents the logical work session.
+
+Day summaries and tag rollups retain `conversation_count` as the physical
+conversation count and add `logical_session_count` plus
+`logical_conversation_ids_json` so weekly and cross-provider reducers can count
+logical sessions without re-walking parent pointers. The Python API exposes
+`get_logical_session(conversation_id)` as the compact read-pull envelope for
+agents and MCP callers; `get_session_topology` remains the full graph view.
+
 ## Learning Corrections (Feedback Loop)
 
 User corrections are stored in `user_corrections` and live outside the

--- a/polylogue/api/insights.py
+++ b/polylogue/api/insights.py
@@ -40,7 +40,8 @@ from polylogue.insights.productivity import (
     ProductivityRollupInsightQuery,
 )
 from polylogue.insights.tool_usage import ToolUsageInsight, ToolUsageInsightQuery
-from polylogue.insights.topology import ConversationRef, SessionTopology
+from polylogue.insights.topology import ConversationRef, LogicalSession, SessionTopology
+from polylogue.types import ConversationId
 
 if TYPE_CHECKING:
 
@@ -391,3 +392,21 @@ class PolylogueInsightsMixin:
         if topology is None:
             return []
         return topology.thread_refs(resolved)
+
+    async def get_logical_session(self, conversation_id: str) -> LogicalSession | None:
+        """Return the compact logical-session read-pull envelope."""
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return None
+        topology = await self.repository.get_session_topology(resolved)
+        if topology is None:
+            return None
+        return LogicalSession(
+            conversation_id=ConversationId(resolved),
+            root_id=topology.root_id,
+            thread=tuple(topology.thread_refs(resolved)),
+            siblings=tuple(topology.sibling_refs(resolved)),
+            descendants=tuple(topology.descendant_refs(resolved)),
+            cycle_detected=topology.cycle_detected,
+        )

--- a/polylogue/archive/session/documents.py
+++ b/polylogue/archive/session/documents.py
@@ -80,6 +80,7 @@ class SessionProfileDocument(TypedDict):
     terminal_state_confidence: float
     terminal_state_evidence: dict[str, object]
     cost_is_estimated: bool
+    logical_conversation_id: str | None
     compaction_count: int
     thread_id: str | None
     continuation_depth: int

--- a/polylogue/archive/session/models.py
+++ b/polylogue/archive/session/models.py
@@ -136,6 +136,7 @@ class SessionProfile:
     terminal_state_confidence: float = 0.0
     terminal_state_evidence: dict[str, int | float | str | None] = field(default_factory=dict)
     cost_is_estimated: bool = False
+    logical_conversation_id: str | None = None
     thread_id: str | None = None
     continuation_depth: int = 0
     compaction_count: int = 0
@@ -212,6 +213,7 @@ class SessionProfile:
             "terminal_state_confidence": self.terminal_state_confidence,
             "terminal_state_evidence": dict(self.terminal_state_evidence),
             "cost_is_estimated": self.cost_is_estimated,
+            "logical_conversation_id": self.logical_conversation_id,
             "compaction_count": self.compaction_count,
             "thread_id": self.thread_id,
             "continuation_depth": self.continuation_depth,
@@ -287,6 +289,7 @@ class SessionProfile:
             terminal_state_confidence=coerce_float(payload.get("terminal_state_confidence"), 0.0),
             terminal_state_evidence=_scalar_mapping(payload.get("terminal_state_evidence")),
             cost_is_estimated=bool(payload.get("cost_is_estimated", False)),
+            logical_conversation_id=optional_string(payload.get("logical_conversation_id")),
             compaction_count=coerce_int(payload.get("compaction_count"), 0),
             thread_id=optional_string(payload.get("thread_id")),
             continuation_depth=coerce_int(payload.get("continuation_depth"), 0),

--- a/polylogue/archive/session/session_summaries.py
+++ b/polylogue/archive/session/session_summaries.py
@@ -15,6 +15,8 @@ from polylogue.archive.session.session_profile import SessionProfile
 class DaySessionSummary:
     date: date
     session_count: int
+    logical_session_count: int
+    logical_conversation_ids: tuple[str, ...]
     total_cost_usd: float
     total_duration_ms: int
     total_tool_active_duration_ms: int
@@ -29,6 +31,7 @@ class DaySessionSummary:
         return {
             "date": self.date.isoformat(),
             "session_count": self.session_count,
+            "logical_session_count": self.logical_session_count,
             "total_cost_usd": round(self.total_cost_usd, 4),
             "total_duration_ms": self.total_duration_ms,
             "total_tool_active_duration_ms": self.total_tool_active_duration_ms,
@@ -46,6 +49,7 @@ class WeekSessionSummary:
     iso_week: str
     day_summaries: tuple[DaySessionSummary, ...]
     session_count: int
+    logical_session_count: int
     total_cost_usd: float
     total_duration_ms: int
     total_tool_active_duration_ms: int
@@ -56,6 +60,7 @@ class WeekSessionSummary:
             "iso_week": self.iso_week,
             "day_summaries": [day.to_dict() for day in self.day_summaries],
             "session_count": self.session_count,
+            "logical_session_count": self.logical_session_count,
             "total_cost_usd": round(self.total_cost_usd, 4),
             "total_duration_ms": self.total_duration_ms,
             "total_tool_active_duration_ms": self.total_tool_active_duration_ms,
@@ -85,6 +90,11 @@ def summarize_day(
     total_wall = 0
     total_messages = 0
     total_words = 0
+    logical_ids = {
+        profile.logical_conversation_id or profile.conversation_id
+        for profile in profiles
+        if (profile.logical_conversation_id or profile.conversation_id)
+    }
     for profile in profiles:
         total_cost += profile.total_cost_usd
         total_duration += profile.total_duration_ms
@@ -100,6 +110,8 @@ def summarize_day(
     return DaySessionSummary(
         date=target_date,
         session_count=len(profiles),
+        logical_session_count=len(logical_ids),
+        logical_conversation_ids=tuple(sorted(logical_ids)),
         total_cost_usd=total_cost,
         total_duration_ms=total_duration,
         total_tool_active_duration_ms=total_tool_active,
@@ -118,6 +130,7 @@ def summarize_week(day_summaries: Sequence[DaySessionSummary]) -> WeekSessionSum
             iso_week="",
             day_summaries=(),
             session_count=0,
+            logical_session_count=0,
             total_cost_usd=0.0,
             total_duration_ms=0,
             total_tool_active_duration_ms=0,
@@ -129,6 +142,9 @@ def summarize_week(day_summaries: Sequence[DaySessionSummary]) -> WeekSessionSum
         iso_week=f"{iso[0]}-W{iso[1]:02d}",
         day_summaries=tuple(day_summaries),
         session_count=sum(day.session_count for day in day_summaries),
+        logical_session_count=len(
+            {logical_id for day in day_summaries for logical_id in day.logical_conversation_ids if logical_id}
+        ),
         total_cost_usd=sum(day.total_cost_usd for day in day_summaries),
         total_duration_ms=sum(day.total_duration_ms for day in day_summaries),
         total_tool_active_duration_ms=sum(day.total_tool_active_duration_ms for day in day_summaries),

--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -216,6 +216,7 @@ class SessionProfileInsight(ArchiveInsightModel):
     insight_kind: str = "session_profile"
     semantic_tier: str = "merged"
     conversation_id: str
+    logical_conversation_id: str
     provider_name: str
     title: str | None = None
     provenance: ArchiveInsightProvenance
@@ -234,7 +235,8 @@ class SessionProfileInsight(ArchiveInsightModel):
         include_inference = tier in {"merged", "inference"}
         return cls(
             semantic_tier=tier,
-            conversation_id=record.conversation_id,
+            conversation_id=str(record.conversation_id),
+            logical_conversation_id=str(record.logical_conversation_id),
             provider_name=record.provider_name,
             title=record.title,
             provenance=_record_provenance(record),
@@ -390,6 +392,7 @@ class SessionTagRollupInsight(ArchiveInsightModel):
     insight_kind: str = "session_tag_rollup"
     tag: str
     conversation_count: int
+    logical_session_count: int = 0
     explicit_count: int
     auto_count: int
     provider_breakdown: dict[str, int]

--- a/polylogue/insights/archive_models.py
+++ b/polylogue/insights/archive_models.py
@@ -81,6 +81,7 @@ class SessionEvidencePayload(ArchiveInsightModel):
     tags: tuple[str, ...] = ()
     is_continuation: bool = False
     parent_id: str | None = None
+    logical_conversation_id: str | None = None
     thinking_duration_ms: int = 0
     output_duration_ms: int = 0
     tool_duration_ms: int = 0
@@ -271,6 +272,7 @@ class WorkThreadPayload(ArchiveInsightModel):
 class DaySessionSummaryPayload(ArchiveInsightModel):
     date: str
     session_count: int = 0
+    logical_session_count: int = 0
     total_cost_usd: float = 0.0
     total_duration_ms: int = 0
     total_tool_active_duration_ms: int = 0
@@ -286,6 +288,7 @@ class WeekSessionSummaryPayload(ArchiveInsightModel):
     iso_week: str
     day_summaries: tuple[DaySessionSummaryPayload, ...] = ()
     session_count: int = 0
+    logical_session_count: int = 0
     total_cost_usd: float = 0.0
     total_duration_ms: int = 0
     total_tool_active_duration_ms: int = 0

--- a/polylogue/insights/archive_rollups.py
+++ b/polylogue/insights/archive_rollups.py
@@ -31,6 +31,7 @@ from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZ
 @dataclass(slots=True)
 class _TagRollupBucket:
     conversation_count: int = 0
+    logical_conversation_ids: set[str] = field(default_factory=set)
     explicit_count: int = 0
     auto_count: int = 0
     repos: Counter[str] = field(default_factory=Counter)
@@ -41,6 +42,7 @@ class _TagRollupBucket:
 @dataclass(slots=True)
 class _TagAggregateBucket:
     conversation_count: int = 0
+    logical_conversation_ids: set[str] = field(default_factory=set)
     explicit_count: int = 0
     auto_count: int = 0
     provider_breakdown: Counter[str] = field(default_factory=Counter)
@@ -72,6 +74,7 @@ def build_session_tag_rollup_records(
             key = (profile.provider, bucket_day_text, tag)
             bucket = grouped.setdefault(key, _TagRollupBucket())
             bucket.conversation_count += 1
+            bucket.logical_conversation_ids.add(profile.logical_conversation_id or profile.conversation_id)
             if tag in explicit_tags:
                 bucket.explicit_count += 1
             if tag in auto_tags:
@@ -96,6 +99,8 @@ def build_session_tag_rollup_records(
                 input_high_water_mark_source=classify_aggregate_hwm_source(bucket.source_updated_at),
                 input_row_count=bucket.conversation_count,
                 conversation_count=bucket.conversation_count,
+                logical_session_count=len(bucket.logical_conversation_ids),
+                logical_conversation_ids=tuple(sorted(bucket.logical_conversation_ids)),
                 explicit_count=bucket.explicit_count,
                 auto_count=bucket.auto_count,
                 repo_breakdown=dict(bucket.repos),
@@ -112,6 +117,7 @@ def aggregate_session_tag_rollup_insights(
     for row in rows:
         bucket = grouped.setdefault(row.tag, _TagAggregateBucket())
         bucket.conversation_count += row.conversation_count
+        bucket.logical_conversation_ids.update(row.logical_conversation_ids)
         bucket.explicit_count += row.explicit_count
         bucket.auto_count += row.auto_count
         bucket.provider_breakdown[row.provider_name] += row.conversation_count
@@ -124,6 +130,7 @@ def aggregate_session_tag_rollup_insights(
             SessionTagRollupInsight(
                 tag=tag,
                 conversation_count=bucket.conversation_count,
+                logical_session_count=len(bucket.logical_conversation_ids),
                 explicit_count=bucket.explicit_count,
                 auto_count=bucket.auto_count,
                 provider_breakdown=dict(bucket.provider_breakdown),

--- a/polylogue/insights/archive_summaries.py
+++ b/polylogue/insights/archive_summaries.py
@@ -24,6 +24,7 @@ from polylogue.storage.runtime import DaySessionSummaryRecord
 @dataclass(slots=True)
 class _DayAggregateBucket:
     session_count: int = 0
+    logical_conversation_ids: set[str] = field(default_factory=set)
     total_cost_usd: float = 0.0
     total_duration_ms: int = 0
     total_tool_active_duration_ms: int = 0
@@ -84,6 +85,8 @@ def build_day_session_summary_records(
                 input_high_water_mark_source=classify_aggregate_hwm_source(source_updates),
                 input_row_count=summary.session_count,
                 conversation_count=summary.session_count,
+                logical_session_count=summary.logical_session_count,
+                logical_conversation_ids=summary.logical_conversation_ids,
                 total_cost_usd=summary.total_cost_usd,
                 total_duration_ms=summary.total_duration_ms,
                 total_tool_active_duration_ms=summary.total_tool_active_duration_ms,
@@ -106,6 +109,7 @@ def _aggregate_day_buckets(
     for row in rows:
         bucket = grouped.setdefault(row.day, _DayAggregateBucket())
         bucket.session_count += row.conversation_count
+        bucket.logical_conversation_ids.update(row.logical_conversation_ids)
         bucket.total_cost_usd += row.total_cost_usd
         bucket.total_duration_ms += row.total_duration_ms
         bucket.total_tool_active_duration_ms += row.total_tool_active_duration_ms
@@ -129,6 +133,8 @@ def _aggregate_day_summaries(
         summary = DaySessionSummary(
             date=datetime.fromisoformat(day).date(),
             session_count=bucket.session_count,
+            logical_session_count=len(bucket.logical_conversation_ids),
+            logical_conversation_ids=tuple(sorted(bucket.logical_conversation_ids)),
             total_cost_usd=bucket.total_cost_usd,
             total_duration_ms=bucket.total_duration_ms,
             total_tool_active_duration_ms=bucket.total_tool_active_duration_ms,

--- a/polylogue/insights/topology.py
+++ b/polylogue/insights/topology.py
@@ -276,8 +276,22 @@ class SessionTopology(BaseModel):
         return thread
 
 
+class LogicalSession(BaseModel):
+    """Compact read-pull view of one logical session lineage."""
+
+    model_config = ConfigDict(frozen=True)
+
+    conversation_id: ConversationId
+    root_id: ConversationId
+    thread: tuple[ConversationRef, ...] = Field(default_factory=tuple)
+    siblings: tuple[ConversationRef, ...] = Field(default_factory=tuple)
+    descendants: tuple[ConversationRef, ...] = Field(default_factory=tuple)
+    cycle_detected: bool = False
+
+
 __all__ = [
     "ConversationRef",
+    "LogicalSession",
     "SessionTopology",
     "TopologyEdge",
     "TopologyEdgeKind",

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -229,6 +229,17 @@ class MCPSessionTopologyPayload(SurfacePayloadModel):
     thread: tuple[MCPConversationRefPayload, ...]
 
 
+class MCPLogicalSessionPayload(SurfacePayloadModel):
+    """Compact envelope for ``get_logical_session`` (#866)."""
+
+    conversation_id: str
+    root_id: str
+    thread: tuple[MCPConversationRefPayload, ...]
+    siblings: tuple[MCPConversationRefPayload, ...]
+    descendants: tuple[MCPConversationRefPayload, ...]
+    cycle_detected: bool = False
+
+
 class MCPNeighborCandidatesPayload(SurfacePayloadModel):
     """Bounded envelope for ``neighbor_candidates``.
 
@@ -337,6 +348,21 @@ def session_topology_payload(topology: object, *, conversation_id: str) -> MCPSe
         descendants=tuple(_ref_payload(ref) for ref in topology.descendant_refs(conversation_id)),
         siblings=tuple(_ref_payload(ref) for ref in topology.sibling_refs(conversation_id)),
         thread=tuple(_ref_payload(ref) for ref in topology.thread_refs(conversation_id)),
+    )
+
+
+def logical_session_payload(logical_session: object) -> MCPLogicalSessionPayload:
+    """Build the typed MCP payload for ``get_logical_session`` (#866)."""
+    from polylogue.insights.topology import LogicalSession
+
+    assert isinstance(logical_session, LogicalSession)
+    return MCPLogicalSessionPayload(
+        conversation_id=str(logical_session.conversation_id),
+        root_id=str(logical_session.root_id),
+        thread=tuple(_ref_payload(ref) for ref in logical_session.thread),
+        siblings=tuple(_ref_payload(ref) for ref in logical_session.siblings),
+        descendants=tuple(_ref_payload(ref) for ref in logical_session.descendants),
+        cycle_detected=logical_session.cycle_detected,
     )
 
 
@@ -688,6 +714,7 @@ __all__ = [
     "MCPMessagePayload",
     "MCPMessagesListPayload",
     "MCPMetadataPayload",
+    "MCPLogicalSessionPayload",
     "MCPMutationStatusPayload",
     "MCPReaderActionAvailabilityPayload",
     "MutationResultPayload",
@@ -720,6 +747,8 @@ __all__ = [
     "conversation_summary_list_payload",
     "model_json_document",
     "neighbor_candidates_payload",
+    "logical_session_payload",
     "normalize_role",
     "session_tree_payload",
+    "session_topology_payload",
 ]

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -16,6 +16,7 @@ from polylogue.mcp.payloads import (
     MCPStatsByPayload,
     conversation_query_result_payload,
     conversation_search_result_payload,
+    logical_session_payload,
     neighbor_candidates_payload,
     session_topology_payload,
     session_tree_payload,
@@ -270,6 +271,22 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(session_topology_payload(topology, conversation_id=str(topology.target_id)))
 
         return await hooks.async_safe_call("get_session_topology", run)
+
+    @mcp.tool()
+    async def get_logical_session(conversation_id: str) -> str:
+        """Return compact logical-session lineage for read-pull consumers."""
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            logical_session = await poly.get_logical_session(conversation_id)
+            if logical_session is None:
+                return hooks.error_json(
+                    f"Conversation not found: {conversation_id}",
+                    code="not_found",
+                )
+            return hooks.json_payload(logical_session_payload(logical_session))
+
+        return await hooks.async_safe_call("get_logical_session", run)
 
     @mcp.tool()
     async def get_stats_by(group_by: Literal["provider", "month", "year"] = "provider") -> str:

--- a/polylogue/storage/insights/aggregate/records.py
+++ b/polylogue/storage/insights/aggregate/records.py
@@ -20,6 +20,8 @@ class SessionTagRollupRecord(BaseModel):
     input_high_water_mark_source: str | None = None
     input_row_count: int = 0
     conversation_count: int = 0
+    logical_session_count: int = 0
+    logical_conversation_ids: tuple[str, ...] = ()
     explicit_count: int = 0
     auto_count: int = 0
     repo_breakdown: dict[str, int]
@@ -44,6 +46,8 @@ class DaySessionSummaryRecord(BaseModel):
     input_high_water_mark_source: str | None = None
     input_row_count: int = 0
     conversation_count: int = 0
+    logical_session_count: int = 0
+    logical_conversation_ids: tuple[str, ...] = ()
     total_cost_usd: float = 0.0
     total_duration_ms: int = 0
     total_tool_active_duration_ms: int = 0

--- a/polylogue/storage/insights/session/profiles.py
+++ b/polylogue/storage/insights/session/profiles.py
@@ -220,6 +220,7 @@ def profile_evidence_payload(profile: SessionProfile) -> SessionEvidencePayload:
         tags=profile.tags,
         is_continuation=profile.is_continuation,
         parent_id=profile.parent_id,
+        logical_conversation_id=profile.logical_conversation_id,
         thinking_duration_ms=profile.thinking_duration_ms,
         output_duration_ms=profile.output_duration_ms,
         tool_duration_ms=profile.tool_duration_ms,
@@ -278,10 +279,15 @@ def build_session_profile_record(
     profile: SessionProfile,
     *,
     analysis: SessionAnalysis | None = None,
+    logical_conversation_id: str | None = None,
     materialized_at: str | None = None,
 ) -> SessionProfileRecord:
     built_at = materialized_at or now_iso()
     evidence = profile_evidence_payload(profile)
+    resolved_logical_conversation_id = (
+        logical_conversation_id or profile.logical_conversation_id or profile.conversation_id
+    )
+    evidence = evidence.model_copy(update={"logical_conversation_id": resolved_logical_conversation_id})
     inference = profile_inference_payload(profile)
     enrichment = session_enrichment_payload(profile, analysis)
     evidence_search_text = profile_evidence_search_text(profile)
@@ -289,6 +295,7 @@ def build_session_profile_record(
     source_updated_at = profile.updated_at.isoformat() if profile.updated_at else None
     return SessionProfileRecord(
         conversation_id=ConversationId(profile.conversation_id),
+        logical_conversation_id=ConversationId(resolved_logical_conversation_id),
         materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
         materialized_at=built_at,
         source_updated_at=source_updated_at,
@@ -356,6 +363,7 @@ def build_session_profile_record(
 def hydrate_session_profile(record: SessionProfileRecord) -> SessionProfile:
     merged_payload: SessionProfileDocument = {
         "conversation_id": str(record.conversation_id),
+        "logical_conversation_id": str(record.logical_conversation_id),
         "provider": record.provider_name,
         "title": record.title,
         "inferred_topic": record.inference_payload.inferred_topic,

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -49,6 +49,7 @@ from polylogue.storage.insights.session.threads import (
     build_thread_records_for_roots_sync,
     iter_root_id_pages_async,
     iter_root_id_pages_sync,
+    thread_root_ids_async,
     thread_root_ids_sync,
 )
 from polylogue.storage.insights.session.timeline_rows import (
@@ -527,6 +528,7 @@ def build_session_insight_records(
     conversation: Conversation,
     *,
     compaction_count: int | None = None,
+    logical_conversation_id: str | None = None,
 ) -> SessionInsightRecordBundle:
     from polylogue.storage.insights.session.repo_identity import attribution_to_observations
 
@@ -551,6 +553,7 @@ def build_session_insight_records(
         profile_record=build_session_profile_record(
             profile,
             analysis=analysis,
+            logical_conversation_id=logical_conversation_id,
             materialized_at=materialized_at,
         ),
         latency_profile_record=build_session_latency_profile_record(
@@ -569,12 +572,15 @@ def build_session_insight_record_bundles(
     conversations: Iterable[Conversation],
     *,
     compaction_counts_by_conversation: dict[str, int] | None = None,
+    logical_conversation_ids_by_conversation: dict[str, str] | None = None,
 ) -> list[SessionInsightRecordBundle]:
     compaction_counts = compaction_counts_by_conversation or {}
+    logical_ids = logical_conversation_ids_by_conversation or {}
     return [
         build_session_insight_records(
             conversation,
             compaction_count=compaction_counts.get(str(conversation.id)),
+            logical_conversation_id=logical_ids.get(str(conversation.id)),
         )
         for conversation in conversations
     ]
@@ -698,9 +704,11 @@ def rebuild_session_insights_sync(
     for chunk in conversation_chunks:
         saw_conversation_ids = True
         batch = load_sync_batch(conn, chunk)
+        root_ids_by_conversation = thread_root_ids_sync(conn, chunk)
         record_bundles = build_session_insight_record_bundles(
             hydrate_conversations(batch),
             compaction_counts_by_conversation=batch.compaction_counts_by_conversation,
+            logical_conversation_ids_by_conversation=root_ids_by_conversation,
         )
         chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
         replace_session_profiles_bulk_sync(conn, [bundle.profile_record for bundle in record_bundles])
@@ -844,9 +852,11 @@ async def rebuild_session_insights_async(
     if conversation_ids is None:
         async for chunk in iter_conversation_id_pages_async(conn, page_size=page_size):
             batch = await load_async_batch(conn, chunk)
+            root_ids_by_conversation = await thread_root_ids_async(conn, chunk)
             record_bundles = build_session_insight_record_bundles(
                 hydrate_conversations(batch),
                 compaction_counts_by_conversation=batch.compaction_counts_by_conversation,
+                logical_conversation_ids_by_conversation=root_ids_by_conversation,
             )
             chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
             for bundle in record_bundles:
@@ -893,9 +903,11 @@ async def rebuild_session_insights_async(
     else:
         for chunk_ids in chunked(list(conversation_ids), size=page_size):
             batch = await load_async_batch(conn, chunk_ids)
+            root_ids_by_conversation = await thread_root_ids_async(conn, chunk_ids)
             record_bundles = build_session_insight_record_bundles(
                 hydrate_conversations(batch),
                 compaction_counts_by_conversation=batch.compaction_counts_by_conversation,
+                logical_conversation_ids_by_conversation=root_ids_by_conversation,
             )
             chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
             for bundle in record_bundles:

--- a/polylogue/storage/insights/session/records.py
+++ b/polylogue/storage/insights/session/records.py
@@ -22,6 +22,7 @@ from polylogue.types import ConversationId
 
 class SessionProfileRecord(BaseModel):
     conversation_id: ConversationId
+    logical_conversation_id: ConversationId
     materializer_version: int = SESSION_INSIGHT_MATERIALIZER_VERSION
     materialized_at: str
     source_updated_at: str | None = None
@@ -86,6 +87,7 @@ class SessionProfileRecord(BaseModel):
 
     @field_validator(
         "conversation_id",
+        "logical_conversation_id",
         "provider_name",
         "materialized_at",
         "search_text",

--- a/polylogue/storage/insights/session/refresh.py
+++ b/polylogue/storage/insights/session/refresh.py
@@ -270,9 +270,11 @@ async def _apply_session_insight_conversation_update_async(
             affected_groups={old_group} if old_group is not None else set(),
         )
 
+    thread_root_id = await thread_root_id_async(conn, conversation_id)
     record_bundle = build_session_insight_records(
         hydrated[0],
         compaction_count=batch.compaction_counts_by_conversation.get(conversation_id),
+        logical_conversation_id=thread_root_id,
     )
     await replace_session_profile(conn, record_bundle.profile_record, transaction_depth)
     await replace_session_latency_profile(conn, record_bundle.latency_profile_record, transaction_depth)
@@ -310,7 +312,7 @@ async def _apply_session_insight_conversation_update_async(
             work_events=record_bundle.work_event_count,
             phases=record_bundle.phase_count,
         ),
-        thread_root_id=await thread_root_id_async(conn, conversation_id),
+        thread_root_id=thread_root_id,
         affected_groups=affected_groups,
     )
 
@@ -497,6 +499,7 @@ async def _apply_session_insight_conversation_updates_async(
             record_bundle = build_session_insight_records(
                 hydrated_conversation,
                 compaction_count=batch.compaction_counts_by_conversation.get(conversation_id),
+                logical_conversation_id=root_ids_by_conversation.get(conversation_id),
             )
             record_bundles.append(record_bundle)
 

--- a/polylogue/storage/insights/session/storage.py
+++ b/polylogue/storage/insights/session/storage.py
@@ -31,6 +31,7 @@ SqlBindings = tuple[SqlValue, ...]
 
 _SESSION_PROFILE_BASE_COLUMNS = (
     "conversation_id",
+    "logical_conversation_id",
     "materializer_version",
     "materialized_at",
     "source_updated_at",
@@ -236,6 +237,7 @@ def _legacy_profile_payload_json(record: SessionProfileRecord) -> str | None:
             **record.evidence_payload.model_dump(mode="json"),
             **record.inference_payload.model_dump(mode="json"),
             "conversation_id": str(record.conversation_id),
+            "logical_conversation_id": str(record.logical_conversation_id),
             "provider": record.provider_name,
             "title": record.title,
         }
@@ -260,6 +262,7 @@ def session_profile_insert_values(
 ) -> SqlBindings:
     base_values: list[SqlValue] = [
         record.conversation_id,
+        record.logical_conversation_id,
         record.materializer_version,
         record.materialized_at,
         record.source_updated_at,
@@ -519,6 +522,8 @@ def session_tag_rollup_insert_values(record: SessionTagRollupRecord) -> SqlBindi
         record.input_high_water_mark_source,
         record.input_row_count,
         record.conversation_count,
+        record.logical_session_count,
+        _json_array_or_none(record.logical_conversation_ids),
         record.explicit_count,
         record.auto_count,
         _json_or_none(record.repo_breakdown),
@@ -538,6 +543,8 @@ def day_session_summary_insert_values(record: DaySessionSummaryRecord) -> SqlBin
         record.input_high_water_mark_source,
         record.input_row_count,
         record.conversation_count,
+        record.logical_session_count,
+        _json_array_or_none(record.logical_conversation_ids),
         record.total_cost_usd,
         record.total_duration_ms,
         record.total_tool_active_duration_ms,
@@ -775,6 +782,8 @@ def replace_session_tag_rollup_rows_sync(
                     "input_high_water_mark_source",
                     "input_row_count",
                     "conversation_count",
+                    "logical_session_count",
+                    "logical_conversation_ids_json",
                     "explicit_count",
                     "auto_count",
                     "repo_breakdown_json",
@@ -811,6 +820,8 @@ def replace_day_session_summaries_sync(
                     "input_high_water_mark_source",
                     "input_row_count",
                     "conversation_count",
+                    "logical_session_count",
+                    "logical_conversation_ids_json",
                     "total_cost_usd",
                     "total_duration_ms",
                     "total_tool_active_duration_ms",

--- a/polylogue/storage/sqlite/queries/mappers_insight_aggregates.py
+++ b/polylogue/storage/sqlite/queries/mappers_insight_aggregates.py
@@ -32,6 +32,8 @@ def _row_to_session_tag_rollup_record(row: sqlite3.Row) -> SessionTagRollupRecor
         input_high_water_mark_source=_row_text(row, "input_high_water_mark_source"),
         input_row_count=int(_row_int(row, "input_row_count", 0) or 0),
         conversation_count=int(_row_int(row, "conversation_count", 0) or 0),
+        logical_session_count=int(_row_int(row, "logical_session_count", 0) or 0),
+        logical_conversation_ids=_json_text_tuple(_parse_json(_row_text(row, "logical_conversation_ids_json"))),
         explicit_count=int(_row_int(row, "explicit_count", 0) or 0),
         auto_count=int(_row_int(row, "auto_count", 0) or 0),
         repo_breakdown=_json_int_dict(
@@ -57,6 +59,8 @@ def _row_to_day_session_summary_record(row: sqlite3.Row) -> DaySessionSummaryRec
         input_high_water_mark_source=_row_text(row, "input_high_water_mark_source"),
         input_row_count=int(_row_int(row, "input_row_count", 0) or 0),
         conversation_count=int(_row_int(row, "conversation_count", 0) or 0),
+        logical_session_count=int(_row_int(row, "logical_session_count", 0) or 0),
+        logical_conversation_ids=_json_text_tuple(_parse_json(_row_text(row, "logical_conversation_ids_json"))),
         total_cost_usd=float(_row_float(row, "total_cost_usd", 0.0) or 0.0),
         total_duration_ms=int(_row_int(row, "total_duration_ms", 0) or 0),
         total_tool_active_duration_ms=int(_row_int(row, "total_tool_active_duration_ms", 0) or 0),

--- a/polylogue/storage/sqlite/queries/mappers_insight_profiles.py
+++ b/polylogue/storage/sqlite/queries/mappers_insight_profiles.py
@@ -67,6 +67,7 @@ def _row_to_session_profile_record(row: sqlite3.Row) -> SessionProfileRecord:
         )
     return SessionProfileRecord(
         conversation_id=ConversationId(row["conversation_id"]),
+        logical_conversation_id=ConversationId(_row_text(row, "logical_conversation_id") or row["conversation_id"]),
         materializer_version=int(_row_int(row, "materializer_version", 1) or 1),
         materialized_at=row["materialized_at"],
         source_updated_at=_row_text(row, "source_updated_at"),

--- a/polylogue/storage/sqlite/queries/session_insight_summary_queries.py
+++ b/polylogue/storage/sqlite/queries/session_insight_summary_queries.py
@@ -114,11 +114,13 @@ async def replace_session_tag_rollup_rows(
                 input_high_water_mark_source,
                 input_row_count,
                 conversation_count,
+                logical_session_count,
+                logical_conversation_ids_json,
                 explicit_count,
                 auto_count,
                 repo_breakdown_json,
                 search_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [session_tag_rollup_insert_values(record) for record in records],
         )
@@ -152,6 +154,8 @@ async def replace_day_session_summaries(
                 input_high_water_mark_source,
                 input_row_count,
                 conversation_count,
+                logical_session_count,
+                logical_conversation_ids_json,
                 total_cost_usd,
                 total_duration_ms,
                 total_tool_active_duration_ms,
@@ -162,7 +166,7 @@ async def replace_day_session_summaries(
                 repos_active_json,
                 payload_json,
                 search_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [day_session_summary_insert_values(record) for record in records],
         )

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -75,7 +75,7 @@ from polylogue.storage.sqlite.schema_ddl_repo_identity import (
     REPO_IDENTITY_DDL as _REPO_IDENTITY_DDL,
 )
 
-SCHEMA_VERSION = 12  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240, #1241, #1252, #1258, #1260, #1253, #1486, #1526, #1527, #1528, #1530).
+SCHEMA_VERSION = 13  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240, #1241, #1252, #1258, #1260, #1253, #1486, #1526, #1527, #1528, #1530, #866).
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_insight_aggregates.py
+++ b/polylogue/storage/sqlite/schema_ddl_insight_aggregates.py
@@ -67,6 +67,8 @@ SESSION_INSIGHT_AGGREGATE_DDL = (
     + MATERIALIZATION_COLUMNS_SQL
     + """
             conversation_count INTEGER NOT NULL DEFAULT 0,
+            logical_session_count INTEGER NOT NULL DEFAULT 0,
+            logical_conversation_ids_json TEXT NOT NULL DEFAULT '[]',
             explicit_count INTEGER NOT NULL DEFAULT 0,
             auto_count INTEGER NOT NULL DEFAULT 0,
             repo_breakdown_json TEXT NOT NULL DEFAULT '{}',
@@ -86,6 +88,8 @@ SESSION_INSIGHT_AGGREGATE_DDL = (
     + MATERIALIZATION_COLUMNS_SQL
     + """
             conversation_count INTEGER NOT NULL DEFAULT 0,
+            logical_session_count INTEGER NOT NULL DEFAULT 0,
+            logical_conversation_ids_json TEXT NOT NULL DEFAULT '[]',
             total_cost_usd REAL NOT NULL DEFAULT 0,
             total_duration_ms INTEGER NOT NULL DEFAULT 0,
             total_tool_active_duration_ms INTEGER NOT NULL DEFAULT 0,

--- a/polylogue/storage/sqlite/schema_ddl_insight_profiles.py
+++ b/polylogue/storage/sqlite/schema_ddl_insight_profiles.py
@@ -9,7 +9,8 @@ from polylogue.storage.sqlite.schema_ddl_insight_common import (
 SESSION_INSIGHT_PROFILE_DDL = (
     """
         CREATE TABLE IF NOT EXISTS session_profiles (
-            conversation_id TEXT PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,"""
+            conversation_id TEXT PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+            logical_conversation_id TEXT NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,"""
     + MATERIALIZATION_COLUMNS_SQL
     + """
             provider_name TEXT NOT NULL,
@@ -69,6 +70,9 @@ SESSION_INSIGHT_PROFILE_DDL = (
 
         CREATE INDEX IF NOT EXISTS idx_session_profiles_provider
         ON session_profiles(provider_name);
+
+        CREATE INDEX IF NOT EXISTS idx_session_profiles_logical_conversation
+        ON session_profiles(logical_conversation_id);
 
         CREATE INDEX IF NOT EXISTS idx_session_profiles_sort
         ON session_profiles(source_sort_key DESC);

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -39,6 +39,8 @@ EXPECTED_TOOL_NAMES = {
     "delete_conversation",
     "get_conversation_summary",
     "get_session_tree",
+    "get_session_topology",
+    "get_logical_session",
     "get_stats_by",
     "readiness_check",
     "rebuild_index",
@@ -216,6 +218,8 @@ def make_polylogue_mock() -> MagicMock:
     poly.get_conversation_summary = AsyncMock(return_value=None)
     poly.get_conversation_stats = AsyncMock(return_value={})
     poly.get_session_tree = AsyncMock(return_value=[])
+    poly.get_session_topology = AsyncMock(return_value=None)
+    poly.get_logical_session = AsyncMock(return_value=None)
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))
     poly.get_conversation = AsyncMock(return_value=None)
     poly.get_session_profile_insight = AsyncMock(return_value=None)

--- a/tests/unit/api/test_topology_api.py
+++ b/tests/unit/api/test_topology_api.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.api import Polylogue
-from polylogue.insights.topology import ConversationRef, SessionTopology
+from polylogue.insights.topology import ConversationRef, LogicalSession, SessionTopology
 from tests.infra.storage_records import ConversationBuilder, db_setup
 
 
@@ -145,6 +145,26 @@ async def test_get_thread_orders_ancestors_self_descendants(workspace_env: dict[
 
 
 @pytest.mark.asyncio
+async def test_get_logical_session_returns_compact_read_pull_view(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        logical = await polylogue.get_logical_session("continuation")
+    finally:
+        await polylogue.close()
+
+    assert isinstance(logical, LogicalSession)
+    assert str(logical.conversation_id) == "continuation"
+    assert str(logical.root_id) == "root"
+    assert [str(ref.conversation_id) for ref in logical.thread] == ["root", "continuation", "fork"]
+    assert {str(ref.conversation_id) for ref in logical.siblings} == {"subagent", "sidechain"}
+    assert [str(ref.conversation_id) for ref in logical.descendants] == ["fork"]
+    assert logical.cycle_detected is False
+
+
+@pytest.mark.asyncio
 async def test_topology_api_unknown_conversation_returns_empty(workspace_env: dict[str, Path]) -> None:
     db_path = db_setup(workspace_env)
     _seed_lineage(db_path)
@@ -156,6 +176,7 @@ async def test_topology_api_unknown_conversation_returns_empty(workspace_env: di
         descendants = await polylogue.get_descendants("never-ingested")
         siblings = await polylogue.get_siblings("never-ingested")
         thread = await polylogue.get_thread("never-ingested")
+        logical = await polylogue.get_logical_session("never-ingested")
     finally:
         await polylogue.close()
 
@@ -164,6 +185,7 @@ async def test_topology_api_unknown_conversation_returns_empty(workspace_env: di
     assert descendants == []
     assert siblings == []
     assert thread == []
+    assert logical is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/insights/test_productivity.py
+++ b/tests/unit/insights/test_productivity.py
@@ -68,6 +68,7 @@ def _profile(
     )
     return SessionProfileInsight(
         conversation_id=conversation_id,
+        logical_conversation_id=conversation_id,
         provider_name=provider,
         title=None,
         provenance=_DEFAULT_PROVENANCE,

--- a/tests/unit/insights/test_rigor_audit.py
+++ b/tests/unit/insights/test_rigor_audit.py
@@ -73,6 +73,7 @@ def _enrichment_provenance() -> ArchiveEnrichmentProvenance:
 def _profile(conversation_id: str = "c1") -> SessionProfileInsight:
     return SessionProfileInsight(
         conversation_id=conversation_id,
+        logical_conversation_id=conversation_id,
         provider_name="claude-code",
         provenance=_provenance(),
         evidence=SessionEvidencePayload(message_count=10, word_count=200),

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -54,6 +54,10 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
         "envelope",
         frozenset({"target_id", "root_id", "nodes", "edges", "ancestors", "descendants", "siblings", "thread"}),
     ),
+    "get_logical_session": (
+        "envelope",
+        frozenset({"conversation_id", "root_id", "thread", "siblings", "descendants", "cycle_detected"}),
+    ),
     "get_messages": ("envelope", frozenset({"messages", "total"})),
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     "find_abandoned_sessions": ("envelope", frozenset({"items", "total"})),

--- a/tests/unit/mcp/test_insight_shape_tools.py
+++ b/tests/unit/mcp/test_insight_shape_tools.py
@@ -18,6 +18,7 @@ from tests.unit.mcp.test_tool_contracts import _inference_provenance, _provenanc
 def _profile() -> SessionProfileInsight:
     return SessionProfileInsight(
         conversation_id="conv-1",
+        logical_conversation_id="conv-1",
         provider_name="claude-code",
         title="Profiled Session",
         semantic_tier="merged",

--- a/tests/unit/mcp/test_logical_session_tool.py
+++ b/tests/unit/mcp/test_logical_session_tool.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from polylogue.insights.topology import ConversationRef, LogicalSession
+from polylogue.types import ConversationId
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface, make_polylogue_mock
+
+
+def test_logical_session_tool_returns_compact_envelope(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.get_logical_session = AsyncMock(
+            return_value=LogicalSession(
+                conversation_id=ConversationId("fork"),
+                root_id=ConversationId("root"),
+                thread=(
+                    ConversationRef(conversation_id=ConversationId("root"), provider_name="claude-code", depth=0),
+                    ConversationRef(conversation_id=ConversationId("fork"), provider_name="claude-code", depth=1),
+                ),
+                siblings=(),
+                descendants=(),
+                cycle_detected=False,
+            )
+        )
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["get_logical_session"].fn,
+            conversation_id="fork",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["conversation_id"] == "fork"
+    assert parsed["root_id"] == "root"
+    assert [item["conversation_id"] for item in parsed["thread"]] == ["root", "fork"]
+    assert parsed["cycle_detected"] is False
+
+
+def test_logical_session_tool_returns_not_found(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.get_logical_session = AsyncMock(return_value=None)
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["get_logical_session"].fn,
+            conversation_id="missing",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["code"] == "not_found"

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -598,6 +598,7 @@ class TestInsightTools:
     async def test_session_profile_tool_uses_archive_insight_contract(self, mcp_server: MCPServerUnderTest) -> None:
         insight = SessionProfileInsight(
             conversation_id="conv-1",
+            logical_conversation_id="conv-1",
             provider_name="claude-code",
             title="Profiled Session",
             semantic_tier="merged",
@@ -624,6 +625,7 @@ class TestInsightTools:
     async def test_insight_list_tools_use_archive_queries(self, mcp_server: MCPServerUnderTest) -> None:
         profile = SessionProfileInsight(
             conversation_id="conv-1",
+            logical_conversation_id="conv-1",
             provider_name="claude-code",
             title="Profiled Session",
             semantic_tier="merged",

--- a/tests/unit/storage/test_dead_schema_sweep.py
+++ b/tests/unit/storage/test_dead_schema_sweep.py
@@ -54,7 +54,7 @@ def test_schema_version_is_9() -> None:
     # cross-source repo identity surface for slice C of #864), then
     # 8 → 9 by #1486 (provider-event payload split and content-block
     # canonical message body storage).
-    assert SCHEMA_VERSION == 12
+    assert SCHEMA_VERSION == 13
 
 
 def test_content_blocks_table_has_no_media_type_column(fresh_schema_db: Mapping[str, sqlite3.Connection]) -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -69,6 +69,76 @@ async def test_apply_session_insight_conversation_updates_async_batches_hydrated
 
 
 @pytest.mark.asyncio
+async def test_session_insight_refresh_materializes_logical_session_identity(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "logical-session.db"
+    with open_connection(db_path) as conn:
+        for conversation_id, parent_id in (("root", None), ("continuation", "root"), ("fork", "continuation")):
+            store_records(
+                conversation=make_conversation(
+                    conversation_id,
+                    provider_name="claude-code",
+                    title=conversation_id,
+                    parent_conversation_id=parent_id,
+                    updated_at="2026-05-25T10:00:00+00:00",
+                ),
+                messages=[
+                    make_message(
+                        f"{conversation_id}:msg-1",
+                        conversation_id,
+                        text=f"{conversation_id} logical identity test",
+                        timestamp="2026-05-25T10:00:00+00:00",
+                    )
+                ],
+                attachments=[],
+                conn=conn,
+            )
+        conn.commit()
+
+    backend = SQLiteBackend(db_path=db_path)
+    async with backend.connection() as conn:
+        await _apply_session_insight_conversation_updates_async(
+            conn,
+            ["root", "continuation", "fork"],
+            transaction_depth=1,
+            page_size=10,
+        )
+        await refresh_async_provider_day_aggregates(
+            conn,
+            {("claude-code", "2026-05-25")},
+            transaction_depth=1,
+        )
+        await conn.commit()
+
+    with open_connection(db_path) as conn:
+        profile_rows = conn.execute(
+            """
+            SELECT conversation_id, logical_conversation_id
+            FROM session_profiles
+            ORDER BY conversation_id
+            """
+        ).fetchall()
+        day_summary = conn.execute(
+            """
+            SELECT conversation_count, logical_session_count, logical_conversation_ids_json
+            FROM day_session_summaries
+            WHERE provider_name = 'claude-code' AND day = '2026-05-25'
+            """
+        ).fetchone()
+
+    assert {tuple(row) for row in profile_rows} == {
+        ("continuation", "root"),
+        ("fork", "root"),
+        ("root", "root"),
+    }
+    assert day_summary is not None
+    assert int(day_summary["conversation_count"]) == 3
+    assert int(day_summary["logical_session_count"]) == 1
+    assert json.loads(day_summary["logical_conversation_ids_json"]) == ["root"]
+
+
+@pytest.mark.asyncio
 async def test_apply_session_insight_conversation_updates_async_counts_provider_event_compactions(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Materializes logical session identity for continuation/fork/subagent lineages and exposes a compact read-pull API/MCP envelope for agents.

## Problem

#866 already has durable topology edges and graph reads, but session profiles and rollups still counted physical conversations only. Continuations, forks, sidechains, and subagents could inflate daily/tag/workspace views even though they belong to one logical work session. Read-pull consumers also had to use the full topology graph when they only needed the root/thread/sibling navigation envelope.

## Solution

- Bump canonical schema to v13 and add `session_profiles.logical_conversation_id`.
- Compute logical roots in full rebuild and incremental refresh using the existing thread-root helpers.
- Preserve physical `conversation_count`, then add `logical_session_count` and `logical_conversation_ids_json` to day summaries and tag rollups.
- Make week summaries union day-level logical ids instead of summing day logical counts blindly.
- Add `LogicalSession`, Python API `get_logical_session()`, and MCP `get_logical_session` with a compact typed payload.
- Document the contract in `docs/architecture.md` and `docs/internals.md`.

## Verification

- `ruff format --check polylogue tests && ruff check polylogue tests` -> clean
- `python -m mypy polylogue tests/unit/mcp/test_logical_session_tool.py tests/unit/mcp/test_tool_contracts.py tests/unit/api/test_topology_api.py tests/unit/storage/test_session_insight_refresh.py` -> clean across 857 files
- `pytest tests/unit/api/test_topology_api.py tests/unit/mcp/test_logical_session_tool.py tests/unit/mcp/test_tool_contracts.py::TestInsightTools::test_session_profile_tool_uses_archive_insight_contract tests/unit/mcp/test_tool_contracts.py::TestInsightTools::test_insight_list_tools_use_archive_queries tests/unit/mcp/test_tool_contracts.py::TestMutationTools::test_session_tree_returns_envelope tests/unit/mcp/test_envelope_contracts.py tests/unit/storage/test_session_insight_refresh.py tests/unit/storage/test_dead_schema_sweep.py tests/unit/insights/test_productivity.py tests/unit/insights/test_rigor_audit.py tests/unit/mcp/test_insight_shape_tools.py -q` -> 113 passed
- `devtools render-all --check` -> OK
- `devtools verify --quick` -> PASS in 33.51s locally and PASS in 32.64s from pre-push

Ref #866
