### PR TITLE
fix(daemon): use read-only connection for /metrics db-space scrape

### DIFF
--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -841,9 +841,9 @@ def _emit_db_space_metrics(lines: list[str], db: Path) -> None:
             samples=[(None, file_size)],
         )
 
-        import sqlite3 as _sqlite3
+        from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
-        space_conn = _sqlite3.connect(str(db))
+        space_conn = open_readonly_connection(db)
         try:
             page_size = int(space_conn.execute("PRAGMA page_size").fetchone()[0])
             page_count = int(space_conn.execute("PRAGMA page_count").fetchone()[0])


### PR DESCRIPTION
## Summary

Single-line fix: `/metrics` Prometheus scrape now uses
`open_readonly_connection` for the db-space (`PRAGMA page_size`/
`page_count`/`freelist_count`) read, matching the existing read-only
pattern at the same module's other scrape connection (line 577).

## Problem

`polylogue/daemon/metrics.py:846` was opening a sync read-write
`sqlite3.connect(str(db))` to read PRAGMAs. Under WAL contention a
scrape would compete with the daemon writer for the database file
lock. Inconsistent with the rest of the module — line 577 already
uses `open_readonly_connection`.

## Solution

Swap the import + call. `open_readonly_connection` is the documented
helper in `polylogue/storage/sqlite/connection_profile.py:118` and
already takes a `Path` or `str` path argument.

## Verification

```
grep -n sqlite3.connect polylogue/daemon/metrics.py   # → no match
ruff check polylogue/daemon/metrics.py                # → pass
mypy polylogue/daemon/metrics.py                      # → pass
```

Ref #1600 (deployment-drift audit that surfaced this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database space metrics collection to use read-only database access for improved efficiency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->