### PR TITLE
feat(surfaces): MessageRenderEnvelope — additive fields for unified reader payload (#1487)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -98,8 +98,8 @@ exceptions:
     reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275) and scoped/global facets entrypoint (#1269); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
 
   - path: polylogue/surfaces/payloads.py
-    ceiling: 1250
-    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269) and the ReaderActionState / READER_ACTION_IDS / repair_path / inspect_path closed vocabulary (#1488); split candidate: per-domain payload modules under polylogue/surfaces/"
+    ceiling: 1300
+    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269), the ReaderActionState / READER_ACTION_IDS closed vocabulary (#1488), and the MessageRenderEnvelope additions (branch_index, has_paste, has_tool_use, has_thinking, token/cache usage, model_name, attachment_refs, raw_id, source_path; #1487); split candidate: per-domain payload modules under polylogue/surfaces/"
 
   - path: tests/unit/storage/test_backend.py
     ceiling: 1750

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -255,7 +255,19 @@ def reader_message_actions() -> dict[str, ReaderActionAvailabilityPayload]:
 
 
 class ConversationMessagePayload(SurfacePayloadModel):
-    """Machine-readable message payload shared across CLI and MCP surfaces."""
+    """Machine-readable message payload shared across CLI and MCP surfaces.
+
+    #1487: this is the canonical ``MessageRenderEnvelope`` for every
+    reader entry. Both conversation-detail and paginated-message
+    endpoints emit this exact shape so the UI can render parent/branch
+    state, paste/attachment flags, raw/source refs, usage/cost
+    metadata, and disabled actions without per-endpoint special cases.
+
+    Every field beyond the original id/role/text/target_ref/anchor/
+    actions/timestamp/message_type/content_blocks/parent_id set is
+    additive with sensible default — so existing callers that only
+    set the original fields continue to work unchanged.
+    """
 
     id: str
     role: str
@@ -267,6 +279,35 @@ class ConversationMessagePayload(SurfacePayloadModel):
     message_type: str = "message"
     content_blocks: list[dict[str, object]] = Field(default_factory=list)
     parent_id: str | None = None
+    # #1487 envelope: branch/lineage state.
+    branch_index: int = 0
+    # #1487 envelope: per-message content flags. Surface what the storage
+    # layer already projects (#1201/#1583) so the reader does not have
+    # to re-derive them from the rendered text.
+    has_paste: bool = False
+    has_tool_use: bool = False
+    has_thinking: bool = False
+    # #1487 envelope: usage/cost metadata. Carries through from parsers
+    # that populated token counts (claude-code session JSONL records
+    # usage; codex sometimes does). All four default to zero so
+    # rendering paths can compute cost without dispatching on presence.
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    model_name: str | None = None
+    # #1487 envelope: provider attachment identifiers for the message.
+    # Tuple (immutable + ordered) so the reader can render them in
+    # parser order and the test contract pins exact equality.
+    attachment_refs: tuple[str, ...] = ()
+    # #1487 envelope: raw/source refs so the inspector can deep-link
+    # to provenance without re-querying. ``raw_id`` is the
+    # content-addressed blob id from ``raw_conversations``;
+    # ``source_path`` is the on-disk path the conversation was
+    # acquired from. Both default to None for messages whose
+    # conversation has no recorded raw artifact.
+    raw_id: str | None = None
+    source_path: str | None = None
 
     @classmethod
     def from_message(
@@ -274,6 +315,8 @@ class ConversationMessagePayload(SurfacePayloadModel):
         message: Message,
         *,
         conversation_id: object | None = None,
+        raw_id: str | None = None,
+        source_path: str | None = None,
     ) -> ConversationMessagePayload:
         raw_message_type = getattr(message, "message_type", None)
         if raw_message_type is None:
@@ -287,6 +330,11 @@ class ConversationMessagePayload(SurfacePayloadModel):
             if conversation_id is not None
             else None
         )
+        attachment_refs = tuple(
+            str(getattr(attachment, "id", ""))
+            for attachment in getattr(message, "attachments", ())
+            if getattr(attachment, "id", None)
+        )
         return cls(
             id=str(message.id),
             role=normalize_role(message.role),
@@ -297,6 +345,18 @@ class ConversationMessagePayload(SurfacePayloadModel):
             message_type=message_type,
             content_blocks=message.content_blocks,
             parent_id=message.parent_id,
+            branch_index=int(getattr(message, "branch_index", 0) or 0),
+            has_paste=bool(getattr(message, "has_paste", False)),
+            has_tool_use=bool(getattr(message, "has_tool_use", False)),
+            has_thinking=bool(getattr(message, "has_thinking", False)),
+            input_tokens=int(getattr(message, "input_tokens", 0) or 0),
+            output_tokens=int(getattr(message, "output_tokens", 0) or 0),
+            cache_read_tokens=int(getattr(message, "cache_read_tokens", 0) or 0),
+            cache_write_tokens=int(getattr(message, "cache_write_tokens", 0) or 0),
+            model_name=getattr(message, "model_name", None),
+            attachment_refs=attachment_refs,
+            raw_id=raw_id,
+            source_path=source_path,
         )
 
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -226,7 +226,8 @@ class TestReaderSearchState:
         }
         assert row["anchor"] == "conversation-c1"
         assert row["actions"]["open"]["enabled"] is True
-        assert row["actions"]["annotate"] == {"enabled": True}
+        assert row["actions"]["annotate"]["enabled"] is True
+        assert row["actions"]["annotate"]["state"] == "enabled"
 
     def test_facets_envelope_includes_scoped_flag(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -314,7 +315,8 @@ class TestReaderConversationState:
         }
         assert message["anchor"] == "message-m-c1"
         assert message["actions"]["copy_text"]["enabled"] is True
-        assert message["actions"]["annotate"] == {"enabled": True}
+        assert message["actions"]["annotate"]["enabled"] is True
+        assert message["actions"]["annotate"]["state"] == "enabled"
 
     def test_unknown_conversation_yields_404(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):

--- a/tests/unit/surfaces/test_message_render_envelope.py
+++ b/tests/unit/surfaces/test_message_render_envelope.py
@@ -1,0 +1,255 @@
+"""``MessageRenderEnvelope`` contract for ``ConversationMessagePayload`` (#1487).
+
+Pins the unified envelope every reader path emits — conversation detail,
+paginated message windows, MCP ``get_messages``, future bulk export. The
+contract enumerates which fields must be present (with their defaults)
+and asserts that a roundtrip through ``Message`` populates every typed
+slot from the canonical Message model.
+
+If a new field is added to ``ConversationMessagePayload``, this test
+must learn about it (the field list is exhaustively checked). That
+prevents the divergence the issue worried about — detail emitting one
+field set, paginated emitting another.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from polylogue.archive.message.models import Message
+from polylogue.archive.message.roles import Role
+from polylogue.archive.message.types import MessageType
+from polylogue.surfaces.payloads import (
+    ConversationMessagePayload,
+    ReaderActionAvailabilityPayload,
+    TargetRefPayload,
+)
+
+# The canonical envelope field set. Adding a new field to
+# ``ConversationMessagePayload`` requires extending this list — that's
+# the point: the contract should know about every emitted field so
+# downstream surfaces never silently drop one.
+_ENVELOPE_FIELDS: tuple[str, ...] = (
+    "id",
+    "role",
+    "text",
+    "target_ref",
+    "anchor",
+    "actions",
+    "timestamp",
+    "message_type",
+    "content_blocks",
+    "parent_id",
+    "branch_index",
+    "has_paste",
+    "has_tool_use",
+    "has_thinking",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "model_name",
+    "attachment_refs",
+    "raw_id",
+    "source_path",
+)
+
+
+def _build_message(**overrides: object) -> Message:
+    defaults: dict[str, object] = {
+        "id": "m1",
+        "role": Role.USER,
+        "text": "hello",
+        "timestamp": datetime(2026, 5, 27, 10, 0, tzinfo=UTC),
+        "message_type": MessageType.MESSAGE,
+        "parent_id": None,
+        "branch_index": 0,
+        "has_paste": False,
+        "has_tool_use": False,
+        "has_thinking": False,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "model_name": None,
+    }
+    defaults.update(overrides)
+    return Message(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Field-set contract — exhaustive
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_field_set_is_exhaustive() -> None:
+    """``ConversationMessagePayload`` field set matches the canonical envelope.
+
+    The contract is exact equality — extra fields would silently widen
+    the surface; missing fields would silently drop one. Either case
+    requires updating ``_ENVELOPE_FIELDS`` deliberately.
+    """
+    assert set(ConversationMessagePayload.model_fields) == set(_ENVELOPE_FIELDS), (
+        "ConversationMessagePayload field set drifted from the canonical envelope. "
+        "Update tests/unit/surfaces/test_message_render_envelope.py:_ENVELOPE_FIELDS "
+        "to match, and verify the detail and paginated message endpoints both emit "
+        "the new field."
+    )
+
+
+def test_envelope_minimal_construction_uses_default_envelope_fields() -> None:
+    """The minimum required kwargs are id/role/text; everything else has a default."""
+    payload = ConversationMessagePayload(id="m1", role="user", text="hi")
+
+    assert payload.target_ref is None
+    assert payload.anchor is None
+    assert payload.timestamp is None
+    assert payload.parent_id is None
+    assert payload.branch_index == 0
+    assert payload.has_paste is False
+    assert payload.has_tool_use is False
+    assert payload.has_thinking is False
+    assert payload.input_tokens == 0
+    assert payload.output_tokens == 0
+    assert payload.cache_read_tokens == 0
+    assert payload.cache_write_tokens == 0
+    assert payload.model_name is None
+    assert payload.attachment_refs == ()
+    assert payload.raw_id is None
+    assert payload.source_path is None
+    assert payload.message_type == "message"
+
+
+# ---------------------------------------------------------------------------
+# from_message: every typed slot populated from the canonical Message model
+# ---------------------------------------------------------------------------
+
+
+def test_from_message_propagates_branch_lineage_state() -> None:
+    msg = _build_message(branch_index=3, parent_id="m-parent")
+    payload = ConversationMessagePayload.from_message(msg, conversation_id="c1")
+    assert payload.branch_index == 3
+    assert payload.parent_id == "m-parent"
+
+
+def test_from_message_propagates_content_flags() -> None:
+    msg = _build_message(has_paste=True, has_tool_use=True, has_thinking=True)
+    payload = ConversationMessagePayload.from_message(msg, conversation_id="c1")
+    assert payload.has_paste is True
+    assert payload.has_tool_use is True
+    assert payload.has_thinking is True
+
+
+def test_from_message_propagates_usage_and_model() -> None:
+    msg = _build_message(
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=5,
+        cache_write_tokens=2,
+        model_name="claude-sonnet-4-6",
+    )
+    payload = ConversationMessagePayload.from_message(msg, conversation_id="c1")
+    assert payload.input_tokens == 10
+    assert payload.output_tokens == 20
+    assert payload.cache_read_tokens == 5
+    assert payload.cache_write_tokens == 2
+    assert payload.model_name == "claude-sonnet-4-6"
+
+
+def test_from_message_carries_explicit_raw_and_source_refs() -> None:
+    """``raw_id``/``source_path`` are caller-supplied because they live on
+    the conversation, not the message."""
+    msg = _build_message()
+    payload = ConversationMessagePayload.from_message(
+        msg,
+        conversation_id="c1",
+        raw_id="raw-sha256-abc",
+        source_path="/home/user/.claude/projects/p/c1.jsonl",
+    )
+    assert payload.raw_id == "raw-sha256-abc"
+    assert payload.source_path == "/home/user/.claude/projects/p/c1.jsonl"
+
+
+def test_from_message_carries_target_ref_when_conversation_id_supplied() -> None:
+    msg = _build_message()
+    payload = ConversationMessagePayload.from_message(msg, conversation_id="c1")
+    assert payload.target_ref == TargetRefPayload.message(conversation_id="c1", message_id="m1")
+    assert payload.anchor == "message-m1"
+
+
+def test_from_message_omits_target_ref_when_no_conversation_id() -> None:
+    """Without ``conversation_id`` the message can't be deep-linked."""
+    msg = _build_message()
+    payload = ConversationMessagePayload.from_message(msg)
+    assert payload.target_ref is None
+    # Anchor stays present because it only needs the message id.
+    assert payload.anchor == "message-m1"
+
+
+# ---------------------------------------------------------------------------
+# Back-compat with the existing test_web_reader contract test
+# ---------------------------------------------------------------------------
+
+
+def test_construction_with_only_legacy_fields_still_works() -> None:
+    """The roundtrip pattern from ``test_reader_target_ref_and_action_payloads_roundtrip``
+    in tests/unit/daemon/test_web_reader.py must still construct cleanly."""
+    payload = ConversationMessagePayload(
+        id="m-c1",
+        role="user",
+        text="Hello reader",
+        target_ref=TargetRefPayload.message(conversation_id="c1", message_id="m-c1"),
+        anchor="message-m-c1",
+        actions={"annotate": ReaderActionAvailabilityPayload(enabled=True)},
+    )
+    dump = payload.model_dump(mode="json", exclude_none=True)
+    assert dump["target_ref"]["identity_key"] == "message:c1:m-c1"
+    assert dump["actions"]["annotate"]["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Serialization stability — additive fields don't bloat the common payload
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_payload_serializes_compactly_with_exclude_none() -> None:
+    """The default envelope serializes without the typed envelope additions
+    crowding the JSON. Defaults that are False/0/() must still appear so
+    the contract is observable; only the optional ``None`` defaults are
+    omitted under ``exclude_none``."""
+    payload = ConversationMessagePayload(id="m1", role="user", text="hi")
+    blob = json.loads(payload.to_json(exclude_none=True))
+
+    # Required: typed envelope fields are observable (the test would
+    # fail-fast if a new None-default field crept in).
+    assert blob["branch_index"] == 0
+    assert blob["has_paste"] is False
+    assert blob["input_tokens"] == 0
+    assert blob["attachment_refs"] == []
+
+    # None defaults are correctly omitted.
+    assert "target_ref" not in blob
+    assert "parent_id" not in blob
+    assert "raw_id" not in blob
+    assert "source_path" not in blob
+    assert "model_name" not in blob
+
+
+# ---------------------------------------------------------------------------
+# Negative: envelope rejects free-form extras
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_rejects_unknown_fields() -> None:
+    """``extra="forbid"`` on SurfacePayloadModel keeps the contract closed."""
+    with pytest.raises(ValidationError):
+        ConversationMessagePayload(  # type: ignore[call-arg]
+            id="m1",
+            role="user",
+            text="hi",
+            mystery_field="surprise",
+        )


### PR DESCRIPTION
## Summary

Lands the typed unified envelope from #1487 without changing rendering.
\`ConversationMessagePayload\` is now the canonical
\`MessageRenderEnvelope\` for every reader path; both conversation-detail
and paginated-message endpoints emit the same shape so the UI can render
parent/branch state, paste/attachment flags, raw/source refs, usage/cost
metadata, and disabled actions without per-endpoint special cases.

Ref #1487.

## What landed

Additive fields on \`ConversationMessagePayload\` (all with sensible
defaults; existing callers unaffected):

| Field | Default | Source |
|---|---|---|
| \`branch_index\` | \`0\` | already on \`Message\`; surface it |
| \`has_paste\` | \`False\` | storage projection |
| \`has_tool_use\` | \`False\` | storage projection |
| \`has_thinking\` | \`False\` | storage projection |
| \`input_tokens\` | \`0\` | usage from claude-code/codex |
| \`output_tokens\` | \`0\` | usage |
| \`cache_read_tokens\` | \`0\` | usage |
| \`cache_write_tokens\` | \`0\` | usage |
| \`model_name\` | \`None\` | usage |
| \`attachment_refs\` | \`()\` | provider attachment ids |
| \`raw_id\` | \`None\` | conversation-level raw provenance (caller-supplied) |
| \`source_path\` | \`None\` | conversation-level source path (caller-supplied) |

\`from_message\` populates every typed slot from \`Message\` via
\`getattr\` so partial Message inputs continue to construct.

## What this PR does not do

- Reader UI rendering for the new fields (frontend work).
- MCP \`get_messages\` payload changes (already returns
  \`ConversationMessagePayload\`, so the new fields surface automatically
  on next response).

## Verification

Verification angles:

- **Exhaustive field-set contract** ✓ — the test fails if a future
  field is added without updating the canonical \`_ENVELOPE_FIELDS\`
  tuple. Forces explicit acknowledgement, preventing the divergence
  the issue worried about.
- **Default behavior** ✓ —
  \`test_envelope_minimal_construction_uses_default_envelope_fields\`
  pins every default value.
- **from_message propagation** ✓ — four parametrized tests cover
  branch lineage, content flags, usage+model, and raw/source refs.
- **Target-ref behavior** ✓ — two tests pin presence/absence based
  on \`conversation_id\` argument.
- **Counterfactual** ✓ — \`test_envelope_rejects_unknown_fields\`
  proves \`extra="forbid"\` still rejects typos at construction
  time.
- **Back-compat** ✓ —
  \`test_construction_with_only_legacy_fields_still_works\` pins the
  daemon/test_web_reader.py construction pattern.
- **Serialization stability** ✓ — \`exclude_none=True\` keeps the
  payload compact while observable typed defaults (0, False, ()) stay
  visible.

Out-of-scope test fixups: two existing daemon/test_web_reader.py tests
asserted exact dict equality \`{"enabled": True}\` against action
payloads. The \`state\` field landed in PR #1664 means
\`{"enabled": True, "state": "enabled"}\` is the current shape; updated
to assert the individual fields. The change is structural, not
semantic.

Commands run:

\`\`\`
$ nix develop -c pytest tests/unit/surfaces/test_message_render_envelope.py
11 passed in 0.10s

$ nix develop -c pytest tests/unit/surfaces/ tests/unit/daemon/test_web_reader.py \\
    tests/unit/mcp/ tests/unit/cli/test_query_exec.py
601 passed in 76.34s

$ nix develop -c devtools verify --quick
exit_code: 0
\`\`\`

## File budget

\`polylogue/surfaces/payloads.py\` bumps from 1250 to 1300 lines for
the envelope additions. Existing split-candidate (per-domain payload
modules under \`polylogue/surfaces/\`) stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message payloads now include expanded metadata: branch tracking, token/cache metrics, model name, attachment references, and content flags.

* **Tests**
  * Added comprehensive test coverage for message payload structure and serialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->