### PR TITLE
fix(daemon): gate OTLP receiver on observability_enabled + body cap + remote-auth (#1604)

### DIFF
--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -217,6 +217,28 @@ class PolylogueConfig:
         return bool(self._data.get("embedding_enabled"))
 
     @property
+    def observability_enabled(self) -> bool:
+        """Return whether the OTLP HTTP receiver routes are accepted.
+
+        The receiver is OFF by default (closes #1604 — the routes were
+        previously unconditionally enabled in front of the auth gate
+        despite a code comment claiming otherwise). Operators opt in
+        via TOML ``observability_enabled = true`` or the env var
+        ``POLYLOGUE_OBSERVABILITY_ENABLED=1``.
+        """
+        return bool(self._data.get("observability_enabled"))
+
+    @property
+    def otlp_max_body_bytes(self) -> int:
+        """Maximum accepted Content-Length for OTLP POST bodies.
+
+        Default 8 MiB matches typical OTLP exporter batch sizes; clients
+        sending more receive 413. Configurable via TOML
+        ``otlp_max_body_bytes`` or env ``POLYLOGUE_OTLP_MAX_BODY_BYTES``.
+        """
+        return int(str(self._data.get("otlp_max_body_bytes", 8 * 1024 * 1024)))
+
+    @property
     def embedding_model(self) -> str:
         return str(self._data.get("embedding_model", "voyage-4"))
 
@@ -517,6 +539,13 @@ def _default_config_values() -> dict[str, object]:
         # supplying VOYAGE_API_KEY (e.g., for one-off CLI use) does not
         # incur ongoing daemon-driven spend.
         "embedding_enabled": False,
+        # OTLP HTTP receiver and other observability routes (see
+        # ``polylogue/daemon/otlp_receiver.py``). Default off; the
+        # receiver was previously documented-but-not-actually gated,
+        # which made it an unauthenticated write surface under
+        # ``--insecure-allow-remote`` (closes #1604).
+        "observability_enabled": False,
+        "otlp_max_body_bytes": 8 * 1024 * 1024,
         "embedding_model": "voyage-4",
         "embedding_dimension": 1024,
         # Soft monthly cap on embedding spend. 0 = unlimited; the default
@@ -773,6 +802,8 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
     env_map = {
         "POLYLOGUE_ARCHIVE_ROOT": "archive_root",
         "POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS": "embedding_enabled",
+        "POLYLOGUE_OBSERVABILITY_ENABLED": "observability_enabled",
+        "POLYLOGUE_OTLP_MAX_BODY_BYTES": "otlp_max_body_bytes",
         "VOYAGE_API_KEY": "voyage_api_key",
         "POLYLOGUE_FORCE_PLAIN": "force_plain",
         "POLYLOGUE_THEME": "theme",

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -841,11 +841,22 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         path, params = self._parse_path()
 
-        # OTLP receiver endpoints — unauthenticated, same posture as
-        # /metrics and /healthz/*.  OTLP exporters don't carry credentials
-        # and the daemon binds to loopback by default.  gated behind
-        # observability_enabled config flag (#1321).
+        # OTLP receiver endpoints (#1321) gated on the explicit
+        # ``observability_enabled`` config flag (closes #1604). When
+        # the flag is off the routes return 404 so the receiver does
+        # not advertise itself to opportunistic scanners. When on AND
+        # the daemon is bound non-loopback we still require the
+        # configured auth token — OTLP exporters that DO carry
+        # credentials are the only safe non-loopback case.
         if path == ["v1", "traces"] or path == ["v1", "metrics"] or path == ["v1", "logs"]:
+            from polylogue.config import load_polylogue_config
+            from polylogue.core.loopback import is_loopback_host
+
+            if not load_polylogue_config().observability_enabled:
+                self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+                return
+            if not is_loopback_host(self._api_host) and not self._check_auth():
+                return
             self._handle_otlp_post(path)
             return
 
@@ -1876,11 +1887,16 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         Routes to ``handle_traces``, ``handle_metrics``, or ``handle_logs``
         in ``polylogue/daemon/otlp_receiver.py`` based on *path*.
         """
+        from polylogue.config import load_polylogue_config
         from polylogue.daemon.otlp_receiver import handle_logs, handle_metrics, handle_traces
 
         signal = path[1]  # 'traces', 'metrics', or 'logs'
         content_type = self.headers.get("Content-Type", "application/x-protobuf")
         content_length = int(self.headers.get("Content-Length", 0))
+        max_body = load_polylogue_config().otlp_max_body_bytes
+        if content_length > max_body:
+            self._send_error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "payload_too_large")
+            return
         body = self.rfile.read(content_length) if content_length > 0 else b""
 
         if signal == "traces":

--- a/polylogue/daemon/otlp_receiver.py
+++ b/polylogue/daemon/otlp_receiver.py
@@ -7,9 +7,22 @@ Tempo, Grafana Agent, and any OpenTelemetry SDK that exports via
 
 Design notes:
 
-- **Unauthenticated** — same posture as ``/metrics`` and ``/healthz/*``.
-  The daemon binds to loopback by default; OTLP exporters don't carry
-  credentials.
+- **Opt-in only** — the routes are gated on the
+  ``observability_enabled`` config flag (default off, env override
+  ``POLYLOGUE_OBSERVABILITY_ENABLED``). When the flag is off the
+  daemon returns ``404 Not Found`` so the receiver doesn't advertise
+  itself. Closes #1604, which documented that an earlier version of
+  this docstring claimed gating that was not actually implemented.
+- **Loopback unauthenticated; remote requires the daemon auth token**
+  — when ``observability_enabled`` is on AND the daemon is bound
+  non-loopback, the route runs through ``_check_auth`` so exporters
+  that DO carry credentials are the only safe non-loopback case.
+  Loopback callers still bypass auth, matching ``/metrics`` and
+  ``/healthz/*``.
+- **Body cap** — ``Content-Length`` is capped at
+  ``otlp_max_body_bytes`` (default 8 MiB; override
+  ``POLYLOGUE_OTLP_MAX_BODY_BYTES``); over-limit POSTs receive
+  ``413 Payload Too Large``.
 - **Graceful fallback** — when ``opentelemetry-proto`` is not installed
   the endpoints return ``501 Not Implemented`` rather than crashing.
 - **Content-type negotiation** — ``application/x-protobuf`` and

--- a/tests/unit/daemon/test_daemon_http_security.py
+++ b/tests/unit/daemon/test_daemon_http_security.py
@@ -812,3 +812,99 @@ class TestNoTokenLogging:
                         offenders.append(f"{py_file.relative_to(repo_root)}:{lineno}: {line.strip()}")
 
         assert not offenders, "potential token-logging code paths:\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
+# OTLP gating (#1604): observability_enabled flag, body cap, loopback-vs-remote
+# ---------------------------------------------------------------------------
+
+
+class TestOtlpGating:
+    """The OTLP receiver routes must obey ``observability_enabled`` and a
+    body-size cap before any payload is read or persisted. The earlier
+    implementation routed to the receiver unconditionally despite a
+    comment claiming otherwise — see #1604."""
+
+    OTLP_PATHS = ["/v1/traces", "/v1/metrics", "/v1/logs"]
+
+    @pytest.mark.parametrize("path", OTLP_PATHS)
+    def test_disabled_observability_returns_404(self, path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "polylogue.config.load_polylogue_config",
+            lambda: SimpleNamespace(observability_enabled=False, otlp_max_body_bytes=8 * 1024 * 1024),
+        )
+        handler = _make_handler("POST", path, origin="")
+        send_error, _ = _capture_responses(handler)
+        handler.do_POST()
+        send_error.assert_called_once_with(HTTPStatus.NOT_FOUND, "not_found")
+
+    @pytest.mark.parametrize("path", OTLP_PATHS)
+    def test_enabled_loopback_skips_auth(self, path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``observability_enabled`` is on and the daemon is on loopback,
+        the route proceeds without requiring the auth token (matches
+        ``/metrics`` and ``/healthz/*``)."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "polylogue.config.load_polylogue_config",
+            lambda: SimpleNamespace(observability_enabled=True, otlp_max_body_bytes=8 * 1024 * 1024),
+        )
+
+        handler = _make_handler("POST", path)
+        # Stub the receiver so we don't actually need opentelemetry-proto here.
+        otlp_handler_called = []
+
+        def fake_handle_otlp_post(p: list[str]) -> None:
+            otlp_handler_called.append(p)
+            handler.send_response(200)
+
+        handler._handle_otlp_post = fake_handle_otlp_post  # type: ignore[method-assign]
+        handler.send_response = MagicMock()  # type: ignore[method-assign]
+
+        handler.do_POST()
+
+        assert otlp_handler_called, f"OTLP handler must be invoked when enabled+loopback for {path}"
+
+    @pytest.mark.parametrize("path", OTLP_PATHS)
+    def test_enabled_non_loopback_without_token_returns_401(self, path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bound non-loopback ⇒ require the auth token even with the
+        observability flag on."""
+        from types import SimpleNamespace
+
+        class RemoteMockServer:
+            auth_token = "secret"
+            api_host = "0.0.0.0"  # not loopback
+
+        monkeypatch.setattr(
+            "polylogue.config.load_polylogue_config",
+            lambda: SimpleNamespace(observability_enabled=True, otlp_max_body_bytes=8 * 1024 * 1024),
+        )
+
+        handler = _make_handler("POST", path)
+        handler.server = cast("DaemonAPIHTTPServer", RemoteMockServer())
+        send_error, _ = _capture_responses(handler)
+
+        handler.do_POST()
+
+        send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
+
+    @pytest.mark.parametrize("path", OTLP_PATHS)
+    def test_body_over_cap_returns_413(self, path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Oversize ``Content-Length`` ⇒ 413 before the body is read or
+        persisted, preventing storage-amplification."""
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "polylogue.config.load_polylogue_config",
+            lambda: SimpleNamespace(observability_enabled=True, otlp_max_body_bytes=1024),  # 1 KiB cap
+        )
+
+        big_body = b"x" * 4096  # 4 KiB > 1 KiB cap
+        handler = _make_handler("POST", path, body=big_body)
+        send_error, _ = _capture_responses(handler)
+
+        handler.do_POST()
+
+        send_error.assert_called_with(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "payload_too_large")


### PR DESCRIPTION
## Summary

The OTLP HTTP receiver added in #1321 routed `POST /v1/traces|metrics|logs`
before `_check_auth` and `_check_cross_origin`, with a comment claiming
the routes were "gated behind `observability_enabled` config flag (#1321)".
No such flag existed. This change implements the flag.

## Problem

`polylogue/daemon/http.py:do_POST` returned the OTLP branch before
running any gate. Default `--host 127.0.0.1` made this safe in practice
today, but with `--insecure-allow-remote --api-auth-token X` set, the
OTLP routes were an unauthenticated write surface that the configured
auth token didn't cover. Storage-amplification (unbounded body →
`otlp_telemetry` BLOB) and CPU-drain (malformed protobuf decode loops)
were trivially reachable. Discovered during the 2026-05-26 audit
(#1600); filed as #1604 CRITICAL.

## Solution

- `polylogue/config.py` adds `observability_enabled` (default `False`)
  and `otlp_max_body_bytes` (default 8 MiB) properties + env-var
  mappings (`POLYLOGUE_OBSERVABILITY_ENABLED`,
  `POLYLOGUE_OTLP_MAX_BODY_BYTES`).
- `polylogue/daemon/http.py:do_POST` gates the OTLP branch:
  - Flag off ⇒ 404 (route does not advertise itself).
  - Flag on + loopback bind ⇒ proceeds without auth (matches
    `/metrics`, `/healthz/*`).
  - Flag on + non-loopback bind ⇒ runs through `_check_auth`; missing
    or invalid token ⇒ 401.
- `_handle_otlp_post` checks `Content-Length` against the cap before
  any `rfile.read`; over-limit ⇒ 413.
- `polylogue/daemon/otlp_receiver.py` docstring rewritten — removes
  the false "Unauthenticated" claim, documents the opt-in posture
  and body cap.

## Verification

```
pytest -q tests/unit/daemon/test_daemon_http_security.py \
          tests/unit/daemon/test_otlp_receiver.py
# → 214 passed
```

New `TestOtlpGating` test class covers:

- disabled-flag → 404 on all three signal paths,
- enabled + loopback → handler invoked without auth,
- enabled + non-loopback + no token → 401,
- body over cap → 413 before read.

```
devtools verify-file-budgets   # → clean
devtools render-all --check    # → all generated surfaces sync OK
ruff check / mypy              # → pass on touched files
```

Closes #1604. Ref #1600.