### PR TITLE
fix(mcp): gate semantic search on embedding readiness

### DIFF
--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -50,6 +51,25 @@ class _MCPEmbeddingStatusEnv:
     config: Config
 
 
+async def _count_query_results(
+    ops: Any,
+    request_spec: Any,
+    fallback_store: Any,
+) -> int:
+    """Count query results through archive operations when available.
+
+    Unit tests often use plain ``MagicMock`` operation objects. In production,
+    ``ArchiveOperations.count_conversations`` is present and keeps semantic
+    readiness/vector-provider handling aligned with the fetch path.
+    """
+    count_method = getattr(ops, "count_conversations", None)
+    if callable(count_method):
+        result = count_method(request_spec)
+        if inspect.isawaitable(result):
+            return int(await result)
+    return int(await request_spec.count(fallback_store))
+
+
 def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def _search(**kwargs: object) -> str:
         if "query" not in kwargs:
@@ -80,7 +100,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     limit=(spec.limit or clamped_limit) + clamped_limit,
                 )
             results = await ops.search_conversation_hits(spec)
-            total = await spec.count(hooks.get_query_store())
+            total = await _count_query_results(ops, spec, hooks.get_query_store())
             diagnostics = await ops.diagnose_query_miss(spec) if not results else None
             return hooks.json_payload(
                 conversation_search_result_payload(
@@ -115,7 +135,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             clamped_offset = max(0, request.offset)
             spec = request.build_spec(hooks.clamp_limit)
             conversations = await ops.query_conversations(spec)
-            total = await spec.count(hooks.get_query_store())
+            total = await _count_query_results(ops, spec, hooks.get_query_store())
             diagnostics = None
             if not conversations:
                 try:

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -18,6 +18,7 @@ from polylogue.archive.semantic.pricing import (
 )
 from polylogue.config import ConfigError
 from polylogue.core.timestamps import parse_timestamp
+from polylogue.errors import DatabaseError
 from polylogue.insights.archive import (
     ArchiveDebtInsight,
     ArchiveDebtInsightQuery,
@@ -116,6 +117,7 @@ if TYPE_CHECKING:
     from polylogue.archive.stats import ArchiveStats as StorageArchiveStats
     from polylogue.config import Config
     from polylogue.pipeline.services.indexing import IndexStatus
+    from polylogue.protocols import VectorProvider
     from polylogue.storage.archive_views import ConversationRenderProjection
     from polylogue.storage.insights.session.runtime import SessionInsightCounts
     from polylogue.storage.repository import ConversationRepository
@@ -303,6 +305,45 @@ class ArchiveSearchMixin:
         @property
         def config(self) -> Config: ...
 
+        @property
+        def backend(self) -> SQLiteBackend: ...
+
+    async def _vector_provider_for_query_spec(self, spec: ConversationQuerySpec) -> VectorProvider | None:
+        """Return a vector provider for explicit semantic/hybrid query specs.
+
+        ``auto`` is intentionally not promoted here. CLI auto-elevation has
+        its own UX path; archive operations only enforce that explicit
+        semantic requests and explicit hybrid requests do not silently run
+        without usable vectors.
+        """
+        if not spec.similar_text and spec.retrieval_lane != "hybrid":
+            return None
+
+        archive_stats = await self.repository.get_archive_stats()
+        retrieval_ready = getattr(archive_stats, "retrieval_ready", None)
+        if not isinstance(retrieval_ready, bool):
+            embedded_messages = int(getattr(archive_stats, "embedded_messages", 0) or 0)
+            stale_messages = int(getattr(archive_stats, "stale_embedding_messages", 0) or 0)
+            retrieval_ready = max(embedded_messages - stale_messages, 0) > 0
+        if not retrieval_ready:
+            status = getattr(archive_stats, "embedding_readiness_status", None) or "none"
+            raise DatabaseError(
+                "Semantic or hybrid retrieval requires retrieval-ready embeddings "
+                f"(current status: {status}). Run `polylogue embed status`, then "
+                "`polylogue embed backfill` or let polylogued converge after enabling embeddings."
+            )
+
+        from polylogue.storage.search_providers import create_vector_provider
+
+        vector_provider = create_vector_provider(self.config, db_path=self.backend.db_path)
+        if vector_provider is None:
+            raise DatabaseError(
+                "Semantic or hybrid retrieval requires vector search support, but vector provider initialization "
+                "failed or embeddings are disabled. Run `polylogue embed status`, then `polylogue embed enable` "
+                "if needed."
+            )
+        return vector_provider
+
     async def get_conversation(
         self,
         conversation_id: str,
@@ -355,7 +396,8 @@ class ArchiveSearchMixin:
         *,
         content_projection: ContentProjectionSpec | None = None,
     ) -> list[Conversation]:
-        conversations = await spec.list(self.repository)
+        vector_provider = await self._vector_provider_for_query_spec(spec)
+        conversations = await spec.list(self.repository, vector_provider=vector_provider)
         if content_projection is None or not content_projection.filters_content():
             return conversations
         return [conversation.with_content_projection(content_projection) for conversation in conversations]
@@ -363,11 +405,16 @@ class ArchiveSearchMixin:
     async def search_conversation_hits(self, spec: ConversationQuerySpec) -> list[ConversationSearchHit]:
         from polylogue.archive.query.search_hits import search_hits_for_plan
 
-        hits = await search_hits_for_plan(spec.to_plan(), self.repository)
+        vector_provider = await self._vector_provider_for_query_spec(spec)
+        hits = await search_hits_for_plan(spec.to_plan(vector_provider=vector_provider), self.repository)
         if not hits:
             return hits
         counts = await self.repository.get_message_counts_batch([hit.conversation_id for hit in hits])
         return [hit.with_message_count(counts.get(hit.conversation_id)) for hit in hits]
+
+    async def count_conversations(self, spec: ConversationQuerySpec) -> int:
+        vector_provider = await self._vector_provider_for_query_spec(spec)
+        return await spec.count(self.repository, vector_provider=vector_provider)
 
     async def neighbor_candidates(
         self,

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -417,6 +417,28 @@ class TestQueryTools:
         mock_ops.diagnose_query_miss.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_search_counts_through_archive_operations(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.search_conversation_hits = AsyncMock(return_value=[])
+            mock_ops.count_conversations = AsyncMock(return_value=42)
+            mock_ops.diagnose_query_miss = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
+
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="semantic planning",
+                similar_text="semantic planning",
+                limit=10,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["total"] == 42
+        mock_ops.count_conversations.assert_awaited_once()
+        spec = mock_ops.count_conversations.await_args.args[0]
+        assert spec.similar_text == "semantic planning"
+
+    @pytest.mark.asyncio
     async def test_query_tools_reject_unknown_message_type(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()

--- a/tests/unit/operations/test_archive_search_semantic_readiness.py
+++ b/tests/unit/operations/test_archive_search_semantic_readiness.py
@@ -1,0 +1,80 @@
+"""Semantic-readiness gates for archive search operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from polylogue.archive.query.spec import ConversationQuerySpec
+from polylogue.errors import DatabaseError
+from polylogue.operations.archive import ArchiveOperations
+
+
+def _ops(repo: MagicMock, *, db_path: Path) -> ArchiveOperations:
+    backend = MagicMock(db_path=db_path)
+    config = MagicMock(db_path=db_path)
+    return ArchiveOperations(config=config, repository=repo, backend=backend)
+
+
+@pytest.mark.asyncio
+async def test_semantic_count_rejects_unready_embeddings(tmp_path: Path) -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(
+        return_value=SimpleNamespace(
+            retrieval_ready=False,
+            embedding_readiness_status="stale",
+            embedded_messages=10,
+            stale_embedding_messages=10,
+        )
+    )
+
+    with pytest.raises(DatabaseError, match="retrieval-ready embeddings"):
+        await _ops(repo, db_path=tmp_path / "archive.db").count_conversations(
+            ConversationQuerySpec(similar_text="memory leak")
+        )
+
+    repo.get_archive_stats.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_explicit_hybrid_rejects_missing_vector_provider(tmp_path: Path) -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=SimpleNamespace(retrieval_ready=True))
+
+    with (
+        patch("polylogue.storage.search_providers.create_vector_provider", return_value=None),
+        pytest.raises(DatabaseError, match="vector search support"),
+    ):
+        await _ops(repo, db_path=tmp_path / "archive.db").count_conversations(
+            ConversationQuerySpec(query_terms=("fts",), retrieval_lane="hybrid")
+        )
+
+
+@pytest.mark.asyncio
+async def test_semantic_count_passes_ready_vector_provider(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=SimpleNamespace(retrieval_ready=True))
+    provider = MagicMock(name="vector_provider")
+    seen: dict[str, object] = {}
+
+    async def fake_count(
+        self: ConversationQuerySpec,
+        repository: object,
+        *,
+        vector_provider: object | None = None,
+    ) -> int:
+        seen["repository"] = repository
+        seen["vector_provider"] = vector_provider
+        return 7
+
+    monkeypatch.setattr(ConversationQuerySpec, "count", fake_count)
+    with patch("polylogue.storage.search_providers.create_vector_provider", return_value=provider):
+        total = await _ops(repo, db_path=tmp_path / "archive.db").count_conversations(
+            ConversationQuerySpec(similar_text="memory leak")
+        )
+
+    assert total == 7
+    assert seen == {"repository": repo, "vector_provider": provider}


### PR DESCRIPTION
## Summary

Gates semantic and explicit hybrid archive operations on embedding retrieval readiness, and routes MCP search/list counts through the same operations path. This closes the gap where the CLI handled #1503 readiness carefully but MCP/API search could still fail as an internal vector-provider error or silently omit the vector lane for explicit hybrid search.

## Problem

MCP `search` builds `ConversationQuerySpec` directly and `ArchiveOperations.search_conversation_hits` compiled it without a vector provider. A `similar_text` request could therefore reach repository vector search with no provider, and explicit `retrieval_lane=hybrid` could run text/action fusion without usable vectors. That contradicts the #1503 contract that semantic search must be visibly ready before semantic/hybrid retrieval is served.

## Solution

- Added archive-operation vector-provider gating for `similar_text` and explicit `retrieval_lane=hybrid`.
- Reused archive embedding stats to reject unready/stale vector state with a typed `DatabaseError` carrying operator next-step commands.
- Passed the provider through query/search/count operations when vectors are ready.
- Made MCP `search` and `list_conversations` count through `ArchiveOperations.count_conversations` when present, so count/fetch readiness behavior stays aligned.
- Added focused operation and MCP contract tests.

## Verification

- `pytest -q tests/unit/operations/test_archive_search_semantic_readiness.py tests/unit/mcp/test_tool_contracts.py::TestQueryTools::test_search_counts_through_archive_operations --tb=short` -> 4 passed
- `python -m mypy polylogue/operations/archive.py polylogue/mcp/server_tools.py tests/unit/operations/test_archive_search_semantic_readiness.py tests/unit/mcp/test_tool_contracts.py` -> success
- `devtools verify --json` -> exit_code 0, 723 affected tests passed
- `git push` pre-push quick baseline -> exit_code 0

Ref #1503