### PR TITLE
fix(viewport): tighten affected_paths heuristic — reject sed, version strings, attribute access (#1622)

### DIFF
--- a/polylogue/archive/viewport/models.py
+++ b/polylogue/archive/viewport/models.py
@@ -12,7 +12,6 @@ from polylogue.archive.viewport.enums import ContentType, ToolCategory
 from polylogue.archive.viewport.tools import (
     PATH_PATTERN,
     clean_metadata_path_candidate,
-    clean_path_candidate,
     clean_shell_path_candidate,
 )
 from polylogue.types import Provider
@@ -74,7 +73,12 @@ class ToolCall(BaseModel):
     def affected_paths(self) -> list[str]:
         paths: list[str] = []
         for field in ("file_path", "path", "file", "filename"):
-            value = clean_path_candidate(self.input.get(field))
+            # Input fields named ``file_path``/``path``/``file``/``filename``
+            # *usually* hold a path, but not always — some tool inputs
+            # repurpose the names for model versions, Python attribute
+            # tokens, or other non-paths. Apply the same shape filter the
+            # metadata path uses (#1622).
+            value = clean_metadata_path_candidate(self.input.get(field))
             if value:
                 paths.append(value)
 

--- a/polylogue/archive/viewport/tools.py
+++ b/polylogue/archive/viewport/tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from pathlib import PurePosixPath
 
 from polylogue.archive.viewport.enums import ToolCategory
 from polylogue.core.json import JSONValue
@@ -12,6 +11,23 @@ from polylogue.core.json import JSONValue
 PATH_PATTERN = re.compile(r'(?:^|[\s"\'])(/[^\s"\']+|[./][^\s"\']+)')
 NOISE_PATH_TOKENS = frozenset({"...", "//", "/dev/null", "|", "||", "&&", ";"})
 METADATA_FILE_BASENAME_ALLOWLIST = frozenset({"LICENSE", "COPYING", "NOTICE", "Makefile", "Dockerfile", "Justfile"})
+
+# Match a sed-style substitution token (``s/find/replace/flags``) — these
+# come out of shell-command path extraction with a leading slash and look
+# like real paths to the naive PATH_PATTERN. The trailing flags are
+# optional. The leading address part (``[!]?[0-9]*[a-z]?``) is intentionally
+# tolerant since real sed expressions vary widely.
+_SED_SUBSTITUTION_RE = re.compile(r"(?:^|/)!?(s|y)/[^/]*?/[^/]*?/[a-z0-9]*$")
+
+# Path-extension shape: a trailing ``.`` followed by a leading letter
+# and 0-5 more alphanumeric characters. Catches ``.py``, ``.md``,
+# ``.json``, ``.tsx``, ``.yaml`` etc. without locking the codebase
+# into an enumerated allowlist. Rejects long or punctuation-bearing
+# suffixes that ``PurePosixPath.suffix`` would otherwise treat as
+# paths (``.provider_name``), and digit-only suffixes that come from
+# version strings (``.7`` in ``4.7``). Requiring a leading letter is
+# the cheap discriminator that handles both.
+_PATH_EXTENSION_RE = re.compile(r"\.[A-Za-z][A-Za-z0-9]{0,5}$")
 
 
 def classify_tool(name: str, input_data: Mapping[str, JSONValue]) -> ToolCategory:
@@ -96,7 +112,9 @@ def clean_path_candidate(value: object) -> str | None:
         return None
     if candidate.startswith("-"):
         return None
-    if any(ch in candidate for ch in "*?[]{}"):
+    if any(ch in candidate for ch in "*?[]{}<>"):
+        return None
+    if _SED_SUBSTITUTION_RE.search(candidate):
         return None
     return candidate
 
@@ -105,13 +123,18 @@ def looks_like_path_candidate(value: object) -> bool:
     candidate = clean_path_candidate(value)
     if candidate is None:
         return False
+    # Absolute or explicit-relative paths are accepted as-is — the
+    # leading prefix is itself the path signal.
     if candidate.startswith(("/", "~/", "./", "../")):
         return True
-    if "/" in candidate:
-        return True
-    if candidate.startswith("."):
-        return True
-    if PurePosixPath(candidate).suffix:
+    # Otherwise require a *file-extension-shaped* suffix (``.py``,
+    # ``.md``, ``.tsx`` …). This rejects Python attribute access
+    # (``insight.provider_name``), version numbers (``4.7``), email
+    # TLDs in brackets, and other false-positive ``.suffix`` matches
+    # that ``PurePosixPath`` would otherwise treat as paths. Tokens
+    # like ``kwargs/fields`` and ``dataclass/function`` (slash but no
+    # extension) also stop here — they're code, not paths.
+    if _PATH_EXTENSION_RE.search(candidate):
         return True
     return candidate in METADATA_FILE_BASENAME_ALLOWLIST
 

--- a/tests/unit/archive/test_tool_path_extraction.py
+++ b/tests/unit/archive/test_tool_path_extraction.py
@@ -1,0 +1,96 @@
+"""Regression coverage for path-extraction heuristics in ToolCall (#1622).
+
+The naive shape filter accepted any token with a slash as a path,
+which surfaced sed expressions, Python attribute access, email
+addresses in angle brackets, and version numbers in
+``ToolCall.affected_paths``. Tighten the filter so non-path tokens
+are rejected up front.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.archive.viewport.models import ToolCall
+from polylogue.archive.viewport.tools import (
+    clean_metadata_path_candidate,
+    clean_path_candidate,
+    looks_like_path_candidate,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/dst_provider_name/!s/provider_name/source_name/g",  # sed expression
+        "s/old/new/g",  # bare sed
+        "!s/foo/bar/",  # negated sed
+    ],
+)
+def test_clean_path_candidate_rejects_sed_substitution(value: str) -> None:
+    assert clean_path_candidate(value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "<noreply@anthropic.com>",
+        "<placeholder>",
+        "{template}",
+    ],
+)
+def test_clean_path_candidate_rejects_angle_brace_wrappers(value: str) -> None:
+    assert clean_path_candidate(value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "4.7",  # version number — `.7` is not an extension shape
+        "<noreply@anthropic.com>",  # rejected upstream by clean_path_candidate
+        "insight.provider_name",  # Python attribute access — long suffix
+        "kwargs/fields",  # slash but no extension
+        "dataclass/function",  # same
+        "/dst_provider_name/!s/provider_name/source_name/g",  # sed
+    ],
+)
+def test_looks_like_path_candidate_rejects_known_false_positives(value: str) -> None:
+    assert not looks_like_path_candidate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/realm/project/polylogue/file.py",
+        "./file.py",
+        "../file.txt",
+        "README.md",
+        "Makefile",
+        "polylogue/archive.py",
+        "data/raw.json",
+        "/etc/hosts",  # absolute, no extension — still a path
+        "~/.local/share/polylogue/polylogue.db",
+    ],
+)
+def test_looks_like_path_candidate_accepts_real_paths(value: str) -> None:
+    assert looks_like_path_candidate(value)
+
+
+def test_tool_call_affected_paths_filters_input_field_junk() -> None:
+    """ToolCall.affected_paths applies the shape filter to input fields too."""
+    call = ToolCall(
+        name="custom-tool",
+        input={
+            "file_path": "4.7",  # model version — not a path
+            "path": "kwargs/fields",  # Python attr — not a path
+            "file": "/realm/project/polylogue/file.py",  # real path
+        },
+    )
+    assert call.affected_paths == ["/realm/project/polylogue/file.py"]
+
+
+def test_clean_metadata_path_candidate_consistency() -> None:
+    """The metadata-path helper composes the cleaner and shape filter."""
+    assert clean_metadata_path_candidate("README.md") == "README.md"
+    assert clean_metadata_path_candidate("kwargs/fields") is None
+    assert clean_metadata_path_candidate("4.7") is None


### PR DESCRIPTION
## Summary

`mcp__polylogue__build_context_pack` and other surfaces consuming `ToolCall.affected_paths` returned junk: model versions (`4.7`), email addresses (`<noreply@anthropic.com>`), sed expressions (`/dst/!s/foo/bar/g`), Python attribute access (`insight.provider_name`), and slash-separated code tokens (`kwargs/fields`, `dataclass/function`). Closes #1622.

## Problem

Two leaks in the path heuristic:

1. **`ToolCall.affected_paths` for input fields skipped `looks_like_path_candidate`.** The four input keys `file_path`/`path`/`file`/`filename` are *usually* paths — but for some tools they hold model versions, prompt template tokens, or other strings. The code used `clean_path_candidate` (which only rejects shell noise) without the shape filter that metadata-path extraction already applies.
2. **`looks_like_path_candidate`'s "any token with a slash is a path" rule.** `kwargs/fields` and `dataclass/function` pass that test. So does any slash-bearing Python expression or URL fragment.

## Solution

Three changes:

- `ToolCall.affected_paths`: switch input-field extraction to `clean_metadata_path_candidate` (same helper the `metadata.path` branch already uses). Input fields and metadata fields are equally subject to non-path content.
- `looks_like_path_candidate`: drop the bare-slash and bare-leading-dot rules. Keep the absolute/relative-prefix rule. Replace "has any suffix" with a stricter extension shape `\.[A-Za-z][A-Za-z0-9]{0,5}$` — leading letter, 1-6 alnum total — which catches real extensions (`.py`, `.md`, `.tsx`, `.yaml`) but rejects digit-only (`.7` in `4.7`) and long-word (`.provider_name`) suffixes.
- `clean_path_candidate`: reject tokens containing `<` or `>` (catches `<noreply@anthropic.com>`, `<placeholder>` family). Reject sed-substitution shapes (`s/.../.../[flags]`, `!s/.../.../`, the leading slash variant) via a dedicated regex — these come through PATH_PATTERN with a leading slash and look absolute.

## Verification

```
$ pytest tests/unit/archive/test_tool_path_extraction.py
23 passed

$ pytest tests/unit/archive/ tests/unit/insights/ tests/unit/mcp/test_context_pack.py
264 passed

$ devtools verify --quick
"exit_code": 0
```

New test file pins five contracts:
- `clean_path_candidate` rejects sed substitutions (`s/.../...`/, `/dst/!s/.../...`/, `!s/.../.../).
- `clean_path_candidate` rejects angle-brace wrappers (`<email>`, `{template}`).
- `looks_like_path_candidate` rejects six representative junk tokens from production data.
- `looks_like_path_candidate` accepts representative real paths (absolute, relative, extension-bearing, allowlist).
- `ToolCall.affected_paths` integration test: an input dict with one real path among two junk tokens returns only the real path.

## Out of scope

The bigger #1622 also flags:
- `total_conversations`/`total_messages`/`total_tool_calls` reporting 0 — separate hydrator issue, fixed by #1636 for the `total_messages` part.
- Empty `unknown` rows in `messages` projection — same root cause as #1617 (claude-code progress events), now fixed by PR #1641.

This PR addresses only the path-extraction half of #1622.

Existing junk values in `action_events.affected_paths` rows will clear on the next materialization pass (`polylogue insights rebuild` or the daemon's debt loop kicking in). Live extractions are clean from this PR forward.