### PR TITLE
fix(facets): hydrate ConversationSummary.message_count from conversation_stats (#1623)

### DIFF
--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -145,6 +145,7 @@ def conversation_summary_from_record(
     record: ConversationRecord,
     *,
     tags: tuple[str, ...] = (),
+    message_count: int | None = None,
 ) -> ConversationSummary:
     """Hydrate a ConversationSummary domain model from a ConversationRecord."""
     return ConversationSummary(
@@ -157,6 +158,7 @@ def conversation_summary_from_record(
         metadata=record.metadata or {},
         parent_id=record.parent_conversation_id,
         branch_type=record.branch_type,
+        message_count=message_count,
         tags_m2m=tags,
     )
 

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -197,8 +197,15 @@ class RepositoryArchiveConversationMixin:
         conv_records = await self.queries.list_conversation_summaries(query)
         ids = [str(record.conversation_id) for record in conv_records]
         tags_by_id = await self._fetch_tags_by_conversation(ids)
+        # #1623: hydrate message_count from conversation_stats so callers
+        # like compute_facets see a real total instead of summing zeros.
+        counts_by_id = await self.queries.get_message_counts_batch(ids) if ids else {}
         return [
-            conversation_summary_from_record(record, tags=tags_by_id.get(str(record.conversation_id), ()))
+            conversation_summary_from_record(
+                record,
+                tags=tags_by_id.get(str(record.conversation_id), ()),
+                message_count=counts_by_id.get(str(record.conversation_id)),
+            )
             for record in conv_records
         ]
 

--- a/tests/unit/storage/test_summary_message_count.py
+++ b/tests/unit/storage/test_summary_message_count.py
@@ -1,0 +1,55 @@
+"""Regression coverage for #1623: `ConversationSummary.message_count` hydration.
+
+Without this the facets surface reports ``total_messages: 0`` because
+``compute_facets`` sums ``s.message_count or 0`` over summaries whose
+``message_count`` field defaults to ``None``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.query_models import ConversationRecordQuery
+from polylogue.storage.repository import ConversationRepository
+from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+from tests.infra.storage_records import ConversationBuilder
+
+
+@pytest.mark.asyncio
+async def test_list_summaries_by_query_populates_message_count(tmp_path: Path) -> None:
+    db_path = tmp_path / "summary-counts.db"
+
+    (
+        ConversationBuilder(db_path, "conv-three")
+        .provider("chatgpt")
+        .add_message("m1", role="user", text="hi")
+        .add_message("m2", role="assistant", text="hello")
+        .add_message("m3", role="user", text="bye")
+        .save()
+    )
+    (ConversationBuilder(db_path, "conv-one").provider("chatgpt").add_message("m4", role="user", text="ping").save())
+
+    backend = SQLiteBackend(db_path=db_path)
+    repo = ConversationRepository(backend=backend)
+    try:
+        summaries = await repo.list_summaries_by_query(ConversationRecordQuery(provider="chatgpt", limit=10))
+        counts = {str(s.id): s.message_count for s in summaries}
+        assert counts == {"conv-three": 3, "conv-one": 1}
+    finally:
+        await repo.close()
+
+
+@pytest.mark.asyncio
+async def test_list_summaries_by_query_returns_none_for_unknown_conversations(tmp_path: Path) -> None:
+    """Empty-result path doesn't error and doesn't issue a count query."""
+    db_path = tmp_path / "summary-empty.db"
+
+    backend = SQLiteBackend(db_path=db_path)
+    repo = ConversationRepository(backend=backend)
+    try:
+        summaries = await repo.list_summaries_by_query(ConversationRecordQuery(provider="chatgpt", limit=10))
+        assert summaries == []
+    finally:
+        await repo.close()


### PR DESCRIPTION
## Summary

`polylogue facets` and the API equivalents reported `total_messages: 0` on a populated archive because hydrated `ConversationSummary` instances had `message_count=None`. This PR threads the count through the hydrator from the existing `conversation_stats` table. Part 1 of 3 for #1623.

## Problem

`polylogue/archive/query/facets.py:81`:
```python
for s in summaries:
    total_conversations += 1
    total_messages += s.message_count or 0  # always 0 — message_count is None
```

`polylogue/storage/hydrators.py:conversation_summary_from_record` constructs every `ConversationSummary` without setting `message_count`, so the model defaults to `None`. The facets surface ends up reporting `total_messages: 0` on a 3.74M-message archive.

Verified on the production archive at the time of filing:
```
$ polylogue facets --format json | jq '.total_messages, .total_conversations'
0
7972
```

## Solution

Two small changes:

1. `conversation_summary_from_record` accepts an optional `message_count` keyword and threads it onto the pydantic model.
2. `list_summaries_by_query` batches one `get_message_counts_batch` query alongside the existing `_fetch_tags_by_conversation` call and feeds the result into the hydrator. This is the single funnel for both scoped and global facets, so the fix lands once.

`get_message_counts_batch` was already implemented (`polylogue/storage/sqlite/queries/message_query_stats.py:49`) and is already used by CLI and operations layers — this PR just adds it to the summary-listing path.

## Out of scope

Three substrate bugs were catalogued in #1623's root-cause comment. This PR addresses bug 1 only. Two remain:

- **Bug 2**: `repos`, `cwd_prefixes` always empty. `compute_facets` doesn't extract them from `provider_meta`. Small substrate enhancement — a separate PR.
- **Bug 3**: `message_types`, `action_types`, `has_flags` always empty. These need separate SQL aggregates against `messages` and `action_events`. Substantially larger — a separate PR.

## Verification

```
$ pytest tests/unit/storage/test_summary_message_count.py
2 passed

$ devtools verify --quick
"exit_code": 0
```

The new test file pins both paths:
- `test_list_summaries_by_query_populates_message_count` — counts match on-disk truth.
- `test_list_summaries_by_query_returns_none_for_unknown_conversations` — empty-result path doesn't trip the new count-batch call.

Existing facets tests (`tests/unit/archive/test_facets.py`, 9 cases) already construct summaries with explicit `message_count` values and continue to pass — the hydrator change is additive.