### PR TITLE
feat(cli): harmonize list output fields with MCP shape (#1673)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -541,13 +541,30 @@ components:
             $ref: '#/components/schemas/ReaderActionAvailabilityPayload'
           title: Actions
           type: object
+        created_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Created At
+        updated_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Updated At
         date:
           anyOf:
           - type: string
           - type: 'null'
           default: null
           title: Date
+        message_count:
+          default: 0
+          title: Message Count
+          type: integer
         messages:
+          default: 0
           title: Messages
           type: integer
         tags:
@@ -589,7 +606,6 @@ components:
       - id
       - provider
       - title
-      - messages
       title: ConversationListRowPayload
       type: object
   x-polylogue-ranking-policy:

--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -95,8 +95,8 @@ exceptions:
     reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275), scoped/global facets entrypoint (#1269), and SQL-backed facet family aggregators (#1672); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
 
   - path: polylogue/surfaces/payloads.py
-    ceiling: 1300
-    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269), the ReaderActionState / READER_ACTION_IDS closed vocabulary (#1488), and the MessageRenderEnvelope additions (branch_index, has_paste, has_tool_use, has_thinking, token/cache usage, model_name, attachment_refs, raw_id, source_path; #1487); split candidate: per-domain payload modules under polylogue/surfaces/"
+    ceiling: 1320
+    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269), the ReaderActionState / READER_ACTION_IDS closed vocabulary (#1488), MessageRenderEnvelope additions (#1487), SQL-backed facet families (#1672), and ConversationListRowPayload created_at/updated_at/message_count harmonization (#1673); split candidate: per-domain payload modules under polylogue/surfaces/"
 
   - path: tests/unit/storage/test_backend.py
     ceiling: 1750

--- a/docs/schemas/cli-output/conversation-list-row.schema.json
+++ b/docs/schemas/cli-output/conversation-list-row.schema.json
@@ -183,6 +183,18 @@
       "default": null,
       "title": "Anchor"
     },
+    "created_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Created At"
+    },
     "cwd_display": {
       "anyOf": [
         {
@@ -222,7 +234,13 @@
       "title": "Id",
       "type": "string"
     },
+    "message_count": {
+      "default": 0,
+      "title": "Message Count",
+      "type": "integer"
+    },
     "messages": {
+      "default": 0,
       "title": "Messages",
       "type": "integer"
     },
@@ -277,6 +295,18 @@
       "title": "Title",
       "type": "string"
     },
+    "updated_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Updated At"
+    },
     "words": {
       "anyOf": [
         {
@@ -293,8 +323,7 @@
   "required": [
     "id",
     "provider",
-    "title",
-    "messages"
+    "title"
   ],
   "title": "Conversation List Row",
   "type": "object",

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -451,8 +451,14 @@ class ConversationListRowPayload(SurfacePayloadModel):
     target_ref: TargetRefPayload | None = None
     anchor: str | None = None
     actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_conversation_actions)
-    date: str | None = None
-    messages: int
+    # #1673 (field-name harmonization): created_at/updated_at replace the
+    # single ``date`` field; ``message_count`` replaces ``messages``.
+    # Old keys are kept for one release cycle so consumers can migrate.
+    created_at: str | None = None
+    updated_at: str | None = None
+    date: str | None = None  # deprecated — use created_at
+    message_count: int = 0
+    messages: int = 0  # deprecated — use message_count
     tags: tuple[str, ...] = ()
     summary: str | None = None
     words: int | None = None
@@ -463,14 +469,21 @@ class ConversationListRowPayload(SurfacePayloadModel):
     @classmethod
     def from_conversation(cls, conversation: Conversation) -> ConversationListRowPayload:
         conversation_id = str(conversation.id)
+        created_at = conversation.created_at.isoformat() if conversation.created_at else None
+        updated_at = conversation.updated_at.isoformat() if conversation.updated_at else None
+        display_date = conversation.display_date.isoformat() if conversation.display_date else None
+        msg_count = len(conversation.messages)
         return cls(
             id=conversation_id,
             provider=str(conversation.provider),
             title=conversation.display_title,
             target_ref=TargetRefPayload.conversation(conversation_id),
             anchor=reader_anchor("conversation", conversation_id),
-            date=conversation.display_date.isoformat() if conversation.display_date else None,
-            messages=len(conversation.messages),
+            created_at=created_at,
+            updated_at=updated_at,
+            date=display_date,  # deprecated — kept for one release cycle
+            message_count=msg_count,
+            messages=msg_count,  # deprecated — kept for one release cycle
             tags=tuple(conversation.tags),
             summary=conversation.summary,
             words=sum(message.word_count for message in conversation.messages),
@@ -491,14 +504,20 @@ class ConversationListRowPayload(SurfacePayloadModel):
         cwd_display: str | None = None,
     ) -> ConversationListRowPayload:
         conversation_id = str(summary.id)
+        created_at = summary.created_at.isoformat() if summary.created_at else None
+        updated_at = summary.updated_at.isoformat() if summary.updated_at else None
+        display_date = summary.display_date.isoformat() if summary.display_date else None
         return cls(
             id=conversation_id,
             provider=str(summary.provider),
             title=summary.display_title,
             target_ref=TargetRefPayload.conversation(conversation_id),
             anchor=reader_anchor("conversation", conversation_id),
-            date=summary.display_date.isoformat() if summary.display_date else None,
-            messages=message_count,
+            created_at=created_at,
+            updated_at=updated_at,
+            date=display_date,  # deprecated — kept for one release cycle
+            message_count=message_count,
+            messages=message_count,  # deprecated — kept for one release cycle
             tags=tuple(summary.tags),
             summary=summary.summary,
             words=word_count,


### PR DESCRIPTION
## Summary

Rename `date` → `created_at`/`updated_at` and `messages` → `message_count` in `ConversationListRowPayload`. Old keys kept as deprecated aliases for one release cycle. JSON schema for CLI output regenerated.

Closes #1673

## Verification

- `nix develop -c pytest tests/unit/cli/test_cli_output_schemas.py -q` → 13 passed
- `nix develop -c devtools render-cli-output-schemas` → clean
- `nix develop -c devtools render-openapi` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)