### PR TITLE
fix(cli): resolve --latest for `messages` and `raw` verbs (#1626)

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -7,6 +7,7 @@ a specific action on the matched conversations.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 
 import click
@@ -219,6 +220,38 @@ def _execute_query_verb(
     execute_query_request(env, request)
 
 
+def _resolve_target_conversation_id(request: RootModeRequest) -> str | None:
+    """Resolve the active filter chain to one conversation id (#1626).
+
+    Used by verbs that operate on a single conversation (``messages``,
+    ``raw``) so root-level filters like ``--latest`` and ``-p codex``
+    pick a conversation without forcing the operator to also pass an
+    ``--id``. Returns ``None`` if the chain matches zero conversations.
+    """
+    from polylogue.api.sync.bridge import run_coroutine_sync
+
+    params = dict(request.params)
+    explicit = cast("str | None", params.get("conv_id"))
+    if explicit:
+        return explicit
+
+    spec = request.query_spec()
+    if not spec.latest and not spec.has_filters():
+        return None
+
+    one_match_spec = replace(spec, limit=1)
+
+    async def _resolve() -> str | None:
+        from polylogue.api import Polylogue
+        from polylogue.config import Config
+
+        async with Polylogue.open(config=cast("Config | None", params.get("_config"))) as api:
+            summaries = await one_match_spec.list_summaries(api.repository)
+        return str(summaries[0].id) if summaries else None
+
+    return run_coroutine_sync(_resolve())
+
+
 @click.command("messages")
 @click.argument("conversation_id", required=False, shell_complete=_complete_conversation_id)
 @click.option("--message-role", "-r", "message_role", multiple=True, help="Filter by message role")
@@ -258,14 +291,11 @@ def messages_verb(
     from polylogue.cli.messages import run_messages
 
     env: AppEnv = ctx.obj
+    request = _parent_request(ctx)
     if conversation_id is None:
-        request = _parent_request(ctx)
-        params = dict(request.params)
-        conversation_id = cast("str | None", params.get("conv_id"))
+        conversation_id = _resolve_target_conversation_id(request)
         if not conversation_id:
             raise click.UsageError("messages requires a conversation ID (use --id or pass as argument)")
-    else:
-        request = _parent_request(ctx)
 
     run_messages(
         env,
@@ -303,14 +333,11 @@ def raw_verb(
     from polylogue.cli.messages import run_raw
 
     env: AppEnv = ctx.obj
+    request = _parent_request(ctx)
     if conversation_id is None:
-        request = _parent_request(ctx)
-        params = dict(request.params)
-        conversation_id = cast("str | None", params.get("conv_id"))
+        conversation_id = _resolve_target_conversation_id(request)
         if not conversation_id:
             raise click.UsageError("raw requires a conversation ID (use --id or pass as argument)")
-    else:
-        request = _parent_request(ctx)
 
     run_raw(
         env,

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -189,6 +189,47 @@ def test_bulk_export_verb_invokes_run_bulk_export_with_parent_request() -> None:
     assert kwargs == {"output_format": "jsonl", "fields": None}
 
 
+def test_resolve_target_conversation_id_uses_explicit_conv_id() -> None:
+    request = RootModeRequest.from_params({"conv_id": "claude-code:abc123"})
+    assert query_verbs._resolve_target_conversation_id(request) == "claude-code:abc123"
+
+
+def test_resolve_target_conversation_id_returns_none_without_filters_or_latest() -> None:
+    request = RootModeRequest.from_params({})
+    assert query_verbs._resolve_target_conversation_id(request) is None
+
+
+def test_resolve_target_conversation_id_resolves_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1626: ``--latest`` must resolve to the most recent conv without an explicit id."""
+    request = RootModeRequest.from_params({"latest": True})
+
+    captured_limits: list[int | None] = []
+
+    async def fake_list_summaries(self: object, repo: object) -> list[SimpleNamespace]:
+        captured_limits.append(getattr(self, "limit", None))
+        return [SimpleNamespace(id="claude-code:latest-conv-id")]
+
+    monkeypatch.setattr(
+        "polylogue.archive.query.spec.ConversationQuerySpec.list_summaries",
+        fake_list_summaries,
+    )
+
+    class _API:
+        repository = SimpleNamespace()
+
+        async def __aenter__(self) -> _API:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None: ...
+
+    monkeypatch.setattr("polylogue.api.Polylogue.open", lambda **_: _API())
+
+    result = query_verbs._resolve_target_conversation_id(request)
+
+    assert result == "claude-code:latest-conv-id"
+    assert captured_limits == [1]
+
+
 def test_delete_verb_updates_force_and_dry_run_flags() -> None:
     _, child = _context_pair(query_terms=("alpha",))
     wrapped = getattr(query_verbs.delete_verb.callback, "__wrapped__", None)


### PR DESCRIPTION
## Summary

`polylogue --latest raw` and `polylogue --latest messages` rejected with "requires a conversation ID" even though `--latest` is documented as a root-level filter that picks the most recent conversation. `show`/`list`/`count` worked because they run the filter chain. This PR fixes the two single-conversation verbs to do the same. Closes #1626.

## Problem

```
$ polylogue --latest raw
Error: raw requires a conversation ID (use --id or pass as argument)
$ polylogue --latest messages --limit 1
Error: messages requires a conversation ID (use --id or pass as argument)
```

`messages_verb` and `raw_verb` only consulted `params["conv_id"]`, which is set by `--id` or a positional argument. Root-level filters like `--latest`, `-p`, `--tag` were ignored, so any operator workflow that "filter then act on the matching conv" had to manually run `list` first and copy the id.

## Solution

Factor a `_resolve_target_conversation_id` helper in `polylogue/cli/query_verbs.py` that:

1. Returns the explicit `conv_id` if set (preserves the existing `--id`/positional path).
2. Otherwise, if `--latest` or any narrowing filter is in play, runs the active `ConversationQuerySpec` with `limit=1` against the repository and picks the top match.
3. Returns `None` only when the filter chain is empty *and* no explicit id was set — same condition under which the existing `UsageError` makes sense.

`messages_verb` and `raw_verb` both call this helper. The error message is unchanged for the "no filter, no id" case — only the false-positive case is fixed.

## Out of scope

The acceptance criteria called for "a regression test in `tests/unit/cli/` parameterized over the verb set so any new verb that takes an optional conversation ID auto-inherits the `--latest` integration check." This PR adds three focused unit tests for the helper itself; a fuller verb-parameterized integration test would need a real test database fixture and is a clean follow-up.

## Verification

```
$ polylogue --latest raw
{"conversation_id": "claude-code:6b165267-9552-40de-8832-d15b510059bb", ...}
$ polylogue --latest messages --limit 1
 <command-name>/clear</command-name>...

$ pytest tests/unit/cli/test_query_verbs_runtime.py
13 passed (3 new)

$ devtools verify --quick
"exit_code": 0
```

Three new tests pin:
- `test_resolve_target_conversation_id_uses_explicit_conv_id` — explicit id wins.
- `test_resolve_target_conversation_id_returns_none_without_filters_or_latest` — no-op path matches the existing error contract.
- `test_resolve_target_conversation_id_resolves_latest` — `--latest` runs the spec with `limit=1` and returns the top conv id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic conversation ID resolution for `messages` and `raw` commands when no explicit ID is provided.
  * Clearer error messages when a conversation cannot be automatically resolved.

* **Tests**
  * Added unit tests for conversation ID resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->