### PR TITLE
test(maint): fix three inherited test failures (duplicate assertions, stale column, renamed index)

### DIFF
--- a/tests/unit/storage/test_fts5.py
+++ b/tests/unit/storage/test_fts5.py
@@ -100,7 +100,6 @@ async def test_search_includes_conversation_metadata(
     assert hit.title == "My Conversation"
     assert hit.message_id == "msg1"
     assert hit.timestamp is not None and "2024-01-01" in hit.timestamp
-    assert hit.source_name == "my-source"
 
 
 async def test_search_returns_best_message_per_conversation(

--- a/tests/unit/storage/test_repair_blobs.py
+++ b/tests/unit/storage/test_repair_blobs.py
@@ -24,13 +24,15 @@ def _config(workspace_env: dict[str, Path], db_path: Path) -> Config:
 
 def _reference_blob(db_path: Path, blob_hash: str, blob_size: int) -> None:
     with open_connection(db_path) as conn:
+        # Column list has six slots; the seven-value form pre-dated a column
+        # removal and tripped ``OperationalError: 7 values for 6 columns``.
         conn.execute(
             """
             INSERT INTO raw_conversations (
                 raw_id, source_name, source_path, source_index,
                 blob_size, acquired_at
             )
-            VALUES (?, 'test', 'test', 'referenced.json', 0, ?, '2026-05-23T00:00:00+00:00')
+            VALUES (?, 'test', 'test', 0, ?, '2026-05-23T00:00:00+00:00')
             """,
             (blob_hash, blob_size),
         )

--- a/tests/unit/storage/test_schema_safety.py
+++ b/tests/unit/storage/test_schema_safety.py
@@ -58,8 +58,12 @@ class TestSchemaDDLParity:
 
     def test_schema_ddl_has_all_required_indexes(self) -> None:
         """SCHEMA_DDL must create required indexes."""
+        # idx_conversations_provider was renamed to idx_conversations_source_name
+        # when ``provider_name`` graduated to ``source_name`` as the canonical
+        # storage column (#635 umbrella, provider/source vocabulary
+        # transition documented in docs/architecture.md).
         required_indexes = [
-            "idx_conversations_provider",
+            "idx_conversations_source_name",
             "idx_messages_conversation",
         ]
         ddl_lower = SCHEMA_DDL.lower()


### PR DESCRIPTION
Three small fixes for pre-existing test failures discovered during
the 2026-05-27 backlog sweep ([#1657](https://github.com/Sinity/polylogue/issues/1657)).
Each was a stale-test issue rather than a production-code bug.

## Changes

- **\`tests/unit/storage/test_schema_safety.py\`** — required-index
  list named the pre-#635 \`idx_conversations_provider\` index, which
  was renamed to \`idx_conversations_source_name\` during the
  provider->source storage-column vocabulary transition. Updated
  the test, added a one-line comment explaining the rename.

- **\`tests/unit/storage/test_repair_blobs.py\`** — \`_reference_blob\`
  helper's INSERT into \`raw_conversations\` passed seven VALUES
  against a six-column list, tripping \`OperationalError: 7 values
  for 6 columns\`. The extra \`'referenced.json'\` literal pre-dated a
  schema column removal.

- **\`tests/unit/storage/test_fts5.py\`** —
  \`test_search_includes_conversation_metadata\` asserted both
  \`hit.source_name == "claude-ai"\` and \`hit.source_name == "my-source"\`
  on the same row (impossible). Same shape as the duplicate-column
  failures fixed in PR #1651/#1652/#1653. Removed the contradictory
  second assertion.

## Verification

\`\`\`
$ nix develop -c pytest tests/unit/storage/test_repair_blobs.py \\
    tests/unit/storage/test_schema_safety.py tests/unit/storage/test_fts5.py
96 passed in 3.01s

$ nix develop -c devtools verify --quick
exit_code: 0
\`\`\`

## Out of scope

The order-dependent flake in \`test_daemon_http_contracts.py\`
(KeyError 'fts_readiness' / 'component_state' under specific
pytest-randomly seeds) is tracked separately under #1657. It needs
a cross-test mock-state-leak investigation that doesn't fit this
PR's small-cleanup shape.

Ref #1657.