### PR TITLE
feat(devtools): wire nightly scale workflow into benchmark-campaign index (#1220)

### DIFF
--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -1,18 +1,21 @@
 name: Nightly Scale
 
 # Runs the large-tier scale fixtures (issue #1183) outside the normal
-# CI critical path. The default ``devtools verify`` baseline deselects
-# ``scale_large``; this workflow exists so a regression in the large
-# tier still produces a visible signal without burning CI minutes on
-# every PR.
+# CI critical path, captures benchmark results as structured JSON, and
+# compares against the committed baseline to detect regressions (#1220).
 
 on:
   schedule:
     - cron: "37 6 * * *"  # 06:37 UTC daily
   workflow_dispatch:
+    inputs:
+      update-baseline:
+        description: "Update the committed benchmark baseline after a successful run"
+        type: boolean
+        default: false
 
 permissions:
-  contents: read
+  contents: write  # needed to push baseline updates
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,8 +31,74 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
+
       - name: Run large-tier scale tests
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
           HYPOTHESIS_PROFILE: ci
-        run: uv run pytest -q --tb=short --ignore=tests/integration -m "scale_large" -p no:randomly -n 0 tests/benchmarks
+        run: |
+          uv run pytest -q --tb=short --ignore=tests/integration \
+            -m "scale_large" -p no:randomly -n 0 \
+            --benchmark-json=nightly-results.json \
+            --benchmark-group-by=group \
+            tests/benchmarks
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-benchmark-${{ github.run_id }}
+          path: nightly-results.json
+          retention-days: 30
+
+      - name: Compare against baseline
+        id: compare
+        run: |
+          BASELINE="tests/benchmarks/baselines/nightly-baseline.json"
+          if [ ! -f "$BASELINE" ]; then
+            echo "No baseline file yet — saving first baseline."
+            cp nightly-results.json "$BASELINE"
+            echo "comparison=first-run" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Comparing against committed baseline..."
+          uv run python3 -c "
+          import json, sys
+          with open('nightly-results.json') as f: current = json.load(f)
+          with open('$BASELINE') as f: baseline = json.load(f)
+
+          # Build lookup from baseline by fullname
+          baseline_map = {b['fullname']: b['stats']['mean'] for b in baseline.get('benchmarks', [])}
+          regressions = []
+          for b in current.get('benchmarks', []):
+              name = b['fullname']
+              prev = baseline_map.get(name)
+              if prev and prev > 0:
+                  delta_pct = (b['stats']['mean'] - prev) / prev * 100
+                  if delta_pct > 20:
+                      regressions.append((name, delta_pct, prev, b['stats']['mean']))
+
+          if regressions:
+              regressions.sort(key=lambda r: r[1], reverse=True)
+              print(f'FAIL: {len(regressions)} benchmark(s) degraded >20%:')
+              for name, pct, prev_mean, cur_mean in regressions[:5]:
+                  print(f'  {name}: +{pct:.1f}% ({prev_mean:.4f}s → {cur_mean:.4f}s)')
+              sys.exit(1)
+          else:
+              print('OK: no benchmark regressions exceeding 20% threshold.')
+          " || echo "comparison=failed" >> "$GITHUB_OUTPUT"
+
+      - name: Report regression
+        if: failure() && steps.compare.outcome == 'failure'
+        run: |
+          echo "::warning::Benchmark regression detected — nightly results exceed 20% degradation threshold vs baseline."
+
+      - name: Update baseline
+        if: inputs.update-baseline
+        run: |
+          cp nightly-results.json tests/benchmarks/baselines/nightly-baseline.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/benchmarks/baselines/nightly-baseline.json
+          git commit -m "chore(benchmarks): update nightly baseline" || true
+          git push

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -60,33 +60,9 @@ jobs:
             echo "comparison=first-run" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
           echo "Comparing against committed baseline..."
-          uv run python3 -c "
-          import json, sys
-          with open('nightly-results.json') as f: current = json.load(f)
-          with open('$BASELINE') as f: baseline = json.load(f)
-
-          # Build lookup from baseline by fullname
-          baseline_map = {b['fullname']: b['stats']['mean'] for b in baseline.get('benchmarks', [])}
-          regressions = []
-          for b in current.get('benchmarks', []):
-              name = b['fullname']
-              prev = baseline_map.get(name)
-              if prev and prev > 0:
-                  delta_pct = (b['stats']['mean'] - prev) / prev * 100
-                  if delta_pct > 20:
-                      regressions.append((name, delta_pct, prev, b['stats']['mean']))
-
-          if regressions:
-              regressions.sort(key=lambda r: r[1], reverse=True)
-              print(f'FAIL: {len(regressions)} benchmark(s) degraded >20%:')
-              for name, pct, prev_mean, cur_mean in regressions[:5]:
-                  print(f'  {name}: +{pct:.1f}% ({prev_mean:.4f}s → {cur_mean:.4f}s)')
-              sys.exit(1)
-          else:
-              print('OK: no benchmark regressions exceeding 20% threshold.')
-          " || echo "comparison=failed" >> "$GITHUB_OUTPUT"
+          uv run python3 devtools/benchmark_compare_nightly.py "$BASELINE" nightly-results.json --fail-pct 20
+          echo "comparison=completed" >> "$GITHUB_OUTPUT"
 
       - name: Report regression
         if: failure() && steps.compare.outcome == 'failure'

--- a/devtools/benchmark_compare_nightly.py
+++ b/devtools/benchmark_compare_nightly.py
@@ -1,0 +1,52 @@
+"""Compare pytest-benchmark JSON output against a committed baseline (#1220).
+
+Used by the nightly-scale workflow to detect benchmark regressions.
+Exits 0 when within threshold, 1 when regressions exceed --fail-pct.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def compare(baseline: Path, candidate: Path, fail_pct: float) -> int:
+    with open(candidate) as f:
+        current = json.load(f)
+    with open(baseline) as f:
+        prev = json.load(f)
+
+    baseline_map = {b["fullname"]: b["stats"]["mean"] for b in prev.get("benchmarks", [])}
+    regressions: list[tuple[str, float, float, float]] = []
+    for b in current.get("benchmarks", []):
+        name = b["fullname"]
+        bl_mean = baseline_map.get(name)
+        if bl_mean and bl_mean > 0:
+            delta_pct = (b["stats"]["mean"] - bl_mean) / bl_mean * 100
+            if delta_pct > fail_pct:
+                regressions.append((name, delta_pct, bl_mean, b["stats"]["mean"]))
+
+    if regressions:
+        regressions.sort(key=lambda r: r[1], reverse=True)
+        print(f"FAIL: {len(regressions)} benchmark(s) degraded >{fail_pct:.0f}%:")
+        for name, pct, prev_mean, cur_mean in regressions[:10]:
+            print(f"  {name}: +{pct:.1f}% ({prev_mean:.4f}s -> {cur_mean:.4f}s)")
+        return 1
+    else:
+        print(f"OK: no benchmark regressions exceeding {fail_pct:.0f}% threshold.")
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare pytest-benchmark JSON against a baseline.")
+    parser.add_argument("baseline", type=Path, help="Path to baseline JSON.")
+    parser.add_argument("candidate", type=Path, help="Path to candidate JSON.")
+    parser.add_argument("--fail-pct", type=float, default=20.0, help="Regression threshold in percent.")
+    args = parser.parse_args(argv)
+    return compare(args.baseline, args.candidate, args.fail_pct)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Wire the nightly scale workflow into benchmark-campaign infrastructure
so nightly results are captured, archived, and compared against a
committed baseline for regression detection.

## Changes

- Nightly workflow captures pytest-benchmark JSON and uploads as a
  30-day artifact
- `devtools/benchmark_compare_nightly.py` compares results against
  committed baseline, exits non-zero on >20% regression
- Baseline update available via workflow_dispatch input
- Baselines directory at `tests/benchmarks/baselines/`

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly benchmark suite now detects performance regressions and compares results against committed baselines with configurable failure thresholds
  * Added ability to manually trigger baseline updates for benchmark comparisons via workflow dispatch

* **Chores**
  * Enhanced nightly scale workflow with improved benchmark comparison and baseline management capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->