### PR TITLE
fix(search): allow auto cursor follow-up

### DIFF
--- a/polylogue/api/search_envelope_builder.py
+++ b/polylogue/api/search_envelope_builder.py
@@ -21,6 +21,7 @@ from polylogue.surfaces.payloads import (
     SearchEnvelope,
     build_search_envelope,
     decode_search_cursor,
+    search_cursor_lane_matches_request,
 )
 
 if TYPE_CHECKING:
@@ -58,7 +59,7 @@ async def build_archive_search_envelope(
     from polylogue.archive.query.spec import ConversationQuerySpec
 
     decoded_cursor = decode_search_cursor(cursor) if cursor else None
-    if decoded_cursor is not None and decoded_cursor.lane not in {"", retrieval_lane}:
+    if decoded_cursor is not None and not search_cursor_lane_matches_request(decoded_cursor.lane, retrieval_lane):
         raise InvalidSearchCursorError(
             f"cursor was minted for retrieval_lane={decoded_cursor.lane!r} but this request is {retrieval_lane!r}"
         )

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -782,7 +782,7 @@ def apply_search_cursor(
     :class:`InvalidSearchCursorError` so a paginated session cannot
     silently switch ranking policy mid-walk.
     """
-    if retrieval_lane is not None and cursor.lane and retrieval_lane != cursor.lane:
+    if retrieval_lane is not None and not search_cursor_lane_matches_request(cursor.lane, retrieval_lane):
         raise InvalidSearchCursorError(
             f"cursor was minted for retrieval_lane={cursor.lane!r} but this request is {retrieval_lane!r}"
         )
@@ -791,6 +791,22 @@ def apply_search_cursor(
         if _cursor_strictly_before(cursor, hit):
             result.append(hit)
     return tuple(result)
+
+
+def search_cursor_lane_matches_request(cursor_lane: str, requested_lane: str | None) -> bool:
+    """Return whether a cursor lane can be reused for the requested lane.
+
+    ``auto`` is a planner request, not a concrete ranking lane. A first page
+    requested with ``auto`` may resolve to ``dialogue`` and mint a dialogue
+    cursor; the next page should be allowed to pass the same default ``auto``
+    request without being rejected as a lane switch. Concrete lane-to-lane
+    changes still fail.
+    """
+    if not cursor_lane:
+        return True
+    if requested_lane in {None, "", "auto"}:
+        return True
+    return requested_lane == cursor_lane
 
 
 def _cursor_strictly_before(cursor: SearchCursor, hit: ConversationSearchHitPayload) -> bool:
@@ -1131,6 +1147,7 @@ __all__ = [
     "reader_anchor",
     "reader_conversation_actions",
     "reader_message_actions",
+    "search_cursor_lane_matches_request",
     "serialize_surface_payload",
     "validate_metadata_key",
 ]

--- a/tests/unit/api/test_search_envelope_builder.py
+++ b/tests/unit/api/test_search_envelope_builder.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from polylogue.api.search_envelope_builder import build_archive_search_envelope
+from polylogue.archive.conversation.models import ConversationSummary
+from polylogue.archive.query.search_hits import conversation_search_hit_from_summary
+from polylogue.archive.query.spec import ConversationQuerySpec
+from polylogue.surfaces.payloads import ConversationSearchHitPayload, build_search_cursor
+from polylogue.types import ConversationId, Provider
+
+
+def _dialogue_cursor() -> str:
+    summary = ConversationSummary(
+        id=ConversationId("chatgpt:cursor-anchor"),
+        provider=Provider.CHATGPT,
+        title="Cursor anchor",
+    )
+    hit = conversation_search_hit_from_summary(
+        summary,
+        rank=1,
+        retrieval_lane="dialogue",
+        match_surface="message",
+        message_id="m1",
+        snippet="anchor",
+        score=-5.0,
+        score_kind="bm25",
+    )
+    token = build_search_cursor([ConversationSearchHitPayload.from_search_hit(hit)])
+    assert token is not None
+    return token
+
+
+@pytest.mark.asyncio
+async def test_search_envelope_builder_accepts_auto_followup_for_resolved_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_count(self: ConversationQuerySpec, repository: object, *, vector_provider: object = None) -> int:
+        del self, repository, vector_provider
+        return 0
+
+    monkeypatch.setattr(ConversationQuerySpec, "count", fake_count)
+    operations = AsyncMock()
+    operations.search_conversation_hits = AsyncMock(return_value=[])
+
+    envelope = await build_archive_search_envelope(
+        operations,
+        object(),  # type: ignore[arg-type]
+        query="needle",
+        retrieval_lane="auto",
+        cursor=_dialogue_cursor(),
+    )
+
+    assert envelope.hits == ()
+    operations.search_conversation_hits.assert_awaited_once()
+    spec = operations.search_conversation_hits.await_args.args[0]
+    assert isinstance(spec, ConversationQuerySpec)
+    assert spec.retrieval_lane == "auto"

--- a/tests/unit/surfaces/test_search_cursor_pagination.py
+++ b/tests/unit/surfaces/test_search_cursor_pagination.py
@@ -153,6 +153,20 @@ def test_apply_cursor_rejects_lane_mismatch() -> None:
         apply_search_cursor(hits, cursor, retrieval_lane="dialogue")
 
 
+def test_apply_cursor_accepts_auto_request_for_resolved_lane_cursor() -> None:
+    hits = _payloads(
+        [
+            _hit(conv_id="a", rank=1, score=-5.0),
+            _hit(conv_id="b", rank=2, score=-4.0),
+        ]
+    )
+    cursor = SearchCursor(v=1, r=1, s=-5.0, c="a", lane="dialogue")
+
+    survived = apply_search_cursor(hits, cursor, retrieval_lane="auto")
+
+    assert [h.conversation.id for h in survived] == ["b"]
+
+
 # ---------------------------------------------------------------------------
 # Page-after-page stability (the load-bearing invariant)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Allows search cursors minted for a resolved concrete lane, such as `dialogue`, to be reused on the normal follow-up request that still asks for `retrieval_lane=auto`.

## Problem

Ranked search cursors encode the resolved lane so concrete lane switches can be rejected. But `auto` is a planner request, not a concrete ranking lane. A first page with default `auto` can resolve to `dialogue` and mint a dialogue cursor; the Python API search-envelope builder rejected the next default `auto` request before it could fetch the successor page. The shared cursor helper also rejected empty follow-up pages before any hit could establish a resolved lane.

## Solution

- Add a shared cursor/request lane compatibility predicate.
- Treat `auto`, empty, or unspecified requested lanes as compatible with a concrete cursor lane.
- Keep concrete lane switches rejected (`dialogue` cursor with `hybrid` request still fails).
- Cover both `apply_search_cursor` and `build_archive_search_envelope` with focused regressions.

Ref #873

## Verification

- `pytest -q tests/unit/surfaces/test_search_cursor_pagination.py tests/unit/api/test_search_envelope_builder.py tests/unit/surfaces/test_search_envelope_contract.py --tb=short` — 21 passed.
- `ruff format --check polylogue/surfaces/payloads.py polylogue/api/search_envelope_builder.py tests/unit/surfaces/test_search_cursor_pagination.py tests/unit/api/test_search_envelope_builder.py && ruff check ...` — passed.
- `mypy polylogue/surfaces/payloads.py polylogue/api/search_envelope_builder.py tests/unit/surfaces/test_search_cursor_pagination.py tests/unit/api/test_search_envelope_builder.py` — passed.
- `devtools render-all --check` — passed.
- `devtools verify --json` — exit 0; 299 pytest-testmon selected tests passed; total 110.03s.
- pre-push `devtools verify --quick` — exit 0; total 35.68s.