### PR TITLE
test(perf): add regression benchmark for schema check linear scaling (#1223)

### DIFF
--- a/tests/benchmarks/test_schema_linear_scaling.py
+++ b/tests/benchmarks/test_schema_linear_scaling.py
@@ -1,0 +1,54 @@
+"""Regression benchmark: ``verify_raw_corpus`` scales sub-quadratically (#1223).
+
+Commit 19b5465 switched from LIMIT/OFFSET to rowid keyset pagination
+in ``polylogue/schemas/validation/corpus.py``, fixing an O(n²) regression.
+This benchmark asserts the fix holds by measuring wall time across scale
+tiers using the corpus-seeded database fixture.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from polylogue.schemas.validation.corpus import verify_raw_corpus
+from polylogue.schemas.validation.requests import SchemaVerificationRequest
+
+
+def _measure(db_path: Path, record_limit: int | None) -> float:
+    """Run ``verify_raw_corpus`` with *record_limit* and return wall-clock ms."""
+    request = SchemaVerificationRequest(
+        providers=["chatgpt"], max_samples=1, record_limit=record_limit
+    )
+    start = time.perf_counter()
+    verify_raw_corpus(db_path=db_path, request=request)
+    return (time.perf_counter() - start) * 1000
+
+
+@pytest.mark.scale_small
+def test_schema_check_completes_quickly(corpus_seeded_db: Callable[..., Path]) -> None:
+    """Smoke: verify_raw_corpus finishes and returns a valid report."""
+    db = corpus_seeded_db(providers=("chatgpt",), count=10)
+    ms = _measure(db, record_limit=None)
+    assert ms < 30_000, f"10-record corpus took {ms:.0f} ms; expected <30s"
+
+
+@pytest.mark.scale_medium
+def test_schema_check_linear_scaling(corpus_seeded_db: Callable[..., Path]) -> None:
+    """Wall time must grow sub-quadratically across record limits.
+
+    Uses a single seeded DB with 50 records and compares verify_raw_corpus
+    runtime at record_limit=5 vs record_limit=50.
+    O(n) would give ~10× growth; O(n²) would give ~100×.  50× is a safe fence.
+    """
+    db = corpus_seeded_db(providers=("chatgpt",), count=50)
+    ms_5 = _measure(db, record_limit=5)
+    ms_50 = _measure(db, record_limit=50)
+    ratio = ms_50 / ms_5 if ms_5 > 0 else float("inf")
+    assert ratio < 50, (
+        f"Scaling ratio {ratio:.1f}× (5→50 records) exceeds 50× sub-quadratic envelope. "
+        f"(5: {ms_5:.0f} ms, 50: {ms_50:.0f} ms)"
+    )


### PR DESCRIPTION
## Summary

Add benchmark asserting verify_raw_corpus wall time grows
sub-quadratically across scale tiers, pinning the O(n)
keyset-pagination fix from commit 19b5465.

Uses the corpus_seeded_db fixture for proper blob store setup.

## Verification

```
pytest tests/benchmarks/test_schema_linear_scaling.py  # 2 passed
```

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)