### PR TITLE
feat(cli): add --json flag shortcut for --format json (#1689)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -124,6 +124,8 @@ Options:
   --sample INTEGER                Random sample of N conversations
   -o, --output TEXT               Output destinations: browser, clipboard,
                                   stdout (comma-separated)
+  --json                          Shortcut for --format json. Disables color
+                                  and progress for pipeable output. (#1689)
   -f, --format [markdown|json|ndjson|html|obsidian|org|yaml|plaintext|csv]
                                   Output format (for --latest, --stream, or
                                   verb output). `ndjson` emits one JSON

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -134,6 +134,7 @@ def cli(
     # Output
     output: str | None,
     output_format: str | None,
+    output_as_json: bool,
     transform: str | None,
     no_code_blocks: bool,
     no_tool_calls: bool,
@@ -201,6 +202,12 @@ def cli(
         polylogue <subcommand> --help     # per-subcommand help
         polylogue --diagnose <args>       # explain parser decisions
     """
+    # #1689: --json forces plain output and defaults to JSON format.
+    if output_as_json:
+        plain = True
+        if not output_format:
+            output_format = "json"
+
     # Set up logging early so all output goes to stderr
     configure_logging(verbose=verbose)
 

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -295,6 +295,13 @@ OUTPUT_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         help="Output destinations: browser, clipboard, stdout (comma-separated)",
     ),
     click.option(
+        "--json",
+        "output_as_json",
+        is_flag=True,
+        default=False,
+        help="Shortcut for --format json. Disables color and progress for pipeable output. (#1689)",
+    ),
+    click.option(
         "--format",
         "-f",
         "output_format",


### PR DESCRIPTION
Add --json boolean flag that sets --format json and disables color for pipeable agent consumption.