### PR TITLE
feat(live): enrich paste evidence from UserPromptSubmit hook events (#1654)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -83,8 +83,8 @@ exceptions:
     reason: "schema bootstrap owns reviewed version branches through v17, including the v15/v16 -> v17 identity-preserving marks rebuild (#864, #867, #1113, #1114); split candidate: per-version upgrade modules"
 
   - path: polylogue/sources/live/batch.py
-    ceiling: 1175
-    reason: "live ingestion batch processor with metrics, fingerprinting, multi-stage progress tracking, conversation-scoped convergence dispatch, and transient-lock-tolerant failure bookkeeping"
+    ceiling: 1185
+    reason: "live ingestion batch processor with metrics, fingerprinting, multi-stage progress tracking, conversation-scoped convergence dispatch, hook paste enrichment (#1654), and transient-lock-tolerant failure bookkeeping"
 
   - path: polylogue/sources/live/cursor.py
     ceiling: 1180

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -17,7 +17,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 1184
+    loc: 1223
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -346,7 +346,7 @@ files:
     owner: archive-query
     reason: archive-domain query semantics
   - path: polylogue/archive/query/facets.py
-    loc: 123
+    loc: 139
     target: polylogue/archive/query/facets.py
     owner: archive-query
     reason: archive-domain query semantics
@@ -496,7 +496,7 @@ files:
     owner: archive-semantic
     reason: archive-domain semantics
   - path: polylogue/archive/semantic/pricing.py
-    loc: 719
+    loc: 741
     target: polylogue/archive/semantic/pricing.py
     owner: archive-semantic
     reason: archive-domain semantics
@@ -723,7 +723,7 @@ files:
     target: polylogue/cli/commands/feedback.py
     owner: stable
   - path: polylogue/cli/commands/ingest.py
-    loc: 157
+    loc: 159
     target: polylogue/cli/commands/ingest.py
     owner: stable
   - path: polylogue/cli/commands/init.py
@@ -819,11 +819,11 @@ files:
     target: polylogue/cli/query_group.py
     owner: stable
   - path: polylogue/cli/query_output.py
-    loc: 1045
+    loc: 1058
     target: polylogue/cli/query_output.py
     owner: stable
   - path: polylogue/cli/query_output_contracts.py
-    loc: 87
+    loc: 104
     target: polylogue/cli/query_output_contracts.py
     owner: stable
   - path: polylogue/cli/query_progress.py
@@ -839,7 +839,7 @@ files:
     target: polylogue/cli/query_stats.py
     owner: stable
   - path: polylogue/cli/query_verbs.py
-    loc: 375
+    loc: 400
     target: polylogue/cli/query_verbs.py
     owner: stable
   - path: polylogue/cli/root_request.py
@@ -969,7 +969,7 @@ files:
     target: polylogue/cli/shell_completion_values.py
     owner: stable
   - path: polylogue/cli/verb_names.py
-    loc: 22
+    loc: 23
     target: polylogue/cli/verb_names.py
     owner: stable
   - path: polylogue/config.py
@@ -1094,7 +1094,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 986
+    loc: 975
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1166,7 +1166,7 @@ files:
     target: polylogue/daemon/healthz.py
     owner: stable
   - path: polylogue/daemon/http.py
-    loc: 2088
+    loc: 2109
     target: polylogue/daemon/http.py
     owner: stable
   - path: polylogue/daemon/live_ingest_attempt_models.py
@@ -1187,7 +1187,7 @@ files:
     target: polylogue/daemon/maintenance_registry_http.py
     owner: stable
   - path: polylogue/daemon/metrics.py
-    loc: 984
+    loc: 992
     target: polylogue/daemon/metrics.py
     owner: stable
   - path: polylogue/daemon/notification_backends/__init__.py
@@ -1510,7 +1510,7 @@ files:
     target: polylogue/operations/__init__.py
     owner: stable
   - path: polylogue/operations/archive.py
-    loc: 1267
+    loc: 1342
     target: polylogue/operations/archive.py
     owner: stable
   - path: polylogue/operations/completion_aggregates.py
@@ -2487,7 +2487,7 @@ files:
     target: polylogue/sources/assembly.py
     owner: stable
   - path: polylogue/sources/assembly_claude_code.py
-    loc: 154
+    loc: 174
     target: polylogue/sources/assembly_claude_code.py
     owner: stable
   - path: polylogue/sources/assembly_codex.py
@@ -2571,7 +2571,7 @@ files:
     target: polylogue/sources/live/append_ingest.py
     owner: stable
   - path: polylogue/sources/live/batch.py
-    loc: 1170
+    loc: 1178
     target: polylogue/sources/live/batch.py
     owner: stable
   - path: polylogue/sources/live/batch_observability.py
@@ -2614,6 +2614,10 @@ files:
     loc: 45
     target: polylogue/sources/live/deferred_cursor.py
     owner: stable
+  - path: polylogue/sources/live/hook_paste_enrichment.py
+    loc: 123
+    target: polylogue/sources/live/hook_paste_enrichment.py
+    owner: stable
   - path: polylogue/sources/live/metrics.py
     loc: 169
     target: polylogue/sources/live/metrics.py
@@ -2623,7 +2627,7 @@ files:
     target: polylogue/sources/live/sqlite_locking.py
     owner: stable
   - path: polylogue/sources/live/watcher.py
-    loc: 572
+    loc: 574
     target: polylogue/sources/live/watcher.py
     owner: stable
   - path: polylogue/sources/parsers/antigravity.py
@@ -3053,7 +3057,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/query_models.py
-    loc: 249
+    loc: 252
     target: polylogue/storage/query_models.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -3097,11 +3101,11 @@ files:
     target: polylogue/storage/repository/archive/__init__.py
     owner: stable
   - path: polylogue/storage/repository/archive/conversations.py
-    loc: 244
+    loc: 367
     target: polylogue/storage/repository/archive/conversations.py
     owner: stable
   - path: polylogue/storage/repository/archive/queries.py
-    loc: 247
+    loc: 249
     target: polylogue/storage/repository/archive/queries.py
     owner: stable
   - path: polylogue/storage/repository/archive/reads.py
@@ -3114,7 +3118,7 @@ files:
     owner: stable
     cross_cut: { layer: write }
   - path: polylogue/storage/repository/archive/search.py
-    loc: 171
+    loc: 191
     target: polylogue/storage/repository/archive/search.py
     owner: stable
   - path: polylogue/storage/repository/archive/tree.py
@@ -3363,7 +3367,7 @@ files:
     target: polylogue/storage/sqlite/queries/conversations_identity.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/conversations_reads.py
-    loc: 337
+    loc: 342
     target: polylogue/storage/sqlite/queries/conversations_reads.py
     owner: stable
     cross_cut: { layer: read }
@@ -3486,7 +3490,7 @@ files:
     owner: stable
     cross_cut: { layer: read }
   - path: polylogue/storage/sqlite/queries/stats.py
-    loc: 362
+    loc: 408
     target: polylogue/storage/sqlite/queries/stats.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/tool_usage.py
@@ -3594,7 +3598,7 @@ files:
     target: polylogue/surfaces/__init__.py
     owner: stable
   - path: polylogue/surfaces/payloads.py
-    loc: 1282
+    loc: 1305
     target: polylogue/surfaces/payloads.py
     owner: stable
   - path: polylogue/types.py

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -676,6 +676,14 @@ class LiveBatchProcessor:
                     path for path in unique_paths if path in states and bool(getattr(states[path], "converged", False))
                 }
                 debt_items = convergence_debt_from_states(unique_paths, states)
+                # #1654: after convergence, check for new hook events
+                # that carry paste evidence and update matching messages.
+                try:
+                    from polylogue.sources.live.hook_paste_enrichment import enrich_paste_from_hooks
+
+                    enrich_paste_from_hooks(self._cursor._db_path)
+                except Exception:
+                    logger.debug("hook_paste: enrichment failed (non-fatal)", exc_info=True)
                 return (
                     batch_completed,
                     time.perf_counter() - started,

--- a/polylogue/sources/live/hook_paste_enrichment.py
+++ b/polylogue/sources/live/hook_paste_enrichment.py
@@ -1,0 +1,123 @@
+"""Post-ingest paste-evidence enrichment from UserPromptSubmit hook events.
+
+#1654: hook events written to the hooks sidecar directory by
+``polylogue-hook`` carry ground-truth paste markers (``[Pasted text #N]``)
+in the UserPromptSubmit payload. These arrive after the conversation
+JSONL was ingested, so the initial materialization may have missed them.
+
+This module provides a lightweight enrichment step that reads hook
+sidecar JSONL files from disk and updates ``has_paste`` on matching
+messages. It is called by the daemon after each live-ingest batch
+completes.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.message.paste_detection import has_paste_indicator
+from polylogue.logging import get_logger
+from polylogue.paths import hooks_sidecar_dir
+
+logger = get_logger(__name__)
+
+#: Only UserPromptSubmit events carry paste ground truth.
+_PASTE_EVENT_TYPE = "UserPromptSubmit"
+#: Tolerance for matching a hook event timestamp to a message sort_key
+#: (milliseconds — same as history.jsonl matching in assembly_claude_code.py).
+_TIMESTAMP_TOLERANCE_MS = 3000
+
+
+def _iter_hook_paste_events(hooks_dir: Path) -> list[dict[str, object]]:
+    """Scan hook sidecar JSONL files, return UserPromptSubmit events with paste."""
+    events: list[dict[str, object]] = []
+    if not hooks_dir.exists():
+        return events
+    for jsonl_path in hooks_dir.glob("*.jsonl"):
+        try:
+            with open(jsonl_path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    if record.get("event_type") != _PASTE_EVENT_TYPE:
+                        continue
+                    if not has_paste_indicator(record):
+                        continue
+                    events.append(record)
+        except OSError:
+            logger.debug("hook_paste: could not read %s", jsonl_path, exc_info=True)
+    return events
+
+
+def enrich_paste_from_hooks(db_path: Path) -> int:
+    """Scan hook sidecar files and update has_paste on matching messages.
+
+    Returns the number of messages updated.
+    """
+    events = _iter_hook_paste_events(hooks_sidecar_dir())
+    if not events:
+        return 0
+
+    conn = sqlite3.connect(str(db_path))
+    updated = 0
+    try:
+        for event in events:
+            session_id = event.get("session_id")
+            timestamp_str = event.get("timestamp")
+            if not session_id or not timestamp_str:
+                continue
+
+            # Parse the hook event timestamp to a unix-epoch float for
+            # comparison against messages.sort_key.
+            hook_epoch_ms: float = 0.0
+            try:
+                from datetime import datetime
+
+                hook_ts = datetime.fromisoformat(str(timestamp_str).replace("Z", "+00:00"))
+                hook_epoch_ms = hook_ts.timestamp() * 1000
+            except (ValueError, OSError):
+                continue
+            if hook_epoch_ms <= 0:
+                continue
+
+            # Find messages whose conversation carries this session_id
+            # and whose sort_key falls within the tolerance window.
+            rows = conn.execute(
+                """
+                SELECT m.message_id
+                FROM messages m
+                JOIN conversations c ON c.conversation_id = m.conversation_id
+                WHERE c.provider_meta IS NOT NULL
+                  AND json_extract(c.provider_meta, '$.session_id') = ?
+                  AND m.role = 'user'
+                  AND m.has_paste = 0
+                  AND abs(m.sort_key - ?) < ?
+                LIMIT 1
+                """,
+                (str(session_id), hook_epoch_ms, _TIMESTAMP_TOLERANCE_MS),
+            ).fetchall()
+
+            for (message_id,) in rows:
+                conn.execute(
+                    "UPDATE messages SET has_paste = 1 WHERE message_id = ?",
+                    (message_id,),
+                )
+                updated += 1
+
+        if updated:
+            conn.commit()
+    finally:
+        conn.close()
+
+    if updated:
+        logger.info("hook_paste: enriched %d message(s) from hook sidecar events", updated)
+    return updated


### PR DESCRIPTION
## Summary

Wire `has_paste_indicator()` into the daemon's post-ingest convergence cycle. After each live-ingest batch, scans hook sidecar JSONL files for UserPromptSubmit events carrying paste markers, matches them to stored messages by session_id + timestamp proximity, and updates `has_paste=1`.

## Problem

`has_paste_indicator()` existed in `paste_detection.py` but had zero callers. Hook events (UserPromptSubmit) carry ground-truth paste markers before Claude Code expands them, but this evidence was never correlated with stored messages.

## Solution

- `polylogue/sources/live/hook_paste_enrichment.py` — reads hook sidecar JSONL files, extracts UserPromptSubmit events with paste indicators, matches to messages via `json_extract(provider_meta, '$.session_id')` + timestamp proximity, updates `has_paste=1`
- Wired into `LiveBatchProcessor` convergence cycle — called after each batch completes (non-fatal on failure)

Closes #1654

## Verification

- `nix develop -c mypy polylogue/sources/live/hook_paste_enrichment.py` → success
- `nix develop -c devtools verify-layering` → clean (function is in sources/live, no cross-layer import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic enrichment that matches paste markers from hook sidecar files to message records during batch processing.

* **Chores**
  * Updated file-size budget exceptions and topology configuration mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->