### PR TITLE
fix: repair silently-broken read-surface filters and stats queries post-#1743

### DIFF
--- a/polylogue/archive/query/runtime_filters.py
+++ b/polylogue/archive/query/runtime_filters.py
@@ -76,8 +76,13 @@ def apply_common_filters(
         if plan.title:
             lowered = plan.title.lower()
             results = [item for item in results if item.display_title and lowered in item.display_title.lower()]
-        if plan.parent_id:
-            results = [item for item in results if str(item.parent_id or "") == plan.parent_id]
+
+    # parent_id is never SQL-pushed (it is absent from _ArchiveFilterKwargs), so
+    # it must be applied as a residual filter on every path — not only when
+    # sql_pushed=False. The archive path passes sql_pushed=True, which is why
+    # the .parent() filter was previously dropped (#1743 follow-up).
+    if plan.parent_id:
+        results = [item for item in results if str(item.parent_id or "") == plan.parent_id]
 
     if plan.excluded_origins:
         excluded = set(plan.excluded_origins)

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -792,17 +792,29 @@ def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = 
                 desc = comp.get("description", "")
                 env.ui.console.print(f"  [{state_color}]●[/{state_color}] {name}: {desc}")
 
-    # Live ingest
+    # Live ingest. The status payload carries LiveIngestAttemptSummary, which
+    # exposes running_count + per-attempt worker progress in `recent` — it has
+    # no top-level completed_count/total_count, so the previous keys always read
+    # 0 and this section never rendered (#1743 follow-up).
     live = status.get("live_ingest_attempts", {})
     if isinstance(live, dict):
-        completed = live.get("completed_count", 0)
-        total = live.get("total_count", 0)
-        in_flight = live.get("worker_in_flight_count", 0)
-        if total:
-            parts = [f"{completed}/{total} done"]
-            if in_flight:
-                parts.append(f"+{in_flight} in-flight")
-            env.ui.console.print(f"  Ingest: {', '.join(parts)}")
+        running = int(live.get("running_count", 0) or 0)
+        recent = live.get("recent", [])
+        recent_states = [r for r in recent if isinstance(r, dict)] if isinstance(recent, list) else []
+        files_done = sum(int(r.get("worker_completed_count") or 0) for r in recent_states)
+        files_total = sum(int(r.get("worker_total_count") or 0) for r in recent_states)
+        if running or files_total:
+            parts: list[str] = []
+            if running:
+                parts.append(f"{running} running")
+            if files_total:
+                parts.append(f"{files_done}/{files_total} files")
+            for label, key in (("stale", "stale_running_count"), ("stuck", "stuck_running_count")):
+                count = int(live.get(key, 0) or 0)
+                if count:
+                    parts.append(f"{count} {label}")
+            if parts:
+                env.ui.console.print(f"  Ingest: {', '.join(parts)}")
 
     # FTS
     fts = status.get("fts_readiness", {})

--- a/polylogue/storage/repository/vectors/repository_vectors.py
+++ b/polylogue/storage/repository/vectors/repository_vectors.py
@@ -159,13 +159,13 @@ class RepositoryVectorMixin:
 
             cursor = await conn.execute(
                 """
-                SELECT source_name, COUNT(*) as count
+                SELECT origin, COUNT(*) as count
                 FROM sessions
-                GROUP BY source_name
+                GROUP BY origin
                 """
             )
             provider_rows = await cursor.fetchall()
-            providers = {row["source_name"]: row["count"] for row in provider_rows}
+            providers = {row["origin"]: row["count"] for row in provider_rows}
 
             embedding_stats = await read_embedding_stats_async(conn, include_retrieval_bands=False)
         finally:

--- a/polylogue/storage/search_providers/sqlite_vec_queries.py
+++ b/polylogue/storage/search_providers/sqlite_vec_queries.py
@@ -57,7 +57,7 @@ class SqliteVecQueryMixin:
         try:
             source_name = "unknown"
             row = conn.execute(
-                "SELECT source_name FROM sessions WHERE session_id = ?",
+                "SELECT origin FROM sessions WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
             if row:

--- a/tests/unit/archive/test_query_runtime_filters.py
+++ b/tests/unit/archive/test_query_runtime_filters.py
@@ -154,7 +154,11 @@ def test_apply_common_filters_skips_sql_pushed_predicates_but_keeps_shared_ones(
             origins=("codex-session",),
             since=datetime(2026, 4, 25, tzinfo=timezone.utc),
             title="missing",
-            parent_id="other-parent",
+            # parent_id is never SQL-pushed (absent from _ArchiveFilterKwargs),
+            # so it is applied as a residual filter even when sql_pushed=True
+            # (#1743 follow-up). The matching parent keeps the child; the
+            # pushable origins/since/title predicates are the ones being skipped.
+            parent_id="chatgpt:root",
             excluded_tags=("missing",),
             root=False,
         ),

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -943,17 +943,6 @@ class TestSessionFilterBranching:
         elif method == "has_branches":
             assert filter_obj._has_branches is value
 
-    @pytest.mark.xfail(
-        reason=(
-            "Archive gap (#1743): SessionQueryPlan.parent_id is neither "
-            "SQL-pushed in archive_execution._plan_filter_kwargs nor applied as a "
-            "residual filter (runtime_filters only applies parent_id when "
-            "sql_pushed=False, but the archive path passes sql_pushed=True). "
-            "Parent linkage itself resolves correctly; only the .parent() "
-            "filter is dropped. Owned by the production native-execution agent."
-        ),
-        strict=True,
-    )
     @pytest.mark.asyncio
     async def test_parent_filters_by_parent_id(self, filter_repo_branches: Path) -> None:
         root_native_id = "claude-ai-export:ext-root"

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -373,3 +373,32 @@ async def test_repository_search_and_action_search_pass_ordered_ids_to_hydration
     action_result = await repo.search_actions("storage", limit=5)
     assert [str(session.id) for session in action_result] == ["conv-b", "conv-a"]
     assert repo.ordered_ids_seen == ["conv-b", "conv-a"]
+
+
+@pytest.mark.asyncio
+async def test_get_archive_stats_groups_origins_from_origin_column(tmp_path: Path) -> None:
+    """Regression for the #1743 stale-vocabulary bug: get_archive_stats grouped
+    providers via ``SELECT source_name FROM sessions`` — the column is ``origin``
+    post-split, so the query raises ``no such column: source_name`` whenever the
+    method is reached. The only test of the calling path mocked the method, so
+    the broken query shipped. Seed real sessions and assert the async stats path
+    runs and groups by origin without raising.
+    """
+    backend = SQLiteBackend(db_path=tmp_path / "origin-stats.db")
+    repo = SessionRepository(backend=backend)
+    try:
+        for idx in range(2):
+            payload: JSONDocument = {
+                "id": f"gemini-stats-{idx}",
+                "displayName": f"Gemini stats {idx}",
+                "chunkedPrompt": {"chunks": [{"id": "m", "role": "user", "text": "hi"}]},
+            }
+            await ingest_session(parse_chunked_prompt("gemini", payload, f"fallback-{idx}"), backend=backend)
+
+        stats = await repo.get_archive_stats()
+    finally:
+        await repo.close()
+
+    assert stats.total_sessions == 2
+    assert stats.total_messages == 2
+    assert stats.origins == {"aistudio-drive": 2}

--- a/tests/unit/storage/test_vec.py
+++ b/tests/unit/storage/test_vec.py
@@ -281,7 +281,7 @@ def test_upsert_persistence_contract(
     def capture_execute(sql: str, params: tuple[object, ...] | None = None) -> MagicMock:
         insert_calls.append((sql, params))
         cursor = MagicMock()
-        if "SELECT source_name FROM sessions" in sql:
+        if "SELECT origin FROM sessions" in sql:
             cursor.fetchone.return_value = (source_name,) if source_name is not None else None
         return cursor
 


### PR DESCRIPTION
## Summary

Repairs three real read-surface bugs surfaced by a post-#1743 audit: a
silently-dropped `.parent()` filter, two `SELECT source_name FROM sessions`
queries that raise against the post-split schema, and a `polylogue status`
ingest section that never rendered.

## Problem

- **`.parent()` returns unfiltered results.** `parent_id` is absent from
  `_ArchiveFilterKwargs` (never SQL-pushed), but the residual in
  `runtime_filters.apply_common_filters` only applied it when `sql_pushed=False`.
  The archive path passes `sql_pushed=True`, so `.parent(x)` was dropped entirely.
  (Previously a strict-xfail in `test_filters_props.py`.)
- **`source_name` queries crash when reached.** `get_archive_stats` grouped
  providers via `SELECT source_name FROM sessions GROUP BY source_name`, and the
  sqlite-vec embedding write path via `SELECT source_name FROM sessions WHERE
  session_id=?`. The column is `origin` post-split; both raise
  `no such column: source_name`. The only test of the async stats path **mocked**
  `get_archive_stats`, so the broken query shipped. (`session_profiles` /
  `session_tag_rollups` legitimately retain `source_name`; only the `sessions`
  queries were wrong.)
- **`polylogue status` ingest line is dead code.** It read
  `live.completed_count` / `total_count`, which `LiveIngestAttemptSummary` does
  not define (it has `running_count` + per-attempt worker progress in `recent`),
  so the section never displayed.

## Solution

- Apply `parent_id` as an always-on residual filter, matching how `session_id`
  and `tags` are handled.
- `source_name` → `origin` in both `sessions` queries.
- Rewrite the status ingest block to use `running_count`, worker progress
  aggregated from `recent`, and stale/stuck counts.

## Verification

- Un-xfailed `test_parent_filters_by_parent_id` — now passes.
- Added `test_get_archive_stats_groups_origins_from_origin_column` exercising the
  real (unmocked) async stats path against a seeded archive; it fails against the
  old `source_name` query and passes with `origin`.
- `mypy --strict` clean on all changed files.
- 165 filter/query/storage tests + 114 status tests pass.

## Note

Includes one commit (`fix(devtools): make doc-site build reproducible…`) shared
with #1795 (the pre-push gate fix); it collapses on rebase once #1795 merges.