### PR TITLE
fix(config): redact secrets and harden write paths in sources (#1748)

### DIFF
--- a/polylogue/cli/commands/config.py
+++ b/polylogue/cli/commands/config.py
@@ -25,13 +25,28 @@ from polylogue.cli.shared.types import AppEnv
 @click.pass_obj
 def config_command(env: AppEnv, output_format: str, show_layers: bool) -> None:
     """Show resolved Polylogue configuration with precedence sources."""
-    from polylogue.config import describe_config_layers, format_config_toml, load_polylogue_config
+    from polylogue.config import (
+        describe_config_layers,
+        format_config_toml,
+        is_secret_config_key,
+        load_polylogue_config,
+        redact_config_mapping,
+        redact_secret_value,
+    )
 
     cfg = load_polylogue_config()
+
+    def _display_value(key: str) -> object:
+        raw_value = cfg.raw.get(key)
+        if is_secret_config_key(key):
+            return redact_secret_value(raw_value)
+        return raw_value
 
     if show_layers:
         # ``console.print`` interprets ``[brackets]`` as Rich markup; disable
         # markup so JSON output and TOML section headers survive verbatim.
+        # Secret-bearing keys are redacted before display so the layer dump
+        # never reveals a cleartext secret.
         layer_paths = describe_config_layers()
         payload: dict[str, object] = {
             "layers": {
@@ -41,7 +56,9 @@ def config_command(env: AppEnv, output_format: str, show_layers: bool) -> None:
                 "env": "POLYLOGUE_* environment variables",
                 "cli": "CLI overrides (per-invocation)",
             },
-            "values": {key: {"value": cfg.raw.get(key), "layer": cfg.layer_of(key)} for key in sorted(cfg.raw.keys())},
+            "values": {
+                key: {"value": _display_value(key), "layer": cfg.layer_of(key)} for key in sorted(cfg.raw.keys())
+            },
         }
         if output_format == "json":
             import json
@@ -75,8 +92,13 @@ def config_command(env: AppEnv, output_format: str, show_layers: bool) -> None:
 
         # ``console.print`` interprets ``[brackets]`` as Rich markup, which
         # would mangle JSON output and TOML section headers. Print without
-        # markup parsing to preserve exact bytes.
-        env.ui.console.print(json.dumps(cfg.raw, indent=2, default=str), markup=False, highlight=False)
+        # markup parsing to preserve exact bytes. Secret-bearing keys are
+        # redacted so the JSON dump never reveals a cleartext secret.
+        env.ui.console.print(
+            json.dumps(redact_config_mapping(cfg.raw), indent=2, default=str),
+            markup=False,
+            highlight=False,
+        )
     else:
         env.ui.console.print(format_config_toml(cfg.raw), markup=False, highlight=False)
 

--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -116,9 +116,17 @@ def _render_preflight_json(report: PreflightReport) -> None:
 
 
 def _embedding_section_lines(*, enabled: bool, voyage_api_key: str | None) -> list[str]:
-    body: list[str] = ["[embedding]", f"enabled = {str(enabled).lower()}"]
+    import tomli_w
+
+    table: dict[str, object] = {"enabled": enabled}
     if voyage_api_key:
-        body.append(f'voyage_api_key = "{voyage_api_key}"')
+        table["voyage_api_key"] = voyage_api_key
+    # ``tomli_w`` escapes quotes, backslashes, and newlines so a key value
+    # containing TOML metacharacters cannot corrupt the persisted file.
+    rendered = tomli_w.dumps(table).rstrip("\n")
+    body: list[str] = ["[embedding]"]
+    if rendered:
+        body.extend(rendered.splitlines())
     body.append("")
     return body
 

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -10,6 +10,7 @@ Precedence (highest wins):
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -855,12 +856,77 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
                 cfg[cfg_key] = value
 
 
+#: Flat config keys whose values are secrets and must never be rendered in
+#: cleartext on any display surface (``polylogue config`` toml/json/layers,
+#: logs, bug reports). The redaction is keyed on the flat config key so it
+#: applies regardless of the display section/short-key mapping.
+SECRET_CONFIG_KEYS: frozenset[str] = frozenset(
+    {
+        "voyage_api_key",
+        "notification_webhook_secret",
+        "notification_email_password",
+        "api_auth_token",
+        "browser_capture_auth_token",
+    }
+)
+
+#: Placeholder substituted for a secret that is set to a non-empty value.
+SECRET_SET_PLACEHOLDER = "<set>"
+#: Placeholder substituted for a secret that is unset / empty.
+SECRET_UNSET_PLACEHOLDER = "<unset>"
+
+
+def is_secret_config_key(flat_key: str) -> bool:
+    """Return True when ``flat_key`` holds a secret that must be redacted.
+
+    Matches the explicit :data:`SECRET_CONFIG_KEYS` set plus any key that
+    ends in a sensitive suffix (``_api_key``, ``_secret``, ``_password``,
+    ``_auth_token``, ``_token``) or a bare ``auth_token``/``password``/
+    ``secret`` so newly added secret-bearing keys are redacted by default
+    rather than leaking until the set is updated.
+    """
+    if flat_key in SECRET_CONFIG_KEYS:
+        return True
+    sensitive_suffixes = ("_api_key", "_secret", "_password", "_auth_token", "_token")
+    return flat_key in {"auth_token", "password", "secret"} or flat_key.endswith(sensitive_suffixes)
+
+
+def redact_secret_value(value: object) -> str:
+    """Map a secret config value to a non-revealing presence placeholder."""
+    if value is None:
+        return SECRET_UNSET_PLACEHOLDER
+    if isinstance(value, str) and value == "":
+        return SECRET_UNSET_PLACEHOLDER
+    return SECRET_SET_PLACEHOLDER
+
+
+def redact_config_mapping(cfg: Mapping[str, object]) -> dict[str, object]:
+    """Return a copy of ``cfg`` with every secret-bearing key redacted.
+
+    Used by JSON and layer-source display surfaces so a secret value never
+    appears verbatim in shared config output.
+    """
+    redacted: dict[str, object] = {}
+    for key, value in cfg.items():
+        if is_secret_config_key(key):
+            redacted[key] = redact_secret_value(value)
+        else:
+            redacted[key] = value
+    return redacted
+
+
 def format_config_toml(cfg: dict[str, object]) -> str:
     """Render loaded config as TOML for display.
 
     Round-trips with :func:`_merge_toml`: the generated TOML uses short keys
     inside their sections (``[archive] root = ...``) so the output can be
     written back as a ``polylogue.toml`` file and re-loaded.
+
+    Secret-bearing keys are redacted to a presence placeholder
+    (:data:`SECRET_SET_PLACEHOLDER` / :data:`SECRET_UNSET_PLACEHOLDER`) so the
+    rendered TOML can be safely pasted into bug reports, and values are
+    serialized with a real TOML emitter (``tomli_w``) rather than raw f-string
+    interpolation so quotes/backslashes/newlines cannot corrupt the output.
     """
     # (section_name, [(short_key, flat_key), ...])
     sections_layout: list[tuple[str, list[tuple[str, str]]]] = [
@@ -955,27 +1021,31 @@ def format_config_toml(cfg: dict[str, object]) -> str:
         ),
     ]
 
+    import tomli_w
+
     lines: list[str] = []
     for section, key_pairs in sections_layout:
-        section_lines: list[str] = []
+        section_table: dict[str, object] = {}
         for short_key, flat_key in key_pairs:
             if flat_key not in cfg:
                 continue
             value = cfg[flat_key]
             if value is None:
                 continue
-            if isinstance(value, (list, tuple)):
-                items = ", ".join(f'"{v}"' for v in value)
-                section_lines.append(f"{short_key} = [{items}]")
-            elif isinstance(value, str):
-                section_lines.append(f'{short_key} = "{value}"')
-            elif isinstance(value, bool):
-                section_lines.append(f"{short_key} = {str(value).lower()}")
+            if is_secret_config_key(flat_key):
+                section_table[short_key] = redact_secret_value(value)
+                continue
+            if isinstance(value, tuple):
+                section_table[short_key] = list(value)
             else:
-                section_lines.append(f"{short_key} = {value}")
-        if section_lines:
+                section_table[short_key] = value
+        if section_table:
             lines.append(f"[{section}]")
-            lines.extend(section_lines)
+            # ``tomli_w`` escapes quotes/backslashes/newlines correctly, so a
+            # value containing TOML metacharacters cannot break the output.
+            rendered = tomli_w.dumps(section_table).rstrip("\n")
+            if rendered:
+                lines.append(rendered)
             lines.append("")
 
     return "\n".join(lines)
@@ -988,6 +1058,9 @@ __all__ = [
     "DriveConfig",
     "IndexConfig",
     "PolylogueConfig",
+    "SECRET_CONFIG_KEYS",
+    "SECRET_SET_PLACEHOLDER",
+    "SECRET_UNSET_PLACEHOLDER",
     "Source",
     "describe_config_layers",
     "format_config_toml",
@@ -995,5 +1068,8 @@ __all__ = [
     "get_drive_config",
     "get_index_config",
     "get_sources",
+    "is_secret_config_key",
     "load_polylogue_config",
+    "redact_config_mapping",
+    "redact_secret_value",
 ]

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -6,6 +6,7 @@ import io
 import zipfile
 from collections.abc import Iterable
 from pathlib import Path
+from typing import IO
 
 from polylogue.archive.artifact_taxonomy import classify_artifact_path
 from polylogue.logging import get_logger
@@ -46,7 +47,7 @@ class _BoundedZipReader(io.RawIOBase):
     an over-cap payload regardless of the entry's declared sizes.
     """
 
-    def __init__(self, raw: io.BufferedIOBase, *, max_bytes: int, entry_name: str) -> None:
+    def __init__(self, raw: IO[bytes], *, max_bytes: int, entry_name: str) -> None:
         super().__init__()
         self._raw = raw
         self._max_bytes = max_bytes
@@ -56,7 +57,7 @@ class _BoundedZipReader(io.RawIOBase):
     def readable(self) -> bool:
         return True
 
-    def readinto(self, buffer: object) -> int:  # type: ignore[override]
+    def readinto(self, buffer: object) -> int:
         view = memoryview(buffer)  # type: ignore[arg-type]
         chunk = self._raw.read(len(view))
         if not chunk:

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import zipfile
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,6 +20,77 @@ logger = get_logger(__name__)
 
 MAX_COMPRESSION_RATIO = 1000
 MAX_UNCOMPRESSED_SIZE = 10 * 1024 * 1024 * 1024
+
+#: Chunk size used when bounding ZIP entry decompression. Read in fixed
+#: windows so a malicious entry cannot allocate more than this much extra
+#: memory beyond the running total before the ceiling check fires.
+_ZIP_READ_CHUNK_SIZE = 1024 * 1024
+
+
+class ZipBombError(Exception):
+    """Raised when an entry's real decompressed size exceeds the hard cap.
+
+    The declared header sizes (``ZipInfo.file_size`` / ``compress_size``)
+    are attacker-controllable, so they are used only for an early cheap
+    skip. The authoritative ceiling is enforced here against the actual
+    bytes produced by decompression.
+    """
+
+
+class _BoundedZipReader(io.RawIOBase):
+    """Wrap a ZIP entry stream and abort once ``max_bytes`` is exceeded.
+
+    Every read is counted against the real decompressed byte total. If the
+    total would cross ``max_bytes`` the reader raises :class:`ZipBombError`
+    instead of returning the bytes, so downstream consumers never receive
+    an over-cap payload regardless of the entry's declared sizes.
+    """
+
+    def __init__(self, raw: io.BufferedIOBase, *, max_bytes: int, entry_name: str) -> None:
+        super().__init__()
+        self._raw = raw
+        self._max_bytes = max_bytes
+        self._entry_name = entry_name
+        self._total = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: object) -> int:  # type: ignore[override]
+        view = memoryview(buffer)  # type: ignore[arg-type]
+        chunk = self._raw.read(len(view))
+        if not chunk:
+            return 0
+        self._total += len(chunk)
+        if self._total > self._max_bytes:
+            raise ZipBombError(
+                f"ZIP entry {self._entry_name!r} exceeded the {self._max_bytes}-byte decompression ceiling during read"
+            )
+        view[: len(chunk)] = chunk
+        return len(chunk)
+
+    def close(self) -> None:
+        try:
+            self._raw.close()
+        finally:
+            super().close()
+
+
+def open_bounded_zip_entry(
+    zf: zipfile.ZipFile,
+    name: str,
+    *,
+    max_bytes: int = MAX_UNCOMPRESSED_SIZE,
+) -> io.BufferedReader:
+    """Open a ZIP entry with a hard real-byte decompression ceiling.
+
+    Returns a buffered stream that raises :class:`ZipBombError` if the
+    actual decompressed size would exceed ``max_bytes``. This does not
+    trust the (forgeable) declared header sizes — the ceiling is enforced
+    against bytes produced by the decompressor itself.
+    """
+    raw = zf.open(name)
+    return io.BufferedReader(_BoundedZipReader(raw, max_bytes=max_bytes, entry_name=name))
 
 
 class ZipEntryValidator:
@@ -132,26 +204,45 @@ def process_zip(
             )
             emitter = _ConversationEmitter(ctx)
             precomputed_raw: RawConversationData | None = None
-            if capture_raw and entry_should_group:
-                with zf.open(name) as handle:
-                    blob_hash, blob_size = get_blob_store().write_from_fileobj(handle)
-                precomputed_raw = RawConversationData(
-                    raw_bytes=b"",
-                    source_path=f"{zip_path}:{name}",
-                    source_index=None,
-                    file_mtime=file_mtime,
-                    provider_hint=entry_provider_hint,
-                    blob_hash=blob_hash,
-                    blob_size=blob_size,
+            try:
+                if capture_raw and entry_should_group:
+                    # ``open_bounded_zip_entry`` enforces a hard real-byte
+                    # ceiling during decompression, independent of the
+                    # entry's (forgeable) declared header sizes.
+                    with open_bounded_zip_entry(zf, name) as handle:
+                        blob_hash, blob_size = get_blob_store().write_from_fileobj(handle)
+                    precomputed_raw = RawConversationData(
+                        raw_bytes=b"",
+                        source_path=f"{zip_path}:{name}",
+                        source_index=None,
+                        file_mtime=file_mtime,
+                        provider_hint=entry_provider_hint,
+                        blob_hash=blob_hash,
+                        blob_size=blob_size,
+                    )
+                with open_bounded_zip_entry(zf, name) as handle:
+                    yield from emitter.emit(handle, name, precomputed_raw=precomputed_raw)
+            except ZipBombError as exc:
+                logger.warning(
+                    "Skipping ZIP entry %s in %s: %s",
+                    name,
+                    zip_path,
+                    exc,
                 )
-            with zf.open(name) as handle:
-                yield from emitter.emit(handle, name, precomputed_raw=precomputed_raw)
+                _record_cursor_failure(
+                    cursor_state,
+                    f"{zip_path}:{name}",
+                    str(exc),
+                )
+                continue
 
 
 __all__ = [
     "MAX_COMPRESSION_RATIO",
     "MAX_UNCOMPRESSED_SIZE",
+    "ZipBombError",
     "ZipEntryValidator",
+    "open_bounded_zip_entry",
     "process_zip",
     "zip_entry_provider_hint",
 ]

--- a/polylogue/sources/token_store.py
+++ b/polylogue/sources/token_store.py
@@ -7,6 +7,8 @@ Provides a protocol for token persistence with two implementations:
 
 from __future__ import annotations
 
+import os
+import tempfile
 from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
@@ -69,8 +71,25 @@ class FileTokenStore:
     def save(self, key: str, data: str) -> None:
         path = self._path_for_key(key)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(data, encoding="utf-8")
-        path.chmod(0o600)
+        # Write to a temp file created 0o600 from the start, then atomically
+        # replace the destination. A plain ``write_text`` + ``chmod`` leaves
+        # a window where the OAuth token is world-readable under the umask
+        # default (mirrors the blob store's mkstemp pattern).
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(data)
+            os.replace(tmp_path, path)
+        except BaseException:
+            with suppress(FileNotFoundError):
+                tmp_path.unlink()
+            raise
 
     def delete(self, key: str) -> None:
         path = self._path_for_key(key)

--- a/tests/unit/cli/test_config_command.py
+++ b/tests/unit/cli/test_config_command.py
@@ -1,0 +1,100 @@
+"""Regression tests for ``polylogue config`` secret redaction (#1748).
+
+The config command is the artifact users paste into bug reports and share
+with coding agents. A secret value must never appear in cleartext in any of
+its three output surfaces: the default TOML, ``--format json``, and
+``--show-layers`` (in both TOML and JSON forms).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli.commands.config import config_command
+from tests.infra.app_env import make_app_env
+
+_VOYAGE_SECRET = "sk-voyage-LEAKME-0123456789"
+_WEBHOOK_SECRET = "wh-LEAKME-secret-token"
+_EMAIL_PASSWORD = "email-LEAKME-passw0rd"
+_AUTH_TOKEN = "auth-LEAKME-bearer"
+
+_CONFIG_BODY = f"""\
+[embedding]
+enabled = true
+voyage_api_key = "{_VOYAGE_SECRET}"
+
+[notifications]
+webhook_secret = "{_WEBHOOK_SECRET}"
+
+[notifications.email]
+password = "{_EMAIL_PASSWORD}"
+
+[daemon.api]
+auth_token = "{_AUTH_TOKEN}"
+"""
+
+_ALL_SECRETS = (_VOYAGE_SECRET, _WEBHOOK_SECRET, _EMAIL_PASSWORD, _AUTH_TOKEN)
+
+
+@pytest.fixture()
+def config_with_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    cfg = tmp_path / "polylogue.toml"
+    cfg.write_text(_CONFIG_BODY, encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(cfg))
+    # Avoid a site-layer file leaking into the resolved config.
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
+    return cfg
+
+
+def _run(args: list[str]) -> str:
+    env = make_app_env()
+    result = CliRunner().invoke(config_command, obj=env, args=args)
+    assert result.exit_code == 0, (result.output, result.exception)
+    return str(env.ui.console.file.getvalue())
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],  # default toml
+        ["-f", "toml"],
+        ["-f", "json"],
+        ["--show-layers"],
+        ["--show-layers", "-f", "json"],
+    ],
+    ids=["default", "toml", "json", "layers-toml", "layers-json"],
+)
+def test_no_secret_appears_in_config_output(config_with_secrets: Path, args: list[str]) -> None:
+    output = _run(args)
+    for secret in _ALL_SECRETS:
+        assert secret not in output, f"secret leaked in `polylogue config {' '.join(args)}`"
+
+
+def test_redacted_secrets_show_presence_placeholder(config_with_secrets: Path) -> None:
+    # A set secret renders as the presence placeholder, not its value.
+    toml_out = _run(["-f", "toml"])
+    assert "<set>" in toml_out
+    json_out = _run(["-f", "json"])
+    payload = json.loads(json_out)
+    assert payload["voyage_api_key"] == "<set>"
+    assert payload["notification_webhook_secret"] == "<set>"
+
+
+def test_unset_secret_renders_unset_in_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "polylogue.toml"
+    cfg.write_text("[embedding]\nenabled = false\n", encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(cfg))
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
+    payload = json.loads(_run(["-f", "json"]))
+    # An unset secret is reported as <unset>, never as null masquerading as a value.
+    assert payload["voyage_api_key"] == "<unset>"
+
+
+def test_non_secret_values_are_not_redacted(config_with_secrets: Path) -> None:
+    payload = json.loads(_run(["-f", "json"]))
+    # Non-secret config keys must still be visible verbatim.
+    assert payload["embedding_enabled"] is True


### PR DESCRIPTION
## Summary

Three security fixes: secrets leaked through `polylogue config` output, ZIP entries could decompress unbounded amounts of data, and OAuth tokens had a TOCTOU window where they were world-readable.

## Problem

1. `polylogue config` printed the TOML config including `voyage_api_key` and OAuth tokens in plaintext.
2. `decoder_zip.py` read ZIP entries with no real-byte ceiling — only the (attacker-controllable) declared header sizes were checked. A zip bomb with a 1 KB entry claiming 10 GB uncompressed would allocate 10 GB.
3. `FileTokenStore.save` used `write_text` followed by `chmod 0o600`, leaving a window where the file existed with world-readable permissions.

## Solution

1. `config.py`: redact any config value matching a secret key pattern before printing. Emit TOML via the `toml` library so output is always valid and not hand-rolled.
2. `decoder_zip.py`: `_BoundedZipReader` wraps the entry stream and counts actual decompressed bytes, raising `ZipBombError` when the total crosses `MAX_UNCOMPRESSED_SIZE`. The ceiling is enforced against bytes produced by the decompressor itself.
3. `token_store.py`: `FileTokenStore.save` now uses `mkstemp` (mode 0o600 from creation) + `fchmod` + `os.replace` — atomic and never world-readable.

## Verification

```
devtools verify --quick   # exit 0
pytest tests/unit/sources/test_decoder_zip.py tests/unit/sources/test_token_store.py -q
```

Closes #1748