### PR TITLE
fix(cli): add `--json` alias to `polylogue status` to match siblings (#1612)

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -90,11 +90,19 @@ def _fast_message_count(conn: Any) -> int:
     default=None,
     help="Output format (json for machine-readable).",
 )
+@click.option(
+    "--json",
+    "json_alias",
+    is_flag=True,
+    default=False,
+    help="Alias for ``--format json``. Matches the sibling commands' ``--json`` flag (#1612).",
+)
 @click.pass_obj
 def status_command(
     env: AppEnv,
     daemon_url: str,
     output_format: str | None,
+    json_alias: bool,
 ) -> None:
     """Show daemon and archive health.
 
@@ -102,6 +110,8 @@ def status_command(
     liveness, ingestion progress, FTS coverage, insight freshness, and
     component health. Read-only — does not modify state.
     """
+    if json_alias and output_format is None:
+        output_format = "json"
     try:
         req = Request(
             f"{daemon_url}/api/status",

--- a/tests/baselines/showcase/help-status.txt
+++ b/tests/baselines/showcase/help-status.txt
@@ -2,10 +2,14 @@ Usage: polylogue status [OPTIONS]
 
   Show daemon and archive health.
 
-  Queries the running polylogued daemon for archive status: daemon uptime,
+  Queries the running polylogued daemon for archive status: daemon liveness,
   ingestion progress, FTS coverage, insight freshness, and component health.
   Read-only — does not modify state.
 
 Options:
-  --daemon-url TEXT  Daemon API URL.  [default: http://127.0.0.1:8766]
-  -h, --help         Show this message and exit.
+  --daemon-url TEXT    Daemon API URL (env: POLYLOGUE_DAEMON_URL).  [default:
+                       (dynamic)]
+  -f, --format [json]  Output format (json for machine-readable).
+  --json               Alias for ``--format json``. Matches the sibling
+                       commands' ``--json`` flag (#1612).
+  -h, --help           Show this message and exit.

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -465,3 +465,29 @@ class TestDaemonStatus:
         combined = _combined_calls(env)
         assert "no conversations" not in combined.lower()
         assert "running" in combined.lower()
+
+
+@pytest.mark.integration
+def test_status_command_accepts_json_alias_flag(tmp_path: Path) -> None:
+    """`polylogue status --json` is a documented alias for `--format json`.
+
+    Sibling subcommands (`list`, `tags`, `sources`, `stats`) accept `--json`;
+    `status` previously rejected it with "No such option '--json'". Closes #1612.
+    """
+    from tests.infra.cli_subprocess import run_cli
+
+    env = {
+        **os.environ,
+        "POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "polylogue"),
+        "XDG_DATA_HOME": str(tmp_path / "data"),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "XDG_STATE_HOME": str(tmp_path / "state"),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "HOME": str(tmp_path),
+        "POLYLOGUE_DAEMON_URL": "http://127.0.0.1:1",
+    }
+    result = run_cli(["--plain", "status", "--json"], env=env)
+    assert result.exit_code == 0, result.output
+    assert "No such option" not in result.output
+    parsed = json.loads(result.output)
+    assert isinstance(parsed, dict)


### PR DESCRIPTION
## Summary

`polylogue status --json` now succeeds (alias for `--format json`),
matching the convention every other subcommand follows.

## Problem

Sibling subcommands (`list`, `tags`, `sources`, `stats`) accept the
bare `--json` flag as a shorthand for `--format json`. `status`
rejected it:

```
$ polylogue status --json
Usage: polylogue status [OPTIONS]
Try 'polylogue status --help' for help.

Error: No such option '--json'.
Hint: `--json` is not a recognized option. Run `polylogue --help` for the
full option list, or `polylogue "--json"` if you meant to search for that
string.
```

Operator/agent scripts that worked against the other surfaces broke
against `status` with a misleading error hint suggesting the user
meant to search for `"--json"` as a query string. Closes #1612.

## Solution

Add a `--json` boolean alias next to the existing `--format` option in
`polylogue/cli/commands/status.py`. When set and `--format` is unset,
it promotes to `output_format='json'`. Both spellings produce the
identical JSON envelope.

## Verification

```
pytest -q tests/unit/cli/test_status.py        # → 16 passed (incl. new test)
polylogue status --json                        # → JSON envelope, exit 0
polylogue status --format json                 # → same JSON envelope
ruff check / mypy / devtools verify-file-budgets  # → clean
```

New regression test `test_status_command_accepts_json_alias_flag` in
`tests/unit/cli/test_status.py` invokes via the subprocess runner and
asserts exit 0 + valid JSON shape.

Closes #1612. Ref #1600 (operator-discipline forensics where this
inconsistency was discovered), #1618 (broader CLI/MCP shape coherence).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag as a convenient alias for `--format json` in the status command to simplify JSON output formatting.

* **Documentation**
  * Updated help text to document the new `--json` option and clarify available status command parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->