### PR TITLE
fix(embeddings): unify daemon readiness status

### DIFF
--- a/polylogue/daemon/embedding_readiness.py
+++ b/polylogue/daemon/embedding_readiness.py
@@ -4,14 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import polylogue.config as polylogue_config
-from polylogue.storage.embeddings.support import embedded_message_count_sync, optional_count_sync, table_exists_sync
-from polylogue.storage.search_providers.sqlite_vec_support import (
-    ESTIMATED_TOKENS_PER_MESSAGE,
-    VOYAGE_4_COST_PER_1M_TOKENS,
-)
-from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+from polylogue.storage.embeddings.status_payload import embedding_status_payload
 
 
 def _defaults(*, enabled: bool, config_enabled: bool, has_key: bool, model: str, dimension: int) -> dict[str, object]:
@@ -21,20 +17,18 @@ def _defaults(*, enabled: bool, config_enabled: bool, has_key: bool, model: str,
         "embedding_has_voyage_key": has_key,
         "embedding_model": model,
         "embedding_dimension": dimension,
+        "embedding_status": "empty",
+        "embedding_freshness_status": "empty",
+        "embedding_retrieval_ready": False,
         "embedding_pending_count": 0,
         "embedding_pending_message_count": 0,
+        "embedding_pending_message_count_exact": False,
         "embedding_stale_count": 0,
         "embedding_coverage_percent": 0.0,
         "embedding_failure_count": 0,
         "embedding_estimated_cost_usd": 0.0,
         "embedding_latest_catchup_run": None,
     }
-
-
-def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
-    if not table_exists_sync(conn, table):
-        return False
-    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})").fetchall())
 
 
 def embedding_readiness_info(db_file: Path, *, detail: bool = False) -> dict[str, object]:
@@ -55,90 +49,38 @@ def embedding_readiness_info(db_file: Path, *, detail: bool = False) -> dict[str
             dimension=dimension,
         )
 
-    pending = pending_messages = stale = failure = total = total_messages = total_conv = embedded_conv = 0
-    cost = 0.0
-    latest_catchup_run: object | None = None
     try:
-        conn = open_readonly_connection(db_file)
-        try:
-            from polylogue.storage.embeddings.progress import latest_embedding_catchup_run
-
-            embedded_msg = embedded_message_count_sync(conn)
-            if table_exists_sync(conn, "embedding_catchup_runs"):
-                latest_catchup_run = latest_embedding_catchup_run(conn)
-            if _column_exists(conn, "embedding_status", "error_message"):
-                failure = optional_count_sync(
-                    conn, "SELECT COUNT(*) FROM embedding_status WHERE error_message IS NOT NULL"
-                )
-            embedded_conv = optional_count_sync(conn, "SELECT COUNT(*) FROM embedding_status WHERE needs_reindex = 0")
-            total_conv = (
-                int(conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] or 0)
-                if table_exists_sync(conn, "conversations")
-                else 0
-            )
-            if detail:
-                pending = optional_count_sync(
-                    conn,
-                    """
-                    SELECT COUNT(*)
-                    FROM conversations c
-                    LEFT JOIN embedding_status e ON e.conversation_id = c.conversation_id
-                    WHERE e.conversation_id IS NULL OR e.needs_reindex = 1
-                    """,
-                )
-                pending_messages = optional_count_sync(
-                    conn,
-                    """
-                    SELECT COUNT(*)
-                    FROM messages m
-                    JOIN conversations c ON c.conversation_id = m.conversation_id
-                    LEFT JOIN embedding_status e ON e.conversation_id = c.conversation_id
-                    WHERE e.conversation_id IS NULL OR e.needs_reindex = 1
-                    """,
-                )
-                stale = optional_count_sync(
-                    conn,
-                    """
-                    SELECT COUNT(*)
-                    FROM message_embeddings me
-                    JOIN messages m ON m.message_id = me.message_id
-                    LEFT JOIN embeddings_meta em
-                      ON em.target_id = me.message_id
-                     AND em.target_type = 'message'
-                    WHERE em.target_id IS NULL
-                       OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
-                    """,
-                )
-                total_messages = (
-                    int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] or 0)
-                    if table_exists_sync(conn, "messages")
-                    else 0
-                )
-            pending = max(pending, total_conv - embedded_conv)
-            if detail:
-                pending_messages = max(pending_messages, total_messages - embedded_msg if pending > 0 else 0)
-            total = embedded_msg if total_conv > 0 else 0
-            estimated_tokens = (total + pending_messages) * ESTIMATED_TOKENS_PER_MESSAGE
-            cost = round(estimated_tokens * VOYAGE_4_COST_PER_1M_TOKENS / 1_000_000, 2)
-        finally:
-            conn.close()
+        payload = embedding_status_payload(
+            SimpleNamespace(config=SimpleNamespace(db_path=db_file)),
+            include_retrieval_bands=False,
+            include_detail=detail,
+        )
     except (sqlite3.Error, OSError):
-        pass
+        return _defaults(
+            enabled=enabled,
+            config_enabled=config_enabled,
+            has_key=has_key,
+            model=model,
+            dimension=dimension,
+        )
 
-    coverage = (max(0, total_conv - pending) / total_conv * 100) if total_conv > 0 else 0.0
     return {
         "embedding_enabled": enabled,
         "embedding_config_enabled": config_enabled,
         "embedding_has_voyage_key": has_key,
         "embedding_model": model,
         "embedding_dimension": dimension,
-        "embedding_pending_count": pending,
-        "embedding_pending_message_count": pending_messages,
-        "embedding_stale_count": stale,
-        "embedding_coverage_percent": round(coverage, 1),
-        "embedding_failure_count": failure,
-        "embedding_estimated_cost_usd": cost,
-        "embedding_latest_catchup_run": latest_catchup_run,
+        "embedding_status": payload["status"],
+        "embedding_freshness_status": payload["freshness_status"],
+        "embedding_retrieval_ready": payload["retrieval_ready"],
+        "embedding_pending_count": payload["pending_conversations"],
+        "embedding_pending_message_count": payload["pending_messages"] or 0,
+        "embedding_pending_message_count_exact": payload["pending_messages_exact"],
+        "embedding_stale_count": payload["stale_messages"],
+        "embedding_coverage_percent": payload["embedding_coverage_percent"],
+        "embedding_failure_count": payload["failure_count"],
+        "embedding_estimated_cost_usd": payload["total_estimated_cost_usd"],
+        "embedding_latest_catchup_run": payload["latest_catchup_run"],
     }
 
 

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -77,8 +77,12 @@ class EmbeddingReadiness(BaseModel):
     embedding_has_voyage_key: bool = False
     embedding_model: str = ""
     embedding_dimension: int = 0
+    embedding_status: str = "empty"
+    embedding_freshness_status: str = "empty"
+    embedding_retrieval_ready: bool = False
     embedding_pending_count: int = 0
     embedding_pending_message_count: int = 0
+    embedding_pending_message_count_exact: bool = False
     embedding_stale_count: int = 0
     embedding_coverage_percent: float = 0.0
     embedding_failure_count: int = 0
@@ -959,8 +963,14 @@ def build_daemon_status(
             embedding_has_voyage_key=bool(embedding_info.get("embedding_has_voyage_key", False)),
             embedding_model=str(embedding_info.get("embedding_model", "")),
             embedding_dimension=_safe_int(embedding_info.get("embedding_dimension", 0)),
+            embedding_status=str(embedding_info.get("embedding_status", "empty")),
+            embedding_freshness_status=str(embedding_info.get("embedding_freshness_status", "empty")),
+            embedding_retrieval_ready=bool(embedding_info.get("embedding_retrieval_ready", False)),
             embedding_pending_count=_safe_int(embedding_info.get("embedding_pending_count", 0)),
             embedding_pending_message_count=_safe_int(embedding_info.get("embedding_pending_message_count", 0)),
+            embedding_pending_message_count_exact=bool(
+                embedding_info.get("embedding_pending_message_count_exact", False)
+            ),
             embedding_stale_count=_safe_int(embedding_info.get("embedding_stale_count", 0)),
             embedding_coverage_percent=_safe_float(embedding_info.get("embedding_coverage_percent")),
             embedding_failure_count=_safe_int(embedding_info.get("embedding_failure_count", 0)),
@@ -1251,14 +1261,23 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     # Embedding readiness
     embedding = payload.get("embedding_readiness")
     if isinstance(embedding, dict):
+        status = str(embedding.get("embedding_status", "unknown"))
+        freshness = str(embedding.get("embedding_freshness_status", status))
+        retrieval_ready = "ready" if embedding.get("embedding_retrieval_ready") else "not ready"
+        pending_message_count = _safe_int(embedding.get("embedding_pending_message_count"))
+        pending_message_text = (
+            f"{pending_message_count:,} pending msgs"
+            if embedding.get("embedding_pending_message_count_exact")
+            else "pending msgs not calculated"
+        )
         if embedding.get("embedding_enabled"):
             coverage = _safe_float(embedding.get("embedding_coverage_percent"))
             pending = _safe_int(embedding.get("embedding_pending_count"))
-            pending_messages = _safe_int(embedding.get("embedding_pending_message_count"))
             stale = _safe_int(embedding.get("embedding_stale_count"))
             lines.append(
-                f"Embeddings: {coverage:.1f}% coverage, {pending} pending convs, "
-                f"{pending_messages:,} pending msgs, {stale} stale"
+                f"Embeddings: {status}/{freshness}, {retrieval_ready}; "
+                f"{coverage:.1f}% coverage, {pending} pending convs, "
+                f"{pending_message_text}, {stale} stale"
             )
             if _safe_int(embedding.get("embedding_failure_count")) > 0:
                 lines.append(f"  failures: {_safe_int(embedding.get('embedding_failure_count'))}")
@@ -1278,10 +1297,10 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
                 )
         else:
             pending = _safe_int(embedding.get("embedding_pending_count"))
-            pending_messages = _safe_int(embedding.get("embedding_pending_message_count"))
             key_state = "key present" if embedding.get("embedding_has_voyage_key") else "key missing"
             lines.append(
-                f"Embeddings: disabled ({key_state}; {pending} pending convs, {pending_messages:,} pending msgs)"
+                f"Embeddings: disabled ({key_state}; {status}/{freshness}, {retrieval_ready}; "
+                f"{pending} pending convs, {pending_message_text})"
             )
             latest = embedding.get("embedding_latest_catchup_run")
             if isinstance(latest, dict):

--- a/polylogue/storage/embeddings/support.py
+++ b/polylogue/storage/embeddings/support.py
@@ -163,6 +163,7 @@ def is_missing_table_error(exc: sqlite3.OperationalError) -> bool:
     message = str(exc).lower()
     return (
         "no such table" in message
+        or "no such column" in message
         or "does not exist" in message
         or "table not found" in message
         or "no such module: vec0" in message

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -110,6 +110,28 @@ def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: P
     assert f"  {failed}" in lines
 
 
+def test_plain_daemon_status_reports_bounded_embedding_pending_messages() -> None:
+    payload: JSONDocument = {
+        "embedding_readiness": {
+            "embedding_enabled": False,
+            "embedding_has_voyage_key": True,
+            "embedding_status": "none",
+            "embedding_freshness_status": "none",
+            "embedding_retrieval_ready": False,
+            "embedding_pending_count": 7,
+            "embedding_pending_message_count": 0,
+            "embedding_pending_message_count_exact": False,
+        }
+    }
+
+    lines = format_daemon_status_lines(payload)
+
+    assert (
+        "Embeddings: disabled (key present; none/none, not ready; 7 pending convs, pending msgs not calculated)"
+        in lines
+    )
+
+
 def test_daemon_status_caps_failed_file_samples(tmp_path: Path) -> None:
     db = tmp_path / "polylogue.db"
     cursor = CursorStore(db)

--- a/tests/unit/daemon/test_embedding_readiness.py
+++ b/tests/unit/daemon/test_embedding_readiness.py
@@ -196,14 +196,19 @@ def test_readiness_unconfigured_when_enabled_flag_off(
     assert info["embedding_enabled"] is False
     assert info["embedding_config_enabled"] is False
     assert info["embedding_has_voyage_key"] is True
+    assert info["embedding_status"] == "none"
+    assert info["embedding_freshness_status"] == "none"
+    assert info["embedding_retrieval_ready"] is False
     assert info["embedding_pending_count"] == 1
     assert info["embedding_pending_message_count"] == 0
+    assert info["embedding_pending_message_count_exact"] is False
 
     with patch("polylogue.config.load_polylogue_config", return_value=cfg):
         detailed = embedding_readiness_info(db, detail=True)
 
     assert detailed["embedding_pending_count"] == 1
     assert detailed["embedding_pending_message_count"] == 1
+    assert detailed["embedding_pending_message_count_exact"] is True
 
 
 # ── 3. embedding failure branch ────────────────────────────────────


### PR DESCRIPTION
## Summary

Unify daemon embedding readiness with the canonical `polylogue embed status` payload so operator surfaces report the same status, freshness, retrieval-ready, backlog, and latest catch-up state.

## Problem

Daemon status recomputed embedding readiness with a separate SQL path. That made it narrower than the operator embed-status payload and could render bounded default probes as `0 pending msgs`, even when pending-message accounting was intentionally skipped to keep daemon status cheap.

## Solution

`polylogue.daemon.embedding_readiness.embedding_readiness_info()` now maps from `embedding_status_payload()` while preserving bounded default reads. The daemon status model carries `embedding_status`, `embedding_freshness_status`, `embedding_retrieval_ready`, and `embedding_pending_message_count_exact`. Plain status output now says `pending msgs not calculated` when it did not run the exact detail query.

The optional embedding-stat reader also treats missing optional columns like older `embedding_status.error_message` as absent optional schema, so older archives still expose backlog instead of collapsing to empty defaults.

Ref #1503

## Verification

- `pytest -q tests/unit/daemon/test_embedding_readiness.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_embedding_convergence_progress.py tests/unit/cli/test_embed_status_fast.py tests/unit/storage/test_embedding_stats.py --tb=short` — 53 passed.
- `ruff format --check polylogue/daemon/embedding_readiness.py polylogue/daemon/status.py polylogue/storage/embeddings/support.py tests/unit/daemon/test_embedding_readiness.py tests/unit/daemon/test_daemon_status.py` — clean.
- `ruff check polylogue/daemon/embedding_readiness.py polylogue/daemon/status.py polylogue/storage/embeddings/support.py tests/unit/daemon/test_embedding_readiness.py tests/unit/daemon/test_daemon_status.py` — clean.
- `python -m mypy polylogue/daemon/embedding_readiness.py polylogue/daemon/status.py polylogue/storage/embeddings/support.py tests/unit/daemon/test_embedding_readiness.py tests/unit/daemon/test_daemon_status.py` — no issues.
- `devtools render-all --check` — sync OK.
- `devtools verify --quick` — exit 0 locally, total duration 34.2s.
- Pre-push `devtools verify --quick` — exit 0, total duration 32.82s.
