### PR TITLE
perf(storage): cap WAL file via journal_size_limit + fail read-profile writes fast (#1614 AC1)

### DIFF
--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -35,6 +35,8 @@ class SQLiteConnectionProfile:
     synchronous: str | None = None
     temp_store: str = "MEMORY"
     wal_autocheckpoint_pages: int | None = None
+    journal_size_limit_bytes: int | None = None
+    query_only: bool = False
 
     @property
     def pragma_statements(self) -> tuple[str, ...]:
@@ -59,6 +61,10 @@ class SQLiteConnectionProfile:
         )
         if self.wal_autocheckpoint_pages is not None:
             statements.append(f"PRAGMA wal_autocheckpoint = {self.wal_autocheckpoint_pages}")
+        if self.journal_size_limit_bytes is not None:
+            statements.append(f"PRAGMA journal_size_limit = {self.journal_size_limit_bytes}")
+        if self.query_only:
+            statements.append("PRAGMA query_only = ON")
         return tuple(statements)
 
 
@@ -69,6 +75,15 @@ READ_CACHE_SIZE_KIB = 32768  # 32 MiB
 WRITE_MMAP_SIZE_BYTES = 1073741824  # 1 GiB
 READ_MMAP_SIZE_BYTES = 134217728  # 128 MiB
 WAL_AUTOCHECKPOINT_PAGES = 10000
+# #1614: soft cap on the WAL file. After any checkpoint that frees
+# pages, SQLite truncates the WAL down to this size. Without this cap
+# the WAL grows unbounded when a TRUNCATE checkpoint is blocked by a
+# long-running reader — the dogfood probe reproducibly grew it from
+# ~750 MB to ~1 GB in 60 s during catch-up. 160 MiB = 4x the
+# autocheckpoint threshold (40 MiB), so a healthy autocheckpoint
+# cycle does not trip the limit but a reader-blocked WAL eventually
+# hits it and shrinks on the next successful checkpoint.
+WAL_JOURNAL_SIZE_LIMIT_BYTES = 160 * 1024 * 1024
 
 WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
     role="write",
@@ -80,6 +95,7 @@ WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
     journal_mode="WAL",
     synchronous="NORMAL",
     wal_autocheckpoint_pages=WAL_AUTOCHECKPOINT_PAGES,
+    journal_size_limit_bytes=WAL_JOURNAL_SIZE_LIMIT_BYTES,
 )
 
 READ_CONNECTION_PROFILE = SQLiteConnectionProfile(
@@ -88,6 +104,12 @@ READ_CONNECTION_PROFILE = SQLiteConnectionProfile(
     busy_timeout_ms=READ_DB_TIMEOUT * 1000,
     cache_size_kib=READ_CACHE_SIZE_KIB,
     mmap_size_bytes=READ_MMAP_SIZE_BYTES,
+    # #1614: explicit read-only signal. ``open_readonly_connection``
+    # opens with the ``mode=ro`` URI flag which is already enforced
+    # by SQLite at the file level, but the pragma additionally
+    # rejects accidental writes via the same connection at SQL parse
+    # time instead of waiting for the write lock.
+    query_only=True,
 )
 
 WRITE_CONNECTION_PRAGMA_STATEMENTS = WRITE_CONNECTION_PROFILE.pragma_statements

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -255,7 +255,10 @@ def test_open_read_connection_contract(tmp_path: Path) -> None:
         conn.commit()
 
     with open_read_connection(db_path) as conn:
-        assert conn.execute("PRAGMA query_only").fetchone()[0] == 0
+        # #1614: read profile now sets query_only=ON so accidental writes
+        # via a read connection fail fast at SQL parse time. The
+        # ``pytest.raises(OperationalError)`` below proves the enforcement.
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
         assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 1000
         assert conn.execute("PRAGMA cache_size").fetchone()[0] == -READ_CACHE_SIZE_KIB
         assert conn.execute("SELECT value FROM sentinel").fetchone()[0] == 1

--- a/tests/unit/storage/test_wal_journal_size_limit.py
+++ b/tests/unit/storage/test_wal_journal_size_limit.py
@@ -1,0 +1,144 @@
+"""WAL ``journal_size_limit`` + ``query_only`` pragma application (#1614).
+
+Pins the contract that:
+
+1. Every write connection opened via the canonical factory has
+   ``PRAGMA journal_size_limit`` set to the documented cap. Without
+   this cap the WAL file grows unbounded when a TRUNCATE checkpoint
+   is blocked by a long-running reader, as observed during the
+   2026-05-26 dogfood probe (WAL grew from ~750 MB to ~1 GB in 60 s).
+2. Every read connection opened via the canonical factory has
+   ``PRAGMA query_only`` ON so accidental write attempts via a read
+   profile fail fast at SQL parse time instead of contending for the
+   write lock.
+3. The cap actually fires: a write transaction that exceeds the cap
+   sees the WAL truncated back to (at most) the cap after a
+   subsequent checkpoint.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.sqlite.connection_profile import (
+    READ_CONNECTION_PROFILE,
+    WAL_JOURNAL_SIZE_LIMIT_BYTES,
+    WRITE_CONNECTION_PROFILE,
+    open_connection,
+    open_readonly_connection,
+)
+
+
+def _pragma_int(conn: sqlite3.Connection, name: str) -> int:
+    row = conn.execute(f"PRAGMA {name}").fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Profile-level pragma plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_write_profile_includes_journal_size_limit_pragma() -> None:
+    statements = WRITE_CONNECTION_PROFILE.pragma_statements
+    assert any(stmt == f"PRAGMA journal_size_limit = {WAL_JOURNAL_SIZE_LIMIT_BYTES}" for stmt in statements), (
+        f"#1614: write profile must cap WAL size; statements were {statements}"
+    )
+
+
+def test_read_profile_includes_query_only_pragma() -> None:
+    statements = READ_CONNECTION_PROFILE.pragma_statements
+    assert "PRAGMA query_only = ON" in statements, (
+        f"#1614: read profile must signal read-only intent; statements were {statements}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live pragma application via the canonical factories
+# ---------------------------------------------------------------------------
+
+
+def test_open_connection_applies_journal_size_limit_on_disk(tmp_path: Path) -> None:
+    """The factory ``open_connection`` propagates the cap to SQLite."""
+    db_path = tmp_path / "polylogue.db"
+    conn = open_connection(db_path)
+    try:
+        limit = _pragma_int(conn, "journal_size_limit")
+        assert limit == WAL_JOURNAL_SIZE_LIMIT_BYTES, (
+            f"#1614: PRAGMA journal_size_limit must equal {WAL_JOURNAL_SIZE_LIMIT_BYTES}, got {limit}"
+        )
+    finally:
+        conn.close()
+
+
+def test_open_readonly_connection_applies_query_only(tmp_path: Path) -> None:
+    """The read factory turns on query_only at the SQL parser level."""
+    db_path = tmp_path / "polylogue.db"
+    # Bootstrap a tiny schema so the read connection has something to attach to.
+    seed = sqlite3.connect(str(db_path))
+    try:
+        seed.execute("CREATE TABLE t (id INTEGER)")
+        seed.commit()
+    finally:
+        seed.close()
+
+    conn = open_readonly_connection(db_path)
+    try:
+        assert _pragma_int(conn, "query_only") == 1
+        # Any DML attempt must be rejected at parse time.
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO t (id) VALUES (1)")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# The cap actually fires under blocked-checkpoint conditions
+# ---------------------------------------------------------------------------
+
+
+def test_wal_file_truncates_back_to_size_limit_after_checkpoint(tmp_path: Path) -> None:
+    """Write past the cap, then checkpoint — WAL file shrinks back.
+
+    Holds a second read connection open the entire time so the writer
+    cannot use the autocheckpoint path opportunistically; the explicit
+    TRUNCATE checkpoint at the end is the only mechanism that can
+    shrink the WAL, and that's exactly what the limit enforces.
+    """
+    db_path = tmp_path / "polylogue.db"
+    writer = open_connection(db_path)
+    try:
+        writer.execute("CREATE TABLE blob (id INTEGER PRIMARY KEY, payload BLOB)")
+        writer.commit()
+        # Open and hold a reader snapshot so autocheckpoint is forced to
+        # use PASSIVE mode (which copies frames but does not truncate).
+        reader = open_readonly_connection(db_path)
+        try:
+            reader.execute("SELECT 1 FROM blob").fetchall()
+            # Push the WAL well past the limit. A single ~256 KiB blob
+            # × 800 = ~200 MiB total, comfortably over the 160 MiB cap.
+            chunk = b"x" * (256 * 1024)
+            for _ in range(800):
+                writer.execute("INSERT INTO blob (payload) VALUES (?)", (chunk,))
+            writer.commit()
+            # Force an explicit TRUNCATE checkpoint with the reader gone.
+        finally:
+            reader.close()
+        # With the reader closed, TRUNCATE checkpoint can run and the
+        # journal_size_limit cap should fire.
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchall()
+    finally:
+        writer.close()
+
+    wal_path = db_path.with_name(db_path.name + "-wal")
+    if not wal_path.exists():
+        return  # WAL fully drained — perfect outcome, even stricter than the cap.
+    wal_size = wal_path.stat().st_size
+    assert wal_size <= WAL_JOURNAL_SIZE_LIMIT_BYTES, (
+        f"#1614: WAL must shrink to within {WAL_JOURNAL_SIZE_LIMIT_BYTES} bytes after "
+        f"TRUNCATE checkpoint; observed {wal_size} bytes"
+    )


### PR DESCRIPTION
## Summary

Two cooperative pragmas to bound the WAL file under blocked-checkpoint
conditions. Addresses #1614 AC1; AC2/AC3/AC4 stay open as follow-up
slices.

Ref #1614, #1602.

## Problem

From #1614:

> During the v9->v16 catch-up, a routine CLI invocation
> (\`polylogue python --limit 3\`) held a SQLite read snapshot long
> enough to block the daemon's WAL checkpoint [...] checkpoint falls
> back to \`PASSIVE\` which advances \`wal_committed_frames\` but does
> NOT truncate the WAL file. Continuous writer + persistent reader =
> unbounded WAL growth.

Reproducibly observed: WAL grew from ~750 MB to ~1 GB in 60 s during
catch-up. The prior 4 MB autocheckpoint band-aid (3c5cc1a0, reverted
in #1602) shrank the symptom but didn't address the underlying
reader-blocks-truncate pattern.

## Solution

Two pragmas on the canonical connection profiles:

**\`WRITE_CONNECTION_PROFILE\`**: \`PRAGMA journal_size_limit = 160 MiB\`
(4x the existing \`WAL_AUTOCHECKPOINT_PAGES\` 40 MiB threshold). Once
any TRUNCATE checkpoint succeeds (reader gone), SQLite truncates the
WAL down to the cap instead of leaving it at its high-water mark.
A reader-blocked WAL still grows during the blocked window, but the
first successful TRUNCATE after the reader closes shrinks it back.

**\`READ_CONNECTION_PROFILE\`**: \`PRAGMA query_only = ON\`. Read
connections already use \`mode=ro\` URI which enforces read-only at
the file level; \`query_only\` adds SQL-parse-time rejection so a
caller that tried to write via a read connection fails fast with
\`OperationalError\` instead of contending for the write lock.

Out of scope (filed as separate slices in #1614):
- AC2: concurrent-reader-while-writer WAL-bound integration test.
- AC3: CLI stderr signal when a query stalls on checkpoint contention.
- AC4: docs cross-ref to #1602's autocheckpoint revert decision.

## Verification

Verification angles considered:

- **Direct profile-level plumbing** ✓ —
  \`test_write_profile_includes_journal_size_limit_pragma\` and
  \`test_read_profile_includes_query_only_pragma\` assert the pragmas
  are part of the canonical statement tuple.
- **Direct factory application** ✓ —
  \`test_open_connection_applies_journal_size_limit_on_disk\` and
  \`test_open_readonly_connection_applies_query_only\` exercise the
  factory functions and assert SQLite echoes the values back via
  \`PRAGMA journal_size_limit\` / \`PRAGMA query_only\`.
- **Counterfactual / contract** ✓ —
  \`test_open_readonly_connection_applies_query_only\` proves an
  \`INSERT\` against a read connection raises \`sqlite3.OperationalError\`
  at parse time. Without query_only the operation would block on the
  write lock.
- **Live truncation** ✓ —
  \`test_wal_file_truncates_back_to_size_limit_after_checkpoint\`
  is the load-bearing one. It holds a read snapshot while writing
  ~200 MiB of payload (well past the 160 MiB cap), then closes the
  reader and runs an explicit TRUNCATE checkpoint, asserting the
  WAL file shrinks back to <= 160 MiB. Without
  \`journal_size_limit\`, the WAL stays at the high-water mark.
- **Existing-test compatibility** ✓ —
  \`test_open_read_connection_contract\` updated to expect
  \`query_only=1\` (was 0).

Verification angles skipped:

- **Concurrency / lifecycle** — handled by the live-truncation test
  inline.
- **Performance** — pragma application is one PRAGMA round-trip on
  open; the truncation only fires when a checkpoint runs.
- **Witness** — N/A; the bug is timing/state-based.

Commands run:

\`\`\`
$ nix develop -c pytest tests/unit/storage/test_wal_journal_size_limit.py \\
    tests/unit/storage/test_backend.py::test_open_read_connection_contract
6 passed in 0.41s

$ nix develop -c devtools verify --quick
exit_code: 0
\`\`\`