### PR TITLE
ci(pages): deploy PR previews to gh-pages for live URLs (#1592)

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,14 +1,10 @@
 name: GitHub Pages Preview
 
 # Build the documentation site on every pull request that touches a docs or
-# render-pages surface, and upload the resulting site as a workflow artifact
-# so reviewers can download and inspect it locally.
+# render-pages surface, and deploy to the gh-pages branch under /pr/NNN/ so
+# reviewers get a live preview URL at sinity.github.io/polylogue/pr/NNN/.
 #
-# This is the per-PR artifact mode of #1307. Per-PR deployment to a real
-# preview URL (e.g. gh-pages /pr/NNN/) and versioned release trees
-# (/vX.Y.Z/) are deferred — both require switching the master pages.yml
-# from actions/deploy-pages (single-target Pages environment) to a
-# branch-based deploy. Tracked as follow-up issues.
+# #1592: per-PR live preview URLs via branch-based deploy.
 
 on:
   pull_request:
@@ -25,14 +21,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: pages-preview-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy-preview:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -45,30 +41,22 @@ jobs:
       - name: Build site
         run: nix develop --command devtools render-pages
 
-      - name: Upload preview artifact
-        uses: actions/upload-artifact@v4
+      - name: Deploy to gh-pages /pr/NNN/
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          name: docs-site-preview-pr-${{ github.event.pull_request.number || github.run_id }}
-          path: .cache/site/
-          retention-days: 14
-          if-no-files-found: error
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .cache/site
+          destination_dir: pr/${{ github.event.pull_request.number || github.run_id }}
+          keep_files: true
+          commit_message: "ci: deploy docs preview for PR #${{ github.event.pull_request.number || github.run_id }}"
 
       - name: Summary
         run: |
+          PR_NUM="${{ github.event.pull_request.number || github.run_id }}"
           {
-            echo "## Docs preview built"
+            echo "## Docs preview deployed"
             echo ""
-            echo "The rendered site is uploaded as a workflow artifact:"
+            echo "Live preview: https://sinity.github.io/polylogue/pr/${PR_NUM}/"
             echo ""
-            echo "**docs-site-preview-pr-${{ github.event.pull_request.number || github.run_id }}**"
-            echo ""
-            echo "Download from the workflow run page, extract, and serve locally:"
-            echo ""
-            echo '```bash'
-            echo "unzip docs-site-preview-pr-*.zip -d /tmp/polylogue-docs"
-            echo "python -m http.server --directory /tmp/polylogue-docs 8000"
-            echo '```'
-            echo ""
-            echo "Per-PR live deployment and versioned /vX.Y.Z/ trees are tracked as"
-            echo "follow-ups to #1307."
+            echo "The preview will remain available until the next gh-pages cleanup."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Switch from artifact-only preview to branch-based deploy under /pr/NNN/. Live URL at sinity.github.io/polylogue/pr/NNN/.