### PR TITLE
perf(metrics): consolidate raw_conversations COUNT queries (#1629)

### DIFF
--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -914,12 +914,20 @@ def _emit_raw_record_metrics(lines: list[str], conn: sqlite3.Connection) -> None
         )
         return
 
-    total = _scalar_int(conn, "SELECT COUNT(*) FROM raw_conversations")
-    parsed = _scalar_int(conn, "SELECT COUNT(*) FROM raw_conversations WHERE parsed_at IS NOT NULL")
-    validated = _scalar_int(conn, "SELECT COUNT(*) FROM raw_conversations WHERE validated_at IS NOT NULL")
-    with_errors = _scalar_int(
-        conn, "SELECT COUNT(*) FROM raw_conversations WHERE parse_error IS NOT NULL OR validation_status = 'failed'"
-    )
+    # #1629: one scan of raw_conversations instead of four separate COUNT(*).
+    counts = conn.execute(
+        """SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN parsed_at IS NOT NULL THEN 1 ELSE 0 END) AS parsed,
+            SUM(CASE WHEN validated_at IS NOT NULL THEN 1 ELSE 0 END) AS validated,
+            SUM(CASE WHEN parse_error IS NOT NULL OR validation_status = 'failed'
+                THEN 1 ELSE 0 END) AS errors
+        FROM raw_conversations"""
+    ).fetchone()
+    total = counts["total"]
+    parsed = counts["parsed"]
+    validated = counts["validated"]
+    with_errors = counts["errors"]
 
     _emit_metric(
         lines,


### PR DESCRIPTION
## Summary

Consolidate 4 separate `COUNT(*)` scans of `raw_conversations` into one single-pass query. The original bottleneck (WAL reader-block) was already fixed by #1614/#1659. This removes the remaining redundant scans.

Closes #1629

## Verification

- `nix develop -c devtools verify --quick` → exit_code 0 (after render-pages regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized raw record metrics computation by consolidating multiple database queries into a single operation with conditional aggregation logic, reducing query overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->