### PR TITLE
fix: hermes message_count off-by-one, dead tool_result comparison, duplicate DDL (#1751, #1752, #1753)

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -2578,6 +2578,10 @@ files:
     loc: 71
     target: polylogue/sources/live/conversation_convergence.py
     owner: stable
+  - path: polylogue/sources/live/_lag_sample_ddl.py
+    loc: 27
+    target: polylogue/sources/live/_lag_sample_ddl.py
+    owner: stable
   - path: polylogue/sources/live/cursor.py
     loc: 1171
     target: polylogue/sources/live/cursor.py

--- a/polylogue/daemon/cursor_lag_baseline.py
+++ b/polylogue/daemon/cursor_lag_baseline.py
@@ -46,28 +46,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from polylogue.daemon.cursor_lag_status import CursorLagItem, CursorLagSummary
+from polylogue.sources.live._lag_sample_ddl import _LAG_SAMPLE_DDL, _LAG_SAMPLE_INDEX_DDL
 from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
-
-# The substrate table. Created in two places (idempotent ``IF NOT EXISTS``):
-# the dedicated ensure helper here for tests + lazy first-use, and the daemon
-# :class:`~polylogue.sources.live.cursor.CursorStore` on startup so the
-# periodic health loop always finds the table ready.
-_LAG_SAMPLE_DDL = """
-CREATE TABLE IF NOT EXISTS live_cursor_lag_sample (
-    sample_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    family TEXT NOT NULL,
-    observed_at TEXT NOT NULL,
-    max_lag_s REAL NOT NULL,
-    stuck_file_count INTEGER NOT NULL,
-    p50_lag_s REAL NOT NULL,
-    p95_lag_s REAL NOT NULL
-)
-"""
-
-_LAG_SAMPLE_INDEX_DDL = """
-CREATE INDEX IF NOT EXISTS idx_lag_sample_family_time
-ON live_cursor_lag_sample(family, observed_at DESC)
-"""
 
 
 def ensure_lag_sample_table(conn: sqlite3.Connection) -> None:

--- a/polylogue/sources/live/_lag_sample_ddl.py
+++ b/polylogue/sources/live/_lag_sample_ddl.py
@@ -1,0 +1,29 @@
+"""Shared DDL for ``live_cursor_lag_sample`` (#1753).
+
+Both :mod:`polylogue.sources.live.cursor` (creates the table on daemon startup)
+and :mod:`polylogue.daemon.cursor_lag_baseline` (owns the substrate reads/writes)
+need this DDL.  A direct cross-import between those modules creates a circular
+dependency through ``daemon/__init__``, so the schema fragment lives here in a
+leaf module with no intra-package imports.
+"""
+
+from __future__ import annotations
+
+_LAG_SAMPLE_DDL = """
+CREATE TABLE IF NOT EXISTS live_cursor_lag_sample (
+    sample_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    family TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    max_lag_s REAL NOT NULL,
+    stuck_file_count INTEGER NOT NULL,
+    p50_lag_s REAL NOT NULL,
+    p95_lag_s REAL NOT NULL
+)
+"""
+
+_LAG_SAMPLE_INDEX_DDL = """
+CREATE INDEX IF NOT EXISTS idx_lag_sample_family_time
+ON live_cursor_lag_sample(family, observed_at DESC)
+"""
+
+__all__ = ["_LAG_SAMPLE_DDL", "_LAG_SAMPLE_INDEX_DDL"]

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
+from polylogue.sources.live._lag_sample_ddl import _LAG_SAMPLE_DDL, _LAG_SAMPLE_INDEX_DDL
 from polylogue.sources.live.convergence_debt_store import (
     clear_convergence_debt_except_sync,
     record_convergence_debt_sync,
@@ -142,26 +143,9 @@ CREATE TABLE IF NOT EXISTS live_convergence_debt (
 )
 """
 
-# Per-source-family cursor-lag sample history (#1349). The table feeds the
-# anomaly-band rolling baseline computed by
-# :mod:`polylogue.daemon.cursor_lag_baseline`. Daemon-runtime state, not
-# part of SCHEMA_VERSION — same lifecycle as live_cursor / live_convergence_debt.
-_LAG_SAMPLE_DDL = """
-CREATE TABLE IF NOT EXISTS live_cursor_lag_sample (
-    sample_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    family TEXT NOT NULL,
-    observed_at TEXT NOT NULL,
-    max_lag_s REAL NOT NULL,
-    stuck_file_count INTEGER NOT NULL,
-    p50_lag_s REAL NOT NULL,
-    p95_lag_s REAL NOT NULL
-)
-"""
-
-_LAG_SAMPLE_INDEX_DDL = """
-CREATE INDEX IF NOT EXISTS idx_lag_sample_family_time
-ON live_cursor_lag_sample(family, observed_at DESC)
-"""
+# Per-source-family cursor-lag sample history (#1349). Daemon-runtime state,
+# not part of SCHEMA_VERSION — same lifecycle as live_cursor / live_convergence_debt.
+# DDL is shared with cursor_lag_baseline via polylogue.sources.live._lag_sample_ddl.
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/sources/parsers/local_agent.py
+++ b/polylogue/sources/parsers/local_agent.py
@@ -71,7 +71,7 @@ def parse_hermes(payload: JSONDocument, fallback_id: str) -> ParsedConversation:
     )
     provider_meta = _conversation_meta(
         payload,
-        keys=("model", "base_url", "platform", "tools", "message_count"),
+        keys=("model", "base_url", "platform", "tools"),
         source_family="hermes",
     )
     return ParsedConversation(

--- a/polylogue/storage/search_providers/sqlite_vec_embeddings.py
+++ b/polylogue/storage/search_providers/sqlite_vec_embeddings.py
@@ -87,7 +87,7 @@ class SqliteVecEmbeddingMixin:
             return False
         if msg.role == "system":
             return False
-        if msg.role == "tool_result":
+        if msg.role == "tool":
             text = msg.text.strip().lower()
             if text in ("ok", "success", "done", "error", "failed"):
                 return False


### PR DESCRIPTION
## Summary

Three small correctness fixes bundled as one PR: a stale field in Hermes provider_meta, a dead role comparison in the embedding filter, and a duplicated table schema.

## Problem

**#1751** — `local_agent.py` stored `message_count` in Hermes `provider_meta` by reading it from the raw JSON payload (the Hermes exporter's own count). The parser appends an extra system message that the exporter did not count, so the stored value was consistently 1 less than the authoritative `conversation_stats.message_count`. The field is not used by any query — `conversation_stats` is the authoritative source.

**#1752** — `sqlite_vec_embeddings.py:90` compared `msg.role == "tool_result"` to skip trivial tool responses from embedding. `msg.role` is normalized to `"tool"` (Role.TOOL) during parsing; the raw provider string `"tool_result"` never reaches this layer. The guard never fired, causing trivial responses ("ok", "done") to be embedded.

**#1753** — `live_cursor_lag_sample` DDL was defined identically in `sources/live/cursor.py` and `daemon/cursor_lag_baseline.py`. A direct cross-import between those modules creates a cycle through `daemon/__init__`, so the DDL is extracted to `sources/live/_lag_sample_ddl.py` (a leaf module with no intra-package imports) and imported from both.

## Solution

- Drop `message_count` from `local_agent.py`'s `_conversation_meta` keys.
- Change `msg.role == "tool_result"` → `msg.role == "tool"` in `sqlite_vec_embeddings.py`.
- Extract DDL to `_lag_sample_ddl.py`; both consumers import from it.

## Verification

```
devtools verify --quick   # exit 0
python3 -c "from polylogue.sources.live.cursor import CursorStore; from polylogue.daemon.cursor_lag_baseline import ensure_lag_sample_table; print('ok')"
```

Closes #1751
Closes #1752
Closes #1753