### PR TITLE
fix(daemon): debt loop picks up stale profiles, not just missing ones (#1620)

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -982,15 +982,11 @@ def _action_events_exist_for_conversations(conn: sqlite3.Connection, conversatio
 
 
 def _conversation_ids_missing_profiles(conn: sqlite3.Connection) -> list[str]:
-    rows = conn.execute(
-        """
-        SELECT c.conversation_id
-        FROM conversations AS c
-        LEFT JOIN session_profiles AS sp ON sp.conversation_id = c.conversation_id
-        WHERE sp.conversation_id IS NULL
-        ORDER BY COALESCE(c.sort_key, 0) DESC, c.conversation_id
-        """,
-    ).fetchall()
+    """Conversations whose session_profile is missing or stale (#1620)."""
+    from polylogue.storage.insights.session.status import SESSION_PROFILE_REPAIR_CANDIDATES_SQL
+    from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
+
+    rows = conn.execute(SESSION_PROFILE_REPAIR_CANDIDATES_SQL, (SESSION_INSIGHT_MATERIALIZER_VERSION,)).fetchall()
     return [str(row[0]) for row in rows]
 
 

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -583,6 +583,66 @@ def test_insights_stage_defers_hot_large_conversation_debt(
     assert stage.execute_conversations(["conv-hot"]) is False
 
 
+def test_conversation_ids_missing_profiles_includes_stale(tmp_path: Path) -> None:
+    """#1620: the path-fallback debt loop must surface stale profiles, not just missing ones.
+
+    Before the fix, conversations whose JSONL had gone quiet but whose
+    ``conversations.sort_key`` drifted from the materialized
+    ``source_sort_key`` were never picked up by the daemon's debt loop —
+    ``remaining=0`` was reported indefinitely.
+    """
+    db_path = tmp_path / "missing_profiles.sqlite"
+    cutoff_safe_sort_key = 1.0  # well below now - HOT_SOURCE_GRACE_SECONDS
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                sort_key REAL,
+                updated_at TEXT
+            );
+            CREATE TABLE session_profiles (
+                conversation_id TEXT PRIMARY KEY,
+                materializer_version INTEGER,
+                source_sort_key REAL,
+                source_updated_at TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO conversations (conversation_id, sort_key) VALUES ('conv-missing', ?)",
+            (cutoff_safe_sort_key,),
+        )
+        conn.execute(
+            "INSERT INTO conversations (conversation_id, sort_key) VALUES ('conv-stale', ?)",
+            (cutoff_safe_sort_key,),
+        )
+        conn.execute(
+            "INSERT INTO conversations (conversation_id, sort_key) VALUES ('conv-fresh', ?)",
+            (cutoff_safe_sort_key,),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_profiles (conversation_id, materializer_version, source_sort_key)
+            VALUES ('conv-stale', ?, ?)
+            """,
+            (SESSION_INSIGHT_MATERIALIZER_VERSION, cutoff_safe_sort_key + 1000.0),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_profiles (conversation_id, materializer_version, source_sort_key)
+            VALUES ('conv-fresh', ?, ?)
+            """,
+            (SESSION_INSIGHT_MATERIALIZER_VERSION, cutoff_safe_sort_key),
+        )
+        conn.commit()
+
+        ids = stages._conversation_ids_missing_profiles(conn)
+
+    assert set(ids) == {"conv-missing", "conv-stale"}
+
+
 def test_insights_staleness_uses_sort_key_not_timestamp_text(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.sqlite"
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Summary

The daemon's session-insights debt loop fell back to a helper that found only missing profiles, missing the operator-visible "stale" cases. Conversations whose JSONL had gone quiet but whose `conversations.sort_key` had drifted from the materialized profile (e.g. five rows on the production archive with `source_updated_at = 2026-02-18T23:30:25` regardless of the actual conversation timestamp) sat stuck forever. Closes #1620.

## Problem

`polylogue/daemon/convergence_stages.py:_conversation_ids_missing_profiles` ran:

```sql
SELECT c.conversation_id FROM conversations c
LEFT JOIN session_profiles sp ON sp.conversation_id = c.conversation_id
WHERE sp.conversation_id IS NULL
```

The path-driven path of the debt loop catches stale rows fine — when a JSONL changes, the matching conversations get pushed through and `_stale_session_profile_ids` is queried for them. But when *no* path triggers (the fallback path used to drain remaining debt), the loop only saw conversations with no profile *at all*. Conversations with a stale-but-not-missing profile were invisible.

On the production archive five `session_profiles` rows have `source_sort_key = 1771457425.0` (= 2026-02-18T23:30:25) regardless of the conversation's actual `sort_key` — likely a bulk-rebuild side effect of the v9→v16 catch-up. The operator-facing `session_profile_repair_candidate_ids` flagged them, but the daemon's debt loop never picked them up. `remaining=0` was reported indefinitely.

## Solution

Swap the missing-only SQL for `SESSION_PROFILE_REPAIR_CANDIDATES_SQL` — the same query that powers the operator repair-candidate check. It returns both missing rows AND stale ones (wrong materializer version OR `source_sort_key` drift), respecting the `HOT_SOURCE_READY_CUTOFF` so live-appending sessions still defer naturally. The downstream `_hot_insight_conversation_ids` filter is unchanged; cold stale rows now get rebuilt on the next debt tick.

The function rename was tempting (`_conversation_ids_missing_profiles` no longer describes the return set) but the call sites all want "session-profile debt to drain" — the broader semantics is what they always wanted. Leaving the name avoids touching three other call sites for a follow-up rename.

## Verification

```
$ pytest tests/unit/daemon/test_convergence_stages.py
22 passed (1 new)

$ devtools verify --quick
"exit_code": 0
```

New test `test_conversation_ids_missing_profiles_includes_stale` seeds three conversations:
- `conv-missing` (no profile)
- `conv-stale` (profile with mismatched `source_sort_key`)
- `conv-fresh` (profile with matching `source_sort_key`)

and asserts the helper returns `{conv-missing, conv-stale}` — fresh stays out, both kinds of debt come back in.

## Refs

- #1620 (the five stuck profiles)
- `polylogue/storage/insights/session/status.py:353` (the repair-candidate SQL)