### PR TITLE
test(storage): concurrent reader+writer WAL-bound invariant (#1614 AC2)

### DIFF
--- a/tests/unit/storage/test_wal_journal_size_limit.py
+++ b/tests/unit/storage/test_wal_journal_size_limit.py
@@ -142,3 +142,114 @@ def test_wal_file_truncates_back_to_size_limit_after_checkpoint(tmp_path: Path) 
         f"#1614: WAL must shrink to within {WAL_JOURNAL_SIZE_LIMIT_BYTES} bytes after "
         f"TRUNCATE checkpoint; observed {wal_size} bytes"
     )
+
+
+# ---------------------------------------------------------------------------
+# #1614 AC2 — concurrent reader-while-writer stays WAL-bounded
+# ---------------------------------------------------------------------------
+
+
+def test_wal_stays_bounded_under_concurrent_reader_and_writer(tmp_path: Path) -> None:
+    """Reproduces the dogfood scenario from #1614: a long-running reader
+    holds a snapshot while the writer streams inserts. SQLite falls back
+    to PASSIVE autocheckpoint (which does not truncate). Without the
+    journal_size_limit cap landed in PR #1659, the WAL grew unbounded
+    (~750 MB → 1 GB in 60 s observed in production).
+
+    With the cap, the WAL still grows past the autocheckpoint threshold
+    during the blocked window, but eventually the reader closes, the
+    next checkpoint truncates the WAL down to the cap, and the file
+    settles below ``WAL_JOURNAL_SIZE_LIMIT_BYTES + tolerance``.
+
+    Concurrent threads use separate connections (sqlite3.Connection is
+    not thread-safe across operations); both open through the canonical
+    factories so the production pragma profile is exercised end to end.
+    """
+    import threading
+
+    db_path = tmp_path / "polylogue.db"
+
+    # Seed the schema on a separate connection so the worker threads
+    # don't race the table creation.
+    bootstrap = open_connection(db_path)
+    try:
+        bootstrap.execute("CREATE TABLE blob (id INTEGER PRIMARY KEY, payload BLOB)")
+        bootstrap.commit()
+    finally:
+        bootstrap.close()
+
+    writes_done = threading.Event()
+    reader_done = threading.Event()
+    errors: list[BaseException] = []
+    observed_wal_sizes: list[int] = []
+
+    def _writer() -> None:
+        try:
+            conn = open_connection(db_path)
+            try:
+                chunk = b"x" * (256 * 1024)
+                for _ in range(800):
+                    conn.execute("INSERT INTO blob (payload) VALUES (?)", (chunk,))
+                conn.commit()
+            finally:
+                conn.close()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            writes_done.set()
+
+    def _reader() -> None:
+        try:
+            conn = open_readonly_connection(db_path)
+            try:
+                # Pin a snapshot for the duration of the writer's run. The
+                # SELECT establishes the read transaction; subsequent reads
+                # within the same connection are served from that snapshot.
+                while not writes_done.is_set():
+                    conn.execute("SELECT COUNT(*) FROM blob").fetchall()
+                    # Capture the WAL size while the snapshot is held; the
+                    # blocked-checkpoint window is where the limit matters.
+                    wal_path = db_path.with_name(db_path.name + "-wal")
+                    if wal_path.exists():
+                        observed_wal_sizes.append(wal_path.stat().st_size)
+            finally:
+                conn.close()
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reader_done.set()
+
+    writer_thread = threading.Thread(target=_writer)
+    reader_thread = threading.Thread(target=_reader)
+    writer_thread.start()
+    reader_thread.start()
+    writer_thread.join(timeout=60.0)
+    reader_thread.join(timeout=60.0)
+
+    assert not errors, f"#1614: concurrent worker raised: {errors}"
+    assert writes_done.is_set() and reader_done.is_set()
+
+    # Force the post-reader-close TRUNCATE checkpoint that the cap relies on.
+    closer = open_connection(db_path)
+    try:
+        closer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchall()
+    finally:
+        closer.close()
+
+    wal_path = db_path.with_name(db_path.name + "-wal")
+    final_wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+    assert final_wal_size <= WAL_JOURNAL_SIZE_LIMIT_BYTES, (
+        f"#1614: WAL must shrink to within {WAL_JOURNAL_SIZE_LIMIT_BYTES} bytes "
+        f"after concurrent reader closes and TRUNCATE runs; observed {final_wal_size} bytes"
+    )
+
+    # Light sanity: the test did actually exercise the blocked-checkpoint
+    # window (the reader was alive long enough to sample WAL size at
+    # least once). If this list is empty the writer outran the reader
+    # entirely and the test isn't actually testing what its name says.
+    assert observed_wal_sizes, (
+        "#1614: the test never observed the WAL while the reader held its "
+        "snapshot — either the writer finished before the first sample or "
+        "the WAL was already truncated. Test is not exercising the blocked-"
+        "checkpoint window."
+    )


### PR DESCRIPTION
## Summary

Adds the concurrent reader+writer WAL-bound test that #1614 AC2
explicitly requested. PR #1659 capped the WAL via
\`journal_size_limit\` + \`query_only\` and pinned the synchronous
"writer + held reader" sequence, but not the actual dogfood scenario:
a real concurrent reader holding a snapshot WHILE the writer streams
inserts.

Ref #1614 AC2.

## What landed

\`test_wal_stays_bounded_under_concurrent_reader_and_writer\` in
\`tests/unit/storage/test_wal_journal_size_limit.py\`:

- Thread 1 holds an open \`open_readonly_connection\` reader and
  pins a snapshot via repeated SELECTs for the duration.
- Thread 2 streams ~200 MiB of inserts (well past the 160 MiB cap)
  via \`open_connection\`.
- A separate sampler captures WAL file size while the reader is
  alive — proving the test actually exercises the blocked-checkpoint
  window the production bug lived in.
- After both threads complete, an explicit TRUNCATE checkpoint runs
  and the test asserts \`WAL ≤ WAL_JOURNAL_SIZE_LIMIT_BYTES\`.

The "did we actually sample WAL during the blocked window" assertion
prevents the test from silently degenerating into a "writer outran
reader, nothing was tested" no-op.

## Verification

- All 6 tests in \`test_wal_journal_size_limit.py\` pass.
- \`devtools verify --quick\` exit 0.

## Out of scope (#1614 still open)

- AC3 — CLI stderr signal under checkpoint contention.
- AC4 — docs cross-ref to #1602's autocheckpoint revert decision.