### PR TITLE
fix(storage): remove divergent cross-validator, trust canonical content hash (#1747)

### DIFF
--- a/polylogue/storage/repository/archive/writes/conversations.py
+++ b/polylogue/storage/repository/archive/writes/conversations.py
@@ -27,10 +27,20 @@ replaced when explicitly supplied, regardless of hash match — they carry
 supplementary indexing-level data that may be updated without changing the
 semantic content.
 
-``save_via_backend()`` validates that the row graph passed by the caller agrees
-with ``ConversationRecord.content_hash`` by re-deriving the hash from the
-storage records and comparing.  A mismatch is logged as a warning and forces a
-full write instead of the idempotency skip.
+``save_via_backend()`` trusts ``ConversationRecord.content_hash`` directly: it
+compares the stored DB hash against the record hash to decide the idempotency
+skip, exactly as the bulk daemon ingest path does
+(``pipeline/services/ingest_batch/_core.py:_check_content_unchanged``).  There is
+intentionally no re-derivation of the hash from the storage row graph (#1747).
+The row graph is a lossy projection of the parsed conversation and the fallback
+identity rules (``msg-N`` provider-message ids, attachment digest provenance)
+are not reconstructible from the stored records without duplicating — and
+forever tracking — the canonical ``pipeline/ids.py`` logic.  An earlier
+cross-validator attempted that reconstruction; it diverged on essentially every
+conversation (full ``message_id`` instead of the bare provider id, a
+``sort_key`` epoch instead of the original ISO timestamp, no attachment digest),
+producing permanent ``save_via_backend_hash_mismatch`` warning noise and
+defeating the idempotency skip on the single-conversation (CLI/API) path.
 """
 
 from __future__ import annotations
@@ -42,7 +52,7 @@ from polylogue.archive.conversation.models import Conversation
 from polylogue.archive.provider.events import ProviderEvent
 from polylogue.archive.topology.edge import TopologyEdgeRecord
 from polylogue.core.hashing import hash_payload
-from polylogue.core.json import JSONValue, json_document, loads
+from polylogue.core.json import JSONValue, json_document
 from polylogue.pipeline.ids import _content_block_payload, _conversation_hash_payload, _normalize_for_hash
 from polylogue.storage.action_events.rows import attach_blocks_to_messages, build_action_event_records
 from polylogue.storage.conversation_replacement import (
@@ -188,128 +198,6 @@ def provider_event_to_record(event: ProviderEvent) -> ProviderEventRecord:
     )
 
 
-def _content_block_record_to_hash_payload(block: ContentBlockRecord) -> dict[str, JSONValue]:
-    """Build a hash-stable payload for a ``ContentBlockRecord``.
-
-    Mirrors ``_content_block_payload()`` in ``pipeline/ids.py`` but accepts the
-    storage record type instead of the parsed source type.
-    """
-    payload: dict[str, JSONValue] = {
-        "type": str(block.type),
-        "text": _normalize_for_hash(block.text),
-    }
-    if block.tool_name:
-        payload["tool_name"] = _normalize_for_hash(block.tool_name)
-    if block.tool_id:
-        payload["tool_id"] = _normalize_for_hash(block.tool_id)
-    if block.tool_input is not None:
-        # ContentBlockRecord stores tool_input as a JSON string, but the canonical
-        # hash hashes the dict representation.  Parse and re-hash for consistency.
-        try:
-            parsed = loads(block.tool_input)
-            if isinstance(parsed, dict):
-                payload["tool_input"] = hash_payload(parsed)
-            else:
-                payload["tool_input"] = hash_payload(block.tool_input)
-        except Exception:
-            payload["tool_input"] = hash_payload(block.tool_input)
-    # #1240: media_type is carried inside block.metadata (JSON) for image/document
-    # blocks instead of a dedicated column. Re-extract it so the row-graph hash
-    # matches the parser-side hash computed in pipeline/ids.py.
-    if block.metadata:
-        try:
-            parsed_meta = loads(block.metadata)
-        except Exception:
-            parsed_meta = None
-        if isinstance(parsed_meta, dict):
-            media_type = parsed_meta.get("media_type")
-            if isinstance(media_type, str) and media_type:
-                payload["media_type"] = _normalize_for_hash(media_type)
-    return payload
-
-
-def _compute_hash_from_row_graph(
-    *,
-    conversation: ConversationRecord,
-    messages: builtins.list[MessageRecord],
-    attachments: builtins.list[AttachmentRecord],
-    provider_events: builtins.list[ProviderEventRecord] | None = None,
-) -> str:
-    """Re-derive the conversation content hash from the storage record graph.
-
-    Uses the same canonical ``_conversation_hash_payload`` helper as
-    ``pipeline/ids.py`` but sources field values from storage records instead
-    of the domain ``Conversation`` model.  This function exists so that
-    ``save_via_backend`` can validate that the row graph the caller supplied
-    actually agrees with ``ConversationRecord.content_hash``.
-
-    Returns the full SHA-256 hex digest.
-    """
-    messages_payload: list[dict[str, JSONValue]] = []
-    for msg in messages:
-        timestamp_str = None
-        if msg.sort_key is not None:
-            try:
-                dt = datetime.fromtimestamp(msg.sort_key, tz=timezone.utc)
-                timestamp_str = dt.isoformat()
-            except (ValueError, OverflowError, OSError):
-                timestamp_str = str(msg.sort_key)
-
-        msg_entry: dict[str, JSONValue] = {
-            "id": str(msg.message_id),
-            "role": _normalize_for_hash(str(msg.role) if msg.role else None),
-            "text": _normalize_for_hash(msg.text),
-            "timestamp": _normalize_for_hash(timestamp_str),
-        }
-        if msg.content_blocks:
-            msg_entry["content_blocks"] = [_content_block_record_to_hash_payload(b) for b in msg.content_blocks]
-        messages_payload.append(msg_entry)
-
-    attachments_payload: list[dict[str, JSONValue]] = []
-    for att in attachments:
-        att_name: str | None = None
-        if att.provider_meta and isinstance(att.provider_meta, dict):
-            raw_name = att.provider_meta.get("name")
-            if isinstance(raw_name, str):
-                att_name = raw_name
-        if att_name is None:
-            att_name = att.attachment_id
-
-        attachments_payload.append(
-            {
-                "id": _normalize_for_hash(att.attachment_id),
-                "message_id": _normalize_for_hash(att.message_id),
-                "name": _normalize_for_hash(att_name),
-                "mime_type": _normalize_for_hash(att.mime_type),
-                "size_bytes": _normalize_for_hash(att.size_bytes),
-            }
-        )
-
-    provider_events_payload: list[dict[str, JSONValue]] = []
-    if provider_events:
-        for event in provider_events:
-            provider_events_payload.append(
-                {
-                    "event_index": event.event_index,
-                    "event_type": _normalize_for_hash(event.event_type),
-                    "timestamp": _normalize_for_hash(event.timestamp),
-                    "source_message_id": _normalize_for_hash(event.source_message_id),
-                    "payload": hash_payload(event.payload),
-                }
-            )
-
-    return hash_payload(
-        _conversation_hash_payload(
-            title=conversation.title,
-            created_at=conversation.created_at,
-            updated_at=conversation.updated_at,
-            messages=messages_payload,
-            attachments=attachments_payload,
-            provider_events=provider_events_payload,
-        )
-    )
-
-
 async def save_via_backend(
     backend: RepositoryBackendProtocol,
     conversation: ConversationRecord,
@@ -348,37 +236,12 @@ async def save_via_backend(
             existing_hash = row["content_hash"]
         timings["hash_check"] = _time.perf_counter() - t0
 
+        # Trust the canonical pipeline content hash for the idempotency skip,
+        # exactly as the bulk daemon ingest path does (#1747).  The stored DB
+        # hash and the record hash are both produced by
+        # ``pipeline/ids.conversation_content_hashes``; when they agree the
+        # parsed payload is unchanged and the row writes can be skipped.
         content_unchanged = existing_hash is not None and existing_hash == conversation.content_hash
-
-        # ------------------------------------------------------------------
-        # Cross-validate: does the row graph the caller supplied actually
-        # agree with ConversationRecord.content_hash?  A mismatch means the
-        # caller built records that diverged from what was hashed — the hash
-        # is no longer a trustworthy signal for the idempotency skip.
-        # ------------------------------------------------------------------
-        row_graph_hash = _compute_hash_from_row_graph(
-            conversation=conversation,
-            messages=messages,
-            attachments=attachments,
-            provider_events=provider_events_for_write if should_replace_provider_events else None,
-        )
-        if row_graph_hash != conversation.content_hash:
-            from polylogue.logging import get_logger
-
-            logger = get_logger(__name__)
-            logger.warning(
-                "save_via_backend_hash_mismatch",
-                conversation_id=str(conversation.conversation_id),
-                record_hash=str(conversation.content_hash),
-                row_graph_hash=row_graph_hash,
-                content_unchanged=content_unchanged,
-            )
-            if content_unchanged:
-                # The stored DB hash agrees with our (stale) record hash, but
-                # the row graph we are about to write disagrees.  The record
-                # hash is no longer trustworthy — force a full write so that
-                # changed rows are not silently skipped.
-                content_unchanged = False
 
         t0 = _time.perf_counter()
         await conversations_q.save_conversation_record(conn, conversation, backend.transaction_depth)
@@ -410,15 +273,21 @@ async def save_via_backend(
                 timings["save_msgs"] = _time.perf_counter() - t0
                 counts["messages"] = len(messages)
 
-                t0 = _time.perf_counter()
-                await stats_q.upsert_conversation_stats(
-                    conn,
-                    conversation.conversation_id,
-                    conversation.source_name,
-                    messages,
-                    backend.transaction_depth,
-                )
-                timings["upsert_stats"] = _time.perf_counter() - t0
+            # Always upsert the aggregate stats row, even for a zero-message
+            # conversation (#1747).  An empty message list yields an all-zero
+            # row so ``--typed-only`` (paste_count = 0) and provider rollups
+            # that count from ``conversation_stats`` stay consistent with
+            # ``get_provider_conversation_counts`` instead of dropping the
+            # conversation through a missing LEFT JOIN row.
+            t0 = _time.perf_counter()
+            await stats_q.upsert_conversation_stats(
+                conn,
+                conversation.conversation_id,
+                conversation.source_name,
+                messages,
+                backend.transaction_depth,
+            )
+            timings["upsert_stats"] = _time.perf_counter() - t0
 
             t0 = _time.perf_counter()
             all_blocks: builtins.list[ContentBlockRecord] = list(content_blocks or [])

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -169,23 +169,12 @@ async def test_repository_resave_existing_conversation_is_idempotent(workspace_e
             conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
             before = scenario.facts_from_connection(conn)
 
-        # Fix up the UUID hash from ConversationBuilder with a real SHA-256
-        # hash so save_via_backend's row-graph validation can function.
-        from polylogue.storage.repository.archive.writes.conversations import _compute_hash_from_row_graph
-
-        real_hash = _compute_hash_from_row_graph(
-            conversation=conv_record,
-            messages=msg_records,
-            attachments=attachment_records,
-        )
-        conv_record = conv_record.model_copy(update={"content_hash": real_hash})
-
-        # First write: the DB still has the seed's UUID hash, so this
-        # updates the conversation row with the real SHA-256 hash.
+        # First write: no prior DB entry, so this stores the record with
+        # ConversationBuilder's hash (any stable hash value works for
+        # idempotency — the key invariant is DB hash == record hash).
         await repository.save_conversation(conv_record, msg_records, attachment_records)
 
-        # Second write: now DB hash == record hash == row-graph hash, so
-        # the idempotency skip path should be clean.
+        # Second write: DB hash == record hash → idempotency skip fires.
         counts = await repository.save_conversation(conv_record, msg_records, attachment_records)
         assert counts["conversations"] == 0
         assert counts["messages"] == 0
@@ -404,27 +393,14 @@ async def test_repository_record_resave_replaces_explicit_provider_events_on_has
     )
     repository = repository_for_scenario_db(db_path)
     try:
-        from polylogue.storage.repository.archive.writes.conversations import _compute_hash_from_row_graph
-
-        # Fix up the UUID hash from ConversationBuilder with a real SHA-256
-        # hash so that save_via_backend's row-graph validation works correctly.
-        real_hash_pe = _compute_hash_from_row_graph(
-            conversation=conv_record,
-            messages=msg_records,
-            attachments=attachment_records,
-        )
-        conv_record = conv_record.model_copy(update={"content_hash": real_hash_pe})
-
         counts = await repository.save_conversation(
             conv_record,
             msg_records,
             attachment_records,
             provider_events=[replacement],
         )
-        # The row-graph hash (with replacement provider events) does not match
-        # the record hash (computed without provider events).  The validation
-        # detects the mismatch and forces a full write, which includes the
-        # replacement provider events.
+        # First write with replacement provider events — always written since
+        # there is no prior DB entry.
         assert counts["provider_events"] == 1
 
         refreshed = await repository.get(scenario.resolved_conversation_id)
@@ -435,107 +411,14 @@ async def test_repository_record_resave_replaces_explicit_provider_events_on_has
 
 
 # ---------------------------------------------------------------------------
-# Hash honesty tests -- prove that the write path validates row-graph / hash
-# consistency and that action events are correctly derived from content.
+# Hash idempotency tests -- prove that the write path correctly skips on
+# hash match and that action events are correctly derived from content.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio()
-async def test_compute_hash_from_row_graph_matches_domain_hash(workspace_env: Mapping[str, Path]) -> None:
-    """_compute_hash_from_row_graph produces the same hash as the canonical domain path."""
-    from polylogue.storage.hydrators import conversation_from_records
-    from polylogue.storage.repository.archive.writes.conversations import (
-        _compute_hash_from_row_graph,
-        _content_hash_from_metadata_or_domain,
-    )
-
-    scenario = ArchiveScenario(
-        name="hash-roundtrip",
-        provider="claude-code",
-        title="Hash roundtrip",
-        messages=(
-            ScenarioMessage(role="user", text="Roundtrip question", message_id="m1"),
-            ScenarioMessage(role="assistant", text="Roundtrip answer", message_id="m2"),
-        ),
-    )
-    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
-    with open_connection(db_path) as conn:
-        conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
-
-    domain = conversation_from_records(conv_record, msg_records, attachment_records)
-    domain_hash = _content_hash_from_metadata_or_domain(domain, metadata={})
-    row_graph_hash = _compute_hash_from_row_graph(
-        conversation=conv_record,
-        messages=msg_records,
-        attachments=attachment_records,
-    )
-    assert domain_hash == row_graph_hash, f"domain={domain_hash[:16]}... row_graph={row_graph_hash[:16]}..."
-
-
-@pytest.mark.asyncio()
-async def test_hash_consistency_forces_write_on_stale_hash(workspace_env: Mapping[str, Path]) -> None:
-    """When the row graph diverges from the record hash, the write path must not skip."""
-    from polylogue.storage.repository.archive.writes.conversations import _compute_hash_from_row_graph
-
-    scenario = ArchiveScenario(
-        name="stale-hash-fix",
-        provider="chatgpt",
-        title="Stale hash",
-        messages=(
-            ScenarioMessage(role="user", text="Original text", message_id="m1"),
-            ScenarioMessage(role="assistant", text="Original response", message_id="m2"),
-        ),
-    )
-    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
-    repository = repository_for_scenario_db(db_path)
-    try:
-        with open_connection(db_path) as conn:
-            conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
-
-        # Compute the real content hash so the validation sees a consistent
-        # row-graph-to-hash mapping.  ConversationBuilder generates UUID hashes.
-        real_hash = _compute_hash_from_row_graph(
-            conversation=conv_record,
-            messages=msg_records,
-            attachments=attachment_records,
-        )
-        conv_record = conv_record.model_copy(update={"content_hash": real_hash})
-
-        # First write: hash won't match DB (or no prior entry) so full write.
-        counts_init = await repository.save_conversation(conv_record, msg_records, attachment_records)
-        assert counts_init["messages"] == 2
-
-        # Re-save identical records -- hash + row graph both agree -> skip.
-        counts_skip = await repository.save_conversation(conv_record, msg_records, attachment_records)
-        assert counts_skip["skipped_messages"] == 2
-
-        # Modify a message but keep the OLD (now stale) content_hash.
-        modified_messages = [
-            msg_records[0].model_copy(update={"text": "Changed text"}),
-            msg_records[1],
-        ]
-        counts = await repository.save_conversation(
-            conv_record,  # still has old content_hash
-            modified_messages,
-            attachment_records,
-        )
-        # Validation detected the mismatch and forced a full write.
-        assert counts["messages"] == 2, f"Expected 2 messages written, got {counts}"
-        assert counts["skipped_messages"] == 0
-
-        refreshed = await repository.get(scenario.resolved_conversation_id)
-        assert refreshed is not None
-        texts = [msg.text for msg in refreshed.messages]
-        assert "Changed text" in texts
-    finally:
-        await repository.close()
-
-
-@pytest.mark.asyncio()
 async def test_hash_match_skips_writes_when_row_graph_agrees(workspace_env: Mapping[str, Path]) -> None:
-    """When both the stored hash and the row graph agree, writes are correctly skipped."""
-    from polylogue.storage.repository.archive.writes.conversations import _compute_hash_from_row_graph
-
+    """When the stored hash matches the record hash, writes are correctly skipped."""
     scenario = ArchiveScenario(
         name="hash-match-skip",
         provider="chatgpt",
@@ -551,18 +434,10 @@ async def test_hash_match_skips_writes_when_row_graph_agrees(workspace_env: Mapp
         with open_connection(db_path) as conn:
             conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
 
-        # Compute the real content hash and set it.
-        real_hash = _compute_hash_from_row_graph(
-            conversation=conv_record,
-            messages=msg_records,
-            attachments=attachment_records,
-        )
-        conv_record = conv_record.model_copy(update={"content_hash": real_hash})
-
-        # First write stores records with the correct hash.
+        # First write stores records with ConversationBuilder's hash.
         await repository.save_conversation(conv_record, msg_records, attachment_records)
 
-        # Re-save identical records -- everything should be skipped.
+        # Re-save identical records -- DB hash == record hash → everything skipped.
         counts = await repository.save_conversation(conv_record, msg_records, attachment_records)
         assert counts["skipped_conversations"] == 1
         assert counts["skipped_messages"] == 2
@@ -582,7 +457,6 @@ async def test_action_events_are_derived_and_replaced_on_content_change(
     When the hash matches (content unchanged), they are skipped because
     the messages that would produce them haven't changed either.
     """
-    from polylogue.storage.repository.archive.writes.conversations import _compute_hash_from_row_graph
     from polylogue.storage.sqlite.queries import action_events as action_events_q
 
     scenario = ArchiveScenario(
@@ -610,14 +484,6 @@ async def test_action_events_are_derived_and_replaced_on_content_change(
         with open_connection(db_path) as conn:
             conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
 
-        # Compute the real content hash.
-        real_hash = _compute_hash_from_row_graph(
-            conversation=conv_record,
-            messages=msg_records,
-            attachments=attachment_records,
-        )
-        conv_record = conv_record.model_copy(update={"content_hash": real_hash})
-
         # First write creates action events from the tool_use content block.
         counts_init = await repository.save_conversation(conv_record, msg_records, attachment_records)
         assert counts_init["messages"] == 2, "Initial write should persist messages"
@@ -630,12 +496,16 @@ async def test_action_events_are_derived_and_replaced_on_content_change(
         counts = await repository.save_conversation(conv_record, msg_records, attachment_records)
         assert counts["skipped_messages"] == 2, "Identical content should be skipped"
 
-        # Now change a message -- action events must be rebuilt.
+        # Now change a message and provide a new content_hash (mirrors what the
+        # pipeline does when content changes: the hash is recomputed from the new
+        # payload).  The hash change signals content_unchanged=False, so messages
+        # and action events are rebuilt.
         modified = [
             msg_records[0],
             msg_records[1].model_copy(update={"text": "Running it differently"}),
         ]
-        counts2 = await repository.save_conversation(conv_record, modified, attachment_records)
+        changed_conv = conv_record.model_copy(update={"content_hash": "b" * 64})
+        counts2 = await repository.save_conversation(changed_conv, modified, attachment_records)
         assert counts2["messages"] == 2, "Changed message should trigger full write"
 
         async with repository._backend.connection() as aconn:


### PR DESCRIPTION
## Summary

`save_via_backend` contained a cross-validator that re-derived `content_hash` from storage records and forced writes when the hash diverged. The validator produced incorrect hashes on every real conversation (message ID format, sort_key epoch vs ISO timestamp, attachment digest provenance are not reconstructible from stored records), generating permanent `save_via_backend_hash_mismatch` warnings and defeating the idempotency skip on every CLI/API write path.

## Problem

The row graph passed to `save_via_backend` is a lossy projection of the parsed conversation. `_compute_hash_from_row_graph` attempted to reconstruct the canonical `pipeline/ids.py` hash from storage records but diverged on field normalization: `full message_id` instead of bare provider id, `sort_key epoch` instead of original ISO timestamp, `no attachment digest`. Every real conversation hit the mismatch branch.

Also: `upsert_conversation_stats` was inside the `if not content_unchanged` branch, so zero-message conversations never got a stats row, causing them to drop from `--typed-only` and provider rollup queries.

## Solution

- Delete `_compute_hash_from_row_graph` and `_content_block_record_to_hash_payload`. `save_via_backend` now trusts `ConversationRecord.content_hash` directly — the same invariant as the bulk daemon ingest path.
- Move `upsert_conversation_stats` outside the content-unchanged branch so zero-message conversations always get a stats row.
- Update `test_repository_lifecycle_laws.py`: remove tests that exercised the deleted cross-validator; adapt remaining tests to the simpler idempotency model.

## Verification

```
devtools verify --quick   # exit 0
pytest tests/unit/storage/test_repository_lifecycle_laws.py -q
```

Closes #1747