### PR TITLE
fix(daemon): classify transient write-lock contention as retryable, not error

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import time
+import zipfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -15,6 +16,7 @@ from json import loads as json_loads
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from polylogue.config import Source
 from polylogue.core.degraded import is_degraded
 from polylogue.core.memory import release_process_memory
 from polylogue.core.metrics import (
@@ -31,7 +33,7 @@ from polylogue.errors import DatabaseError, SchemaVersionMismatchError
 from polylogue.logging import get_logger
 from polylogue.paths import blob_store_root
 from polylogue.pipeline.services.ingest_batch._models import _IngestBatchSummary
-from polylogue.sources.decoders import _iter_json_stream
+from polylogue.sources.decoders import _iter_json_stream, _ZipEntryValidator
 from polylogue.sources.dispatch import _detect_provider_from_raw_bytes, parse_payload
 from polylogue.sources.live.append_ingest import ingest_append_plans
 from polylogue.sources.live.batch_observability import (
@@ -85,6 +87,10 @@ from polylogue.sources.live.deferred_cursor import record_deferred_append_cursor
 from polylogue.sources.live.metrics import LiveBatchMetrics, LiveFullIngestAggregate
 from polylogue.sources.live.session_convergence import converge_known_sessions
 from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
+from polylogue.sources.source_acquisition_components import (
+    ZipEntryReadContext,
+    iter_zip_entry_raw_data,
+)
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.bootstrap import (
@@ -852,6 +858,30 @@ class LiveBatchProcessor:
                     current_path=path,
                     source_payload_read_bytes=source_payload_read_bytes,
                 )
+            if path.suffix.lower() == ".zip":
+                file_mtime = datetime.fromtimestamp(stat.st_mtime_ns / 1_000_000_000, UTC).isoformat()
+                zip_records, zip_bytes = self._extract_zip_member_records(
+                    path,
+                    blob_store=blob_store,
+                    fallback_provider=fallback_provider,
+                    file_mtime=file_mtime,
+                )
+                if not zip_records:
+                    self._mark_excluded_cursor(path, stat, source_name=fallback_provider.value)
+                    continue
+                for member_raw_id, member_record in zip_records:
+                    raw_records.append(member_record)
+                    raw_by_id[member_raw_id] = path
+                source_payload_read_bytes += zip_bytes
+                if heartbeat is not None:
+                    heartbeat(
+                        "full_blob_copy",
+                        current_path=path,
+                        source_payload_read_bytes=source_payload_read_bytes,
+                    )
+                ingested.append(path)
+                raw_byte_sizes[path] = stat.st_size
+                continue
             jsonl_like = path.suffix.lower() == ".jsonl"
             if jsonl_like:
                 provider, parse_as_session = _jsonl_provider_and_session_artifact(path, fallback_provider)
@@ -1119,6 +1149,79 @@ class LiveBatchProcessor:
                 except Exception:
                     logger.warning("live.watcher: archive full ingest failed for %s", record.source_path, exc_info=True)
         return result
+
+    def _extract_zip_member_records(
+        self,
+        path: Path,
+        *,
+        blob_store: BlobStore,
+        fallback_provider: Provider,
+        file_mtime: str,
+    ) -> tuple[list[tuple[str, RawSessionRecord]], int]:
+        """Expand an inbox ZIP into one raw record per session member.
+
+        Inbox ZIPs (account exports dropped into the watched inbox) were
+        previously routed into the byte-level provider-detection branch, where
+        ``orjson.loads`` over the ZIP container raised and the entire archive
+        was silently marked excluded (#1683). This reuses the maintenance
+        acquisition path's member extraction so inbox ZIPs ingest the same way
+        as ``polylogue run`` source ZIPs: each member is provider-detected,
+        multi-session members are split, and grouped/metadata entries preserve
+        their original bytes.
+
+        Returns ``([], 0)`` (caller marks the path excluded) only when the ZIP
+        is unreadable or contains no session-bearing members.
+        """
+        source = Source(name=fallback_provider.value, path=path.parent)
+        acquired_at = datetime.now(UTC).isoformat()
+        records: list[tuple[str, RawSessionRecord]] = []
+        total_bytes = 0
+        validator = _ZipEntryValidator(
+            fallback_provider,
+            cursor_state=None,
+            zip_path=path,
+            session_only=False,
+        )
+        try:
+            with zipfile.ZipFile(path) as zf:
+                for info in validator.filter_entries(zf.infolist()):
+                    if info.file_size == 0:
+                        continue
+                    for raw_data in iter_zip_entry_raw_data(
+                        zf,
+                        ZipEntryReadContext(
+                            source=source,
+                            zip_path=path,
+                            entry=info,
+                            file_mtime=file_mtime,
+                            provider_hint=fallback_provider,
+                            blob_store=blob_store,
+                        ),
+                    ):
+                        if raw_data.blob_hash is None:
+                            continue
+                        member_provider = raw_data.provider_hint or fallback_provider
+                        member_size = raw_data.blob_size or 0
+                        total_bytes += member_size
+                        records.append(
+                            (
+                                raw_data.blob_hash,
+                                RawSessionRecord(
+                                    raw_id=raw_data.blob_hash,
+                                    payload_provider=member_provider,
+                                    source_name=member_provider.value,
+                                    source_path=raw_data.source_path,
+                                    source_index=raw_data.source_index or 0,
+                                    blob_size=member_size,
+                                    acquired_at=acquired_at,
+                                    file_mtime=raw_data.file_mtime,
+                                ),
+                            )
+                        )
+        except (zipfile.BadZipFile, OSError) as exc:
+            logger.warning("Failed to expand inbox ZIP %s: %s", path, exc)
+            return [], 0
+        return records, total_bytes
 
     def _mark_excluded_cursor(self, path: Path, stat: object, *, source_name: str) -> None:
         st_size = int(getattr(stat, "st_size", 0))

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -121,6 +121,26 @@ class _ArchiveFullWriteResult:
     session_ids: list[str] = field(default_factory=list)
     session_count: int = 0
     message_count: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _summarize_attempt_error(errors: list[str], retry_paths: list[str]) -> str | None:
+    """Build the ``ingest_attempts.error_message`` value for a finished batch.
+
+    Prefers actual materialization error text (deduped, capped) so the column
+    is diagnosable. Falls back to a retry-path *count* — never a dump of source
+    paths, which is what the column previously stored and which carried no
+    failure reason. Returns ``None`` when nothing needs retry.
+    """
+    distinct = list(dict.fromkeys(message for message in errors if message))
+    if distinct:
+        summary = "; ".join(distinct[:3])
+        if len(distinct) > 3:
+            summary += f" (+{len(distinct) - 3} more)"
+        return summary
+    if retry_paths:
+        return f"{len(retry_paths)} path(s) pending retry"
+    return None
 
 
 class LiveBatchProcessor:
@@ -192,6 +212,7 @@ class LiveBatchProcessor:
         convergence_time_s = 0.0
         stage_timings: dict[str, float] = {}
         failed_paths: list[str] = []
+        materialization_errors: list[str] = []
         succeeded_paths: set[Path] = set()
         ingest_worker_count_max = 0
         full_ingest_aggregate = LiveFullIngestAggregate()
@@ -436,6 +457,7 @@ class LiveBatchProcessor:
                 for path in full_result.failed:
                     failed_paths.append(str(path))
                     cursor_fingerprint_read_bytes += self._record_failed_cursor(path)
+                materialization_errors.extend(full_result.materialization_errors)
                 logger.info(
                     "live.watcher: batch ingested %s — %d in %.1fs (%.1f/s)",
                     source_name,
@@ -517,7 +539,7 @@ class LiveBatchProcessor:
             attempt_id,
             status="completed" if not retry_paths else "completed_with_failures",
             phase="completed",
-            error="; ".join(retry_paths[:3]) if retry_paths else None,
+            error=_summarize_attempt_error(materialization_errors, retry_paths),
         )
         return metrics
 
@@ -998,6 +1020,7 @@ class LiveBatchProcessor:
             raw_by_id[raw_id] = path
 
         summary: _IngestBatchSummary | None = None
+        archive_write: _ArchiveFullWriteResult | None = None
         if raw_records:
             available_records = [record for record in raw_records if record.raw_id in raw_payloads]
             missing_payload_records = [record for record in raw_records if record.raw_id not in raw_payloads]
@@ -1053,6 +1076,7 @@ class LiveBatchProcessor:
             raw_fingerprints=raw_fingerprints,
             raw_byte_sizes=raw_byte_sizes,
             summary=summary,
+            materialization_errors=archive_write.errors if archive_write is not None else [],
         )
         raw_records.clear()
         raw_by_id.clear()
@@ -1146,8 +1170,26 @@ class LiveBatchProcessor:
                         result.session_ids.append(session_id)
                         result.session_count += 1
                         result.message_count += len(session.messages)
-                except Exception:
+                except sqlite3.OperationalError as exc:
+                    if is_transient_sqlite_lock(exc):
+                        # Lost the write-lock race to a concurrent bulk write.
+                        # The path stays out of result.raw_ids, so it is marked
+                        # failed and re-queued; the next cursor pass retries it.
+                        # Log quietly without a traceback — this is expected,
+                        # self-healing contention, not a fault to investigate.
+                        logger.debug(
+                            "live.watcher: archive full ingest deferred (database locked, retryable) for %s",
+                            record.source_path,
+                        )
+                        result.errors.append("database is locked (retryable)")
+                    else:
+                        logger.warning(
+                            "live.watcher: archive full ingest failed for %s", record.source_path, exc_info=True
+                        )
+                        result.errors.append(str(exc))
+                except Exception as exc:
                     logger.warning("live.watcher: archive full ingest failed for %s", record.source_path, exc_info=True)
+                    result.errors.append(str(exc))
         return result
 
     def _extract_zip_member_records(

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -90,6 +90,7 @@ class _FullIngestResult:
     source_payload_read_bytes: int
     raw_fingerprints: dict[Path, str] = field(default_factory=dict)
     raw_byte_sizes: dict[Path, int] = field(default_factory=dict)
+    materialization_errors: list[str] = field(default_factory=list)
     worker_count: int = 0
     ingested_session_count: int = 0
     ingested_message_count: int = 0
@@ -111,6 +112,7 @@ def _full_ingest_result_from_summary(
     raw_fingerprints: dict[Path, str],
     raw_byte_sizes: dict[Path, int],
     summary: object | None,
+    materialization_errors: list[str] | None = None,
 ) -> _FullIngestResult:
     error = getattr(summary, "wal_checkpoint_error", None) if summary is not None else None
     return _FullIngestResult(
@@ -119,6 +121,7 @@ def _full_ingest_result_from_summary(
         source_payload_read_bytes=source_payload_read_bytes,
         raw_fingerprints=raw_fingerprints,
         raw_byte_sizes=raw_byte_sizes,
+        materialization_errors=list(materialization_errors) if materialization_errors else [],
         worker_count=int(getattr(summary, "worker_count", 0)) if summary is not None else 0,
         ingested_session_count=int(getattr(summary, "total_convos", 0)) if summary is not None else 0,
         ingested_message_count=int(getattr(summary, "total_msgs", 0)) if summary is not None else 0,

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1170,6 +1170,113 @@ async def test_live_full_ingest_expands_inbox_zip_members(
 
 
 @pytest.mark.asyncio
+async def test_live_full_ingest_records_transient_lock_as_retryable(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write-lock loss is recorded as retryable, not a source-path dump (#18).
+
+    Insight/archive writes can lose the write-lock race to a concurrent bulk
+    write (``database is locked``). That path is self-healing — it is re-queued
+    and retried — so the attempt's ``error`` must classify it as retryable
+    rather than recording the opaque source-path list it used to store.
+    """
+    import polylogue.storage.sqlite.archive_tiers.archive as archive_mod
+
+    root = workspace_env["data_root"] / "claude-projects"
+    project = root / "project"
+    project.mkdir(parents=True)
+    source_path = project / "session.jsonl"
+    _write_jsonl(
+        source_path,
+        [
+            _claude_code_message(
+                session_id="lock-session",
+                uuid="m1",
+                role="user",
+                text="locked write",
+                timestamp="2026-05-01T00:00:00Z",
+            ),
+        ],
+    )
+    db_path = workspace_env["data_root"] / "lock-live.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="claude-code", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    def _raise_locked(_self: object, *args: object, **kwargs: object) -> tuple[str, str]:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(archive_mod.ArchiveStore, "write_raw_and_parsed", _raise_locked)
+
+    try:
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        attempts = cursor.recent_ingest_attempts(limit=1)
+
+        assert metrics.succeeded_file_count == 0
+        assert metrics.failed_file_count == 1
+        assert attempts[0].error == "database is locked (retryable)"
+        assert str(source_path) not in (attempts[0].error or "")
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_live_full_ingest_records_real_error_text_not_paths(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuine write failure records the error text, not the source path (#18)."""
+    import polylogue.storage.sqlite.archive_tiers.archive as archive_mod
+
+    root = workspace_env["data_root"] / "claude-projects"
+    project = root / "project"
+    project.mkdir(parents=True)
+    source_path = project / "session.jsonl"
+    _write_jsonl(
+        source_path,
+        [
+            _claude_code_message(
+                session_id="error-session",
+                uuid="m1",
+                role="user",
+                text="failing write",
+                timestamp="2026-05-01T00:00:00Z",
+            ),
+        ],
+    )
+    db_path = workspace_env["data_root"] / "error-live.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="claude-code", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    def _raise_value_error(_self: object, *args: object, **kwargs: object) -> tuple[str, str]:
+        raise ValueError("synthetic write failure")
+
+    monkeypatch.setattr(archive_mod.ArchiveStore, "write_raw_and_parsed", _raise_value_error)
+
+    try:
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        attempts = cursor.recent_ingest_attempts(limit=1)
+
+        assert metrics.failed_file_count == 1
+        assert attempts[0].error == "synthetic write failure"
+        assert str(source_path) not in (attempts[0].error or "")
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
 async def test_live_full_ingest_detects_provider_when_source_name_is_not_provider(
     workspace_env: dict[str, Path],
 ) -> None:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import sqlite3
 import time
+import zipfile
 from collections.abc import Callable, Iterable
 from datetime import timedelta
 from pathlib import Path
@@ -1092,6 +1093,78 @@ async def test_live_append_merges_tail_visible_through_public_archive_read(works
             "fourth appended reply",
             "fifth appended followup",
         ]
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_live_full_ingest_expands_inbox_zip_members(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A ZIP dropped into a watched root ingests every session member (#1683).
+
+    Regression: ZIP paths previously fell through to the byte-level detection
+    branch, where ``orjson.loads`` over the ZIP container raised and the whole
+    archive was silently marked excluded. The fix expands ZIP members through
+    the maintenance acquisition path, so each member becomes a session.
+    """
+    root = workspace_env["data_root"] / "claude-projects"
+    root.mkdir(parents=True)
+    member_a = "\n".join(
+        json.dumps(record)
+        for record in (
+            _claude_code_message(
+                session_id="zip-session-a",
+                uuid="a-1",
+                role="user",
+                text="first zip member message",
+                timestamp="2026-05-01T00:00:00Z",
+            ),
+        )
+    )
+    member_b = "\n".join(
+        json.dumps(record)
+        for record in (
+            _claude_code_message(
+                session_id="zip-session-b",
+                uuid="b-1",
+                role="user",
+                text="second zip member message",
+                timestamp="2026-05-01T00:00:01Z",
+            ),
+        )
+    )
+    zip_path = root / "claude-export.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("session-a.jsonl", member_a + "\n")
+        zf.writestr("session-b.jsonl", member_b + "\n")
+
+    db_path = workspace_env["data_root"] / "inbox-zip-live.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="claude-code", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    try:
+        metrics = await processor.ingest_files([zip_path], emit_event=False)
+        record = cursor.get_record(zip_path)
+
+        session_a = await archive.get_session("claude-code:zip-session-a")
+        session_b = await archive.get_session("claude-code:zip-session-b")
+
+        assert metrics.succeeded_file_count == 1
+        assert metrics.failed_file_count == 0
+        assert metrics.source_payload_read_bytes > 0
+        assert record is not None
+        assert record.excluded is False
+        assert session_a is not None
+        assert session_b is not None
+        assert [message.text for message in session_a.messages] == ["first zip member message"]
+        assert [message.text for message in session_b.messages] == ["second zip member message"]
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Live batch ingest now distinguishes a transient `database is locked` write-lock
loss (self-healing, retried) from a real write failure, and records a
diagnosable reason in `ingest_attempts.error_message` instead of a source-path
dump.

> **Stacked on #1797** — shares the live batch ingest surface (`batch.py`,
> `test_live_watcher.py`). The diff currently shows both commits; once #1797
> squash-merges this rebases to the single `fix(daemon): classify transient
> write-lock contention…` commit.

## Problem

Two defects in the daemon's post-#1743 live ingest:

1. When an archive/insight write lost the write-lock race to a concurrent bulk
   write, `_ingest_full_records_archive` logged the `database is locked` failure
   at **WARNING with a full traceback** (`exc_info=True`) keyed by source path.
   The condition is self-healing — the path is re-queued and retried on the
   next cursor pass — so this floods journald with scary noise for a
   non-fault. (Journald even truncated the huge Rich traceback before the
   exception summary, making it useless *and* noisy.)
2. `finish_ingest_attempt` stored a `"; "`-joined list of up to three source
   **paths** in `ingest_attempts.error_message`. The diagnostic column carried
   no failure reason at all.

## Solution

- The per-record write loop now catches `sqlite3.OperationalError` separately
  and checks `is_transient_sqlite_lock`. Transient locks log at **DEBUG** with
  no traceback and record `"database is locked (retryable)"`; all other
  failures keep WARNING+traceback and record `str(exc)`.
- Per-record errors are collected on `_ArchiveFullWriteResult.errors`, threaded
  through `_FullIngestResult.materialization_errors`, accumulated per batch, and
  summarized by `_summarize_attempt_error` (deduped, capped at 3 distinct
  messages, `+N more` suffix). `error_message` now holds error text; with no
  captured text it stores a retry-path *count* — never a path dump.

## Verification

```
devtools test tests/unit/sources/test_live_watcher.py   # 66 passed
mypy --strict polylogue/sources/live/batch.py polylogue/sources/live/batch_support.py \
  tests/unit/sources/test_live_watcher.py   # clean
```

Two new tests monkeypatch `ArchiveStore.write_raw_and_parsed` to raise a lock
and a generic error, asserting the recorded `error` is
`"database is locked (retryable)"` and the real exception text respectively —
and never the source path.