### PR TITLE
feat(search): expose lane evidence on hits

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -170,6 +170,27 @@ components:
             type: number
           title: Score Components
           type: object
+        lane_rank:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: null
+          description: Rank within the primary contributing lane, when known.
+          title: Lane Rank
+        lane_contribution:
+          anyOf:
+          - type: number
+          - type: 'null'
+          default: null
+          description: Primary lane contribution to the public score, when known.
+          title: Lane Contribution
+        raw_score:
+          anyOf:
+          - type: number
+          - type: 'null'
+          default: null
+          description: Backend-native score before public interpretation.
+          title: Raw Score
       required:
       - rank
       - retrieval_lane

--- a/docs/schemas/cli-output/conversation-search-hit.schema.json
+++ b/docs/schemas/cli-output/conversation-search-hit.schema.json
@@ -23,6 +23,32 @@
           "default": null,
           "title": "Anchor"
         },
+        "lane_contribution": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Primary lane contribution to the public score, when known.",
+          "title": "Lane Contribution"
+        },
+        "lane_rank": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rank within the primary contributing lane, when known.",
+          "title": "Lane Rank"
+        },
         "match_surface": {
           "title": "Match Surface",
           "type": "string"
@@ -50,6 +76,19 @@
         "rank": {
           "title": "Rank",
           "type": "integer"
+        },
+        "raw_score": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Backend-native score before public interpretation.",
+          "title": "Raw Score"
         },
         "retrieval_lane": {
           "title": "Retrieval Lane",

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -41,6 +41,32 @@
           "default": null,
           "title": "Anchor"
         },
+        "lane_contribution": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Primary lane contribution to the public score, when known.",
+          "title": "Lane Contribution"
+        },
+        "lane_rank": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rank within the primary contributing lane, when known.",
+          "title": "Lane Rank"
+        },
         "match_surface": {
           "title": "Match Surface",
           "type": "string"
@@ -68,6 +94,19 @@
         "rank": {
           "title": "Rank",
           "type": "integer"
+        },
+        "raw_score": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Backend-native score before public interpretation.",
+          "title": "Raw Score"
         },
         "retrieval_lane": {
           "title": "Retrieval Lane",

--- a/docs/search.md
+++ b/docs/search.md
@@ -313,6 +313,8 @@ Each hit's `match` (a `ConversationSearchMatchPayload`) carries:
 | `score` | Raw lane score (semantics depend on `score_kind`). |
 | `score_kind` | One of `"bm25"`, `"rrf"`, `"vector_distance"`, or `null` for identity-only lanes. **Always check this before comparing or ordering by `score` directly.** |
 | `score_components` | Map of per-component contributions explaining the rank. Dialogue (FTS5) hits carry `{"bm25_raw": <relevance>}`; hybrid hits carry per-lane `<lane>_rank` and `<lane>_rrf` entries summed into `score` ([#1267](https://github.com/Sinity/polylogue/issues/1267)). Identity-only lanes (e.g. attachment) carry `{}`. |
+| `lane_rank` / `lane_contribution` | Primary lane rank and contribution when the backend can identify one. For hybrid, this is the strongest contributing RRF lane; all lane details still live in `score_components`. |
+| `raw_score` | Backend-native score before public interpretation. For FTS this is BM25 relevance; for hybrid it is the fused RRF score. |
 | `matched_terms` | FTS terms that triggered the match. |
 | `snippet` | Highlighted excerpt around the match (FTS5 snippet). |
 | `message_id` / `target_ref` / `anchor` | Stable identifiers pointing the reader at the matching message or sub-block. |

--- a/polylogue/archive/query/search_hits.py
+++ b/polylogue/archive/query/search_hits.py
@@ -41,6 +41,9 @@ class ConversationSearchHit:
     matched_terms: tuple[str, ...] = ()
     score_components: dict[str, float] = field(default_factory=dict)
     score_kind: str | None = None
+    lane_rank: int | None = None
+    lane_contribution: float | None = None
+    raw_score: float | None = None
 
     @property
     def conversation_id(self) -> str:
@@ -100,6 +103,9 @@ def conversation_search_hit_from_conversation(
     matched_terms: tuple[str, ...] = (),
     score_components: dict[str, float] | None = None,
     score_kind: str | None = None,
+    lane_rank: int | None = None,
+    lane_contribution: float | None = None,
+    raw_score: float | None = None,
 ) -> ConversationSearchHit:
     terms = search_terms(query_terms)
     matching_message = next(
@@ -122,6 +128,9 @@ def conversation_search_hit_from_conversation(
         matched_terms=matched_terms,
         score_components=score_components or {},
         score_kind=score_kind or default_score_kind(retrieval_lane),
+        lane_rank=lane_rank,
+        lane_contribution=lane_contribution,
+        raw_score=raw_score,
     )
 
 
@@ -137,6 +146,9 @@ def conversation_search_hit_from_summary(
     matched_terms: tuple[str, ...] = (),
     score_components: dict[str, float] | None = None,
     score_kind: str | None = None,
+    lane_rank: int | None = None,
+    lane_contribution: float | None = None,
+    raw_score: float | None = None,
 ) -> ConversationSearchHit:
     return ConversationSearchHit(
         summary=summary,
@@ -149,6 +161,9 @@ def conversation_search_hit_from_summary(
         matched_terms=matched_terms,
         score_components=score_components or {},
         score_kind=score_kind or default_score_kind(retrieval_lane),
+        lane_rank=lane_rank,
+        lane_contribution=lane_contribution,
+        raw_score=raw_score,
     )
 
 
@@ -179,6 +194,24 @@ def _hybrid_score_components(
         components[f"{lane_name}_rrf"] = contribution
         fused += contribution
     return components, (fused if any_lane else None)
+
+
+def primary_lane_evidence(score_components: dict[str, float]) -> tuple[int | None, float | None]:
+    """Return the strongest lane rank/contribution from RRF components."""
+    best_rank: int | None = None
+    best_contribution: float | None = None
+    for key, value in score_components.items():
+        if not key.endswith("_rank"):
+            continue
+        lane = key.removesuffix("_rank")
+        contribution = score_components.get(f"{lane}_rrf")
+        rank = int(value)
+        if contribution is None:
+            continue
+        if best_contribution is None or contribution > best_contribution:
+            best_rank = rank
+            best_contribution = contribution
+    return best_rank, best_contribution
 
 
 def default_score_kind(retrieval_lane: str) -> str | None:
@@ -252,6 +285,7 @@ async def search_hits_for_plan(
             conv_id = str(conversation.id)
             lane_info = lane_ranks.get(conv_id, {})
             score_components, fused_score = _hybrid_score_components(lane_info)
+            lane_rank, lane_contribution = primary_lane_evidence(score_components)
             hits.append(
                 conversation_search_hit_from_conversation(
                     conversation,
@@ -262,6 +296,9 @@ async def search_hits_for_plan(
                     score_kind="rrf" if fused_score is not None else None,
                     score_components=score_components,
                     matched_terms=terms,
+                    lane_rank=lane_rank,
+                    lane_contribution=lane_contribution,
+                    raw_score=fused_score,
                 )
             )
         return hits
@@ -289,6 +326,7 @@ __all__ = [
     "conversation_search_hit_from_summary",
     "default_score_kind",
     "plan_has_search_hit_evidence",
+    "primary_lane_evidence",
     "search_hit_surface",
     "search_hits_for_plan",
     "search_query_text",

--- a/polylogue/storage/repository/archive/search.py
+++ b/polylogue/storage/repository/archive/search.py
@@ -115,6 +115,9 @@ class RepositoryArchiveSearchMixin:
                 matched_terms=hit.matched_terms,
                 score_components=hit.score_components,
                 score_kind=hit.score_kind,
+                lane_rank=hit.lane_rank,
+                lane_contribution=hit.lane_contribution,
+                raw_score=hit.raw_score,
             )
             for hit in evidence_hits
             if hit.conversation_id in summaries_by_id

--- a/polylogue/storage/sqlite/queries/attachment_records.py
+++ b/polylogue/storage/sqlite/queries/attachment_records.py
@@ -247,6 +247,7 @@ async def search_attachment_identity_evidence_hits(
             retrieval_lane="attachment",
             matched_terms=(identity.lower(),),
             score_kind=None,
+            lane_rank=rank,
         )
         for rank, row in enumerate(rows, start=1)
     ]

--- a/polylogue/storage/sqlite/queries/conversations_search.py
+++ b/polylogue/storage/sqlite/queries/conversations_search.py
@@ -87,6 +87,8 @@ async def search_conversation_evidence_hits(
             matched_terms=matched_terms,
             score_components=({"bm25_raw": float(row["relevance"])} if row["relevance"] is not None else {}),
             score_kind="bm25" if row["relevance"] is not None else None,
+            lane_rank=rank,
+            raw_score=float(row["relevance"]) if row["relevance"] is not None else None,
         )
         for rank, row in enumerate(rows, start=1)
     ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -412,6 +412,12 @@ class ConversationSearchMatchPayload(SurfacePayloadModel):
     score_kind: str | None = None
     matched_terms: tuple[str, ...] = ()
     score_components: dict[str, float] = Field(default_factory=dict)
+    lane_rank: int | None = Field(default=None, description="Rank within the primary contributing lane, when known.")
+    lane_contribution: float | None = Field(
+        default=None,
+        description="Primary lane contribution to the public score, when known.",
+    )
+    raw_score: float | None = Field(default=None, description="Backend-native score before public interpretation.")
 
 
 class ConversationSearchHitPayload(SurfacePayloadModel):
@@ -453,6 +459,9 @@ class ConversationSearchHitPayload(SurfacePayloadModel):
                 score_kind=hit.score_kind,
                 matched_terms=hit.matched_terms,
                 score_components=hit.score_components,
+                lane_rank=hit.lane_rank,
+                lane_contribution=hit.lane_contribution,
+                raw_score=hit.raw_score,
             ),
         )
 

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -14,7 +14,13 @@ from polylogue.sources.parsers.drive import parse_chunked_prompt
 from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.repository.archive.search import RepositoryArchiveSearchMixin
 from polylogue.storage.runtime import ConversationRecord
-from polylogue.storage.search.models import ConversationSearchEvidenceHit, ConversationSearchResult
+from polylogue.storage.search.models import (
+    ConversationSearchEvidenceHit,
+    ConversationSearchResult,
+)
+from polylogue.storage.search.models import (
+    ConversationSearchHit as StorageConversationSearchHit,
+)
 from polylogue.storage.search_providers.hybrid_conversations import (
     _resolve_ranked_conversation_hits,
 )
@@ -73,6 +79,10 @@ class _FakeQueries(SQLiteQueryStore):
                 score=hit.score,
                 message_id=f"msg-{hit.conversation_id}",
                 snippet=f"snippet for {hit.conversation_id}",
+                score_components={"bm25_raw": hit.score} if hit.score is not None else {},
+                score_kind="bm25" if hit.score is not None else None,
+                lane_rank=hit.rank,
+                raw_score=hit.score,
             )
             for hit in self.hits.hits
         ]
@@ -164,7 +174,12 @@ def test_resolve_ranked_conversation_hits_preserves_order_and_provider_scope() -
 
 @pytest.mark.asyncio
 async def test_repository_search_summaries_follow_conversation_hit_order() -> None:
-    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    hits = ConversationSearchResult(
+        hits=[
+            StorageConversationSearchHit(conversation_id="conv-b", rank=1, score=1.0),
+            StorageConversationSearchHit(conversation_id="conv-a", rank=2, score=2.0),
+        ]
+    )
     queries = _FakeQueries(
         hits=hits,
         records_by_id={
@@ -183,7 +198,12 @@ async def test_repository_search_summaries_follow_conversation_hit_order() -> No
 
 @pytest.mark.asyncio
 async def test_repository_search_summary_hits_keep_evidence_and_conversation_order() -> None:
-    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    hits = ConversationSearchResult(
+        hits=[
+            StorageConversationSearchHit(conversation_id="conv-b", rank=1, score=1.0),
+            StorageConversationSearchHit(conversation_id="conv-a", rank=2, score=2.0),
+        ]
+    )
     queries = _FakeQueries(
         hits=hits,
         records_by_id={
@@ -200,6 +220,9 @@ async def test_repository_search_summary_hits_keep_evidence_and_conversation_ord
     assert [hit.rank for hit in summary_hits] == [1, 2]
     assert [hit.message_id for hit in summary_hits] == ["msg-conv-b", "msg-conv-a"]
     assert [hit.snippet for hit in summary_hits] == ["snippet for conv-b", "snippet for conv-a"]
+    assert [hit.lane_rank for hit in summary_hits] == [1, 2]
+    assert [hit.raw_score for hit in summary_hits] == [1.0, 2.0]
+    assert [hit.score_components for hit in summary_hits] == [{"bm25_raw": 1.0}, {"bm25_raw": 2.0}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/surfaces/test_search_explanation_contract.py
+++ b/tests/unit/surfaces/test_search_explanation_contract.py
@@ -64,6 +64,9 @@ def _hybrid_hit() -> ConversationSearchHit:
         score=components["text_rrf"] + components["vector_rrf"],
         matched_terms=("needle",),
         score_components=components,
+        lane_rank=1,
+        lane_contribution=components["text_rrf"],
+        raw_score=components["text_rrf"] + components["vector_rrf"],
     )
 
 
@@ -99,6 +102,9 @@ def test_hybrid_hit_carries_rrf_score_and_per_lane_components() -> None:
     assert "text_rrf" in payload.match.score_components
     assert "vector_rank" in payload.match.score_components
     assert "vector_rrf" in payload.match.score_components
+    assert payload.match.lane_rank == 1
+    assert payload.match.lane_contribution == payload.match.score_components["text_rrf"]
+    assert payload.match.raw_score == payload.match.score
     # Fused score equals the sum of lane RRF contributions.
     expected = payload.match.score_components["text_rrf"] + payload.match.score_components["vector_rrf"]
     assert abs(payload.match.score - expected) < 1e-12
@@ -118,6 +124,9 @@ def test_match_payload_required_field_set_is_stable() -> None:
         "score_kind",
         "matched_terms",
         "score_components",
+        "lane_rank",
+        "lane_contribution",
+        "raw_score",
     }
     missing = required - declared
     assert not missing, f"ConversationSearchMatchPayload lost required fields: {missing}"


### PR DESCRIPTION
## Summary

Carries explicit lane-rank, lane-contribution, and raw-score evidence through ranked search hits and the shared public `ConversationSearchMatchPayload`.

## Problem

#873's ranked-search contract called for `lane_rank`, `lane_contribution`, and `raw_score`, but the public match payload only exposed collapsed `score_components`. Consumers could see per-lane hybrid components, but had to infer the primary lane and backend-native score themselves, and the storage evidence bridge dropped fields that already existed on `ConversationSearchEvidenceHit`.

## Solution

- Add `lane_rank`, `lane_contribution`, and `raw_score` to `ConversationSearchHit` and `ConversationSearchMatchPayload`.
- Preserve those fields across storage evidence hits, repository search mapping, generated CLI schemas, and OpenAPI.
- Populate `lane_rank`/`raw_score` for FTS and attachment identity evidence paths.
- Derive the strongest contributing RRF lane for hybrid hits while preserving the full per-lane map in `score_components`.
- Document the added fields in `docs/search.md`.

Ref #873

## Verification

- `pytest -q tests/unit/surfaces/test_search_explanation_contract.py tests/unit/storage/test_search_explanation_wiring.py tests/unit/storage/test_archive_search_contracts.py tests/unit/archive/test_query_search_runtime.py --tb=short` — 32 passed.
- `ruff format --check ... && ruff check ...` on touched code/test files — passed.
- `mypy ...` on touched code/test files — passed.
- `devtools render-all --check` — passed.
- `devtools verify --json` — exit 0; 297 pytest-testmon selected tests passed; total 107.83s.
- pre-push `devtools verify --quick` — exit 0; total 34.64s. The normal `git push` path hit repeated GitHub 500s, so the branch was created through GitHub's Git Data API with an identical tree diff.