### PR TITLE
refactor(search): name storage search DTOs honestly

### DIFF
--- a/polylogue/storage/repository/archive/search.py
+++ b/polylogue/storage/repository/archive/search.py
@@ -10,25 +10,25 @@ if TYPE_CHECKING:
     from polylogue.archive.conversation.models import Conversation, ConversationSummary
     from polylogue.archive.query.search_hits import ConversationSearchHit
     from polylogue.storage.runtime import ConversationRecord
-    from polylogue.storage.search.models import ConversationSearchEvidenceHit, ConversationSearchResult
+    from polylogue.storage.search.models import ConversationSearchEvidenceRow, ConversationSearchResult
     from polylogue.storage.sqlite.query_store import SQLiteQueryStore
 
 
 def _rerank_evidence_hits(
-    hits: builtins.list[ConversationSearchEvidenceHit],
-) -> builtins.list[ConversationSearchEvidenceHit]:
+    hits: builtins.list[ConversationSearchEvidenceRow],
+) -> builtins.list[ConversationSearchEvidenceRow]:
     return [replace(hit, rank=rank) for rank, hit in enumerate(hits, start=1)]
 
 
 def _merge_evidence_hits(
     *,
-    attachment_hits: builtins.list[ConversationSearchEvidenceHit],
-    message_hits: builtins.list[ConversationSearchEvidenceHit],
+    attachment_hits: builtins.list[ConversationSearchEvidenceRow],
+    message_hits: builtins.list[ConversationSearchEvidenceRow],
     limit: int,
-) -> builtins.list[ConversationSearchEvidenceHit]:
+) -> builtins.list[ConversationSearchEvidenceRow]:
     if limit <= 0:
         return []
-    merged: builtins.list[ConversationSearchEvidenceHit] = []
+    merged: builtins.list[ConversationSearchEvidenceRow] = []
     seen: set[str] = set()
     for hit in (*attachment_hits, *message_hits):
         if hit.conversation_id in seen:

--- a/polylogue/storage/search/models.py
+++ b/polylogue/storage/search/models.py
@@ -24,14 +24,16 @@ class SearchResult:
 
 
 @dataclass(frozen=True)
-class ConversationSearchHit:
+class ConversationSearchIdHit:
     conversation_id: str
     rank: int
     score: float | None = None
 
 
 @dataclass(frozen=True)
-class ConversationSearchEvidenceHit:
+class ConversationSearchEvidenceRow:
+    """Storage-level ranked evidence row before archive summary hydration."""
+
     conversation_id: str
     rank: int
     score: float | None = None
@@ -52,13 +54,13 @@ class ConversationSearchEvidenceHit:
 
 @dataclass(frozen=True)
 class ConversationSearchResult:
-    hits: list[ConversationSearchHit]
+    hits: list[ConversationSearchIdHit]
 
     @classmethod
     def from_ids(cls, conversation_ids: Sequence[str]) -> ConversationSearchResult:
         return cls(
             hits=[
-                ConversationSearchHit(conversation_id=conversation_id, rank=rank)
+                ConversationSearchIdHit(conversation_id=conversation_id, rank=rank)
                 for rank, conversation_id in enumerate(conversation_ids, start=1)
             ]
         )
@@ -68,8 +70,8 @@ class ConversationSearchResult:
 
 
 __all__ = [
-    "ConversationSearchEvidenceHit",
-    "ConversationSearchHit",
+    "ConversationSearchEvidenceRow",
+    "ConversationSearchIdHit",
     "ConversationSearchResult",
     "SearchHit",
     "SearchResult",

--- a/polylogue/storage/sqlite/queries/attachment_records.py
+++ b/polylogue/storage/sqlite/queries/attachment_records.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import aiosqlite
 
 from polylogue.storage.runtime import AttachmentRecord
-from polylogue.storage.search.models import ConversationSearchEvidenceHit
+from polylogue.storage.search.models import ConversationSearchEvidenceRow
 from polylogue.storage.sqlite.connection import _build_provider_scope_filter
 from polylogue.storage.sqlite.queries.mappers import _json_object, _parse_json
 from polylogue.types import ConversationId
@@ -132,7 +132,7 @@ async def search_attachment_identity_evidence_hits(
     limit: int = 100,
     providers: list[str] | None = None,
     since: str | None = None,
-) -> list[ConversationSearchEvidenceHit]:
+) -> list[ConversationSearchEvidenceRow]:
     """Search selected attachment identity fields and return evidence-bearing hits."""
     identity = query.strip()
     if not identity or limit <= 0:
@@ -237,7 +237,7 @@ async def search_attachment_identity_evidence_hits(
     cursor = await conn.execute(sql, params)
     rows = await cursor.fetchall()
     return [
-        ConversationSearchEvidenceHit(
+        ConversationSearchEvidenceRow(
             conversation_id=str(row["conversation_id"]),
             rank=rank,
             score=None,

--- a/polylogue/storage/sqlite/queries/conversations_search.py
+++ b/polylogue/storage/sqlite/queries/conversations_search.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import aiosqlite
 
 from polylogue.maintenance.targets import build_maintenance_target_catalog
-from polylogue.storage.search.models import ConversationSearchEvidenceHit, ConversationSearchResult
+from polylogue.storage.search.models import ConversationSearchEvidenceRow, ConversationSearchResult
 
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _MESSAGE_SEARCH_REPAIR_HINT = _MAINTENANCE_TARGET_CATALOG.repair_hint(("dangling_fts",), include_run_all=True)
@@ -51,7 +51,7 @@ async def search_conversation_evidence_hits(
     limit: int = 100,
     providers: list[str] | None = None,
     since: str | None = None,
-) -> list[ConversationSearchEvidenceHit]:
+) -> list[ConversationSearchEvidenceRow]:
     from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_search_readiness_async
     from polylogue.storage.search import build_ranked_conversation_search_query
 
@@ -76,7 +76,7 @@ async def search_conversation_evidence_hits(
 
     matched_terms = extract_match_terms(query)
     return [
-        ConversationSearchEvidenceHit(
+        ConversationSearchEvidenceRow(
             conversation_id=str(row["conversation_id"]),
             rank=rank,
             score=float(row["relevance"]) if row["relevance"] is not None else None,

--- a/polylogue/storage/sqlite/query_store_archive.py
+++ b/polylogue/storage/sqlite/query_store_archive.py
@@ -17,7 +17,7 @@ from polylogue.storage.runtime import (
     MessageRecord,
     ProviderEventRecord,
 )
-from polylogue.storage.search.models import ConversationSearchEvidenceHit, ConversationSearchResult
+from polylogue.storage.search.models import ConversationSearchEvidenceRow, ConversationSearchResult
 from polylogue.storage.sqlite.queries import attachments as attachments_q
 from polylogue.storage.sqlite.queries import conversations as conversations_q
 from polylogue.storage.sqlite.queries import messages as messages_q
@@ -109,7 +109,7 @@ class SQLiteQueryStoreArchiveMixin:
         limit: int = 100,
         providers: list[str] | None = None,
         since: str | None = None,
-    ) -> list[ConversationSearchEvidenceHit]:
+    ) -> list[ConversationSearchEvidenceRow]:
         async with self._connection_factory() as conn:
             return await conversations_q.search_conversation_evidence_hits(conn, query, limit, providers, since)
 
@@ -119,7 +119,7 @@ class SQLiteQueryStoreArchiveMixin:
         limit: int = 100,
         providers: list[str] | None = None,
         since: str | None = None,
-    ) -> list[ConversationSearchEvidenceHit]:
+    ) -> list[ConversationSearchEvidenceRow]:
         async with self._connection_factory() as conn:
             return await attachments_q.search_attachment_identity_evidence_hits(conn, query, limit, providers, since)
 

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -15,11 +15,11 @@ from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.repository.archive.search import RepositoryArchiveSearchMixin
 from polylogue.storage.runtime import ConversationRecord
 from polylogue.storage.search.models import (
-    ConversationSearchEvidenceHit,
+    ConversationSearchEvidenceRow,
     ConversationSearchResult,
 )
 from polylogue.storage.search.models import (
-    ConversationSearchHit as StorageConversationSearchHit,
+    ConversationSearchIdHit as StorageConversationSearchIdHit,
 )
 from polylogue.storage.search_providers.hybrid_conversations import (
     _resolve_ranked_conversation_hits,
@@ -43,7 +43,7 @@ def _conversation_record(conversation_id: str, *, title: str, provider_name: str
 class _FakeQueries(SQLiteQueryStore):
     hits: ConversationSearchResult
     records_by_id: dict[str, ConversationRecord]
-    attachment_hits: list[ConversationSearchEvidenceHit] | None = None
+    attachment_hits: list[ConversationSearchEvidenceRow] | None = None
     last_batch_ids: list[str] | None = None
 
     async def search_conversation_hits(
@@ -70,10 +70,10 @@ class _FakeQueries(SQLiteQueryStore):
         limit: int = 20,
         providers: list[str] | None = None,
         since: str | None = None,
-    ) -> list[ConversationSearchEvidenceHit]:
+    ) -> list[ConversationSearchEvidenceRow]:
         del query, limit, providers, since
         return [
-            ConversationSearchEvidenceHit(
+            ConversationSearchEvidenceRow(
                 conversation_id=hit.conversation_id,
                 rank=hit.rank,
                 score=hit.score,
@@ -93,7 +93,7 @@ class _FakeQueries(SQLiteQueryStore):
         limit: int = 20,
         providers: list[str] | None = None,
         since: str | None = None,
-    ) -> list[ConversationSearchEvidenceHit]:
+    ) -> list[ConversationSearchEvidenceRow]:
         del query, limit, providers, since
         return self.attachment_hits or []
 
@@ -176,8 +176,8 @@ def test_resolve_ranked_conversation_hits_preserves_order_and_provider_scope() -
 async def test_repository_search_summaries_follow_conversation_hit_order() -> None:
     hits = ConversationSearchResult(
         hits=[
-            StorageConversationSearchHit(conversation_id="conv-b", rank=1, score=1.0),
-            StorageConversationSearchHit(conversation_id="conv-a", rank=2, score=2.0),
+            StorageConversationSearchIdHit(conversation_id="conv-b", rank=1, score=1.0),
+            StorageConversationSearchIdHit(conversation_id="conv-a", rank=2, score=2.0),
         ]
     )
     queries = _FakeQueries(
@@ -200,8 +200,8 @@ async def test_repository_search_summaries_follow_conversation_hit_order() -> No
 async def test_repository_search_summary_hits_keep_evidence_and_conversation_order() -> None:
     hits = ConversationSearchResult(
         hits=[
-            StorageConversationSearchHit(conversation_id="conv-b", rank=1, score=1.0),
-            StorageConversationSearchHit(conversation_id="conv-a", rank=2, score=2.0),
+            StorageConversationSearchIdHit(conversation_id="conv-b", rank=1, score=1.0),
+            StorageConversationSearchIdHit(conversation_id="conv-a", rank=2, score=2.0),
         ]
     )
     queries = _FakeQueries(
@@ -228,7 +228,7 @@ async def test_repository_search_summary_hits_keep_evidence_and_conversation_ord
 @pytest.mark.asyncio
 async def test_repository_search_summary_hits_prioritize_attachment_identity_evidence() -> None:
     hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
-    attachment_hit = ConversationSearchEvidenceHit(
+    attachment_hit = ConversationSearchEvidenceRow(
         conversation_id="conv-a",
         rank=1,
         message_id="msg-attachment",


### PR DESCRIPTION
## Summary

This narrows a #873 source of confusion by renaming storage-only search DTOs so they no longer masquerade as the public ranked-hit contract.

## Problem

#873 still listed “split search hit models” as a residual. Reading the code showed the split is legitimate at the data-shape level: storage query helpers return lightweight SQL/id rows before repository hydration, while archive/query returns the public summary-plus-evidence `ConversationSearchHit`. The problem was the storage names, `ConversationSearchHit` and `ConversationSearchEvidenceHit`, which implied a second public ranked-hit model and made future drift more likely.

## Solution

Renamed the storage-only id DTO to `ConversationSearchIdHit` and the pre-hydration evidence DTO to `ConversationSearchEvidenceRow`. Repository search still maps those rows into the public archive `ConversationSearchHit` before surfaces see them. No compatibility aliases were added.

## Verification

- `pytest -q tests/unit/storage/test_archive_search_contracts.py tests/unit/storage/test_search_explanation_wiring.py --tb=short` — 20 passed.
- `ruff format --check` on touched files — passed.
- `ruff check` on touched files — passed.
- `mypy` on touched files — passed.
- `devtools verify --json` — exit 0; 630 pytest-testmon selected tests passed; total 195.14s.
- pre-push `devtools verify --quick` — exit 0; total 34.88s.

Ref #873