### PR TITLE
docs(decisions): add ADR for provider/source column consolidation (#1022)

### DIFF
--- a/docs/plans/decisions/001-provider-source-column-consolidation.md
+++ b/docs/plans/decisions/001-provider-source-column-consolidation.md
@@ -1,0 +1,98 @@
+# ADR 001: Provider/Source Column Consolidation
+
+**Status**: accepted  
+**Date**: 2026-05-25  
+**Issue**: [#1022](https://github.com/Sinity/polylogue/issues/1022)
+
+## Context
+
+Polylogue's schema currently carries two parallel columns on `conversations`
+and `session_profiles`:
+
+| Column | Origin | Purpose |
+|--------|--------|---------|
+| `provider_name` | Legacy (schema v1) | Storage-layer provider token |
+| `source_name` | Added in #864 + follow-ups | Source-family identity token |
+
+This is a column-doubling, not a rename. The `Source` dataclass
+(`polylogue/core/sources.py`) and bidirectional `Provider` ↔ `Source`
+mapping are fully landed. All four decomposition children of #1022 are
+closed (#1214, #1216, #1219, #1221). The remaining work is physical
+schema consolidation: pick one column, drop the other, update all mappers.
+
+## Decision
+
+**Drop `provider_name`. Keep `source_name` as the single canonical column.**
+
+Rationale:
+
+1. **Source-family is the user-facing concept.** CLI flags, MCP parameters,
+   daemon source discovery, and watcher roots all operate on source-family
+   tokens. The column should match what users see.
+2. **`provider_name` conflates three concepts.** It mixes lab identity
+   (OpenAI, Anthropic), product identity (Claude Code, Codex), and
+   source-family identity into one token. `source_name` carries the
+   disambiguated source family.
+3. **Storage compatibility is not a concern.** Per the
+   `polylogue-write-passive-read-pull` crystal, Polylogue has no migration
+   chain. Schema bumps are deletes-then-defines. There are no external
+   consumers of the SQLite schema beyond lynchpin.
+4. **Lynchpin is the only cross-repo consumer** and reads both columns. It
+   can be updated atomically.
+
+## Rejected alternatives
+
+### Keep `provider_name`, drop `source_name`
+
+Rejected because it preserves the conflation. Every new feature that needs
+to distinguish "Claude Code session" from "Claude AI export" (both currently
+`Provider.CLAUDE_CODE` vs `Provider.CLAUDE_AI`) would need a separate
+disambiguation column layered on top of `provider_name`.
+
+### Keep both columns
+
+Rejected because column-doubling is the worst state: twice the storage, twice
+the index maintenance, and every reader must decide which column to trust.
+The dual-vocabulary period was for API surfaces, not for physical schema.
+
+### Rename `provider_name` to `source_name` in-place
+
+SQLite does not support `ALTER TABLE RENAME COLUMN` for columns with indexes
+or FTS content references. An in-place rename would require rebuilding the
+table, which is equivalent to a schema bump. No benefit over drop-and-replace.
+
+## Reversal conditions
+
+- If an external consumer (beyond lynchpin) is discovered that reads
+  `provider_name` and cannot be updated, reconsider the drop.
+- If source-family tokens prove insufficient for a new use case that
+  genuinely needs lab-level identity, add a separate `originating_lab`
+  column rather than reverting to the conflated `provider_name`.
+
+## Migration cost
+
+| Operation | Estimate |
+|-----------|----------|
+| Drop `provider_name` column + index | Schema bump (new `SCHEMA_VERSION`) |
+| Update ~20 mapper files | Mechanical, <1 hour |
+| Update lynchpin consumer | 2 files, <30 min |
+| Re-ingest from source | Operator action (not automated) |
+
+## Cross-repo coordination
+
+Lynchpin reads `provider_name` in:
+- `lynchpin/sources/polylogue.py`
+- `lynchpin/substrate/`
+
+These must be updated to read `source_name` in the same PR or via a
+cross-linked lynchpin issue merged simultaneously. The lynchpin change
+is mechanical: replace column name, no logic changes.
+
+## References
+
+- [#1022](https://github.com/Sinity/polylogue/issues/1022) — umbrella issue
+- [#1219](https://github.com/Sinity/polylogue/issues/1219) — column policy decision (consolidated into #1022)
+- [#1511](https://github.com/Sinity/polylogue/issues/1511) — write-passive cleanup (adjacent, broader scope)
+- `docs/architecture.md` § "Dual Vocabulary Period: Provider and Source"
+- `polylogue/core/provider_identity.py` — vocabulary boundary table
+- `polylogue/core/sources.py` — `Source` dataclass and Provider↔Source mapping

--- a/tests/unit/core/test_sources.py
+++ b/tests/unit/core/test_sources.py
@@ -116,3 +116,81 @@ def test_originating_lab_attribution() -> None:
     }
     for provider, lab in expected_labs.items():
         assert provider_to_source(provider).originating_lab == lab
+
+
+# ── source family separability (#1022) ──────────────────────────────
+
+
+def test_gemini_and_gemini_cli_are_distinct_families() -> None:
+    """Gemini (AI Studio exports) and Gemini CLI are separate source families.
+
+    They share the same originating lab (Google) but have different
+    runtime roots and acquisition paths.
+    """
+    gemini = provider_to_source(Provider.GEMINI)
+    gemini_cli = provider_to_source(Provider.GEMINI_CLI)
+
+    assert gemini.family != gemini_cli.family
+    assert gemini.originating_lab == gemini_cli.originating_lab == "google"
+    assert gemini.runtime_root is None  # AI Studio exports come via Drive/Takeout
+    assert gemini_cli.runtime_root == "~/.gemini/tmp"
+
+
+def test_aistudio_alias_resolves_to_gemini_not_gemini_cli() -> None:
+    """The 'aistudio' token canonicalizes to gemini (AI Studio), not gemini-cli."""
+    from polylogue.core.provider_identity import canonical_runtime_provider
+
+    assert canonical_runtime_provider("aistudio") == "gemini"
+    assert canonical_runtime_provider("aistudio") != "gemini-cli"
+
+
+def test_hermes_is_distinct_source_family() -> None:
+    """Hermes is a separate source family with its own lab attribution."""
+    hermes = provider_to_source(Provider.HERMES)
+
+    assert hermes.family == "hermes-session"
+    assert hermes.originating_lab == "nous"
+    assert source_for_family("hermes-session") is hermes
+    # Not colliding with any other family
+    for provider in Provider:
+        if provider is not Provider.HERMES:
+            assert provider_to_source(provider).family != "hermes-session"
+
+
+def test_antigravity_is_distinct_source_family() -> None:
+    """Antigravity is a separate source family despite Google lab attribution."""
+    antigravity = provider_to_source(Provider.ANTIGRAVITY)
+
+    assert antigravity.family == "antigravity-session"
+    assert antigravity.originating_lab == "google"
+    assert source_for_family("antigravity-session") is antigravity
+    # Not colliding with any other family
+    for provider in Provider:
+        if provider is not Provider.ANTIGRAVITY:
+            assert provider_to_source(provider).family != "antigravity-session"
+
+
+def test_all_source_families_are_unique() -> None:
+    """No two Providers share the same source family token."""
+    families = [provider_to_source(p).family for p in Provider]
+    assert len(families) == len(set(families))
+
+
+def test_source_family_separability_in_filters() -> None:
+    """Each source family can be independently selected via source_for_family.
+
+    This is the programmatic equivalent of CLI --provider / MCP provider
+    filter separability: each family token resolves to exactly one Source,
+    and no two families produce the same Source.
+    """
+    seen: set[str] = set()
+    for provider in Provider:
+        source = provider_to_source(provider)
+        family = source.family
+        # Each family must produce a unique Source
+        assert family not in seen, f"Duplicate family token: {family}"
+        seen.add(family)
+        # source_for_family must round-trip
+        assert source_for_family(family) is source
+        # The reverse lookup must match
+        assert source_to_provider(source) is provider


### PR DESCRIPTION
## Summary

Add Architectural Decision Record 001 documenting the decision to drop
`provider_name` in favor of `source_name` as the single canonical column.
Add source-family separability tests proving aistudio, gemini-cli, hermes,
and antigravity remain independently selectable.

## Problem

The schema carries both `provider_name` and `source_name` columns — a
column-doubling that creates ambiguity about which column is authoritative.
The decision needs to be documented with rationale, rejected alternatives,
and reversal conditions before the column drop can proceed.

## Solution

- **ADR 001**: documents the decision (keep `source_name`, drop
  `provider_name`), rationale, rejected alternatives, reversal conditions,
  migration cost estimate, and cross-repo lynchpin coordination plan.
- **Separability tests**: 6 new tests in `test_sources.py` proving that
  gemini/gemini-cli/aistudio/hermes/antigravity are distinct source
  families that can be independently resolved via `source_for_family`.

## Verification

```
pytest tests/unit/core/test_sources.py -q   # 15 passed (+6 new)
mypy tests/unit/core/test_sources.py        # clean
ruff check / ruff format                    # clean
```

Ref #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)