### PR TITLE
ci(cachix): gate Cachix push job on CACHIX_CACHE_ENABLED repo variable (#1638)

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -23,6 +23,13 @@ concurrency:
 
 jobs:
   push:
+    # Skip silently when the cache hasn't been provisioned. The `polylogue`
+    # cachix cache and the `CACHIX_AUTH_TOKEN` secret live outside this repo;
+    # without them the cachix-action fails and reddens master. Setting the repo
+    # variable `CACHIX_CACHE_ENABLED=true` opts the workflow in once the cache
+    # and token are wired up. Forks and fresh setups stay green by default.
+    # See #1638.
+    if: ${{ vars.CACHIX_CACHE_ENABLED == 'true' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The Cachix push workflow has been failing on every master push for at least 24 hours — the \`polylogue\` cache and/or \`CACHIX_AUTH_TOKEN\` secret are unprovisioned. Gate the job on a new \`CACHIX_CACHE_ENABLED\` repo variable so master stops going red while keeping the workflow intact for whenever the cache is wired up. Refs #1638.

## Problem

\`.github/workflows/cachix.yml\` runs on every master push and tag. Every run since at least 2026-05-25 15:21 UTC has failed with:

\`\`\`
Binary cache polylogue doesn't exist or it's private and you need a token:
Start by visiting https://app.cachix.org and create a personal/cache auth token.
\`\`\`

Both the cache and the secret live outside this repo, so the workflow can't fix itself — it just keeps painting master red.

## Solution

Add a job-level \`if: \${{ vars.CACHIX_CACHE_ENABLED == 'true' }}\` gate. The job is skipped silently when the variable is unset (which is the case today, on forks, and on fresh setups). When the cachix.org cache and \`CACHIX_AUTH_TOKEN\` secret are wired up, an operator flips \`vars.CACHIX_CACHE_ENABLED=true\` on the repo settings to re-enable the push. No change to the job steps themselves.

\`vars.X\` (repo variables) is the right control plane for this — variables are inspectable in the Actions UI, can be set without write access to secrets, and don't show up as a "missing secret" warning when unset.

## Verification

\`\`\`
$ devtools verify-ci-workflows
17 workflow files checked, no errors
$ devtools verify --quick
"exit_code": 0
\`\`\`

The skipped-job will show as \"Skipped\" rather than \"Failed\" in the Actions UI, which is the desired outcome.