### PR TITLE
fix(storage): release blob leases on failure and enforce GC generation gate

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -334,11 +334,30 @@ concurrent GC before the main transaction commits, then calls
 the blob is now durably referenced by `raw_conversations` and the
 lease can drop.
 
+The acquire/release pair is wrapped in `try/finally` keyed by
+`operation_id` (#1746). The lease is committed on its own connection,
+so rolling back the main transaction on failure does NOT undo it — if
+FTS repair or the commit raises, the `finally` opens a fresh
+immediate-commit connection and releases the lease anyway. Without this
+the lease row would leak into `pending_blob_refs` permanently and the
+blob it named could never be GC'd.
+
+The durable backstop is `sweep_orphaned_blob_leases`, run at daemon
+startup (`polylogue/daemon/cli.py:_sweep_orphaned_blob_leases`,
+mirroring `CursorStore._mark_interrupted_attempts` for
+`live_ingest_attempt`). A writer SIGKILLed between acquire and release
+cannot run its `finally`; the sweep deletes any `pending_blob_refs`
+row older than `ORPHAN_LEASE_MAX_AGE_S` (3600 s), a bound generous
+enough that a slow-but-live ingest is never swept out from under
+itself.
+
 `gc_generations` tracks the high-water mark of completed GC runs. The
-"defense-in-depth" age check requires candidate blobs to be older than
-the previous generation plus `MIN_AGE_S` so that a brand-new blob is
-never considered for deletion within the same GC run cycle that
-created it.
+"defense-in-depth" age gate is enforced in `run_blob_gc` (#1746): a
+candidate blob must be older than `max(MIN_AGE_S, now -
+prev_generation.completed_at)`. The generation term means a blob
+created during the same window as the previous GC pass is never
+reclaimed before its eventual reference can land. With no prior
+generation recorded, the static `MIN_AGE_S` floor applies on its own.
 
 - **Known issues**: GC has bugs with orphan detection and integrity
   verification ([#818](https://github.com/Sinity/polylogue/issues/818))

--- a/docs/plans/test-clock-allowlist.yaml
+++ b/docs/plans/test-clock-allowlist.yaml
@@ -63,6 +63,8 @@ files:
     reason: "Blob aging uses time.time() to backdate file mtime; production GC reads file mtime, not datetime.now."
   - path: tests/unit/storage/test_blob_store_contracts.py
     reason: "Same as test_blob_gc_concurrency: time.time() backdates file mtime."
+  - path: tests/unit/storage/test_blob_gc_lease_recovery.py
+    reason: "#1746 lease/GC tests backdate blob mtime and pending_blob_refs.acquired_at with time.time(); production GC reads file mtime and integer acquired_at, not datetime.now()."
   - path: tests/unit/storage/test_raw_ingest_artifacts.py
     reason: "Raw-ingest test uses now() as opaque acquired_at metadata."
   - path: tests/unit/daemon/test_fts_trigger_drift.py

--- a/polylogue/archive/write_effects.py
+++ b/polylogue/archive/write_effects.py
@@ -72,48 +72,60 @@ def commit_archive_write_effects(
     # run sees them. Uses a separate connection (immediate commit) because
     # leases must be visible to other connections before *this* transaction
     # commits its blob references.
-    if blob_hashes and operation_id and db_path:
+    has_lease = bool(blob_hashes and operation_id)
+    if has_lease and db_path:
         from polylogue.storage.blob_gc import acquire_blob_leases
 
         acquire_blob_leases(db_path, blob_hashes, operation_id)
 
-    t_trigger = time.perf_counter()
-    ensure_fts_triggers_sync(conn)
-    trigger_elapsed_s = time.perf_counter() - t_trigger
-    message_fts_elapsed_s = 0.0
-    action_fts_elapsed_s = 0.0
-    if sorted_ids and repair_message_fts:
-        t_message = time.perf_counter()
-        repair_message_fts_index_sync(conn, sorted_ids)
-        message_fts_elapsed_s = time.perf_counter() - t_message
-    if sorted_ids and repair_action_fts:
-        t_action = time.perf_counter()
-        repair_action_fts_index_sync(conn, sorted_ids)
-        action_fts_elapsed_s = time.perf_counter() - t_action
-    t_commit = time.perf_counter()
-    conn.commit()
-    commit_elapsed_s = time.perf_counter() - t_commit
-    total_effect_elapsed_s = trigger_elapsed_s + message_fts_elapsed_s + action_fts_elapsed_s + commit_elapsed_s
-    if total_effect_elapsed_s >= 1.0:
-        logger.info(
-            "slow_archive_write_effects operation=%s conversations=%d ensure_fts_triggers_s=%.3f "
-            "message_fts_s=%.3f action_fts_s=%.3f commit_s=%.3f total_s=%.3f",
-            op.value,
-            len(sorted_ids),
-            trigger_elapsed_s,
-            message_fts_elapsed_s,
-            action_fts_elapsed_s,
-            commit_elapsed_s,
-            total_effect_elapsed_s,
-        )
-
-    # Release blob GC leases after successful commit — the blob references
-    # are now durable and the GC can safely clean unreferenced blobs.
-    if blob_hashes and operation_id:
-        from polylogue.storage.blob_gc import release_operation_leases
-
-        release_operation_leases(conn, operation_id)
+    # The lease was committed on its own connection, so rolling back ``conn``
+    # on failure does NOT undo it. It must be released on every exit path or
+    # the row leaks into ``pending_blob_refs`` forever and the blob it names
+    # can never be GC'd (#1746). ``lease_released`` tracks the success path so
+    # the ``finally`` only runs the recovery release after a failure.
+    lease_released = False
+    try:
+        t_trigger = time.perf_counter()
+        ensure_fts_triggers_sync(conn)
+        trigger_elapsed_s = time.perf_counter() - t_trigger
+        message_fts_elapsed_s = 0.0
+        action_fts_elapsed_s = 0.0
+        if sorted_ids and repair_message_fts:
+            t_message = time.perf_counter()
+            repair_message_fts_index_sync(conn, sorted_ids)
+            message_fts_elapsed_s = time.perf_counter() - t_message
+        if sorted_ids and repair_action_fts:
+            t_action = time.perf_counter()
+            repair_action_fts_index_sync(conn, sorted_ids)
+            action_fts_elapsed_s = time.perf_counter() - t_action
+        t_commit = time.perf_counter()
         conn.commit()
+        commit_elapsed_s = time.perf_counter() - t_commit
+        total_effect_elapsed_s = trigger_elapsed_s + message_fts_elapsed_s + action_fts_elapsed_s + commit_elapsed_s
+        if total_effect_elapsed_s >= 1.0:
+            logger.info(
+                "slow_archive_write_effects operation=%s conversations=%d ensure_fts_triggers_s=%.3f "
+                "message_fts_s=%.3f action_fts_s=%.3f commit_s=%.3f total_s=%.3f",
+                op.value,
+                len(sorted_ids),
+                trigger_elapsed_s,
+                message_fts_elapsed_s,
+                action_fts_elapsed_s,
+                commit_elapsed_s,
+                total_effect_elapsed_s,
+            )
+
+        # Release blob GC leases after successful commit — the blob references
+        # are now durable and the GC can safely clean unreferenced blobs.
+        if has_lease:
+            from polylogue.storage.blob_gc import release_operation_leases
+
+            release_operation_leases(conn, operation_id)
+            conn.commit()
+            lease_released = True
+    finally:
+        if has_lease and not lease_released:
+            _release_leases_on_failure(db_path, operation_id)
 
     if sorted_ids:
         _invalidate_search_cache()
@@ -124,6 +136,41 @@ def commit_archive_write_effects(
         rows_affected=len(sorted_ids),
         status="committed",
     )
+
+
+def _release_leases_on_failure(db_path: str | None, operation_id: str) -> None:
+    """Release leaked blob leases after a failed write-effects pass.
+
+    The leases were committed on a separate connection, so the failing
+    transaction's rollback cannot undo them. Open a fresh immediate-commit
+    connection to drop them, mirroring ``acquire_blob_leases``. Any error here
+    is logged and suppressed so it never masks the original failure that is
+    propagating out of the ``finally``; the daemon-startup
+    ``sweep_orphaned_blob_leases`` is the durable backstop if this best-effort
+    release also fails.
+    """
+    if not db_path:
+        return
+    try:
+        from polylogue.storage.blob_gc import release_operation_leases
+        from polylogue.storage.sqlite.connection_profile import open_connection
+
+        conn = open_connection(db_path)
+        try:
+            release_operation_leases(conn, operation_id)
+            conn.commit()
+        finally:
+            conn.close()
+        logger.warning(
+            "Released leaked blob leases for operation %s after write-effects failure",
+            operation_id,
+        )
+    except Exception:  # pragma: no cover - defensive: never mask the original error
+        logger.warning(
+            "Failed to release leaked blob leases for operation %s after write-effects failure",
+            operation_id,
+            exc_info=True,
+        )
 
 
 def _invalidate_search_cache() -> None:

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -190,6 +190,35 @@ async def _periodic_db_optimize() -> None:
             logger.warning("daemon: DB optimize failed", exc_info=True)
 
 
+def _sweep_orphaned_blob_leases_sync() -> None:
+    """Remove blob leases leaked by writers killed mid-commit (#1746).
+
+    ``commit_archive_write_effects`` acquires a blob lease on a separate
+    immediate-commit connection before the data transaction. If the process is
+    SIGKILLed between acquire and release, the lease row leaks into
+    ``pending_blob_refs`` and permanently blocks GC of that blob. This is the
+    startup counterpart to ``CursorStore._mark_interrupted_attempts`` for
+    ``live_ingest_attempt``.
+    """
+    from polylogue.paths import db_path
+    from polylogue.storage.blob_gc import sweep_orphaned_blob_leases
+
+    db = db_path()
+    if not db.exists():
+        return
+    try:
+        removed = sweep_orphaned_blob_leases(db)
+        if removed:
+            logger.info("daemon: swept %d orphaned blob lease(s) on startup", removed)
+    except Exception:
+        logger.warning("daemon: orphaned blob lease sweep failed", exc_info=True)
+
+
+async def _sweep_orphaned_blob_leases() -> None:
+    """Run the orphaned blob-lease startup sweep without blocking the loop."""
+    await asyncio.to_thread(_sweep_orphaned_blob_leases_sync)
+
+
 async def _periodic_convergence_check(sources: tuple[WatchSource, ...]) -> None:
     """Periodically retry recorded derived convergence debt."""
     from polylogue.paths import db_path
@@ -565,6 +594,9 @@ async def run_daemon_services(
         # archives, bounded SQLite maintenance can fault substantial file cache.
         if not watcher_blocked:
             maintenance_tasks.append(asyncio.create_task(_ensure_fts_startup_readiness()))
+            # Reclaim blob leases leaked by a previously SIGKILLed writer so a
+            # later GC pass is not blocked indefinitely (#1746).
+            maintenance_tasks.append(asyncio.create_task(_sweep_orphaned_blob_leases()))
 
         # Preflight already ran at the top of run_daemon_services (see
         # ``watcher_blocked`` above); reuse that result.

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -63,11 +63,64 @@ MIN_AGE_S = 60
 # GC generation constants
 _INITIAL_GENERATION = 0
 
+# Orphaned-lease sweep bound. A lease whose owning operation crashed before
+# release (see ``commit_archive_write_effects``) is reclaimed once it is older
+# than this many seconds, mirroring ``_mark_interrupted_attempts`` for
+# ``live_ingest_attempt``. Generous so a slow-but-live ingest is never swept
+# out from under itself.
+ORPHAN_LEASE_MAX_AGE_S = 3600
+
 
 def _current_generation(conn: sqlite3.Connection) -> int:
     """Return the latest completed GC generation, or 0 if none."""
     row = conn.execute("SELECT COALESCE(MAX(generation), 0) FROM gc_generations").fetchone()
     return row[0] if row else 0
+
+
+def _previous_generation_completed_at(conn: sqlite3.Connection) -> int | None:
+    """Return ``completed_at`` of the latest completed GC generation, or None.
+
+    Used by ``run_blob_gc`` to enforce safety invariant #3: a blob must be
+    older than the previous generation's completion before it is eligible for
+    deletion (defense-in-depth against clock skew and delayed lease writes).
+    """
+    row = conn.execute("SELECT completed_at FROM gc_generations ORDER BY generation DESC LIMIT 1").fetchone()
+    if row is None:
+        return None
+    completed_at = row[0]
+    return int(completed_at) if completed_at is not None else None
+
+
+def sweep_orphaned_blob_leases(
+    db_path: str | Path,
+    *,
+    max_age_s: int = ORPHAN_LEASE_MAX_AGE_S,
+) -> int:
+    """Remove ``pending_blob_refs`` rows older than ``max_age_s`` seconds.
+
+    A lease is acquired before the data transaction commits and released on
+    every exit path of ``commit_archive_write_effects``. If the owning process
+    is SIGKILLed between acquire and release, the lease row leaks and
+    permanently blocks GC of the blob it names. This sweep is the daemon
+    startup counterpart to ``CursorStore._mark_interrupted_attempts``: it
+    reclaims leases that no live operation could still own.
+
+    Returns the number of orphaned lease rows removed.
+    """
+    cutoff = int(time.time()) - int(max_age_s)
+    conn = open_connection(db_path)
+    try:
+        cursor = conn.execute(
+            "DELETE FROM pending_blob_refs WHERE acquired_at < ?",
+            (cutoff,),
+        )
+        removed = max(cursor.rowcount, 0)
+        conn.commit()
+        if removed:
+            logger.info("Swept %d orphaned blob lease(s) older than %ds", removed, max_age_s)
+        return removed
+    finally:
+        conn.close()
 
 
 def _has_active_lease(conn: sqlite3.Connection, blob_hash: str) -> bool:
@@ -198,7 +251,17 @@ def run_blob_gc(
     conn.row_factory = sqlite3.Row
     try:
         generation = _current_generation(conn)
-        older_than = MIN_AGE_S
+        # Safety invariant #3: a candidate must be older than BOTH the static
+        # MIN_AGE_S floor AND the previous completed GC generation. The
+        # generation high-water mark prevents a blob created during the same
+        # window as the previous GC pass from being reclaimed before its
+        # eventual reference can land (defense-in-depth against clock skew and
+        # delayed lease writes). Without a prior generation the floor applies.
+        prev_completed_at = _previous_generation_completed_at(conn)
+        older_than = float(MIN_AGE_S)
+        if prev_completed_at is not None:
+            since_prev_generation = time.time() - prev_completed_at
+            older_than = max(older_than, since_prev_generation)
         candidates = _candidate_blobs(blob_path, older_than=older_than)
         if not candidates:
             return 0
@@ -395,10 +458,12 @@ def release_operation_leases(
 
 __all__ = [
     "MIN_AGE_S",
+    "ORPHAN_LEASE_MAX_AGE_S",
     "GCHistoryRow",
     "GCRunEvidence",
     "acquire_blob_leases",
     "read_gc_history",
     "release_operation_leases",
     "run_blob_gc",
+    "sweep_orphaned_blob_leases",
 ]

--- a/tests/unit/storage/test_blob_gc_lease_recovery.py
+++ b/tests/unit/storage/test_blob_gc_lease_recovery.py
@@ -1,0 +1,205 @@
+"""Regression tests for blob-lease durability and the GC generation gate (#1746).
+
+Covers three guarantees added in the #1746 fix:
+
+1. ``commit_archive_write_effects`` releases its blob lease on *every* exit
+   path. A failure after lease acquisition must not leak a ``pending_blob_refs``
+   row (the lease is committed on a separate connection, so the failing
+   transaction's rollback cannot undo it).
+2. ``sweep_orphaned_blob_leases`` reclaims leases left behind by a writer that
+   was killed between acquire and release.
+3. ``run_blob_gc`` enforces safety invariant #3: a candidate must be older than
+   the previous completed generation's ``completed_at`` (not merely
+   ``MIN_AGE_S``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive import write_effects
+from polylogue.archive.write_gateway import WriteOperation
+from polylogue.storage.blob_gc import (
+    MIN_AGE_S,
+    acquire_blob_leases,
+    run_blob_gc,
+    sweep_orphaned_blob_leases,
+)
+from polylogue.storage.sqlite.connection_profile import open_connection
+from polylogue.storage.sqlite.schema import _ensure_schema
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    conn = open_connection(db)
+    try:
+        _ensure_schema(conn)
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+def _count_leases(db: Path) -> int:
+    conn = sqlite3.connect(str(db))
+    try:
+        count: int = conn.execute("SELECT COUNT(*) FROM pending_blob_refs").fetchone()[0]
+        return count
+    finally:
+        conn.close()
+
+
+def _set_lease_acquired_at(db: Path, operation_id: str, acquired_at: int) -> None:
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "UPDATE pending_blob_refs SET acquired_at = ? WHERE operation_id = ?",
+            (acquired_at, operation_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_blob(blob_dir: Path, blob_hash: str, *, age_s: float = 0.0) -> None:
+    import os
+
+    shard = blob_dir / blob_hash[:2]
+    shard.mkdir(parents=True, exist_ok=True)
+    blob_file = shard / blob_hash[2:]
+    blob_file.write_bytes(b"data")
+    if age_s > 0:
+        old = time.time() - age_s
+        os.utime(blob_file, (old, old))
+
+
+def test_write_effects_releases_lease_on_failure(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A post-acquire failure in commit_archive_write_effects leaks no lease.
+
+    Force the FTS-trigger step to raise so the function exits abnormally after
+    the lease was acquired on its separate immediate-commit connection. The
+    finally-path recovery release must drop the row.
+    """
+
+    def _boom(_conn: sqlite3.Connection) -> None:
+        raise RuntimeError("simulated FTS failure")
+
+    # ensure_fts_triggers_sync is imported inside the function body, so patch at
+    # the source module.
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.ensure_fts_triggers_sync",
+        _boom,
+    )
+
+    conn = open_connection(db_path)
+    blob_hash = "ab" + "c" * 62
+    try:
+        with pytest.raises(RuntimeError, match="simulated FTS failure"):
+            write_effects.commit_archive_write_effects(
+                conn,
+                WriteOperation.INGEST,
+                {
+                    "changed_conversation_ids": ["conv-1"],
+                    "_blob_hashes": [blob_hash],
+                    "_operation_id": "op-fail",
+                    "_db_path": str(db_path),
+                },
+            )
+    finally:
+        conn.close()
+
+    assert _count_leases(db_path) == 0, "lease leaked after write-effects failure"
+
+
+def test_write_effects_releases_lease_on_success(db_path: Path) -> None:
+    """The normal success path also leaves no residual lease."""
+    conn = open_connection(db_path)
+    blob_hash = "de" + "f" * 62
+    try:
+        write_effects.commit_archive_write_effects(
+            conn,
+            WriteOperation.INGEST,
+            {
+                "changed_conversation_ids": [],
+                "_blob_hashes": [blob_hash],
+                "_operation_id": "op-ok",
+                "_db_path": str(db_path),
+            },
+        )
+    finally:
+        conn.close()
+
+    assert _count_leases(db_path) == 0
+
+
+def test_sweep_removes_orphaned_lease(db_path: Path) -> None:
+    """A lease older than the sweep bound is reclaimed; a fresh one survives."""
+    acquire_blob_leases(db_path, ["aa" + "1" * 62], "op-stale")
+    acquire_blob_leases(db_path, ["bb" + "2" * 62], "op-fresh")
+    # Age the stale lease well past the default bound.
+    _set_lease_acquired_at(db_path, "op-stale", int(time.time()) - 7200)
+
+    removed = sweep_orphaned_blob_leases(db_path, max_age_s=3600)
+
+    assert removed == 1
+    assert _count_leases(db_path) == 1
+    conn = sqlite3.connect(str(db_path))
+    try:
+        survivor = conn.execute("SELECT operation_id FROM pending_blob_refs").fetchone()[0]
+    finally:
+        conn.close()
+    assert survivor == "op-fresh"
+
+
+def test_sweep_keeps_recent_lease(db_path: Path) -> None:
+    """A lease younger than the bound is never swept."""
+    acquire_blob_leases(db_path, ["cc" + "3" * 62], "op-young")
+
+    removed = sweep_orphaned_blob_leases(db_path, max_age_s=3600)
+
+    assert removed == 0
+    assert _count_leases(db_path) == 1
+
+
+def test_gc_age_gate_respects_previous_generation(db_path: Path, tmp_path: Path) -> None:
+    """A blob younger than the previous generation's completion is not deleted.
+
+    Seed a recently-completed generation, then create an unreferenced blob old
+    enough to pass MIN_AGE_S but younger than that generation boundary. The
+    generation gate must keep it; only after it ages past the boundary does GC
+    reclaim it.
+    """
+    blob_dir = tmp_path / "blobs"
+    blob_dir.mkdir()
+    blob_hash = "12" + "3" * 62
+
+    now = int(time.time())
+    # Previous generation completed 1000s ago.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO gc_generations (generation, completed_at, evidence) VALUES (?, ?, ?)",
+            (1, now - 1000, "{}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Blob is older than MIN_AGE_S but younger than the 1000s generation boundary.
+    _make_blob(blob_dir, blob_hash, age_s=MIN_AGE_S + 10)
+    assert MIN_AGE_S + 10 < 1000  # guard the test's own premise
+
+    deleted = run_blob_gc(db_path, blob_dir)
+    assert deleted == 0, "generation gate should have kept the recent blob"
+    assert (blob_dir / blob_hash[:2] / blob_hash[2:]).exists()
+
+    # Age the blob past the generation boundary; now it is eligible.
+    _make_blob(blob_dir, blob_hash, age_s=1100)
+    deleted = run_blob_gc(db_path, blob_dir)
+    assert deleted == 1
+    assert not (blob_dir / blob_hash[:2] / blob_hash[2:]).exists()


### PR DESCRIPTION
## Summary

Closes the two blob-GC durability defects from #1746: blob leases that leaked on any post-acquire write failure, and the `run_blob_gc` age gate that ignored the generation high-water mark its own docs promised.

## Problem

`commit_archive_write_effects` acquired blob leases on a *separate* immediate-commit connection (so they're visible to a concurrent GC before the data transaction commits), but released them only on the success path with no `try/finally`. Any post-acquire exception — FTS repair raising, the commit failing — left the `pending_blob_refs` row for that `operation_id` forever. Because the lease was committed on its own connection, rolling back the main transaction could not undo it. The leaked lease permanently blocked GC of that blob and bloated the table on every failed write.

Separately, `run_blob_gc` fetched the generation high-water mark but never used it in the age computation. The module docstring, `run_blob_gc`'s docstring, and `docs/internals.md` ("GC concurrency model", safety invariant #3) all claimed candidates must be "older than the previous completed GC generation plus MIN_AGE_S" — the documented defense-in-depth did not exist in code.

GC is currently manual-only (`cli/commands/maintenance.py`), so both were latent — but the lease leak still accumulated dead `pending_blob_refs` rows on every failed write.

## Solution

- `archive/write_effects.py`: wrap the acquire→commit→release lifetime in `try/finally`. On success the lease is released and `lease_released` is set; otherwise the `finally` runs `_release_leases_on_failure`, opening a fresh immediate-commit connection to drop the leaked lease. Any error there is logged and suppressed so it never masks the original exception.
- `storage/blob_gc.py`: enforce `older_than = max(MIN_AGE_S, now - prev_generation.completed_at)` via `_previous_generation_completed_at`. Add `sweep_orphaned_blob_leases(db_path, max_age_s=ORPHAN_LEASE_MAX_AGE_S=3600)` reclaiming `pending_blob_refs` rows past the bound — the analogue of `CursorStore._mark_interrupted_attempts`.
- `daemon/cli.py`: run the orphaned-lease sweep at startup (non-blocking via `asyncio.to_thread`).
- `docs/internals.md`: document the try/finally release, startup sweep, and the now-enforced generation age gate.

## Verification

```
nix develop -c pytest tests/unit/storage/test_blob_gc_lease_recovery.py -q   # 7 passed
nix develop -c python3 -m mypy tests/unit/storage/test_blob_gc_lease_recovery.py  # Success
nix develop -c devtools verify --quick                                       # exit 0
```

New regression tests (`test_blob_gc_lease_recovery.py`): a forced FTS-trigger failure mid-`commit_archive_write_effects` leaves zero residual leases; the success path also leaves zero; `sweep_orphaned_blob_leases` removes an aged lease and keeps a fresh one; `run_blob_gc` keeps a blob younger than the previous generation's `completed_at` then deletes it once aged past the boundary.

Closes #1746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orphaned blob-lease recovery sweep on daemon startup to reclaim resources from crashed operations.

* **Bug Fixes**
  * Improved blob-lease durability to prevent leaks during write transaction failures.

* **Documentation**
  * Updated blob storage garbage collection documentation with refined concurrency model details.

* **Tests**
  * Added regression tests for blob-lease recovery and garbage collection safety guarantees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->