### PR TITLE
fix(devtools): close leaked read connection in archive-space-report

### DIFF
--- a/devtools/archive_space_report.py
+++ b/devtools/archive_space_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import Any, cast
 
@@ -106,7 +107,7 @@ def build_space_report(db: Path, *, limit: int = 25, include_objects: bool = Fal
             "db_path": str(db),
             "error": "database_not_found",
         }
-    with open_readonly_connection(db) as conn:
+    with closing(open_readonly_connection(db)) as conn:
         page_size = _scalar_int(conn, "PRAGMA page_size")
         page_count = _scalar_int(conn, "PRAGMA page_count")
         freelist_count = _scalar_int(conn, "PRAGMA freelist_count")


### PR DESCRIPTION
## Summary

Closes the last ResourceWarning leak after #1772: `devtools archive-space-report`
leaked one read connection per invocation. Full unit suite is now **0**
unclosed-database ResourceWarnings (was 3).

## Problem

`build_space_report` opened its read connection with
`with open_readonly_connection(db) as conn:`. That context-manager form only
**commits** on exit — it never **closes** the raw connection
`connection_profile.open_readonly_connection` returns (the same footgun #1772
fixed across `polylogue/`).

This was the real source of the "3 residual" warnings #1772 deferred to #1773.
They were **not** benign aiosqlite fixture artifacts — the tracemalloc filter
used in that investigation excluded `devtools/` frames, masking the real sync
leak site. The discriminating test fixture added in #1772 correctly classified
it as a production (non-test) leak and kept warning about it.

## Solution

Wrap the opener in `contextlib.closing`, matching every other raw-connection
site fixed in #1772.

## Verification

- `pytest tests/unit -n 0 -W default`: **10052 passed, 0 failed, 0**
  unclosed-database ResourceWarnings (was 3).
- `pytest tests/unit/devtools/test_archive_space_report.py`: 0 warnings (was 3),
  stable across reruns.
- `devtools verify --quick`: green.

Closes #1773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database resource management in the archive space reporting utility to ensure proper cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->