### PR TITLE
feat(surfaces): add paste_boundary_state to MessageRenderEnvelope (#1655 follow-up)

### DIFF
--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -308,6 +308,10 @@ class ConversationMessagePayload(SurfacePayloadModel):
     # conversation has no recorded raw artifact.
     raw_id: str | None = None
     source_path: str | None = None
+    # #1655: paste boundary state — exact, projected, whole_message_fallback,
+    # hash_only, or None when the message has no paste evidence. Populated
+    # from the stored ``messages.paste_boundary_state`` column.
+    paste_boundary_state: str | None = None
 
     @classmethod
     def from_message(


### PR DESCRIPTION
Add paste_boundary_state field to ConversationMessagePayload to bridge #1655 to the reader surface.