### PR TITLE
ci(cachix): switch cache from polylogue to sinity

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -42,7 +42,7 @@ jobs:
           name: sinity
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build and push package
-        run: nix build .#sinity --print-out-paths
+        run: nix build .#polylogue --print-out-paths
       - name: Build and push api-python
         run: nix build .#api-python --print-out-paths
       - name: Build and push devshell closure

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,12 +1,12 @@
 name: Cachix
 
-# Push polylogue build closures (package + devshell) to the polylogue cachix
+# Push sinity build closures (package + devshell) to the sinity cachix
 # binary cache on master pushes and tags. Downstream `nix run github:Sinity/polylogue`
-# users with `cache.nixos.org` + `polylogue.cachix.org` configured will hit the
+# users with `cache.nixos.org` + `sinity.cachix.org` configured will hit the
 # cache instead of rebuilding from source.
 #
 # Requires `CACHIX_AUTH_TOKEN` repository secret with write access to the
-# `polylogue` cachix cache.
+# `sinity` cachix cache.
 
 on:
   push:
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   push:
-    # Skip silently when the cache hasn't been provisioned. The `polylogue`
+    # Skip silently when the cache hasn't been provisioned. The `sinity`
     # cachix cache and the `CACHIX_AUTH_TOKEN` secret live outside this repo;
     # without them the cachix-action fails and reddens master. Setting the repo
     # variable `CACHIX_CACHE_ENABLED=true` opts the workflow in once the cache
@@ -39,13 +39,13 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v15
         with:
-          name: polylogue
+          name: sinity
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build and push package
-        run: nix build .#polylogue --print-out-paths
+        run: nix build .#sinity --print-out-paths
       - name: Build and push api-python
         run: nix build .#api-python --print-out-paths
       - name: Build and push devshell closure
         run: |
           nix develop --profile dev-profile --command true
-          nix path-info ./dev-profile --recursive | cachix push polylogue
+          nix path-info ./dev-profile --recursive | cachix push sinity


### PR DESCRIPTION
Cache name changed to sinity (sinity.cachix.org). Build targets unchanged (.polylogue, .api-python). Requires CACHIX_AUTH_TOKEN secret for sinity cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow cache configuration to use a different cache provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->