### PR TITLE
fix(parsers/claude-code): skip type=progress hook lifecycle events (#1617)

### DIFF
--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -180,7 +180,16 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
                 continue
             seen_record_uuids.add(record_uuid)
 
-        if record_type in {"init", "file-history-snapshot", "queue-operation"}:
+        # ``progress`` records are claude-code hook lifecycle events
+        # (`hookEvent`, `hookName`, `command`) carried alongside the
+        # tool they fired on — they are NOT message content. Persisting
+        # them as messages produces empty rows under the ``tool_result``
+        # message_type that dominate the ``role=unknown, text='', blocks=[]``
+        # consumer surface and inflate every messages-table count by
+        # ~23%. See #1617 for the full forensic. We drop them here at the
+        # parser; the hook payload, if useful for analytics, belongs in
+        # a future ``provider_event`` capture, not in the messages table.
+        if record_type in {"init", "file-history-snapshot", "queue-operation", "progress"}:
             continue
 
         if not session_id:

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -62,3 +62,46 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
     assert by_id["command-1"].message_type is MessageType.PROTOCOL
     assert by_id["skill-1"].message_type is MessageType.CONTEXT
     assert by_id["prompt-1"].message_type is MessageType.MESSAGE
+
+
+def test_parse_code_drops_progress_hook_records() -> None:
+    """#1617: ``type=progress`` is a hook lifecycle event, not message content."""
+    items: list[object] = [
+        {
+            "type": "user",
+            "uuid": "u-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067200,
+            "message": {"role": "user", "content": "real prompt"},
+        },
+        {
+            "type": "progress",
+            "uuid": "prog-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067201,
+            "data": {"hookEvent": "PreToolUse", "hookName": "test-hook", "command": "echo"},
+            "parentToolUseID": "tool-1",
+            "toolUseID": "tool-1",
+        },
+        {
+            "type": "progress",
+            "uuid": "prog-2",
+            "sessionId": "sess-1",
+            "timestamp": 1704067202,
+            "data": {"hookEvent": "PostToolUse"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067203,
+            "message": {"role": "assistant", "content": "reply"},
+        },
+    ]
+
+    result = parse_code(items, "fallback-progress")
+
+    # Two real messages survive; both progress hook events are dropped.
+    provider_ids = {m.provider_message_id for m in result.messages}
+    assert provider_ids == {"u-1", "a-1"}
+    assert all("prog" not in pid for pid in provider_ids)


### PR DESCRIPTION
## Summary

`type=progress` records in claude-code JSONL are hook lifecycle events, not message content. The parser was creating one empty `tool_result` row per progress event, contributing **739,900 empty rows (23% of the messages table)** on the production archive. Skip them at the dispatch level. Closes #1617.

## Problem

`polylogue/sources/parsers/claude/code_parser.py` checked for skip-worthy record types at line 183:

```python
if record_type in {"init", "file-history-snapshot", "queue-operation"}:
    continue
```

`progress` was missing from that set. Records with `type=progress` carry `data.hookEvent`/`hookName`/`command` and a `parentToolUseID` pointing at the tool whose hooks fired. They have no `message.content`, so the parser produced rows with `text=""`, `content_blocks=[]`, and `message_type=tool_result` (because `_record_role` maps `progress` → `Role.TOOL`).

Production evidence at the time of filing:

```
$ sqlite3 ~/.local/share/polylogue/polylogue.db "
  SELECT count(*) FROM messages m
  WHERE m.message_type='tool_result'
    AND (m.text IS NULL OR m.text='')
    AND NOT EXISTS (SELECT 1 FROM content_blocks cb WHERE cb.message_id=m.message_id);
"
739,900
```

## Solution

Add `progress` to the existing skip set. Same dispatch point, same semantics as `init`/`file-history-snapshot`/`queue-operation`.

The `_record_role()` branch that mapped `progress`/`result` → `Role.TOOL` is now unreachable for `progress` (the record is filtered before role assignment); kept it in place as defensive code for any future record-routing change. `result` records are unaffected.

## Out of scope

AC #2 of #1617 calls for a one-time migration to drop the 739k existing empty rows. That requires a doctor target (`polylogue doctor --target empty_progress_rows`) or folding into the existing `empty_conversations` repair. The empty rows will also clear on the next `polylogue reset --database && polylogued run` re-ingest. Tracking as follow-up.

AC #4 calls for MCP `get_messages` to defensively skip the empty rows even while they live in the substrate. That's a separate change to MCP read surface; tracking as follow-up.

## Verification

```
$ pytest tests/unit/sources/test_parsers_claude_code_artifacts.py
3 passed

$ pytest tests/unit/sources/ --ignore=tests/unit/sources/test_parsers_props.py
169 passed

$ devtools verify --quick
"exit_code": 0
```

New test `test_parse_code_drops_progress_hook_records` builds a JSONL with two real messages and two `type=progress` hook events, parses it, and asserts only the two real messages survive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved message history management by preventing internal progress tracking and lifecycle events from being recorded as empty message entries. This eliminates unnecessary clutter in conversation logs and ensures that message counts and visible history accurately reflect only meaningful interactions between users and the assistant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->