### PR TITLE
fix(parser): traverse ChatGPT message graph and extract non-parts content (#1744)

### DIFF
--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -26,22 +26,46 @@ def _coerce_float(value: object) -> float | None:
     return None
 
 
-def extract_messages_from_mapping(mapping: Mapping[str, object]) -> tuple[list[ParsedMessage], list[ParsedAttachment]]:
-    entries: list[tuple[float | None, int, ParsedMessage]] = []
-    attachments: list[ParsedAttachment] = []
-    for idx, node in enumerate(mapping.values(), start=1):
-        if not isinstance(node, dict):
-            continue
-        msg = node.get("message")
-        if not isinstance(msg, dict):
-            continue
-        content = msg.get("content")
-        if not isinstance(content, dict):
-            continue
-        parts = content.get("parts") or []
-        if not isinstance(parts, list):
-            continue
-        text_parts = []
+def _resolve_active_path_ids(mapping: Mapping[str, object], current_node: str | None) -> list[str]:
+    """Resolve the node ids to emit, in order, from a ChatGPT message graph.
+
+    When ``current_node`` is present (every real ChatGPT export carries it), walk
+    parent pointers up from it — the active leaf the user last saw — to the root,
+    then reverse. Only this active path is emitted, so abandoned regeneration and
+    edit branches are not flattened into sibling messages (#1744).
+
+    When ``current_node`` is absent (synthetic fixtures, malformed exports), fall
+    back to the original all-nodes-in-insertion-order behavior. That path has no
+    way to know which branch was active, so preserving every node is the
+    lossless choice; downstream sorting by ``create_time`` still applies.
+    """
+    if current_node and current_node in mapping:
+        path: list[str] = []
+        seen: set[str] = set()
+        node_id: str | None = current_node
+        while node_id is not None and node_id in mapping and node_id not in seen:
+            seen.add(node_id)
+            path.append(node_id)
+            node = mapping[node_id]
+            node_id = node.get("parent") if isinstance(node, dict) else None
+        path.reverse()
+        return path
+
+    return list(mapping.keys())
+
+
+def _extract_content_text(content: Mapping[str, object]) -> str:
+    """Extract message text from a ChatGPT content block.
+
+    Handles the common ``parts`` array (strings and structured dicts carrying
+    ``text``) and falls back to non-``parts`` content shapes — ``code`` and
+    ``execution_output`` carry a top-level ``text``, browsing display carries a
+    ``result``. Without this fallback those messages have empty text and are
+    dropped entirely (#1744).
+    """
+    parts = content.get("parts")
+    if isinstance(parts, list):
+        text_parts: list[str] = []
         for part in parts:
             if isinstance(part, str) and part:
                 text_parts.append(part)
@@ -51,7 +75,38 @@ def extract_messages_from_mapping(mapping: Mapping[str, object]) -> tuple[list[P
                 if isinstance(t, str) and t:
                     text_parts.append(t)
                 # Skip image_asset_pointer and other non-text dicts
-        text = "\n".join(text_parts)
+        if text_parts:
+            return "\n".join(text_parts)
+    # Non-parts content shapes: code / execution_output carry top-level text;
+    # browsing display carries a result string.
+    top_text = content.get("text")
+    if isinstance(top_text, str) and top_text:
+        return top_text
+    result = content.get("result")
+    if isinstance(result, str) and result:
+        return result
+    return ""
+
+
+def extract_messages_from_mapping(
+    mapping: Mapping[str, object],
+    current_node: str | None = None,
+) -> tuple[list[ParsedMessage], list[ParsedAttachment]]:
+    entries: list[tuple[float | None, int, ParsedMessage]] = []
+    attachments: list[ParsedAttachment] = []
+    path_ids = _resolve_active_path_ids(mapping, current_node)
+    for idx, node_id in enumerate(path_ids, start=1):
+        node = mapping.get(node_id)
+        if not isinstance(node, dict):
+            continue
+        msg = node.get("message")
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, dict):
+            continue
+        parts = content.get("parts") or []
+        text = _extract_content_text(content)
         if not text:
             continue
         # Role is required - skip messages without one
@@ -159,6 +214,24 @@ def extract_messages_from_mapping(mapping: Mapping[str, object]) -> tuple[list[P
                     metadata={"content_type": content_type},
                 )
             )
+        elif content_type == "code":
+            # Code-interpreter input — top-level text, no parts (#1744).
+            content_blocks.append(
+                ParsedContentBlock(
+                    type=ContentBlockType.CODE,
+                    text=text,
+                    metadata={"content_type": content_type},
+                )
+            )
+        elif content_type == "execution_output":
+            # Code-interpreter output — top-level text, no parts (#1744).
+            content_blocks.append(
+                ParsedContentBlock(
+                    type=ContentBlockType.TOOL_RESULT,
+                    text=text,
+                    metadata={"content_type": content_type},
+                )
+            )
         elif parts:
             for part in parts:
                 if isinstance(part, str) and part:
@@ -236,7 +309,9 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedConversation
     mapping = payload.get("mapping") or {}
     if not isinstance(mapping, dict):
         mapping = {}
-    messages, attachments = extract_messages_from_mapping(mapping)
+    current_node = payload.get("current_node")
+    current_node = current_node if isinstance(current_node, str) else None
+    messages, attachments = extract_messages_from_mapping(mapping, current_node)
     title = payload.get("title") or payload.get("name") or fallback_id
     conv_id = payload.get("id") or payload.get("uuid") or payload.get("conversation_id")
 

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -811,3 +811,148 @@ def test_chatgpt_metadata_permutation_roundtrip(
             assert actual == expected_value, f"[{desc}] {field_name}: expected {expected_value!r}, got {actual!r}"
         else:
             assert actual == expected_value, f"[{desc}] {field_name}: expected {expected_value!r}, got {actual!r}"
+
+
+# ---------------------------------------------------------------------------
+# #1744 — active-leaf graph traversal (abandoned branches not emitted)
+# ---------------------------------------------------------------------------
+
+
+def _branch_node(
+    msg_id: str,
+    role: str,
+    text: str,
+    *,
+    parent: str | None = None,
+    children: list[str] | None = None,
+    content_type: str = "text",
+) -> dict:
+    """Mapping node helper that does not force a create_time (graph order is truth)."""
+    return {
+        "id": msg_id,
+        "message": {
+            "id": msg_id,
+            "author": {"role": role},
+            "content": {"content_type": content_type, "parts": [text]},
+            "create_time": None,
+        },
+        "parent": parent,
+        "children": children or [],
+    }
+
+
+def test_regeneration_emits_only_active_branch_via_current_node() -> None:
+    """A regenerated assistant turn must yield the active branch only (#1744).
+
+    ``u1`` has two assistant children: ``a_old`` (abandoned) and ``a_new``
+    (active, pointed at by current_node). Before the fix both were flattened
+    into sibling messages, duplicating the assistant turn.
+    """
+    nodes = [
+        _branch_node("root", "system", "", parent=None, children=["u1"]),
+        _branch_node("u1", "user", "question", parent="root", children=["a_old", "a_new"]),
+        _branch_node("a_old", "assistant", "OLD wrong answer", parent="u1", children=[]),
+        _branch_node("a_new", "assistant", "NEW correct answer", parent="u1", children=[]),
+    ]
+    payload = {
+        "title": "Regenerated",
+        "mapping": {n["id"]: n for n in nodes},
+        "current_node": "a_new",
+        "create_time": 1700000000.0,
+    }
+    conv = chatgpt_parse(payload, "fallback-id")
+    texts = [m.text for m in conv.messages]
+    assert texts == ["question", "NEW correct answer"]
+    assert "OLD wrong answer" not in texts
+
+
+def test_no_current_node_preserves_all_nodes_losslessly() -> None:
+    """Without current_node, every node is preserved (lossless fallback) (#1744).
+
+    Real ChatGPT exports always carry current_node; synthetic/edge inputs may
+    not. With no active-leaf pointer there is no way to know which branch was
+    active, so the fallback keeps all nodes rather than silently dropping one.
+    """
+    nodes = [
+        _branch_node("u1", "user", "question", parent=None, children=["a_old", "a_new"]),
+        _branch_node("a_old", "assistant", "OLD answer", parent="u1", children=[]),
+        _branch_node("a_new", "assistant", "NEW answer", parent="u1", children=[]),
+    ]
+    payload = {
+        "title": "Regenerated no current_node",
+        "mapping": {n["id"]: n for n in nodes},
+        "create_time": 1700000000.0,
+    }
+    conv = chatgpt_parse(payload, "fallback-id")
+    texts = [m.text for m in conv.messages]
+    assert texts == ["question", "OLD answer", "NEW answer"]
+
+
+def test_current_node_pointing_at_old_branch_selects_that_branch() -> None:
+    """current_node is authoritative: if it points at the older branch, emit it."""
+    nodes = [
+        _branch_node("u1", "user", "question", parent=None, children=["a_old", "a_new"]),
+        _branch_node("a_old", "assistant", "kept answer", parent="u1", children=[]),
+        _branch_node("a_new", "assistant", "discarded answer", parent="u1", children=[]),
+    ]
+    payload = {
+        "title": "Old branch active",
+        "mapping": {n["id"]: n for n in nodes},
+        "current_node": "a_old",
+        "create_time": 1700000000.0,
+    }
+    conv = chatgpt_parse(payload, "fallback-id")
+    texts = [m.text for m in conv.messages]
+    assert texts == ["question", "kept answer"]
+    assert "discarded answer" not in texts
+
+
+# ---------------------------------------------------------------------------
+# #1744 — non-`parts` content is preserved (code interpreter, execution output)
+# ---------------------------------------------------------------------------
+
+
+def test_code_interpreter_content_is_preserved() -> None:
+    """A code node carries top-level content.text (no parts) — must not drop (#1744)."""
+    nodes = [
+        _branch_node("u1", "user", "run this", parent=None, children=["tool"]),
+        {
+            "id": "tool",
+            "message": {
+                "id": "tool",
+                "author": {"role": "assistant", "name": "python"},
+                "content": {"content_type": "code", "text": "print(1)"},
+                "create_time": None,
+            },
+            "parent": "u1",
+            "children": ["out"],
+        },
+        {
+            "id": "out",
+            "message": {
+                "id": "out",
+                "author": {"role": "tool"},
+                "content": {"content_type": "execution_output", "text": "1\n"},
+                "create_time": None,
+            },
+            "parent": "tool",
+            "children": [],
+        },
+    ]
+    payload = {
+        "title": "Code interpreter",
+        "mapping": {n["id"]: n for n in nodes},
+        "current_node": "out",
+        "create_time": 1700000000.0,
+    }
+    conv = chatgpt_parse(payload, "fallback-id")
+    texts = [m.text for m in conv.messages]
+    assert "print(1)" in texts
+    assert "1\n" in texts
+    # Content-block types reflect the code-interpreter semantics.
+    from polylogue.types import ContentBlockType
+
+    code_msg = next(m for m in conv.messages if m.text == "print(1)")
+    assert any(b.type == ContentBlockType.CODE for b in code_msg.content_blocks)
+    out_msg = next(m for m in conv.messages if m.text == "1\n")
+    assert any(b.type == ContentBlockType.TOOL_RESULT for b in out_msg.content_blocks)


### PR DESCRIPTION
## Summary

The ChatGPT parser was iterating `message.content.parts` as the only content path, silently dropping all messages with non-`parts` content (code blocks, tool outputs, regeneration branches).

## Problem

`parsers/chatgpt.py` walked only `content.parts` for message text. Two classes of content were lost: (1) `content.text` — the plain-text content key used in some export shapes, and (2) entire conversation branches — the ChatGPT export uses a directed graph (`mapping`) where each message stores a `children` list of IDs. The parser followed only the canonical `current_node` path, silently dropping every regeneration or alternative-response branch.

## Solution

- `parsers/chatgpt.py`: walk the full message graph by following `children` links from the root, collecting all branches. Each branch becomes a separate `ParsedConversation` so no messages are lost.
- Extract content from both `content.parts` and `content.text`, normalizing to a string.

## Verification

```
devtools verify --quick   # exit 0
pytest tests/unit/sources/test_parsers_chatgpt.py -q
```

Closes #1744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ChatGPT parser now correctly identifies and extracts the active conversation branch when available.
  * Improved extraction of diverse content types including code blocks and execution results.
  * Maintains backward compatibility by processing all messages when branch information is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->