### PR TITLE
docs(insights): clarify work-event kind boundary

### DIFF
--- a/docs/insights-rigor-matrix.md
+++ b/docs/insights-rigor-matrix.md
@@ -83,6 +83,10 @@ API.
   footprint of the event. Inference payload classifies kind/summary;
   rows with `inference.fallback_inference == True` were emitted by the
   heuristic fallback and should be treated as low-rigor.
+- Boundary: `inference.kind` is a coarse event label inferred from local
+  file/tool/text signals. It is not the session-level workflow taxonomy;
+  consumers that need whole-session semantics should use
+  `session_profiles.workflow_shape` and `session_profiles.terminal_state`.
 - Consumer-facing fields: `event_id`, `conversation_id`,
   `provider_name`, `event_index`, `evidence`, `inference`.
 

--- a/docs/insights.md
+++ b/docs/insights.md
@@ -128,16 +128,25 @@ MCP exposes three readers over these same rows:
 
 ## Work Events
 
-File-level operations detected from tool calls and semantic block types.
+Message-range work segments derived from tool calls, message timing, and
+coarse text/action signals. These rows are useful for timeline navigation,
+file/tool context, and rough event grouping. The `kind` label is a weak
+heuristic event label such as `implementation`, `debugging`, `testing`,
+`research`, or `review`; it is not a durable workflow taxonomy and should not
+be treated as the session-level semantic contract. Use `workflow_shape` and
+`terminal_state` on session profiles when the question is about the whole
+session.
 
 ```bash
 polylogue insights work-events
-polylogue insights work-events --kind file_edit
+polylogue insights work-events --kind implementation
 polylogue insights work-events --conversation-id claude-ai:abc123
 ```
 
-Each event has: kind (`file_read`, `file_write`, `file_edit`, `shell`, etc.),
-start/end time, duration, file paths, tools used.
+Each event has: start/end time, duration, file paths, tools used, a short
+summary, and the heuristic event label plus confidence/evidence. File/tool
+categories such as `file_read`, `file_edit`, or `shell` live on action/tool
+surfaces, not in `session_work_events.kind`.
 
 ## Work Phases
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -148,7 +148,7 @@ retrieval lane.
 | Table | Description |
 |-------|-------------|
 | `session_profiles` | Per-session aggregates: repos, tools, costs, durations, message counts |
-| `session_work_events` | File-level work events within sessions |
+| `session_work_events` | Message-range work events with file/tool evidence and weak event labels |
 | `session_phases` | Session segments: planning, implementation, verification, exploration |
 | `work_threads` | Multi-session work groupings |
 | `session_tag_rollups` | Pre-aggregated tag usage stats |


### PR DESCRIPTION
## Summary

Clarifies the documented boundary between session-level semantics and work-event labels. `session_work_events.kind` is now described as a weak heuristic event label over message ranges, while `workflow_shape` and `terminal_state` are the session-level semantic fields consumers should use for whole-session questions.

## Problem

The docs still showed `polylogue insights work-events --kind file_edit` and described work-event kinds as `file_read` / `file_write` / `file_edit` / `shell`. That is stale: those are action/tool categories, not the current `WorkEventKind` labels. Keeping that wording makes the remaining #1511 cleanup more confusing because it suggests the event kind field is a durable file/tool taxonomy.

## Solution

Updated the insight docs, rigor matrix, and schema table summary to state that work events are message-range segments with file/tool evidence plus a weak event label such as `implementation`, `debugging`, `testing`, `research`, or `review`. The docs now explicitly direct whole-session semantic consumers to `session_profiles.workflow_shape` and `session_profiles.terminal_state`.

## Verification

- `devtools render-pages` -> site rebuilt.
- `devtools render-all --check` -> sync OK.
- Pre-push `devtools verify --quick` -> exit 0.

Ref #1511
