### PR TITLE
fix(pipeline): surface silent parse-time record loss across ingest (#1745)

### DIFF
--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -460,6 +460,12 @@ def _build_stream_parse_plan(
             context.raw_source,
             max_samples=64,
             jsonl_dict_only=True,
+            # The sample probe stays bounded (STRICT widens it). The accurate,
+            # whole-file malformed-line count for the operator-facing surface is
+            # produced by the durable artifact observation
+            # (storage/artifacts/inspection.py full-scan, #1745); this probe
+            # only needs to *detect* malformed presence for the advisory warning
+            # and STRICT failure below, which the bounded sample already does.
             scan_full=context.validation_mode is ValidationMode.STRICT,
         )
     except Exception:
@@ -559,15 +565,26 @@ def _validate_parse_plan(
         return _PlanValidation(status=ValidationStatus.SKIPPED)
     if not plan.artifact.schema_eligible or plan.schema_payload is None:
         return _PlanValidation(status=ValidationStatus.PASSED)
-    if plan.malformed_jsonl_lines and context.validation_mode is ValidationMode.STRICT:
+    if plan.malformed_jsonl_lines:
         malformed_error = _format_malformed_jsonl_error(
             malformed_lines=plan.malformed_jsonl_lines,
             malformed_detail=plan.malformed_jsonl_detail,
         )
-        return _PlanValidation(
-            status=ValidationStatus.FAILED,
-            validation_error=malformed_error,
-            parse_error=malformed_error,
+        if context.validation_mode is ValidationMode.STRICT:
+            return _PlanValidation(
+                status=ValidationStatus.FAILED,
+                validation_error=malformed_error,
+                parse_error=malformed_error,
+            )
+        # Advisory mode: do not fail the record, but surface the loss at
+        # WARNING level so it is not silently dropped (#1745). The accurate
+        # whole-file count is also persisted on the durable artifact
+        # observation (storage/artifacts/inspection.py full-scan) and is
+        # rolled into the artifact proof's decode-error tally.
+        logger.warning(
+            "Malformed JSONL lines counted in advisory mode for %s: %s",
+            context.raw_record.source_path or context.raw_record.raw_id,
+            malformed_error,
         )
 
     try:

--- a/polylogue/pipeline/services/validation_runtime.py
+++ b/polylogue/pipeline/services/validation_runtime.py
@@ -36,6 +36,7 @@ def _initial_counts() -> ValidationCounts:
         "drift": 0,
         "skipped_no_schema": 0,
         "errors": 0,
+        "malformed_jsonl_lines": 0,
     }
 
 
@@ -160,11 +161,15 @@ def _validate_record_sync(
                 drift_count=0,
                 counts_delta=counts_delta,
             )
+        # Advisory mode does not fail the record, but the malformed-line loss is
+        # still counted and surfaced rather than silently demoted (#1745).
+        counts_delta["malformed_jsonl_lines"] += malformed_lines
         logger.warning(
-            "Malformed JSONL lines ignored in advisory mode",
+            "Malformed JSONL lines counted in advisory mode",
             raw_id=raw_record.raw_id,
             provider=raw_record.source_name,
             malformed_lines=malformed_lines,
+            malformed_detail=malformed_detail,
         )
 
     validator = _validator_for_payload(

--- a/polylogue/schemas/validation/artifacts.py
+++ b/polylogue/schemas/validation/artifacts.py
@@ -135,6 +135,10 @@ def prove_raw_artifact_coverage(
             stats.unknown_records += 1
         elif observation.support_status is ArtifactSupportStatus.DECODE_FAILED:
             stats.decode_errors += 1
+        elif observation.support_status is ArtifactSupportStatus.PARTIAL_DECODE:
+            # Partial decode is still record loss — count it as a decode error
+            # so it is never silently absent from the artifact proof (#1745).
+            stats.decode_errors += 1
 
     for provider, state in linkage_state.items():
         stats = stats_by_provider.setdefault(

--- a/polylogue/sources/decoder_json.py
+++ b/polylogue/sources/decoder_json.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterable
 from typing import IO, Protocol, TypeAlias, TypeGuard
 
@@ -43,6 +44,33 @@ class IjsonModuleLike(Protocol):
     common: IjsonCommonLike
 
     def items(self, handle: JsonReadable, prefix: str) -> Iterable[JsonValue]: ...
+
+
+class PartialJsonStreamError(ValueError):
+    """A prefixed JSON stream was truncated/corrupted partway through decoding.
+
+    Surfaced instead of silently returning the records accumulated before the
+    corruption. ``recovered`` is the number of items successfully yielded before
+    the failure; ``offset`` is the byte offset of the failure when ``ijson``
+    reports one (``None`` otherwise).
+    """
+
+    def __init__(
+        self,
+        path_name: str,
+        *,
+        recovered: int,
+        offset: int | None,
+        cause: BaseException,
+    ) -> None:
+        self.path_name = path_name
+        self.recovered = recovered
+        self.offset = offset
+        self.cause = cause
+        location = f" at byte offset {offset}" if offset is not None else ""
+        super().__init__(
+            f"partial JSON stream decode of {path_name}: corruption{location} after {recovered} record(s): {cause}"
+        )
 
 
 def _is_json_value(value: object) -> TypeGuard[JsonValue]:
@@ -175,11 +203,44 @@ def _stream_prefixed_items(
             found_any = True
             records.append(item)
         return (found_any, records)
-    except ijson_module.common.JSONError:
+    except ijson_module.common.JSONError as exc:
+        if found_any:
+            # Mid-stream corruption: the array/object was valid for the first
+            # ``len(records)`` items then broke. Returning the partial set here
+            # silently truncates the conversation set, so surface a typed error
+            # instead. A JSONError with zero items found is a normal
+            # "wrong prefix, try the next strategy" signal and is swallowed.
+            offset = _json_error_offset(exc)
+            logger_obj.warning(
+                "Partial JSON stream decode of %s (strategy %s): corruption after %d record(s)%s",
+                path_name,
+                strategy_name,
+                len(records),
+                f" at byte offset {offset}" if offset is not None else "",
+            )
+            raise PartialJsonStreamError(
+                path_name,
+                recovered=len(records),
+                offset=offset,
+                cause=exc,
+            ) from exc
         return (found_any, records)
     except Exception as exc:
         logger_obj.debug("Strategy %s failed for %s: %s", strategy_name, path_name, exc)
         return (found_any, records)
+
+
+def _json_error_offset(exc: BaseException) -> int | None:
+    """Extract a byte/char offset from an ijson JSONError when available."""
+    for attr in ("pos", "offset"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int):
+            return value
+    # ijson messages often embed the byte position, e.g. "... at 1234".
+    match = re.search(r"at (\d+)", str(exc))
+    if match:
+        return int(match.group(1))
+    return None
 
 
 def iter_json_stream_with(
@@ -243,6 +304,7 @@ __all__ = [
     "JsonReadable",
     "JsonValue",
     "LoggerLike",
+    "PartialJsonStreamError",
     "decode_json_bytes",
     "decode_json_bytes_with",
     "iter_json_stream",

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -32,6 +32,30 @@ class AntigravityExportError(RuntimeError):
     """Raised when Antigravity's local export surface cannot be queried."""
 
 
+class AntigravityBinaryUnavailableError(AntigravityExportError):
+    """Raised when the Antigravity language-server binary is not installed.
+
+    This is the benign case — Antigravity is simply not present — and callers
+    should fall back to the brain-artifact walk at INFO level without treating
+    it as data loss.
+    """
+
+
+class AntigravityPartialExportError(AntigravityExportError):
+    """Raised when the language-server export aborts mid-iteration.
+
+    Distinct from a binary-absent condition: some conversations were already
+    obtained before the failure, so the remainder is genuinely at risk of being
+    dropped. Carries obtained-vs-expected counts so callers can surface the loss
+    instead of silently truncating.
+    """
+
+    def __init__(self, message: str, *, obtained: int, expected: int) -> None:
+        self.obtained = obtained
+        self.expected = expected
+        super().__init__(f"{message} (obtained {obtained} of {expected} conversations)")
+
+
 @dataclass(frozen=True, slots=True)
 class AntigravityConversationSummary:
     cascade_id: str
@@ -88,7 +112,7 @@ class AntigravityLanguageServerClient:
             return
         binary = self.language_server_path or discover_language_server()
         if binary is None:
-            raise AntigravityExportError("Antigravity language_server_linux_x64 was not found")
+            raise AntigravityBinaryUnavailableError("Antigravity language_server_linux_x64 was not found")
 
         cmd = [
             str(binary),
@@ -292,8 +316,23 @@ def iter_language_server_exports(
     if owned_client:
         runtime_client.start()
     try:
-        for summary in runtime_client.search_conversations():
-            markdown = runtime_client.export_markdown(summary.cascade_id)
+        summaries = runtime_client.search_conversations()
+        expected = len(summaries)
+        for obtained, summary in enumerate(summaries):
+            try:
+                markdown = runtime_client.export_markdown(summary.cascade_id)
+            except AntigravityExportError as exc:
+                # A mid-iteration export failure would otherwise abort the
+                # generator after yielding only the conversations seen so far,
+                # silently dropping the remainder. Surface obtained-vs-expected
+                # so the caller can distinguish partial loss from a benign
+                # binary-absent fallback. ``obtained`` is the number already
+                # yielded (the index of the failing summary).
+                raise AntigravityPartialExportError(
+                    f"Antigravity export aborted on cascade {summary.cascade_id}: {exc}",
+                    obtained=obtained,
+                    expected=expected,
+                ) from exc
             yield parse_markdown_export_payload(markdown_export_payload(summary, markdown), summary.cascade_id)
     finally:
         if owned_client:
@@ -401,9 +440,11 @@ def _string(value: object) -> str | None:
 
 
 __all__ = [
+    "AntigravityBinaryUnavailableError",
     "AntigravityConversationSummary",
     "AntigravityExportError",
     "AntigravityLanguageServerClient",
+    "AntigravityPartialExportError",
     "discover_language_server",
     "iter_language_server_exports",
     "looks_like_brain_metadata",

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -333,7 +333,8 @@ def iter_language_server_exports(
                     obtained=obtained,
                     expected=expected,
                 ) from exc
-            yield parse_markdown_export_payload(markdown_export_payload(summary, markdown), summary.cascade_id)
+            else:
+                yield parse_markdown_export_payload(markdown_export_payload(summary, markdown), summary.cascade_id)
     finally:
         if owned_client:
             runtime_client.close()

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -58,7 +58,29 @@ def iter_source_conversations_with_raw(
         try:
             for conversation in antigravity.iter_language_server_exports(source.path):
                 yield (None, conversation)
+        except antigravity.AntigravityBinaryUnavailableError as exc:
+            # Benign: Antigravity is simply not installed. Fall back to the
+            # brain-artifact walk at INFO — this is not data loss.
+            logger.info(
+                "Antigravity language server unavailable for %s; using parseable artifacts: %s",
+                source.path,
+                exc,
+            )
+        except antigravity.AntigravityPartialExportError as exc:
+            # Mid-export failure: some conversations were obtained before the
+            # abort and the remainder is dropped. Surface obtained-vs-expected
+            # loudly instead of conflating it with a benign fallback.
+            logger.error(
+                "Antigravity language-server export of %s truncated mid-iteration: "
+                "obtained %d of %d conversations; %d lost before fallback: %s",
+                source.path,
+                exc.obtained,
+                exc.expected,
+                max(exc.expected - exc.obtained, 0),
+                exc,
+            )
         except antigravity.AntigravityExportError as exc:
+            # Connection/protocol failure before any conversation was obtained.
             logger.warning(
                 "Antigravity language-server export failed for %s; falling back to parseable artifacts: %s",
                 source.path,

--- a/polylogue/storage/artifacts/inspection.py
+++ b/polylogue/storage/artifacts/inspection.py
@@ -120,9 +120,16 @@ def _support_status(
     artifact_kind: str,
     has_supported_resolution: bool,
     had_decode_error: bool,
+    partial_decode: bool = False,
 ) -> ArtifactSupportStatus:
-    if had_decode_error or malformed_jsonl_lines > 0:
+    if had_decode_error:
         return ArtifactSupportStatus.DECODE_FAILED
+    if malformed_jsonl_lines > 0:
+        # A stream that still produced valid records lost only *some* lines —
+        # that is partial loss, distinct from a wholesale decode failure. The
+        # caller sets ``partial_decode`` once it has an accurate (full-scan,
+        # not prefix-bounded) malformed-line count for a stream artifact.
+        return ArtifactSupportStatus.PARTIAL_DECODE if partial_decode else ArtifactSupportStatus.DECODE_FAILED
     if artifact_kind == ArtifactKind.UNKNOWN.value:
         return ArtifactSupportStatus.UNKNOWN
     if not parse_as_conversation or not schema_eligible:
@@ -181,6 +188,67 @@ def _should_retry_full_json_inspection(record: RawConversationRecord, *, wire_fo
     return _full_json_inspection_allowed(record) and wire_format == "jsonl"
 
 
+def _full_scan_malformed_jsonl(record: RawConversationRecord) -> tuple[int, bool]:
+    """Stream the entire blob to count malformed JSONL lines.
+
+    The prefix-based classification only inspects the first 64 KB, so malformed
+    content past the prefix never marks the artifact failed (#1745). This scan
+    streams the whole blob line-by-line (never materializing it) so the
+    malformed-line count and decode status reflect the full artifact.
+
+    Returns ``(malformed_lines, had_valid_records)``. ``had_valid_records`` is
+    ``True`` when at least one line decoded successfully; the sampling helper
+    raises ``ValueError`` only when no valid record exists, which is the
+    no-valid-records signal.
+    """
+    from polylogue.archive.raw_payload.decode import _sample_jsonl_payload_with_detail
+
+    blob_path = get_blob_store().blob_path(record.raw_id)
+    try:
+        _samples, malformed_lines, _detail = _sample_jsonl_payload_with_detail(
+            blob_path,
+            max_samples=1,
+            jsonl_dict_only=False,
+            scan_full=True,
+        )
+    except ValueError:
+        # No valid JSONL records at all — leave the decision to the prefix-based
+        # classification (which will have surfaced a decode error already).
+        return 0, False
+    return malformed_lines, True
+
+
+def _stream_loss_accounting(
+    record: RawConversationRecord,
+    *,
+    wire_format: str | None,
+    prefix_malformed_lines: int,
+) -> tuple[int, bool]:
+    """Return ``(malformed_lines, partial_decode)`` for a stream artifact.
+
+    For JSONL artifacts larger than the inspection prefix, runs a full-file scan
+    so the malformed-line count is accurate rather than prefix-bounded. Marks
+    ``partial_decode`` when malformed lines coexist with valid records (some
+    records survived, some were lost).
+
+    The decision keys off the *source path* being a JSONL/stream artifact, not
+    the envelope ``wire_format``: a large JSONL file's inspection prefix is
+    truncated to its first line, which decodes as a single JSON object
+    (``wire_format == "json"``), so trusting ``wire_format`` here would skip the
+    full scan exactly when loss past the prefix is most likely (#1745).
+    """
+    is_stream = _prefers_json_stream(record.source_path) or wire_format == "jsonl"
+    if not is_stream or record.blob_size <= _INSPECTION_PREFIX_BYTES:
+        # The prefix already covered the whole file (or this is not a stream).
+        # Reaching the success branch with malformed lines means valid records
+        # decoded too, so any loss here is partial.
+        return prefix_malformed_lines, prefix_malformed_lines > 0
+    malformed_lines, had_valid_records = _full_scan_malformed_jsonl(record)
+    if malformed_lines == 0:
+        return malformed_lines, False
+    return malformed_lines, had_valid_records
+
+
 def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRecord:
     """Inspect one raw record into a durable artifact observation.
 
@@ -205,11 +273,16 @@ def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRe
         resolution: SchemaResolution | None = None
         has_supported_resolution = False
 
-        if (
-            envelope.artifact.parse_as_conversation
-            and envelope.artifact.schema_eligible
-            and envelope.malformed_jsonl_lines == 0
-        ):
+        # The envelope's malformed count comes from the inspection prefix only.
+        # For stream artifacts larger than the prefix, re-scan the whole blob so
+        # malformed lines past the prefix are not silently invisible (#1745).
+        malformed_jsonl_lines, partial_decode = _stream_loss_accounting(
+            record,
+            wire_format=envelope.wire_format,
+            prefix_malformed_lines=envelope.malformed_jsonl_lines,
+        )
+
+        if envelope.artifact.parse_as_conversation and envelope.artifact.schema_eligible and malformed_jsonl_lines == 0:
             resolution, has_supported_resolution = _resolve_payload_support(
                 registry=registry,
                 payload_provider=payload_provider,
@@ -223,10 +296,11 @@ def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRe
         support_status = _support_status(
             parse_as_conversation=envelope.artifact.parse_as_conversation,
             schema_eligible=envelope.artifact.schema_eligible,
-            malformed_jsonl_lines=envelope.malformed_jsonl_lines,
+            malformed_jsonl_lines=malformed_jsonl_lines,
             artifact_kind=envelope.artifact.kind.value,
             has_supported_resolution=has_supported_resolution,
             had_decode_error=False,
+            partial_decode=partial_decode,
         )
 
         return ArtifactObservationRecord(
@@ -243,7 +317,7 @@ def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRe
             parse_as_conversation=envelope.artifact.parse_as_conversation,
             schema_eligible=envelope.artifact.schema_eligible,
             support_status=support_status,
-            malformed_jsonl_lines=envelope.malformed_jsonl_lines,
+            malformed_jsonl_lines=malformed_jsonl_lines,
             decode_error=None,
             bundle_scope=bundle_scope,
             cohort_id=schema_cluster_id(envelope.payload, envelope.artifact.cohort),

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -81,7 +81,7 @@ from polylogue.storage.sqlite.schema_ddl_repo_identity import (
     REPO_IDENTITY_DDL as _REPO_IDENTITY_DDL,
 )
 
-SCHEMA_VERSION = 21  # Canonical schema. No migration chain: mismatch → re-ingest from source. Added per-role message counts to conversation_stats (user/assistant/system/tool) to eliminate the messages-table scan from provider metrics.
+SCHEMA_VERSION = 22  # Canonical schema. No migration chain: mismatch → re-ingest from source. Added per-role message counts to conversation_stats (user/assistant/system/tool) to eliminate the messages-table scan from provider metrics.
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_aux.py
+++ b/polylogue/storage/sqlite/schema_ddl_aux.py
@@ -32,6 +32,7 @@ ARTIFACT_OBSERVATION_DDL = """
                     'recognized_unparsed',
                     'unsupported_parseable',
                     'decode_failed',
+                    'partial_decode',
                     'unknown'
                 )),
             malformed_jsonl_lines INTEGER NOT NULL DEFAULT 0,

--- a/polylogue/types.py
+++ b/polylogue/types.py
@@ -129,6 +129,7 @@ class ArtifactSupportStatus(str, Enum):
     RECOGNIZED_UNPARSED = "recognized_unparsed"
     UNSUPPORTED_PARSEABLE = "unsupported_parseable"
     DECODE_FAILED = "decode_failed"
+    PARTIAL_DECODE = "partial_decode"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/tests/unit/pipeline/test_malformed_jsonl_accounting.py
+++ b/tests/unit/pipeline/test_malformed_jsonl_accounting.py
@@ -1,0 +1,144 @@
+"""Regression tests: malformed JSONL counts are accurate and surfaced (#1745).
+
+Two surfaces are covered:
+
+1. The stream parse plan now scans the *whole* stream for malformed-line
+   accounting even in advisory mode (``scan_full`` was previously tied to
+   STRICT, undercounting past the 64-record sample). The accurate, whole-file
+   count lands on the durable artifact observation for the blob.
+2. ``_validate_parse_plan`` surfaces malformed lines on a schema-eligible plan:
+   STRICT fails the record; ADVISORY does not fail but emits a WARNING (rather
+   than silently demoting the loss).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.artifact_taxonomy import ArtifactClassification, ArtifactKind
+from polylogue.pipeline.services.ingest_worker import (
+    _IngestContext,
+    _ParsePlan,
+    _validate_parse_plan,
+    ingest_record,
+)
+from polylogue.storage.artifacts.inspection import inspect_raw_artifact
+from polylogue.storage.blob_store import BlobStore, reset_blob_store
+from polylogue.storage.runtime import RawConversationRecord
+from polylogue.types import Provider, ValidationMode, ValidationStatus
+
+
+@pytest.fixture
+def blob_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[BlobStore]:
+    root = tmp_path / "blobs"
+    store = BlobStore(root)
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: root)
+    reset_blob_store()
+    yield store
+    reset_blob_store()
+
+
+def _valid_line(i: int) -> bytes:
+    return (
+        b'{"type":"user","uuid":"u%d","sessionId":"s1","parentUuid":null,'
+        b'"cwd":"/tmp","message":{"role":"user","content":"hi %d"}}\n' % (i, i)
+    )
+
+
+def _make_record(store: BlobStore, content: bytes, *, source_path: str) -> RawConversationRecord:
+    raw_id, blob_size = store.write_from_bytes(content)
+    return RawConversationRecord(
+        raw_id=raw_id,
+        source_name="claude-code",
+        source_path=source_path,
+        payload_provider=Provider.CLAUDE_CODE,
+        source_index=None,
+        blob_size=blob_size,
+        acquired_at="2026-01-01T00:00:00+00:00",
+        file_mtime=None,
+    )
+
+
+def test_advisory_stream_counts_malformed_past_sample_boundary(blob_store: BlobStore, tmp_path: Path) -> None:
+    """Malformed lines past the 64-sample boundary are counted; record not failed.
+
+    The accurate whole-file count is surfaced on the durable artifact
+    observation for the same blob (not the 64-sample undercount).
+    """
+    lines = [_valid_line(i) for i in range(120)]
+    lines.insert(80, b"{ not valid json line A\n")
+    lines.insert(101, b"{ not valid json line B\n")
+    content = b"".join(lines)
+
+    record = _make_record(blob_store, content, source_path="agent-z/session.jsonl")
+
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(blob_store.root))
+    # Advisory mode does not fail the record.
+    assert result.validation_status != ValidationStatus.FAILED.value
+
+    observation = inspect_raw_artifact(record)
+    assert observation.malformed_jsonl_lines >= 2
+
+
+def _context(record: RawConversationRecord, *, mode: ValidationMode, tmp_path: Path) -> _IngestContext:
+    return _IngestContext(
+        raw_record=record,
+        raw_source=tmp_path / "unused",
+        archive_root=tmp_path / "archive",
+        validation_mode=mode,
+        measure_serialized_size=False,
+        source_name=record.source_name or "",
+        fallback_timestamp=None,
+    )
+
+
+def _schema_eligible_plan(malformed: int) -> _ParsePlan:
+    artifact = ArtifactClassification(
+        provider=Provider.CLAUDE_CODE,
+        kind=ArtifactKind.CONVERSATION_DOCUMENT,
+        parse_as_conversation=True,
+        schema_eligible=True,
+        default_priority=100,
+        reason="test schema-eligible artifact",
+    )
+    return _ParsePlan(
+        provider=Provider.CLAUDE_CODE,
+        payload_provider=str(Provider.CLAUDE_CODE),
+        artifact=artifact,
+        mode="payload",
+        schema_payload={"k": "v"},
+        payload={"k": "v"},
+        malformed_jsonl_lines=malformed,
+        malformed_jsonl_detail="line 7: broken",
+    )
+
+
+def test_strict_fails_on_malformed_schema_eligible_plan(blob_store: BlobStore, tmp_path: Path) -> None:
+    """STRICT mode fails a schema-eligible plan carrying malformed lines."""
+    record = _make_record(blob_store, _valid_line(0), source_path="conv.json")
+    plan = _schema_eligible_plan(malformed=3)
+
+    validation = _validate_parse_plan(_context(record, mode=ValidationMode.STRICT, tmp_path=tmp_path), plan)
+
+    assert validation.status is ValidationStatus.FAILED
+    assert validation.parse_error is not None
+    assert "Malformed JSONL" in (validation.parse_error or "")
+
+
+def test_advisory_warns_but_does_not_fail_schema_eligible_plan(
+    blob_store: BlobStore, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """ADVISORY mode surfaces malformed lines at WARNING without failing (#1745)."""
+    record = _make_record(blob_store, _valid_line(0), source_path="conv.json")
+    plan = _schema_eligible_plan(malformed=3)
+
+    with caplog.at_level(logging.WARNING):
+        validation = _validate_parse_plan(_context(record, mode=ValidationMode.ADVISORY, tmp_path=tmp_path), plan)
+
+    assert validation.status is not ValidationStatus.FAILED
+    # The loss is surfaced, not silently demoted.
+    assert any("Malformed JSONL lines counted in advisory mode" in rec.message for rec in caplog.records)

--- a/tests/unit/sources/test_silent_ingest_loss.py
+++ b/tests/unit/sources/test_silent_ingest_loss.py
@@ -1,0 +1,140 @@
+"""Regression tests for surfaced parse-time record loss (#1745).
+
+Each test asserts that a loss path is *surfaced* — raised as a typed error,
+counted accurately, or escalated to a durable status — rather than silently
+dropping records while the parse reports success.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.sources.decoder_json import (
+    JsonValue,
+    PartialJsonStreamError,
+    iter_json_stream,
+)
+from polylogue.sources.parsers.antigravity import (
+    AntigravityBinaryUnavailableError,
+    AntigravityConversationSummary,
+    AntigravityExportError,
+    AntigravityLanguageServerClient,
+    AntigravityPartialExportError,
+    iter_language_server_exports,
+)
+
+# ---------------------------------------------------------------------------
+# AC #1 — mid-stream JSON corruption raises a typed partial-decode error
+# ---------------------------------------------------------------------------
+
+
+def test_mid_stream_corruption_raises_partial_decode_error() -> None:
+    """A top-level array valid for the first N items then truncated must raise.
+
+    The previous behaviour returned the records accumulated before the
+    corruption with ``found_any=True`` and logged nothing, silently truncating
+    the conversation set.
+    """
+    # Valid first two objects, then the array is cut off mid-token.
+    truncated = b'[{"id": 1}, {"id": 2}, {"id": 3'
+    handle = io.BytesIO(truncated)
+
+    with pytest.raises(PartialJsonStreamError) as excinfo:
+        list(iter_json_stream(handle, "conversations.json"))
+
+    err = excinfo.value
+    assert err.recovered >= 2
+    assert "conversations.json" in str(err)
+
+
+def test_clean_array_does_not_raise() -> None:
+    """A well-formed array must still decode all records without raising."""
+    handle = io.BytesIO(b'[{"id": 1}, {"id": 2}, {"id": 3}]')
+    records = list(iter_json_stream(handle, "conversations.json"))
+    ids = [cast(dict[str, JsonValue], r)["id"] for r in records]
+    assert ids == [1, 2, 3]
+
+
+def test_wrong_prefix_with_zero_items_falls_through_not_raises() -> None:
+    """A single top-level object (no array) must not raise PartialJsonStreamError.
+
+    Strategy 1 ("item") finds zero items and a JSONError there is a normal
+    "try the next strategy" signal — it must be swallowed, not surfaced.
+    """
+    handle = io.BytesIO(b'{"conversations": [{"id": 1}]}')
+    records = list(iter_json_stream(handle, "single.json"))
+    # The object is yielded as a single record (dict payload, no unpack match).
+    assert records
+
+
+# ---------------------------------------------------------------------------
+# AC #4 — Antigravity distinguishes missing-binary from mid-export failure
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    """Minimal stand-in for AntigravityLanguageServerClient."""
+
+    def __init__(self, summaries: list[AntigravityConversationSummary], fail_at: int | None) -> None:
+        self._summaries = summaries
+        self._fail_at = fail_at
+        self.closed = False
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    def search_conversations(self) -> list[AntigravityConversationSummary]:
+        return self._summaries
+
+    def export_markdown(self, cascade_id: str) -> str:
+        index = [s.cascade_id for s in self._summaries].index(cascade_id)
+        if self._fail_at is not None and index >= self._fail_at:
+            raise AntigravityExportError(f"export failed for {cascade_id}")
+        return f"### User Input\nhello {cascade_id}\n"
+
+
+def _as_client(fake: _FakeClient) -> AntigravityLanguageServerClient:
+    return cast(AntigravityLanguageServerClient, fake)
+
+
+def test_antigravity_export_error_taxonomy_is_distinguishable() -> None:
+    """Missing-binary and mid-export are distinct typed subtypes of the export error."""
+    summary = AntigravityConversationSummary(cascade_id="c1")
+    client = _FakeClient([summary], fail_at=None)
+    # Sanity: with a working client all conversations are obtained.
+    convos = list(iter_language_server_exports(Path("/tmp/x"), client=_as_client(client)))
+    assert len(convos) == 1
+
+    # Both are AntigravityExportError subtypes so the broad fallback still
+    # catches them, but callers can distinguish benign vs. lossy.
+    assert issubclass(AntigravityBinaryUnavailableError, AntigravityExportError)
+    assert issubclass(AntigravityPartialExportError, AntigravityExportError)
+
+
+def test_antigravity_mid_export_failure_reports_obtained_vs_expected() -> None:
+    """A mid-iteration failure raises AntigravityPartialExportError with counts.
+
+    Previously the generator yielded the conversations seen before the failure
+    then aborted into the fallback, indistinguishable from "not installed".
+    """
+    summaries = [AntigravityConversationSummary(cascade_id=f"c{i}") for i in range(5)]
+    client = _FakeClient(summaries, fail_at=3)
+
+    obtained: list[object] = []
+    with pytest.raises(AntigravityPartialExportError) as excinfo:
+        for convo in iter_language_server_exports(Path("/tmp/x"), client=_as_client(client)):
+            obtained.append(convo)
+
+    err = excinfo.value
+    assert err.expected == 5
+    assert err.obtained == 3
+    assert len(obtained) == 3
+    # The lost remainder is visible in the message.
+    assert "3 of 5" in str(err)

--- a/tests/unit/storage/test_artifact_loss_surfacing.py
+++ b/tests/unit/storage/test_artifact_loss_surfacing.py
@@ -1,0 +1,105 @@
+"""Regression tests: artifact DECODE_FAILED/PARTIAL_DECODE covers the whole file (#1745).
+
+The artifact support status is derived from raw inspection. Inspection reads
+only a 64 KB prefix to bound memory, so malformed JSONL content *past* the
+prefix used to be invisible and the artifact was never flagged. These tests
+assert that loss past the prefix is surfaced via a full-scan fallback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.artifacts.inspection import (
+    _INSPECTION_PREFIX_BYTES,
+    inspect_raw_artifact,
+)
+from polylogue.storage.blob_store import BlobStore, reset_blob_store
+from polylogue.storage.runtime import RawConversationRecord
+from polylogue.types import ArtifactSupportStatus, Provider
+
+
+@pytest.fixture
+def blob_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[BlobStore]:
+    root = tmp_path / "blobs"
+    store = BlobStore(root)
+    # inspect_raw_artifact resolves the blob store via get_blob_store(), which
+    # reads paths.blob_store_root(). Point both at the test root.
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: root)
+    monkeypatch.setattr("polylogue.storage.blob_store.blob_store_root", lambda: root, raising=False)
+    reset_blob_store()
+    yield store
+    reset_blob_store()
+
+
+def _write_record(
+    store: BlobStore,
+    *,
+    content: bytes,
+    source_path: str,
+    source_name: str = "claude-code",
+) -> RawConversationRecord:
+    raw_id, blob_size = store.write_from_bytes(content)
+    return RawConversationRecord(
+        raw_id=raw_id,
+        source_name=source_name,
+        source_path=source_path,
+        payload_provider=Provider.CLAUDE_CODE,
+        source_index=None,
+        blob_size=blob_size,
+        acquired_at="2026-01-01T00:00:00+00:00",
+        file_mtime=None,
+    )
+
+
+def _valid_line(i: int) -> bytes:
+    return (
+        b'{"type":"user","uuid":"u%d","sessionId":"s","parentUuid":null,'
+        b'"cwd":"/tmp","message":{"role":"user","content":"hi %d"}}\n' % (i, i)
+    )
+
+
+def test_malformed_line_past_prefix_is_surfaced(blob_store: BlobStore) -> None:
+    """Malformed content past the 64 KB prefix flags the artifact (not silent)."""
+    lines: list[bytes] = []
+    size = 0
+    i = 0
+    while size <= _INSPECTION_PREFIX_BYTES * 2:
+        line = _valid_line(i)
+        lines.append(line)
+        size += len(line)
+        i += 1
+    # Malformed line lives far past the prefix boundary.
+    lines.append(b"{ this is not valid json at all\n")
+    lines.append(_valid_line(i + 1))
+    content = b"".join(lines)
+    assert len(content) > _INSPECTION_PREFIX_BYTES
+
+    record = _write_record(blob_store, content=content, source_path="agent-x/session.jsonl")
+    observation = inspect_raw_artifact(record)
+
+    assert observation.malformed_jsonl_lines >= 1
+    # Valid records coexist with the bad line → partial loss, surfaced.
+    assert observation.support_status in {
+        ArtifactSupportStatus.PARTIAL_DECODE,
+        ArtifactSupportStatus.DECODE_FAILED,
+    }
+
+
+def test_clean_large_jsonl_is_not_flagged(blob_store: BlobStore) -> None:
+    """A clean JSONL file larger than the prefix is not falsely flagged."""
+    lines = [_valid_line(i) for i in range(2000)]
+    content = b"".join(lines)
+    assert len(content) > _INSPECTION_PREFIX_BYTES
+
+    record = _write_record(blob_store, content=content, source_path="agent-y/session.jsonl")
+    observation = inspect_raw_artifact(record)
+
+    assert observation.malformed_jsonl_lines == 0
+    assert observation.support_status not in {
+        ArtifactSupportStatus.PARTIAL_DECODE,
+        ArtifactSupportStatus.DECODE_FAILED,
+    }


### PR DESCRIPTION
## Summary

Several ingest code paths dropped records silently with no convergence debt, no health counters, and no accurate accounting. This PR surfaces mid-stream corruption, fixes undercounting of malformed JSONL lines, adds a `partial_decode` artifact status, and surfaces per-trajectory errors from the Antigravity parser.

## Problem

1. `decoder_json._stream_prefixed_items`: mid-stream `JSONError` returned only records accumulated before the corruption, logged nothing, and let the caller treat the partial list as complete success.
2. `ingest_worker.counted_stream`: malformed JSONL count came only from a 64-line probe (`max_samples=64`), understating loss on large files. Advisory mode demoted the count to a warning and marked the record valid.
3. `artifacts/inspection.py`: `DECODE_FAILED` was set from a 64 KB prefix check only.
4. Antigravity parser: per-trajectory export errors were swallowed, silently dropping all remaining conversations after the first failure.

## Solution

- `decoder_json`: log and surface mid-stream corruption; expose `PartialJsonStreamError` for callers that need to distinguish partial from total failure.
- `validation_runtime`: track actual `malformed_jsonl_lines` from the full stream.
- `artifacts/inspection`: new `PARTIAL_DECODE` status for mid-stream truncations that yielded some records.
- `antigravity`: raise `AntigravityPartialExportError` with obtained/expected counts instead of swallowing failures.
- `source_parsing`: propagate decode advisory counts to caller.
- `ingest_worker`: record malformed counts into convergence debt.

Schema: SCHEMA_VERSION 21 → 22 (adds `partial_decode` to `artifact_observations` CHECK constraint; no migration chain — re-ingest from source on mismatch via `polylogue reset --database && polylogued run`).

## Verification

```
devtools verify --quick   # exit 0
pytest tests/unit/pipeline/test_malformed_jsonl_accounting.py \
       tests/unit/sources/test_silent_ingest_loss.py \
       tests/unit/storage/test_artifact_loss_surfacing.py -q
```

Closes #1745