### PR TITLE
fix(watcher): accept .zip, .json, .ndjson in inbox watch source

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -75,8 +75,8 @@ exceptions:
     reason: "tiered health checks (fast/medium/expensive) with typed alerts, FTS-trigger drift detection + auto-restore (#1229), maintenance failure escalation (#1198), cursor-lag SLO + auto-calibrating anomaly band (#1232/#1349), and INFO-severity bulk-stage gating for the FTS trigger drift probe (#1613); split candidate: per-tier modules under daemon/health/"
 
   - path: tests/unit/sources/test_live_watcher.py
-    ceiling: 1600
-    reason: "kitchen-sink live-ingest test file (cursor, watcher, batch, debounce, bootstrap); split candidate: per-subject suites under tests/unit/sources/live/"
+    ceiling: 1620
+    reason: "kitchen-sink live-ingest test file (cursor, watcher, batch, debounce, bootstrap) + inbox suffix coverage (#1683); split candidate: per-subject suites under tests/unit/sources/live/"
 
   - path: polylogue/storage/sqlite/schema_bootstrap.py
     ceiling: 1700

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -530,7 +530,9 @@ def default_sources() -> tuple[WatchSource, ...]:
         WatchSource(name="gemini-cli", root=gemini_cli_path(), suffixes=(".json", ".jsonl")),
         WatchSource(name="hermes", root=hermes_sessions_path(), suffixes=(".json",)),
         WatchSource(name="antigravity", root=antigravity_path(), suffixes=(".metadata.json",)),
-        WatchSource(name="inbox", root=archive_root() / "inbox"),
+        # #1683: inbox accepts archive, zip, and json-line formats so that
+        # GDPR exports (typically .zip) and raw .json dumps are observed.
+        WatchSource(name="inbox", root=archive_root() / "inbox", suffixes=(".jsonl", ".zip", ".json", ".ndjson")),
         WatchSource(name="hooks", root=hooks_sidecar_dir()),
     )
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1513,6 +1513,17 @@ def test_watch_source_accepts_configured_suffixes(tmp_path: Path) -> None:
     assert src.accepts(tmp_path / "README.md") is False
 
 
+def test_inbox_source_accepts_zip_and_archive_formats() -> None:
+    """#1683: inbox must accept .zip (GDPR exports), .json, .jsonl, .ndjson."""
+    from polylogue.sources.live.watcher import default_sources
+
+    inbox = next(s for s in default_sources() if s.name == "inbox")
+    assert ".zip" in inbox.suffixes
+    assert ".json" in inbox.suffixes
+    assert ".jsonl" in inbox.suffixes
+    assert ".ndjson" in inbox.suffixes
+
+
 # --- end-to-end via watchfiles -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fix the inbox WatchSource to accept `.zip`, `.json`, and `.ndjson` in addition to `.jsonl`. Without this, GDPR exports dropped in inbox are silently ignored despite `POST /api/ingest` returning 202.

## Problem

`POST /api/ingest` (and `polylogue ingest` CLI) returns HTTP 202 for any staged file, but the live watcher's inbox `WatchSource` defaulted to `suffixes=(".jsonl",)`. A `.zip` dropped in `inbox/` was silently ignored forever — the operator sees "202 accepted" but the file is never observed. GDPR exports from ChatGPT and claude.ai are typically `.zip` archives.

The pipeline already handles `.zip`/`.json`/`.ndjson` — `source_walk.py` declares all four as `_SUPPORTED_EXTENSIONS`, and `source_parsing.py`/`source_acquisition.py` have `zipfile` handling. The gap was only in the watcher's suffix filter.

## Solution

`polylogue/sources/live/watcher.py`: inbox `WatchSource` now uses `suffixes=(".jsonl", ".zip", ".json", ".ndjson")`.

## Verification

- `nix develop -c pytest tests/unit/sources/test_live_watcher.py -k "suffix or inbox" -q` → 3 passed
- `nix develop -c devtools verify --quick` → exit_code 0

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The inbox source now accepts additional file formats: `.zip`, `.json`, `.jsonl`, and `.ndjson`.

* **Tests**
  * Added verification that the inbox source correctly declares support for the new file formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->