### PR TITLE
feat(embeddings): expose status next actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -842,7 +842,7 @@ The `polylogue embed` group is the operator-facing onboarding surface:
 | `polylogue embed enable` (alias `activate`) | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
 | `polylogue embed backfill` | Run a bounded, resumable embedding batch with per-conversation cost feedback; honours `embedding_max_cost_usd` as a soft cap and persists run progress. |
 | `polylogue embed disable` | Flip `embedding.enabled = false` without dropping existing embeddings — previously-embedded messages remain queryable via `--similar`. |
-| `polylogue embed status` | Coverage / freshness / latest catch-up snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |
+| `polylogue embed status` | Coverage / freshness / configured model+cap / latest catch-up / next-action snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |
 
 The CLI orchestrates substrate primitives under
 `polylogue.storage.embeddings` (`iter_pending_conversations`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,7 +261,7 @@ The `polylogue embed` group is the operator-facing onboarding surface:
 | `polylogue embed enable` (alias `activate`) | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
 | `polylogue embed backfill` | Run a bounded, resumable embedding batch with per-conversation cost feedback; honours `embedding_max_cost_usd` as a soft cap and persists run progress. |
 | `polylogue embed disable` | Flip `embedding.enabled = false` without dropping existing embeddings — previously-embedded messages remain queryable via `--similar`. |
-| `polylogue embed status` | Coverage / freshness / latest catch-up snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |
+| `polylogue embed status` | Coverage / freshness / configured model+cap / latest catch-up / next-action snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |
 
 The CLI orchestrates substrate primitives under
 `polylogue.storage.embeddings` (`iter_pending_conversations`,

--- a/docs/search.md
+++ b/docs/search.md
@@ -221,7 +221,8 @@ Semantic search stays unavailable until embeddings are both enabled and
 materialized. The activation path is deliberately bounded:
 
 1. `polylogue embed status` shows config state, key presence, coverage,
-   backlog, latest catch-up progress, and the next safe command.
+   configured model/dimension, monthly cost cap, backlog, latest catch-up
+   progress, and `next_action` (`code`, `reason`, `command`) for automation.
 2. `polylogue embed preflight --max-conversations 10` estimates the next
    bounded window without contacting Voyage.
 3. `polylogue embed enable --yes` enables the daemon stage when a Voyage key is

--- a/polylogue/cli/shared/embed_stats.py
+++ b/polylogue/cli/shared/embed_stats.py
@@ -69,20 +69,13 @@ def _render_latest_catchup_run(payload: EmbeddingStatusPayload) -> None:
 
 
 def _render_next_actions(payload: EmbeddingStatusPayload) -> None:
-    if payload["total_conversations"] <= 0:
+    action = payload["next_action"]
+    command = action["command"]
+    if command is None:
         return
-    if not payload["daemon_stage_enabled"]:
-        if payload["has_voyage_api_key"]:
-            click.echo("  Activation:            polylogue embed enable --yes")
-        else:
-            click.echo("  Activation:            polylogue embed enable --voyage-api-key ...")
-    if payload["pending_conversations"] > 0:
-        click.echo("  Next preflight:        polylogue embed preflight --max-conversations 10")
-        if payload["daemon_stage_enabled"]:
-            click.echo("  Catch-up:              polylogued will process bounded batches, or run:")
-        else:
-            click.echo("  Catch-up:              after enabling, run:")
-        click.echo("                         polylogue embed backfill --max-conversations 10")
+    click.echo(f"  Next action:           {action['code']}")
+    click.echo(f"  Reason:                {action['reason']}")
+    click.echo(f"  Command:               {command}")
 
 
 def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool = False) -> None:
@@ -95,6 +88,11 @@ def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool
     click.echo(f"  Config enabled:        {'yes' if payload['config_enabled'] else 'no'}")
     click.echo(f"  Voyage key:            {'present' if payload['has_voyage_api_key'] else 'missing'}")
     click.echo(f"  Daemon stage:          {'enabled' if payload['daemon_stage_enabled'] else 'disabled'}")
+    click.echo(f"  Configured model:      {payload['configured_model']} ({payload['configured_dimension']}d)")
+    if payload["monthly_cost_cap_usd"] > 0:
+        click.echo(f"  Monthly cost cap:      ${payload['monthly_cost_cap_usd']:.2f}")
+    else:
+        click.echo("  Monthly cost cap:      unbounded")
     click.echo(f"  Status:                {payload['status']}")
     click.echo(f"  Total conversations:   {payload['total_conversations']}")
     click.echo(f"  Embedded conversations:{payload['embedded_conversations']:>4}")

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -35,10 +35,19 @@ class RetrievalBandPayload(TypedDict, total=False):
     source_documents: int
 
 
+class EmbeddingNextActionPayload(TypedDict):
+    code: str
+    command: str | None
+    reason: str
+
+
 class EmbeddingStatusPayload(TypedDict):
     config_enabled: bool
     has_voyage_api_key: bool
     daemon_stage_enabled: bool
+    configured_model: str
+    configured_dimension: int
+    monthly_cost_cap_usd: float
     status: str
     total_conversations: int
     embedded_conversations: int
@@ -59,6 +68,7 @@ class EmbeddingStatusPayload(TypedDict):
     failure_count: int
     total_estimated_cost_usd: float
     latest_catchup_run: EmbeddingCatchupRunPayload | None
+    next_action: EmbeddingNextActionPayload
 
 
 def _payload_int(value: object) -> int:
@@ -113,10 +123,72 @@ def _retrieval_ready(stats: EmbeddingStatsSnapshot) -> bool:
     return stats.embedded_messages > stats.stale_messages
 
 
+def _next_action(
+    *,
+    config_enabled: bool,
+    has_voyage_api_key: bool,
+    total_conversations: int,
+    pending_conversations: int,
+    retrieval_ready: bool,
+    stale_messages: int,
+    failure_count: int,
+) -> EmbeddingNextActionPayload:
+    if total_conversations <= 0:
+        return {
+            "code": "archive_empty",
+            "command": None,
+            "reason": "Archive contains no conversations to embed.",
+        }
+    if not has_voyage_api_key:
+        return {
+            "code": "set_voyage_key",
+            "command": "polylogue embed enable --voyage-api-key ...",
+            "reason": "Semantic retrieval needs a Voyage API key before embedding can run.",
+        }
+    if not config_enabled:
+        return {
+            "code": "enable_embeddings",
+            "command": "polylogue embed enable --yes",
+            "reason": "A Voyage key is available, but embedding convergence is disabled in config.",
+        }
+    if failure_count > 0 and pending_conversations > 0:
+        return {
+            "code": "inspect_failures",
+            "command": "polylogue embed status --detail",
+            "reason": "Recent embedding failures exist while backlog remains.",
+        }
+    if stale_messages > 0:
+        return {
+            "code": "refresh_stale",
+            "command": "polylogue embed backfill --max-conversations 10",
+            "reason": "Existing vectors are stale for at least one message.",
+        }
+    if pending_conversations > 0:
+        return {
+            "code": "drain_backlog",
+            "command": "polylogue embed backfill --max-conversations 10",
+            "reason": "Embedding convergence is enabled and pending conversations remain.",
+        }
+    if retrieval_ready:
+        return {
+            "code": "ready",
+            "command": "polylogue --semantic <query>",
+            "reason": "Embeddings are retrieval-ready.",
+        }
+    return {
+        "code": "run_preflight",
+        "command": "polylogue embed preflight --detail",
+        "reason": "Embedding state is inconclusive; inspect exact pending-message and retrieval-band details.",
+    }
+
+
 def _payload_from_stats(
     *,
     config_enabled: bool,
     has_voyage_api_key: bool,
+    configured_model: str,
+    configured_dimension: int,
+    monthly_cost_cap_usd: float,
     total_conversations: int,
     stats: EmbeddingStatsSnapshot,
     latest_catchup_run: EmbeddingCatchupRunPayload | None,
@@ -129,10 +201,14 @@ def _payload_from_stats(
         embedded_conversations=embedded_conversations,
         pending_conversations=pending_conversations,
     )
+    retrieval_ready = _retrieval_ready(stats)
     return {
         "config_enabled": config_enabled,
         "has_voyage_api_key": has_voyage_api_key,
         "daemon_stage_enabled": config_enabled and has_voyage_api_key,
+        "configured_model": configured_model,
+        "configured_dimension": configured_dimension,
+        "monthly_cost_cap_usd": monthly_cost_cap_usd,
         "status": status,
         "total_conversations": total_conversations,
         "embedded_conversations": embedded_conversations,
@@ -147,7 +223,7 @@ def _payload_from_stats(
             ),
             1,
         ),
-        "retrieval_ready": _retrieval_ready(stats),
+        "retrieval_ready": retrieval_ready,
         "freshness_status": _freshness_status(status, stats),
         "stale_messages": stats.stale_messages,
         "messages_missing_provenance": stats.messages_missing_provenance,
@@ -159,6 +235,15 @@ def _payload_from_stats(
         "failure_count": stats.failure_count,
         "total_estimated_cost_usd": stats.total_estimated_cost_usd,
         "latest_catchup_run": latest_catchup_run,
+        "next_action": _next_action(
+            config_enabled=config_enabled,
+            has_voyage_api_key=has_voyage_api_key,
+            total_conversations=total_conversations,
+            pending_conversations=pending_conversations,
+            retrieval_ready=retrieval_ready,
+            stale_messages=stats.stale_messages,
+            failure_count=stats.failure_count,
+        ),
     }
 
 
@@ -180,6 +265,9 @@ def embedding_status_payload(
         return _payload_from_stats(
             config_enabled=bool(cfg.embedding_enabled),
             has_voyage_api_key=bool(cfg.voyage_api_key),
+            configured_model=cfg.embedding_model,
+            configured_dimension=cfg.embedding_dimension,
+            monthly_cost_cap_usd=cfg.embedding_max_cost_usd,
             total_conversations=0,
             stats=EmbeddingStatsSnapshot(),
             latest_catchup_run=None,
@@ -201,6 +289,9 @@ def embedding_status_payload(
     return _payload_from_stats(
         config_enabled=bool(cfg.embedding_enabled),
         has_voyage_api_key=bool(cfg.voyage_api_key),
+        configured_model=cfg.embedding_model,
+        configured_dimension=cfg.embedding_dimension,
+        monthly_cost_cap_usd=cfg.embedding_max_cost_usd,
         total_conversations=total_conversations,
         stats=embedding_stats,
         latest_catchup_run=latest_run,

--- a/tests/unit/cli/test_embed.py
+++ b/tests/unit/cli/test_embed.py
@@ -74,6 +74,9 @@ def _embedding_status_payload(
         "config_enabled": False,
         "has_voyage_api_key": False,
         "daemon_stage_enabled": False,
+        "configured_model": "voyage-4",
+        "configured_dimension": 1024,
+        "monthly_cost_cap_usd": 5.0,
         "status": status,
         "total_conversations": total_conversations,
         "embedded_conversations": embedded_conversations,
@@ -99,6 +102,13 @@ def _embedding_status_payload(
         "failure_count": 0,
         "total_estimated_cost_usd": 0.0,
         "latest_catchup_run": None,
+        "next_action": {
+            "code": "archive_empty" if total_conversations == 0 else "set_voyage_key",
+            "command": None if total_conversations == 0 else "polylogue embed enable --voyage-api-key ...",
+            "reason": "Archive contains no conversations to embed."
+            if total_conversations == 0
+            else "Semantic retrieval needs a Voyage API key before embedding can run.",
+        },
     }
 
 

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -24,6 +24,9 @@ class _Cfg:
     def __init__(self, *, embedding_enabled: bool, voyage_api_key: str | None) -> None:
         self.embedding_enabled = embedding_enabled
         self.voyage_api_key = voyage_api_key
+        self.embedding_model = "voyage-4"
+        self.embedding_dimension = 1024
+        self.embedding_max_cost_usd = 5.0
 
 
 def _env(db_path: Path) -> Any:
@@ -106,7 +109,15 @@ def test_status_json_bypasses_schema_version_gate_for_operator_readiness(tmp_pat
     assert payload["status"] == "none"
     assert payload["config_enabled"] is False
     assert payload["has_voyage_api_key"] is True
+    assert payload["configured_model"] == "voyage-4"
+    assert payload["configured_dimension"] == 1024
+    assert payload["monthly_cost_cap_usd"] == 5.0
     assert payload["pending_conversations"] == 2
+    assert payload["next_action"] == {
+        "code": "enable_embeddings",
+        "command": "polylogue embed enable --yes",
+        "reason": "A Voyage key is available, but embedding convergence is disabled in config.",
+    }
 
 
 def test_status_json_counts_empty_vec0_rowids_as_zero_embeddings(tmp_path: Path) -> None:
@@ -142,6 +153,7 @@ def test_status_json_reports_config_gate_combinations(
     assert payload["config_enabled"] is config_enabled
     assert payload["has_voyage_api_key"] is has_key
     assert payload["daemon_stage_enabled"] is stage_enabled
+    assert payload["next_action"]["code"] == ("set_voyage_key" if not has_key else "enable_embeddings")
 
 
 def test_status_json_detail_mode_runs_exact_retrieval_accounting(
@@ -206,16 +218,16 @@ def test_status_json_includes_latest_catchup_run(tmp_path: Path) -> None:
     assert latest["planned_conversations"] == 2
 
 
-def test_status_text_prints_bounded_next_actions(tmp_path: Path) -> None:
+def test_status_text_prints_machine_readable_next_action(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"
     _seed_archive_without_embedding_ledgers(db_path)
 
     output = _run_status_text(db_path, cfg=_Cfg(embedding_enabled=False, voyage_api_key="vk-live"))
 
-    assert "Activation:            polylogue embed enable --yes" in output
-    assert "Next preflight:        polylogue embed preflight --max-conversations 10" in output
-    assert "Catch-up:              after enabling, run:" in output
-    assert "polylogue embed backfill --max-conversations 10" in output
+    assert "Configured model:      voyage-4 (1024d)" in output
+    assert "Monthly cost cap:      $5.00" in output
+    assert "Next action:           enable_embeddings" in output
+    assert "Command:               polylogue embed enable --yes" in output
 
 
 def test_status_text_prints_daemon_catchup_when_enabled(tmp_path: Path) -> None:
@@ -224,5 +236,38 @@ def test_status_text_prints_daemon_catchup_when_enabled(tmp_path: Path) -> None:
 
     output = _run_status_text(db_path, cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
 
-    assert "Activation:" not in output
-    assert "Catch-up:              polylogued will process bounded batches, or run:" in output
+    assert "Next action:           drain_backlog" in output
+    assert "Command:               polylogue embed backfill --max-conversations 10" in output
+
+
+def test_status_json_reports_ready_next_action(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    _seed_archive_without_embedding_ledgers(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE embedding_status (
+                conversation_id TEXT PRIMARY KEY,
+                embedded_message_count INTEGER,
+                needs_reindex INTEGER DEFAULT 0,
+                error_message TEXT
+            )
+            """
+        )
+        conn.execute("CREATE TABLE message_embeddings (message_id TEXT PRIMARY KEY)")
+        conn.executemany(
+            "INSERT INTO embedding_status (conversation_id, embedded_message_count, needs_reindex) VALUES (?, ?, 0)",
+            [("conv-1", 1), ("conv-2", 1)],
+        )
+        conn.executemany("INSERT INTO message_embeddings (message_id) VALUES (?)", [("msg-1",), ("msg-2",)])
+        conn.commit()
+
+    payload = _run_status(db_path, cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
+
+    assert payload["status"] == "complete"
+    assert payload["retrieval_ready"] is True
+    assert payload["next_action"] == {
+        "code": "ready",
+        "command": "polylogue --semantic <query>",
+        "reason": "Embeddings are retrieval-ready.",
+    }


### PR DESCRIPTION
## Summary

Make `polylogue embed status` a machine-readable operator contract by exposing configured model/dimension, monthly cost cap, and the next action as structured JSON.

## Problem

Semantic search activation still required humans and agents to infer what to do from prose. The status JSON showed coverage/backlog, but not the configured embedding model, configured dimension, cost cap, or a single typed next action. That made automation brittle and left the live archive's current state less obvious than it should be.

## Solution

`embedding_status_payload` now includes:

- `configured_model`
- `configured_dimension`
- `monthly_cost_cap_usd`
- `next_action: {code, reason, command}`

The text renderer consumes the same `next_action` field instead of duplicating presentation-only branching. On the current live archive, the read-only JSON status now reports key present, config disabled, `voyage-4`/1024d, `$5.00` cap, and `next_action.code = enable_embeddings` with `polylogue embed enable --yes`.

No config was changed, no daemon was restarted, and no Voyage API calls were made.

## Verification

- `pytest -q tests/unit/cli/test_embed_status_fast.py tests/unit/cli/test_embed.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_embedding_readiness.py tests/unit/daemon/test_metrics_endpoint.py --tb=short` — 74 passed
- `ruff format --check polylogue/storage/embeddings/status_payload.py polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py tests/unit/cli/test_embed.py` — passed
- `ruff check polylogue/storage/embeddings/status_payload.py polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py tests/unit/cli/test_embed.py` — passed
- `python -m mypy polylogue/storage/embeddings/status_payload.py polylogue/cli/shared/embed_stats.py tests/unit/cli/test_embed_status_fast.py tests/unit/cli/test_embed.py` — success
- `POLYLOGUE_FORCE_PLAIN=1 polylogue embed status --format json` — live read-only status showed `next_action.code = enable_embeddings`
- `devtools render-all --check` — passed
- `devtools verify --quick` — exit 0, 35.14s before commit; pre-push quick gate exit 0, 34.86s after commit
- `devtools verify --json` — exit 0, 31 affected tests passed, 41.67s

Ref #1503
