### PR TITLE
docs: correct stale archive.db filename to polylogue.db

### DIFF
--- a/docs/design/whole-product.md
+++ b/docs/design/whole-product.md
@@ -21,7 +21,7 @@ The user installs polylogue, runs it with no arguments, and sees:
 $ polylogue
 
 Polylogue — your AI memory
-Archive: /home/user/.local/share/polylogue/archive.db
+Archive: /home/user/.local/share/polylogue/polylogue.db
 Sources configured: 1  (1 active, 0 stale)
 Last ingestion: 2 minutes ago
 

--- a/polylogue/insights/storage.py
+++ b/polylogue/insights/storage.py
@@ -69,7 +69,7 @@ class InsightsDB:
         """Create an InsightsDB rooted next to the archive database.
 
         The insights database lives at ``<archive_dir>/insights.db``,
-        alongside the main ``<archive_dir>/archive.db``.
+        alongside the main ``<archive_dir>/polylogue.db``.
         """
         return cls(Path(archive_dir) / "insights.db")
 


### PR DESCRIPTION
## Summary

Two stale references to the legacy `archive.db` filename still pointed at a name the codebase retired when the canonical archive file became `polylogue.db`. This PR fixes both — a docstring describing the sibling layout of `insights.db`, and a sample CLI banner in the whole-product design doc.

## Problem

While dogfooding the archive (2026-05-26 post-v9→v16 deploy) I read `polylogue/insights/storage.py:72` and noticed the docstring still described the main archive file as `archive.db`. The actual file at `~/.local/share/polylogue/polylogue.db` (and matched by `polylogue.paths.db_path`) has been `polylogue.db` for many months — only a defensive `archive.db → polylogue.db` symlink remains for legacy-name consumers (see the dogfood memory note from 2026-05-26).

`docs/design/whole-product.md:24` carried the same stale name in a sample first-run banner.

## Solution

Update both references in place. No code paths or runtime behavior change — comments and docs only.

## Verification

```
$ devtools verify --quick
"exit_code": 0
```

The `render-all` step also re-rendered downstream surfaces that pick up the docs source.