### PR TITLE
fix(cli): give honest next-step guidance after polylogue ingest

### DIFF
--- a/polylogue/cli/commands/ingest.py
+++ b/polylogue/cli/commands/ingest.py
@@ -150,7 +150,9 @@ def ingest_command(
         f"  Staged file:  {staged}\n"
         f"  Operation:    {operation.operation_id}\n"
         f"  Daemon:       {daemon_url}\n"
-        f"  Next:         run 'polylogue status' to watch the daemon converge."
+        f"  Next:         the daemon will process the staged file automatically.\n"
+        f"                Check progress:  journalctl --user -u polylogued.service -f\n"
+        f"                Verify ingested: polylogue stats"
     )
 
 

--- a/tests/unit/cli/test_ingest.py
+++ b/tests/unit/cli/test_ingest.py
@@ -97,10 +97,12 @@ def test_ingest_command_stages_local_path_before_daemon_request(
     assert captured["timeout"] == 5
 
     # Truthfulness: success output must point at observable state — the
-    # staged inbox path AND a pointer to 'polylogue status' so the user
-    # can verify processing is actually happening.
+    # staged inbox path AND actionable next-step guidance. The old
+    # "polylogue status" message was misleading (status doesn't show
+    # recent completed operations); #1679 replaced it with journalctl
+    # for live progress and polylogue stats to verify the import landed.
     assert str(staged) in result.output
-    assert "polylogue status" in result.output
+    assert "polylogue stats" in result.output
 
 
 def test_ingest_rejects_missing_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace the misleading "run polylogue status to watch the daemon converge" message with actionable guidance that actually works.

## Problem

`polylogue ingest` printed "Next: run 'polylogue status' to watch the daemon converge" — but `polylogue status` doesn't show recent completed operations. By the time the user types the command, the operation is done and status shows nothing, giving the impression the ingest silently failed.

## Solution

Replace the guidance with two actually-working next steps:
- `journalctl --user -u polylogued.service -f` for live progress
- `polylogue stats` to verify the import landed

## Verification

- `nix develop -c pytest tests/unit/cli/test_ingest.py -q` → 8 passed
- `nix develop -c devtools verify --quick` → exit_code 0

Ref #1679

🤖 Generated with [Claude Code](https://claude.com/claude-code)