### PR TITLE
perf(insights): emit progress per table during full session-insight rebuild

### DIFF
--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -653,6 +653,28 @@ def _refresh_thread_roots_sync(
     return len(normalized_root_ids)
 
 
+def _delete_tables_with_progress_sync(
+    conn: sqlite3.Connection,
+    *,
+    tables: Sequence[str],
+    progress_callback: ProgressCallback | None,
+) -> None:
+    """Delete every row in ``tables`` while emitting one progress event per table.
+
+    The progress event's ``desc`` names the table so an operator log can tell
+    "stuck on session_work_events" from "stuck on session_profiles". The
+    ``amount`` argument is the number of rows deleted; callers that only care
+    about table-step granularity can ignore it.
+    """
+    for table in tables:
+        deleted = conn.execute(f"DELETE FROM {table}").rowcount
+        if progress_callback is not None:
+            progress_callback(
+                int(max(deleted, 0)),
+                desc=f"rebuild: cleared {table}",
+            )
+
+
 def rebuild_session_insights_sync(
     conn: sqlite3.Connection,
     *,
@@ -664,13 +686,28 @@ def rebuild_session_insights_sync(
     conversation_chunks: Iterable[Sequence[str]]
     previous_profile_groups: set[tuple[str, str]] = set()
     if conversation_ids is None:
-        conn.execute("DELETE FROM session_work_events")
-        conn.execute("DELETE FROM session_phases")
-        conn.execute("DELETE FROM session_latency_profiles")
-        conn.execute("DELETE FROM session_profiles")
-        conn.execute("DELETE FROM session_tag_rollups")
-        conn.execute("DELETE FROM conversation_repo_observations")
-        conn.execute("DELETE FROM repo_identities")
+        # #1607: the seven DELETEs hold the write lock for seconds-to-minutes
+        # at archive scale and were previously silent. Emit a progress
+        # heartbeat per table so the operator sees forward motion instead
+        # of "polylogue qa --rebuild-insights" hanging with no output.
+        # The full rebuild stays inside one transaction (the implicit tx
+        # started by the first DELETE spans every subsequent DML through
+        # the final ``conn.commit()`` at the bottom of this function), so
+        # a SIGKILL mid-rebuild rolls the WAL back to the prior state on
+        # the next open — the prior insights are intact, not emptied.
+        _delete_tables_with_progress_sync(
+            conn,
+            tables=(
+                "session_work_events",
+                "session_phases",
+                "session_latency_profiles",
+                "session_profiles",
+                "session_tag_rollups",
+                "conversation_repo_observations",
+                "repo_identities",
+            ),
+            progress_callback=progress_callback,
+        )
         conversation_chunks = iter_conversation_id_pages_sync(conn, page_size=page_size)
     else:
         conversation_ids = tuple(dict.fromkeys(str(conversation_id) for conversation_id in conversation_ids))
@@ -821,13 +858,23 @@ async def rebuild_session_insights_async(
     )
 
     if conversation_ids is None:
-        await conn.execute("DELETE FROM session_work_events")
-        await conn.execute("DELETE FROM session_phases")
-        await conn.execute("DELETE FROM session_latency_profiles")
-        await conn.execute("DELETE FROM session_profiles")
-        await conn.execute("DELETE FROM session_tag_rollups")
-        await conn.execute("DELETE FROM conversation_repo_observations")
-        await conn.execute("DELETE FROM repo_identities")
+        # See _delete_tables_with_progress_sync for the sync analogue and
+        # the #1607 context. The implicit transaction spans every DML
+        # through the eventual COMMIT, so SIGKILL mid-rebuild rolls back
+        # to prior state on next open.
+        for table in (
+            "session_work_events",
+            "session_phases",
+            "session_latency_profiles",
+            "session_profiles",
+            "session_tag_rollups",
+            "conversation_repo_observations",
+            "repo_identities",
+        ):
+            cursor = await conn.execute(f"DELETE FROM {table}")
+            if progress_callback is not None:
+                rowcount = getattr(cursor, "rowcount", 0) or 0
+                progress_callback(int(rowcount if rowcount > 0 else 0), desc=f"rebuild: cleared {table}")
     elif not conversation_ids:
         await conn.execute("DELETE FROM work_threads")
         await conn.execute("DELETE FROM session_phases")

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -712,9 +712,22 @@ def test_session_insight_rebuild_sync_reports_progress(cli_workspace: CliWorkspa
             progress_total=2,
         )
 
-    assert observed == [
+    # The full-rebuild path now also emits a "rebuild: cleared <table>"
+    # event per DELETE before the chunk-level Materializing events (#1607).
+    materialize_events = [event for event in observed if event[1] and event[1].startswith("Materializing:")]
+    assert materialize_events == [
         (1, "Materializing: 1/2"),
         (1, "Materializing: 2/2"),
+    ]
+    cleared_events = [event for event in observed if event[1] and event[1].startswith("rebuild: cleared ")]
+    assert [desc for _, desc in cleared_events] == [
+        "rebuild: cleared session_work_events",
+        "rebuild: cleared session_phases",
+        "rebuild: cleared session_latency_profiles",
+        "rebuild: cleared session_profiles",
+        "rebuild: cleared session_tag_rollups",
+        "rebuild: cleared conversation_repo_observations",
+        "rebuild: cleared repo_identities",
     ]
 
 

--- a/tests/unit/storage/test_dead_schema_sweep.py
+++ b/tests/unit/storage/test_dead_schema_sweep.py
@@ -42,7 +42,7 @@ def fresh_schema_db() -> Generator[Mapping[str, sqlite3.Connection], None, None]
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_14() -> None:
+def test_schema_version_is_16() -> None:
     # Bumped from 3 → 4 by #1241 (action_events_fts external-content),
     # then 4 → 5 by #1252 (first-class attachment native identifiers
     # + upload_origin column for the #1199 attachment library), then
@@ -54,8 +54,9 @@ def test_schema_version_is_14() -> None:
     # cross-source repo identity surface for slice C of #864), then
     # 8 → 9 by #1486 (provider-event payload split and content-block
     # canonical message body storage), then 13 → 14 by #1511
-    # (session_work_events.kind renamed to heuristic_label).
-    assert SCHEMA_VERSION == 14
+    # (session_work_events.kind renamed to heuristic_label). Bumped to
+    # 16 by subsequent schema-touching PRs.
+    assert SCHEMA_VERSION == 16
 
 
 def test_content_blocks_table_has_no_media_type_column(fresh_schema_db: Mapping[str, sqlite3.Connection]) -> None:

--- a/tests/unit/storage/test_query_mappers.py
+++ b/tests/unit/storage/test_query_mappers.py
@@ -273,5 +273,4 @@ class TestRowToRawConversation:
         result = _row_to_raw_conversation(row)
         assert isinstance(result, RawConversationRecord)
         assert result.raw_id == "sha256hash"
-        assert result.source_name == "chatgpt"
         assert result.source_name == "inbox"

--- a/tests/unit/storage/test_session_insight_rebuild_progress.py
+++ b/tests/unit/storage/test_session_insight_rebuild_progress.py
@@ -1,0 +1,196 @@
+"""Progress reporting + atomicity invariants for ``rebuild_session_insights_sync`` (#1607).
+
+Pins two contracts:
+
+1. The seven DELETEs that open a full rebuild emit a progress event per
+   table (instead of running silently for seconds-to-minutes against
+   the production-scale insight tables). Operators tailing the log see
+   forward motion at table granularity, not "stuck at start".
+
+2. The full rebuild runs as a single transaction — the implicit
+   transaction started by the first DELETE spans every subsequent DML
+   through the eventual ``conn.commit()``. A SIGKILL or unraised
+   exception before COMMIT must leave the prior insights intact rather
+   than emptying the archive.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.insights.session.rebuild import (
+    _delete_tables_with_progress_sync,
+    rebuild_session_insights_sync,
+)
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _seed_insight_tables(conn: sqlite3.Connection, conversation_id: str = "conv-1") -> None:
+    """Populate a couple of insight rows so DELETEs have something to clear."""
+    conn.execute(
+        """
+        INSERT INTO session_profiles (conversation_id, logical_conversation_id, provider_name,
+            session_date, first_message_at, last_message_at, message_count, user_message_count,
+            assistant_message_count, total_words, total_tool_use, total_thinking, total_paste,
+            heuristic_label, primary_topic_tag)
+        VALUES (?, ?, 'claude-code', '2026-03-01', '2026-03-01T10:00:00+00:00',
+            '2026-03-01T10:05:00+00:00', 2, 1, 1, 10, 0, 0, 0, 'idle', NULL)
+        """,
+        (conversation_id, conversation_id),
+    )
+    conn.commit()
+
+
+def _count_profiles(db_path: Path) -> int:
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()
+        return int(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Progress reporting
+# ---------------------------------------------------------------------------
+
+
+def test_delete_tables_with_progress_emits_one_event_per_table(tmp_path: Path) -> None:
+    """The helper that wraps the seven DELETEs must emit a progress event
+    per table so the operator sees forward motion at table granularity."""
+    db_path = tmp_path / "polylogue.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("CREATE TABLE a (id INT)")
+        conn.execute("CREATE TABLE b (id INT)")
+        conn.execute("CREATE TABLE c (id INT)")
+        conn.execute("INSERT INTO a VALUES (1), (2), (3)")
+        conn.execute("INSERT INTO b VALUES (1)")
+        # c stays empty
+        conn.commit()
+
+        events: list[tuple[int, str | None]] = []
+
+        def progress(amount: int, desc: str | None = None) -> None:
+            events.append((amount, desc))
+
+        _delete_tables_with_progress_sync(
+            conn,
+            tables=("a", "b", "c"),
+            progress_callback=progress,
+        )
+    finally:
+        conn.close()
+
+    assert [desc for _, desc in events] == [
+        "rebuild: cleared a",
+        "rebuild: cleared b",
+        "rebuild: cleared c",
+    ]
+    # rowcount per table: 3, 1, 0
+    assert [amount for amount, _ in events] == [3, 1, 0]
+
+
+def test_delete_tables_progress_callback_is_optional(tmp_path: Path) -> None:
+    """Missing callback must not raise; the DELETEs still execute."""
+    db_path = tmp_path / "polylogue.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("CREATE TABLE t (id INT)")
+        conn.execute("INSERT INTO t VALUES (1), (2)")
+        conn.commit()
+
+        _delete_tables_with_progress_sync(conn, tables=("t",), progress_callback=None)
+
+        remaining = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        assert remaining == 0
+    finally:
+        conn.close()
+
+
+def test_full_rebuild_emits_progress_for_each_deleted_table(
+    cli_workspace: dict[str, Path],
+) -> None:
+    """The full ``rebuild_session_insights_sync(conversation_ids=None)`` path
+    must surface DELETE progress through the user-supplied callback so
+    "polylogue ... --rebuild-insights" stops hanging silently."""
+    db_path = cli_workspace["db_path"]
+    (
+        ConversationBuilder(db_path, "conv-1")
+        .provider("claude-code")
+        .title("seed")
+        .updated_at("2026-03-01T10:10:00+00:00")
+        .add_message("u1", role="user", text="hi", timestamp="2026-03-01T10:00:00+00:00")
+        .save()
+    )
+
+    events: list[str | None] = []
+
+    def progress(amount: int, desc: str | None = None) -> None:
+        events.append(desc)
+
+    with open_connection(db_path) as conn:
+        rebuild_session_insights_sync(conn, progress_callback=progress)
+
+    delete_events = [desc for desc in events if desc and desc.startswith("rebuild: cleared ")]
+    assert delete_events == [
+        "rebuild: cleared session_work_events",
+        "rebuild: cleared session_phases",
+        "rebuild: cleared session_latency_profiles",
+        "rebuild: cleared session_profiles",
+        "rebuild: cleared session_tag_rollups",
+        "rebuild: cleared conversation_repo_observations",
+        "rebuild: cleared repo_identities",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Atomicity — SIGKILL/exception mid-rebuild leaves prior insights intact
+# ---------------------------------------------------------------------------
+
+
+def test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles(
+    cli_workspace: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the rebuild loop raises between the DELETE phase and ``conn.commit()``,
+    the implicit transaction must roll back so prior session_profiles
+    survive — not the "seconds-to-minutes of empty archive" the #1607
+    report worried about.
+    """
+    db_path = cli_workspace["db_path"]
+    (
+        ConversationBuilder(db_path, "conv-existing")
+        .provider("claude-code")
+        .title("prior")
+        .updated_at("2026-02-01T10:10:00+00:00")
+        .add_message("u1", role="user", text="hello", timestamp="2026-02-01T10:00:00+00:00")
+        .save()
+    )
+
+    # Establish a baseline of insight rows by running one successful rebuild.
+    with open_connection(db_path) as conn:
+        rebuild_session_insights_sync(conn)
+    baseline = _count_profiles(db_path)
+    assert baseline >= 1, "baseline rebuild produced no profiles"
+
+    # Now arrange for the next rebuild's inner loop to fail after the
+    # DELETE phase. Patch a function called from inside the chunk loop.
+    from polylogue.storage.insights.session import rebuild as rebuild_module
+
+    def _explode(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("simulated mid-rebuild failure")
+
+    monkeypatch.setattr(rebuild_module, "build_session_insight_record_bundles", _explode)
+
+    with (
+        open_connection(db_path) as conn,
+        pytest.raises(RuntimeError, match="simulated mid-rebuild failure"),
+    ):
+        rebuild_session_insights_sync(conn)
+
+    # The post-failure count must equal the baseline. If the DELETEs had
+    # leaked past their implicit transaction, this would be 0.
+    surviving = _count_profiles(db_path)
+    assert surviving == baseline, f"rebuild failure emptied prior insights: baseline={baseline}, surviving={surviving}"


### PR DESCRIPTION
## Summary

Surface DELETE-phase progress in ``rebuild_session_insights_sync`` so
the operator log shows forward motion at table granularity instead of
"hang" until the first chunk inserts. The seven unconditional DELETEs
hold the write lock for seconds at production scale, minutes at 10x.

Also pin the atomicity invariant that #1607 questioned — the implicit
transaction started by the first DELETE actually does span every
subsequent DML through the eventual ``conn.commit()``, so a SIGKILL
mid-rebuild does not leave the archive empty.

Ref #1607

## Problem

From #1607:

> ``polylogue/storage/insights/session/rebuild.py:667-673`` runs seven
> unconditional ``DELETE`` statements at the start of every full
> insight rebuild [...] cumulative DELETE phase is on the order of
> seconds of pure write-lock-under-trigger. On a future 10x archive,
> this scales to minutes. During those seconds-to-minutes [...] there
> is no progress reporting; the operator sees no output until the
> first new row lands.

The "non-transactional" framing in the issue is wrong (see Solution
below), but the silent DELETE phase is a real operator-experience
gap. ``polylogue qa --rebuild-insights`` looked hung on the
production archive every time.

## Solution

New helper ``_delete_tables_with_progress_sync`` loops the seven
DELETEs and emits one ``ProgressCallback`` event per table
(``desc="rebuild: cleared <name>"``, ``amount=rowcount``). The
``rebuild_session_insights_sync(conversation_ids=None)`` full-rebuild
path and its async counterpart route DELETEs through the helper,
threading the existing ``progress_callback`` parameter through.
Targeted rebuilds (``conversation_ids != None``) are unchanged
because their DELETEs are per-conversation and finish quickly.

The CLI progress sink already attached to ``rebuild_session_insights_sync``
(``make_session_insight_progress_callback``) now naturally surfaces a
"rebuild: cleared session_work_events" → ... → "rebuild: cleared
repo_identities" sequence before the materialize loop's "Materializing:
1/N" output. No CLI changes required.

### Atomicity (AC2)

#1607 claims the DELETEs and the rebuild loop are non-transactional
and that a SIGKILL between them leaves the archive empty. Tracing
the code shows otherwise:

- ``conn.execute("DELETE ...")`` opens an implicit transaction (Python
  sqlite3 default isolation).
- Every subsequent ``replace_*_bulk_sync`` runs DML without
  committing — they all stay in the same implicit tx.
- The function commits exactly once at the bottom via
  ``conn.commit()``.

In WAL mode, the DELETEs are not durable until COMMIT. A SIGKILL
between DELETE and INSERT rolls back the WAL on next open. Pinned
by ``test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles``
which:

1. Runs one rebuild to establish a baseline of session_profiles.
2. Monkeypatches ``build_session_insight_record_bundles`` to raise
   ``RuntimeError`` from inside the chunk loop.
3. Asserts that ``COUNT(session_profiles)`` after the failed rebuild
   equals the baseline (not zero).

The "AC1 declared op-spec contract" and "AC4 refuse-or-pause live
ingest" branches require new infrastructure and stay open against
#1607.

## Verification

Verification angles considered:

- **Direct behavior** ✓ —
  ``test_delete_tables_with_progress_emits_one_event_per_table``
  exercises the helper with a 3-table scenario, asserts
  ``desc=...`` for each and ``amount=`` matching ``rowcount``
  (including 0 for empty tables).
- **Direct integration** ✓ —
  ``test_full_rebuild_emits_progress_for_each_deleted_table`` runs the
  real ``rebuild_session_insights_sync`` with a seeded conversation
  and asserts the seven cleared-table events fire in order.
- **Counterfactual / robustness** ✓ —
  ``test_delete_tables_progress_callback_is_optional`` pins that
  ``progress_callback=None`` does not raise and still runs the
  DELETEs.
- **Atomicity invariant** ✓ —
  ``test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles``
  proves the #1607 "non-atomic" hypothesis wrong with executable
  evidence.
- **Existing-test compatibility** ✓ —
  ``test_session_insight_rebuild_sync_reports_progress`` updated to
  filter "Materializing:" events from "rebuild: cleared" events;
  both sequences pinned.

Verification angles skipped:

- **Concurrency / lifecycle** — N/A; the function is single-threaded
  inside one transaction.
- **Performance / amplification** — the helper itself runs the same
  seven DELETEs as before; the extra callback invocation is constant
  overhead per table.

Inherited test failures fixed alongside (CLAUDE.md §19a):

- ``tests/unit/storage/test_dead_schema_sweep.py`` —
  ``test_schema_version_is_14`` was asserting against an outdated
  constant. Schema is now 16. Renamed the test, updated the comment.
- ``tests/unit/storage/test_query_mappers.py`` —
  ``test_maps_all_fields`` asserted ``source_name == "chatgpt"`` and
  ``source_name == "inbox"`` on the same row. Removed the
  duplicate-and-contradictory assertion; seed sets "inbox".

Commands run:

```
$ nix develop -c pytest tests/unit/storage/test_session_insight_rebuild_progress.py \
    tests/unit/cli/test_insights.py::test_session_insight_rebuild_sync_reports_progress
5 passed in 0.21s

$ nix develop -c devtools verify --quick
exit_code: 0
```

## Notes

- Other pre-existing test failures (``test_repair_blobs.py``,
  ``test_fts5.py``, ``test_schema_safety.py``, the cross-test order
  flake in ``test_daemon_http_contracts.py`` mentioned in #1652)
  are out of scope here. They reproduce on master too. Will be
  tracked as a follow-up sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session rebuild operations now emit progress feedback events as tables are cleared, providing real-time visibility into ongoing operations.

* **Bug Fixes**
  * Improved transaction error handling to ensure data integrity—failed rebuild operations now automatically roll back to preserve existing data.

* **Tests**
  * Added comprehensive test coverage for progress event reporting and transaction atomicity during rebuild operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->