### PR TITLE
fix(phases): fall back to provider_event timestamps when messages have none (#1624)

### DIFF
--- a/polylogue/archive/phase/extraction.py
+++ b/polylogue/archive/phase/extraction.py
@@ -105,7 +105,33 @@ def extract_phases(
 
     if phase_start_time is not None:
         phases.append(_build_phase(messages, phase_start_idx, len(messages), phase_start_time, prev_time))
+        return phases
 
+    # Fallback for sources where messages carry no timestamps but
+    # provider_events do (codex pre-Dec-2025, hermes per-request dumps).
+    # See #1624 — without this, session_phases is empty for 30% of the
+    # archive, blinding `find_resume_candidates`, the phases lens, and
+    # workflow_shape_distribution to anything codex/hermes.
+    return _phases_from_provider_events(conversation, messages)
+
+
+def _phases_from_provider_events(
+    conversation: Conversation,
+    messages: Sequence[MessageSemanticFacts],
+) -> list[SessionPhase]:
+    event_timestamps = sorted(event.timestamp for event in conversation.provider_events if event.timestamp is not None)
+    if not event_timestamps:
+        return []
+
+    phases: list[SessionPhase] = []
+    phase_start_time = event_timestamps[0]
+    prev_time = event_timestamps[0]
+    for timestamp in event_timestamps[1:]:
+        if (timestamp - prev_time) > _PHASE_GAP:
+            phases.append(_build_phase(messages, 0, len(messages), phase_start_time, prev_time))
+            phase_start_time = timestamp
+        prev_time = timestamp
+    phases.append(_build_phase(messages, 0, len(messages), phase_start_time, prev_time))
     return phases
 
 

--- a/tests/unit/archive/test_phase_extraction.py
+++ b/tests/unit/archive/test_phase_extraction.py
@@ -1,0 +1,143 @@
+"""Phase-extraction regression tests covering the provider-events fallback (#1624)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from polylogue.archive.message.messages import MessageCollection
+from polylogue.archive.message.models import Message
+from polylogue.archive.phase.extraction import extract_phases
+from polylogue.archive.provider.events import ProviderEvent
+from polylogue.types import ConversationId, Provider, ProviderEventId
+from tests.infra.builders import make_conv, make_msg
+
+
+def _untimed_msg(idx: int) -> Message:
+    return make_msg(
+        id=f"m{idx}",
+        role="user" if idx % 2 == 0 else "assistant",
+        provider="codex",
+        text=f"message {idx}",
+        timestamp=None,
+    )
+
+
+def test_extract_phases_falls_back_to_provider_events_when_messages_have_no_timestamps() -> None:
+    started_at = datetime(2026, 5, 24, 10, 0, tzinfo=timezone.utc)
+    ended_at = started_at + timedelta(minutes=2)
+    conversation = make_conv(
+        id="conv-codex-no-msg-ts",
+        provider=Provider.CODEX,
+        title="Codex pre-Dec-2025",
+        messages=MessageCollection(messages=[_untimed_msg(0), _untimed_msg(1)]),
+        provider_events=(
+            ProviderEvent(
+                id=ProviderEventId("conv-codex-no-msg-ts:event-0"),
+                conversation_id=ConversationId("conv-codex-no-msg-ts"),
+                provider=Provider.CODEX,
+                event_index=0,
+                event_type="function_call",
+                timestamp=started_at,
+                payload={"call_id": "c1", "name": "exec"},
+            ),
+            ProviderEvent(
+                id=ProviderEventId("conv-codex-no-msg-ts:event-1"),
+                conversation_id=ConversationId("conv-codex-no-msg-ts"),
+                provider=Provider.CODEX,
+                event_index=1,
+                event_type="function_call_output",
+                timestamp=ended_at,
+                payload={"call_id": "c1", "status": "ok"},
+            ),
+        ),
+    )
+
+    phases = extract_phases(conversation)
+
+    assert len(phases) == 1
+    phase = phases[0]
+    assert phase.start_time == started_at
+    assert phase.end_time == ended_at
+    assert phase.duration_ms == 120_000
+    assert phase.message_range == (0, 2)
+
+
+def test_extract_phases_splits_provider_events_on_idle_gap() -> None:
+    burst_a_start = datetime(2026, 5, 24, 10, 0, tzinfo=timezone.utc)
+    burst_a_end = burst_a_start + timedelta(minutes=1)
+    burst_b_start = burst_a_end + timedelta(minutes=10)
+    burst_b_end = burst_b_start + timedelta(minutes=1)
+    conversation = make_conv(
+        id="conv-codex-bursts",
+        provider=Provider.CODEX,
+        title="Codex two bursts",
+        messages=MessageCollection(messages=[_untimed_msg(i) for i in range(4)]),
+        provider_events=tuple(
+            ProviderEvent(
+                id=ProviderEventId(f"conv-codex-bursts:event-{i}"),
+                conversation_id=ConversationId("conv-codex-bursts"),
+                provider=Provider.CODEX,
+                event_index=i,
+                event_type="function_call",
+                timestamp=ts,
+                payload={"call_id": f"c{i}"},
+            )
+            for i, ts in enumerate([burst_a_start, burst_a_end, burst_b_start, burst_b_end])
+        ),
+    )
+
+    phases = extract_phases(conversation)
+
+    assert len(phases) == 2
+    assert (phases[0].start_time, phases[0].end_time) == (burst_a_start, burst_a_end)
+    assert (phases[1].start_time, phases[1].end_time) == (burst_b_start, burst_b_end)
+
+
+def test_extract_phases_returns_empty_when_no_timestamps_anywhere() -> None:
+    conversation = make_conv(
+        id="conv-codex-zero",
+        provider=Provider.CODEX,
+        title="No times at all",
+        messages=MessageCollection(messages=[_untimed_msg(0)]),
+        provider_events=(),
+    )
+
+    assert extract_phases(conversation) == []
+
+
+def test_extract_phases_prefers_message_timestamps_when_present() -> None:
+    started_at = datetime(2026, 5, 24, 10, 0, tzinfo=timezone.utc)
+    conversation = make_conv(
+        id="conv-claude-code",
+        provider=Provider.CLAUDE_CODE,
+        title="Normal claude-code",
+        messages=MessageCollection(
+            messages=[
+                make_msg(id="m0", role="user", provider="claude-code", text="hi", timestamp=started_at),
+                make_msg(
+                    id="m1",
+                    role="assistant",
+                    provider="claude-code",
+                    text="hello",
+                    timestamp=started_at + timedelta(minutes=1),
+                ),
+            ]
+        ),
+        provider_events=(
+            ProviderEvent(
+                id=ProviderEventId("conv-claude-code:event-0"),
+                conversation_id=ConversationId("conv-claude-code"),
+                provider=Provider.CLAUDE_CODE,
+                event_index=0,
+                event_type="session_meta",
+                timestamp=started_at - timedelta(hours=10),
+                payload={},
+            ),
+        ),
+    )
+
+    phases = extract_phases(conversation)
+
+    assert len(phases) == 1
+    assert phases[0].start_time == started_at
+    assert phases[0].end_time == started_at + timedelta(minutes=1)


### PR DESCRIPTION
## Summary

`session_phases` was empty for 2,411 conversations (codex 2,255 + hermes 156, ~30% of the production archive) because `extract_phases` only inspected message timestamps. Those sources put session timing on `provider_events`, not on messages. This PR adds the same provider-events fallback the session-timing path already uses, with regression tests.

Closes #1624.

## Problem

`polylogue/archive/phase/extraction.py:79` iterated messages and `continue`d past any `timestamp is None`. For codex pre-Dec-2025 (the entire codex history we hold) and hermes per-request dumps, every message timestamp is None, so the loop produced no phases and the materializer wrote zero rows.

Production evidence at the time of filing (2026-05-26):

```
$ sqlite3 ~/.local/share/polylogue/polylogue.db "
    SELECT c.source_name, count(DISTINCT c.conversation_id) convs,
           (SELECT count(*) FROM session_phases p
            WHERE p.source_name=c.source_name) phases
    FROM conversations c GROUP BY c.source_name;
"
antigravity   116    116
claude-code  5425  13263
codex        2255      0       ← gap
gemini-cli     20     44
hermes        156      0       ← gap
```

`polylogue/archive/session/runtime.py` already handles this case for session windows by falling back to `provider_event.timestamp` — but the phase extractor didn't.

## Solution

When the message-timestamped path produces zero phases (no message carried a usable timestamp), fall back to building phases from `conversation.provider_events`. The fallback applies the same 5-minute `_PHASE_GAP` idle-gap segmentation to the sorted event timestamps.

Because provider events don't map back to specific message indices, fallback phases cover the full message range `(0, len(messages))`. This is a deliberate trade — we get a valid session-window record for codex/hermes (unblocking downstream consumers) at the cost of fine-grained per-event message segmentation. The message-timestamped path is unchanged.

The fallback still returns `[]` when both messages and events lack timestamps — preserving the prior contract for that case.

## Verification

```
$ pytest tests/unit/archive/test_phase_extraction.py
4 passed in 0.04s

$ devtools verify --quick
"exit_code": 0
```

Test cases pin:
- Codex shape (untimed messages + two events): single phase with the event window.
- Codex with two event bursts ≥5min apart: two phases, one per burst.
- No timestamps anywhere: empty list (unchanged behavior).
- Normal claude-code (messages have timestamps, events also exist with much earlier ts): message timestamps still win.

Post-merge, running `polylogue insights rebuild --insight session_phase_inference` against the production archive should populate phases for the codex + hermes conversations. I haven't included that rebuild in this PR — it's an operator action.