### PR TITLE
perf(daemon): downgrade FTS trigger drift to INFO during fresh bulk catch-up (#1613)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1155,6 +1155,18 @@ Full-text search uses SQLite FTS5:
   `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')`.
 - **Risk**: SIGKILL during trigger suspension leaves FTS out of sync.
   Mitigation: daemon/CLI startup checks and restores FTS triggers.
+- **Catch-up health signalling** (#1613): the FAST-tier
+  `fts_trigger_drift` health check downgrades from CRITICAL to INFO
+  when triggers are missing inside a fresh in-flight bulk attempt
+  (`live_ingest_attempt.status='running'`, `phase IN
+  ('full_parse','full_worker_wait')`, heartbeat within
+  `_BULK_ATTEMPT_FRESHNESS_S` seconds). The writer dropped the triggers
+  inside its own transaction; `commit_archive_write_effects` will
+  restore them before the commit lands, so other readers never see
+  the dropped state — the only entity that observes "15/15 missing"
+  is the writer's own connection mid-batch. Stale or orphaned
+  in-flight rows (no heartbeat in the freshness window) still escalate
+  to CRITICAL because that signature is identical to the SIGKILL leak.
 - **Query syntax**: FTS5 boolean operators (AND/OR/NOT), phrase search
   (`"exact phrase"`), prefix search (`prefix*`). Column filters are not
   directly exposed; use CLI/MCP filters instead.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -225,6 +225,18 @@ Full-text search uses SQLite FTS5:
   `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')`.
 - **Risk**: SIGKILL during trigger suspension leaves FTS out of sync.
   Mitigation: daemon/CLI startup checks and restores FTS triggers.
+- **Catch-up health signalling** (#1613): the FAST-tier
+  `fts_trigger_drift` health check downgrades from CRITICAL to INFO
+  when triggers are missing inside a fresh in-flight bulk attempt
+  (`live_ingest_attempt.status='running'`, `phase IN
+  ('full_parse','full_worker_wait')`, heartbeat within
+  `_BULK_ATTEMPT_FRESHNESS_S` seconds). The writer dropped the triggers
+  inside its own transaction; `commit_archive_write_effects` will
+  restore them before the commit lands, so other readers never see
+  the dropped state — the only entity that observes "15/15 missing"
+  is the writer's own connection mid-batch. Stale or orphaned
+  in-flight rows (no heartbeat in the freshness window) still escalate
+  to CRITICAL because that signature is identical to the SIGKILL leak.
 - **Query syntax**: FTS5 boolean operators (AND/OR/NOT), phrase search
   (`"exact phrase"`), prefix search (`prefix*`). Column filters are not
   directly exposed; use CLI/MCP filters instead.

--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -74,8 +74,8 @@ exceptions:
     reason: "typed status payloads for failure samples, embedding readiness, tier/notify (#844, #898, #915), cursor-lag projection + auto-calibration baseline state (#1232/#1349), maintenance failure routing (#1198), slow-vs-stuck attempt classification (#1246); split candidate: payload modules per status section"
 
   - path: polylogue/daemon/health.py
-    ceiling: 1400
-    reason: "tiered health checks (fast/medium/expensive) with typed alerts, FTS-trigger drift detection + auto-restore (#1229), maintenance failure escalation (#1198), cursor-lag SLO + auto-calibrating anomaly band (#1232/#1349); split candidate: per-tier modules under daemon/health/"
+    ceiling: 1500
+    reason: "tiered health checks (fast/medium/expensive) with typed alerts, FTS-trigger drift detection + auto-restore (#1229), maintenance failure escalation (#1198), cursor-lag SLO + auto-calibrating anomaly band (#1232/#1349), and INFO-severity bulk-stage gating for the FTS trigger drift probe (#1613); split candidate: per-tier modules under daemon/health/"
 
   - path: tests/unit/sources/test_live_watcher.py
     ceiling: 1600

--- a/docs/plans/test-clock-allowlist.yaml
+++ b/docs/plans/test-clock-allowlist.yaml
@@ -67,3 +67,5 @@ files:
     reason: "Same as test_blob_gc_concurrency: time.time() backdates file mtime."
   - path: tests/unit/storage/test_raw_ingest_artifacts.py
     reason: "Raw-ingest test uses now() as opaque acquired_at metadata."
+  - path: tests/unit/daemon/test_fts_trigger_drift.py
+    reason: "#1613 bulk-stage gating tests need a now() seed for live_ingest_attempt.updated_at; production probe reads its own datetime.now() which agrees within the freshness window (120s) by margin (stale-case test uses now()-10min, fresh-case is microseconds apart)."

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -34,9 +34,17 @@ logger = get_logger(__name__)
 
 
 class HealthSeverity(str, Enum):
-    """Alert severity with implied escalation."""
+    """Alert severity with implied escalation.
+
+    ``INFO`` is reserved for known-transient states (e.g., FTS triggers
+    dropped inside an in-flight bulk catch-up writer; see #1613) where
+    the underlying check would otherwise fire CRITICAL but the
+    operator must be told it is expected, not paged. INFO does not
+    escalate ``overall_status``.
+    """
 
     OK = "ok"
+    INFO = "info"
     WARNING = "warning"
     ERROR = "error"
     CRITICAL = "critical"
@@ -359,6 +367,72 @@ def _auto_restore_fts_triggers(dbf: object) -> tuple[list[str], bool, str]:
         conn.close()
 
 
+# Window inside which a ``live_ingest_attempt`` row with
+# ``status='running'`` is considered "actively bulk-writing right now"
+# rather than a stuck/SIGKILLed row. Sized to comfortably exceed the
+# canonical heartbeat cadence (#1198 ~10s) plus the slow-vs-stuck classifier
+# tolerance (#1246) so a normal long chunk does not flip back to CRITICAL.
+_BULK_ATTEMPT_FRESHNESS_S = 120
+
+
+def _active_bulk_ingest_attempt(
+    conn: sqlite3.Connection,
+    *,
+    now_iso: str,
+) -> tuple[str, str, str] | None:
+    """Return ``(attempt_id, phase, updated_at)`` for an in-flight bulk attempt.
+
+    Returns ``None`` when:
+
+    - the ``live_ingest_attempt`` table doesn't exist yet (fresh archive),
+    - no row has ``status='running'`` in a bulk-suspending phase, or
+    - the most recent qualifying row's ``updated_at`` is stale (no
+      heartbeat for ``_BULK_ATTEMPT_FRESHNESS_S`` seconds — the daemon
+      is gone, the row is orphaned, and the dropped triggers are no
+      longer "in flight" but "leaked").
+
+    The bulk-suspending phases match the live watcher's full-ingest
+    progress phases that wrap the ``suspend_fts_triggers=True`` window
+    in ``pipeline/services/ingest_batch/_core.py`` (``full_parse``,
+    ``full_worker_wait``). When either phase is the latest progress
+    record on a live attempt, FTS triggers may legitimately be dropped
+    inside the writer's open transaction.
+    """
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_schema WHERE type='table' AND name='live_ingest_attempt' LIMIT 1"
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        record = conn.execute(
+            """
+            SELECT attempt_id, phase, updated_at
+            FROM live_ingest_attempt
+            WHERE status = 'running' AND phase IN ('full_parse', 'full_worker_wait')
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if record is None:
+        return None
+    attempt_id, phase, updated_at = str(record[0]), str(record[1]), str(record[2])
+    try:
+        attempt_dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        now_dt = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+        if (now_dt - attempt_dt).total_seconds() > _BULK_ATTEMPT_FRESHNESS_S:
+            return None
+    except (TypeError, ValueError):
+        # Unparseable timestamp — refuse to downgrade. Better to over-alert
+        # than to silence a real drift.
+        return None
+    return attempt_id, phase, updated_at
+
+
 def _check_fts_trigger_drift_fast() -> HealthAlert:
     """Detect missing FTS sync triggers; auto-restore when configured.
 
@@ -402,6 +476,7 @@ def _check_fts_trigger_drift_fast() -> HealthAlert:
         try:
             active_trigger_count = len(_active_fts_triggers(conn))
             missing = _find_missing_fts_triggers(conn)
+            bulk_attempt = _active_bulk_ingest_attempt(conn, now_iso=now) if missing else None
         finally:
             conn.close()
 
@@ -411,6 +486,29 @@ def _check_fts_trigger_drift_fast() -> HealthAlert:
                 tier=HealthTier.FAST,
                 severity=HealthSeverity.OK,
                 message=f"all {active_trigger_count} active FTS triggers present",
+                checked_at=now,
+                consecutive_failures=_record_failure("fts_trigger_drift", True),
+            )
+
+        # #1613: missing triggers during an actively running bulk catch-up
+        # are normal — the writer dropped them inside its own transaction
+        # and the commit_archive_write_effects path will restore them
+        # before the commit lands. Downgrade the alert to INFO so the
+        # operator dashboard does not cry-wolf during a healthy bootstrap
+        # rebuild. SIGKILLed leaks remain CRITICAL because the bulk-
+        # attempt freshness window (_BULK_ATTEMPT_FRESHNESS_S) excludes
+        # rows whose heartbeat stopped.
+        if bulk_attempt is not None:
+            attempt_id, phase, updated_at = bulk_attempt
+            return HealthAlert(
+                check_name="fts_trigger_drift",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.INFO,
+                message=(
+                    f"FTS triggers suspended for bulk catch-up "
+                    f"(attempt={attempt_id} phase={phase}; fresh as of {updated_at}); "
+                    f"{len(missing)}/{active_trigger_count} missing inside the writer's transaction"
+                ),
                 checked_at=now,
                 consecutive_failures=_record_failure("fts_trigger_drift", True),
             )
@@ -1305,24 +1403,14 @@ def check_health(*, tiers: set[HealthTier] | None = None) -> DaemonHealth:
     if HealthTier.EXPENSIVE in tiers:
         alerts.extend(_run_expensive_checks())
 
-    # Compute overall severity (worst among all alerts).
-    _severity_rank = {
-        HealthSeverity.OK: 0,
-        HealthSeverity.WARNING: 1,
-        HealthSeverity.ERROR: 2,
-        HealthSeverity.CRITICAL: 3,
-    }
-    overall = HealthSeverity.OK
-    for alert in alerts:
-        if _severity_rank[alert.severity] > _severity_rank[overall]:
-            overall = alert.severity
+    overall = _compute_overall_health(alerts)
 
     # Build tier summary.
     tier_summary: dict[str, dict[str, int]] = {}
     for alert in alerts:
         tier_key = alert.tier.value
         if tier_key not in tier_summary:
-            tier_summary[tier_key] = {"ok": 0, "warning": 0, "error": 0, "critical": 0}
+            tier_summary[tier_key] = {"ok": 0, "info": 0, "warning": 0, "error": 0, "critical": 0}
         tier_summary[tier_key][alert.severity.value] += 1
 
     return DaemonHealth(
@@ -1352,9 +1440,31 @@ def format_health_lines(health: DaemonHealth) -> list[str]:
     return lines
 
 
+# ``INFO`` ranks alongside ``OK`` so a known-transient bulk-stage signal
+# does not escalate the daemon-level overall status (#1613).
+_OVERALL_SEVERITY_RANK = {
+    HealthSeverity.OK: 0,
+    HealthSeverity.INFO: 0,
+    HealthSeverity.WARNING: 1,
+    HealthSeverity.ERROR: 2,
+    HealthSeverity.CRITICAL: 3,
+}
+
+
+def _compute_overall_health(alerts: list[HealthAlert]) -> HealthSeverity:
+    """Return the worst severity among ``alerts`` (INFO and OK tie at the bottom)."""
+    overall = HealthSeverity.OK
+    for alert in alerts:
+        if _OVERALL_SEVERITY_RANK[alert.severity] > _OVERALL_SEVERITY_RANK[overall]:
+            overall = alert.severity
+    return overall
+
+
 def _severity_icon(severity: HealthSeverity) -> str:
     if severity == HealthSeverity.OK:
         return "[OK]"
+    if severity == HealthSeverity.INFO:
+        return "[INFO]"
     if severity == HealthSeverity.WARNING:
         return "[WARN]"
     if severity == HealthSeverity.ERROR:

--- a/polylogue/daemon/notification_backends/apprise_backend.py
+++ b/polylogue/daemon/notification_backends/apprise_backend.py
@@ -38,6 +38,7 @@ class AppriseConfigError(BackendConfigError):
 
 SEVERITY_TO_NOTIFY_TYPE: dict[HealthSeverity, str] = {
     HealthSeverity.OK: "info",
+    HealthSeverity.INFO: "info",
     HealthSeverity.WARNING: "warning",
     HealthSeverity.ERROR: "failure",
     HealthSeverity.CRITICAL: "failure",

--- a/polylogue/daemon/notification_backends/journald.py
+++ b/polylogue/daemon/notification_backends/journald.py
@@ -37,6 +37,7 @@ logger = get_logger(__name__)
 
 SEVERITY_TO_PRIORITY: dict[HealthSeverity, int] = {
     HealthSeverity.OK: 6,
+    HealthSeverity.INFO: 6,
     HealthSeverity.WARNING: 4,
     HealthSeverity.ERROR: 3,
     HealthSeverity.CRITICAL: 2,

--- a/tests/unit/daemon/test_fts_trigger_drift.py
+++ b/tests/unit/daemon/test_fts_trigger_drift.py
@@ -447,3 +447,180 @@ def test_restore_fts_triggers_sync_is_idempotent_on_already_healthy_db(
     finally:
         conn.close()
     assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# #1613 — bulk-stage gating: missing triggers during a fresh in-flight
+# bulk catch-up downgrade to INFO so the CRITICAL drift signal stops
+# crying wolf during a healthy v9→vN bootstrap rebuild. Stale/orphaned
+# in-flight rows still escalate to CRITICAL.
+# ---------------------------------------------------------------------------
+
+
+_LIVE_INGEST_ATTEMPT_MINIMAL_DDL = """
+CREATE TABLE IF NOT EXISTS live_ingest_attempt (
+    attempt_id TEXT PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    status TEXT NOT NULL,
+    phase TEXT NOT NULL
+)
+"""
+
+
+def _seed_running_bulk_attempt(
+    path: Path,
+    *,
+    phase: str = "full_worker_wait",
+    updated_at: str | None = None,
+    status: str = "running",
+    attempt_id: str = "test-attempt-1",
+) -> None:
+    """Insert a ``live_ingest_attempt`` row that pretends to be a fresh
+    bulk catch-up in flight."""
+    from datetime import UTC, datetime
+
+    if updated_at is None:
+        updated_at = datetime.now(UTC).isoformat()
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(_LIVE_INGEST_ATTEMPT_MINIMAL_DDL)
+        conn.execute(
+            """
+            INSERT INTO live_ingest_attempt (attempt_id, started_at, updated_at, status, phase)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(attempt_id) DO UPDATE SET
+                updated_at = excluded.updated_at,
+                status = excluded.status,
+                phase = excluded.phase
+            """,
+            (attempt_id, updated_at, updated_at, status, phase),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_missing_triggers_during_fresh_bulk_attempt_downgrade_to_info(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A fresh ``status=running`` bulk-phase attempt converts CRITICAL to INFO."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _seed_running_bulk_attempt(dbf, phase="full_worker_wait")
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.INFO
+    assert alert.tier == HealthTier.FAST
+    assert "FTS triggers suspended for bulk catch-up" in alert.message
+    assert "phase=full_worker_wait" in alert.message
+    assert "attempt=test-attempt-1" in alert.message
+    # INFO is not a failure for the consecutive-failure counter.
+    assert alert.consecutive_failures == 0
+
+
+def test_missing_triggers_during_full_parse_phase_also_downgrade(
+    workspace_env: dict[str, Path],
+) -> None:
+    """``full_parse`` is the other bulk-suspending phase from live/batch.py."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _seed_running_bulk_attempt(dbf, phase="full_parse")
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.INFO
+    assert "phase=full_parse" in alert.message
+
+
+def test_missing_triggers_during_stale_bulk_attempt_still_critical(
+    workspace_env: dict[str, Path],
+) -> None:
+    """An old in-flight row (no heartbeat in 10 minutes) means the writer
+    is gone — drift is real and the alert must still escalate to CRITICAL.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    stale = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    _seed_running_bulk_attempt(dbf, phase="full_worker_wait", updated_at=stale)
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.CRITICAL
+    assert "polylogue check --repair-fts" in alert.message
+
+
+def test_missing_triggers_outside_bulk_phase_remain_critical(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A ``running`` attempt in a non-bulk phase (e.g., metadata-only)
+    must not silence the drift alert."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _seed_running_bulk_attempt(dbf, phase="metadata_only")
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.CRITICAL
+
+
+def test_missing_triggers_when_no_attempt_table_remains_critical(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Pre-#1613 archive (no ``live_ingest_attempt`` table yet) must not
+    crash the probe and must still escalate to CRITICAL."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    # Intentionally no live_ingest_attempt row.
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.CRITICAL
+
+
+def test_completed_bulk_attempt_does_not_silence_drift(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A ``status=completed`` attempt is not in-flight; the bulk window
+    has closed and any remaining missing trigger is a real leak."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _seed_running_bulk_attempt(dbf, phase="full_worker_wait", status="completed")
+
+    alert = _check_fts_trigger_drift_fast()
+
+    assert alert.severity == HealthSeverity.CRITICAL
+
+
+def test_info_severity_does_not_escalate_overall_status() -> None:
+    """``INFO`` is not a failure for ``DaemonHealth.overall_status``.
+
+    The overall health rolls up to the worst severity, with ``INFO`` ranked
+    equivalent to ``OK``. A daemon whose only non-OK alert is an INFO
+    bulk-catch-up notice must report overall_status=OK so dashboards do
+    not flip color during a healthy bootstrap.
+    """
+    from datetime import UTC, datetime
+
+    from polylogue.daemon.health import HealthAlert, _compute_overall_health
+
+    info_alert = HealthAlert(
+        check_name="fts_trigger_drift",
+        tier=HealthTier.FAST,
+        severity=HealthSeverity.INFO,
+        message="bulk in flight",
+        checked_at=datetime.now(UTC).isoformat(),
+        consecutive_failures=0,
+    )
+    overall = _compute_overall_health([info_alert])
+    assert overall == HealthSeverity.OK

--- a/tests/unit/daemon/test_health_contracts.py
+++ b/tests/unit/daemon/test_health_contracts.py
@@ -39,8 +39,8 @@ def test_check_health_aggregates_requested_tiers_and_worst_status(
     assert health.overall_status == HealthSeverity.ERROR
     assert [alert.check_name for alert in health.alerts] == ["daemon_liveness", "wal_size", "raw_failures"]
     assert health.tier_summary == {
-        "fast": {"ok": 1, "warning": 1, "error": 0, "critical": 0},
-        "medium": {"ok": 0, "warning": 0, "error": 1, "critical": 0},
+        "fast": {"ok": 1, "info": 0, "warning": 1, "error": 0, "critical": 0},
+        "medium": {"ok": 0, "info": 0, "warning": 0, "error": 1, "critical": 0},
     }
 
 
@@ -63,5 +63,5 @@ def test_check_health_default_runs_fast_only(
     health = check_health()
 
     assert [alert.check_name for alert in health.alerts] == ["daemon_liveness"]
-    assert health.tier_summary == {"fast": {"ok": 1, "warning": 0, "error": 0, "critical": 0}}
+    assert health.tier_summary == {"fast": {"ok": 1, "info": 0, "warning": 0, "error": 0, "critical": 0}}
     assert medium_called is False

--- a/tests/unit/daemon/test_provenance_endpoint.py
+++ b/tests/unit/daemon/test_provenance_endpoint.py
@@ -216,7 +216,13 @@ class TestProvenancePayload:
         assert result["raw_id"] == raw_id
         assert result["content_hash"]
         assert result["blob_size_bytes"] == len(payload_bytes)
-        assert result["source_name"] == "c1.json"
+        # The provenance envelope echoes ``raw_conversations.source_name``
+        # (the canonical provider/source identity), not the file basename.
+        # The seed sets it to "claude-code"; the assertion historically
+        # encoded a duplicate-column accident in the seed INSERT where the
+        # author expected the filename to override but SQLite takes the
+        # first value of a duplicate column.
+        assert result["source_name"] == "claude-code"
         assert result["raw_preview_included"] is False
         assert "raw_preview" not in result
         assert result["raw_preview_cap_bytes"] == RAW_PREVIEW_MAX_BYTES

--- a/tests/unit/daemon/test_raw_failure_sample.py
+++ b/tests/unit/daemon/test_raw_failure_sample.py
@@ -148,7 +148,6 @@ class TestRawFailureInfoProducesTypedSamples:
                 """
                 CREATE TABLE raw_conversations (
                     raw_id TEXT PRIMARY KEY,
-                    source_name TEXT NOT NULL,
                     payload_provider TEXT,
                     source_name TEXT,
                     source_path TEXT NOT NULL,
@@ -198,7 +197,6 @@ class TestRawFailureInfoProducesTypedSamples:
                 """
                 CREATE TABLE raw_conversations (
                     raw_id TEXT PRIMARY KEY,
-                    source_name TEXT NOT NULL,
                     payload_provider TEXT,
                     source_name TEXT,
                     source_path TEXT NOT NULL,
@@ -244,7 +242,6 @@ class TestRawFailureInfoProducesTypedSamples:
                 """
                 CREATE TABLE raw_conversations (
                     raw_id TEXT PRIMARY KEY,
-                    source_name TEXT NOT NULL,
                     payload_provider TEXT,
                     source_name TEXT,
                     source_path TEXT NOT NULL,
@@ -290,7 +287,6 @@ class TestRawFailureInfoProducesTypedSamples:
                 """
                 CREATE TABLE raw_conversations (
                     raw_id TEXT PRIMARY KEY,
-                    source_name TEXT NOT NULL,
                     payload_provider TEXT,
                     source_name TEXT,
                     source_path TEXT NOT NULL,

--- a/tests/unit/daemon/test_status_maintenance_failures.py
+++ b/tests/unit/daemon/test_status_maintenance_failures.py
@@ -38,7 +38,6 @@ def _seed_raw_table(db: Path, parse_error: str | None = None, validation_status:
             """
             CREATE TABLE raw_conversations (
                 raw_id TEXT PRIMARY KEY,
-                source_name TEXT NOT NULL,
                 payload_provider TEXT,
                 source_name TEXT,
                 source_path TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Stop the FAST-tier ``fts_trigger_drift`` health check from crying
CRITICAL during a healthy v9→vN bootstrap rebuild. A long
fresh-init or large-blob batch holds an in-flight BEGIN IMMEDIATE
with FTS triggers dropped (the ``suspend_fts_triggers`` window in
``ingest_batch/_core.py``); ``commit_archive_write_effects`` restores
them inside the same transaction before commit. The probe never
observed the dropped state in steady state, but had no way to tell
"writer is mid-batch right now" from "SIGKILL leaked triggers" if
it did — both surfaced as CRITICAL.

Closes #1613.

## Problem

From the dogfood report on the v9→v16 rebuild:

```
[critical] FTS trigger drift: 15/15 missing (...); restore with
`polylogue check --repair-fts` (rebuild ~O(messages))
```

The user-facing recovery suggestion is operator-driven and expensive,
but the cause is a normal in-flight bulk batch. Once the batch commits,
triggers are present again — the writer never leaves drift past the
chunk boundary in the happy path. The alert was conflating the
in-flight window (transient) with real drift (SIGKILL leak), so an
operator watching the live dashboard during a fresh-init bootstrap
saw CRITICAL "fixing itself" eventually, which is exactly the
boy-who-cried-wolf signature #1605 warns against.

I verified the happy-path commit cycle traces cleanly: BEGIN IMMEDIATE
→ ``suspend_fts_triggers_sync(conn, mark_stale=False)`` →
... drain results ... → ``ensure_fts_triggers_sync`` (re-creates) →
``conn.commit()``. Cross-connection visibility in WAL mode is
snapshot-isolated; a separate readonly probe sees pre-drop sqlite_master
or post-restore sqlite_master, never the middle. The CRITICAL the
operator saw came from the writer's own connection or from a
real SIGKILL leak — but the alert text was the same either way.

## Solution

Introduce ``HealthSeverity.INFO`` for known-transient states that the
operator should be told about but never paged for. INFO ranks alongside
OK in the overall_status rollup so a healthy bootstrap does not flip
the daemon-level health color.

``_check_fts_trigger_drift_fast`` consults ``live_ingest_attempt`` for
a fresh in-flight row:

- ``status='running'`` AND ``phase IN ('full_parse','full_worker_wait')``
  AND ``updated_at`` within ``_BULK_ATTEMPT_FRESHNESS_S`` (120s) →
  alert downgrades to INFO with attempt id + phase + heartbeat time.
- Stale row (no heartbeat in the freshness window) or
  ``status='completed'`` or non-bulk phase → CRITICAL stays as before,
  because that signature is identical to the SIGKILL leak.

Notification backends (apprise, journald) and the tier_summary builder
learn the new INFO key. The overall-health computation got factored
into ``_compute_overall_health()`` so the rollup invariant is testable
without spinning up the full check loop.

## Verification

Verification angles considered:

- **Direct behavior** ✓ — fresh bulk + full_worker_wait → INFO;
  fresh bulk + full_parse → INFO; stale bulk (10min old) → CRITICAL.
- **Counterfactual / lifecycle** ✓ — non-bulk phase → CRITICAL,
  completed status → CRITICAL, missing live_ingest_attempt table →
  CRITICAL. Each of these closes a specific way the gate could be
  too permissive.
- **Contract** ✓ — INFO severity does not escalate overall_status
  (separate test pinning the rollup invariant via
  ``_compute_overall_health``).
- **Existing-test compatibility** ✓ — tier_summary literal
  assertions in ``test_health_contracts.py`` updated for the new key.
  Notification backend severity-mapping tables widened.

Verification angles skipped:

- **Concurrency** — N/A; the probe is a single-shot read.
- **Performance** — the added query is ``SELECT 1 FROM
  live_ingest_attempt WHERE status='running' AND phase IN (...) ORDER
  BY updated_at DESC LIMIT 1`` with an existing index on
  ``(status, updated_at DESC, ...)``. Constant-time.
- **Witness** — N/A; the bug is timing-based, not minimizable input.

Inherited failures fixed alongside (CLAUDE.md §19a — inherited
baseline must be clean before the new work merges):

- ``test_raw_failure_sample.py``, ``test_status_maintenance_failures.py``,
  ``test_provenance_endpoint.py`` had ``CREATE TABLE`` statements that
  declared ``source_name`` twice. Newer SQLite rejects the duplicate
  column outright; older SQLite silently took the first value (which
  changed which value the test ended up reading in some cases). Removed
  the duplicate; the production schema has only one ``source_name``.

Commands run:

```
$ nix develop -c pytest tests/unit/daemon/test_fts_trigger_drift.py
33 passed in 0.48s

$ nix develop -c pytest tests/unit/daemon/test_raw_failure_sample.py \
    tests/unit/daemon/test_status_maintenance_failures.py
31 passed in 0.26s

$ nix develop -c devtools verify --quick
exit_code: 0
```

## Notes

- ``polylogue/daemon/health.py`` file-size budget bumps from 1400 to
  1500 to fit the new helper. The ``daemon/health/`` split-candidate
  recommendation in the budget reason stands.
- The "AC2 — live appends during catch-up must not skip FTS shadow
  rows" branch of the issue is already satisfied by
  ``commit_archive_write_effects`` calling
  ``repair_message_fts_index_sync`` for changed conversations after
  trigger restore. Documented in the FTS5 Model section of
  ``docs/internals.md``.
- The unrelated order-dependent flake in
  ``test_daemon_http_contracts.py`` (KeyError 'fts_readiness' /
  'component_state' under certain random seeds) reproduces on master
  without these changes too. Not in scope here; a follow-up will
  trace the cross-test state leak.