### PR TITLE
feat(mcp): support query-scoped facets

### DIFF
--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -158,13 +158,15 @@ class MCPContentProjectionRequest:
 def conversation_query_request_signature(
     *,
     include_query: bool,
+    query_required: bool = False,
 ) -> inspect.Signature:
     """Build an ``inspect.Signature`` mirroring ``MCPConversationQueryRequest``.
 
     ``include_query`` controls whether the ``query`` parameter is surfaced —
-    ``search`` exposes it as required, ``list_conversations`` omits it. The
-    resulting signature drives MCP ``inputSchema`` derivation so the JSON
-    schema and the typed request model cannot drift.
+    ``search`` exposes it as required, ``facets`` exposes it as optional, and
+    ``list_conversations`` omits it. The resulting signature drives MCP
+    ``inputSchema`` derivation so the JSON schema and the typed request model
+    cannot drift.
     """
     type_hints = typing.get_type_hints(
         MCPConversationQueryRequest,
@@ -179,7 +181,7 @@ def conversation_query_request_signature(
         # ``search`` exposes ``query`` as a required parameter to preserve the
         # historical MCP tool surface — even though the dataclass default is
         # ``None`` so other call sites can build empty requests.
-        if field.name == "query" and include_query:
+        if field.name == "query" and include_query and query_required:
             parameters.append(
                 inspect.Parameter(
                     field.name,

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -89,7 +89,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("search", run)
 
-    cast(Any, _search).__signature__ = conversation_query_request_signature(include_query=True)
+    cast(Any, _search).__signature__ = conversation_query_request_signature(include_query=True, query_required=True)
     _search.__name__ = "search"
     _search.__doc__ = (
         "Search the archive for conversations matching ``query``. "
@@ -212,7 +212,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("facets", run)
 
-    cast(Any, _facets).__signature__ = conversation_query_request_signature(include_query=False)
+    cast(Any, _facets).__signature__ = conversation_query_request_signature(include_query=True)
     _facets.__name__ = "facets"
     _facets.__doc__ = (
         "Compute scoped and global facet aggregates over the archive. "

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -1083,6 +1083,18 @@
           "default": null,
           "title": "Provider"
         },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Query"
+        },
         "referenced_path": {
           "anyOf": [
             {

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -1,6 +1,6 @@
-"""Contract: ``search``/``list_conversations`` inputSchema is derived from the request dataclass.
+"""Contract: query tool inputSchema is derived from the request dataclass.
 
-Audit #1282 (R3) refactored the two query tools so their parameters are
+Audit #1282 (R3) refactored the query tools so their parameters are
 auto-generated from :class:`MCPConversationQueryRequest`. This test guards
 against silent drift between the dataclass and the published MCP tool schema:
 if a field is added to or removed from the dataclass and a tool definition is
@@ -30,7 +30,7 @@ def _registered_schemas() -> SchemaMap:
     server = FastMCP("schema-derivation-test")
     register_query_tools(server, hooks)
     tools = asyncio.run(server.list_tools())
-    return {tool.name: tool.inputSchema for tool in tools if tool.name in {"search", "list_conversations"}}
+    return {tool.name: tool.inputSchema for tool in tools if tool.name in {"search", "list_conversations", "facets"}}
 
 
 def _dataclass_field_names() -> set[str]:
@@ -64,6 +64,16 @@ def test_list_conversations_schema_matches_dataclass_fields_excluding_query(
     )
 
 
+def test_facets_schema_matches_dataclass_fields(schemas: SchemaMap) -> None:
+    schema = schemas["facets"]
+    properties = set(schema.get("properties", {}).keys())
+    assert properties == _dataclass_field_names(), (
+        "facets inputSchema drifted from MCPConversationQueryRequest. "
+        f"missing={sorted(_dataclass_field_names() - properties)}, "
+        f"extra={sorted(properties - _dataclass_field_names())}"
+    )
+
+
 def test_search_marks_query_required(schemas: SchemaMap) -> None:
     required = schemas["search"].get("required") or []
     assert "query" in required, "search must keep ``query`` required for backwards compatibility"
@@ -76,9 +86,15 @@ def test_list_conversations_has_no_required_parameters(
     assert required == [], "list_conversations historically accepts zero required parameters"
 
 
+def test_facets_query_is_optional(schemas: SchemaMap) -> None:
+    required = schemas["facets"].get("required") or []
+    assert "query" in schemas["facets"].get("properties", {})
+    assert required == [], "facets supports query-scoped counts but must remain callable with no filters"
+
+
 def test_limit_and_offset_preserve_pydantic_constraints(schemas: SchemaMap) -> None:
     """The derived schema must preserve the ``ge=1``/``ge=0`` annotations from the TypeAliases."""
-    for name in ("search", "list_conversations"):
+    for name in ("search", "list_conversations", "facets"):
         properties = schemas[name].get("properties", {})
         limit = properties["limit"]
         offset = properties["offset"]


### PR DESCRIPTION
## Summary

MCP `facets` now exposes the shared optional `query` field, so clients can request query-scoped facet counts through the same typed request contract used by CLI/API/daemon surfaces.

## Problem

#873 expects scoped facets to be available consistently across the public read surfaces. CLI, API, and daemon HTTP already accepted query-scoped facet requests, but the MCP tool signature explicitly omitted `query`, leaving agent clients with only global/filter facets.

## Solution

`conversation_query_request_signature()` now distinguishes whether `query` is included from whether it is required: `search` keeps `query` required, while `facets` exposes it as optional. The MCP query schema derivation tests now cover `facets`, and the committed MCP tool-schema witness was regenerated to preserve the published wire contract.

## Verification

- `pytest -q tests/unit/mcp/test_tool_schema_witness.py tests/unit/mcp/test_query_tool_schema_derivation.py --tb=short` → 10 passed
- `devtools verify --json` → PASS, 1 affected pytest node selected
- pre-push `devtools verify --quick` → PASS

Ref #873