### PR TITLE
test: clear remaining inherited failures — suite is green single-process

### DIFF
--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -16,7 +16,7 @@
     "repos": {},
     "cwd_prefixes": {},
     "message_types": {
-      "message": 10
+      "message": 6
     },
     "action_types": {},
     "has_flags": {
@@ -26,7 +26,7 @@
     },
     "time_range": null,
     "total_conversations": 2,
-    "total_messages": 10,
+    "total_messages": 6,
     "scoped": {
       "providers": {
         "chatgpt": 2
@@ -34,7 +34,7 @@
       "tags": {},
       "repos": {},
       "message_types": {
-        "message": 10
+        "message": 6
       },
       "action_types": {},
       "has_flags": {
@@ -43,7 +43,7 @@
         "has_paste": 0
       },
       "total_conversations": 2,
-      "total_messages": 10
+      "total_messages": 6
     },
     "global": {
       "providers": {
@@ -52,7 +52,7 @@
       "tags": {},
       "repos": {},
       "message_types": {
-        "message": 10
+        "message": 6
       },
       "action_types": {},
       "has_flags": {
@@ -61,7 +61,7 @@
         "has_paste": 0
       },
       "total_conversations": 2,
-      "total_messages": 10
+      "total_messages": 6
     },
     "idf": {
       "providers": {
@@ -107,8 +107,8 @@
         "created_at": "<TIMESTAMP>",
         "updated_at": "<TIMESTAMP>",
         "date": "<TIMESTAMP>",
-        "message_count": 5,
-        "messages": 5,
+        "message_count": 3,
+        "messages": 3,
         "tags": []
       },
       {
@@ -139,8 +139,8 @@
         "created_at": "<TIMESTAMP>",
         "updated_at": "<TIMESTAMP>",
         "date": "<TIMESTAMP>",
-        "message_count": 5,
-        "messages": 5,
+        "message_count": 3,
+        "messages": 3,
         "tags": []
       }
     ],
@@ -159,10 +159,10 @@
     "rows": [],
     "summary": {
       "conversations": 2,
-      "messages_total": 10,
-      "messages_user": 6,
-      "messages_assistant": 4,
-      "words_approx": 254,
+      "messages_total": 6,
+      "messages_user": 4,
+      "messages_assistant": 2,
+      "words_approx": 181,
       "attachment_refs": 0,
       "distinct_attachments": 0,
       "providers": {
@@ -201,7 +201,7 @@
       "next_action": "polylogue init"
     },
     "conversations": 2,
-    "messages": 10,
+    "messages": 6,
     "raw_records": 2
   }
   
@@ -215,15 +215,15 @@
 # ---
 # name: test_plain_list_provider_filter_snapshot
   '''
-  chatgpt:402913ec-9ef2-49  <TIMESTAMP>  chatgpt       corpus-01 (5 msgs)
-  chatgpt:8a476a87-e49d-48  <TIMESTAMP>  chatgpt       corpus-00 (5 msgs)
+  chatgpt:402913ec-9ef2-49  <TIMESTAMP>  chatgpt       corpus-01 (3 msgs)
+  chatgpt:8a476a87-e49d-48  <TIMESTAMP>  chatgpt       corpus-00 (3 msgs)
   
   '''
 # ---
 # name: test_plain_list_snapshot
   '''
-  chatgpt:402913ec-9ef2-49  <TIMESTAMP>  chatgpt       corpus-01 (5 msgs)
-  chatgpt:8a476a87-e49d-48  <TIMESTAMP>  chatgpt       corpus-00 (5 msgs)
+  chatgpt:402913ec-9ef2-49  <TIMESTAMP>  chatgpt       corpus-01 (3 msgs)
+  chatgpt:8a476a87-e49d-48  <TIMESTAMP>  chatgpt       corpus-00 (3 msgs)
   
   '''
 # ---
@@ -232,8 +232,8 @@
   
   Conversations: 2
   
-  Messages: 10 total (6 user, 4 assistant)
-  Words: ~254
+  Messages: 6 total (4 user, 2 assistant)
+  Words: ~181
   Providers: chatgpt (2)
   Attachment refs: 0
   Unique attachments: 0

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -1331,7 +1331,7 @@ def test_async_execute_query_summary_list_uses_evidence_hits_for_search_contract
 
     repo.search_summary_hits.assert_awaited_once_with("needle", limit=5, providers=None, since=None)
     filter_chain.list_summaries.assert_not_called()
-    mock_output_search_hits.assert_awaited_once_with(env, [hit], plan.output, repo, cursor=None)
+    mock_output_search_hits.assert_awaited_once_with(env, [hit], plan.output, repo, total=None, cursor=None)
     mock_output_summary_list.assert_not_called()
 
 

--- a/tests/unit/site/test_renderer_behavior.py
+++ b/tests/unit/site/test_renderer_behavior.py
@@ -309,7 +309,7 @@ site_url = "/polylogue/"
 [[pages]]
 path = "/architecture/contributing/"
 title = "Contributing"
-template = "standard.html"
+template = "doc.html"
 [pages.data]
 source_command = "render-cli-reference"
 custom_marker = "frontmatter-roundtrip-ok"
@@ -331,7 +331,7 @@ custom_marker = "frontmatter-roundtrip-ok"
     real_render = Template.render
 
     def _spy(self: Template, *args: object, **kwargs: object) -> str:
-        if self.name == "standard.html":
+        if self.name == "doc.html":
             captured.update(kwargs)
         return real_render(self, *args, **kwargs)
 

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -583,10 +583,15 @@ async def test_async_read_connection_closes_cleanly_after_pool_teardown(tmp_path
     await slow_backend.close()
 
 
-async def test_async_backend_connection_error_surfaces() -> None:
+async def test_async_backend_connection_error_surfaces(tmp_path: Path) -> None:
     """Invalid targets must surface an error instead of silently succeeding."""
+    # A missing DB reads as empty (None) by design; an *existing* file that is
+    # not a valid SQLite database is a genuine invalid target and must surface an
+    # error rather than silently returning None.
+    bogus = tmp_path / "not-a-database.sqlite"
+    bogus.write_bytes(b"this is plainly not a sqlite database header\n" * 64)
     with pytest.raises((OSError, PermissionError, Exception)):
-        backend = SQLiteBackend(db_path=Path("/nonexistent/deeply/nested/path/db.db"))
+        backend = SQLiteBackend(db_path=bogus)
         await backend.get_conversation("test")
 
 

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -479,11 +479,16 @@ async def test_action_events_are_derived_and_replaced_on_content_change(
         ),
     )
     db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
-    repository = repository_for_scenario_db(db_path)
-    try:
-        with open_connection(db_path) as conn:
-            conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
+    with open_connection(db_path) as conn:
+        conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
 
+    # seed_workspace_scenarios already persisted the scenario into db_path, so
+    # exercise save_conversation against a FRESH archive: a genuine first write
+    # (which derives action events), not an idempotent re-save of seeded rows.
+    fresh_db = workspace_env["data_root"] / "polylogue" / "lifecycle-fresh.db"
+    fresh_db.parent.mkdir(parents=True, exist_ok=True)
+    repository = repository_for_scenario_db(fresh_db)
+    try:
         # First write creates action events from the tool_use content block.
         counts_init = await repository.save_conversation(conv_record, msg_records, attachment_records)
         assert counts_init["messages"] == 2, "Initial write should persist messages"


### PR DESCRIPTION
## Summary

Fixes the last 11 inherited test failures (revealed by a single-process run; the earlier `-n 16` runs hid them among xdist flakes). After this, `pytest tests/unit -n 0` is **10052 passed, 0 failed**.

## Fixes

- **plain_cli snapshots (7)**: regenerated to current counts. Verified this is NOT a message-drop — persisted count == `conversation_stats.message_count` == the parser's active-path output (three layers agree); the change is the merged #1744 ChatGPT active-path traversal fix.
- **query_exec_laws**: the mock now expects the `total=` kwarg added by #1749.
- **repository_lifecycle**: the test double-wrote (seed + save), so `save_conversation` was an idempotent re-save reporting 0; route the write to a fresh DB so it's a genuine first write.
- **backend**: a missing DB reads as `None` by design (graceful empty archive); the test now uses a genuinely-invalid target (a non-SQLite file) so error-surfacing is actually exercised.
- **renderer**: the `standard.html` template was renamed to `doc.html`.

## Verification

```
pytest tests/unit -p no:randomly -n 0  ->  10052 passed, 0 failed (7m26s)
```