### PR TITLE
test(search): pin envelope evidence equivalence

### DIFF
--- a/polylogue/api/search_envelope_builder.py
+++ b/polylogue/api/search_envelope_builder.py
@@ -12,6 +12,7 @@ adapters stay thin and the per-file LOC budget on
 from __future__ import annotations
 
 from contextlib import suppress
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from polylogue.surfaces.payloads import (
@@ -25,8 +26,78 @@ from polylogue.surfaces.payloads import (
 )
 
 if TYPE_CHECKING:
+    from polylogue.archive.query.spec import ConversationQuerySpec
     from polylogue.operations import ArchiveOperations
     from polylogue.storage.repository import ConversationRepository
+
+
+def _search_query_text(spec: ConversationQuerySpec) -> str:
+    plan = spec.to_plan()
+    if plan.fts_terms:
+        return " ".join(plan.fts_terms)
+    if plan.similar_text:
+        return plan.similar_text
+    return ""
+
+
+async def build_search_envelope_for_spec(
+    operations: ArchiveOperations,
+    repository: ConversationRepository,
+    spec: ConversationQuerySpec,
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+    query: str | None = None,
+) -> SearchEnvelope:
+    """Build a :class:`SearchEnvelope` from an already-normalized query spec.
+
+    Daemon HTTP accepts the full ``ConversationQuerySpec`` filter surface,
+    while the public Python API exposes a smaller keyword facade. Keeping the
+    cursor, diagnostics, and hit-payload assembly here prevents those surfaces
+    from drifting while still letting each caller own parameter parsing.
+    """
+    display_limit = limit if limit is not None else (spec.limit or 50)
+    display_offset = offset if offset is not None else spec.offset
+    decoded_cursor = decode_search_cursor(spec.cursor) if spec.cursor else None
+    if decoded_cursor is not None and not search_cursor_lane_matches_request(decoded_cursor.lane, spec.retrieval_lane):
+        raise InvalidSearchCursorError(
+            f"cursor was minted for retrieval_lane={decoded_cursor.lane!r} but this request is {spec.retrieval_lane!r}"
+        )
+
+    fetch_spec = spec
+    if decoded_cursor is not None:
+        # Advance the SQL fetch past the cursor anchor; the builder will drop
+        # any straggler rows whose (score, conversation_id) sort at or before
+        # the anchor under the lane's natural ordering.
+        fetch_spec = replace(
+            spec,
+            offset=decoded_cursor.r,
+            limit=(spec.limit or display_limit) + display_limit,
+            cursor=spec.cursor,
+        )
+
+    hits = await operations.search_conversation_hits(fetch_spec)
+    total = await spec.count(repository)
+    diagnostics_payload: QueryMissDiagnosticsPayload | None = None
+    if not hits and spec.has_filters():
+        with suppress(Exception):
+            raw_diag = await operations.diagnose_query_miss(spec)
+            diagnostics_payload = QueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
+    hit_payloads = [
+        ConversationSearchHitPayload.from_search_hit(hit, message_count=hit.summary.message_count) for hit in hits
+    ]
+    resolved_lane = hits[0].retrieval_lane if hits else spec.retrieval_lane
+    return build_search_envelope(
+        hit_payloads,
+        total=total,
+        limit=display_limit,
+        offset=display_offset,
+        query=query if query is not None else _search_query_text(spec),
+        retrieval_lane=resolved_lane,
+        sort=spec.sort,
+        diagnostics=diagnostics_payload,
+        cursor=decoded_cursor,
+    )
 
 
 async def build_archive_search_envelope(
@@ -58,16 +129,6 @@ async def build_archive_search_envelope(
     """
     from polylogue.archive.query.spec import ConversationQuerySpec
 
-    decoded_cursor = decode_search_cursor(cursor) if cursor else None
-    if decoded_cursor is not None and not search_cursor_lane_matches_request(decoded_cursor.lane, retrieval_lane):
-        raise InvalidSearchCursorError(
-            f"cursor was minted for retrieval_lane={decoded_cursor.lane!r} but this request is {retrieval_lane!r}"
-        )
-
-    # Advance the SQL fetch past the cursor anchor; the builder will drop
-    # any straggler rows whose (score, conversation_id) sort at or before
-    # the anchor under the lane's natural ordering.
-    effective_offset = decoded_cursor.r if decoded_cursor is not None else offset
     spec = ConversationQuerySpec.from_params(
         {
             "query": query,
@@ -76,36 +137,20 @@ async def build_archive_search_envelope(
             "until": until,
             "retrieval_lane": retrieval_lane,
             "sort": sort,
-            # Fetch one extra page worth so the post-fetch cursor trim
-            # cannot starve the response when the anchor row drifts.
-            "limit": limit + (limit if decoded_cursor is not None else 0),
-            "offset": effective_offset,
+            "limit": limit,
+            "offset": offset,
             "cursor": cursor,
         },
         strict=True,
     )
-    hits = await operations.search_conversation_hits(spec)
-    total = await spec.count(repository)
-    diagnostics_payload: QueryMissDiagnosticsPayload | None = None
-    if not hits and spec.has_filters():
-        with suppress(Exception):
-            raw_diag = await operations.diagnose_query_miss(spec)
-            diagnostics_payload = QueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
-    hit_payloads = [
-        ConversationSearchHitPayload.from_search_hit(hit, message_count=hit.summary.message_count) for hit in hits
-    ]
-    resolved_lane = hits[0].retrieval_lane if hits else retrieval_lane
-    return build_search_envelope(
-        hit_payloads,
-        total=total,
+    return await build_search_envelope_for_spec(
+        operations,
+        repository,
+        spec,
         limit=limit,
         offset=offset,
         query=query,
-        retrieval_lane=resolved_lane,
-        sort=sort,
-        diagnostics=diagnostics_payload,
-        cursor=decoded_cursor,
     )
 
 
-__all__ = ["build_archive_search_envelope"]
+__all__ = ["build_archive_search_envelope", "build_search_envelope_for_spec"]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -8,7 +8,6 @@ import functools
 import json
 import os
 from collections.abc import Callable, Mapping
-from dataclasses import replace
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePath
@@ -39,7 +38,6 @@ from polylogue.errors import PolylogueError
 from polylogue.logging import get_logger
 from polylogue.paths import db_path
 from polylogue.surfaces.payloads import (
-    ConversationSearchHitPayload,
     MutationResultPayload,
     QueryErrorPayload,
     QueryMissDiagnosticsPayload,
@@ -48,7 +46,6 @@ from polylogue.surfaces.payloads import (
     _build_flags_from_conversation,
     _extract_cwd,
     _extract_repo,
-    build_search_envelope,
     reader_anchor,
     reader_conversation_actions,
     reader_message_actions,
@@ -1171,7 +1168,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             query_params["cursor"] = cursor
 
         async def _list(poly: Polylogue) -> object:
-            return await self._do_list(poly, query_params, limit, offset, cursor=cursor)
+            return await self._do_list(poly, query_params, limit, offset)
 
         result = self._sync_run(_list)
         self._send_json(HTTPStatus.OK, result)
@@ -1182,8 +1179,6 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         query_params: dict[str, object],
         limit: int,
         offset: int,
-        *,
-        cursor: str | None = None,
     ) -> object:
         from polylogue.archive.query.spec import ConversationQuerySpec
 
@@ -1195,7 +1190,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # When search terms are present, return ranked result envelope with
         # per-hit match evidence instead of plain row dicts.
         if query_text and not query_params.get("similar_text"):
-            return await self._do_search_list(poly, spec, limit, offset, cursor=cursor)
+            return await self._do_search_list(poly, spec, limit, offset)
 
         filter_obj = spec.build_filter(poly.repository)
         summaries = await filter_obj.list_summaries()
@@ -1253,71 +1248,28 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         spec: ConversationQuerySpec,
         limit: int,
         offset: int,
-        *,
-        cursor: str | None = None,
     ) -> object:
         """Return the canonical :class:`SearchEnvelope` for ranked queries.
 
         The same envelope ships across CLI JSON, MCP, Python API, and daemon
-        HTTP (#1266). Construction goes through ``build_search_envelope`` so
+        HTTP (#1266). Construction goes through the shared spec builder so
         the cursor / next_offset / ranking-policy fields stay aligned with
         the other surfaces. When ``cursor`` is supplied the response page
         starts strictly after the anchor (#1268).
         """
-        from polylogue.archive.query.search_hits import search_hits_for_plan
-        from polylogue.surfaces.payloads import InvalidSearchCursorError, decode_search_cursor
+        from polylogue.api.search_envelope_builder import build_search_envelope_for_spec
+        from polylogue.surfaces.payloads import InvalidSearchCursorError
 
-        decoded_cursor = None
-        if cursor:
-            try:
-                decoded_cursor = decode_search_cursor(cursor)
-            except InvalidSearchCursorError as exc:
-                return {"ok": False, "error": "invalid_cursor", "detail": str(exc)}
-
-        if decoded_cursor is not None:
-            # Push effective offset forward so the underlying fetch starts
-            # past the anchor; fetch a buffered window so post-fetch trim
-            # cannot starve the response.
-            spec = replace(
+        try:
+            envelope = await build_search_envelope_for_spec(
+                poly.operations,
+                poly.repository,
                 spec,
-                offset=decoded_cursor.r,
-                limit=(spec.limit or limit) + limit,
-                cursor=cursor,
+                limit=limit,
+                offset=offset,
             )
-
-        plan = spec.to_plan()
-        hits = await search_hits_for_plan(plan, poly.repository)
-        total = await spec.count(poly.repository)
-
-        diagnostics = None
-        if not hits and spec.has_filters():
-            with contextlib.suppress(Exception):
-                try:
-                    raw_diag = await poly.operations.diagnose_query_miss(spec)
-                    diagnostics = QueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
-                except Exception:
-                    pass
-
-        hit_payloads = [
-            ConversationSearchHitPayload.from_search_hit(hit, message_count=hit.summary.message_count) for hit in hits
-        ]
-        query_text = ""
-        if plan.fts_terms:
-            query_text = " ".join(plan.fts_terms)
-        elif plan.similar_text:
-            query_text = plan.similar_text
-        resolved_lane = hits[0].retrieval_lane if hits else (plan.retrieval_lane or "auto")
-        envelope = build_search_envelope(
-            hit_payloads,
-            total=total,
-            limit=limit,
-            offset=offset,
-            query=query_text,
-            retrieval_lane=resolved_lane,
-            sort=plan.sort,
-            diagnostics=diagnostics,
-            cursor=decoded_cursor,
-        )
+        except InvalidSearchCursorError as exc:
+            return {"ok": False, "error": "invalid_cursor", "detail": str(exc)}
         return envelope.model_dump(mode="json")
 
     # ------------------------------------------------------------------

--- a/tests/unit/surfaces/test_search_envelope_contract.py
+++ b/tests/unit/surfaces/test_search_envelope_contract.py
@@ -73,7 +73,10 @@ def _hit(rank: int = 1) -> ConversationSearchHit:
         snippet="…matched [needle]…",
         score=-7.42,
         matched_terms=("needle",),
-        score_components={},
+        score_components={"bm25_raw": -7.42},
+        lane_rank=rank,
+        lane_contribution=-7.42,
+        raw_score=-7.42,
     )
 
 
@@ -113,12 +116,31 @@ def test_envelope_ranking_policy_defaults_are_declared() -> None:
 def _normalise_envelope_dict(payload: dict[str, Any]) -> dict[str, Any]:
     """Reduce an envelope to the comparable cross-surface invariants.
 
-    We do not compare ``hits`` payloads byte-for-byte — surfaces may attach
-    extra evidence (e.g., target_ref actions). What MUST match across
-    surfaces is the envelope-level metadata: pagination, query echo,
-    ranking-policy declaration, and the per-hit identity fields.
+    We do not compare ``hits`` payloads byte-for-byte because surfaces may
+    attach extra presentation evidence (e.g., target_ref actions). What MUST
+    match across surfaces is the envelope-level metadata plus the canonical
+    per-hit ranked-search explanation carried by ``match``.
     """
     hits: list[dict[str, Any]] = list(payload["hits"])
+
+    def normalise_match(hit: dict[str, Any]) -> dict[str, Any]:
+        match = dict(hit["match"])
+        return {
+            "conversation_id": hit["conversation"]["id"],
+            "rank": match["rank"],
+            "retrieval_lane": match["retrieval_lane"],
+            "match_surface": match["match_surface"],
+            "message_id": match["message_id"],
+            "snippet": match["snippet"],
+            "score": match["score"],
+            "score_kind": match["score_kind"],
+            "matched_terms": tuple(match["matched_terms"]),
+            "score_components": match["score_components"],
+            "lane_rank": match["lane_rank"],
+            "lane_contribution": match["lane_contribution"],
+            "raw_score": match["raw_score"],
+        }
+
     return {
         "total": payload.get("total"),
         "limit": payload["limit"],
@@ -131,6 +153,7 @@ def _normalise_envelope_dict(payload: dict[str, Any]) -> dict[str, Any]:
         "hit_conversation_ids": tuple(hit["conversation"]["id"] for hit in hits),
         "hit_ranks": tuple(hit["match"]["rank"] for hit in hits),
         "hit_lanes": tuple(hit["match"]["retrieval_lane"] for hit in hits),
+        "hit_matches": tuple(normalise_match(hit) for hit in hits),
     }
 
 
@@ -202,6 +225,7 @@ def test_all_surfaces_emit_semantically_equivalent_envelope() -> None:
     assert api_norm["hit_conversation_ids"] == mcp_norm["hit_conversation_ids"] == cli_norm["hit_conversation_ids"]
     assert api_norm["hit_ranks"] == mcp_norm["hit_ranks"] == cli_norm["hit_ranks"] == (1, 2)
     assert api_norm["hit_lanes"] == mcp_norm["hit_lanes"] == cli_norm["hit_lanes"]
+    assert api_norm["hit_matches"] == mcp_norm["hit_matches"] == cli_norm["hit_matches"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This hardens #873 by making ranked-search envelope construction converge for API and daemon HTTP, then strengthening the cross-surface contract test so API, MCP, and CLI JSON must preserve the same per-hit explanation evidence.

## Problem

#1562 exposed lane rank, lane contribution, and raw backend scores on ranked hits, but the cross-surface envelope test still compared only conversation ids, ranks, and lanes. A surface could silently drop or rewrite snippets, score kind, matched terms, score components, lane contribution, or raw score without failing that contract. Daemon HTTP also duplicated the API envelope builder’s cursor, diagnostics, and payload-assembly logic, increasing the chance of exactly that drift.

## Solution

Added `build_search_envelope_for_spec()` in `polylogue/api/search_envelope_builder.py` for callers that already have a full `ConversationQuerySpec`. The public API keyword builder now parses parameters and delegates to it, while daemon HTTP keeps its broader HTTP filter parser and delegates the ranked envelope construction to the same spec-based path.

`tests/unit/surfaces/test_search_envelope_contract.py` now compares the canonical `match` explanation fields across API/helper, MCP, and CLI JSON: match surface, message id, snippet, score, score kind, matched terms, score components, lane rank, lane contribution, and raw score.

## Verification

- `pytest -q tests/unit/api/test_search_envelope_builder.py tests/unit/surfaces/test_search_envelope_contract.py tests/unit/surfaces/test_search_explanation_contract.py tests/unit/daemon/test_web_reader.py -k "search_envelope or query_search or no_results_query or bad_date" --tb=short` — 11 passed, 68 deselected.
- `ruff format --check polylogue/api/search_envelope_builder.py polylogue/daemon/http.py tests/unit/surfaces/test_search_envelope_contract.py` — passed.
- `ruff check polylogue/api/search_envelope_builder.py polylogue/daemon/http.py tests/unit/surfaces/test_search_envelope_contract.py` — passed.
- `mypy polylogue/api/search_envelope_builder.py polylogue/daemon/http.py tests/unit/surfaces/test_search_envelope_contract.py tests/unit/surfaces/test_search_explanation_contract.py tests/unit/api/test_search_envelope_builder.py` — passed.
- `devtools verify --json` — exit 0; 415 pytest-testmon selected tests passed; total 98.24s.
- pre-push `devtools verify --quick` — exit 0; total 37.35s.

Ref #873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search operations now return explicit error responses when invalid cursors are provided during conversation search.

* **Tests**
  * Strengthened cross-surface search result verification with enhanced validation of scoring metadata across different access methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->