### PR TITLE
chore(verify): only notify on failure; passes stay silent

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -623,8 +623,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.seed_testmon:
             _write_testmon_seed_stamp(history_entry)
 
-    # Notify on long-running verify.
-    if total_duration > 30:
+    # Notify only on failure. Passing runs stay silent — the terminal
+    # already shows the green summary and a desktop popup per run is
+    # spammy when verify is invoked on every push.
+    if exit_code != 0:
         _notify(
             _format_completion_notification(
                 exit_code=exit_code,

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -421,3 +421,41 @@ def test_completion_notification_omits_unknown_pytest_count() -> None:
     )
 
     assert summary == "PASS (118s)"
+
+
+def test_verify_does_not_notify_on_pass() -> None:
+    """Passing verify runs stay silent — only failures send a desktop popup."""
+
+    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+        return 0, 0.01, {}
+
+    with (
+        patch("devtools.verify._run", side_effect=fake_run),
+        patch("devtools.verify._git_head", return_value="head"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+        patch("devtools.verify._notify") as notify,
+    ):
+        rc = main(["--quick", "--json"])
+
+    assert rc == 0
+    notify.assert_not_called()
+
+
+def test_verify_notifies_on_failure() -> None:
+    """Failing verify runs still send a desktop popup so the operator notices."""
+
+    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+        return 1, 0.01, {}
+
+    with (
+        patch("devtools.verify._run", side_effect=fake_run),
+        patch("devtools.verify._git_head", return_value="head"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+        patch("devtools.verify._notify") as notify,
+    ):
+        rc = main(["--quick", "--json"])
+
+    assert rc == 1
+    notify.assert_called_once()


### PR DESCRIPTION
## Summary

`devtools verify` was sending a desktop notification on every completed run that took longer than 30 seconds, including successful ones. The git pre-push hook runs `verify --quick` on every push, so a normal edit-commit-push cycle fired a green PASS popup each time. Over a day of active work that's dozens of useless notifications drowning out the ones that actually matter.

Only notify when the run fails. Passes stay silent.

## Problem

`devtools/verify.py:627` fired the popup whenever `total_duration > 30` regardless of `exit_code`. The terminal already prints a green summary for passing runs; the only signal value of the popup was the failure case. With pre-push verify enabled, this came up dozens of times a day.

## Solution

Replace the duration gate with an exit-code gate:

```python
# before
if total_duration > 30:
    _notify(_format_completion_notification(...))

# after
if exit_code != 0:
    _notify(_format_completion_notification(...))
```

The `_format_completion_notification` helper still handles both branches — callers may still construct the PASS string for tests or future use — so the existing formatter tests cover both pass and fail messages.

## Verification

- `pytest tests/unit/devtools/test_verify.py` → 34 passed. Adds two regression tests pinning the gate:
  - `test_verify_does_not_notify_on_pass` — `_notify` is not called for `exit_code=0`
  - `test_verify_notifies_on_failure` — `_notify` is called once for `exit_code=1`
- `devtools verify --quick` exits 0 cleanly.

## Out of scope

- The `> 30s` threshold is gone entirely. Fast failing runs (a 5s lint failure) now notify too — that matches operator expectation that "verify failed" means "look at this." If someone wants the threshold back, it's a one-line restore.
- No changes to the formatter or to `_notify` itself; the popup content for failures is unchanged.