### PR TITLE
fix(daemon): write fts_freshness_state ready rows after startup readiness pass (#1628)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -66,8 +66,8 @@ exceptions:
     reason: "shared operation contracts for ingest/maintenance/mutation/insight aggregation routes (#861, #862, #1134); split candidate: per-domain operation modules under operations/"
 
   - path: polylogue/daemon/cli.py
-    ceiling: 1110
-    reason: "fresh-init FTS readiness race guard (#1603) added 4 lines; split candidate: lift _ensure_fts_startup_readiness_sync into daemon/fts_startup.py"
+    ceiling: 1130
+    reason: "fresh-init FTS readiness race guard (#1603, +4) and post-catchup freshness write (#1628, +15) added lines; split candidate: lift _ensure_fts_startup_readiness_sync and _record_fts_freshness_snapshot_sync into daemon/fts_startup.py"
 
   - path: polylogue/daemon/status.py
     ceiling: 1380

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -97,6 +97,25 @@ def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
     return row is not None
 
 
+def _record_fts_freshness_snapshot_sync(conn: sqlite3.Connection) -> None:
+    """Write per-surface freshness rows after a successful startup readiness pass.
+
+    Without this, the bounded-repair and healthy startup paths leave
+    ``fts_freshness_state`` empty, so ``/healthz/ready`` returns 503
+    indefinitely and ``message_fts_search_readiness_sync`` keeps refusing
+    queries even though triggers + index are intact (#1628).
+    """
+    from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
+    from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
+
+    try:
+        snapshot = fts_invariant_snapshot_sync(conn)
+    except sqlite3.Error:
+        logger.warning("daemon: FTS startup freshness snapshot failed", exc_info=True)
+        return
+    record_fts_invariant_snapshot_sync(conn, snapshot)
+
+
 def _active_fts_triggers_sync(conn: sqlite3.Connection) -> tuple[str, ...]:
     expected: list[str] = []
     if _table_exists_sync(conn, "messages") and _table_exists_sync(conn, "messages_fts"):
@@ -199,6 +218,7 @@ def _ensure_fts_startup_readiness_sync() -> None:
             if not outcome.success:
                 logger.warning("daemon: bounded FTS repair failed after trigger restore: %s", outcome.detail)
                 rebuild_fts_index_sync(conn)
+            _record_fts_freshness_snapshot_sync(conn)
             conn.commit()
             logger.info("daemon: FTS trigger recovery complete.")
             return
@@ -213,6 +233,7 @@ def _ensure_fts_startup_readiness_sync() -> None:
             logger.info("daemon: FTS rebuild complete.")
             return
 
+        _record_fts_freshness_snapshot_sync(conn)
         conn.commit()
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -415,6 +415,11 @@ def test_ensure_fts_startup_readiness_runs_bounded_repair(
         "polylogue.storage.fts.dangling_repair.repair_stale_fts_rows",
         lambda fake_conn: _record_successful_repair(fake_conn, repairs),
     )
+    freshness_calls: list[FakeConnection] = []
+    monkeypatch.setattr(
+        "polylogue.daemon.cli._record_fts_freshness_snapshot_sync",
+        lambda fake_conn: freshness_calls.append(fake_conn),
+    )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
@@ -423,6 +428,9 @@ def test_ensure_fts_startup_readiness_runs_bounded_repair(
     assert repairs == [conn]
     assert conn.committed is True
     assert conn.closed is True
+    # #1628: healthy path must write freshness snapshot so /healthz/ready
+    # stops returning 503 on a fully populated archive.
+    assert freshness_calls == [conn]
 
 
 def test_ensure_fts_startup_readiness_rebuilds_when_bounded_repair_fails(
@@ -669,6 +677,11 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
         "polylogue.storage.fts.dangling_repair.repair_missing_fts_rows",
         lambda fake_conn: SimpleNamespace(success=True, repaired_count=3, detail="repaired"),
     )
+    freshness_calls: list[FakeConnection] = []
+    monkeypatch.setattr(
+        "polylogue.daemon.cli._record_fts_freshness_snapshot_sync",
+        lambda fake_conn: freshness_calls.append(fake_conn),
+    )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
@@ -676,6 +689,8 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
     assert rebuilds == []
     assert conn.committed is True
     assert conn.closed is True
+    # #1628: trigger-recovery path must also write freshness snapshot rows.
+    assert freshness_calls == [conn]
 
 
 def test_periodic_db_optimize_does_not_run_on_startup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/storage/test_fts_trigger_lifecycle.py
+++ b/tests/unit/storage/test_fts_trigger_lifecycle.py
@@ -442,3 +442,149 @@ def test_sigkill_mid_bulk_recovery_via_daemon_startup(tmp_path: Path, monkeypatc
         assert indexed >= 2, f"FTS index not repopulated after recovery: {indexed} rows"
     finally:
         final.close()
+
+
+# ---------------------------------------------------------------------------
+# #1628 — startup must write fts_freshness_state ready rows so /healthz/ready
+# stops returning 503 indefinitely on a fully healthy archive.
+# ---------------------------------------------------------------------------
+
+_FRESHNESS_SURFACES = (
+    "messages_fts",
+    "action_events_fts",
+    "session_work_events_fts",
+    "work_threads_fts",
+)
+
+
+def _freshness_state_rows(conn: sqlite3.Connection) -> dict[str, str]:
+    rows = conn.execute("SELECT surface, state FROM fts_freshness_state").fetchall()
+    return {str(row[0]): str(row[1]) for row in rows}
+
+
+def test_startup_writes_freshness_ready_rows_on_healthy_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1628: a healthy archive must end startup with state=ready rows for every
+    FTS surface so the readiness probe and search gate stop refusing requests.
+
+    Without the fix, ``_ensure_fts_startup_readiness_sync`` takes the bounded-
+    repair path (no missing triggers, no stale rows), commits, and returns
+    without ever writing freshness rows. The probe then reports the surfaces
+    as ``unknown`` indefinitely.
+    """
+    import asyncio
+
+    db_file = tmp_path / "fts_healthy.db"
+    conn = _bootstrap_fts_db(db_file)
+    try:
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (1, "m1", "c1", "alpha bravo"),
+        )
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (2, "m2", "c1", "charlie delta"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    from polylogue.daemon import cli as daemon_cli
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db_file)
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    final = sqlite3.connect(str(db_file))
+    try:
+        rows = _freshness_state_rows(final)
+        for surface in _FRESHNESS_SURFACES:
+            assert rows.get(surface) == "ready", f"startup did not mark {surface} ready; freshness rows={rows}"
+    finally:
+        final.close()
+
+
+def test_startup_writes_freshness_ready_rows_after_sigkill_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1628: the trigger-recovery branch must also write freshness rows.
+
+    Without the fix, the SIGKILL-recovery path commits restored triggers and a
+    bounded missing-row repair but never writes ``fts_freshness_state``, so
+    operators see a healed index that the readiness probe still calls
+    not-ready.
+    """
+    import asyncio
+
+    db_file = tmp_path / "fts_sigkill_freshness.db"
+    conn = _bootstrap_fts_db(db_file)
+    try:
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (1, "m1", "c1", "alpha bravo"),
+        )
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (2, "m2", "c1", "charlie delta"),
+        )
+        conn.commit()
+        suspend_fts_triggers_sync(conn)
+        conn.commit()
+        assert _trigger_names(conn).isdisjoint(_EXPECTED_TRIGGERS)
+    finally:
+        conn.close()
+
+    from polylogue.daemon import cli as daemon_cli
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db_file)
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    final = sqlite3.connect(str(db_file))
+    try:
+        rows = _freshness_state_rows(final)
+        for surface in _FRESHNESS_SURFACES:
+            assert rows.get(surface) == "ready", f"sigkill recovery did not mark {surface} ready; freshness rows={rows}"
+    finally:
+        final.close()
+
+
+def test_startup_freshness_unblocks_search_readiness_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1628: after startup, ``message_fts_search_readiness_sync`` must report
+    ready=True so the FTS search path stops raising
+    ``Search index is incomplete``.
+
+    This is the user-visible regression the freshness write fixes — the
+    readiness gate is what blocked ``mcp__polylogue__search`` and
+    ``polylogue --query`` against a healthy converged archive.
+    """
+    import asyncio
+
+    db_file = tmp_path / "fts_search_gate.db"
+    conn = _bootstrap_fts_db(db_file)
+    try:
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (1, "m1", "c1", "alpha bravo"),
+        )
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (2, "m2", "c1", "charlie delta"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.storage.fts.fts_lifecycle import message_fts_search_readiness_sync
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db_file)
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    final = sqlite3.connect(str(db_file))
+    try:
+        readiness = message_fts_search_readiness_sync(final)
+        assert bool(readiness["ready"]) is True, (
+            f"search readiness still not ready after startup; readiness={dict(readiness)}"
+        )
+    finally:
+        final.close()


### PR DESCRIPTION
## Summary

Wire post-startup freshness-state writes into the daemon's FTS readiness
path so `/healthz/ready` stops returning 503 and search stops being
gated against a perfectly healthy converged archive.

Closes #1628

## Problem

On a converged archive with all 15 FTS triggers present, intact FTS5
index, and zero convergence debt:

- `SELECT count(*) FROM fts_freshness_state` returns 0.
- `/healthz/ready` returns `503 not_ready` with `reason: fts_not_fresh`
  forever.
- `mcp__polylogue__search` and `polylogue --query` refuse with "Search
  index is incomplete. Run `polylogue doctor --repair --target
  dangling_fts`."
- The suggested operator action does not fix it.

Root cause: `_ensure_fts_startup_readiness_sync` calls
`ensure_fts_freshness_table_sync(conn)` (creates the empty table) but
on the two non-rebuild branches — bounded-repair success after trigger
recovery, and the healthy "ensure index + repair stale rows" path —
returns without ever writing a row. Only the full-rebuild branches
write freshness state, via `rebuild_fts_index_sync ->
record_fts_invariant_snapshot_sync`. A normal restart on a healthy
archive therefore never records `state=ready`, and
`fts_readiness_info` correctly reports every surface as unknown.

`freshness_records is None` is the "no table at all" sentinel and lets
the probe optimistically pass; the bug only bites when the table
exists but is empty (`{}`), which is exactly the steady state.

## Solution

Add `_record_fts_freshness_snapshot_sync(conn)` to `daemon/cli.py`. It
calls `fts_invariant_snapshot_sync(conn)` (the same exact-invariant
function used by `fts_readiness_info(exact=True)` and convergence's
post-repair path) and writes the result via
`record_fts_invariant_snapshot_sync` — per-surface, with measured
source/indexed row counts and the proper detail string for any surface
that fails the invariant.

Call sites:

- Trigger-recovery success path (post `repair_missing_fts_rows` OR
  fallback `rebuild_fts_index_sync`). The fallback rebuild also writes
  freshness, but the second snapshot is idempotent (`ON CONFLICT
  DO UPDATE`) and reflects the actual final state.
- Healthy bounded-repair path (post `ensure_fts_index_sync +
  repair_stale_fts_rows`). This was the dominant gap in production —
  one daemon restart on a healthy archive left no freshness rows.

Failures from the snapshot itself (e.g. SQLite OperationalError on a
half-bootstrapped database) are logged and swallowed so startup never
panics on the freshness write.

## Verification

Verification angles considered:

- **Direct behavior** ✓ — `test_startup_writes_freshness_ready_rows_on_healthy_archive`
  asserts all four surfaces (`messages_fts`, `action_events_fts`,
  `session_work_events_fts`, `work_threads_fts`) have `state=ready`
  after the healthy bounded-repair path.
- **Lifecycle / SIGKILL recovery** ✓ —
  `test_startup_writes_freshness_ready_rows_after_sigkill_recovery`
  drops all triggers, simulates process death, calls startup, asserts
  freshness rows are written on the trigger-recovery success branch.
- **Contract / user-visible regression** ✓ —
  `test_startup_freshness_unblocks_search_readiness_gate` calls
  `message_fts_search_readiness_sync` after startup and asserts
  `ready=True`. This is the exact gate that produced "Search index is
  incomplete" in production.
- **Counterfactual** ✓ — covered implicitly by the SIGKILL-recovery
  test: the recovery branch previously committed restored triggers and
  bounded repair, then returned. Asserting `state=ready` rows for all
  four surfaces would have failed before this change.
- **Existing-test compatibility** ✓ — the two `test_daemon_cli.py`
  tests for the bounded-repair and trigger-missing paths get a
  positive assertion that `_record_fts_freshness_snapshot_sync` was
  invoked; this prevents a future edit from quietly removing the
  freshness write again.

Verification angles skipped:

- **Property test** — N/A. The fix is a single deterministic call site;
  there is no shape-of-input invariant to fuzz.
- **Performance / amplification** — `fts_invariant_snapshot_sync` is
  the same function already used per request by `fts_readiness_info(exact=True)`
  and by convergence after every chunk; running it once on daemon
  startup adds no new amplification class.
- **Witness** — N/A. There is no minimizable input that triggers the
  bug; it triggers on any successful startup on a healthy archive.

Commands run:

```
$ nix develop -c pytest tests/unit/storage/test_fts_trigger_lifecycle.py \
    tests/unit/daemon/test_daemon_cli.py \
    tests/unit/storage/test_dangling_fts_derived_surfaces.py \
    tests/unit/daemon/test_health_contract.py \
    tests/unit/daemon/test_health_contracts.py
60 passed in 1.02s

$ nix develop -c devtools verify --quick
exit_code: 0
```

## Notes

- File budget for `polylogue/daemon/cli.py` ticks up from 1110 → 1130
  to accommodate the helper + two call sites. The reason field records
  the future split candidate (#1628 reaffirms the existing #1603
  recommendation to lift the startup FTS readiness logic into
  `daemon/fts_startup.py`).
- The fix is intentionally scoped to startup. The catch-up path
  already writes freshness via `_mark_message_fts_ready_after_targeted_repair`
  per chunk and via `rebuild_fts_index_sync` for full rebuilds. The
  daemon convergence-complete signal is not yet a separate hook; if
  catch-up later moves out of band, an explicit "convergence complete"
  freshness write would replicate this pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved indefinite startup blocking that occurred after data repair operations, ensuring the readiness check completes and search functionality is properly initialized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->