### PR TITLE
feat(devtools): add archive space report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1474,6 +1474,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
 | `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools failure-context` | Join testmon, git history, fixtures, and witnesses for a pytest failure ID into a JSON envelope. |
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |

--- a/devtools/archive_space_report.py
+++ b/devtools/archive_space_report.py
@@ -1,0 +1,183 @@
+"""Read-only SQLite space report for archive schema-size work (#1486)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+from polylogue.paths import db_path as default_db_path
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+REPORT_VERSION = 1
+
+
+def _scalar_int(conn: sqlite3.Connection, sql: str) -> int:
+    row = conn.execute(sql).fetchone()
+    return int(row[0] or 0) if row is not None else 0
+
+
+def _object_types(conn: sqlite3.Connection) -> dict[str, str]:
+    rows = conn.execute(
+        """
+        SELECT name, type
+        FROM sqlite_master
+        WHERE type IN ('table', 'index')
+        """
+    ).fetchall()
+    return {str(row[0]): str(row[1]) for row in rows}
+
+
+def _category(name: str, object_type: str) -> str:
+    if object_type == "index":
+        return "index"
+    if name.startswith("sqlite_"):
+        return "sqlite_internal"
+    if name.startswith("raw_") or name in {"artifact_observations"}:
+        return "raw"
+    if "fts" in name or name.endswith("_docsize") or name.endswith("_config"):
+        return "fts"
+    if name.startswith(("session_", "work_", "day_", "week_", "provider_analytics", "cost_")):
+        return "insights"
+    if name.startswith(("message_embeddings", "embedding_")):
+        return "embeddings"
+    if name.startswith(("pending_blob_refs", "gc_generations")):
+        return "blob_gc"
+    return "archive"
+
+
+def _safe_dbstat_rows(conn: sqlite3.Connection) -> tuple[list[dict[str, object]], str | None]:
+    object_types = _object_types(conn)
+    try:
+        rows = conn.execute(
+            """
+            SELECT name, SUM(pgsize) AS bytes, COUNT(*) AS pages
+            FROM dbstat
+            GROUP BY name
+            ORDER BY bytes DESC, name
+            """
+        ).fetchall()
+    except sqlite3.Error as exc:
+        return [], f"dbstat_unavailable: {exc}"
+
+    items: list[dict[str, object]] = []
+    for row in rows:
+        name = str(row[0])
+        object_type = object_types.get(name, "sqlite_internal" if name.startswith("sqlite_") else "unknown")
+        bytes_value = int(row[1] or 0)
+        items.append(
+            {
+                "name": name,
+                "type": object_type,
+                "category": _category(name, object_type),
+                "bytes": bytes_value,
+                "mb": round(bytes_value / 1_048_576, 3),
+                "pages": int(row[2] or 0),
+            }
+        )
+    return items, None
+
+
+def _int_value(value: object) -> int:
+    return int(cast(int | float | str | bytes | bytearray, value))
+
+
+def _category_totals(items: list[dict[str, object]]) -> dict[str, dict[str, int | float]]:
+    totals: dict[str, dict[str, int | float]] = {}
+    for item in items:
+        category = str(item["category"])
+        current = totals.setdefault(category, {"bytes": 0, "objects": 0})
+        current["bytes"] = _int_value(current["bytes"]) + _int_value(item["bytes"])
+        current["objects"] = _int_value(current["objects"]) + 1
+    for value in totals.values():
+        value["mb"] = round(_int_value(value["bytes"]) / 1_048_576, 3)
+    return dict(sorted(totals.items(), key=lambda kv: (-_int_value(kv[1]["bytes"]), kv[0])))
+
+
+def build_space_report(db: Path, *, limit: int = 25, include_objects: bool = False) -> dict[str, object]:
+    """Return a read-only space report for ``db``."""
+
+    if not db.exists():
+        return {
+            "ok": False,
+            "report_version": REPORT_VERSION,
+            "db_path": str(db),
+            "error": "database_not_found",
+        }
+    with open_readonly_connection(db) as conn:
+        page_size = _scalar_int(conn, "PRAGMA page_size")
+        page_count = _scalar_int(conn, "PRAGMA page_count")
+        freelist_count = _scalar_int(conn, "PRAGMA freelist_count")
+        objects, dbstat_error = _safe_dbstat_rows(conn) if include_objects else ([], "dbstat_skipped")
+    file_bytes = db.stat().st_size
+    allocated_bytes = page_size * page_count
+    freelist_bytes = page_size * freelist_count
+    return {
+        "ok": True,
+        "report_version": REPORT_VERSION,
+        "db_path": str(db),
+        "file_bytes": file_bytes,
+        "file_mb": round(file_bytes / 1_048_576, 3),
+        "allocated_bytes": allocated_bytes,
+        "allocated_mb": round(allocated_bytes / 1_048_576, 3),
+        "freelist_bytes": freelist_bytes,
+        "freelist_mb": round(freelist_bytes / 1_048_576, 3),
+        "page_size": page_size,
+        "page_count": page_count,
+        "freelist_count": freelist_count,
+        "dbstat_available": include_objects and dbstat_error is None,
+        "dbstat_error": dbstat_error,
+        "object_scan_requested": include_objects,
+        "category_totals": _category_totals(objects),
+        "objects": objects[: max(1, limit)],
+        "object_count": len(objects),
+    }
+
+
+def _print_human(report: dict[str, object]) -> None:
+    if not report.get("ok"):
+        print(f"archive-space-report: {report.get('error')} ({report.get('db_path')})")
+        return
+    print(f"Archive space report: {report['db_path']}")
+    print(
+        f"  file: {report['file_mb']} MiB; allocated: {report['allocated_mb']} MiB; "
+        f"freelist: {report['freelist_mb']} MiB"
+    )
+    print("")
+    print("Categories:")
+    category_totals = cast(dict[str, dict[str, Any]], report["category_totals"])
+    for category, data in category_totals.items():
+        print(f"  {category:16s} {data['mb']:>10} MiB  {data['objects']:>4} objects")
+    if not report["object_scan_requested"]:
+        print("\nObject scan skipped. Re-run with --objects for dbstat table/index bytes.")
+        return
+    if not report["dbstat_available"]:
+        print(f"\ndbstat unavailable: {report['dbstat_error']}")
+        return
+    print("")
+    print("Largest objects:")
+    objects = cast(list[dict[str, Any]], report["objects"])
+    for item in objects:
+        print(f"  {item['name'][:48]:48s} {item['mb']:>10} MiB  {item['type']}/{item['category']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Report SQLite archive space by table/index using dbstat.")
+    parser.add_argument("--db", type=Path, default=default_db_path(), help="Archive database path.")
+    parser.add_argument("--limit", type=int, default=25, help="Largest object rows to include.")
+    parser.add_argument("--objects", action="store_true", help="Run the dbstat table/index object scan.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args(argv)
+
+    report = build_space_report(args.db, limit=args.limit, include_objects=args.objects)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_human(report)
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -237,6 +237,21 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "archive-space-report",
+        "maintenance",
+        "Report SQLite archive file/page/object space by table and index.",
+        "devtools.archive_space_report",
+        use_when=(
+            "Capture read-only dbstat evidence before/after schema rebuilds, VACUUM, "
+            "blob cleanup, or storage-layout changes."
+        ),
+        examples=(
+            "devtools archive-space-report",
+            "devtools archive-space-report --json",
+            "devtools archive-space-report --objects --db /path/to/polylogue.db --limit 50",
+        ),
+    ),
+    CommandSpec(
         "scenario-projections",
         "verification",
         "Render the authored scenario-bearing verification projections.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -151,6 +151,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
 | `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools failure-context` | Join testmon, git history, fixtures, and witnesses for a pytest failure ID into a JSON envelope. |
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |

--- a/tests/unit/devtools/test_archive_space_report.py
+++ b/tests/unit/devtools/test_archive_space_report.py
@@ -1,0 +1,82 @@
+"""Tests for ``devtools archive-space-report``."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from devtools.archive_space_report import build_space_report, main
+
+
+def _seed_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE raw_conversations(raw_id TEXT PRIMARY KEY, blob_size INTEGER NOT NULL);
+            CREATE TABLE conversations(conversation_id TEXT PRIMARY KEY, provider_meta TEXT);
+            CREATE TABLE messages(message_id TEXT PRIMARY KEY, conversation_id TEXT, text TEXT);
+            CREATE INDEX idx_messages_conversation ON messages(conversation_id);
+            INSERT INTO raw_conversations VALUES ('raw-1', 100);
+            INSERT INTO conversations VALUES ('c1', '{"source":"test"}');
+            INSERT INTO messages VALUES ('m1', 'c1', 'hello');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_build_space_report_groups_dbstat_objects(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    _seed_db(db)
+
+    report = build_space_report(db, limit=10, include_objects=True)
+
+    assert report["ok"] is True
+    assert report["dbstat_available"] is True
+    assert cast(int, report["file_bytes"]) > 0
+    categories = report["category_totals"]
+    assert isinstance(categories, dict)
+    assert "raw" in categories
+    assert "archive" in categories
+    assert "index" in categories
+    objects = report["objects"]
+    assert isinstance(objects, list)
+    assert any(item["name"] == "raw_conversations" for item in objects)
+
+
+def test_missing_database_reports_error(tmp_path: Path) -> None:
+    report = build_space_report(tmp_path / "missing.db")
+
+    assert report == {
+        "ok": False,
+        "report_version": 1,
+        "db_path": str(tmp_path / "missing.db"),
+        "error": "database_not_found",
+    }
+
+
+def test_build_space_report_skips_object_scan_by_default(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    _seed_db(db)
+
+    report = build_space_report(db)
+
+    assert report["ok"] is True
+    assert report["object_scan_requested"] is False
+    assert report["dbstat_error"] == "dbstat_skipped"
+    assert report["objects"] == []
+
+
+def test_main_json_returns_success_for_existing_database(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    db = tmp_path / "polylogue.db"
+    _seed_db(db)
+
+    assert main(["--db", str(db), "--json", "--objects", "--limit", "3"]) == 0
+    out = capsys.readouterr().out
+    assert '"ok": true' in out
+    assert '"object_count"' in out


### PR DESCRIPTION
## Summary

Adds a read-only `devtools archive-space-report` command for archive storage/schema work. The default report captures cheap SQLite file/page/freelist evidence, while table/index attribution via `dbstat` is opt-in with `--objects` so agents do not accidentally launch a full object scan on the live archive.

## Problem

#1486/#1552 need repeatable before/after evidence for schema-size cleanup, reingest, VACUUM, and blob/store layout changes. The existing path was ad hoc SQL, and a live object attribution scan can be expensive on the current multi-GB archive if launched casually.

## Solution

- Add `devtools/archive_space_report.py` with a read-only report over file size, allocated pages, freelist pages, and optional `dbstat` object bytes.
- Group object attribution into coarse categories (`raw`, `fts`, `insights`, `embeddings`, `blob_gc`, indexes, archive tables) for schema cleanup triage.
- Register the command in the devtools catalog and regenerate generated docs/agent surfaces.
- Add focused unit coverage for payload shape, missing DB handling, default no-object-scan behavior, and CLI JSON output.

## Verification

- `pytest -q tests/unit/devtools/test_archive_space_report.py --tb=short` -> 4 passed
- `devtools --list-commands | rg "archive-space-report"` -> command listed
- `devtools verify --json` -> `exit_code: 0`, `pytest testmon` 45 passed
- `git push` pre-push quick baseline -> `exit_code: 0`

Ref #1486
Ref #1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `devtools archive-space-report` command to analyze and report SQLite archive storage usage, including space breakdown by table and index with both human-readable and JSON output formats.

* **Documentation**
  * Updated developer tools documentation with the new archive-space-report command.

* **Tests**
  * Added comprehensive test coverage for the archive-space-report functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->