### PR TITLE
fix(schema): remove duplicate source_name column from artifact_observations DDL

### DIFF
--- a/polylogue/storage/sqlite/schema_ddl_aux.py
+++ b/polylogue/storage/sqlite/schema_ddl_aux.py
@@ -16,9 +16,8 @@ ARTIFACT_OBSERVATION_DDL = """
         CREATE TABLE IF NOT EXISTS artifact_observations (
             observation_id TEXT PRIMARY KEY,
             raw_id TEXT NOT NULL REFERENCES raw_conversations(raw_id) ON DELETE CASCADE,
-            source_name TEXT NOT NULL,
             payload_provider TEXT,
-            source_name TEXT,
+            source_name TEXT NOT NULL,
             source_path TEXT NOT NULL,
             source_index INTEGER,
             file_mtime TEXT,


### PR DESCRIPTION
The sed rename of provider_name→source_name created a duplicate
column in artifact_observations (the table already had source_name).
This prevented schema bootstrap after database reset.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>