### PR TITLE
feat(facets): wire SQL-backed aggregators for repos, message_types, action_types, has_flags

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -91,8 +91,8 @@ exceptions:
     reason: "durable live ingest cursor, attempt, and stage telemetry including cgroup file-cache/RSS fields for catch-up pressure diagnosis; split candidate: move attempt/stage event persistence into sources/live/attempts.py"
 
   - path: polylogue/api/archive.py
-    ceiling: 1200
-    reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275) and scoped/global facets entrypoint (#1269); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
+    ceiling: 1230
+    reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275), scoped/global facets entrypoint (#1269), and SQL-backed facet family aggregators (#1672); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
 
   - path: polylogue/surfaces/payloads.py
     ceiling: 1300

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -206,6 +206,21 @@ class PolylogueArchiveMixin:
             filter_obj = spec.build_filter(self.repository)
             scoped_summaries = await filter_obj.list_summaries()
             scoped_buckets = compute_facets(scoped_summaries)
+            # #1672: SQL aggregators scoped to matching conversations.
+            scoped_ids = [s.id for s in scoped_summaries]
+            scoped_sql = await self.repository.aggregate_facet_families(
+                conversation_ids=scoped_ids if scoped_ids else None,
+            )
+            scoped_buckets = _FacetBuckets(
+                providers=scoped_buckets.providers,
+                tags=scoped_buckets.tags,
+                repos=scoped_sql.get("repos", {}),
+                message_types=scoped_sql.get("message_types", {}),
+                action_types=scoped_sql.get("action_types", {}),
+                has_flags=scoped_sql.get("has_flags", {}),
+                total_conversations=scoped_buckets.total_conversations,
+                total_messages=scoped_buckets.total_messages,
+            )
         else:
             scoped_buckets = global_buckets
 
@@ -216,6 +231,10 @@ class PolylogueArchiveMixin:
             return FacetBucketsPayload(
                 providers=dict(b.providers),
                 tags=dict(b.tags),
+                repos=dict(b.repos),
+                message_types=dict(b.message_types),
+                action_types=dict(b.action_types),
+                has_flags=dict(b.has_flags),
                 total_conversations=b.total_conversations,
                 total_messages=b.total_messages,
             )
@@ -225,6 +244,10 @@ class PolylogueArchiveMixin:
                 "scoped_to_query": scoped_to_query,
                 "providers": dict(active.providers),
                 "tags": dict(active.tags),
+                "repos": dict(active.repos),
+                "message_types": dict(active.message_types),
+                "action_types": dict(active.action_types),
+                "has_flags": dict(active.has_flags),
                 "total_conversations": active.total_conversations,
                 "total_messages": active.total_messages,
                 "scoped": _payload(scoped_buckets),
@@ -238,15 +261,31 @@ class PolylogueArchiveMixin:
 
         Uses the same fluent filter machinery as the scoped path with
         no active predicates so both buckets are derived from one code
-        path.
+        path.  Per-message families (message_types, action_types,
+        has_flags) and repos are populated via SQL aggregators (#1672).
         """
+        from polylogue.archive.query.facets import FacetBuckets as _Buckets
         from polylogue.archive.query.facets import compute_facets
         from polylogue.archive.query.spec import ConversationQuerySpec
 
         empty_spec = ConversationQuerySpec()
         filter_obj = empty_spec.build_filter(self.repository)
         summaries = await filter_obj.list_summaries()
-        return compute_facets(summaries)
+        base = compute_facets(summaries)
+
+        # #1672: SQL-backed families that can't be derived from summaries.
+        sql_buckets = await self.repository.aggregate_facet_families()
+
+        return _Buckets(
+            providers=base.providers,
+            tags=base.tags,
+            repos=sql_buckets.get("repos", {}),
+            message_types=sql_buckets.get("message_types", {}),
+            action_types=sql_buckets.get("action_types", {}),
+            has_flags=sql_buckets.get("has_flags", {}),
+            total_conversations=base.total_conversations,
+            total_messages=base.total_messages,
+        )
 
     async def health_check(self) -> ReadinessReport:
         """Return the canonical archive readiness report."""

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -207,7 +207,7 @@ class PolylogueArchiveMixin:
             scoped_summaries = await filter_obj.list_summaries()
             scoped_buckets = compute_facets(scoped_summaries)
             # #1672: SQL aggregators scoped to matching conversations.
-            scoped_ids = [s.id for s in scoped_summaries]
+            scoped_ids = [str(s.id) for s in scoped_summaries]
             scoped_sql = await self.repository.aggregate_facet_families(
                 conversation_ids=scoped_ids if scoped_ids else None,
             )

--- a/polylogue/archive/query/facets.py
+++ b/polylogue/archive/query/facets.py
@@ -118,7 +118,14 @@ def compute_idf(buckets: FacetBuckets) -> dict[str, dict[str, float]]:
     if total <= 0:
         return {}
     out: dict[str, dict[str, float]] = {}
-    for family_name, family in (("providers", buckets.providers), ("tags", buckets.tags)):
+    for family_name, family in (
+        ("providers", buckets.providers),
+        ("tags", buckets.tags),
+        ("repos", buckets.repos),
+        ("message_types", buckets.message_types),
+        ("action_types", buckets.action_types),
+        ("has_flags", buckets.has_flags),
+    ):
         family_out: dict[str, float] = {}
         for value, count in family.items():
             if count <= 0:

--- a/polylogue/archive/query/facets.py
+++ b/polylogue/archive/query/facets.py
@@ -32,10 +32,19 @@ class FacetBuckets:
     and value the number of conversations in the input set that carry
     the bucket. ``total_conversations``/``total_messages`` describe the
     input set itself.
+
+    The per-message families (``message_types``, ``action_types``,
+    ``has_flags``) and ``repos`` are populated by SQL-backed aggregators
+    because they require scanning tables beyond the conversation summary
+    surface.
     """
 
     providers: dict[str, int] = field(default_factory=dict)
     tags: dict[str, int] = field(default_factory=dict)
+    repos: dict[str, int] = field(default_factory=dict)
+    message_types: dict[str, int] = field(default_factory=dict)
+    action_types: dict[str, int] = field(default_factory=dict)
+    has_flags: dict[str, int] = field(default_factory=dict)
     total_conversations: int = 0
     total_messages: int = 0
 

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -249,5 +249,143 @@ class RepositoryArchiveConversationMixin:
         ):
             yield message_from_record(record, attachments=[], provider=source_name)
 
+    async def aggregate_facet_families(
+        self,
+        *,
+        conversation_ids: list[str] | None = None,
+    ) -> dict[str, dict[str, int]]:
+        """Run per-family SQL aggregators for facets that can't be computed
+        from conversation summaries alone.
+
+        Returns a dict keyed by family name (``repos``, ``message_types``,
+        ``action_types``, ``has_flags``). When ``conversation_ids`` is
+        provided, results are scoped to those conversations.
+
+        #1672 (phase 2 of #1623).
+        """
+        result: dict[str, dict[str, int]] = {
+            "repos": {},
+            "message_types": {},
+            "action_types": {},
+            "has_flags": {},
+        }
+        async with self._backend.connection() as conn:
+            # repos — grouped by git_repository_url on conversations
+            if conversation_ids is not None:
+                placeholders = ",".join("?" for _ in conversation_ids)
+                repo_rows = await (
+                    await conn.execute(
+                        f"""
+                        SELECT git_repository_url, count(*) AS n
+                        FROM conversations
+                        WHERE git_repository_url IS NOT NULL
+                          AND conversation_id IN ({placeholders})
+                        GROUP BY git_repository_url
+                        """,
+                        conversation_ids,
+                    )
+                ).fetchall()
+            else:
+                repo_rows = await (
+                    await conn.execute(
+                        """
+                        SELECT git_repository_url, count(*) AS n
+                        FROM conversations
+                        WHERE git_repository_url IS NOT NULL
+                        GROUP BY git_repository_url
+                        """
+                    )
+                ).fetchall()
+            result["repos"] = {row[0]: row[1] for row in repo_rows if row[0]}
+
+            # message_types
+            if conversation_ids is not None:
+                placeholders = ",".join("?" for _ in conversation_ids)
+                mt_rows = await (
+                    await conn.execute(
+                        f"""
+                        SELECT message_type, count(*) AS n
+                        FROM messages
+                        WHERE conversation_id IN ({placeholders})
+                        GROUP BY message_type
+                        """,
+                        conversation_ids,
+                    )
+                ).fetchall()
+            else:
+                mt_rows = await (
+                    await conn.execute(
+                        """
+                        SELECT message_type, count(*) AS n
+                        FROM messages
+                        GROUP BY message_type
+                        """
+                    )
+                ).fetchall()
+            result["message_types"] = {row[0]: row[1] for row in mt_rows if row[0]}
+
+            # action_types
+            if conversation_ids is not None:
+                placeholders = ",".join("?" for _ in conversation_ids)
+                at_rows = await (
+                    await conn.execute(
+                        f"""
+                        SELECT action_kind, count(*) AS n
+                        FROM action_events
+                        WHERE conversation_id IN ({placeholders})
+                        GROUP BY action_kind
+                        """,
+                        conversation_ids,
+                    )
+                ).fetchall()
+            else:
+                at_rows = await (
+                    await conn.execute(
+                        """
+                        SELECT action_kind, count(*) AS n
+                        FROM action_events
+                        GROUP BY action_kind
+                        """
+                    )
+                ).fetchall()
+            result["action_types"] = {row[0]: row[1] for row in at_rows if row[0]}
+
+            # has_flags — booleans on messages
+            if conversation_ids is not None:
+                placeholders = ",".join("?" for _ in conversation_ids)
+                flag_rows = await (
+                    await conn.execute(
+                        f"""
+                        SELECT
+                            coalesce(sum(has_tool_use), 0) AS tool_use,
+                            coalesce(sum(has_thinking), 0) AS thinking,
+                            coalesce(sum(has_paste), 0)   AS paste
+                        FROM messages
+                        WHERE conversation_id IN ({placeholders})
+                        """,
+                        conversation_ids,
+                    )
+                ).fetchall()
+            else:
+                flag_rows = await (
+                    await conn.execute(
+                        """
+                        SELECT
+                            coalesce(sum(has_tool_use), 0) AS tool_use,
+                            coalesce(sum(has_thinking), 0) AS thinking,
+                            coalesce(sum(has_paste), 0)   AS paste
+                        FROM messages
+                        """
+                    )
+                ).fetchall()
+            row = flag_rows[0] if flag_rows else (0, 0, 0)
+            result["has_flags"] = {
+                "has_tool_use": row[0],
+                "has_thinking": row[1],
+                "has_paste": row[2],
+            }
+
+        return result
+
 
 __all__ = ["RepositoryArchiveConversationMixin"]

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -272,122 +272,94 @@ class RepositoryArchiveConversationMixin:
         # Empty list produces SQL ``IN ()`` which is a syntax error.
         if conversation_ids is not None and not conversation_ids:
             return result
+        # SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999. When the
+        # scoped path passes >900 IDs we chunk and merge so the query
+        # never exceeds the engine limit. The global path (None) has no
+        # IN clause and does not need chunking.
+        _max_in_vars = 900
+
+        from typing import Any
+
+        async def _scoped_rows(
+            conn: Any,
+            scoped_sql: str,
+            global_sql: str,
+            params: list[str] | None,
+        ) -> list[Any]:
+            """Run a possibly-chunked scoped query or a single global query."""
+            if params is None:
+                return list(await (await conn.execute(global_sql)).fetchall())
+            rows: list[object] = []
+            for i in range(0, len(params), _max_in_vars):
+                chunk = params[i : i + _max_in_vars]
+                placeholders = ",".join("?" for _ in chunk)
+                rows.extend(await (await conn.execute(scoped_sql.format(placeholders), chunk)).fetchall())
+            return rows
+
+        # Accumulate keyed results from possibly-chunked rows.
+        def _keyed(rows: list[Any]) -> dict[str, int]:
+            return {row[0]: row[1] for row in rows if row[0]}
+
         async with self._backend.connection() as conn:
-            # repos — grouped by git_repository_url on conversations
-            if conversation_ids is not None:
-                placeholders = ",".join("?" for _ in conversation_ids)
-                repo_rows = await (
-                    await conn.execute(
-                        f"""
-                        SELECT git_repository_url, count(*) AS n
-                        FROM conversations
-                        WHERE git_repository_url IS NOT NULL
-                          AND conversation_id IN ({placeholders})
-                        GROUP BY git_repository_url
-                        """,
-                        conversation_ids,
-                    )
-                ).fetchall()
-            else:
-                repo_rows = await (
-                    await conn.execute(
-                        """
-                        SELECT git_repository_url, count(*) AS n
-                        FROM conversations
-                        WHERE git_repository_url IS NOT NULL
-                        GROUP BY git_repository_url
-                        """
-                    )
-                ).fetchall()
-            result["repos"] = {row[0]: row[1] for row in repo_rows if row[0]}
+            ids = conversation_ids  # None → global, list → scoped
 
-            # message_types
-            if conversation_ids is not None:
-                placeholders = ",".join("?" for _ in conversation_ids)
-                mt_rows = await (
-                    await conn.execute(
-                        f"""
-                        SELECT message_type, count(*) AS n
-                        FROM messages
-                        WHERE conversation_id IN ({placeholders})
-                        GROUP BY message_type
-                        """,
-                        conversation_ids,
-                    )
-                ).fetchall()
-            else:
-                mt_rows = await (
-                    await conn.execute(
-                        """
-                        SELECT message_type, count(*) AS n
-                        FROM messages
-                        GROUP BY message_type
-                        """
-                    )
-                ).fetchall()
-            result["message_types"] = {row[0]: row[1] for row in mt_rows if row[0]}
+            result["repos"] = _keyed(
+                await _scoped_rows(
+                    conn,
+                    """SELECT git_repository_url, count(*) AS n
+                    FROM conversations
+                    WHERE git_repository_url IS NOT NULL
+                      AND conversation_id IN ({})
+                    GROUP BY git_repository_url""",
+                    """SELECT git_repository_url, count(*) AS n
+                    FROM conversations
+                    WHERE git_repository_url IS NOT NULL
+                    GROUP BY git_repository_url""",
+                    ids,
+                )
+            )
 
-            # action_types
-            if conversation_ids is not None:
-                placeholders = ",".join("?" for _ in conversation_ids)
-                at_rows = await (
-                    await conn.execute(
-                        f"""
-                        SELECT action_kind, count(*) AS n
-                        FROM action_events
-                        WHERE conversation_id IN ({placeholders})
-                        GROUP BY action_kind
-                        """,
-                        conversation_ids,
-                    )
-                ).fetchall()
-            else:
-                at_rows = await (
-                    await conn.execute(
-                        """
-                        SELECT action_kind, count(*) AS n
-                        FROM action_events
-                        GROUP BY action_kind
-                        """
-                    )
-                ).fetchall()
-            result["action_types"] = {row[0]: row[1] for row in at_rows if row[0]}
+            result["message_types"] = _keyed(
+                await _scoped_rows(
+                    conn,
+                    """SELECT message_type, count(*) AS n
+                    FROM messages
+                    WHERE conversation_id IN ({})
+                    GROUP BY message_type""",
+                    """SELECT message_type, count(*) AS n
+                    FROM messages
+                    GROUP BY message_type""",
+                    ids,
+                )
+            )
 
-            # has_flags — booleans on messages
-            if conversation_ids is not None:
-                placeholders = ",".join("?" for _ in conversation_ids)
-                flag_rows = await (
-                    await conn.execute(
-                        f"""
-                        SELECT
-                            coalesce(sum(has_tool_use), 0) AS tool_use,
-                            coalesce(sum(has_thinking), 0) AS thinking,
-                            coalesce(sum(has_paste), 0)   AS paste
-                        FROM messages
-                        WHERE conversation_id IN ({placeholders})
-                        """,
-                        conversation_ids,
-                    )
-                ).fetchall()
-            else:
-                flag_rows = await (
-                    await conn.execute(
-                        """
-                        SELECT
-                            coalesce(sum(has_tool_use), 0) AS tool_use,
-                            coalesce(sum(has_thinking), 0) AS thinking,
-                            coalesce(sum(has_paste), 0)   AS paste
-                        FROM messages
-                        """
-                    )
-                ).fetchall()
-            flag_list = list(flag_rows)
-            row = flag_list[0] if flag_list else (0, 0, 0)
-            result["has_flags"] = {
-                "has_tool_use": row[0],
-                "has_thinking": row[1],
-                "has_paste": row[2],
-            }
+            result["action_types"] = _keyed(
+                await _scoped_rows(
+                    conn,
+                    """SELECT action_kind, count(*) AS n
+                    FROM action_events
+                    WHERE conversation_id IN ({})
+                    GROUP BY action_kind""",
+                    """SELECT action_kind, count(*) AS n
+                    FROM action_events
+                    GROUP BY action_kind""",
+                    ids,
+                )
+            )
+
+            flag_rows = await _scoped_rows(
+                conn,
+                """SELECT coalesce(sum(has_tool_use),0), coalesce(sum(has_thinking),0),
+                coalesce(sum(has_paste),0) FROM messages WHERE conversation_id IN ({})""",
+                """SELECT coalesce(sum(has_tool_use),0), coalesce(sum(has_thinking),0),
+                coalesce(sum(has_paste),0) FROM messages""",
+                ids,
+            )
+            # Merge chunked flag rows by summing corresponding columns.
+            tool_use = sum(r[0] for r in flag_rows)
+            thinking = sum(r[1] for r in flag_rows)
+            paste = sum(r[2] for r in flag_rows)
+            result["has_flags"] = {"has_tool_use": tool_use, "has_thinking": thinking, "has_paste": paste}
 
         return result
 

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -378,7 +378,8 @@ class RepositoryArchiveConversationMixin:
                         """
                     )
                 ).fetchall()
-            row = flag_rows[0] if flag_rows else (0, 0, 0)
+            flag_list = list(flag_rows)
+            row = flag_list[0] if flag_list else (0, 0, 0)
             result["has_flags"] = {
                 "has_tool_use": row[0],
                 "has_thinking": row[1],

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -269,6 +269,9 @@ class RepositoryArchiveConversationMixin:
             "action_types": {},
             "has_flags": {},
         }
+        # Empty list produces SQL ``IN ()`` which is a syntax error.
+        if conversation_ids is not None and not conversation_ids:
+            return result
         async with self._backend.connection() as conn:
             # repos — grouped by git_repository_url on conversations
             if conversation_ids is not None:

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1112,6 +1112,10 @@ class FacetBucketsPayload(SurfacePayloadModel):
 
     providers: dict[str, int] = Field(default_factory=dict)
     tags: dict[str, int] = Field(default_factory=dict)
+    repos: dict[str, int] = Field(default_factory=dict)
+    message_types: dict[str, int] = Field(default_factory=dict)
+    action_types: dict[str, int] = Field(default_factory=dict)
+    has_flags: dict[str, int] = Field(default_factory=dict)
     total_conversations: int = 0
     total_messages: int = 0
 

--- a/tests/unit/archive/test_facets.py
+++ b/tests/unit/archive/test_facets.py
@@ -117,6 +117,10 @@ class TestFacetsResponseEnvelope:
         assert dumped["scoped"] == {
             "providers": {"chatgpt": 1},
             "tags": {},
+            "repos": {},
+            "message_types": {},
+            "action_types": {},
+            "has_flags": {},
             "total_conversations": 1,
             "total_messages": 0,
         }


### PR DESCRIPTION
## Summary

Add direct SQL GROUP BY aggregators for the four per-message/per-table facet families that the Python-side `compute_facets()` couldn't populate from ConversationSummary objects.

## Problem

`polylogue facets` returned empty `repos`, `message_types`, `action_types`, and `has_flags` buckets despite a full archive. `compute_facets()` only rolled up `providers` and `tags` from ConversationSummary — the other families had no computation path. The `FacetsResponse` model already declared the fields; they were unconditionally `{}`.

(#1623 reported this; #1672 is the phase-2 implementation plan.)

## Solution

- `RepositoryArchiveConversationMixin.aggregate_facet_families()` — runs SQL GROUP BY queries for each of the four families against the `conversations`, `messages`, and `action_events` tables. Supports both global (unfiltered) and scoped (filtered by `conversation_ids`) paths.
- `Polylogue._compute_global_facets()` merges SQL results into `FacetBuckets`.
- `Polylogue.facets()` merges SQL results for scoped buckets too (filtered to matching conversation IDs).
- `FacetBuckets` and `FacetBucketsPayload` gain the four new `dict[str, int]` fields.

## Verification

- `nix develop -c pytest tests/ -k facet -q` → 35 passed
- `nix develop -c pytest tests/unit/api/ -q` → 173 passed
- `nix develop -c devtools verify --quick` → exit_code 0
- `nix develop -c mypy polylogue/storage/repository/archive/conversations.py polylogue/api/archive.py` → success

Closes #1672. Fixes #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced facet results with additional filtering options: repositories, message types, action types, and flags are now available in both scoped and global facet views, powered by SQL-backed aggregation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->