### PR TITLE
fix(devtools): fill #1737 gaps — PyYAML parsers, stale spine docs

### DIFF
--- a/devtools/verify_slos.py
+++ b/devtools/verify_slos.py
@@ -30,49 +30,16 @@ DEFAULT_TIER = "cheap-local"
 
 
 # ---------------------------------------------------------------------------
-# YAML parsing (tiny, no PyYAML dependency)
+# YAML parsing
 # ---------------------------------------------------------------------------
 
 
 def _parse_slo_catalog(text: str) -> dict[str, dict[str, object]]:
     """Parse the SLO catalog YAML and return a surface → config dict."""
-    surfaces: dict[str, dict[str, object]] = {}
-    current_surface: str | None = None
-    current_config: dict[str, object] | None = None
+    import yaml
 
-    for raw_line in text.splitlines():
-        line = raw_line.rstrip()
-        if not line or line.lstrip().startswith("#"):
-            continue
-        stripped = line.lstrip()
-        indent = len(line) - len(stripped)
-
-        if indent == 0 and stripped.endswith(":"):
-            # Top-level key (e.g. "surfaces:")
-            pass
-        elif indent == 2 and not stripped.startswith("-") and stripped.endswith(":"):
-            # Surface name (e.g. "  query:")
-            current_surface = stripped.rstrip(":")
-            current_config = {}
-            surfaces[current_surface] = current_config
-        elif indent == 4 and current_config is not None and ": " in stripped:
-            key, _, value = stripped.partition(": ")
-            current_config[key] = _coerce_slo_value(value.strip())
-        elif indent == 4 and current_config is not None and stripped.endswith(":"):
-            # Start of a nested block — skip for now
-            pass
-
-    return surfaces
-
-
-def _coerce_slo_value(value: str) -> str | int:
-    """Coerce a YAML scalar to str or int."""
-    if value.startswith('"') and value.endswith('"'):
-        return value[1:-1]
-    try:
-        return int(value)
-    except ValueError:
-        return value
+    data = yaml.safe_load(text)
+    return {k: dict(v) for k, v in data["surfaces"].items()}
 
 
 # ---------------------------------------------------------------------------

--- a/devtools/verify_topology.py
+++ b/devtools/verify_topology.py
@@ -23,6 +23,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from devtools import repo_root as _get_root
 
 ROOT = _get_root()
@@ -32,53 +34,8 @@ KERNEL_OWNERS = frozenset({"kernel", "storage-root", "stable"})
 
 
 def parse_yaml(text: str) -> list[dict[str, Any]]:
-    """Tiny YAML parser for our flat list-of-records shape.
-
-    Avoids a PyYAML dep so this can run in any environment. Format is fixed
-    by `build_projection.py`.
-    """
-    rows: list[dict[str, Any]] = []
-    current: dict[str, Any] | None = None
-    for raw in text.splitlines():
-        line = raw.rstrip()
-        if not line or line.lstrip().startswith("#"):
-            continue
-        if line == "files:":
-            continue
-        if line.startswith("  - path: "):
-            if current is not None:
-                rows.append(current)
-            current = {"path": line[len("  - path: ") :].strip(), "cross_cut": {}}
-            continue
-        if current is None:
-            continue
-        stripped = line.lstrip()
-        indent = len(line) - len(stripped)
-        if indent != 4:
-            continue
-        if ": " in stripped:
-            key, _, value = stripped.partition(": ")
-            value = value.strip()
-            if value.startswith('"') and value.endswith('"'):
-                value = value[1:-1].replace('\\"', '"')
-            if key == "loc":
-                try:
-                    current[key] = int(value)
-                except ValueError:
-                    current[key] = 0
-            elif key == "cross_cut":
-                inner = value.strip("{ }")
-                tags = {}
-                if inner:
-                    for pair in inner.split(", "):
-                        k, _, v = pair.partition(": ")
-                        tags[k.strip()] = v.strip()
-                current[key] = tags
-            else:
-                current[key] = value
-    if current is not None:
-        rows.append(current)
-    return rows
+    data: dict[str, list[dict[str, Any]]] = yaml.safe_load(text)
+    return data["files"]
 
 
 def walk_tree() -> set[str]:

--- a/docs/architecture-spine.md
+++ b/docs/architecture-spine.md
@@ -11,7 +11,7 @@ with the implementation; this document records the *why* and the *rules*.
 | **Archive Substrate** | Owns stored meaning: acquisition, parsing, persistence, query | `sources/`, `pipeline/`, `storage/`, `archive/`, `operations/` |
 | **Derived Read Models** | Stored insights computed over the archive | `insights/`, `storage/insights/session/` |
 | **Surfaces** | Expose the archive to users and machines | `cli/`, `mcp/`, `api/`, `rendering/`, `ui/`, `daemon/` |
-| **Verification** | Schema, showcase, devtools, tests | `schemas/`, `showcase/`, `proof/`, `devtools/`, `tests/` |
+| **Verification** | Schema, showcase, devtools, tests | `schemas/`, `showcase/`, `devtools/`, `tests/` |
 
 **Rules:**
 - New semantics go into substrate or insights first, then surfaces adapt.
@@ -26,11 +26,7 @@ Every `docs/plans/*.yaml` manifest is enforced by a lint in `devtools verify`.
 |----------|------|-----------------|
 | `layering.yaml` | `verify-layering` | Surface-to-substrate coupling |
 | `topology-target.yaml` | `verify-topology` | Orphaned/unclassified modules |
-| `file-size-budgets.yaml` | `verify-file-budgets` | Unbounded file growth |
-| `test-ownership.yaml` | `verify-test-ownership` | Untested production modules |
-| `suppressions.yaml` | `verify-suppressions` | Stale suppressions |
 | `campaign-coverage.yaml` | `verify-manifests` | Missing campaign declarations |
-| `migrations.yaml` | `verify-migrations` | Incomplete migration records |
 | `coverage-manifest.yaml` | `verify-manifests` | Stale gap/coverage declarations |
 
 ## Major Decisions

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import pytest
 
@@ -826,7 +826,7 @@ def _branch_node(
     parent: str | None = None,
     children: list[str] | None = None,
     content_type: str = "text",
-) -> dict:
+) -> dict[str, Any]:
     """Mapping node helper that does not force a create_time (graph order is truth)."""
     return {
         "id": msg_id,


### PR DESCRIPTION
## Summary

The original #1737 commit (78d99387) deleted the proof catalog and all ceremonial verification infrastructure. Two items from the issue scope were left open: the hand-rolled YAML parsers and four stale rows in `docs/architecture-spine.md`.

## Problem

**Hand-rolled YAML parsers** — `verify_topology.py` contained a bespoke `parse_yaml()` that claimed to avoid a PyYAML dependency, but PyYAML is already used in five other devtools lints. The parser silently mishandled YAML inline flow maps (`cross_cut: { api: async }`) via string splitting. `verify_slos.py` had the same pattern with `_parse_slo_catalog()` / `_coerce_slo_value()`.

**Stale architecture-spine.md** — The Guardrails table still listed four deleted manifest/lint pairs (`verify-file-budgets`, `verify-test-ownership`, `verify-suppressions`, `verify-migrations`) and the Verification ring still referenced `proof/` — deleted in the original commit.

**Pre-existing mypy error** — `_branch_node()` in `test_parsers_chatgpt.py` (added by PR #1755) had a bare `dict` return type; tightened to `dict[str, Any]` to resolve a type error introduced when the function is used in mixed-type node lists.

## Solution

- `verify_topology.py:parse_yaml()` → `yaml.safe_load(text)["files"]` (4 lines vs 47).
- `verify_slos.py:_parse_slo_catalog()` → `yaml.safe_load(text)["surfaces"]` (3 lines vs 30; `_coerce_slo_value` deleted).
- `docs/architecture-spine.md`: remove 4 stale table rows, remove `proof/` from ring listing.
- `tests/unit/sources/test_parsers_chatgpt.py`: `_branch_node() -> dict[str, Any]`.

## Verification

```
devtools verify --quick   # exit 0
python3 devtools/verify_topology.py   # realized=855 declared=855 blocking=False
```

Closes #1737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated YAML parsing in developer verification tools to use standard PyYAML library instead of custom line-based parsers.
* **Documentation**
  * Updated architecture documentation to include new Verification module under the Surfaces ecosystem and clarify manifest enforcement details.
* **Tests**
  * Enhanced test code with improved type annotations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->