### PR TITLE
fix(search): gate semantic queries on embedding readiness

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -245,7 +245,7 @@ lane based on archive state and the query shape:
 |-----------|---------------|
 | `--lexical` flag set | `dialogue` (forced FTS-only, even with embeddings enabled) |
 | `--semantic` flag set, or `--similar <text>` given | `semantic` (vector-only) |
-| Embeddings enabled + ≥1 message embedded + FTS query present | `hybrid` |
+| Embeddings retrieval-ready + FTS query present | `hybrid` |
 | Otherwise | `dialogue` |
 
 The elevation rule lives in

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -273,6 +273,22 @@ def _stats_dimension(plan: QueryExecutionPlan) -> str:
     return plan.stats_dimension or "all"
 
 
+def _archive_embedding_retrieval_ready(archive_stats: object) -> bool:
+    retrieval_ready = getattr(archive_stats, "retrieval_ready", None)
+    if isinstance(retrieval_ready, bool):
+        return retrieval_ready
+    embedded_messages = int(getattr(archive_stats, "embedded_messages", 0) or 0)
+    stale_messages = int(getattr(archive_stats, "stale_embedding_messages", 0) or 0)
+    return max(embedded_messages - stale_messages, 0) > 0
+
+
+def _archive_embedding_readiness_status(archive_stats: object) -> str:
+    status = getattr(archive_stats, "embedding_readiness_status", None)
+    if isinstance(status, str) and status:
+        return status
+    return "ready" if _archive_embedding_retrieval_ready(archive_stats) else "none"
+
+
 async def _diagnose_query_miss(
     repo: QueryExecutionStore,
     selection: ConversationQuerySpec,
@@ -411,7 +427,7 @@ async def _maybe_elevate_to_hybrid(
     if vector_provider is None:
         return plan
     archive_stats = await repo.get_archive_stats()
-    if archive_stats.embedded_messages <= 0:
+    if not _archive_embedding_retrieval_ready(archive_stats):
         return plan
     return replace(plan, selection=replace(selection, retrieval_lane="hybrid"))
 
@@ -427,9 +443,12 @@ async def _execute_query_plan(
     vector_provider: VectorProvider | None = None
     if plan.selection.similar_text:
         archive_stats = await repo.get_archive_stats()
-        if archive_stats.embedded_messages <= 0:
+        if not _archive_embedding_retrieval_ready(archive_stats):
+            status = _archive_embedding_readiness_status(archive_stats)
             click.echo(
-                "Error: --similar/--semantic requires existing embeddings. Run `polylogue embed status`, then `polylogue embed backfill` or let polylogued converge after enabling embeddings.",
+                "Error: --similar/--semantic requires retrieval-ready embeddings "
+                f"(current status: {status}). Run `polylogue embed status`, then "
+                "`polylogue embed backfill` or let polylogued converge after enabling embeddings.",
                 err=True,
             )
             raise SystemExit(1)

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -440,9 +440,12 @@ class TestBackfillCommand:
 
 
 class TestHybridAutoElevation:
-    def _stub_repo(self, embedded: int) -> Any:
+    def _stub_repo(self, embedded: int, *, stale: int = 0, retrieval_ready: bool | None = None) -> Any:
         stats = MagicMock()
         stats.embedded_messages = embedded
+        stats.stale_embedding_messages = stale
+        if retrieval_ready is not None:
+            stats.retrieval_ready = retrieval_ready
         repo = MagicMock()
         repo.get_archive_stats = AsyncMock(return_value=stats)
         return repo
@@ -455,6 +458,17 @@ class TestHybridAutoElevation:
     def test_no_embeddings_keeps_auto(self) -> None:
         plan = _make_plan(ConversationQuerySpec(query_terms=("foo",), retrieval_lane="auto"))
         out = asyncio.run(_maybe_elevate_to_hybrid(plan, vector_provider=MagicMock(), repo=self._stub_repo(0)))
+        assert out.selection.retrieval_lane == "auto"
+
+    def test_stale_embeddings_keep_auto(self) -> None:
+        plan = _make_plan(ConversationQuerySpec(query_terms=("foo",), retrieval_lane="auto"))
+        out = asyncio.run(
+            _maybe_elevate_to_hybrid(
+                plan,
+                vector_provider=MagicMock(),
+                repo=self._stub_repo(100, stale=100, retrieval_ready=False),
+            )
+        )
         assert out.selection.retrieval_lane == "auto"
 
     def test_no_fts_terms_keeps_auto(self) -> None:

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -244,8 +244,37 @@ async def test_async_execute_query_errors_for_similar_without_embeddings() -> No
 
     assert exc_info.value.code == 1
     mock_echo.assert_called_once()
-    assert "requires existing embeddings" in mock_echo.call_args.args[0]
+    assert "requires retrieval-ready embeddings" in mock_echo.call_args.args[0]
     assert "polylogue embed backfill" in mock_echo.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_async_execute_query_errors_for_similar_when_vectors_are_stale() -> None:
+    from polylogue.cli.query import async_execute_query
+
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(
+        return_value=SimpleNamespace(
+            embedded_messages=10,
+            stale_embedding_messages=10,
+            retrieval_ready=False,
+            embedding_readiness_status="stale",
+        )
+    )
+    env = _make_env(repo=repo, config=MagicMock())
+
+    with (
+        patch("polylogue.cli.shared.helpers.load_effective_config", return_value=MagicMock()),
+        patch("polylogue.storage.search_providers.create_vector_provider", return_value=MagicMock()),
+        patch("click.echo") as mock_echo,
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await async_execute_query(env, _make_params(similar_text="sqlite locking regression"))
+
+    assert exc_info.value.code == 1
+    mock_echo.assert_called_once()
+    assert "requires retrieval-ready embeddings" in mock_echo.call_args.args[0]
+    assert "current status: stale" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Make semantic query execution and hybrid auto-elevation use the archive embedding readiness contract instead of raw embedded-message counts.

## Problem

`--semantic`, `--similar`, and automatic hybrid promotion checked only whether `embedded_messages > 0`. That is weaker than the archive contract: an archive can have embedded rows that are stale or otherwise not retrieval-ready. In that state semantic search should fail fast and auto search should stay lexical.

## Solution

Query execution now uses a small readiness helper that prefers `ArchiveStats.retrieval_ready` and falls back to `embedded_messages - stale_embedding_messages > 0` for tests/lightweight doubles. Semantic failures include the current embedding readiness status. Hybrid auto-elevation no longer promotes when vectors are stale or unusable.

`docs/search.md` now describes the same retrieval-ready hybrid promotion condition.

Ref #1503

## Verification

- `pytest -q tests/unit/cli/test_query_exec.py tests/unit/cli/test_embed_activation.py --tb=short` — 98 passed.
- `ruff format --check polylogue/cli/query.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_embed_activation.py` — clean.
- `ruff check polylogue/cli/query.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_embed_activation.py` — clean.
- `python -m mypy polylogue/cli/query.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_embed_activation.py` — no issues.
- `devtools render-pages` — site cache refreshed after docs edit.
- `devtools render-all --check` — sync OK.
- `devtools verify --quick` — exit 0 locally, total duration 34.29s before docs edit; pre-push rerun after docs edit exited 0, total duration 33.2s.
