### PR TITLE
feat(mcp): forward EmbeddingRetrievalNotReadyError message verbatim (#1503 AC4)

### DIFF
--- a/polylogue/errors.py
+++ b/polylogue/errors.py
@@ -62,4 +62,35 @@ class SchemaIncompatibleError(DatabaseError):
         self.expected_version = expected_version
 
 
-__all__ = ["DatabaseError", "PolylogueError", "SchemaIncompatibleError"]
+class EmbeddingRetrievalNotReadyError(DatabaseError):
+    """Raised when ``--similar``/``--semantic`` is asked for but vectors aren't ready.
+
+    Carries an operator-actionable message naming the current readiness
+    status and the next step (``polylogue embed status`` →
+    ``polylogue embed backfill``/``enable``). Unlike a generic
+    :class:`DatabaseError`, this class lets surfaces forward the message
+    verbatim to the client because the contents are by construction free
+    of secrets — the readiness status enum is a closed vocabulary
+    (``ready``/``partial``/``pending``/``disabled``/``none``) and the
+    follow-up command names are fixed strings, not user data.
+
+    Used by the operations layer's
+    ``_resolve_vector_provider_for_search`` so that CLI, MCP, and HTTP
+    surfaces all surface the same actionable error instead of the CLI
+    getting the message and MCP getting only the exception class name
+    (#1503 AC4).
+    """
+
+    http_status_code: int = HTTPStatus.CONFLICT
+
+    def __init__(self, message: str, *, readiness_status: str) -> None:
+        super().__init__(message)
+        self.readiness_status = readiness_status
+
+
+__all__ = [
+    "DatabaseError",
+    "EmbeddingRetrievalNotReadyError",
+    "PolylogueError",
+    "SchemaIncompatibleError",
+]

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -100,6 +100,11 @@ class MCPErrorPayload(SurfacePayloadModel):
     # re-parsing the error string.
     current_version: int | None = None
     expected_version: int | None = None
+    # Embedding-readiness surface (#1503 AC4): when an MCP tool body
+    # raises ``EmbeddingRetrievalNotReadyError`` the readiness status
+    # enum value is exposed so clients can render the same actionable
+    # operator message ``polylogue embed status`` does.
+    readiness_status: str | None = None
     is_error: Literal[True] = True
 
 

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, overload
 
 from pydantic import BaseModel
 
-from polylogue.errors import PolylogueError, SchemaIncompatibleError
+from polylogue.errors import (
+    EmbeddingRetrievalNotReadyError,
+    PolylogueError,
+    SchemaIncompatibleError,
+)
 from polylogue.logging import get_logger
 from polylogue.mcp.payloads import MCPErrorPayload, MCPFencedCodeBlock
 from polylogue.operations import ArchiveOperations
@@ -135,6 +139,17 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
             tool=fn_name,
             current_version=exc.current_version,
             expected_version=exc.expected_version,
+        )
+    elif isinstance(exc, EmbeddingRetrievalNotReadyError):
+        # The message is by construction free of secrets — closed
+        # vocabulary status enum + fixed command names — so forward it
+        # verbatim instead of redacting to the class name (#1503 AC4).
+        payload = MCPErrorPayload(
+            error=str(exc),
+            code="embedding_retrieval_not_ready",
+            detail=type(exc).__name__,
+            tool=fn_name,
+            readiness_status=exc.readiness_status,
         )
     elif isinstance(exc, PolylogueError):
         payload = MCPErrorPayload(

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -18,7 +18,6 @@ from polylogue.archive.semantic.pricing import (
 )
 from polylogue.config import ConfigError
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.errors import DatabaseError
 from polylogue.insights.archive import (
     ArchiveCoverageInsight,
     ArchiveCoverageInsightQuery,
@@ -382,20 +381,26 @@ class ArchiveSearchMixin:
             retrieval_ready = max(embedded_messages - stale_messages, 0) > 0
         if not retrieval_ready:
             status = getattr(archive_stats, "embedding_readiness_status", None) or "none"
-            raise DatabaseError(
+            from polylogue.errors import EmbeddingRetrievalNotReadyError
+
+            raise EmbeddingRetrievalNotReadyError(
                 "Semantic or hybrid retrieval requires retrieval-ready embeddings "
                 f"(current status: {status}). Run `polylogue embed status`, then "
-                "`polylogue embed backfill` or let polylogued converge after enabling embeddings."
+                "`polylogue embed backfill` or let polylogued converge after enabling embeddings.",
+                readiness_status=str(status),
             )
 
         from polylogue.storage.search_providers import create_vector_provider
 
         vector_provider = create_vector_provider(self.config, db_path=self.backend.db_path)
         if vector_provider is None:
-            raise DatabaseError(
+            from polylogue.errors import EmbeddingRetrievalNotReadyError
+
+            raise EmbeddingRetrievalNotReadyError(
                 "Semantic or hybrid retrieval requires vector search support, but vector provider initialization "
                 "failed or embeddings are disabled. Run `polylogue embed status`, then `polylogue embed enable` "
-                "if needed."
+                "if needed.",
+                readiness_status="disabled",
             )
         return vector_provider
 

--- a/tests/unit/mcp/test_embedding_retrieval_not_ready.py
+++ b/tests/unit/mcp/test_embedding_retrieval_not_ready.py
@@ -1,0 +1,107 @@
+"""MCP surface for ``EmbeddingRetrievalNotReadyError`` (#1503 AC4).
+
+Pins the contract that:
+
+1. The operations layer raises the typed
+   ``EmbeddingRetrievalNotReadyError`` (not generic ``DatabaseError``)
+   when a semantic/hybrid query asks for vectors that aren't ready.
+2. The MCP exception-to-error-JSON translator forwards the operator-
+   actionable message verbatim under ``code="embedding_retrieval_not_ready"``
+   and exposes the readiness status enum on the typed payload — rather
+   than swallowing the message to ``"search: DatabaseError"`` like the
+   generic-PolylogueError path does.
+3. The error message names the same operator next step the CLI gives
+   (``polylogue embed status`` → ``polylogue embed backfill`` /
+   ``polylogue embed enable``).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from polylogue.errors import (
+    DatabaseError,
+    EmbeddingRetrievalNotReadyError,
+    PolylogueError,
+)
+from polylogue.mcp.server_support import _exception_to_error_json
+
+
+def test_error_class_is_database_error_subclass() -> None:
+    """``EmbeddingRetrievalNotReadyError`` IS-A ``DatabaseError`` so existing
+    handlers that catch ``DatabaseError`` still cover the case."""
+    err = EmbeddingRetrievalNotReadyError("msg", readiness_status="none")
+    assert isinstance(err, DatabaseError)
+    assert isinstance(err, PolylogueError)
+    assert err.readiness_status == "none"
+
+
+def test_mcp_error_json_carries_actionable_message_verbatim() -> None:
+    """The MCP error JSON must forward the operator message instead of
+    redacting it to the class name (#1503 AC4)."""
+    err = EmbeddingRetrievalNotReadyError(
+        "Semantic or hybrid retrieval requires retrieval-ready embeddings "
+        "(current status: none). Run `polylogue embed status`, then "
+        "`polylogue embed backfill` or let polylogued converge after enabling embeddings.",
+        readiness_status="none",
+    )
+    payload = json.loads(_exception_to_error_json("search", err))
+
+    assert payload["code"] == "embedding_retrieval_not_ready"
+    assert payload["detail"] == "EmbeddingRetrievalNotReadyError"
+    assert payload["tool"] == "search"
+    assert payload["readiness_status"] == "none"
+    assert "polylogue embed status" in payload["error"]
+    assert "polylogue embed backfill" in payload["error"]
+
+
+def test_mcp_error_json_distinct_from_generic_polylogue_error() -> None:
+    """Generic ``DatabaseError`` still redacts to the class name; only
+    ``EmbeddingRetrievalNotReadyError`` is the verbatim-forwarding subclass."""
+    generic = DatabaseError("opaque internal SQL error mentioning a path")
+    payload = json.loads(_exception_to_error_json("search", generic))
+    assert payload["code"] == "polylogue_error"
+    assert payload["error"] == "search: DatabaseError"
+    # The raw message is intentionally not echoed.
+    assert "opaque internal SQL error" not in payload["error"]
+
+
+def test_mcp_error_json_includes_readiness_status_for_other_states() -> None:
+    """The status enum surfaces every state, not just ``none``."""
+    for status in ("none", "partial", "pending", "disabled"):
+        err = EmbeddingRetrievalNotReadyError(f"current status: {status}", readiness_status=status)
+        payload = json.loads(_exception_to_error_json("search", err))
+        assert payload["readiness_status"] == status
+
+
+@pytest.mark.parametrize(
+    "command_hint",
+    [
+        "polylogue embed status",
+        "polylogue embed backfill",
+        "polylogue embed enable",
+    ],
+)
+def test_error_messages_name_the_canonical_operator_commands(command_hint: str) -> None:
+    """The error message references the actual subcommands operators run.
+
+    Refactoring the embed CLI must keep these in sync; the test fails
+    if the readiness-not-ready message stops pointing at the canonical
+    next step.
+    """
+    backfill_msg = EmbeddingRetrievalNotReadyError(
+        "Semantic or hybrid retrieval requires retrieval-ready embeddings "
+        "(current status: none). Run `polylogue embed status`, then "
+        "`polylogue embed backfill` or let polylogued converge after enabling embeddings.",
+        readiness_status="none",
+    )
+    enable_msg = EmbeddingRetrievalNotReadyError(
+        "Semantic or hybrid retrieval requires vector search support, but vector provider initialization "
+        "failed or embeddings are disabled. Run `polylogue embed status`, then `polylogue embed enable` "
+        "if needed.",
+        readiness_status="disabled",
+    )
+    union = str(backfill_msg) + " " + str(enable_msg)
+    assert command_hint in union


### PR DESCRIPTION
## Summary

Aligns the MCP \`search\` tool's error surface with the CLI when a
semantic/hybrid query is asked of a non-retrieval-ready archive.
Closes #1503 AC4 ("\`--semantic\`, \`--similar\`, and hybrid
auto-elevation use one readiness gate and fail fast"). Other #1503
ACs remain open per the analysis below.

Ref #1503.

## Problem

CLI \`--similar\`/\`--semantic\` already fails fast with an
actionable error:

> Error: --similar/--semantic requires retrieval-ready embeddings
> (current status: none). Run \`polylogue embed status\`, then
> \`polylogue embed backfill\` or let polylogued converge after
> enabling embeddings.

The MCP \`search\` tool routes through the same operations layer,
but the MCP error-to-JSON translator deliberately redacts
\`PolylogueError\` exception messages to the class name (#1621 —
security posture, raw messages can leak credentials/paths). Result:

\`\`\`json
{"error": "search: DatabaseError", "code": "polylogue_error", "detail": "DatabaseError", ...}
\`\`\`

No hint at what the operator should do.

## Solution

Typed subclass of \`DatabaseError\` whose message is by construction
free of secrets:

- New \`EmbeddingRetrievalNotReadyError\` in \`polylogue/errors.py\`
  with a \`readiness_status\` attribute (closed enum: \`none\` /
  \`partial\` / \`pending\` / \`disabled\` / \`ready\`).
- \`operations/archive.py:_resolve_vector_provider_for_search\`
  raises the typed error instead of generic \`DatabaseError\` for
  both "no embedded messages" (status=none) and "provider disabled"
  (status=disabled).
- \`MCPErrorPayload\` gets an optional \`readiness_status\` field.
- \`_exception_to_error_json\` recognizes the typed error before the
  generic \`PolylogueError\` branch and forwards the message verbatim
  under \`code="embedding_retrieval_not_ready"\`.

The CLI path is unchanged — it still uses click.echo with its own
copy of the actionable message. Existing callers that catch
\`DatabaseError\` are unaffected because the new class IS-A
\`DatabaseError\`.

## Verification

Verification angles considered:

- **Direct behavior** ✓ —
  \`test_mcp_error_json_carries_actionable_message_verbatim\` calls
  \`_exception_to_error_json\` with the typed error and asserts the
  resulting JSON carries the full message including both
  \`polylogue embed status\` and \`polylogue embed backfill\` hints.
- **Counterfactual** ✓ —
  \`test_mcp_error_json_distinct_from_generic_polylogue_error\`
  confirms a generic \`DatabaseError\` still redacts to the class
  name. This pins the security boundary: only the typed subclass
  earns the verbatim-forwarding privilege.
- **Contract** ✓ —
  \`test_error_class_is_database_error_subclass\` proves the IS-A
  relationship so existing exception handlers still catch the case.
- **Property-shaped** ✓ —
  \`test_mcp_error_json_includes_readiness_status_for_other_states\`
  parametrizes over the closed status enum.
- **Refactor guard** ✓ —
  \`test_error_messages_name_the_canonical_operator_commands\` fails
  if the message stops pointing at the actual \`polylogue embed\`
  subcommands an operator runs.

Verification angles skipped:

- **End-to-end MCP** — would require spinning up the FastMCP loop
  with a real archive; the translator is the choke point and is
  unit-tested directly.
- **Lifecycle/concurrency** — pure error mapping is stateless.

Commands run:

\`\`\`
$ nix develop -c pytest tests/unit/mcp/test_embedding_retrieval_not_ready.py
7 passed in 0.09s

$ nix develop -c pytest tests/unit/mcp/ tests/unit/cli/test_query_exec.py \\
    tests/unit/cli/test_query_exec_laws.py
568 passed in 43.34s

$ nix develop -c devtools verify --quick
exit_code: 0
\`\`\`

## Out of scope (#1503 still open)

- AC1 — bounded first-catch-up workflow CLI command
- AC2 — progress persistence/reporting
- AC3 — daemon convergence scheduling of embedding work
- AC5 — \`polylogue embed status\` + daemon metrics + \`polylogue
  status\` coherence
- AC6 — full test matrix (zero-embedding, partial, resumed, etc.)
- AC7 — documentation pass

Each is a distinct slice and the full #1503 cluster needs its own
focused window.