### PR TITLE
ci: restore push/pull_request triggers accidentally removed by #718

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,11 @@ name: actionlint
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@ name: CI
 
 on:
   workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -2,6 +2,20 @@ name: Dependency Audit
 
 on:
   workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/dep-audit.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/dep-audit.yml"
+  schedule:
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,15 @@ name: Nix
 
 on:
   workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Restores the `push` / `pull_request` CI triggers that were **accidentally removed** by #718, re-enabling automatic test/lint/nix gating on `master` and PRs.

## Problem

#718 (`refactor(cli): remove foreground resource policy`) — a PR whose scope was entirely CLI resource policy, with **no mention of CI** — silently reverted the trigger blocks on four workflows, leaving each with only `workflow_dispatch:` (manual-only):

| Workflow | Before #718 | After #718 |
|----------|-------------|------------|
| `ci.yml` (lint + test ×3 Python) | push + pull_request | **dispatch only** |
| `nix.yml` (nix build + flake check) | push + pull_request | **dispatch only** |
| `actionlint.yml` | pull_request | **dispatch only** |
| `dep-audit.yml` | push + pull_request + weekly schedule | **dispatch only** |

Consequence: the CI test gate has not run automatically since **2026-05-02** (the last `ci.yml`/`nix.yml` runs are on `9029a37a`). Across the ~20 commits merged since, **~61 unit-test failures accumulated undetected** — see #1765. This is the root cause of the test debt.

(`pr-policy.yml` and `proof-comment.yml` were also gutted by #718, but those stay deleted — that was the intentional ceremonial-verification cleanup in #1737, not collateral. `codeql.yml` retains a working trigger and is unaffected.)

## Solution

Restore the exact pre-#718 `on:` blocks (verified against `git show 8b2b0fae~1:.github/workflows/<f>.yml`):
- `ci.yml` / `nix.yml`: `push: [master]` + `pull_request: [master]` (opened/reopened/synchronize/ready_for_review)
- `actionlint.yml`: `pull_request: [master]` (paths: `.github/workflows/**`, `.github/actions/**`)
- `dep-audit.yml`: push/pull_request (paths: `pyproject.toml`, `uv.lock`, the workflow) + weekly `cron: 0 6 * * 1`

## Verification

```
python3 -c "import yaml; ..."  # all four on: blocks parse with push/pull_request restored
```

## ⚠️ Expected: re-enabling CI surfaces the pre-existing failures

Once merged, `ci.yml` will run on `master` and PRs and will be **red** until the inherited test failures are cleared. That is the intended signal, not a regression introduced here. The known failures are partly fixed in **#1765** (collection error, keyset, config, stale tests) and partly still open (a handful of real-bug candidates triaged in #1765's body). Recommended order: merge #1765, work the remaining real failures, then this fix's CI will go green. Merging this first is also fine — it just makes the existing red state visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow triggers to automatically run validation checks on pull requests and commits targeting the master branch, improving consistency of continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->