### PR TITLE
perf(storage): keyset pagination in iter_messages, O(1) blob scan (#1750)

### DIFF
--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -98,7 +98,10 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
 def _raw_conversation_hashes(conn: sqlite3.Connection) -> list[str]:
     if not _table_exists(conn, "raw_conversations"):
         return []
-    rows = conn.execute("SELECT raw_id FROM raw_conversations ORDER BY acquired_at DESC, raw_id").fetchall()
+    # No ORDER BY: the result is consumed unordered into a set
+    # (scan_blob_integrity builds ``set(referenced)``), so sorting the full
+    # raw_conversations scan on unindexed ``acquired_at`` was pure overhead.
+    rows = conn.execute("SELECT raw_id FROM raw_conversations").fetchall()
     return [str(row[0]) for row in rows if row[0]]
 
 

--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -131,19 +131,55 @@ async def iter_messages(
     message_roles: MessageRoleFilter = (),
     limit: int | None = None,
 ) -> AsyncIterator[MessageRecord]:
-    offset = 0
+    """Stream a conversation's messages in deterministic order, chunked.
+
+    Pagination is keyset, not ``LIMIT/OFFSET``: each chunk is seeded by the
+    previous chunk's last ``(sort_key, message_id)`` so a single conversation's
+    stream stays linear instead of re-scanning and discarding all prior rows
+    (O(M^2)) on every chunk. The ordering
+    ``(sort_key IS NULL), sort_key, message_id`` is unchanged and served by
+    ``idx_messages_conversation_sortkey``. ``message_id`` is the table primary
+    key (globally unique), so the keyset cursor is a total order with no skipped
+    or duplicated rows across chunk boundaries. NULL-``sort_key`` rows form the
+    ordering tail and are advanced by a distinct cursor branch.
+    """
     yielded = 0
     effective_roles = message_roles or ((Role.USER, Role.ASSISTANT) if dialogue_only else ())
     role_values = message_role_sql_values(effective_roles)
 
+    # Keyset cursor of the previous chunk's final row. ``have_cursor``
+    # distinguishes the first chunk from a genuine NULL-sort_key boundary
+    # (``last_sort`` is None in both cases).
+    last_sort: float | None = None
+    last_id: str = ""
+    have_cursor = False
+
     while True:
         query = "SELECT * FROM messages WHERE conversation_id = ?"
-        params: list[str | int] = [conversation_id]
+        params: list[str | float] = [conversation_id]
 
         if role_values:
             placeholders = ",".join("?" for _ in role_values)
             query += f" AND role IN ({placeholders})"
             params.extend(role_values)
+
+        if have_cursor:
+            if last_sort is not None:
+                # Cursor in the non-NULL sort_key group: advance within it and
+                # always include the NULL group that follows in the ordering.
+                query += (
+                    " AND ("
+                    "(sort_key IS NOT NULL"
+                    " AND (sort_key > ? OR (sort_key = ? AND message_id > ?)))"
+                    " OR sort_key IS NULL"
+                    ")"
+                )
+                params.extend([last_sort, last_sort, last_id])
+            else:
+                # Cursor in the NULL sort_key group (ordering tail): only
+                # NULL-sort_key rows with a greater message_id remain.
+                query += " AND sort_key IS NULL AND message_id > ?"
+                params.append(last_id)
 
         query += " ORDER BY (sort_key IS NULL), sort_key, message_id"
 
@@ -154,8 +190,8 @@ async def iter_messages(
                 break
             fetch_limit = min(chunk_size, remaining)
 
-        query += " LIMIT ? OFFSET ?"
-        params.extend([fetch_limit, offset])
+        query += " LIMIT ?"
+        params.append(fetch_limit)
 
         cursor = await conn.execute(query, tuple(params))
         rows = list(await cursor.fetchall())
@@ -163,13 +199,17 @@ async def iter_messages(
         if not rows:
             break
 
+        last_row = rows[-1]
+        last_sort = last_row["sort_key"]
+        last_id = str(last_row["message_id"])
+        have_cursor = True
+
         for row in rows:
             yield _row_to_message(row)
             yielded += 1
             if limit is not None and yielded >= limit:
                 return
 
-        offset += len(rows)
         if len(rows) < fetch_limit:
             break
 

--- a/tests/unit/storage/test_blob_integrity_referenced_scan.py
+++ b/tests/unit/storage/test_blob_integrity_referenced_scan.py
@@ -1,0 +1,70 @@
+"""Tests for the referenced-raw-id scan (#1750 F4).
+
+``_raw_conversation_hashes`` dropped a redundant ``ORDER BY acquired_at DESC,
+raw_id`` — its result is consumed as an unordered set, so the sort over the full
+``raw_conversations`` scan was pure overhead. These tests pin the contract that
+actually matters: the full set of non-empty ``raw_id`` values is returned
+(order irrelevant).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.blob_integrity import _raw_conversation_hashes
+from polylogue.storage.sqlite.schema import _ensure_schema
+
+
+def _init_db(tmp_path: Path) -> sqlite3.Connection:
+    db = tmp_path / "archive.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    _ensure_schema(conn)
+    conn.commit()
+    return conn
+
+
+def _insert_raw(conn: sqlite3.Connection, raw_id: str, acquired_at: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO raw_conversations (
+            raw_id, source_name, source_path, source_index, blob_size, acquired_at, file_mtime
+        ) VALUES (?, 'codex', ?, 0, 1, ?, ?)
+        """,
+        (raw_id, f"/src/{raw_id}.jsonl", acquired_at, acquired_at),
+    )
+
+
+def test_returns_all_non_empty_raw_ids(tmp_path: Path) -> None:
+    conn = _init_db(tmp_path)
+    try:
+        _insert_raw(conn, "r_b", "2026-01-02")
+        _insert_raw(conn, "r_a", "2026-01-03")
+        _insert_raw(conn, "r_c", "2026-01-01")
+        conn.commit()
+        result = set(_raw_conversation_hashes(conn))
+    finally:
+        conn.close()
+    assert result == {"r_a", "r_b", "r_c"}
+
+
+def test_empty_table(tmp_path: Path) -> None:
+    conn = _init_db(tmp_path)
+    try:
+        assert _raw_conversation_hashes(conn) == []
+    finally:
+        conn.close()
+
+
+def test_missing_table_returns_empty(tmp_path: Path) -> None:
+    db = tmp_path / "bare.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        assert _raw_conversation_hashes(conn) == []
+    finally:
+        conn.close()
+
+
+__all__: list[str] = []

--- a/tests/unit/storage/test_iter_messages_keyset.py
+++ b/tests/unit/storage/test_iter_messages_keyset.py
@@ -100,7 +100,7 @@ async def _reference_offset_walk(
     conn: aiosqlite.Connection,
     conversation_id: str,
     chunk_size: int,
-    role_values: list[str],
+    role_values: tuple[str, ...] | list[str],
     limit: int | None,
 ) -> list[str]:
     """Pre-#1750 LIMIT/OFFSET walk — the contract the keyset rewrite preserves."""

--- a/tests/unit/storage/test_iter_messages_keyset.py
+++ b/tests/unit/storage/test_iter_messages_keyset.py
@@ -1,0 +1,228 @@
+"""Old-vs-new equivalence for keyset-paginated ``iter_messages`` (#1750 F1).
+
+``iter_messages`` was converted from ``LIMIT ? OFFSET ?`` chunking to keyset
+pagination seeded by the previous chunk's last ``(sort_key, message_id)``. The
+keyset stream must produce exactly the same rows in exactly the same order as:
+
+* the canonical single-query ordering (``get_messages``), and
+* a reference ``LIMIT/OFFSET`` walk reproducing the pre-#1750 behavior,
+
+across every chunk-size boundary, every ``sort_key`` shape (non-NULL, duplicate
+sort_key ties broken by ``message_id``, NULL tail, all-NULL), the role filter,
+and the optional ``limit``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from polylogue.archive.message.roles import MessageRoleFilter, Role, message_role_sql_values
+from polylogue.storage.sqlite.queries.message_query_reads import get_messages, iter_messages
+from polylogue.storage.sqlite.schema import _ensure_schema
+
+CONV = "conv-keyset"
+
+# (message_id, sort_key, role) fixtures covering every ordering edge case.
+_SCENARIOS: dict[str, list[tuple[str, float | None, str]]] = {
+    "all_non_null": [
+        ("m03", 3.0, "user"),
+        ("m01", 1.0, "assistant"),
+        ("m02", 2.0, "user"),
+        ("m04", 4.0, "assistant"),
+        ("m05", 5.0, "user"),
+    ],
+    "duplicate_sort_keys": [
+        # ties on sort_key must break by message_id
+        ("m_b", 1.0, "user"),
+        ("m_a", 1.0, "assistant"),
+        ("m_d", 2.0, "user"),
+        ("m_c", 2.0, "assistant"),
+        ("m_e", 3.0, "user"),
+    ],
+    "null_tail": [
+        ("m02", 2.0, "user"),
+        ("m01", 1.0, "assistant"),
+        ("nz", None, "user"),
+        ("na", None, "assistant"),
+        ("nm", None, "user"),
+    ],
+    "all_null": [
+        ("z", None, "user"),
+        ("a", None, "assistant"),
+        ("m", None, "user"),
+        ("b", None, "assistant"),
+    ],
+    "boundary_at_null_transition": [
+        ("s2", 9.0, "user"),
+        ("s1", 8.0, "assistant"),
+        ("n3", None, "user"),
+        ("n1", None, "assistant"),
+        ("n2", None, "user"),
+        ("n4", None, "assistant"),
+    ],
+    "single": [("only", 1.0, "user")],
+}
+
+
+def _seed(conn: sqlite3.Connection, rows: list[tuple[str, float | None, str]]) -> None:
+    conn.execute(
+        """
+        INSERT INTO conversations (
+            conversation_id, provider_conversation_id, source_name, title, version
+        ) VALUES (?, 'p1', 'codex', 'Keyset', 1)
+        """,
+        (CONV,),
+    )
+    conn.executemany(
+        """
+        INSERT INTO messages (message_id, conversation_id, role, sort_key, version)
+        VALUES (?, ?, ?, ?, 1)
+        """,
+        [(mid, CONV, role, sort_key) for mid, sort_key, role in rows],
+    )
+    conn.commit()
+
+
+def _make_db(tmp_path: object, rows: list[tuple[str, float | None, str]]) -> str:
+    db_path = str(tmp_path) + "/keyset.db"
+    sync_conn = sqlite3.connect(db_path)
+    sync_conn.row_factory = sqlite3.Row
+    _ensure_schema(sync_conn)
+    _seed(sync_conn, rows)
+    sync_conn.close()
+    return db_path
+
+
+async def _reference_offset_walk(
+    conn: aiosqlite.Connection,
+    conversation_id: str,
+    chunk_size: int,
+    role_values: list[str],
+    limit: int | None,
+) -> list[str]:
+    """Pre-#1750 LIMIT/OFFSET walk — the contract the keyset rewrite preserves."""
+    out: list[str] = []
+    offset = 0
+    yielded = 0
+    while True:
+        query = "SELECT * FROM messages WHERE conversation_id = ?"
+        params: list[str | int] = [conversation_id]
+        if role_values:
+            placeholders = ",".join("?" for _ in role_values)
+            query += f" AND role IN ({placeholders})"
+            params.extend(role_values)
+        query += " ORDER BY (sort_key IS NULL), sort_key, message_id"
+        fetch_limit = chunk_size
+        if limit is not None:
+            remaining = limit - yielded
+            if remaining <= 0:
+                break
+            fetch_limit = min(chunk_size, remaining)
+        query += " LIMIT ? OFFSET ?"
+        params.extend([fetch_limit, offset])
+        cursor = await conn.execute(query, tuple(params))
+        rows = list(await cursor.fetchall())
+        if not rows:
+            break
+        for row in rows:
+            out.append(str(row["message_id"]))
+            yielded += 1
+            if limit is not None and yielded >= limit:
+                return out
+        offset += len(rows)
+        if len(rows) < fetch_limit:
+            break
+    return out
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 4, 5, 6, 7, 100])
+async def test_keyset_matches_canonical_and_offset(tmp_path: object, scenario: str, chunk_size: int) -> None:
+    rows = _SCENARIOS[scenario]
+    db_path = _make_db(tmp_path, rows)
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        canonical = [m.message_id for m in await get_messages(conn, CONV)]
+        keyset = [m.message_id async for m in iter_messages(conn, CONV, chunk_size=chunk_size)]
+        reference = await _reference_offset_walk(conn, CONV, chunk_size, [], None)
+
+    assert keyset == canonical
+    assert keyset == reference
+    assert len(keyset) == len(rows)
+    assert len(set(keyset)) == len(keyset)
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("chunk_size", [1, 2, 3])
+@pytest.mark.parametrize("roles", [(Role.USER,), (Role.USER, Role.ASSISTANT)])
+async def test_keyset_with_role_filter(
+    tmp_path: object, scenario: str, chunk_size: int, roles: MessageRoleFilter
+) -> None:
+    rows = _SCENARIOS[scenario]
+    db_path = _make_db(tmp_path, rows)
+    role_values = message_role_sql_values(roles)
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        keyset = [m.message_id async for m in iter_messages(conn, CONV, chunk_size=chunk_size, message_roles=roles)]
+        reference = await _reference_offset_walk(conn, CONV, chunk_size, role_values, None)
+    assert keyset == reference
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("chunk_size", [1, 2, 3])
+@pytest.mark.parametrize("limit", [0, 1, 2, 3, 4, 100])
+async def test_keyset_with_limit(tmp_path: object, scenario: str, chunk_size: int, limit: int) -> None:
+    rows = _SCENARIOS[scenario]
+    db_path = _make_db(tmp_path, rows)
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        keyset = [m.message_id async for m in iter_messages(conn, CONV, chunk_size=chunk_size, limit=limit)]
+        reference = await _reference_offset_walk(conn, CONV, chunk_size, [], limit)
+    assert keyset == reference
+    assert len(keyset) <= limit
+
+
+async def test_keyset_empty_conversation(tmp_path: object) -> None:
+    db_path = _make_db(tmp_path, _SCENARIOS["single"])
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        assert [m.message_id async for m in iter_messages(conn, "missing", chunk_size=2)] == []
+
+
+async def test_keyset_isolates_conversations(tmp_path: object) -> None:
+    """The keyset cursor must not bleed rows from a sibling conversation."""
+    db_path = str(tmp_path) + "/iso.db"
+    sync_conn = sqlite3.connect(db_path)
+    sync_conn.row_factory = sqlite3.Row
+    _ensure_schema(sync_conn)
+    for cid, rows in (
+        ("convA", [("a1", 1.0, "user"), ("a2", None, "user"), ("a3", 2.0, "user")]),
+        ("convB", [("b1", 1.0, "user"), ("b2", None, "user")]),
+    ):
+        sync_conn.execute(
+            """
+            INSERT INTO conversations (
+                conversation_id, provider_conversation_id, source_name, title, version
+            ) VALUES (?, 'p', 'codex', 't', 1)
+            """,
+            (cid,),
+        )
+        sync_conn.executemany(
+            "INSERT INTO messages (message_id, conversation_id, role, sort_key, version) VALUES (?, ?, ?, ?, 1)",
+            [(mid, cid, role, sk) for mid, sk, role in rows],
+        )
+    sync_conn.commit()
+    sync_conn.close()
+
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        got = [m.message_id async for m in iter_messages(conn, "convA", chunk_size=2)]
+        canonical = [m.message_id for m in await get_messages(conn, "convA")]
+    assert got == canonical
+    assert set(got) == {"a1", "a2", "a3"}
+
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary

Two latent O(M²) / wasted-work hazards: `iter_messages` used `LIMIT/OFFSET` chunking that re-scanned all prior rows on each chunk, and `_raw_conversation_hashes` sorted the full `raw_conversations` table on an unindexed column before immediately consuming the result as an unordered set.

## Problem

1. `iter_messages` (chunk_size=100 default): fetching chunk N required a full scan + discard of rows 0..N-1. A 10,000-message conversation took O(M²/chunk_size) total work — ~500,000 row reads instead of 10,000.
2. `_raw_conversation_hashes`: `ORDER BY acquired_at DESC, raw_id` on a column with no index forced a full table sort. The sorted result was immediately converted to a set — the sort was pure overhead on every GC scan.

## Solution

1. **Keyset pagination**: `iter_messages` now seeds each chunk from the previous chunk's last `(sort_key, message_id)`. The ordering `(sort_key IS NULL), sort_key, message_id` is unchanged and served by `idx_messages_conversation_sortkey`. NULL-sort_key rows (ordering tail) advance via a distinct cursor branch so the total order is maintained across chunk boundaries with no skips or duplicates.
2. **Drop wasted ORDER BY**: `_raw_conversation_hashes` removes the `ORDER BY` since the caller consumes the result as a set.

## Verification

```
devtools verify --quick   # exit 0
pytest tests/unit/storage/test_iter_messages_keyset.py \
       tests/unit/storage/test_blob_integrity_referenced_scan.py -q
# keyset test covers all chunk sizes 1..100, all scenario shapes
# (non-null, duplicate sort keys, null tail, all-null, boundary transitions)
```

Closes #1750