### PR TITLE
fix(cli): wrap list/summary JSON output in paginated envelope (#1618)

### DIFF
--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -202,15 +202,28 @@ def format_list(
     output_format: str,
     fields: str | None,
 ) -> str:
-    """Format a list of conversations for output."""
+    """Format a list of conversations for output.
+
+    #1618: JSON and YAML emit a paginated envelope
+    (``{"items": [...], "total": N, "limit": N, "offset": 0}``) instead
+    of a bare array so the shape matches the MCP
+    ``list_conversations`` tool. ``next_offset`` is omitted because
+    the CLI doesn't paginate today (it returns the full match set);
+    when CLI pagination lands it will populate the same field MCP
+    already does. Bare-array consumers must read ``.items``.
+    """
     from polylogue.rendering.formatting import _conv_to_dict
 
     if output_format == "json":
-        return json.dumps([_conv_to_dict(c, fields) for c in results], indent=2)
+        items = [_conv_to_dict(c, fields) for c in results]
+        envelope = {"items": items, "total": len(items), "limit": len(items), "offset": 0}
+        return json.dumps(envelope, indent=2)
     if output_format == "yaml":
         import yaml
 
-        return str(yaml.dump([_conv_to_dict(c, fields) for c in results], default_flow_style=False, allow_unicode=True))
+        items = [_conv_to_dict(c, fields) for c in results]
+        envelope = {"items": items, "total": len(items), "limit": len(items), "offset": 0}
+        return str(yaml.dump(envelope, default_flow_style=False, allow_unicode=True, sort_keys=False))
     if output_format == "csv":
         return conversations_to_csv(results)
 

--- a/polylogue/cli/query_output_contracts.py
+++ b/polylogue/cli/query_output_contracts.py
@@ -49,16 +49,33 @@ class StructuredRowsDocument:
 
     def render(self, output_format: QueryOutputFormat) -> str:
         if output_format == "json":
-            return json.dumps(list(self.rows), indent=2)
+            # #1618: paginated envelope matches the MCP list_conversations
+            # tool. The CLI doesn't paginate today so ``limit`` mirrors
+            # ``total`` and ``offset`` is 0; future CLI pagination will
+            # populate the same fields MCP already does.
+            envelope = {
+                "items": list(self.rows),
+                "total": len(self.rows),
+                "limit": len(self.rows),
+                "offset": 0,
+            }
+            return json.dumps(envelope, indent=2)
         if output_format == "ndjson":
             # JSON Lines streaming form: one JSON document per line, no
             # outer array, no indentation. Stable for shell pipelines and
             # LLM tool-use harnesses that want incremental parsing (#1272).
+            # Pagination context does not apply to a streaming form.
             return "\n".join(json.dumps(row, separators=(",", ":")) for row in self.rows)
         if output_format == "yaml":
             import yaml
 
-            return yaml.dump(list(self.rows), default_flow_style=False, allow_unicode=True)
+            envelope = {
+                "items": list(self.rows),
+                "total": len(self.rows),
+                "limit": len(self.rows),
+                "offset": 0,
+            }
+            return yaml.dump(envelope, default_flow_style=False, allow_unicode=True, sort_keys=False)
         if output_format == "csv":
             return self._render_csv()
         return "\n".join(self.text_lines)

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -323,13 +323,15 @@ class CLISurface:
         except json.JSONDecodeError as exc:
             raise AssertionError(f"CLI list output is not JSON ({query_case.name!r}): {output!r}") from exc
         # Three shapes can land here:
-        #   * list mode: ``[{"id": ..., ...}, ...]``
-        #   * search-hit mode: ``[{"conversation": {"id": ...}, ...}, ...]``
+        #   * list mode envelope (#1618): ``{"items": [...], "total": ..., ...}``
+        #   * search-hit mode (legacy bare array): ``[{"conversation": {"id": ...}, ...}, ...]``
         #   * typed ranked-result envelope (PR #1370):
         #     ``{"hits": [{"conversation": {"id": ...}, "match": {...}}, ...], "limit": ..., ...}``
         # All three project to the same id tuple for parity comparison.
         if isinstance(parsed, dict) and isinstance(parsed.get("hits"), list):
             parsed = parsed["hits"]
+        elif isinstance(parsed, dict) and isinstance(parsed.get("items"), list):
+            parsed = parsed["items"]
         if not isinstance(parsed, list):
             raise AssertionError(f"CLI list output is not a JSON array ({query_case.name!r}): {parsed!r}")
         ids: list[str] = []

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -545,9 +545,14 @@ def test_output_summary_list_contract(case: SummaryOutputCase, output_format: st
         asyncio.run(_output_summary_list(env, summaries, output, repo))
 
     if output_format == "json":
-        assert json.loads(mock_echo.call_args[0][0]) == _structured_rows(case)
+        # #1618: envelope shape carries items/total/limit/offset.
+        payload = json.loads(mock_echo.call_args[0][0])
+        assert payload["items"] == _structured_rows(case)
+        assert payload["total"] == len(case.summaries)
     elif output_format == "yaml":
-        assert yaml.safe_load(mock_echo.call_args[0][0]) == _structured_rows(case)
+        payload = yaml.safe_load(mock_echo.call_args[0][0])
+        assert payload["items"] == _structured_rows(case)
+        assert payload["total"] == len(case.summaries)
     elif output_format == "csv":
         assert list(csv.DictReader(io.StringIO(mock_echo.call_args[0][0]))) == _csv_rows(case)
     else:
@@ -2063,9 +2068,11 @@ class TestSearchQueryContracts:
         assert result.exit_code == 0, case_id
 
         if expectation == "json_list":
+            # #1618: envelope shape, not bare array.
             data = json.loads(result.output)
-            assert isinstance(data, list), case_id
-            assert data and "id" in data[0], case_id
+            assert isinstance(data, dict), case_id
+            assert isinstance(data.get("items"), list), case_id
+            assert data["items"] and "id" in data["items"][0], case_id
         elif expectation == "json_single":
             data = json.loads(result.output)
             assert isinstance(data, (list, dict)), case_id
@@ -2118,11 +2125,14 @@ class TestSearchEdgeCases:
         assert result_lower.exit_code == result_upper.exit_code
 
         if result_lower.exit_code == 0:
-            # Both should find results (FTS5 is case-insensitive by default)
+            # Both should find results (FTS5 is case-insensitive by default).
+            # #1618: envelope shape carries items list under "items".
             data_lower = json.loads(result_lower.output)
             data_upper = json.loads(result_upper.output)
-            assert len(data_lower) > 0
-            assert len(data_upper) > 0
+            items_lower = data_lower["items"] if isinstance(data_lower, dict) else data_lower
+            items_upper = data_upper["items"] if isinstance(data_upper, dict) else data_upper
+            assert len(items_lower) > 0
+            assert len(items_upper) > 0
 
     def test_search_multiple_terms(self, search_workspace: SearchWorkspace) -> None:
         """Search with multiple query terms."""
@@ -2135,8 +2145,10 @@ class TestSearchEdgeCases:
         result = runner.invoke(cli, ["--plain", "Python", "exception", "list", "-f", "json"])
         assert result.exit_code in (0, 2)
         if result.exit_code == 0:
+            # #1618: envelope shape, not bare array.
             data = json.loads(result.output)
-            assert isinstance(data, list)
+            assert isinstance(data, dict)
+            assert isinstance(data.get("items"), list)
 
 
 class TestSearchIndexRebuild:

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -461,8 +461,12 @@ class TestListFormatting:
             text_lines=("conv-a  claude-ai  A (2 msgs)",),
         )
 
-        assert json.loads(document.with_selected_fields("id,title").render("json")) == [{"id": "conv-a", "title": "A"}]
-        assert yaml.safe_load(document.render("yaml"))[0]["provider"] == "claude-ai"
+        # #1618: JSON/YAML render via envelope, not bare array.
+        json_payload = json.loads(document.with_selected_fields("id,title").render("json"))
+        assert json_payload["items"] == [{"id": "conv-a", "title": "A"}]
+        assert json_payload["total"] == 1
+        yaml_payload = yaml.safe_load(document.render("yaml"))
+        assert yaml_payload["items"][0]["provider"] == "claude-ai"
         assert document.render("csv").splitlines()[0] == "id,provider,title,messages"
         assert document.render("text") == "conv-a  claude-ai  A (2 msgs)"
 
@@ -482,11 +486,13 @@ class TestListFormatting:
             assert token in rendered, (case.name, token)
         if case.name == "json_selected":
             payload = json.loads(rendered)
-            assert payload[0] == {"id": "conv-1234567890abcdef", "title": "Example Conversation"}
+            # #1618: envelope shape, not bare array.
+            assert payload["items"][0] == {"id": "conv-1234567890abcdef", "title": "Example Conversation"}
+            assert payload["total"] == 2
         if case.name == "yaml":
             payload = yaml.safe_load(rendered)
-            assert payload[0]["id"] == "conv-1234567890abcdef"
-            assert payload[0]["provider"] == "claude-ai"
+            assert payload["items"][0]["id"] == "conv-1234567890abcdef"
+            assert payload["items"][0]["provider"] == "claude-ai"
 
     @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "text"])
     def test_format_summary_list_contract(self, output_format: str) -> None:
@@ -508,13 +514,15 @@ class TestListFormatting:
 
         if output_format == "json":
             payload = json.loads(rendered)
-            assert payload[0]["id"] == "conv-summary-1"
-            assert payload[0]["messages"] == 7
-            assert payload[0]["tags"] == ["alpha", "beta"]
+            # #1618: envelope shape, not bare array.
+            assert payload["items"][0]["id"] == "conv-summary-1"
+            assert payload["items"][0]["messages"] == 7
+            assert payload["items"][0]["tags"] == ["alpha", "beta"]
+            assert payload["total"] == 1
         elif output_format == "yaml":
             payload = yaml.safe_load(rendered)
-            assert payload[0]["provider"] == "claude-ai"
-            assert payload[0]["summary"] == "Summary text"
+            assert payload["items"][0]["provider"] == "claude-ai"
+            assert payload["items"][0]["summary"] == "Summary text"
         elif output_format == "csv":
             assert "id,date,provider,title,messages,tags,summary" in rendered
             assert "conv-summary-1" in rendered
@@ -553,14 +561,15 @@ class TestListFormatting:
 
         if output_format == "json":
             payload = json.loads(rendered)
-            assert payload[0]["conversation"]["id"] == "conv-hit-1"
-            assert payload[0]["conversation"]["message_count"] == 4
-            assert payload[0]["match"]["message_id"] == "msg-hit-1"
-            assert payload[0]["match"]["snippet"] == "[needle] in context"
+            # #1618: envelope shape, not bare array.
+            assert payload["items"][0]["conversation"]["id"] == "conv-hit-1"
+            assert payload["items"][0]["conversation"]["message_count"] == 4
+            assert payload["items"][0]["match"]["message_id"] == "msg-hit-1"
+            assert payload["items"][0]["match"]["snippet"] == "[needle] in context"
         elif output_format == "yaml":
             payload = yaml.safe_load(rendered)
-            assert payload[0]["conversation"]["provider"] == "claude-ai"
-            assert payload[0]["match"]["retrieval_lane"] == "dialogue"
+            assert payload["items"][0]["conversation"]["provider"] == "claude-ai"
+            assert payload["items"][0]["match"]["retrieval_lane"] == "dialogue"
         elif output_format == "csv":
             assert "id,date,provider,title,messages,rank,retrieval_lane,match_surface,message_id,snippet" in rendered
             assert "conv-hit-1" in rendered
@@ -590,10 +599,47 @@ class TestListFormatting:
         rendered = format_search_hit_list([hit], "json", None, message_counts={"conv-attachment-hit": 1})
         payload = json.loads(rendered)
 
-        assert payload[0]["match"]["match_surface"] == "attachment"
-        assert payload[0]["match"]["retrieval_lane"] == "attachment"
-        assert payload[0]["match"]["message_id"] == "msg-doc"
-        assert "attachment.provider_file_id=drive-file-1" in payload[0]["match"]["snippet"]
+        # #1618: envelope shape, not bare array.
+        assert payload["items"][0]["match"]["match_surface"] == "attachment"
+        assert payload["items"][0]["match"]["retrieval_lane"] == "attachment"
+        assert payload["items"][0]["match"]["message_id"] == "msg-doc"
+        assert "attachment.provider_file_id=drive-file-1" in payload["items"][0]["match"]["snippet"]
+
+    def test_cli_list_json_envelope_matches_mcp_list_conversations_shape(self) -> None:
+        """#1618: CLI ``--format json`` list output emits the same
+        ``{"items": [...], "total": N, "limit": N, "offset": N}`` envelope
+        that MCP ``list_conversations`` returns. Bare-array output was the
+        pre-fix shape; both surfaces now align.
+        """
+        document = StructuredRowsDocument(
+            rows=(
+                {"id": "conv-a", "provider": "claude-ai", "title": "A", "messages": 3},
+                {"id": "conv-b", "provider": "claude-ai", "title": "B", "messages": 5},
+            ),
+            csv_headers=("id", "provider", "title", "messages"),
+            csv_rows=(("conv-a", "claude-ai", "A", 3), ("conv-b", "claude-ai", "B", 5)),
+            text_lines=("conv-a  claude-ai  A (3 msgs)", "conv-b  claude-ai  B (5 msgs)"),
+        )
+        json_payload = json.loads(document.render("json"))
+        yaml_payload = yaml.safe_load(document.render("yaml"))
+
+        for payload in (json_payload, yaml_payload):
+            assert set(payload.keys()) == {"items", "total", "limit", "offset"}, (
+                f"#1618: envelope must carry items/total/limit/offset, got {sorted(payload.keys())}"
+            )
+            assert isinstance(payload["items"], list)
+            assert len(payload["items"]) == 2
+            assert payload["total"] == 2
+            assert payload["offset"] == 0
+            # ``limit`` mirrors ``total`` until CLI pagination lands.
+            assert payload["limit"] == 2
+
+        # ndjson stays a streaming form — no envelope. Pinned so a future
+        # refactor doesn't accidentally wrap ndjson too (would break shell
+        # pipelines that read line-by-line).
+        ndjson_lines = [line for line in document.render("ndjson").splitlines() if line]
+        parsed = [json.loads(line) for line in ndjson_lines]
+        assert [row["id"] for row in parsed] == ["conv-a", "conv-b"]
 
     def test_format_summary_and_search_use_provider_display_label(self) -> None:
         summary = ConversationSummary(
@@ -616,8 +662,12 @@ class TestListFormatting:
         summary_payload = json.loads(format_summary_list([summary], "json", None, message_counts={str(summary.id): 1}))
         search_payload = json.loads(format_search_hit_list([hit], "json", None, message_counts={str(summary.id): 1}))
 
-        assert summary_payload[0]["title"] == "Project Plan: Please review the attached project plan."
-        assert search_payload[0]["conversation"]["title"] == "Project Plan: Please review the attached project plan."
+        # #1618: envelope shape, not bare array.
+        assert summary_payload["items"][0]["title"] == "Project Plan: Please review the attached project plan."
+        assert (
+            search_payload["items"][0]["conversation"]["title"]
+            == "Project Plan: Please review the attached project plan."
+        )
 
 
 class TestStreamingOutput:


### PR DESCRIPTION
Closes #1618 AC1. AC2 (field-name harmonization `date`/`messages` → `created_at`/`updated_at`/`message_count`) and AC3 (cross-surface coherence probe) stay open.

Both CLI `polylogue list --format json` and MCP `list_conversations` now emit `{"items": [...], "total": N, "limit": N, "offset": 0}`. CSV/text and NDJSON unchanged.

Verification: 208 CLI tests pass; devtools verify --quick exit 0.