### PR TITLE
fix(cli)+test: blackboard -l alias, stale exercise/config pins

### DIFF
--- a/polylogue/cli/commands/blackboard.py
+++ b/polylogue/cli/commands/blackboard.py
@@ -78,7 +78,7 @@ def blackboard_post(
 )
 @click.option("--scope-repo", "-r")
 @click.option("--unresolved", is_flag=True, help="Only show unresolved notes (blockers, questions).")
-@click.option("--limit", "-n", type=int, default=20)
+@click.option("--limit", "-l", type=int, default=20)
 @click.pass_obj
 def blackboard_list(
     env: AppEnv,

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -563,7 +563,11 @@ class TestPolylogueConfigFormatTOML:
 
         cfg = load_polylogue_config(cli_overrides={"source_roots": ("/a", "/b")})
         formatted = format_config_toml(cfg.raw)
-        assert 'roots = ["/a", "/b"]' in formatted
+        # The TOML serializer renders arrays multi-line; assert the array shape
+        # and both members rather than a single-line spelling.
+        assert "roots = [" in formatted
+        assert '"/a"' in formatted
+        assert '"/b"' in formatted
 
 
 class TestPolylogueConfigLayerPrecedence:

--- a/tests/unit/showcase/test_exercise_catalog.py
+++ b/tests/unit/showcase/test_exercise_catalog.py
@@ -69,7 +69,6 @@ class TestExercisesByGroup:
         observed = {command_path.display_name for command_path in inventory_command_paths()}
         assert {
             "diagnostics turns",
-            "insights analytics",
             "schema explain",
         } <= observed
 


### PR DESCRIPTION
## Summary

Three more inherited-failure fixes (continuing #1765/#1767/#1768).

## Changes

- **`blackboard list --limit`**: used `-n`, violating the repo-wide `-l/--limit` convention enforced by `test_flag_aliases_consistent`. Aligned to `-l` (small CLI fix).
- **`exercise_catalog`**: dropped the `insights analytics` nested path from the pin — that command path no longer exists.
- **`config source_roots`**: the TOML serializer now renders arrays multi-line (`roots = [\n "/a",\n "/b",\n]`); the test pinned the old single-line spelling. Assert the array shape + members robustly. (Confirmed the cli-override is correctly applied — it was purely a formatting-style drift.)

## Verification

```
pytest <theme_aliases, exercise_catalog, config source_roots, help/terminal snapshots>  # all pass
```

## Deferred (intentionally not touched)

The remaining inherited failures cluster on the **in-flux `provider`/`source_name` vocabulary** (#1743 is actively redesigning this) and a product decision — editing them blind risks encoding the wrong interpretation:
- `resilience` (4), `ingestion_chaos`, `parsing_service`, `pipeline_probe` (2), `parsers_local_agent` — all turn on parsed `source_name` being the source-config name (`'test'`) vs the detected origin (`'claude-code'`/`'codex'`). Likely a real regression in the origin-vs-source conflation, but it belongs to the #1743 redesign or an explicit operator call.
- `ASSURANCE_REGISTRY` — the 6 new commands need declared output contracts (#1272), a per-command product decision.