### PR TITLE
perf(insights): route cost_rollups through summary-only path (#1671)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -62,8 +62,8 @@ exceptions:
     reason: "blob orphan/integrity (#818) + message_type backfill (#839); split candidate: lift backfill into pipeline/services"
 
   - path: polylogue/operations/archive.py
-    ceiling: 1300
-    reason: "shared operation contracts for ingest/maintenance/mutation/insight aggregation routes (#861, #862, #1134); split candidate: per-domain operation modules under operations/"
+    ceiling: 1400
+    reason: "shared operation contracts for ingest/maintenance/mutation/insight aggregation routes (#861, #862, #1134) + summary-only cost rollup path (#1671); split candidate: per-domain operation modules under operations/"
 
 
   - path: polylogue/daemon/status.py

--- a/polylogue/archive/semantic/pricing.py
+++ b/polylogue/archive/semantic/pricing.py
@@ -535,9 +535,30 @@ def estimate_message_cost(
 
 
 def _conversation_level_estimate(conversation: Conversation) -> CostEstimatePayload | None:
-    source_name = _provider_text(conversation.provider)
-    provider_meta = _record(conversation.provider_meta)
-    raw = _record(provider_meta.get("raw")) or provider_meta
+    return estimate_cost_from_provider_meta(
+        source_name=_provider_text(conversation.provider),
+        conversation_id=str(conversation.id),
+        provider_meta=conversation.provider_meta,
+    )
+
+
+def estimate_cost_from_provider_meta(
+    *,
+    source_name: str,
+    conversation_id: str,
+    provider_meta: object,
+) -> CostEstimatePayload | None:
+    """Estimate session cost from ``provider_meta`` alone — no messages required.
+
+    Returns ``None`` when ``provider_meta`` carries neither a ``total_cost_usd``
+    value nor enough usage/model evidence to estimate. Callers that have the
+    full message stream may fall through to ``estimate_conversation_cost``
+    for a per-message aggregation; bulk/aggregate callers (#1621) that want
+    bounded cost without loading messages should accept a ``None`` here as
+    "unavailable for this session" and report it as such.
+    """
+    pm = _record(provider_meta)
+    raw = _record(pm.get("raw")) or pm
     exact = (
         _coerce_float(raw.get("total_cost_usd"))
         or _coerce_float(raw.get("costUSD"))
@@ -551,7 +572,7 @@ def _conversation_level_estimate(conversation: Conversation) -> CostEstimatePayl
     if exact is not None and exact > 0.0:
         return _exact_estimate(
             source_name=source_name,
-            conversation_id=str(conversation.id),
+            conversation_id=conversation_id,
             model_name=model_name,
             usage=usage,
             total_usd=exact,
@@ -559,7 +580,7 @@ def _conversation_level_estimate(conversation: Conversation) -> CostEstimatePayl
     if usage.billable_tokens > 0 or model_name:
         return _estimate_from_usage(
             source_name=source_name,
-            conversation_id=str(conversation.id),
+            conversation_id=conversation_id,
             model_name=model_name,
             usage=usage,
             provenance=("conversation_provider_meta",),
@@ -713,6 +734,7 @@ __all__ = [
     "_normalize_model",
     "estimate_conversation_cost",
     "estimate_cost",
+    "estimate_cost_from_provider_meta",
     "estimate_message_cost",
     "generated_at",
     "harmonize_session_cost",

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -12,8 +13,10 @@ from polylogue.archive.conversation.models import ConversationSummary
 from polylogue.archive.query.spec import ConversationQuerySpec
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec, project_message_content
 from polylogue.archive.semantic.pricing import (
+    CostEstimatePayload,
     _normalize_model,
     estimate_conversation_cost,
+    estimate_cost_from_provider_meta,
     generated_at,
 )
 from polylogue.config import ConfigError
@@ -304,15 +307,23 @@ def _week_coverage_insight(insight: WeekSessionSummaryInsight) -> ArchiveCoverag
     )
 
 
-def _session_cost_insight(conversation: Conversation, *, materialized_at: str) -> SessionCostInsight:
-    estimate = estimate_conversation_cost(conversation)
-    source_updated = conversation.updated_at or conversation.created_at
+def _build_session_cost_insight(
+    *,
+    conversation_id: str,
+    source_name: str,
+    title: str | None,
+    created_at: datetime | None,
+    updated_at: datetime | None,
+    estimate: CostEstimatePayload,
+    materialized_at: str,
+) -> SessionCostInsight:
+    source_updated = updated_at or created_at
     return SessionCostInsight(
-        conversation_id=str(conversation.id),
-        source_name=str(conversation.provider),
-        title=conversation.title,
-        created_at=conversation.created_at.isoformat() if conversation.created_at is not None else None,
-        updated_at=conversation.updated_at.isoformat() if conversation.updated_at is not None else None,
+        conversation_id=conversation_id,
+        source_name=source_name,
+        title=title,
+        created_at=created_at.isoformat() if created_at is not None else None,
+        updated_at=updated_at.isoformat() if updated_at is not None else None,
         estimate=estimate,
         provenance=ArchiveInsightProvenance(
             materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
@@ -320,6 +331,50 @@ def _session_cost_insight(conversation: Conversation, *, materialized_at: str) -
             source_updated_at=source_updated.isoformat() if source_updated is not None else None,
             source_sort_key=source_updated.timestamp() if source_updated is not None else None,
         ),
+    )
+
+
+def _session_cost_insight(conversation: Conversation, *, materialized_at: str) -> SessionCostInsight:
+    return _build_session_cost_insight(
+        conversation_id=str(conversation.id),
+        source_name=str(conversation.provider),
+        title=conversation.title,
+        created_at=conversation.created_at,
+        updated_at=conversation.updated_at,
+        estimate=estimate_conversation_cost(conversation),
+        materialized_at=materialized_at,
+    )
+
+
+def _session_cost_insight_from_summary(
+    summary: ConversationSummary,
+    *,
+    materialized_at: str,
+) -> SessionCostInsight:
+    """#1671: build SessionCostInsight from a summary's provider_meta alone."""
+    source_name = str(summary.provider)
+    conversation_id = str(summary.id)
+    estimate = estimate_cost_from_provider_meta(
+        source_name=source_name,
+        conversation_id=conversation_id,
+        provider_meta=summary.provider_meta,
+    ) or CostEstimatePayload(
+        source_name=source_name,
+        conversation_id=conversation_id,
+        status="unavailable",
+        confidence=0.0,
+        missing_reasons=("provider_meta_no_cost",),
+        unavailable_reason="no_tokens",
+        provenance=("conversation_provider_meta",),
+    )
+    return _build_session_cost_insight(
+        conversation_id=conversation_id,
+        source_name=source_name,
+        title=summary.title,
+        created_at=summary.created_at,
+        updated_at=summary.updated_at,
+        estimate=estimate,
+        materialized_at=materialized_at,
     )
 
 
@@ -985,17 +1040,37 @@ class ArchiveInsightAggregateMixin:
         self,
         query: CostRollupInsightQuery | None = None,
     ) -> list[CostRollupInsight]:
+        """Aggregate per-(source_name, model) cost rollups across the archive.
+
+        #1671: this path used to fetch every Conversation with messages via
+        ``list_session_cost_insights`` so it could call
+        ``estimate_conversation_cost`` per session. On a 7.9K-conversation
+        archive that pulled 3.7M message rows into Python and hung the MCP
+        stdio loop past its 60s deadline (#1621).
+
+        Now we route through summaries: ``list_session_cost_insights_from_summaries``
+        reads only conversation metadata + provider_meta and computes each
+        session's cost via ``estimate_cost_from_provider_meta``. Sessions
+        whose provider_meta does not carry a usable cost end up as
+        ``status="unavailable"`` rollups — accurate for the aggregate view
+        because the unavailable bucket is itself one of the reported rollup
+        states.
+        """
         request = _default_query(query, CostRollupInsightQuery)
-        session_costs = await self.list_session_cost_insights(
-            SessionCostInsightQuery(
-                provider=request.provider,
-                since=request.since,
-                until=request.until,
-                model=request.model,
-                limit=None,
-            )
+        materialized_at = generated_at()
+        summaries = await self.repository.list_summaries(
+            provider=request.provider,
+            since=request.since,
+            until=request.until,
+            limit=None,
+            include_provider_meta=True,
         )
-        rollups = aggregate_cost_rollup_insights(session_costs, materialized_at=generated_at())
+        session_costs = [
+            _session_cost_insight_from_summary(summary, materialized_at=materialized_at) for summary in summaries
+        ]
+        if request.model:
+            session_costs = [insight for insight in session_costs if _cost_model_matches(insight, request.model)]
+        rollups = aggregate_cost_rollup_insights(session_costs, materialized_at=materialized_at)
         return _slice_insights(rollups, offset=request.offset, limit=request.limit)
 
     async def get_insight_readiness_report(

--- a/polylogue/storage/query_models.py
+++ b/polylogue/storage/query_models.py
@@ -32,6 +32,7 @@ class ConversationListQueryKwargs(TypedDict):
     max_messages: int | None
     min_words: int | None
     message_type: str | None
+    include_provider_meta: bool
 
 
 class ConversationCountQueryKwargs(TypedDict):
@@ -87,6 +88,7 @@ class ConversationRecordQuery:
     min_words: int | None = None
     since_session_id: str | None = None
     message_type: str | None = None
+    include_provider_meta: bool = False
 
     def with_limit(self, limit: int | None) -> ConversationRecordQuery:
         return replace(self, limit=limit)
@@ -138,6 +140,7 @@ class ConversationRecordQuery:
             "max_messages": self.max_messages,
             "min_words": self.min_words,
             "message_type": self.message_type,
+            "include_provider_meta": self.include_provider_meta,
         }
 
     def to_count_kwargs(self) -> ConversationCountQueryKwargs:

--- a/polylogue/storage/repository/archive/queries.py
+++ b/polylogue/storage/repository/archive/queries.py
@@ -52,6 +52,7 @@ class RepositoryArchiveQueryMixin:
         max_messages: int | None = None,
         min_words: int | None = None,
         message_type: str | None = None,
+        include_provider_meta: bool = False,
     ) -> list[ConversationSummary]:
         return await self.list_summaries_by_query(
             ConversationRecordQuery(
@@ -75,6 +76,7 @@ class RepositoryArchiveQueryMixin:
                 max_messages=max_messages,
                 min_words=min_words,
                 message_type=message_type,
+                include_provider_meta=include_provider_meta,
             )
         )
 

--- a/polylogue/storage/sqlite/queries/conversations_reads.py
+++ b/polylogue/storage/sqlite/queries/conversations_reads.py
@@ -61,7 +61,9 @@ async def list_conversations(
     max_messages: int | None = None,
     min_words: int | None = None,
     message_type: str | None = None,
+    include_provider_meta: bool = False,
 ) -> list[ConversationRecord]:
+    del include_provider_meta  # list_conversations always loads via SELECT *
     use_stats_join = _needs_stats_join(
         has_tool_use=has_tool_use,
         has_thinking=has_thinking,
@@ -152,6 +154,7 @@ async def list_conversation_summaries(
     max_messages: int | None = None,
     min_words: int | None = None,
     message_type: str | None = None,
+    include_provider_meta: bool = False,
 ) -> list[ConversationRecord]:
     use_stats_join = _needs_stats_join(
         has_tool_use=has_tool_use,
@@ -162,6 +165,8 @@ async def list_conversation_summaries(
         max_messages=max_messages,
         min_words=min_words,
     )
+    pm_qualified = "c.provider_meta" if include_provider_meta else "NULL AS provider_meta"
+    pm_bare = "provider_meta" if include_provider_meta else "NULL AS provider_meta"
     where_sql, params = _build_conversation_filters(
         source=source,
         provider=provider,
@@ -189,7 +194,7 @@ async def list_conversation_summaries(
 
     if use_stats_join:
         from_clause = "FROM conversations c LEFT JOIN conversation_stats cs ON cs.conversation_id = c.conversation_id"
-        select_clause = """
+        select_clause = f"""
         SELECT
             c.conversation_id,
             c.source_name,
@@ -199,7 +204,7 @@ async def list_conversation_summaries(
             c.updated_at,
             c.sort_key,
             c.content_hash,
-            NULL AS provider_meta,
+            {pm_qualified},
             c.metadata,
             c.version,
             c.parent_conversation_id,
@@ -209,7 +214,7 @@ async def list_conversation_summaries(
         order_clause = "ORDER BY (c.sort_key IS NULL) ASC, c.sort_key DESC, c.conversation_id DESC"
     else:
         from_clause = "FROM conversations"
-        select_clause = """
+        select_clause = f"""
         SELECT
             conversation_id,
             source_name,
@@ -219,7 +224,7 @@ async def list_conversation_summaries(
             updated_at,
             sort_key,
             content_hash,
-            NULL AS provider_meta,
+            {pm_bare},
             metadata,
             version,
             parent_conversation_id,

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -667,7 +667,6 @@ def _insert_raw_record(
                 actual_raw_id,
                 source_name,
                 payload_provider,
-                source_name,
                 source_path,
                 0,
                 blob_size,

--- a/tests/unit/insights/test_cost_rollup_summary_path.py
+++ b/tests/unit/insights/test_cost_rollup_summary_path.py
@@ -1,0 +1,77 @@
+"""Regression: cost_rollups uses summary-only path (#1671).
+
+Before #1671 ``list_cost_rollup_insights`` loaded every Conversation with
+its full message stream so it could call ``estimate_conversation_cost``.
+On a 7.9K-conversation archive that pulled 3.7M message rows into Python
+and hung the MCP stdio loop past its 60s deadline (#1621).
+
+The new path reads only conversation rows (with ``provider_meta``) and
+derives cost from ``provider_meta`` alone via
+``estimate_cost_from_provider_meta``. Sessions without usable cost
+evidence in ``provider_meta`` surface as ``status="unavailable"`` rather
+than triggering message hydration.
+
+The contract this test pins:
+
+* ``list_cost_rollup_insights`` aggregates costs from ``provider_meta``
+  alone — a session whose ``provider_meta`` carries ``total_cost_usd``
+  contributes that exact amount to the rollup.
+* The rollup completes without loading message bodies (no
+  ``ConversationRepository.list`` / ``get_many`` calls); the only
+  conversation read is ``list_summaries_by_query``.
+* Sessions whose ``provider_meta`` lacks cost evidence appear in the
+  rollup as ``status="unavailable"`` rather than triggering an
+  expensive message-hydration fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from polylogue.api import Polylogue
+from polylogue.insights.archive import CostRollupInsightQuery
+from tests.infra.storage_records import ConversationBuilder
+
+
+@pytest.mark.asyncio
+async def test_cost_rollups_aggregate_provider_meta_without_message_load(
+    cli_workspace: dict[str, Path],
+) -> None:
+    db_path = cli_workspace["db_path"]
+    (
+        ConversationBuilder(db_path, "conv-priced")
+        .provider("claude-code")
+        .title("Priced session")
+        .provider_meta({"total_cost_usd": 2.50, "model": "claude-sonnet-4-5"})
+        .updated_at("2026-03-01T10:00:00+00:00")
+        .add_message("u1", role="user", text="hello")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "conv-no-cost")
+        .provider("claude-code")
+        .title("No cost evidence")
+        .provider_meta({})
+        .updated_at("2026-03-01T11:00:00+00:00")
+        .add_message("u1", role="user", text="hello")
+        .save()
+    )
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+
+    target = "polylogue.storage.repository.archive.conversations.RepositoryArchiveConversationMixin.list_by_query"
+    with patch(target, side_effect=AssertionError("messages loaded")) as spy:
+        rollups = await archive.list_cost_rollup_insights(CostRollupInsightQuery(provider="claude-code"))
+        assert spy.call_count == 0
+
+    total = sum(rollup.total_usd for rollup in rollups)
+    assert total == pytest.approx(2.50)
+    merged_status_counts: dict[str, int] = {}
+    for rollup in rollups:
+        for key, value in rollup.status_counts.items():
+            merged_status_counts[key] = merged_status_counts.get(key, 0) + value
+    assert merged_status_counts.get("exact", 0) == 1
+    assert merged_status_counts.get("unavailable", 0) == 1


### PR DESCRIPTION
## Summary

`list_cost_rollup_insights` no longer iterates Conversations with their full message streams. It now reads conversation summaries with `provider_meta` and derives each session's cost from `provider_meta` alone via the newly-extracted `estimate_cost_from_provider_meta` helper.

## Problem

`list_cost_rollup_insights` was calling `list_session_cost_insights`, which uses `ConversationRepository.list(...)` to hydrate every Conversation with its full `MessageCollection` so `estimate_conversation_cost` could aggregate per-message cost facts. On a 7.9K-conversation production archive that pulled 3.7M message rows into Python and blew past the 60s MCP stdio deadline (#1621), causing the `cost_rollups` MCP tool to hang.

Cost facts relevant to aggregate rollups already live in `conversations.provider_meta` (`total_cost_usd`, `usage`, `model`). Loading messages just to re-derive what the conversation row already states is pure overhead.

## Solution

- `polylogue/archive/semantic/pricing.py`: Extract `estimate_cost_from_provider_meta(source_name, conversation_id, provider_meta)` as a public function from `_conversation_level_estimate`. Cost can now be derived from a `ConversationSummary` without loading messages.
- `polylogue/storage/sqlite/queries/conversations_reads.py`: Add `include_provider_meta` flag to `list_conversation_summaries`. Default remains `False`, preserving the pre-existing `test_list_summaries_by_query_omits_large_provider_meta_payloads` contract for all other summary readers.
- `polylogue/storage/query_models.py`, `polylogue/storage/repository/archive/queries.py`: Thread `include_provider_meta` through `ConversationRecordQuery` and `list_summaries`.
- `polylogue/operations/archive.py`: Rewrite `list_cost_rollup_insights` to call `list_summaries(include_provider_meta=True)` and build `SessionCostInsight`s via a new `_session_cost_insight_from_summary` helper. Sessions whose `provider_meta` lacks cost evidence surface as `status=\"unavailable\"` with `missing_reasons=(\"provider_meta_no_cost\",)` — accurate for the aggregate view because \"unavailable\" is itself a reported rollup state. Factored `_build_session_cost_insight` shared between the Conversation-based and Summary-based builders so the size budget remained reasonable (`docs/plans/file-size-budgets.yaml` ceiling bumped 1300→1400 with #1671 rationale).
- Adjacent: fix pre-existing `tests/unit/core/test_schema_validation.py::_insert_raw_record` passing 8 values into a 7-column INSERT (duplicate `source_name`).

Targeted callers that need message-level cost accuracy still call `list_session_cost_insights` and get the full message-hydrating path.

## Verification

```
nix develop -c devtools verify --quick   # exit_code: 0
nix develop -c pytest tests/unit/insights/test_cost_rollup_summary_path.py tests/unit/core/test_facade_api.py tests/unit/insights/ tests/unit/storage/test_cost_queries.py tests/unit/core/test_pricing.py tests/unit/mcp/test_cost_outlook_tool.py tests/unit/cli/test_cost_outlook_cli.py
# 158+ passed
```

The new `tests/unit/insights/test_cost_rollup_summary_path.py` pins the contract:
- `list_cost_rollup_insights` returns aggregated rollups using only `provider_meta`-derived costs
- `RepositoryArchiveConversationMixin.list_by_query` is **not** called (patched with side_effect)
- Sessions with `total_cost_usd` in `provider_meta` aggregate as `status=\"exact\"`
- Sessions without cost evidence aggregate as `status=\"unavailable\"`

Closes #1671. Ref #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect parameter handling in raw record data persistence.

* **Performance Improvements**
  * Cost rollup reports now compute more efficiently by leveraging provider metadata summaries, reducing the need to load complete conversation data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->