### PR TITLE
feat(devtools): add `devtools test` focused runner so agents avoid raw pytest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,12 +377,18 @@ devtools verify
 # pytest-testmon's dependency database
 devtools verify --seed-testmon --skip-slow
 
-# Stop on first failure
-pytest -x --ignore=tests/integration
+# Focused inner-loop runs — prefer `devtools test` over raw pytest. It runs the
+# selection through the managed harness (repo env, single-process by default,
+# live output) and serializes overlapping runs from the same checkout so two
+# suites do not race. Any pytest arguments go after the command name.
+devtools test tests/unit/storage/test_hybrid_laws.py
+devtools test -k "test_name"
+devtools test tests/unit/pipeline -x
+POLYLOGUE_PYTEST_WORKERS=8 devtools test tests/unit/storage   # override workers
 
-# Specific file or test
+# Raw pytest still works for ad-hoc needs the wrapper does not cover:
+pytest -x --ignore=tests/integration
 pytest tests/unit/storage/test_hybrid_laws.py
-pytest -k "test_name"
 
 # Explicit full non-integration pytest diagnostic
 devtools verify --all
@@ -1437,6 +1443,8 @@ These are the commands worth remembering during normal repo work:
   Common forms: `devtools render-all`, `devtools render-all --check`.
 - `devtools verify`: Run format, lint, mypy, render-all, and test checks locally before pushing.
   Common forms: `devtools verify`, `devtools verify --quick`, `devtools verify --lab`.
+- `devtools test`: Run a specific test file, directory, or -k/-m selection in the inner loop without invoking raw pytest.
+  Common forms: `devtools test tests/unit/pipeline`, `devtools test -k hybrid`, `devtools test tests/unit/storage -x`.
 - `devtools mutmut-campaign`: Run or inspect focused mutation-testing work without shrinking the committed mutmut scope.
   Common forms: `devtools mutmut-campaign list`, `devtools mutmut-campaign run filters`.
 - `devtools benchmark-campaign`: Record durable benchmark artifacts or compare a candidate run against a baseline artifact.
@@ -1483,6 +1491,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-audit` | Run committed provider schema package quality checks. |
 | `devtools schema-generate` | Generate provider schema packages and optional evidence clusters. |
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
+| `devtools test` | Run a focused pytest selection through the managed harness. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,12 +13,18 @@ devtools verify
 # pytest-testmon's dependency database
 devtools verify --seed-testmon --skip-slow
 
-# Stop on first failure
-pytest -x --ignore=tests/integration
+# Focused inner-loop runs — prefer `devtools test` over raw pytest. It runs the
+# selection through the managed harness (repo env, single-process by default,
+# live output) and serializes overlapping runs from the same checkout so two
+# suites do not race. Any pytest arguments go after the command name.
+devtools test tests/unit/storage/test_hybrid_laws.py
+devtools test -k "test_name"
+devtools test tests/unit/pipeline -x
+POLYLOGUE_PYTEST_WORKERS=8 devtools test tests/unit/storage   # override workers
 
-# Specific file or test
+# Raw pytest still works for ad-hoc needs the wrapper does not cover:
+pytest -x --ignore=tests/integration
 pytest tests/unit/storage/test_hybrid_laws.py
-pytest -k "test_name"
 
 # Explicit full non-integration pytest diagnostic
 devtools verify --all

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -162,6 +162,19 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
+        "test",
+        "verification",
+        "Run a focused pytest selection through the managed harness.",
+        "devtools.run_tests",
+        use_when="Run a specific test file, directory, or -k/-m selection in the inner loop without invoking raw pytest.",
+        examples=(
+            "devtools test tests/unit/pipeline",
+            "devtools test -k hybrid",
+            "devtools test tests/unit/storage -x",
+        ),
+        featured=True,
+    ),
+    CommandSpec(
         "coverage-gate",
         "verification",
         "Run pytest with the repository coverage floor from pyproject.toml.",

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -1,0 +1,110 @@
+"""``devtools test`` — focused pytest runner through the managed harness.
+
+Agents and humans should never invoke raw ``pytest`` for inner-loop checks.
+This command forwards a selection (paths, ``-k``/``-m`` expressions, ``-x``,
+…) to pytest with:
+
+- the repository's managed environment (``POLYLOGUE_ROOT`` and friends, a
+  repo-local pycache prefix);
+- a single-process worker default (``-n 0``) for fast focused runs, overridable
+  with ``-n`` in the selection or ``POLYLOGUE_PYTEST_WORKERS``;
+- live, streamed output (unlike ``devtools verify``, which captures);
+- a checkout-scoped lock that serializes overlapping runs so two suites from
+  the same checkout do not race and burn CPU. Concurrency is already
+  *correctness*-safe at the conftest level (#1785, per-run tmpfs basetemp); the
+  lock is the throughput guard. Set ``POLYLOGUE_TEST_NO_LOCK=1`` to bypass it.
+
+For the full pre-PR gate use ``devtools verify``; this command is the inner
+loop, not a substitute for it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_LOCK_PATH = ROOT / ".cache" / "test-run.lock"
+
+
+def _managed_env() -> dict[str, str]:
+    """Mirror devtools.verify's subprocess environment for parity."""
+    env = os.environ.copy()
+    env["POLYLOGUE_ROOT"] = str(ROOT)
+    env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
+    env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
+    return env
+
+
+def _has_worker_flag(selection: list[str]) -> bool:
+    """True when the caller already chose an xdist worker count."""
+    return any(arg.startswith(("-n", "--numprocesses")) for arg in selection)
+
+
+def _worker_args(selection: list[str]) -> list[str]:
+    """Default focused runs to a single process; honor an explicit override."""
+    if _has_worker_flag(selection):
+        return []
+    workers = os.environ.get("POLYLOGUE_PYTEST_WORKERS", "0").strip() or "0"
+    return ["-n", workers]
+
+
+def build_pytest_cmd(selection: list[str]) -> list[str]:
+    """Compose the pytest command for a focused selection."""
+    return ["pytest", *selection, *_worker_args(selection)]
+
+
+@contextlib.contextmanager
+def _run_lock(*, enabled: bool) -> Iterator[None]:
+    """Serialize concurrent ``devtools test`` runs from the same checkout."""
+    if not enabled:
+        yield
+        return
+    _LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _LOCK_PATH.open("a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            handle.seek(0)
+            holder = handle.read().strip() or "another run"
+            sys.stderr.write(
+                f"devtools test: waiting for in-flight run ({holder}) — set POLYLOGUE_TEST_NO_LOCK=1 to skip\n"
+            )
+            sys.stderr.flush()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"pid={os.getpid()}")
+        handle.flush()
+        try:
+            yield
+        finally:
+            handle.seek(0)
+            handle.truncate()
+
+
+def main(argv: list[str] | None = None) -> int:
+    selection = list(sys.argv[1:] if argv is None else argv)
+    # The control-plane dispatch may append a bare ``--json`` machine-readable
+    # flag; it is meaningless for a streamed test run, so drop it before pytest.
+    selection = [arg for arg in selection if arg != "--json"]
+    if not selection:
+        sys.stderr.write(
+            "devtools test: give a selection, e.g.\n"
+            "  devtools test tests/unit/pipeline\n"
+            "  devtools test -k hybrid\n"
+            "  devtools test tests/unit/storage -x\n"
+            "For the full pre-PR gate use `devtools verify`.\n"
+        )
+        return 2
+
+    cmd = build_pytest_cmd(selection)
+    no_lock = os.environ.get("POLYLOGUE_TEST_NO_LOCK") == "1"
+    with _run_lock(enabled=not no_lock):
+        result = subprocess.run(cmd, cwd=str(ROOT), env=_managed_env())
+    return result.returncode

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -61,6 +61,8 @@ These are the commands worth remembering during normal repo work:
   Common forms: `devtools render-all`, `devtools render-all --check`.
 - `devtools verify`: Run format, lint, mypy, render-all, and test checks locally before pushing.
   Common forms: `devtools verify`, `devtools verify --quick`, `devtools verify --lab`.
+- `devtools test`: Run a specific test file, directory, or -k/-m selection in the inner loop without invoking raw pytest.
+  Common forms: `devtools test tests/unit/pipeline`, `devtools test -k hybrid`, `devtools test tests/unit/storage -x`.
 - `devtools mutmut-campaign`: Run or inspect focused mutation-testing work without shrinking the committed mutmut scope.
   Common forms: `devtools mutmut-campaign list`, `devtools mutmut-campaign run filters`.
 - `devtools benchmark-campaign`: Record durable benchmark artifacts or compare a candidate run against a baseline artifact.
@@ -107,6 +109,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-audit` | Run committed provider schema package quality checks. |
 | `devtools schema-generate` | Generate provider schema packages and optional evidence clusters. |
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
+| `devtools test` | Run a focused pytest selection through the managed harness. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -1,0 +1,69 @@
+"""Tests for the ``devtools test`` focused runner (devtools/run_tests.py)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import run_tests
+
+
+def test_build_pytest_cmd_defaults_to_single_process() -> None:
+    cmd = run_tests.build_pytest_cmd(["tests/unit/pipeline"])
+    assert cmd[0] == "pytest"
+    assert "tests/unit/pipeline" in cmd
+    assert cmd[-2:] == ["-n", "0"]
+
+
+def test_build_pytest_cmd_respects_explicit_worker_flag() -> None:
+    cmd = run_tests.build_pytest_cmd(["tests/unit", "-n", "4"])
+    # No injected -n when the caller already chose one.
+    assert cmd.count("-n") == 1
+    assert cmd[-2:] == ["-n", "4"]
+
+
+def test_build_pytest_cmd_honors_workers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_WORKERS", "8")
+    cmd = run_tests.build_pytest_cmd(["tests/unit"])
+    assert cmd[-2:] == ["-n", "8"]
+
+
+def test_main_requires_a_selection(capsys: pytest.CaptureFixture[str]) -> None:
+    assert run_tests.main([]) == 2
+    err = capsys.readouterr().err
+    assert "give a selection" in err
+    assert "devtools verify" in err
+
+
+def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
+    monkeypatch.setattr("devtools.run_tests.subprocess.run", _fake_run)
+    assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
+    assert "--json" not in captured["cmd"]
+    assert "tests/unit/pipeline" in captured["cmd"]
+
+
+def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(cmd, 5)
+
+    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
+    monkeypatch.setattr("devtools.run_tests.subprocess.run", _fake_run)
+    assert run_tests.main(["tests/unit/does_not_exist"]) == 5
+
+
+def test_managed_env_sets_repo_roots() -> None:
+    env = run_tests._managed_env()
+    assert env["POLYLOGUE_ROOT"] == str(run_tests.ROOT)
+    assert env["POLYLOGUE_REPO_ROOT"] == str(run_tests.ROOT)
+    assert env["PYTHONPYCACHEPREFIX"] == str(run_tests.ROOT / ".cache" / "pycache")
+    assert Path(env["POLYLOGUE_ROOT"]).is_dir()


### PR DESCRIPTION
## Summary

Adds `devtools test <pytest args>` — a focused inner-loop runner that routes a
selection through the managed harness, so agents and humans never hand-roll raw
`pytest`. Complements `devtools verify` (the full gate); it is not a substitute.

## Problem

`devtools` owned the full verification gate (`verify`) but had no comfortable
entrypoint for "run this file / `-k` expr / directory." The result: agents reach
for raw `pytest`, hand-rolling worker counts, env, and tmpfs handling — exactly
the ad-hoc path that, in a recent session, led to launching overlapping suites
that raced on shared test state and produced false failures.

## Solution

`devtools/run_tests.py` (`devtools test`):

- Forwards any selection (paths, `-k`/`-m`, `-x`, …) to pytest via the
  control-plane dispatch's existing passthrough (`allow_extra_args` /
  `ignore_unknown_options`).
- Managed environment parity with `verify` (`POLYLOGUE_ROOT`,
  `POLYLOGUE_REPO_ROOT`, repo-local `PYTHONPYCACHEPREFIX`).
- Single-process default (`-n 0`) for fast focused runs; override with an
  explicit `-n` or `POLYLOGUE_PYTEST_WORKERS`.
- Live, streamed output (unlike `verify`, which captures for aggregation).
- A checkout-scoped `flock` serializes overlapping `devtools test` runs so two
  suites from one checkout don't burn CPU racing. Correctness under concurrency
  is already guaranteed by the per-run tmpfs basetemp (#1785); this lock is the
  throughput guard. `POLYLOGUE_TEST_NO_LOCK=1` bypasses it.
- Empty selection prints guidance and exits 2 (does not silently run the whole
  suite — that's `devtools verify`).

Registered as a featured catalog command; `docs/devtools.md` + `AGENTS.md`
regenerated; `TESTING.md` steers the inner loop to `devtools test`.

## Verification

```
devtools test tests/unit/devtools/test_run_tests.py   -> 7 passed (dogfooded, -n 0)
# two concurrent runs, same selection:
  -> exactly one printed "waiting for in-flight run"; both passed (lock works)
devtools verify --quick   -> EXIT 0 (ruff/mypy/render-all/verify-doc-commands + all gates)
```

New unit tests in `tests/unit/devtools/test_run_tests.py` cover worker-default
and override, `--json` stripping, the no-selection guard, exit-code
passthrough, and managed-env contents.