### PR TITLE
feat(mcp): expose embedding readiness status

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -505,6 +505,20 @@ class MCPMetadataPayload(SurfacePayloadModel):
         return json.dumps(self.root, indent=2)
 
 
+class MCPEmbeddingStatusPayload(SurfacePayloadModel):
+    """Canonical embedding readiness payload exposed over MCP (#1503)."""
+
+    root: dict[str, object]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> MCPEmbeddingStatusPayload:
+        return cls(root=dict(payload))
+
+    def to_json(self, *, exclude_none: bool = False) -> str:
+        del exclude_none
+        return json.dumps(self.root, indent=2)
+
+
 class MCPUserMarkPayload(SurfacePayloadModel):
     target_type: str = "conversation"
     target_id: str

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from polylogue.config import ConfigError
 from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPConversationSummaryPayload,
+    MCPEmbeddingStatusPayload,
     MCPMessagePayload,
     MCPMessagesListPayload,
     MCPRawArtifactPayload,
@@ -37,8 +39,14 @@ from polylogue.mcp.server_support import role_allows
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
+    from polylogue.config import Config
     from polylogue.mcp.server_support import ServerCallbacks
     from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
+
+
+@dataclass(frozen=True)
+class _MCPEmbeddingStatusEnv:
+    config: Config
 
 
 def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
@@ -195,6 +203,20 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
 
         return await hooks.async_safe_call("stats", run)
+
+    @mcp.tool()
+    def embedding_status(detail: bool = False) -> str:
+        def run() -> str:
+            from polylogue.storage.embeddings.status_payload import embedding_status_payload
+
+            payload = embedding_status_payload(
+                _MCPEmbeddingStatusEnv(hooks.get_config()),
+                include_retrieval_bands=detail,
+                include_detail=detail,
+            )
+            return hooks.json_payload(MCPEmbeddingStatusPayload.from_payload(dict(payload)))
+
+        return hooks.safe_call("embedding_status", run)
 
     async def _facets(**kwargs: object) -> str:
         # Reuse the conversation query request so MCP facets share the

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -526,6 +526,20 @@
     }
   },
   {
+    "name": "embedding_status",
+    "parameters": {
+      "properties": {
+        "detail": {
+          "default": false,
+          "title": "Detail",
+          "type": "boolean"
+        }
+      },
+      "title": "embedding_statusArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "export_conversation",
     "parameters": {
       "properties": {

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -19,6 +19,7 @@ EXPECTED_TOOL_NAMES = {
     "get_conversation",
     "neighbor_candidates",
     "stats",
+    "embedding_status",
     "facets",
     "add_tag",
     "remove_tag",

--- a/tests/unit/mcp/test_embedding_status_tool.py
+++ b/tests/unit/mcp/test_embedding_status_tool.py
@@ -1,0 +1,61 @@
+"""Runtime contract for the MCP ``embedding_status`` tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface
+
+
+def test_embedding_status_returns_canonical_payload(mcp_server: MCPServerUnderTest) -> None:
+    payload = {
+        "config_enabled": False,
+        "has_voyage_api_key": True,
+        "retrieval_ready": False,
+        "status": "none",
+        "next_action": {
+            "code": "enable_embeddings",
+            "command": "polylogue embed enable --yes",
+            "reason": "A Voyage key is available, but embedding convergence is disabled in config.",
+        },
+    }
+    with (
+        patch("polylogue.mcp.server._get_config", return_value=MagicMock(name="config")) as mock_get_config,
+        patch(
+            "polylogue.storage.embeddings.status_payload.embedding_status_payload", return_value=payload
+        ) as mock_status,
+    ):
+        raw = invoke_surface(mcp_server._tool_manager._tools["embedding_status"].fn)
+
+    parsed = json.loads(raw)
+    assert parsed == payload
+    mock_get_config.assert_called_once()
+    mock_status.assert_called_once()
+    assert mock_status.call_args.kwargs == {
+        "include_retrieval_bands": False,
+        "include_detail": False,
+    }
+
+
+def test_embedding_status_detail_requests_exact_readiness_bands(mcp_server: MCPServerUnderTest) -> None:
+    payload = {
+        "config_enabled": True,
+        "has_voyage_api_key": True,
+        "retrieval_ready": True,
+        "status": "complete",
+        "retrieval_bands": {"message_embeddings": {"ready": True}},
+        "next_action": {"code": "ready", "command": "polylogue --semantic <query>", "reason": "ready"},
+    }
+    with patch(
+        "polylogue.storage.embeddings.status_payload.embedding_status_payload", return_value=payload
+    ) as mock_status:
+        raw = invoke_surface(mcp_server._tool_manager._tools["embedding_status"].fn, detail=True)
+
+    parsed = json.loads(raw)
+    assert parsed["retrieval_bands"] == {"message_embeddings": {"ready": True}}
+    mock_status.assert_called_once()
+    assert mock_status.call_args.kwargs == {
+        "include_retrieval_bands": True,
+        "include_detail": True,
+    }

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -80,6 +80,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "archive_coverage": "single_object",
     "cost_outlook": "single_object",
     "stats": "single_object",
+    "embedding_status": "single_object",
     "facets": "single_object",
     "build_context_pack": "single_object",
     "readiness_check": "single_object",


### PR DESCRIPTION
## Summary

Adds a read-only MCP `embedding_status` tool that returns the same canonical embedding readiness payload used by `polylogue embed status`, including `next_action` and optional detail bands.

## Problem

#1503 has made the CLI and daemon embedding readiness paths operational, but MCP clients still had to infer semantic-search availability from archive stats. That leaves agent workflows blind to the canonical reason semantic retrieval is unavailable and the exact next command to run.

## Solution

The new MCP tool wraps `embedding_status_payload()` behind a small payload adapter and supports `detail=true` for exact retrieval-band/detail reads. The tool is registered in the MCP surface inventories, classified as a single-object response, covered by runtime tests, and reflected in the committed MCP tool-schema witness.

This is read-only: it does not enable embeddings, start the daemon, or call Voyage.

## Verification

- `pytest -q tests/unit/mcp/test_embedding_status_tool.py tests/unit/mcp/test_envelope_contracts.py::TestRegistryWideClassification tests/unit/mcp/test_tool_schema_witness.py --tb=short` → 8 passed
- `ruff format --check ...` / `ruff check ...` / `mypy ...` on touched files → passed
- `devtools verify --json` → PASS, 347 affected pytest nodes selected
- pre-push `devtools verify --quick` → PASS

Ref #1503