### PR TITLE
perf(daemon/metrics): aggregate per-source counts via conversation_stats (#1629)

### DIFF
--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -748,29 +748,50 @@ def _emit_archive_metrics(lines: list[str], conn: sqlite3.Connection) -> None:
             samples=[(None, 0)],
         )
 
-    # Per-provider message counts (resilient to missing column)
-    if _table_exists(conn, "messages") and "source_name" in _columns(conn, "messages"):
+    # Per-provider message counts. Aggregate through ``conversation_stats``
+    # instead of a full GROUP BY scan over ``messages`` — on a 3.7 M-row
+    # archive that scan took ~3.5 s on every scrape (#1629) even with the
+    # ``idx_messages_source_role`` covering index. ``conversation_stats``
+    # is maintained per-conversation by ``upsert_conversation_stats`` and
+    # is two orders of magnitude smaller; the ~5-row drift versus the
+    # exact count is acceptable for a metric.
+    if (
+        _table_exists(conn, "conversations")
+        and "source_name" in _columns(conn, "conversations")
+        and _table_exists(conn, "conversation_stats")
+        and "message_count" in _columns(conn, "conversation_stats")
+    ):
+        msg_rows = conn.execute(
+            """
+            SELECT c.source_name, COALESCE(SUM(cs.message_count), 0)
+            FROM conversations AS c
+            LEFT JOIN conversation_stats AS cs ON cs.conversation_id = c.conversation_id
+            GROUP BY c.source_name
+            ORDER BY c.source_name
+            """
+        ).fetchall()
+    elif _table_exists(conn, "messages") and "source_name" in _columns(conn, "messages"):
         msg_rows = conn.execute(
             "SELECT source_name, COUNT(*) FROM messages GROUP BY source_name ORDER BY source_name"
         ).fetchall()
     else:
         msg_rows = []
-        if msg_rows:
-            _emit_metric(
-                lines,
-                name="polylogue_archive_messages_total",
-                help_text="Total messages in the archive by source family.",
-                metric_type="gauge",
-                samples=[({"source": str(row[0])}, int(row[1])) for row in msg_rows],
-            )
-        else:
-            _emit_metric(
-                lines,
-                name="polylogue_archive_messages_total",
-                help_text="Total messages.",
-                metric_type="gauge",
-                samples=[(None, 0)],
-            )
+    if msg_rows:
+        _emit_metric(
+            lines,
+            name="polylogue_archive_messages_total",
+            help_text="Total messages in the archive by source family.",
+            metric_type="gauge",
+            samples=[({"source": str(row[0])}, int(row[1])) for row in msg_rows],
+        )
+    else:
+        _emit_metric(
+            lines,
+            name="polylogue_archive_messages_total",
+            help_text="Total messages.",
+            metric_type="gauge",
+            samples=[(None, 0)],
+        )
 
 
 def _emit_throughput_metrics(lines: list[str], conn: sqlite3.Connection) -> None:

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -352,6 +352,37 @@ class TestFormatMetricsReadsArchiveState:
         assert 'polylogue_embedding_latest_catchup_messages{state="embedded"} 2' in body
         assert "polylogue_embedding_latest_catchup_estimated_cost_usd 0.003" in body
 
+    def test_archive_messages_total_uses_conversation_stats(self, tmp_path: Path) -> None:
+        """#1629: per-source message counts avoid the 3.7M-row GROUP BY scan.
+
+        Reading from ``conversation_stats`` (one row per conversation) is
+        two orders of magnitude cheaper than ``SELECT source_name, COUNT(*)
+        FROM messages GROUP BY source_name`` on a steady-state archive.
+        """
+        db = tmp_path / "archive.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE conversations (
+                    conversation_id TEXT PRIMARY KEY,
+                    source_name TEXT NOT NULL
+                );
+                CREATE TABLE conversation_stats (
+                    conversation_id TEXT PRIMARY KEY,
+                    message_count INTEGER NOT NULL
+                );
+                INSERT INTO conversations VALUES ('c1', 'claude-code'), ('c2', 'claude-code'), ('c3', 'codex');
+                INSERT INTO conversation_stats VALUES ('c1', 100), ('c2', 50), ('c3', 30);
+                """
+            )
+
+        body = format_metrics(db)
+
+        assert 'polylogue_archive_conversations_total{source="claude-code"} 2' in body
+        assert 'polylogue_archive_conversations_total{source="codex"} 1' in body
+        assert 'polylogue_archive_messages_total{source="claude-code"} 150' in body
+        assert 'polylogue_archive_messages_total{source="codex"} 30' in body
+
     def test_embedding_metrics_tolerate_partial_tables(self, tmp_path: Path) -> None:
         db = tmp_path / "archive.db"
         with sqlite3.connect(db) as conn:


### PR DESCRIPTION
## Summary

`/metrics` scrape took ~3.5 s per call on the production archive because `_emit_archive_metrics` did `SELECT source_name, COUNT(*) FROM messages GROUP BY source_name` — a full scan of the 3.7 M-row messages table on every scrape. Switch to the equivalent aggregate over `conversation_stats` (8 K rows). Same answer, 44× faster. While in the same block, fix a pre-existing indent bug that silently zeroed the messages metric. Refs #1629.

## Problem

```sql
-- Old (every scrape)
SELECT source_name, COUNT(*) FROM messages GROUP BY source_name;
-- → 3.5 s wall, even with the idx_messages_source_role covering index
```

The full-scan cost was a load-bearing reason `/metrics` was unscrapeable at default 10-30 s Prometheus intervals.

There was also a latent bug in the same block: the `if msg_rows: emit; else: emit-zero` branches were indented one level too deep, sitting inside the *fallback* `else` rather than the dispatch level. Result: the per-source messages metric never emitted real values — only the zero-sample placeholder when no source-name column existed. This PR straightens that out, so the metric now actually surfaces non-zero counts for the first time.

## Solution

```sql
SELECT c.source_name, COALESCE(SUM(cs.message_count), 0)
FROM conversations c
LEFT JOIN conversation_stats cs ON cs.conversation_id = c.conversation_id
GROUP BY c.source_name;
-- → 80 ms wall on the same archive
```

`conversation_stats` is maintained per-conversation by `upsert_conversation_stats` in the archive write path, so the values stay close to truth. Drift seen on the live archive: 5 messages out of 3.7 M across the whole table (0.0002 %). For a Prometheus gauge that's well within acceptable.

The original full-scan path is preserved as a fallback when `conversation_stats` isn't present, so fresh archives and schema-bump windows still work.

## Verification

```
$ pytest tests/unit/daemon/test_metrics_endpoint.py
16 passed (1 new)

$ devtools verify --quick
"exit_code": 0
```

`test_archive_messages_total_uses_conversation_stats` seeds 3 conversations across 2 sources with explicit `message_count` totals and asserts the resulting exposition lines:

```
polylogue_archive_conversations_total{source="claude-code"} 2
polylogue_archive_conversations_total{source="codex"} 1
polylogue_archive_messages_total{source="claude-code"} 150
polylogue_archive_messages_total{source="codex"} 30
```

The pre-existing messages metric tests didn't catch the indent bug because they tested per-source labels via the `_make_db` fixture that omitted `source_name` on `messages` — exercising the fallback branch that was emitting the zero placeholder. New test exercises the happy path that was effectively dead before this PR.

## Out of scope

`/metrics` has other slow queries (#1629's full list — `embedding_status_payload`, recent-attempt durations, FTS trigger drift). This PR addresses the dominant cost. Follow-ups will pick off the remaining hotspots one by one.