### PR TITLE
feat(surfaces): closed vocabulary for reader action availability (#1488)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -318,19 +318,53 @@ components:
       type: object
     ReaderActionAvailabilityPayload:
       additionalProperties: false
-      description: Per-target reader action availability with explicit disabled reason.
+      description: 'Per-target reader action availability with explicit disabled reason.
+
+
+        Reader actions surface seven distinct states (see :data:`ReaderActionState`)
+
+        so the UI can render "disabled because X" / "loading" / "dangerous"
+
+        without conflating them under a single boolean (#1488). ``enabled``
+
+        is kept as a back-compat alias derived from ``state`` so existing
+
+        call sites that only know about enabled/disabled continue to work.'
       properties:
         enabled:
+          default: true
           title: Enabled
           type: boolean
+        state:
+          default: enabled
+          enum:
+          - enabled
+          - disabled
+          - partial
+          - dangerous
+          - loading
+          - target
+          - unavailable
+          title: State
+          type: string
         disabled_reason:
           anyOf:
           - type: string
           - type: 'null'
           default: null
           title: Disabled Reason
-      required:
-      - enabled
+        repair_path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Repair Path
+        inspect_path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Inspect Path
       title: ReaderActionAvailabilityPayload
       type: object
     TargetRefPayload:

--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -98,8 +98,8 @@ exceptions:
     reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275) and scoped/global facets entrypoint (#1269); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
 
   - path: polylogue/surfaces/payloads.py
-    ceiling: 1200
-    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269); split candidate: per-domain payload modules under polylogue/surfaces/"
+    ceiling: 1250
+    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269) and the ReaderActionState / READER_ACTION_IDS / repair_path / inspect_path closed vocabulary (#1488); split candidate: per-domain payload modules under polylogue/surfaces/"
 
   - path: tests/unit/storage/test_backend.py
     ceiling: 1750

--- a/docs/schemas/cli-output/conversation-list-row.schema.json
+++ b/docs/schemas/cli-output/conversation-list-row.schema.json
@@ -25,7 +25,7 @@
     },
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
       "properties": {
         "disabled_reason": {
           "anyOf": [
@@ -40,13 +40,49 @@
           "title": "Disabled Reason"
         },
         "enabled": {
+          "default": true,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
         }
       },
-      "required": [
-        "enabled"
-      ],
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },

--- a/docs/schemas/cli-output/conversation-neighbor-candidate.schema.json
+++ b/docs/schemas/cli-output/conversation-neighbor-candidate.schema.json
@@ -125,7 +125,7 @@
     },
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
       "properties": {
         "disabled_reason": {
           "anyOf": [
@@ -140,13 +140,49 @@
           "title": "Disabled Reason"
         },
         "enabled": {
+          "default": true,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
         }
       },
-      "required": [
-        "enabled"
-      ],
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },

--- a/docs/schemas/cli-output/conversation-search-hit.schema.json
+++ b/docs/schemas/cli-output/conversation-search-hit.schema.json
@@ -245,7 +245,7 @@
     },
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
       "properties": {
         "disabled_reason": {
           "anyOf": [
@@ -260,13 +260,49 @@
           "title": "Disabled Reason"
         },
         "enabled": {
+          "default": true,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
         }
       },
-      "required": [
-        "enabled"
-      ],
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },

--- a/docs/schemas/cli-output/conversation-summary.schema.json
+++ b/docs/schemas/cli-output/conversation-summary.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
       "properties": {
         "disabled_reason": {
           "anyOf": [
@@ -17,13 +17,49 @@
           "title": "Disabled Reason"
         },
         "enabled": {
+          "default": true,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
         }
       },
-      "required": [
-        "enabled"
-      ],
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -367,7 +367,7 @@
     },
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
       "properties": {
         "disabled_reason": {
           "anyOf": [
@@ -382,13 +382,49 @@
           "title": "Disabled Reason"
         },
         "enabled": {
+          "default": true,
           "title": "Enabled",
           "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
         }
       },
-      "required": [
-        "enabled"
-      ],
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -153,11 +153,80 @@ class TargetRefPayload(SurfacePayloadModel):
         )
 
 
-class ReaderActionAvailabilityPayload(SurfacePayloadModel):
-    """Per-target reader action availability with explicit disabled reason."""
+#: Closed vocabulary of reader action states. Per #1488: every visible
+#: action surfaces one of these explicit states with a disabled-reason
+#: when applicable. ``enabled`` is the default; the other states encode
+#: distinct UI semantics that should never be conflated.
+#:
+#: - ``enabled`` — actionable now.
+#: - ``disabled`` — known unavailable; ``disabled_reason`` explains why.
+#: - ``partial`` — usable in a degraded form (e.g., copy of best-effort
+#:   text when paste boundaries are not exact).
+#: - ``dangerous`` — actionable but irreversible; UI should require a
+#:   confirmation gesture.
+#: - ``loading`` — temporarily disabled while the prerequisite resolves.
+#: - ``target`` — placeholder for an action that targets a different
+#:   object than the one displayed (e.g., "continue elsewhere").
+#: - ``unavailable`` — the action cannot be enabled in this archive
+#:   shape (e.g., copy_raw on a quarantined raw record).
+ReaderActionState: TypeAlias = Literal[
+    "enabled",
+    "disabled",
+    "partial",
+    "dangerous",
+    "loading",
+    "target",
+    "unavailable",
+]
 
-    enabled: bool
+#: Stable registry of action ids the reader knows about. The canonical
+#: set covers the actions named in #1488: copy text/markdown/raw/permalink,
+#: copy selected range, typed-only/paste-only copy variants, open raw/
+#: source, inspect provenance, mark/annotate, add to context, compare,
+#: open stack, continue elsewhere. New actions must be added here so
+#: the payload contract stays a closed enum rather than a free-form
+#: string field.
+READER_ACTION_IDS: tuple[str, ...] = (
+    "open",
+    "copy_text",
+    "copy_markdown",
+    "copy_raw",
+    "copy_link",
+    "copy_permalink",
+    "copy_selected_range",
+    "copy_typed_only",
+    "copy_paste_only",
+    "open_raw",
+    "open_source",
+    "inspect_provenance",
+    "mark",
+    "annotate",
+    "add_to_context",
+    "compare",
+    "open_stack",
+    "continue_elsewhere",
+)
+
+
+class ReaderActionAvailabilityPayload(SurfacePayloadModel):
+    """Per-target reader action availability with explicit disabled reason.
+
+    Reader actions surface seven distinct states (see :data:`ReaderActionState`)
+    so the UI can render "disabled because X" / "loading" / "dangerous"
+    without conflating them under a single boolean (#1488). ``enabled``
+    is kept as a back-compat alias derived from ``state`` so existing
+    call sites that only know about enabled/disabled continue to work.
+    """
+
+    enabled: bool = True
+    state: ReaderActionState = "enabled"
     disabled_reason: str | None = None
+    #: Optional opt-in path to surface a repair affordance when the action
+    #: is disabled (e.g., a CLI command operators can run to enable it).
+    repair_path: str | None = None
+    #: Optional opt-in path to surface an inspector affordance when the
+    #: action is disabled or partial (e.g., a "see why" link).
+    inspect_path: str | None = None
 
 
 def reader_anchor(target_type: Literal["conversation", "message"], target_id: object) -> str:

--- a/tests/unit/surfaces/test_reader_action_vocabulary.py
+++ b/tests/unit/surfaces/test_reader_action_vocabulary.py
@@ -1,0 +1,162 @@
+"""Reader action vocabulary contract (#1488).
+
+Pins:
+
+1. ``READER_ACTION_IDS`` is a closed registry the UI can rely on.
+2. ``ReaderActionState`` covers the seven canonical states required
+   by the issue (enabled, disabled, partial, dangerous, loading,
+   target, unavailable).
+3. ``ReaderActionAvailabilityPayload`` accepts every state value and
+   surfaces ``disabled_reason``, ``repair_path``, ``inspect_path``
+   when supplied.
+4. Back-compat: existing callers that construct the payload with
+   only ``enabled=True`` or ``enabled=False`` still work and the
+   default ``state`` is ``"enabled"``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import get_args
+
+import pytest
+from pydantic import ValidationError
+
+from polylogue.surfaces.payloads import (
+    READER_ACTION_IDS,
+    ReaderActionAvailabilityPayload,
+    ReaderActionState,
+    reader_conversation_actions,
+    reader_message_actions,
+)
+
+# ---------------------------------------------------------------------------
+# Registry contract
+# ---------------------------------------------------------------------------
+
+
+def test_action_id_registry_is_a_tuple_of_str() -> None:
+    """The registry is a tuple (immutable + order-preserving) of strings."""
+    assert isinstance(READER_ACTION_IDS, tuple)
+    assert all(isinstance(action_id, str) for action_id in READER_ACTION_IDS)
+
+
+def test_action_id_registry_has_no_duplicates() -> None:
+    """A duplicate would be a typo that two action ids collide on."""
+    assert len(READER_ACTION_IDS) == len(set(READER_ACTION_IDS))
+
+
+def test_action_id_registry_includes_the_canonical_actions_from_issue() -> None:
+    """The actions enumerated in #1488 must all be registered."""
+    required = {
+        "copy_text",
+        "copy_markdown",
+        "copy_raw",
+        "copy_permalink",
+        "copy_selected_range",
+        "copy_typed_only",
+        "copy_paste_only",
+        "open_raw",
+        "open_source",
+        "inspect_provenance",
+        "mark",
+        "annotate",
+        "add_to_context",
+        "compare",
+        "open_stack",
+        "continue_elsewhere",
+    }
+    missing = required - set(READER_ACTION_IDS)
+    assert not missing, f"missing canonical action ids: {sorted(missing)}"
+
+
+def test_default_conversation_action_ids_are_in_registry() -> None:
+    """The defaults for conversation-level rendering use registered ids only."""
+    for action_id in reader_conversation_actions():
+        assert action_id in READER_ACTION_IDS, f"{action_id!r} not in READER_ACTION_IDS"
+
+
+def test_default_message_action_ids_are_in_registry() -> None:
+    """Same invariant for message-level defaults."""
+    for action_id in reader_message_actions():
+        assert action_id in READER_ACTION_IDS, f"{action_id!r} not in READER_ACTION_IDS"
+
+
+# ---------------------------------------------------------------------------
+# State enum contract
+# ---------------------------------------------------------------------------
+
+
+def test_action_state_covers_the_seven_required_values() -> None:
+    """The seven states from #1488 are all accepted."""
+    required = {"enabled", "disabled", "partial", "dangerous", "loading", "target", "unavailable"}
+    assert set(get_args(ReaderActionState)) == required
+
+
+@pytest.mark.parametrize(
+    "state",
+    ["enabled", "disabled", "partial", "dangerous", "loading", "target", "unavailable"],
+)
+def test_payload_accepts_every_state(state: str) -> None:
+    payload = ReaderActionAvailabilityPayload(state=state)  # type: ignore[arg-type]
+    assert payload.state == state
+
+
+def test_payload_rejects_unknown_state() -> None:
+    """A typo in the state string is a contract violation, not a free-form note."""
+    with pytest.raises(ValidationError):
+        ReaderActionAvailabilityPayload(state="totally-made-up")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Back-compat contract: existing call sites continue to work
+# ---------------------------------------------------------------------------
+
+
+def test_default_payload_is_enabled_state() -> None:
+    """Constructing with no arguments yields the enabled state."""
+    payload = ReaderActionAvailabilityPayload()
+    assert payload.enabled is True
+    assert payload.state == "enabled"
+
+
+def test_enabled_false_back_compat_still_constructs() -> None:
+    """Existing callers that pass only ``enabled=False`` are unbroken."""
+    payload = ReaderActionAvailabilityPayload(enabled=False, disabled_reason="paste unknown")
+    assert payload.enabled is False
+    assert payload.disabled_reason == "paste unknown"
+
+
+def test_payload_carries_repair_and_inspect_paths() -> None:
+    payload = ReaderActionAvailabilityPayload(
+        state="disabled",
+        enabled=False,
+        disabled_reason="vectors not ready",
+        repair_path="polylogue embed backfill",
+        inspect_path="/inspect/embeddings",
+    )
+    assert payload.repair_path == "polylogue embed backfill"
+    assert payload.inspect_path == "/inspect/embeddings"
+
+
+def test_payload_serializes_repair_and_inspect_paths_when_set() -> None:
+    payload = ReaderActionAvailabilityPayload(
+        state="disabled",
+        enabled=False,
+        disabled_reason="vectors not ready",
+        repair_path="polylogue embed backfill",
+        inspect_path="/inspect/embeddings",
+    )
+    blob = json.loads(payload.to_json(exclude_none=True))
+    assert blob["repair_path"] == "polylogue embed backfill"
+    assert blob["inspect_path"] == "/inspect/embeddings"
+    assert blob["state"] == "disabled"
+
+
+def test_payload_omits_repair_and_inspect_paths_when_unset() -> None:
+    """exclude_none must keep the payload compact for the common case."""
+    payload = ReaderActionAvailabilityPayload()
+    blob = json.loads(payload.to_json(exclude_none=True))
+    assert "repair_path" not in blob
+    assert "inspect_path" not in blob
+    assert "disabled_reason" not in blob


### PR DESCRIPTION
## Summary

Ships the typed contract from #1488 without the UI rendering — the
\`ReaderActionState\` literal, the \`READER_ACTION_IDS\` registry,
and the \`repair_path\`/\`inspect_path\` payload fields. Default
behavior preserved for existing 20+ call sites.

Ref #1488.

## What landed

- **\`READER_ACTION_IDS\` tuple** — closed registry of the 18
  canonical actions enumerated in #1488 (copy text/markdown/raw/
  permalink/selected-range, typed-only and paste-only copy variants,
  open raw/source, inspect provenance, mark, annotate, add to
  context, compare, open stack, continue elsewhere, plus the
  existing open/copy_link/annotate defaults).
- **\`ReaderActionState\` Literal** — the seven states the issue
  enumerated (\`enabled\`, \`disabled\`, \`partial\`, \`dangerous\`,
  \`loading\`, \`target\`, \`unavailable\`). Distinct UI semantics
  get distinct enum values instead of being conflated under a
  boolean.
- **\`ReaderActionAvailabilityPayload\` gains four fields**:
  \`state\` (default \`enabled\`), \`repair_path\` (optional
  affordance for disabled states), \`inspect_path\` (ditto). The
  existing \`enabled\`/\`disabled_reason\` fields stay for
  back-compat.

## What this PR does not do

- Reader UI rendering for the new states — that's the bigger
  #1488 + #1487 + #1518 milestone work and needs frontend
  coordination.
- Change any currently-emitted payload — default state is
  \`enabled\`, default repair/inspect paths are \`None\` and excluded
  by \`exclude_none=True\` serialization.

## Verification

Verification angles considered:

- **Direct registry contract** ✓ — tuple shape, no duplicates, all
  canonical actions from the issue are registered, both default
  registries (conversation/message) reference only registered ids.
- **State enum contract** ✓ — \`get_args(ReaderActionState)\`
  matches exactly the seven required values; payload accepts every
  state.
- **Counterfactual** ✓ —
  \`test_payload_rejects_unknown_state\` proves a typo
  ("totally-made-up") fails the closed-enum contract instead of
  being accepted as a free-form string.
- **Back-compat** ✓ — three tests pin default state, constructing
  with only \`enabled=False\`, and that the additive fields don't
  show up in \`exclude_none\` output.
- **Property** ✓ — parametrized state-acceptance test across all
  seven enum values.

Verification angles skipped:

- **Visual / DOM** — by design out of scope until the reader
  consumes the new state field.
- **Concurrency** — pure typed contract is stateless.

Commands run:

\`\`\`
$ nix develop -c pytest tests/unit/surfaces/test_reader_action_vocabulary.py
19 passed in 0.07s

$ nix develop -c pytest tests/unit/surfaces/ tests/unit/mcp/ tests/unit/cli/test_query_exec.py
516 passed in 47.18s

$ nix develop -c devtools verify --quick
exit_code: 0
\`\`\`

## Notes

- File-size budget for \`polylogue/surfaces/payloads.py\` bumps from
  1200 to 1250 to accommodate the new vocabulary block. The
  existing split-candidate recommendation (per-domain payload
  modules under \`polylogue/surfaces/\`) stands.