### PR TITLE
feat(surfaces): add ContextPreamble envelope for SessionStart injection (#1696)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -95,8 +95,8 @@ exceptions:
     reason: "archive facade for read/query/insight/maintenance surfaces; added audit_insights_rigor entrypoint (#1275), scoped/global facets entrypoint (#1269), and SQL-backed facet family aggregators (#1672); split candidate: extract per-domain facades (insights, maintenance) under polylogue/api/"
 
   - path: polylogue/surfaces/payloads.py
-    ceiling: 1320
-    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269), the ReaderActionState / READER_ACTION_IDS closed vocabulary (#1488), MessageRenderEnvelope additions (#1487), SQL-backed facet families (#1672), and ConversationListRowPayload created_at/updated_at/message_count harmonization (#1673); split candidate: per-domain payload modules under polylogue/surfaces/"
+    ceiling: 1400
+    reason: "typed payload models for CLI/MCP/daemon surfaces; added FacetTimeRange + scoped/global facet envelopes (#1269), ReaderActionState (#1488), MessageRenderEnvelope (#1487), facet families (#1672), list-row harmonization (#1673), and ContextPreamble envelope (#1696); split candidate: per-domain payload modules under polylogue/surfaces/"
 
   - path: tests/unit/storage/test_backend.py
     ceiling: 1750

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1174,6 +1174,87 @@ class FacetsResponse(SurfacePayloadModel):
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
 
+class ContextPreamble(SurfacePayloadModel):
+    """Typed delivery envelope for SessionStart context injection (#1696).
+
+    Assembled by polylogue MCP tools and delivered via SessionStart hook
+    scripts so new agent sessions receive relevant context: prior sessions,
+    open issues, git state, lineage, guidance.
+    """
+
+    preamble_version: str = "1.0"
+    injected_at: str | None = None
+    source_tool_calls: dict[str, str] = Field(default_factory=dict)
+
+    session_lineage: ContextPreambleLineage | None = None
+    recent_related_sessions: list[ContextPreambleSession] = Field(default_factory=list)
+    open_issues: list[ContextPreambleIssue] = Field(default_factory=list)
+    project_state: ContextPreambleProjectState | None = None
+    blackboard_notes: list[ContextPreambleBlackboardNote] = Field(default_factory=list)
+    guidance: str | None = None
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleLineage(SurfacePayloadModel):
+    """Session lineage for the context preamble."""
+
+    logical_session_root: str | None = None
+    parent_session_id: str | None = None
+    sibling_session_ids: list[str] = Field(default_factory=list)
+    continuation_chain_depth: int = 0
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleSession(SurfacePayloadModel):
+    """A recent related session for the context preamble."""
+
+    session_id: str
+    title: str | None = None
+    date: str | None = None
+    terminal_state: str | None = None
+    summary: str | None = None
+    provider: str | None = None
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleIssue(SurfacePayloadModel):
+    """A GitHub issue for the context preamble."""
+
+    number: int
+    title: str
+    state: str = "open"
+    labels: list[str] = Field(default_factory=list)
+    active_session: str | None = None
+    url: str | None = None
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleProjectState(SurfacePayloadModel):
+    """Current project state for the context preamble."""
+
+    branch: str | None = None
+    recent_commits: list[str] = Field(default_factory=list)
+    active_worktrees: list[str] = Field(default_factory=list)
+    dirty_files: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleBlackboardNote(SurfacePayloadModel):
+    """A blackboard note for the context preamble."""
+
+    key: str
+    content: str
+    repo: str | None = None
+    created_at: str | None = None
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
 class MutationResultPayload(SurfacePayloadModel):
     """Shared result envelope for tag, metadata, and delete mutations.
 
@@ -1256,6 +1337,12 @@ __all__ = [
     "ConversationListResponse",
     "ConversationListRowPayload",
     "ConversationMessagePayload",
+    "ContextPreamble",
+    "ContextPreambleBlackboardNote",
+    "ContextPreambleIssue",
+    "ContextPreambleLineage",
+    "ContextPreambleProjectState",
+    "ContextPreambleSession",
     "ConversationNeighborCandidatePayload",
     "ConversationNeighborReasonPayload",
     "ConversationSearchHitPayload",


### PR DESCRIPTION
## Summary

Define `ContextPreamble` + 5 companion Pydantic models for typed context delivery to new agent sessions via SessionStart hooks.

Models:
- `ContextPreamble` — top-level envelope with preamble_version, injected_at, source_tool_calls
- `ContextPreambleLineage` — logical session root, parent, siblings, chain depth
- `ContextPreambleSession` — recent related session with title, date, terminal state, summary
- `ContextPreambleIssue` — GitHub issue with number, title, labels, active_session
- `ContextPreambleProjectState` — branch, recent commits, worktrees, dirty files
- `ContextPreambleBlackboardNote` — keyed note with repo scope

All frozen, forbid-extra, fully typed. Models exported from surfaces/payloads.py.

Ref #1696

## Verification

- `nix develop -c mypy polylogue/surfaces/payloads.py` → success
- `nix develop -c pytest tests/unit/ -k payload -q` → 325 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)