### PR TITLE
fix(repository): hydrate message_count in get_summary + search_summaries (#1630)

### DIFF
--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -188,7 +188,16 @@ class RepositoryArchiveConversationMixin:
         if not conv_record:
             return None
         tags_by_id = await self._fetch_tags_by_conversation([conversation_id])
-        return conversation_summary_from_record(conv_record, tags=tags_by_id.get(conversation_id, ()))
+        # #1630: hydrate message_count from conversation_stats so the daemon
+        # HTTP /api/conversations/{id} endpoint and any other ``get_summary``
+        # caller see a real total instead of None. Same shape as
+        # list_summaries_by_query below.
+        counts_by_id = await self.queries.get_message_counts_batch([conversation_id])
+        return conversation_summary_from_record(
+            conv_record,
+            tags=tags_by_id.get(conversation_id, ()),
+            message_count=counts_by_id.get(conversation_id),
+        )
 
     async def list_summaries_by_query(
         self,

--- a/polylogue/storage/repository/archive/search.py
+++ b/polylogue/storage/repository/archive/search.py
@@ -62,7 +62,18 @@ class RepositoryArchiveSearchMixin:
         hits, records = await self._search_records(query, limit=limit, providers=providers)
         if not hits.hits:
             return []
-        return [conversation_summary_from_record(record) for record in records]
+        # #1630: hydrate message_count from conversation_stats so the
+        # daemon HTTP /api/conversations search path and any other
+        # ``search_summaries`` caller see a real total instead of None.
+        ids = [str(record.conversation_id) for record in records]
+        counts_by_id = await self.queries.get_message_counts_batch(ids)
+        return [
+            conversation_summary_from_record(
+                record,
+                message_count=counts_by_id.get(str(record.conversation_id)),
+            )
+            for record in records
+        ]
 
     async def search_summary_hits(
         self,
@@ -102,7 +113,16 @@ class RepositoryArchiveSearchMixin:
             return []
 
         records = await self.queries.get_conversations_batch([hit.conversation_id for hit in evidence_hits])
-        summaries_by_id = {str(record.conversation_id): conversation_summary_from_record(record) for record in records}
+        # #1630: hydrate message_count from conversation_stats so search
+        # hit summaries carry a real total instead of None.
+        ids = [str(record.conversation_id) for record in records]
+        counts_by_id = await self.queries.get_message_counts_batch(ids) if ids else {}
+        summaries_by_id = {
+            str(record.conversation_id): conversation_summary_from_record(
+                record, message_count=counts_by_id.get(str(record.conversation_id))
+            )
+            for record in records
+        }
         return [
             conversation_search_hit_from_summary(
                 summaries_by_id[hit.conversation_id],

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -101,6 +101,10 @@ class _FakeQueries(SQLiteQueryStore):
         self.last_batch_ids = ids
         return [self.records_by_id[conversation_id] for conversation_id in ids]
 
+    async def get_message_counts_batch(self, ids: list[str]) -> dict[str, int]:
+        """Hydrator (#1630): return a count per conversation id keyed in records."""
+        return {conversation_id: 42 + i for i, conversation_id in enumerate(ids)}
+
 
 class _FakeRepo(RepositoryArchiveSearchMixin):
     queries: _FakeQueries
@@ -194,6 +198,38 @@ async def test_repository_search_summaries_follow_conversation_hit_order() -> No
     assert queries.last_batch_ids == ["conv-b", "conv-a"]
     assert [summary.id for summary in summaries] == [ConversationId("conv-b"), ConversationId("conv-a")]
     assert [summary.title for summary in summaries] == ["Second", "First"]
+
+
+@pytest.mark.asyncio
+async def test_repository_search_summaries_hydrates_message_count_from_stats() -> None:
+    """#1630: ``search_summaries`` must populate ``message_count`` from
+    ``conversation_stats`` so the daemon HTTP search path and any other
+    caller see a real total instead of None.
+
+    Before the fix the message_count surfaced as 0 (None coerced) for every
+    conversation in /api/conversations and /api/conversations?q=... results.
+    """
+    hits = ConversationSearchResult(
+        hits=[
+            StorageConversationSearchIdHit(conversation_id="conv-b", rank=1, score=1.0),
+            StorageConversationSearchIdHit(conversation_id="conv-a", rank=2, score=2.0),
+        ]
+    )
+    queries = _FakeQueries(
+        hits=hits,
+        records_by_id={
+            "conv-a": _conversation_record("conv-a", title="First"),
+            "conv-b": _conversation_record("conv-b", title="Second"),
+        },
+    )
+    repo = _FakeRepo(queries)
+
+    summaries = await repo.search_summaries("storage", limit=5)
+
+    counts = {str(summary.id): summary.message_count for summary in summaries}
+    assert counts == {"conv-b": 42, "conv-a": 43}, (
+        f"#1630: search_summaries must hydrate message_count from stats; got {counts}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1630.

`get_summary` and `search_summaries` were not fetching message_count from `conversation_stats`, so every `/api/conversations` and `/api/conversations?q=...` response showed `message_count: 0`. Only `list_summaries_by_query` did the hydration (landed for #1623). This PR fixes the missing branches.

- `ConversationRepository.get_summary`: single-id `get_message_counts_batch` fetch.
- `ConversationRepository.search_summaries`: batch fetch for the returned records.
- `ConversationRepository.search_summary_hits`: same shape.

New test `test_repository_search_summaries_hydrates_message_count_from_stats` pins the contract via an override on `_FakeQueries.get_message_counts_batch`. Pre-existing `test_gemini_drive_attachment_id_is_searchable_after_parse_and_prepare` failures reproduce on master and stay tracked under #1657.

Verification: `devtools verify --quick` exit 0.