### PR TITLE
fix(watcher): interleave catch-up scan by source family (#1616)

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -213,7 +213,7 @@ class LiveWatcher:
                             stat=stat,
                         )
                     )
-        return tuple(sorted(candidates, key=lambda candidate: candidate.path))
+        return tuple(_interleave_by_source(candidates))
 
     def _plan_catch_up(self, candidates: tuple[CandidateSourceFile, ...]) -> CatchUpPlan:
         if not candidates:
@@ -478,6 +478,33 @@ class LiveWatcher:
             except OSError:
                 continue
         return path.suffix == ".jsonl"
+
+
+def _interleave_by_source(candidates: list[CandidateSourceFile]) -> list[CandidateSourceFile]:
+    """Round-robin candidates across source families (#1616).
+
+    Plain alphabetical sort by path puts all of one source's files
+    before any of another's, so a long-source-first catch-up hides
+    small-source ingestion progress for hours. Bucket by source_name,
+    sort each bucket by path for determinism, then round-robin across
+    buckets so the first chunk contains some of every present family.
+    """
+    buckets: dict[str, list[CandidateSourceFile]] = {}
+    for candidate in candidates:
+        buckets.setdefault(candidate.source_name, []).append(candidate)
+    for source_name in buckets:
+        buckets[source_name].sort(key=lambda candidate: candidate.path)
+    ordered: list[CandidateSourceFile] = []
+    iterators = [iter(buckets[name]) for name in sorted(buckets)]
+    while iterators:
+        next_round = []
+        for it in iterators:
+            picked = next(it, None)
+            if picked is not None:
+                ordered.append(picked)
+                next_round.append(it)
+        iterators = next_round
+    return ordered
 
 
 def default_sources() -> tuple[WatchSource, ...]:

--- a/tests/unit/sources/test_live_watcher_catchup_order.py
+++ b/tests/unit/sources/test_live_watcher_catchup_order.py
@@ -1,0 +1,55 @@
+"""Regression coverage for catch-up scan ordering (#1616)."""
+
+from __future__ import annotations
+
+from os import stat_result
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import polylogue.sources.live.watcher as live_watcher
+
+
+def _candidate(source: str, path: str) -> live_watcher.CandidateSourceFile:
+    fake_stat = cast("stat_result", SimpleNamespace(st_size=0, st_mode=0o100644, st_mtime=0))
+    return live_watcher.CandidateSourceFile(
+        path=Path(path),
+        source_name=source,
+        suffix=Path(path).suffix,
+        stat=fake_stat,
+    )
+
+
+def test_interleave_by_source_round_robins_families() -> None:
+    """Catch-up scans interleave by source so every family progresses early."""
+    candidates = [
+        _candidate("claude-code", "/home/u/.claude/projects/a/1.jsonl"),
+        _candidate("claude-code", "/home/u/.claude/projects/a/2.jsonl"),
+        _candidate("claude-code", "/home/u/.claude/projects/a/3.jsonl"),
+        _candidate("codex", "/home/u/.codex/sessions/x/1.jsonl"),
+        _candidate("codex", "/home/u/.codex/sessions/x/2.jsonl"),
+        _candidate("hermes", "/home/u/.hermes/sessions/h.json"),
+        _candidate("gemini-cli", "/home/u/.gemini/tmp/g.jsonl"),
+    ]
+
+    ordered = live_watcher._interleave_by_source(candidates)
+
+    first_round_sources = {c.source_name for c in ordered[:4]}
+    assert first_round_sources == {"claude-code", "codex", "gemini-cli", "hermes"}
+    assert sorted(c.path for c in ordered) == sorted(c.path for c in candidates)
+    claude_paths = [c.path for c in ordered if c.source_name == "claude-code"]
+    assert claude_paths == sorted(claude_paths)
+
+
+def test_interleave_by_source_empty_input_returns_empty() -> None:
+    assert live_watcher._interleave_by_source([]) == []
+
+
+def test_interleave_by_source_single_source_preserves_alphabetical_order() -> None:
+    candidates = [
+        _candidate("claude-code", "/p/zz.jsonl"),
+        _candidate("claude-code", "/p/aa.jsonl"),
+        _candidate("claude-code", "/p/mm.jsonl"),
+    ]
+    ordered = live_watcher._interleave_by_source(candidates)
+    assert [c.path.name for c in ordered] == ["aa.jsonl", "mm.jsonl", "zz.jsonl"]


### PR DESCRIPTION
## Summary

`LiveWatcher._scan_catch_up_candidates` sorted purely by path, so claude-code/codex JSONLs landed at the head and gemini-cli/hermes at the tail. On the v9→v16 fresh-init, 321 small-source files queued behind 11,710 large-source files — operators saw zero gemini-cli/hermes ingestion for hours. Round-robin across source families so every family progresses early. Closes #1616.

## Problem

```python
# polylogue/sources/live/watcher.py:_scan_catch_up_candidates
return tuple(sorted(candidates, key=lambda c: c.path))
```

Source roots `/home/u/.claude/` < `/home/u/.codex/` < `/home/u/.gemini/` < `/home/u/.hermes/` alphabetically, so a plain path sort partitioned the work front-to-back: hours of claude-code, then codex, then a thin tail of small-source files.

Operators monitoring via `SELECT source_name, count(*) FROM conversations GROUP BY source_name` had no signal that the small sources were even queued.

## Solution

Factor an `_interleave_by_source` helper that:

1. Buckets candidates by `source_name`.
2. Sorts each bucket alphabetically by path (preserves prior determinism within a source).
3. Round-robins across buckets in alphabetical `source_name` order.

Result: the first N picks include one file from each present source family. Operators watching ingest see every family progress from the first chunk onward.

## Verification

```
$ pytest tests/unit/sources/test_live_watcher_catchup_order.py
3 passed

$ pytest tests/unit/sources/test_live_watcher.py
61 passed

$ devtools verify --quick
"exit_code": 0
```

New test file pins three contracts:
- `test_interleave_by_source_round_robins_families` — with 4 source families and 7 candidates, the first 4 picks cover every family.
- `test_interleave_by_source_empty_input_returns_empty` — empty input still empty.
- `test_interleave_by_source_single_source_preserves_alphabetical_order` — single-source determinism unchanged.

## Out of scope

AC #2 of #1616 asks for per-source progress reporting in the catch-up log lines. That's a separate change to the chunk-processing log surfaces and is tracked as a follow-up.