### PR TITLE
fix(devtools): preserve testmon affected selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,11 +354,15 @@ not a substitute for the default baseline. The default command fails fast when
 silent full-suite fallback.
 
 `devtools verify` does not replay a prior verify result. It always runs the
-static gates and lets pytest-testmon decide affected tests from the current
-source, dependency, and Python-version state. If pytest configuration,
-dependency locks, or shared test infrastructure changed since the seed, the
-default command automatically widens the pytest step to `--testmon-noselect`
-and refreshes dependency data.
+static gates and then invokes pytest-testmon for affected-test selection from
+the current source, dependency, and Python-version state. The default pytest
+step combines marker filters with `--testmon-forceselect` so scale-tier
+deselection does not silently expand the run back to the whole suite; affected
+testmon runs are single-process by default to avoid xdist collection skew.
+Polylogue does not maintain a parallel changed-file router for helper/config
+paths; use `devtools verify --seed-testmon` when you intentionally want to
+refresh the dependency database and `devtools verify --all` for an explicit full
+diagnostic.
 
 Add `devtools build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
@@ -396,7 +400,8 @@ All commands below assume you are inside the project devshell. See
 # Normal repository verification
 devtools verify
 
-# First run after checkout or dependency/test harness changes
+# First run after checkout, or when you intentionally want to refresh
+# pytest-testmon's dependency database
 devtools verify --seed-testmon --skip-slow
 
 # Stop on first failure
@@ -421,16 +426,18 @@ whole suite.
 
 Plain focused `pytest` runs are single-process by default so small inner-loop
 checks do not spawn a worker pool. `devtools verify` keeps pytest-testmon as
-the affected-test selector and runs the selected tests with xdist workers
-(`-n 8` by default, override with `POLYLOGUE_PYTEST_WORKERS`). Full diagnostic
-and seed runs use the same worker override and default to `-n 16`.
+the affected-test selector and runs selected tests single-process (`-n 0` by
+default, override with `POLYLOGUE_PYTEST_WORKERS`). Because the default gate
+also applies marker filters for scale tiers, it passes `--testmon-forceselect`
+so pytest-testmon still selects affected tests instead of letting pytest marker
+selection expand the run. Full diagnostic and seed runs use the same worker
+override and default to `-n 16`.
 
 The default path does not replay cached verify results. Every invocation runs
-the static gates and lets pytest-testmon evaluate current source, package, and
-Python-version state. Changes to pytest configuration, dependency locks, or
-shared test infrastructure automatically widen the pytest step to
-`--testmon-noselect` so the dependency database is refreshed without requiring
-a manual full-suite bypass.
+the static gates and then invokes pytest-testmon for affected-test selection.
+Polylogue does not maintain a parallel changed-file router for helper/config
+paths; explicit full collection is limited to `devtools verify --seed-testmon`
+for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,11 +261,15 @@ not a substitute for the default baseline. The default command fails fast when
 silent full-suite fallback.
 
 `devtools verify` does not replay a prior verify result. It always runs the
-static gates and lets pytest-testmon decide affected tests from the current
-source, dependency, and Python-version state. If pytest configuration,
-dependency locks, or shared test infrastructure changed since the seed, the
-default command automatically widens the pytest step to `--testmon-noselect`
-and refreshes dependency data.
+static gates and then invokes pytest-testmon for affected-test selection from
+the current source, dependency, and Python-version state. The default pytest
+step combines marker filters with `--testmon-forceselect` so scale-tier
+deselection does not silently expand the run back to the whole suite; affected
+testmon runs are single-process by default to avoid xdist collection skew.
+Polylogue does not maintain a parallel changed-file router for helper/config
+paths; use `devtools verify --seed-testmon` when you intentionally want to
+refresh the dependency database and `devtools verify --all` for an explicit full
+diagnostic.
 
 Add `devtools build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,7 +9,8 @@ All commands below assume you are inside the project devshell. See
 # Normal repository verification
 devtools verify
 
-# First run after checkout or dependency/test harness changes
+# First run after checkout, or when you intentionally want to refresh
+# pytest-testmon's dependency database
 devtools verify --seed-testmon --skip-slow
 
 # Stop on first failure
@@ -34,16 +35,18 @@ whole suite.
 
 Plain focused `pytest` runs are single-process by default so small inner-loop
 checks do not spawn a worker pool. `devtools verify` keeps pytest-testmon as
-the affected-test selector and runs the selected tests with xdist workers
-(`-n 8` by default, override with `POLYLOGUE_PYTEST_WORKERS`). Full diagnostic
-and seed runs use the same worker override and default to `-n 16`.
+the affected-test selector and runs selected tests single-process (`-n 0` by
+default, override with `POLYLOGUE_PYTEST_WORKERS`). Because the default gate
+also applies marker filters for scale tiers, it passes `--testmon-forceselect`
+so pytest-testmon still selects affected tests instead of letting pytest marker
+selection expand the run. Full diagnostic and seed runs use the same worker
+override and default to `-n 16`.
 
 The default path does not replay cached verify results. Every invocation runs
-the static gates and lets pytest-testmon evaluate current source, package, and
-Python-version state. Changes to pytest configuration, dependency locks, or
-shared test infrastructure automatically widen the pytest step to
-`--testmon-noselect` so the dependency database is refreshed without requiring
-a manual full-suite bypass.
+the static gates and then invokes pytest-testmon for affected-test selection.
+Polylogue does not maintain a parallel changed-file router for helper/config
+paths; explicit full collection is limited to `devtools verify --seed-testmon`
+for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -131,18 +131,6 @@ TESTMON_DATA = Path(".testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
-TESTMON_GLOBAL_INVALIDATORS = (
-    ".python-version",
-    "conftest.py",
-    "noxfile.py",
-    "pyproject.toml",
-    "pytest.ini",
-    "setup.cfg",
-    "tox.ini",
-    "uv.lock",
-    "tests/conftest.py",
-    "tests/infra/",
-)
 
 
 def _load_history() -> list[dict[str, Any]]:
@@ -315,7 +303,6 @@ def build_verify_steps(
     commit: bool = False,
     seed_testmon: bool = False,
     full_pytest: bool = False,
-    testmon_global: bool = False,
 ) -> list[tuple[str, list[str]]]:
     steps: list[tuple[str, list[str]]] = [
         ("ruff format", ["ruff", "format", "--check", "polylogue/", "tests/", "devtools/"]),
@@ -392,13 +379,9 @@ def build_verify_steps(
         elif full_pytest:
             pytest_cmd.extend(_pytest_worker_args(default="16"))
             steps.append(("pytest full", pytest_cmd))
-        elif testmon_global:
-            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")])
-            steps.append(("pytest testmon-global", pytest_cmd))
         else:
-            pytest_cmd.extend(["--testmon", *_pytest_worker_args(default="8")])
-            if skip_slow:
-                pytest_cmd.append("--testmon-forceselect")
+            pytest_cmd.extend(["--testmon", *_pytest_worker_args(default="0")])
+            pytest_cmd.append("--testmon-forceselect")
             steps.append(("pytest testmon", pytest_cmd))
 
     if lab:
@@ -479,49 +462,6 @@ def _file_fingerprint(path: Path) -> str:
 def _pytest_worker_args(*, default: str) -> list[str]:
     workers = os.environ.get("POLYLOGUE_PYTEST_WORKERS", default).strip() or default
     return ["-n", workers]
-
-
-def _read_testmon_seed_stamp() -> dict[str, Any] | None:
-    try:
-        raw: object = json.loads(TESTMON_SEED_STAMP.read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
-    return raw if isinstance(raw, dict) else None
-
-
-def _git_changed_paths(base: str | None) -> set[str] | None:
-    changed: set[str] = set()
-    commands: list[list[str]] = []
-    if base:
-        commands.append(["git", "diff", "--name-only", f"{base}..HEAD"])
-    commands.append(["git", "diff", "--name-only", "HEAD"])
-    commands.append(["git", "ls-files", "--others", "--exclude-standard"])
-
-    for command in commands:
-        result = subprocess.run(command, capture_output=True, text=True)
-        if result.returncode != 0:
-            return None
-        changed.update(line for line in result.stdout.splitlines() if line.strip())
-    return changed
-
-
-def _is_testmon_global_invalidator(path: str) -> bool:
-    if not path:
-        return False
-    if path.endswith((".toml", ".ini", ".cfg")) and (
-        path.startswith("tests/") or path in {"pyproject.toml", "setup.cfg", "tox.ini", "pytest.ini"}
-    ):
-        return True
-    return any(path == invalidator or path.startswith(invalidator) for invalidator in TESTMON_GLOBAL_INVALIDATORS)
-
-
-def _testmon_requires_global_collection() -> bool:
-    seed = _read_testmon_seed_stamp()
-    base = seed.get("git_head") if seed else None
-    changed = _git_changed_paths(base if isinstance(base, str) else None)
-    if changed is None:
-        return True
-    return any(_is_testmon_global_invalidator(path) for path in changed)
 
 
 def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, commit: bool) -> str | None:
@@ -613,10 +553,6 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(preflight_error)
         return 2
 
-    testmon_global = (
-        not (args.quick or args.commit or args.seed_testmon or full_pytest) and _testmon_requires_global_collection()
-    )
-
     head = _git_head()
     t0 = time.monotonic()
 
@@ -635,7 +571,6 @@ def main(argv: list[str] | None = None) -> int:
         skip_slow=bool(args.skip_slow),
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,
-        testmon_global=testmon_global,
     )
 
     step_results: list[dict[str, Any]] = []
@@ -685,7 +620,7 @@ def main(argv: list[str] | None = None) -> int:
     _save_history(history_entry)
     if exit_code == 0:
         _stamp_head()
-        if args.seed_testmon or testmon_global:
+        if args.seed_testmon:
             _write_testmon_seed_stamp(history_entry)
 
     # Notify on long-running verify.

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -182,7 +182,8 @@ Target:
 Outcome:
 
 - `devtools verify` now runs the static/generated gates plus
-  `pytest --testmon -n 0` for affected per-test selection.
+  `pytest --testmon --testmon-forceselect` for affected per-test selection
+  under the default scale-tier marker filter.
 - `devtools verify --seed-testmon --skip-slow` is the explicit full
   non-integration seed/update path. It writes `.testmondata` and
   `.cache/testmon/seed.json`; default verify refuses ad hoc or missing seed
@@ -191,13 +192,15 @@ Outcome:
   diagnostic. `--affected` and `_affected_test_files()` were removed.
 - The verify runner now stops after the first failed step, preventing format or
   lint failures from cascading into expensive pytest runs.
-- Full/seed pytest worker count defaults to 8 and can be adjusted with
-  `POLYLOGUE_PYTEST_WORKERS`; affected testmon runs use `-n 0` to avoid xdist
-  overhead for small selections.
+- Full/seed pytest worker count defaults to 16, affected testmon runs default
+  to `-n 0` single-process to avoid xdist collection skew under
+  `--testmon-forceselect`, and both can be adjusted with
+  `POLYLOGUE_PYTEST_WORKERS`.
 - The extra `devtools` worktree-result replay cache was removed. Every
   invocation now reaches pytest-testmon, which owns package/Python/source
-  invalidation; harness/config/dependency-lock changes automatically widen to
-  `--testmon-noselect` instead of relying on a manual full-suite bypass.
+  invalidation. The later #1549 cleanup removed Polylogue's hand-maintained
+  changed-file invalidator; explicit full collection is now limited to
+  `--seed-testmon` and `--all` / `--full`.
 
 Measured locally:
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -11,7 +11,6 @@ from devtools.verify import (
     PYTEST_REPORT_PATH,
     ROOT,
     _format_completion_notification,
-    _is_testmon_global_invalidator,
     _parse_pytest_test_count,
     _pytest_command_metadata,
     _pytest_metadata_from_report,
@@ -60,8 +59,9 @@ def test_default_verify_uses_pytest_testmon() -> None:
     assert label == "pytest testmon"
     assert "--testmon" in command
     assert "--testmon-noselect" not in command
+    assert "--testmon-forceselect" in command
     assert "-n" in command
-    assert command[command.index("-n") + 1] == "8"
+    assert command[command.index("-n") + 1] == "0"
 
 
 def test_pytest_step_requests_structured_json_report() -> None:
@@ -69,7 +69,6 @@ def test_pytest_step_requests_structured_json_report() -> None:
     for kwargs in (
         {"seed_testmon": True},
         {"full_pytest": True},
-        {"testmon_global": True},
         {},  # default testmon
     ):
         steps = build_verify_steps(quick=False, lab=False, skip_slow=False, **kwargs)
@@ -124,19 +123,18 @@ def test_default_testmon_worker_count_can_be_overridden(monkeypatch: pytest.Monk
     assert command[command.index("-n") + 1] == "3"
 
 
-def test_global_testmon_invalidator_runs_full_collection(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("POLYLOGUE_PYTEST_WORKERS", raising=False)
-
-    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, testmon_global=True)
+def test_marker_filters_keep_testmon_selection_forced() -> None:
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False)
 
     label, command = steps[-1]
-    assert label == "pytest testmon-global"
-    assert "--testmon" in command
-    assert "--testmon-noselect" in command
-    assert command[command.index("-n") + 1] == "16"
+    assert label == "pytest testmon"
+    marker_expr = command[command.index("-m") + 1]
+    assert "not scale_medium" in marker_expr
+    assert "not scale_large" in marker_expr
+    assert "--testmon-forceselect" in command
 
 
-def test_skip_slow_keeps_testmon_selection_forced() -> None:
+def test_skip_slow_composes_with_forced_testmon_selection() -> None:
     steps = build_verify_steps(quick=False, lab=False, skip_slow=True)
 
     label, command = steps[-1]
@@ -174,16 +172,6 @@ def test_lab_verify_includes_medium_scale_marker() -> None:
     assert "not scale_large" in marker_expr
     assert "not scale_medium" not in marker_expr
     assert "scale_small" not in marker_expr
-
-
-def test_global_testmon_invalidators_cover_harness_and_config() -> None:
-    assert _is_testmon_global_invalidator("pyproject.toml")
-    assert _is_testmon_global_invalidator("uv.lock")
-    assert _is_testmon_global_invalidator("tests/conftest.py")
-    assert _is_testmon_global_invalidator("tests/infra/storage_records.py")
-    assert _is_testmon_global_invalidator("tests/unit/pytest.ini")
-    assert not _is_testmon_global_invalidator("polylogue/cli/click_app.py")
-    assert not _is_testmon_global_invalidator("docs/execution-plan.md")
 
 
 def test_lab_verify_delegates_to_lab_scenario() -> None:


### PR DESCRIPTION
## Summary

Make the default `devtools verify` path actually preserve pytest-testmon affected-test selection instead of silently expanding through Polylogue's own invalidator or pytest marker selection behavior.

## Problem

While validating #1548, `devtools verify` widened a narrow branch into a 9,513-test run. There were two separate causes:

1. `devtools/verify.py` carried a hand-maintained changed-file invalidator list that forced `--testmon-noselect` for config and `tests/infra/` paths.
2. Even after removing that list, the default pytest step still passed `-m not scale_medium and not scale_large`. Pytest-testmon documents that ordinary pytest selectors such as `-m` deactivate selection unless `--testmon-forceselect` is supplied, so the default command still ran effectively all tests.

## Solution

- Remove the homegrown global invalidator path from `devtools verify`.
- Keep explicit full collection only under `--seed-testmon` and `--all` / `--full`.
- Add `--testmon-forceselect` to the default affected-test step because the command always uses marker filters for scale tiers.
- Run default affected-testmon single-process (`-n 0`) to avoid xdist collection skew with forced testmon selection; seed/full diagnostics keep worker pools.
- Update tests and workflow docs to describe the real mechanism.

Closes #1549

## Verification

- `pytest -q tests/unit/devtools/test_verify.py --tb=short` -> 32 passed in 5.16s
- `ruff format --check devtools/verify.py tests/unit/devtools/test_verify.py && ruff check devtools/verify.py tests/unit/devtools/test_verify.py` -> all checks passed
- `python -m mypy devtools/verify.py tests/unit/devtools/test_verify.py` -> success
- `devtools render-all` -> regenerated AGENTS/docs surfaces
- `devtools verify --json` -> exit 0, pytest step `pytest testmon`, `pytest_workers: 0`, `pytest_selection: testmon`, `count: 32`, total 42.67s
- pre-push `devtools verify --quick` -> exit 0, total 33.08s