### PR TITLE
feat(cli): add polylogue recent command (#1680)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -184,6 +184,7 @@ Commands:
   neighbors          Show semantic neighbors for a conversation.
   open               Open matched conversation in the daemon web reader.
   raw                Show raw archive payloads for matched conversations.
+  recent
   reset              Reset local archive state.
   resume             Resume from recent conversation context.
   resume-candidates  Rank resume candidates for the current context.

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `5`
 - synthetic benchmark campaigns: `7`
-- scenario projections: `264`
+- scenario projections: `265`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `5`
-  - exercise: `158`
+  - exercise: `159`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `7`
@@ -404,6 +404,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-neighbors` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | neighbors help |
 | `exercise` | `help-open` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | open help |
 | `exercise` | `help-raw` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | raw help |
+| `exercise` | `help-recent` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | recent help |
 | `exercise` | `help-reset` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | reset help |
 | `exercise` | `help-resume` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | resume help |
 | `exercise` | `help-resume-candidates` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | resume-candidates help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,7 +8,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `594`
+- subjects: `595`
 - claims: `37`
 - runner bindings: `37`
 - proof obligations: `471`
@@ -40,7 +40,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `assurance.coverage_gap` | 20 |
 | `assurance.coverage_item` | 107 |
 | `assurance.coverage_manifest` | 9 |
-| `cli.command` | 73 |
+| `cli.command` | 74 |
 | `cli.json_command` | 5 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -118,6 +118,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue neighbors` | `polylogue/cli/click_app.py` `polylogue neighbors` |
 | `polylogue open` | `polylogue/cli/click_app.py` `polylogue open` |
 | `polylogue raw` | `polylogue/cli/click_app.py` `polylogue raw` |
+| `polylogue recent` | `polylogue/cli/click_app.py` `polylogue recent` |
 | `polylogue reset` | `polylogue/cli/click_app.py` `polylogue reset` |
 | `polylogue resume` | `polylogue/cli/click_app.py` `polylogue resume` |
 | `polylogue resume-candidates` | `polylogue/cli/click_app.py` `polylogue resume-candidates` |

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -120,6 +120,31 @@ def stats_verb(ctx: click.Context, stats_by: str | None, output_format: str | No
     _execute_query_verb(ctx, request)
 
 
+@click.command("recent")
+@click.option("--limit", "-n", type=int, default=10, show_default=True, help="Maximum conversations to list.")
+@click.option("--provider", "-p", "provider_filter", default=None, help="Filter by provider.")
+@click.option("--format", "-f", "output_format", default=None, help="Output format: json, ndjson, yaml, csv.")
+@click.pass_context
+def recent_verb(
+    ctx: click.Context,
+    limit: int,
+    provider_filter: str | None,
+    output_format: str | None,
+) -> None:
+    """List the most recently updated conversations."""
+    request = _parent_request(ctx).with_param_updates(
+        list_mode=True,
+        sort="updated_at",
+        reverse=True,
+        limit=limit,
+    )
+    if provider_filter:
+        request = request.with_param_updates(provider=provider_filter)
+    if output_format:
+        request = request.with_param_updates(output_format=output_format)
+    _execute_query_verb(ctx, request)
+
+
 @click.command("show")
 @click.argument("target_terms", nargs=-1)
 @click.pass_context

--- a/polylogue/cli/verb_names.py
+++ b/polylogue/cli/verb_names.py
@@ -14,6 +14,7 @@ VERB_NAMES: frozenset[str] = frozenset(
         "messages",
         "raw",
         "select",
+        "recent",
     }
 )
 QUERY_VERB_NAMES = VERB_NAMES


### PR DESCRIPTION
## Summary

Add `polylogue recent` verb that lists the 10 most recently updated conversations. Supports `--limit`, `--provider`, `--format` flags. Thin wrapper over list mode with `sort=updated_at` descending.

Closes #1680

## Verification

- `nix develop -c pytest tests/ -k "recent or verb_names or query_verbs" -q` → 29 passed
- `nix develop -c devtools verify --quick` → exit_code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)