### PR TITLE
feat(devtools): add safe worktree gc (#1222)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1480,6 +1480,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |
 | `devtools witness-minimize` | Apply minimization heuristics to a local witness — shrink, redact, set privacy classification. |
 | `devtools witness-promote` | Promote a minimized local witness to tests/witnesses/ for durable commit. |
+| `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
 | `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
 
 <!-- END GENERATED: devtools-command-catalog -->

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -237,6 +237,23 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "worktree-gc",
+        "maintenance",
+        "Safe worktree garbage collection — list and remove merged or abandoned git worktrees.",
+        "devtools.worktree_gc",
+        use_when=(
+            "Clean up agent and feature worktrees that have been merged or whose branches "
+            "have been deleted. Dry-run by default; pass --apply to remove safe candidates. "
+            "Never removes dirty worktrees or the main worktree."
+        ),
+        examples=(
+            "devtools worktree-gc",
+            "devtools worktree-gc --json",
+            "devtools worktree-gc --apply",
+            "devtools worktree-gc --apply --force",
+        ),
+    ),
+    CommandSpec(
         "archive-space-report",
         "maintenance",
         "Report SQLite archive file/page/object space by table and index.",

--- a/devtools/worktree_gc.py
+++ b/devtools/worktree_gc.py
@@ -1,0 +1,379 @@
+"""Safe worktree garbage collection for agent and feature worktrees (#1222).
+
+Parses ``git worktree list --porcelain``, classifies candidates, checks
+dirty state, and applies removals only for safe entries.  Never removes
+dirty worktrees or the main worktree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeEntry:
+    path: Path
+    head: str
+    branch: str | None = None
+    bare: bool = False
+    locked: bool = False
+    detached: bool = False
+    prunable: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class GcCandidate:
+    entry: WorktreeEntry
+    reason: str
+    safe: bool
+    blocked_reason: str | None = None
+    action: str | None = None
+
+
+def _run_git(args: list[str], *, cwd: Path | None = None) -> str:
+    """Run a git command and return stripped stdout.  Raises on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    result.check_returncode()
+    return result.stdout.strip()
+
+
+def _run_git_nullable(args: list[str], *, cwd: Path | None = None) -> str | None:
+    """Run a git command; return stripped stdout or None on failure."""
+    try:
+        return _run_git(args, cwd=cwd)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def parse_worktree_list(porcelain: str) -> list[WorktreeEntry]:
+    """Parse ``git worktree list --porcelain`` output."""
+    entries: list[WorktreeEntry] = []
+    current: dict[str, Any] = {}
+    for line in porcelain.splitlines():
+        line = line.strip()
+        if not line:
+            if current:
+                entries.append(_build_entry(current))
+                current = {}
+            continue
+        if " " in line:
+            key, _, value = line.partition(" ")
+            current[key] = value
+        else:
+            current[line] = True
+    if current:
+        entries.append(_build_entry(current))
+    return entries
+
+
+def _build_entry(raw: dict[str, Any]) -> WorktreeEntry:
+    return WorktreeEntry(
+        path=Path(raw["worktree"]),
+        head=raw.get("HEAD", ""),
+        branch=raw.get("branch"),
+        bare="bare" in raw,
+        locked="locked" in raw,
+        detached="detached" in raw,
+        prunable="prunable" in raw,
+    )
+
+
+def _merged_branches(repo_root: Path, target: str = "master") -> set[str]:
+    """Return set of branch refs fully merged into *target*."""
+    out = _run_git(["branch", "--merged", target, "--format=%(refname)"], cwd=repo_root)
+    if not out:
+        return set()
+    return {line.strip() for line in out.splitlines()}
+
+
+def _existing_branches(repo_root: Path) -> set[str]:
+    """Return set of all local branch refs."""
+    out = _run_git(["branch", "--format=%(refname)"], cwd=repo_root)
+    if not out:
+        return set()
+    return {line.strip() for line in out.splitlines()}
+
+
+def check_dirty(worktree_path: Path) -> bool:
+    """Return True if the worktree has uncommitted changes."""
+    if not worktree_path.exists():
+        return False
+    out = _run_git_nullable(["status", "--porcelain"], cwd=worktree_path)
+    return bool(out)
+
+
+def classify_candidates(
+    entries: list[WorktreeEntry],
+    *,
+    repo_root: Path,
+    merged: set[str],
+    existing: set[str],
+) -> list[GcCandidate]:
+    """Classify each worktree entry as a candidate or blocked."""
+    candidates: list[GcCandidate] = []
+    for entry in entries:
+        if entry.bare:
+            continue
+        if entry.path == repo_root:
+            continue
+        candidates.append(_classify_one(entry, merged=merged, existing=existing))
+    return candidates
+
+
+def _classify_one(
+    entry: WorktreeEntry,
+    *,
+    merged: set[str],
+    existing: set[str],
+) -> GcCandidate:
+    if entry.prunable:
+        dirty = check_dirty(entry.path)
+        if dirty:
+            return GcCandidate(
+                entry=entry,
+                reason="prunable",
+                safe=False,
+                blocked_reason="dirty",
+            )
+        return GcCandidate(
+            entry=entry,
+            reason="prunable",
+            safe=False,
+            action="prune",
+            blocked_reason="requires-prune",
+        )
+
+    if entry.branch is None:
+        if entry.detached:
+            dirty = check_dirty(entry.path)
+            if dirty:
+                return GcCandidate(
+                    entry=entry,
+                    reason="detached",
+                    safe=False,
+                    blocked_reason="dirty",
+                )
+            return GcCandidate(
+                entry=entry,
+                reason="detached",
+                safe=False,
+                action="remove-force",
+                blocked_reason="requires-force",
+            )
+        return GcCandidate(
+            entry=entry,
+            reason="unknown",
+            safe=False,
+            blocked_reason="no-branch-ref",
+        )
+
+    if entry.branch not in existing:
+        dirty = check_dirty(entry.path)
+        if dirty:
+            return GcCandidate(
+                entry=entry,
+                reason="branch-deleted",
+                safe=False,
+                blocked_reason="dirty",
+            )
+        return GcCandidate(
+            entry=entry,
+            reason="branch-deleted",
+            safe=True,
+            action="remove",
+        )
+
+    if entry.branch in merged:
+        dirty = check_dirty(entry.path)
+        if dirty:
+            return GcCandidate(
+                entry=entry,
+                reason="merged",
+                safe=False,
+                blocked_reason="dirty",
+            )
+        if entry.locked:
+            return GcCandidate(
+                entry=entry,
+                reason="merged",
+                safe=False,
+                blocked_reason="locked",
+            )
+        return GcCandidate(
+            entry=entry,
+            reason="merged",
+            safe=True,
+            action="remove",
+        )
+
+    return GcCandidate(
+        entry=entry,
+        reason="unmerged",
+        safe=False,
+        blocked_reason="branch-not-merged",
+    )
+
+
+def collect_candidates(repo_root: Path, *, target: str = "master") -> tuple[list[GcCandidate], list[WorktreeEntry]]:
+    """Run git commands and return classified candidates plus all entries."""
+    porcelain = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    entries = parse_worktree_list(porcelain)
+    merged = _merged_branches(repo_root, target=target)
+    existing = _existing_branches(repo_root)
+    candidates = classify_candidates(entries, repo_root=repo_root, merged=merged, existing=existing)
+    return candidates, entries
+
+
+def apply_removals(candidates: list[GcCandidate], *, repo_root: Path, force: bool = False) -> list[dict[str, object]]:
+    """Remove safe candidates.  Returns per-entry result dicts."""
+    results: list[dict[str, object]] = []
+    removed = 0
+
+    for c in candidates:
+        if c.reason == "prunable":
+            results.append({"path": str(c.entry.path), "removed": False, "reason": "prunable-skipped"})
+            continue
+
+        if c.safe and c.action == "remove":
+            ok = _run_git_nullable(["worktree", "remove", str(c.entry.path)], cwd=repo_root) is not None
+            results.append({"path": str(c.entry.path), "removed": ok, "reason": c.reason})
+            if ok:
+                removed += 1
+            continue
+
+        if force and c.action == "remove-force" and not check_dirty(c.entry.path):
+            ok = _run_git_nullable(["worktree", "remove", "--force", str(c.entry.path)], cwd=repo_root) is not None
+            results.append({"path": str(c.entry.path), "removed": ok, "reason": c.reason})
+            if ok:
+                removed += 1
+            continue
+
+        results.append(
+            {
+                "path": str(c.entry.path),
+                "removed": False,
+                "reason": c.reason,
+                "blocked": c.blocked_reason,
+            }
+        )
+
+    _run_git_nullable(["worktree", "prune"], cwd=repo_root)
+    results.append({"prune": True, "removed_count": removed})
+
+    return results
+
+
+def _build_payload(
+    candidates: list[GcCandidate],
+    apply_results: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    entries: list[dict[str, object]] = []
+    for c in candidates:
+        entry: dict[str, object] = {
+            "path": str(c.entry.path),
+            "branch": c.entry.branch or (f"HEAD {c.entry.head[:8]}" if c.entry.head else "unknown"),
+            "head": c.entry.head,
+            "reason": c.reason,
+            "action": c.action,
+            "safe": c.safe,
+            "blocked_reason": c.blocked_reason,
+            "locked": c.entry.locked,
+        }
+        entries.append(entry)
+
+    payload: dict[str, object] = {
+        "worktrees": entries,
+        "safe_count": sum(1 for c in candidates if c.safe),
+        "blocked_count": sum(1 for c in candidates if not c.safe),
+        "total_count": len(candidates),
+    }
+    if apply_results is not None:
+        payload["results"] = apply_results
+    return payload
+
+
+def _print_human(payload: dict[str, object]) -> None:
+    entries = cast(list[dict[str, object]], payload["worktrees"])
+    if not entries:
+        print("No linked worktrees found.")
+        return
+
+    print(f"{'PATH':<50} {'BRANCH':<40} {'REASON':<20} {'SAFE':<6} {'BLOCKED'}")
+    print("-" * 140)
+    for e in entries:
+        path = str(e["path"])
+        branch = str(e["branch"])
+        reason = str(e["reason"])
+        safe = "yes" if e["safe"] else "no"
+        blocked = str(e.get("blocked_reason") or "")
+        if len(path) > 49:
+            path = "..." + path[-46:]
+        if len(branch) > 39:
+            branch = "..." + branch[-36:]
+        print(f"{path:<50} {branch:<40} {reason:<20} {safe:<6} {blocked}")
+
+    print(f"\n{payload['safe_count']} safe, {payload['blocked_count']} blocked, {payload['total_count']} total")
+
+    results = cast(list[dict[str, object]] | None, payload.get("results"))
+    if results:
+        removed = sum(1 for r in results if r.get("removed"))
+        pruned = any(r.get("prune") for r in results)
+        if removed:
+            print(f"\nRemoved {removed} worktree(s).")
+        if pruned:
+            print("Pruned stale worktree metadata.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Safe worktree garbage collection.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply removals (default: dry-run only).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow removal of clean detached/broken worktrees.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    parser.add_argument(
+        "--target",
+        default="master",
+        help="Target branch for merge check (default: master).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(_run_git(["rev-parse", "--show-toplevel"]))
+    candidates, _entries = collect_candidates(repo_root, target=args.target)
+
+    apply_results = None
+    if args.apply:
+        apply_results = apply_removals(candidates, repo_root=repo_root, force=args.force)
+
+    payload = _build_payload(candidates, apply_results=apply_results)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -157,6 +157,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |
 | `devtools witness-minimize` | Apply minimization heuristics to a local witness — shrink, redact, set privacy classification. |
 | `devtools witness-promote` | Promote a minimized local witness to tests/witnesses/ for durable commit. |
+| `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
 | `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
 
 <!-- END GENERATED: devtools-command-catalog -->

--- a/tests/unit/devtools/test_worktree_gc.py
+++ b/tests/unit/devtools/test_worktree_gc.py
@@ -1,0 +1,456 @@
+"""Tests for ``devtools worktree-gc``."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools.worktree_gc import (
+    GcCandidate,
+    WorktreeEntry,
+    _build_payload,
+    apply_removals,
+    check_dirty,
+    classify_candidates,
+    collect_candidates,
+    main,
+    parse_worktree_list,
+)
+
+# ── porcelain parsing ──────────────────────────────────────────────
+
+PORCELAIN_SAMPLE = """\
+worktree /home/user/repo
+HEAD abc123def456789
+branch refs/heads/master
+bare
+
+worktree /home/user/repo-feat
+HEAD def456789abc123
+branch refs/heads/feature/foo
+
+worktree /home/user/repo-detached
+HEAD fff111222333444
+detached
+
+worktree /home/user/repo-locked
+HEAD aaa111bbb222ccc
+branch refs/heads/feature/locked
+locked
+"""
+
+
+def test_parse_worktree_list() -> None:
+    entries = parse_worktree_list(PORCELAIN_SAMPLE)
+
+    assert len(entries) == 4
+
+    master = entries[0]
+    assert master.path == Path("/home/user/repo")
+    assert master.branch == "refs/heads/master"
+    assert master.bare is True
+
+    feat = entries[1]
+    assert feat.path == Path("/home/user/repo-feat")
+    assert feat.branch == "refs/heads/feature/foo"
+    assert feat.bare is False
+
+    detached = entries[2]
+    assert detached.path == Path("/home/user/repo-detached")
+    assert detached.detached is True
+    assert detached.branch is None
+
+    locked = entries[3]
+    assert locked.locked is True
+
+
+def test_parse_worktree_list_empty() -> None:
+    assert parse_worktree_list("") == []
+
+
+# ── dirty check ────────────────────────────────────────────────────
+
+
+def test_check_dirty_clean(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """check_dirty returns False for a clean git repo."""
+    repo = _make_repo(tmp_path / "repo")
+    # Worktree entry pointing at the repo itself won't be dirty
+    # because status --porcelain returns empty for clean repo.
+
+    # Simulate by checking the repo itself — it's clean after init+commit.
+    assert check_dirty(repo) is False
+
+
+def test_check_dirty_true(tmp_path: Path) -> None:
+    """check_dirty returns True when there are uncommitted changes."""
+    repo = _make_repo(tmp_path / "repo")
+    (repo / "new-file.txt").write_text("hello")
+    assert check_dirty(repo) is True
+
+
+def test_check_dirty_missing_path(tmp_path: Path) -> None:
+    """check_dirty returns False for non-existent paths (prunable)."""
+    assert check_dirty(tmp_path / "nonexistent") is False
+
+
+# ── classification ─────────────────────────────────────────────────
+
+
+def _entry(**kw: Any) -> WorktreeEntry:
+    defaults: dict[str, Any] = {
+        "path": Path("/tmp/worktrees/feat"),
+        "head": "abc123",
+        "branch": "refs/heads/feature/foo",
+    }
+    defaults.update(kw)
+    return WorktreeEntry(**defaults)
+
+
+def test_classify_merged_safe() -> None:
+    c = classify_candidates(
+        [_entry(branch="refs/heads/feature/merged")],
+        repo_root=Path("/tmp/repo"),
+        merged={"refs/heads/feature/merged", "refs/heads/master"},
+        existing={"refs/heads/feature/merged", "refs/heads/master"},
+    )
+    assert len(c) == 1
+    assert c[0].reason == "merged"
+    assert c[0].safe is True
+    assert c[0].action == "remove"
+
+
+def test_classify_unmerged_blocked() -> None:
+    c = classify_candidates(
+        [_entry(branch="refs/heads/feature/active")],
+        repo_root=Path("/tmp/repo"),
+        merged={"refs/heads/master"},
+        existing={"refs/heads/feature/active", "refs/heads/master"},
+    )
+    assert c[0].reason == "unmerged"
+    assert c[0].safe is False
+    assert c[0].blocked_reason == "branch-not-merged"
+
+
+def test_classify_branch_deleted_safe(tmp_path: Path) -> None:
+    """Worktree whose branch ref no longer exists = safe to remove."""
+    repo = _make_repo(tmp_path / "repo")
+    c = classify_candidates(
+        [_entry(branch="refs/heads/gone", path=repo)],
+        repo_root=Path("/tmp/repo"),
+        merged=set(),
+        existing=set(),
+    )
+    assert c[0].reason == "branch-deleted"
+    assert c[0].safe is True
+    assert c[0].action == "remove"
+
+
+def test_classify_detached_requires_force() -> None:
+    c = classify_candidates(
+        [_entry(branch=None, detached=True)],
+        repo_root=Path("/tmp/repo"),
+        merged=set(),
+        existing=set(),
+    )
+    assert c[0].reason == "detached"
+    assert c[0].safe is False
+    assert c[0].action == "remove-force"
+    assert c[0].blocked_reason == "requires-force"
+
+
+def test_classify_no_branch_ref_blocked() -> None:
+    c = classify_candidates(
+        [_entry(branch=None, detached=False)],
+        repo_root=Path("/tmp/repo"),
+        merged=set(),
+        existing=set(),
+    )
+    assert c[0].safe is False
+    assert c[0].blocked_reason == "no-branch-ref"
+
+
+def test_classify_bare_skipped() -> None:
+    """Main (bare) worktree is never a candidate."""
+    entries: list[WorktreeEntry] = [
+        _entry(path=Path("/tmp/repo"), branch="refs/heads/master", bare=True),
+        _entry(path=Path("/tmp/repo-feat"), branch="refs/heads/feature/merged"),
+    ]
+    c = classify_candidates(
+        entries,
+        repo_root=Path("/tmp/repo"),
+        merged={"refs/heads/feature/merged", "refs/heads/master"},
+        existing={"refs/heads/feature/merged", "refs/heads/master"},
+    )
+    assert len(c) == 1
+    assert c[0].entry.branch == "refs/heads/feature/merged"
+
+
+def test_classify_repo_root_skipped(tmp_path: Path) -> None:
+    """Worktree at repo root path is skipped."""
+    repo = _make_repo(tmp_path / "repo-root")
+    entries: list[WorktreeEntry] = [
+        _entry(path=repo, branch="refs/heads/feature/x"),
+    ]
+    c = classify_candidates(
+        entries,
+        repo_root=repo,
+        merged={"refs/heads/feature/x"},
+        existing={"refs/heads/feature/x"},
+    )
+    assert len(c) == 0
+
+
+def test_classify_locked_merged_blocked(tmp_path: Path) -> None:
+    """Locked worktree with merged branch is blocked, not safe."""
+    repo = _make_repo(tmp_path / "repo")
+    c = classify_candidates(
+        [_entry(branch="refs/heads/feature/merged", locked=True, path=repo)],
+        repo_root=Path("/tmp/repo"),
+        merged={"refs/heads/feature/merged", "refs/heads/master"},
+        existing={"refs/heads/feature/merged", "refs/heads/master"},
+    )
+    assert c[0].reason == "merged"
+    assert c[0].safe is False
+    assert c[0].blocked_reason == "locked"
+
+
+def test_classify_dirty_never_safe(tmp_path: Path) -> None:
+    """Dirty check is deferred in classify (no fs access). Test via apply."""
+    repo = _make_repo(tmp_path / "repo-dirty")
+    (repo / "unstaged").write_text("x")
+    entry_dirty = _entry(branch="refs/heads/feature/merged", path=repo)
+
+    c = classify_candidates(
+        [entry_dirty],
+        repo_root=Path("/tmp/repo"),
+        merged={"refs/heads/feature/merged"},
+        existing={"refs/heads/feature/merged"},
+    )
+    assert c[0].safe is False
+    assert c[0].blocked_reason == "dirty"
+
+
+# ── apply ──────────────────────────────────────────────────────────
+
+
+def test_apply_removes_clean_merged(tmp_path: Path) -> None:
+    """apply_removals removes safe merged worktrees."""
+    repo = _make_repo(tmp_path / "main")
+    wt_path = _make_worktree(repo, tmp_path / "wt-merged", "feature/merged")
+
+    candidates: list[GcCandidate] = [
+        GcCandidate(
+            entry=WorktreeEntry(path=wt_path, head="abc", branch="refs/heads/feature/merged"),
+            reason="merged",
+            safe=True,
+            action="remove",
+        )
+    ]
+    results = apply_removals(candidates, repo_root=repo)
+    assert results[0].get("removed") is True
+    # prune should have been called
+    assert any(r.get("prune") for r in results)
+
+
+def test_apply_skips_blocked(tmp_path: Path) -> None:
+    """Blocked candidates are not removed."""
+    repo = _make_repo(tmp_path / "repo")
+    candidates: list[GcCandidate] = [
+        GcCandidate(
+            entry=WorktreeEntry(path=tmp_path / "nonexistent-wt", head="abc", branch="refs/heads/feature/unmerged"),
+            reason="unmerged",
+            safe=False,
+            blocked_reason="branch-not-merged",
+        )
+    ]
+    results = apply_removals(candidates, repo_root=repo)
+    assert results[0].get("removed") is False
+
+
+def test_apply_force_removes_detached_clean(tmp_path: Path) -> None:
+    """With --force, clean detached worktrees are removed."""
+    repo = _make_repo(tmp_path / "main")
+    wt_path = _make_worktree(repo, tmp_path / "wt-detached", "feature/detached")
+    # Detach HEAD
+    subprocess.run(["git", "-C", str(wt_path), "checkout", "--detach"], capture_output=True)
+
+    candidates: list[GcCandidate] = [
+        GcCandidate(
+            entry=WorktreeEntry(path=wt_path, head="abc", branch=None, detached=True),
+            reason="detached",
+            safe=False,
+            action="remove-force",
+            blocked_reason="requires-force",
+        )
+    ]
+    results = apply_removals(candidates, repo_root=repo, force=True)
+    assert results[0].get("removed") is True
+
+
+def test_apply_prunable_skipped(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    candidates: list[GcCandidate] = [
+        GcCandidate(
+            entry=WorktreeEntry(path=tmp_path / "gone", head="abc", prunable=True),
+            reason="prunable",
+            safe=False,
+            action="prune",
+            blocked_reason="requires-prune",
+        )
+    ]
+    results = apply_removals(candidates, repo_root=repo)
+    assert results[0].get("removed") is False
+    assert results[0].get("reason") == "prunable-skipped"
+
+
+# ── payload / JSON ─────────────────────────────────────────────────
+
+
+def test_build_payload_shape() -> None:
+    candidates: list[GcCandidate] = [
+        GcCandidate(
+            entry=WorktreeEntry(
+                path=Path("/tmp/wt"),
+                head="abc123",
+                branch="refs/heads/feature/merged",
+                locked=False,
+            ),
+            reason="merged",
+            safe=True,
+            action="remove",
+        ),
+    ]
+    payload = _build_payload(candidates)
+    assert payload["safe_count"] == 1
+    assert payload["blocked_count"] == 0
+    assert payload["total_count"] == 1
+    entries = payload["worktrees"]
+    assert isinstance(entries, list)
+    assert entries[0]["path"] == "/tmp/wt"
+    assert entries[0]["reason"] == "merged"
+    assert entries[0]["safe"] is True
+
+
+def test_main_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """main --json emits valid JSON with expected keys."""
+    repo = _make_repo(tmp_path / "repo")
+    # Run from within the repo
+    import os
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(repo)
+        exit_code = main(["--json"])
+    finally:
+        os.chdir(orig_cwd)
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "worktrees" in payload
+    assert "safe_count" in payload
+    assert "total_count" in payload
+
+
+# ── end-to-end with synthetic repo ─────────────────────────────────
+
+
+def test_collect_end_to_end(tmp_path: Path) -> None:
+    """Full pipeline on a synthetic repo with merged + unmerged worktrees."""
+    repo = _make_repo(tmp_path / "repo")
+
+    # Create a branch, merge it, then create a worktree for it
+    _run_git(["checkout", "-b", "feature/merged"], cwd=repo)
+    (repo / "merged-file.txt").write_text("merged work")
+    _run_git(["add", "merged-file.txt"], cwd=repo)
+    _run_git(["commit", "-m", "merged commit"], cwd=repo)
+    _run_git(["checkout", "master"], cwd=repo)
+    _run_git(["merge", "feature/merged"], cwd=repo)
+
+    merged_wt = _make_worktree(repo, tmp_path / "wt-merged", "feature/merged")
+
+    # Create an unmerged branch worktree
+    _run_git(["checkout", "-b", "feature/active"], cwd=repo)
+    (repo / "active-file.txt").write_text("active work")
+    _run_git(["add", "active-file.txt"], cwd=repo)
+    _run_git(["commit", "-m", "active commit"], cwd=repo)
+    _run_git(["checkout", "master"], cwd=repo)
+
+    active_wt = _make_worktree(repo, tmp_path / "wt-active", "feature/active")
+
+    candidates, entries = collect_candidates(repo)
+
+    merged_c = next((c for c in candidates if c.entry.path == merged_wt), None)
+    active_c = next((c for c in candidates if c.entry.path == active_wt), None)
+
+    assert merged_c is not None
+    assert merged_c.reason == "merged"
+    assert merged_c.safe is True
+    assert merged_c.action == "remove"
+
+    assert active_c is not None
+    assert active_c.reason == "unmerged"
+    assert active_c.safe is False
+    assert active_c.blocked_reason == "branch-not-merged"
+
+
+def test_dirty_blocks_in_collect(tmp_path: Path) -> None:
+    """collect_candidates marks dirty merged worktrees as blocked."""
+    repo = _make_repo(tmp_path / "repo")
+
+    _run_git(["checkout", "-b", "feature/done"], cwd=repo)
+    (repo / "f.txt").write_text("x")
+    _run_git(["add", "f.txt"], cwd=repo)
+    _run_git(["commit", "-m", "done"], cwd=repo)
+    _run_git(["checkout", "master"], cwd=repo)
+    _run_git(["merge", "feature/done"], cwd=repo)
+
+    dirty_wt = _make_worktree(repo, tmp_path / "wt-dirty", "feature/done")
+    (dirty_wt / "unstaged.txt").write_text("oops")
+
+    candidates, _entries = collect_candidates(repo)
+    dc = next((c for c in candidates if c.entry.path == dirty_wt), None)
+    assert dc is not None
+    assert dc.safe is False
+    assert dc.blocked_reason == "dirty"
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _run_git(args: list[str], *, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _make_repo(path: Path) -> Path:
+    """Create a git repo with an initial commit on master."""
+    path.mkdir(parents=True, exist_ok=True)
+    _run_git(["init", "-b", "master"], cwd=path)
+    _run_git(["config", "user.email", "test@test"], cwd=path)
+    _run_git(["config", "user.name", "Test"], cwd=path)
+    (path / "README.md").write_text("# test")
+    _run_git(["add", "README.md"], cwd=path)
+    _run_git(["commit", "-m", "initial"], cwd=path)
+    return path
+
+
+def _make_worktree(repo: Path, worktree_path: Path, branch: str) -> Path:
+    """Create a linked worktree for *branch* and return its path.
+
+    If *branch* does not exist locally it is created first.
+    """
+    result = subprocess.run(
+        ["git", "branch", "--list", branch.removeprefix("refs/heads/")],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        _run_git(["worktree", "add", str(worktree_path), branch], cwd=repo)
+    else:
+        _run_git(["worktree", "add", "-b", branch, str(worktree_path)], cwd=repo)
+    return worktree_path


### PR DESCRIPTION
## Summary

Add `devtools worktree-gc` — a safe cleanup command for merged and abandoned git worktrees that accumulate after PR merges and agent sessions.

## Problem

Merged or abandoned agent worktrees accumulate and manual cleanup is risky. Dirty worktrees can contain uncommitted work that must never be deleted. Without tooling, operators either leave stale worktrees to rot or risk data loss.

## Solution

`devtools/worktree_gc.py` with pure-ish functions:

- **Parse**: `parse_worktree_list()` parses `git worktree list --porcelain`
- **Classify**: `classify_candidates()` tags each worktree as `merged`, `branch-deleted`, `detached`, `unmerged`, or `prunable`
- **Safety**: `check_dirty()` runs `git status --porcelain`; dirty worktrees are never removed. Main (bare) worktree and repo-root are always skipped.
- **Apply**: `apply_removals()` removes only safe candidates, supports `--force` for clean detached entries, and always runs `git worktree prune` afterward.
- **Output**: human table by default; `--json` emits stable payload with path, branch, head, reason, action, safe, blocked_reason per entry.

CLI shape:
```
devtools worktree-gc              # dry-run (default)
devtools worktree-gc --json       # machine-readable
devtools worktree-gc --apply      # remove safe candidates
devtools worktree-gc --apply --force  # also remove clean detached
```

## Verification

```
pytest -q tests/unit/devtools/test_worktree_gc.py  # 22 passed
python -m mypy devtools/worktree_gc.py tests/unit/devtools/test_worktree_gc.py  # clean
ruff format --check / ruff check  # clean
devtools verify --quick           # all 21 static/generated gates pass
devtools render-all --check       # all surfaces in sync
devtools verify                   # 63 testmon-selected tests pass, exit 0
```

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)