### PR TITLE
fix(sources): parse JSON from non-seekable zip-entry streams

### DIFF
--- a/polylogue/sources/decoder_json.py
+++ b/polylogue/sources/decoder_json.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import re
 from collections.abc import Iterable
@@ -253,6 +254,13 @@ def iter_json_stream_with(
     if path_name.lower().endswith((".jsonl", ".jsonl.txt", ".ndjson")):
         yield from _iter_jsonl_stream(logger_obj, handle, path_name)
         return
+
+    # The ijson multi-strategy parse below rewinds via ``handle.seek(0)``. A
+    # ZIP-entry stream (zipfile.ZipExtFile) is not seekable, so materialize it
+    # into a seekable buffer once before the seeking strategies run.
+    seekable = getattr(handle, "seekable", None)
+    if callable(seekable) and not seekable():
+        handle = io.BytesIO(handle.read())
 
     if unpack_lists:
         found_any, records = _stream_prefixed_items(


### PR DESCRIPTION
## Problem

Every JSON conversation export packaged inside a `.zip` (ChatGPT/Claude web exports) silently failed to ingest with `File or stream is not seekable` and was skipped.

`process_zip` opens each entry via `zipfile.ZipExtFile` (non-seekable). For individual-JSON entries the path is `emit → _emit_individual → _iter_json_stream → iter_json_stream_with`, which rewinds with `handle.seek(0)` between its ijson multi-strategy attempts. A zip entry can't seek, so the parse raised and the file was dropped at the acquisition boundary. (`_emit_grouped` already materialized to `BytesIO`; the individual path did not.)

This is a real ingestion regression for zipped exports — surfaced once the suite could collect again (#1765) and confirmed by tracing the swallowed exception at `source_parsing.py:163`.

## Solution

In `iter_json_stream_with`, before the seeking strategies, materialize a non-seekable handle into a `BytesIO` once (the function inherently requires seeking; bounded zip entries are safe to read fully). Added the missing `import io`.

## Verification

```
pytest tests/unit/sources/test_source_laws.py tests/unit/sources/test_acquisition_encoding.py  # 123 passed (was 5 failing)
```
Fixes the zip round-trip, raw-capture, multi-conversation-zip, BOM-in-zip, and partial-corruption cases.