### PR TITLE
test: cover archive_query, status, and insight registry pure surfaces

### DIFF
--- a/tests/unit/cli/commands/test_status.py
+++ b/tests/unit/cli/commands/test_status.py
@@ -1,0 +1,1013 @@
+"""Tests for pure functions in polylogue.cli.commands.status."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.cli.commands.status import (
+    _ARCHIVE_CLI_ROUTES,
+    _ARCHIVE_FACADE_ROUTES,
+    _ARCHIVE_TIER_ENUM,
+    _BUILTIN_DAEMON_URL,
+    _archive_cli_route_status,
+    _archive_facade_route_status,
+    _archive_missing_materialization,
+    _archive_missing_rows,
+    _archive_one_tier_status,
+    _archive_primary_tier_count,
+    _archive_readiness_counts,
+    _archive_route_count_summary,
+    _archive_runtime_path_status,
+    _archive_status_surfaces,
+    _archive_table_counts,
+    _archive_tier_files,
+    _archive_tier_status,
+    _column_exists,
+    _default_daemon_url,
+    _direct_archive_counts,
+    _fast_count,
+    _fmt_bytes,
+    _table_exists,
+)
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+
+
+class TestDefaultDaemonUrl:
+    """Tests for _default_daemon_url()."""
+
+    def test_returns_builtin_when_env_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without POLYLOGUE_DAEMON_URL env var, returns the built-in URL."""
+        monkeypatch.delenv("POLYLOGUE_DAEMON_URL", raising=False)
+        assert _default_daemon_url() == _BUILTIN_DAEMON_URL
+
+    def test_returns_override_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With POLYLOGUE_DAEMON_URL env var, returns the override."""
+        override_url = "http://custom.host:9999"
+        monkeypatch.setenv("POLYLOGUE_DAEMON_URL", override_url)
+        assert _default_daemon_url() == override_url
+
+    def test_empty_env_var_returns_builtin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty string env var is falsy, returns built-in."""
+        monkeypatch.setenv("POLYLOGUE_DAEMON_URL", "")
+        assert _default_daemon_url() == _BUILTIN_DAEMON_URL
+
+
+class TestFmtBytes:
+    """Tests for _fmt_bytes(n)."""
+
+    def test_small_bytes_formats_as_kb(self) -> None:
+        """Values <1MB format as KB."""
+        assert _fmt_bytes(500_000) == "500 KB"
+        assert _fmt_bytes(100_000) == "100 KB"
+        assert _fmt_bytes(1_000) == "1 KB"
+
+    def test_megabytes_format_with_decimal(self) -> None:
+        """Values >=1MB and <1GB format with one decimal place."""
+        assert _fmt_bytes(5_000_000) == "5.0 MB"
+        assert _fmt_bytes(1_500_000) == "1.5 MB"
+        assert _fmt_bytes(1_000_000) == "1.0 MB"
+
+    def test_gigabytes_format_with_decimal(self) -> None:
+        """Values >=1GB format with one decimal place."""
+        assert _fmt_bytes(5_000_000_000) == "5.0 GB"
+        assert _fmt_bytes(1_500_000_000) == "1.5 GB"
+        assert _fmt_bytes(1_000_000_000) == "1.0 GB"
+
+    def test_boundary_values(self) -> None:
+        """Test exact boundary values."""
+        assert _fmt_bytes(999_000) == "999 KB"
+        assert _fmt_bytes(1_000_000) == "1.0 MB"
+        assert _fmt_bytes(999_900_000) == "999.9 MB"
+        assert _fmt_bytes(1_000_000_000) == "1.0 GB"
+
+    def test_zero_and_small_values(self) -> None:
+        """Test zero and very small values."""
+        assert _fmt_bytes(0) == "0 KB"
+        assert _fmt_bytes(1) == "0 KB"  # rounds down
+
+
+class TestArchiveFacadeRouteStatus:
+    """Tests for _archive_facade_route_status()."""
+
+    def test_returns_checked_true(self) -> None:
+        """Always returns checked=True."""
+        result = _archive_facade_route_status()
+        assert result["checked"] is True
+
+    def test_total_method_count_matches_routes(self) -> None:
+        """total_method_count equals length of routes dict."""
+        result = _archive_facade_route_status()
+        assert result["total_method_count"] == len(_ARCHIVE_FACADE_ROUTES)
+        assert result["total_method_count"] == len(result["routes"])
+
+    def test_route_counts_sum_to_total(self) -> None:
+        """Sum of route_counts values equals total_method_count."""
+        result = _archive_facade_route_status()
+        total = sum(result["route_counts"].values())
+        assert total == result["total_method_count"]
+
+    def test_tier_counts_include_all_tiers(self) -> None:
+        """tier_counts includes all distinct tier values."""
+        result = _archive_facade_route_status()
+        expected_tiers = {"source", "index", "embeddings", "user", "none"}
+        assert set(result["tier_counts"].keys()).issubset(expected_tiers)
+
+    def test_unsupported_methods_empty_for_current_catalog(self) -> None:
+        """Current catalog has no unsupported methods."""
+        result = _archive_facade_route_status()
+        assert result["unsupported_methods"] == []
+        assert result["unsupported_method_count"] == 0
+
+    def test_archive_ready_method_count_counts_routed_and_direct(self) -> None:
+        """archive_ready_method_count sums archive_routed + archive_direct."""
+        result = _archive_facade_route_status()
+        routed = result["route_counts"].get("archive_routed", 0)
+        direct = result["route_counts"].get("archive_direct", 0)
+        assert result["archive_ready_method_count"] == routed + direct
+
+    def test_each_route_has_required_keys(self) -> None:
+        """Each route entry has route, tier, detail keys."""
+        result = _archive_facade_route_status()
+        for info in result["routes"].values():
+            assert "route" in info
+            assert "tier" in info
+            assert "detail" in info
+            assert isinstance(info["route"], str)
+            assert isinstance(info["tier"], str)
+            assert isinstance(info["detail"], str)
+
+    def test_route_values_are_valid(self) -> None:
+        """Each route value is one of the valid types."""
+        result = _archive_facade_route_status()
+        valid_routes = {"archive_routed", "archive_direct", "not_archive_runtime", "unsupported"}
+        for info in result["routes"].values():
+            assert info["route"] in valid_routes
+
+    def test_tier_values_are_valid(self) -> None:
+        """Each tier value is one of the valid tiers."""
+        result = _archive_facade_route_status()
+        valid_tiers = {"source", "index", "embeddings", "user", "none"}
+        for info in result["routes"].values():
+            assert info["tier"] in valid_tiers
+
+
+class TestArchiveCliRouteStatus:
+    """Tests for _archive_cli_route_status()."""
+
+    def test_returns_checked_true(self) -> None:
+        """Always returns checked=True."""
+        result = _archive_cli_route_status()
+        assert result["checked"] is True
+
+    def test_total_command_count_matches_routes(self) -> None:
+        """total_command_count equals length of _ARCHIVE_CLI_ROUTES."""
+        result = _archive_cli_route_status()
+        assert result["total_command_count"] == len(_ARCHIVE_CLI_ROUTES)
+        assert result["total_command_count"] == len(result["routes"])
+
+    def test_route_counts_sum_to_total(self) -> None:
+        """Sum of route_counts equals total_command_count."""
+        result = _archive_cli_route_status()
+        total = sum(result["route_counts"].values())
+        assert total == result["total_command_count"]
+
+    def test_unsupported_commands_empty_for_current_catalog(self) -> None:
+        """Current catalog has no unsupported commands."""
+        result = _archive_cli_route_status()
+        assert result["unsupported_commands"] == []
+        assert result["unsupported_command_count"] == 0
+
+    def test_archive_ready_command_count(self) -> None:
+        """archive_ready_command_count sums archive_routed + archive_direct."""
+        result = _archive_cli_route_status()
+        routed = result["route_counts"].get("archive_routed", 0)
+        direct = result["route_counts"].get("archive_direct", 0)
+        assert result["archive_ready_command_count"] == routed + direct
+
+
+class TestArchiveRuntimePathStatus:
+    """Tests for _archive_runtime_path_status()."""
+
+    def test_returns_checked_true(self) -> None:
+        """Always returns checked=True."""
+        result = _archive_runtime_path_status()
+        assert result["checked"] is True
+
+    def test_archive_runtime_ready_when_no_blockers(self) -> None:
+        """archive_runtime_ready is True when no unsupported primary methods."""
+        result = _archive_runtime_path_status()
+        assert result["archive_runtime_ready"] is True
+        assert result["final_shape_blockers"] == []
+
+    def test_primary_ingest_store_is_archive_file_set(self) -> None:
+        """primary_ingest_store reports archive_file_set for current catalog."""
+        result = _archive_runtime_path_status()
+        assert result["primary_ingest_store"] == "archive_file_set"
+
+    def test_ingest_write_mode_is_archive(self) -> None:
+        """ingest_write_mode is 'archive' for current catalog."""
+        result = _archive_runtime_path_status()
+        assert result["ingest_write_mode"] == "archive"
+
+    def test_archive_ingest_write_targets(self) -> None:
+        """archive_ingest_write_targets includes source.db and index.db."""
+        result = _archive_runtime_path_status()
+        assert set(result["archive_ingest_write_targets"]) == {"source.db", "index.db"}
+
+    def test_archive_tier_targets_complete(self) -> None:
+        """archive_tier_targets includes all five tiers."""
+        result = _archive_runtime_path_status()
+        assert set(result["archive_tier_targets"]) == {"source.db", "index.db", "embeddings.db", "user.db", "ops.db"}
+
+    def test_facade_tier_route_counts_populated(self) -> None:
+        """facade_tier_route_counts is populated from facade status."""
+        result = _archive_runtime_path_status()
+        assert isinstance(result["facade_tier_route_counts"], dict)
+        assert len(result["facade_tier_route_counts"]) > 0
+
+    def test_cli_tier_route_counts_populated(self) -> None:
+        """cli_tier_route_counts is populated from CLI status."""
+        result = _archive_runtime_path_status()
+        assert isinstance(result["cli_tier_route_counts"], dict)
+        assert len(result["cli_tier_route_counts"]) > 0
+
+
+class TestArchiveRouteCountSummary:
+    """Tests for _archive_route_count_summary()."""
+
+    def test_none_returns_none(self) -> None:
+        """None input returns 'none'."""
+        assert _archive_route_count_summary(None) == "none"
+
+    def test_empty_dict_returns_none(self) -> None:
+        """Empty dict returns 'none'."""
+        assert _archive_route_count_summary({}) == "none"
+
+    def test_non_dict_returns_none(self) -> None:
+        """Non-dict input returns 'none'."""
+        assert _archive_route_count_summary([]) == "none"
+        assert _archive_route_count_summary("invalid") == "none"
+
+    def test_single_tier_count(self) -> None:
+        """Single tier formats correctly."""
+        result = _archive_route_count_summary({"index": 3})
+        assert result == "index:3"
+
+    def test_multiple_tiers_sorted(self) -> None:
+        """Multiple tiers are sorted alphabetically by key."""
+        result = _archive_route_count_summary({"index": 3, "user": 2, "source": 1})
+        assert result == "index:3,source:1,user:2"
+
+    def test_preserves_counts(self) -> None:
+        """Counts are accurately preserved."""
+        counts = {"a": 10, "z": 5, "m": 20}
+        result = _archive_route_count_summary(counts)
+        assert "a:10" in result
+        assert "z:5" in result
+        assert "m:20" in result
+
+
+class TestArchivePrimaryTierCount:
+    """Tests for _archive_primary_tier_count()."""
+
+    def test_index_tier_with_sessions(self) -> None:
+        """index tier with sessions in counts returns ('sessions', count)."""
+        result = _archive_primary_tier_count("index", {"sessions": 42})
+        assert result == ("sessions", 42)
+
+    def test_source_tier_with_raw_sessions(self) -> None:
+        """source tier with raw_sessions in counts returns ('raw_sessions', count)."""
+        result = _archive_primary_tier_count("source", {"raw_sessions": 100})
+        assert result == ("raw_sessions", 100)
+
+    def test_user_tier_with_annotations(self) -> None:
+        """user tier with annotations in counts returns ('annotations', count)."""
+        result = _archive_primary_tier_count("user", {"annotations": 5})
+        assert result == ("annotations", 5)
+
+    def test_embeddings_tier_with_embedding_status(self) -> None:
+        """embeddings tier with embedding_status returns ('embedding_status', count)."""
+        result = _archive_primary_tier_count("embeddings", {"embedding_status": 1})
+        assert result == ("embedding_status", 1)
+
+    def test_ops_tier_with_ingest_attempts(self) -> None:
+        """ops tier with ingest_attempts returns ('ingest_attempts', count)."""
+        result = _archive_primary_tier_count("ops", {"ingest_attempts": 10})
+        assert result == ("ingest_attempts", 10)
+
+    def test_returns_none_when_primary_table_missing(self) -> None:
+        """Returns None when primary table not in counts."""
+        result = _archive_primary_tier_count("index", {})
+        assert result is None
+
+    def test_returns_none_for_unknown_tier(self) -> None:
+        """Returns None for unknown tier."""
+        result = _archive_primary_tier_count("unknown", {"anything": 5})
+        assert result is None
+
+
+class TestArchiveTierFiles:
+    """Tests for _archive_tier_files()."""
+
+    def test_returns_all_five_tiers(self, tmp_path: Path) -> None:
+        """Returns dict with all five tier names."""
+        result = _archive_tier_files(tmp_path)
+        expected_tiers = {"source", "index", "embeddings", "user", "ops"}
+        assert set(result.keys()) == expected_tiers
+
+    def test_each_tier_maps_to_correct_path(self, tmp_path: Path) -> None:
+        """Each tier maps to the correct .db file path."""
+        result = _archive_tier_files(tmp_path)
+        assert result["source"] == tmp_path / "source.db"
+        assert result["index"] == tmp_path / "index.db"
+        assert result["embeddings"] == tmp_path / "embeddings.db"
+        assert result["user"] == tmp_path / "user.db"
+        assert result["ops"] == tmp_path / "ops.db"
+
+    def test_paths_are_path_objects(self, tmp_path: Path) -> None:
+        """Returned values are Path objects."""
+        result = _archive_tier_files(tmp_path)
+        for path in result.values():
+            assert isinstance(path, Path)
+
+
+class TestFastCount:
+    """Tests for _fast_count()."""
+
+    def test_counts_rows_in_table(self, tmp_path: Path) -> None:
+        """Counts rows correctly from a simple table."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO test (id) VALUES (1), (2), (3)")
+            conn.commit()
+            result = _fast_count(conn, "SELECT COUNT(*) FROM test")
+            assert result == 3
+        finally:
+            conn.close()
+
+    def test_returns_zero_for_empty_table(self, tmp_path: Path) -> None:
+        """Returns 0 for empty table."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+            conn.commit()
+            result = _fast_count(conn, "SELECT COUNT(*) FROM test")
+            assert result == 0
+        finally:
+            conn.close()
+
+    def test_uses_parameters(self, tmp_path: Path) -> None:
+        """Correctly uses parameterized queries."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+            conn.execute("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'a')")
+            conn.commit()
+            result = _fast_count(conn, "SELECT COUNT(*) FROM test WHERE value = ?", ("a",))
+            assert result == 2
+        finally:
+            conn.close()
+
+    def test_handles_null_result(self, tmp_path: Path) -> None:
+        """Handles NULL return value gracefully."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+            result = _fast_count(conn, "SELECT NULL")
+            assert result == 0
+        finally:
+            conn.close()
+
+
+class TestTableExists:
+    """Tests for _table_exists()."""
+
+    def test_returns_true_for_existing_table(self, tmp_path: Path) -> None:
+        """Returns True when table exists."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE mytable (id INTEGER PRIMARY KEY)")
+            assert _table_exists(conn, "mytable") is True
+        finally:
+            conn.close()
+
+    def test_returns_false_for_nonexistent_table(self, tmp_path: Path) -> None:
+        """Returns False when table does not exist."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            assert _table_exists(conn, "nonexistent") is False
+        finally:
+            conn.close()
+
+    def test_works_with_sqlite_master(self, tmp_path: Path) -> None:
+        """Correctly queries sqlite_master."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE first (id INTEGER)")
+            conn.execute("CREATE TABLE second (id INTEGER)")
+            assert _table_exists(conn, "first") is True
+            assert _table_exists(conn, "second") is True
+            assert _table_exists(conn, "third") is False
+        finally:
+            conn.close()
+
+
+class TestColumnExists:
+    """Tests for _column_exists()."""
+
+    def test_returns_true_for_existing_column(self, tmp_path: Path) -> None:
+        """Returns True when column exists."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE mytable (id INTEGER, name TEXT)")
+            assert _column_exists(conn, "mytable", "id") is True
+            assert _column_exists(conn, "mytable", "name") is True
+        finally:
+            conn.close()
+
+    def test_returns_false_for_nonexistent_column(self, tmp_path: Path) -> None:
+        """Returns False when column does not exist."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE mytable (id INTEGER)")
+            assert _column_exists(conn, "mytable", "missing") is False
+        finally:
+            conn.close()
+
+    def test_works_with_multiple_columns(self, tmp_path: Path) -> None:
+        """Works correctly with multiple columns."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE mytable (id INTEGER, name TEXT, value REAL, active INTEGER)")
+            assert _column_exists(conn, "mytable", "id") is True
+            assert _column_exists(conn, "mytable", "name") is True
+            assert _column_exists(conn, "mytable", "value") is True
+            assert _column_exists(conn, "mytable", "active") is True
+            assert _column_exists(conn, "mytable", "missing") is False
+        finally:
+            conn.close()
+
+
+class TestArchiveTableCounts:
+    """Tests for _archive_table_counts()."""
+
+    def test_counts_existing_tables(self, tmp_path: Path) -> None:
+        """Counts all existing tables in the list."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+            conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2)")
+            conn.execute("INSERT INTO messages VALUES (1), (2), (3)")
+            conn.commit()
+            result = _archive_table_counts(conn, ["sessions", "messages"])
+            assert result["sessions"] == 2
+            assert result["messages"] == 3
+        finally:
+            conn.close()
+
+    def test_omits_nonexistent_tables(self, tmp_path: Path) -> None:
+        """Only returns counts for tables that exist."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1)")
+            conn.commit()
+            result = _archive_table_counts(conn, ["sessions", "nonexistent", "missing"])
+            assert "sessions" in result
+            assert "nonexistent" not in result
+            assert "missing" not in result
+        finally:
+            conn.close()
+
+    def test_empty_list_returns_empty_dict(self, tmp_path: Path) -> None:
+        """Empty table list returns empty dict."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            result = _archive_table_counts(conn, [])
+            assert result == {}
+        finally:
+            conn.close()
+
+
+class TestArchiveOneTierStatus:
+    """Tests for _archive_one_tier_status()."""
+
+    def test_missing_file_returns_missing_status(self, tmp_path: Path) -> None:
+        """Missing file returns version_status='missing'."""
+        nonexistent = tmp_path / "nonexistent.db"
+        result = _archive_one_tier_status("index", nonexistent)
+        assert result["exists"] is False
+        assert result["version_status"] == "missing"
+        assert result["size_bytes"] is None
+        assert result["user_version"] is None
+
+    def test_existing_empty_file_with_correct_version(self, tmp_path: Path) -> None:
+        """Existing file with correct version returns 'ok'."""
+        db_path = tmp_path / "index.db"
+        conn = sqlite3.connect(db_path)
+        expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM["index"]]
+        conn.execute(f"PRAGMA user_version = {expected_version}")
+        conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        result = _archive_one_tier_status("index", db_path)
+        assert result["exists"] is True
+        assert result["user_version"] == expected_version
+        assert result["expected_user_version"] == expected_version
+        assert result["version_status"] == "ok"
+        assert result["size_bytes"] is not None
+        assert result["table_counts"]["sessions"] == 0
+
+    def test_version_mismatch(self, tmp_path: Path) -> None:
+        """File with mismatched version returns 'mismatch'."""
+        db_path = tmp_path / "index.db"
+        conn = sqlite3.connect(db_path)
+        expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM["index"]]
+        wrong_version = expected_version + 999
+        conn.execute(f"PRAGMA user_version = {wrong_version}")
+        conn.commit()
+        conn.close()
+
+        result = _archive_one_tier_status("index", db_path)
+        assert result["user_version"] == wrong_version
+        assert result["expected_user_version"] == expected_version
+        assert result["version_status"] == "mismatch"
+
+    def test_table_counts_include_existing_tables(self, tmp_path: Path) -> None:
+        """table_counts includes rows from existing tables."""
+        db_path = tmp_path / "index.db"
+        conn = sqlite3.connect(db_path)
+        expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM["index"]]
+        conn.execute(f"PRAGMA user_version = {expected_version}")
+        conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+        conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO sessions VALUES (1), (2)")
+        conn.execute("INSERT INTO messages VALUES (1)")
+        conn.commit()
+        conn.close()
+
+        result = _archive_one_tier_status("index", db_path)
+        assert result["table_counts"]["sessions"] == 2
+        assert result["table_counts"]["messages"] == 1
+
+
+class TestArchiveTierStatus:
+    """Tests for _archive_tier_status()."""
+
+    def test_returns_status_for_all_tiers(self, tmp_path: Path) -> None:
+        """Returns status dict for all five tiers."""
+        result = _archive_tier_status(tmp_path)
+        expected_tiers = {"source", "index", "embeddings", "user", "ops"}
+        assert set(result.keys()) == expected_tiers
+
+    def test_all_missing_tiers(self, tmp_path: Path) -> None:
+        """When no tier files exist, all show as missing."""
+        result = _archive_tier_status(tmp_path)
+        for status in result.values():
+            assert status["exists"] is False
+            assert status["version_status"] == "missing"
+
+    def test_with_existing_index_tier(self, tmp_path: Path) -> None:
+        """Correctly detects existing index.db."""
+        db_path = tmp_path / "index.db"
+        conn = sqlite3.connect(db_path)
+        expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM["index"]]
+        conn.execute(f"PRAGMA user_version = {expected_version}")
+        conn.commit()
+        conn.close()
+
+        result = _archive_tier_status(tmp_path)
+        assert result["index"]["exists"] is True
+        assert result["index"]["version_status"] == "ok"
+        assert result["source"]["exists"] is False
+        assert result["user"]["exists"] is False
+
+
+class TestDirectArchiveCounts:
+    """Tests for _direct_archive_counts()."""
+
+    def test_empty_archive_returns_zeros(self, tmp_path: Path) -> None:
+        """Archive with no sessions returns zeros."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            result = _direct_archive_counts(conn)
+            assert result["sessions"] == 0
+            assert result["messages"] == 0
+            assert result["raw_records"] == 0
+        finally:
+            conn.close()
+
+    def test_with_sessions_and_message_count_column(self, tmp_path: Path) -> None:
+        """Uses message_count column when available."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, message_count INTEGER)")
+            conn.execute("INSERT INTO sessions VALUES (1, 5), (2, 3)")
+            conn.commit()
+            result = _direct_archive_counts(conn)
+            assert result["sessions"] == 2
+            assert result["messages"] == 8  # sum of message_count
+        finally:
+            conn.close()
+
+    def test_with_sessions_and_messages_table(self, tmp_path: Path) -> None:
+        """Falls back to counting messages table when message_count column absent."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+            conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id INTEGER)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2)")
+            conn.execute("INSERT INTO messages VALUES (1, 1), (2, 1), (3, 2)")
+            conn.commit()
+            result = _direct_archive_counts(conn)
+            assert result["sessions"] == 2
+            assert result["messages"] == 3
+        finally:
+            conn.close()
+
+
+class TestArchiveMissingRows:
+    """Tests for _archive_missing_rows()."""
+
+    def test_nonexistent_table_counts_all_sessions(self, tmp_path: Path) -> None:
+        """When table missing, returns count of all sessions."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3)")
+            conn.commit()
+            result = _archive_missing_rows(conn, "profiles", "session_id")
+            assert result == 3
+        finally:
+            conn.close()
+
+    def test_all_sessions_covered(self, tmp_path: Path) -> None:
+        """When all sessions are covered, returns 0."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute("CREATE TABLE profiles (session_id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3)")
+            conn.execute("INSERT INTO profiles VALUES (1), (2), (3)")
+            conn.commit()
+            result = _archive_missing_rows(conn, "profiles", "session_id")
+            assert result == 0
+        finally:
+            conn.close()
+
+    def test_partial_coverage(self, tmp_path: Path) -> None:
+        """Counts sessions not covered in the table."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute("CREATE TABLE profiles (session_id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3), (4)")
+            conn.execute("INSERT INTO profiles VALUES (1), (3)")
+            conn.commit()
+            result = _archive_missing_rows(conn, "profiles", "session_id")
+            assert result == 2  # sessions 2 and 4 are missing
+        finally:
+            conn.close()
+
+
+class TestArchiveMissingMaterialization:
+    """Tests for _archive_missing_materialization()."""
+
+    def test_nonexistent_table_counts_all_sessions(self, tmp_path: Path) -> None:
+        """When table missing, returns count of all sessions."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3)")
+            conn.commit()
+            result = _archive_missing_materialization(conn, "session_profile")
+            assert result == 3
+        finally:
+            conn.close()
+
+    def test_all_sessions_materialized(self, tmp_path: Path) -> None:
+        """When all sessions have materializations, returns 0."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute(
+                "CREATE TABLE insight_materialization (session_id INTEGER, insight_type TEXT, PRIMARY KEY (session_id, insight_type))"
+            )
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3)")
+            conn.execute(
+                "INSERT INTO insight_materialization VALUES (1, 'session_profile'), (2, 'session_profile'), (3, 'session_profile')"
+            )
+            conn.commit()
+            result = _archive_missing_materialization(conn, "session_profile")
+            assert result == 0
+        finally:
+            conn.close()
+
+    def test_partial_materialization(self, tmp_path: Path) -> None:
+        """Counts sessions without the specific insight type."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute(
+                "CREATE TABLE insight_materialization (session_id INTEGER, insight_type TEXT, PRIMARY KEY (session_id, insight_type))"
+            )
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3), (4)")
+            conn.execute("INSERT INTO insight_materialization VALUES (1, 'session_profile'), (3, 'session_profile')")
+            conn.commit()
+            result = _archive_missing_materialization(conn, "session_profile")
+            assert result == 2  # sessions 2 and 4
+        finally:
+            conn.close()
+
+    def test_multiple_insight_types(self, tmp_path: Path) -> None:
+        """Different insight types are tracked separately."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute(
+                "CREATE TABLE insight_materialization (session_id INTEGER, insight_type TEXT, PRIMARY KEY (session_id, insight_type))"
+            )
+            conn.execute("INSERT INTO sessions VALUES (1), (2), (3)")
+            conn.execute(
+                "INSERT INTO insight_materialization VALUES (1, 'session_profile'), (2, 'work_events'), (3, 'session_profile')"
+            )
+            conn.commit()
+            # Check work_events: only session 2 has it, so sessions 1 and 3 are missing
+            result = _archive_missing_materialization(conn, "work_events")
+            assert result == 2
+        finally:
+            conn.close()
+
+
+class TestArchiveReadinessCounts:
+    """Tests for _archive_readiness_counts()."""
+
+    def test_basic_counts_with_empty_archive(self, tmp_path: Path) -> None:
+        """Counts all zeros for empty archive."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY)")
+            conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY)")
+            conn.commit()
+            result = _archive_readiness_counts(conn, source_conn=None, source_check_available=False)
+            assert result["session_count"] == 0
+            assert result["message_count"] == 0
+            assert result["raw_link_count"] == 0
+        finally:
+            conn.close()
+
+    def test_counts_with_data(self, tmp_path: Path) -> None:
+        """Counts correctly with data present."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY, raw_id TEXT)")
+            conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1, 'raw1'), (2, 'raw2')")
+            conn.execute("INSERT INTO messages VALUES (1), (2), (3)")
+            conn.commit()
+            result = _archive_readiness_counts(conn, source_conn=None, source_check_available=False)
+            assert result["session_count"] == 2
+            assert result["message_count"] == 3
+            assert result["raw_link_count"] == 2
+        finally:
+            conn.close()
+
+    def test_missing_raw_session_detection(self, tmp_path: Path) -> None:
+        """Detects sessions with raw_id that don't exist in source."""
+        db_path = tmp_path / "test.db"
+        source_path = tmp_path / "source.db"
+        conn = sqlite3.connect(db_path)
+        source_conn = sqlite3.connect(source_path)
+        try:
+            conn.execute("CREATE TABLE sessions (session_id INTEGER PRIMARY KEY, raw_id TEXT)")
+            source_conn.execute("CREATE TABLE raw_sessions (raw_id TEXT PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES (1, 'raw1'), (2, 'raw2'), (3, 'raw3')")
+            source_conn.execute("INSERT INTO raw_sessions VALUES ('raw1'), ('raw2')")
+            conn.commit()
+            source_conn.commit()
+            result = _archive_readiness_counts(conn, source_conn=source_conn, source_check_available=True)
+            assert result["missing_raw_session_count"] == 1  # raw3 is missing
+        finally:
+            conn.close()
+            source_conn.close()
+
+
+class TestArchiveStatusSurfaces:
+    """Tests for _archive_status_surfaces()."""
+
+    def test_archive_sessions_always_ready(self) -> None:
+        """archive_sessions surface is always ready=True."""
+        counts: dict[str, int] = {
+            "session_count": 0,
+            "raw_link_count": 0,
+            "missing_raw_session_count": 0,
+            "message_count": 0,
+            "text_block_count": 0,
+            "messages_fts_count": 0,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["archive_sessions"]["ready"] is True
+        assert result["archive_sessions"]["blockers"] == []
+
+    def test_tool_usage_always_ready(self) -> None:
+        """tool_usage surface is always ready=True."""
+        counts: dict[str, int] = {
+            "session_count": 0,
+            "raw_link_count": 0,
+            "missing_raw_session_count": 0,
+            "message_count": 0,
+            "text_block_count": 0,
+            "messages_fts_count": 0,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["tool_usage"]["ready"] is True
+
+    def test_raw_artifacts_unavailable_when_source_check_unavailable(self) -> None:
+        """raw_artifacts shows ready=None when source_check_available is False."""
+        counts: dict[str, int] = {
+            "session_count": 1,
+            "raw_link_count": 1,
+            "missing_raw_session_count": 0,
+            "message_count": 1,
+            "text_block_count": 1,
+            "messages_fts_count": 1,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=False)
+        assert result["raw_artifacts"]["ready"] is None
+        assert "source_tier_unavailable" in result["raw_artifacts"]["blockers"]
+
+    def test_raw_artifacts_failed_when_missing(self) -> None:
+        """raw_artifacts shows ready=False when missing_raw_session_count > 0."""
+        counts: dict[str, int] = {
+            "session_count": 1,
+            "raw_link_count": 1,
+            "missing_raw_session_count": 1,
+            "message_count": 1,
+            "text_block_count": 1,
+            "messages_fts_count": 1,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["raw_artifacts"]["ready"] is False
+        assert "missing_source_raw_sessions" in result["raw_artifacts"]["blockers"]
+
+    def test_search_fts_mismatch_blocker(self) -> None:
+        """search surface blocked when text_block_count != messages_fts_count."""
+        counts: dict[str, int] = {
+            "session_count": 1,
+            "raw_link_count": 0,
+            "missing_raw_session_count": 0,
+            "message_count": 10,
+            "text_block_count": 10,
+            "messages_fts_count": 8,  # mismatch
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["search"]["ready"] is False
+        assert "messages_fts_row_mismatch" in result["search"]["blockers"]
+
+    def test_materialization_blockers(self) -> None:
+        """Surfaces blocked when materialization missing."""
+        counts: dict[str, int] = {
+            "session_count": 2,
+            "raw_link_count": 0,
+            "missing_raw_session_count": 0,
+            "message_count": 1,
+            "text_block_count": 1,
+            "messages_fts_count": 1,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 1,  # missing for 1 session
+            "phase_row_count": 0,
+            "missing_phases_materialization": 2,  # missing for all 2 sessions
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["timeline_work_events"]["ready"] is False
+        assert "missing_work_events_materialization" in result["timeline_work_events"]["blockers"]
+        assert result["timeline_phases"]["ready"] is False
+        assert "missing_phases_materialization" in result["timeline_phases"]["blockers"]
+
+    def test_all_surfaces_present(self) -> None:
+        """All expected surfaces are present in result."""
+        counts: dict[str, int] = {
+            "session_count": 0,
+            "raw_link_count": 0,
+            "missing_raw_session_count": 0,
+            "message_count": 0,
+            "text_block_count": 0,
+            "messages_fts_count": 0,
+            "profile_row_count": 0,
+            "missing_profile_row_count": 0,
+            "work_event_row_count": 0,
+            "missing_work_events_materialization": 0,
+            "phase_row_count": 0,
+            "missing_phases_materialization": 0,
+            "thread_count": 0,
+            "missing_thread_materialization": 0,
+            "action_count": 0,
+            "missing_session_profile_materialization": 0,
+            "missing_latency_materialization": 0,
+        }
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        expected_surfaces = {
+            "archive_sessions",
+            "raw_artifacts",
+            "search",
+            "session_profiles",
+            "timeline_work_events",
+            "timeline_phases",
+            "threads",
+            "tool_usage",
+            "latency_profiles",
+        }
+        assert set(result.keys()) == expected_surfaces

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -1,0 +1,917 @@
+"""Tests for pure helper functions in polylogue.cli.archive_query."""
+
+from __future__ import annotations
+
+import csv
+import io
+import types
+from typing import cast
+
+import click
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.cli.archive_query import (
+    _build_cursor,
+    _csv,
+    _csv_tokens,
+    _decode_cursor,
+    _ellipsize,
+    _has_value,
+    _hit_line,
+    _limit,
+    _message_removed_by_transform,
+    _message_roles,
+    _message_type,
+    _metadata_pairs,
+    _offset,
+    _optional_date_ms,
+    _optional_int,
+    _optional_str,
+    _paginate_rows,
+    _project_payload,
+    _resolve_excluded_origins,
+    _resolve_origins,
+    _selected_fields,
+    _sort,
+    _stats_by_line,
+    _summary_line,
+    _tool_tokens,
+    _transform,
+    _tuple_tokens,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary
+from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow
+
+
+# Tests for _resolve_origins
+class TestResolveOrigins:
+    """Tests for _resolve_origins."""
+
+    def test_explicit_origin_single(self) -> None:
+        """Single origin returns as tuple."""
+        params: dict[str, object] = {"origin": "claude-code-session"}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session",)
+
+    def test_explicit_origin_csv(self) -> None:
+        """CSV origins are parsed and deduplicated."""
+        params: dict[str, object] = {"origin": "claude-code-session,chatgpt-export"}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session", "chatgpt-export")
+
+    def test_explicit_origin_deduped(self) -> None:
+        """Duplicate origins are deduplicated."""
+        params: dict[str, object] = {"origin": "claude-code-session,claude-code-session"}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session",)
+
+    def test_explicit_origin_stripped(self) -> None:
+        """Whitespace is stripped."""
+        params: dict[str, object] = {"origin": "  claude-code-session  ,  chatgpt-export  "}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session", "chatgpt-export")
+
+    def test_empty_params(self) -> None:
+        """Empty params returns empty tuple."""
+        result = _resolve_origins({})
+        assert result == ()
+
+    def test_provider_to_origin_mapping(self) -> None:
+        """Provider is mapped to origin."""
+        params: dict[str, object] = {"provider": "claude-code"}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session",)
+
+    def test_provider_csv(self) -> None:
+        """Multiple providers are mapped."""
+        params: dict[str, object] = {"provider": "claude-code,chatgpt"}
+        result = _resolve_origins(params)
+        assert result == ("claude-code-session", "chatgpt-export")
+
+    def test_invalid_provider(self) -> None:
+        """Invalid provider raises UsageError."""
+        params: dict[str, object] = {"provider": "bogus-provider"}
+        with pytest.raises(click.UsageError, match="cannot map provider"):
+            _resolve_origins(params)
+
+
+# Tests for _resolve_excluded_origins
+class TestResolveExcludedOrigins:
+    """Tests for _resolve_excluded_origins."""
+
+    def test_explicit_excluded_origin(self) -> None:
+        """Explicit excluded origins are parsed."""
+        params: dict[str, object] = {"exclude_origin": "claude-code-session,chatgpt-export"}
+        result = _resolve_excluded_origins(params)
+        assert result == ("claude-code-session", "chatgpt-export")
+
+    def test_exclude_provider(self) -> None:
+        """Excluded provider is mapped."""
+        params: dict[str, object] = {"exclude_provider": "claude-code"}
+        result = _resolve_excluded_origins(params)
+        assert result == ("claude-code-session",)
+
+    def test_exclude_provider_csv(self) -> None:
+        """Multiple excluded providers are mapped."""
+        params: dict[str, object] = {"exclude_provider": "claude-code,chatgpt"}
+        result = _resolve_excluded_origins(params)
+        assert result == ("claude-code-session", "chatgpt-export")
+
+    def test_invalid_exclude_provider(self) -> None:
+        """Invalid exclude provider raises UsageError."""
+        params: dict[str, object] = {"exclude_provider": "bogus-provider"}
+        with pytest.raises(click.UsageError, match="cannot map excluded provider"):
+            _resolve_excluded_origins(params)
+
+    def test_empty_params(self) -> None:
+        """Empty params returns empty tuple."""
+        result = _resolve_excluded_origins({})
+        assert result == ()
+
+
+# Tests for _csv_tokens
+class TestCsvTokens:
+    """Tests for _csv_tokens."""
+
+    def test_none_value(self) -> None:
+        """None returns empty tuple."""
+        result = _csv_tokens(None)
+        assert result == ()
+
+    def test_single_string(self) -> None:
+        """Single comma-separated string is split."""
+        result = _csv_tokens("a,b,c")
+        assert result == ("a", "b", "c")
+
+    def test_whitespace_stripped(self) -> None:
+        """Whitespace is stripped from each token."""
+        result = _csv_tokens("  a  ,  b  ,  c  ")
+        assert result == ("a", "b", "c")
+
+    def test_empty_tokens_dropped(self) -> None:
+        """Empty tokens are dropped."""
+        result = _csv_tokens("a,,b")
+        assert result == ("a", "b")
+
+    def test_tuple_of_strings(self) -> None:
+        """Tuple of CSV strings is flattened."""
+        result = _csv_tokens(("a,b", "c,d"))
+        assert result == ("a", "b", "c", "d")
+
+    def test_empty_tuple(self) -> None:
+        """Empty tuple returns empty tuple (not ('()',))."""
+        result = _csv_tokens(())
+        assert result == ()
+
+    def test_list_of_strings(self) -> None:
+        """List of CSV strings is flattened."""
+        result = _csv_tokens(["a,b", "c"])
+        assert result == ("a", "b", "c")
+
+
+# Tests for _tuple_tokens
+class TestTupleTokens:
+    """Tests for _tuple_tokens."""
+
+    def test_none_value(self) -> None:
+        """None returns empty tuple."""
+        result = _tuple_tokens(None)
+        assert result == ()
+
+    def test_string_value(self) -> None:
+        """Single string is wrapped in tuple."""
+        result = _tuple_tokens("value")
+        assert result == ("value",)
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty tuple."""
+        result = _tuple_tokens("")
+        assert result == ()
+
+    def test_whitespace_string(self) -> None:
+        """Whitespace-only string returns empty tuple."""
+        result = _tuple_tokens("   ")
+        assert result == ()
+
+    def test_iterable(self) -> None:
+        """Iterable values are stripped and collected."""
+        result = _tuple_tokens(["a", "b", "c"])
+        assert result == ("a", "b", "c")
+
+    def test_iterable_with_empty_strings(self) -> None:
+        """Empty strings in iterable are dropped."""
+        result = _tuple_tokens(["a", "", "b"])
+        assert result == ("a", "b")
+
+
+# Tests for _metadata_pairs
+class TestMetadataPairs:
+    """Tests for _metadata_pairs."""
+
+    def test_none_value(self) -> None:
+        """None returns empty tuple."""
+        result = _metadata_pairs(None)
+        assert result == ()
+
+    def test_list_of_pairs(self) -> None:
+        """List of 2-tuples is converted to tuple of string pairs."""
+        result = _metadata_pairs([("key1", "value1"), ("key2", "value2")])
+        assert result == (("key1", "value1"), ("key2", "value2"))
+
+    def test_list_of_lists(self) -> None:
+        """List of lists with 2+ elements works."""
+        result = _metadata_pairs([["key1", "value1"], ["key2", "value2"]])
+        assert result == (("key1", "value1"), ("key2", "value2"))
+
+    def test_non_iterable_raises_error(self) -> None:
+        """Non-iterable value raises UsageError."""
+        with pytest.raises(click.UsageError, match="expects key/value pairs"):
+            _metadata_pairs("not-a-list")
+
+    def test_non_pair_element_raises_error(self) -> None:
+        """Element that is not a 2+ sequence raises UsageError."""
+        with pytest.raises(click.UsageError, match="expects key/value pairs"):
+            _metadata_pairs([("key", "value"), "not-a-pair"])
+
+    def test_single_element_raises_error(self) -> None:
+        """1-element sequence raises UsageError."""
+        with pytest.raises(click.UsageError, match="expects key/value pairs"):
+            _metadata_pairs([["single"]])
+
+
+# Tests for _tool_tokens
+class TestToolTokens:
+    """Tests for _tool_tokens."""
+
+    def test_lowercases_tokens(self) -> None:
+        """Tool tokens are lowercased."""
+        result = _tool_tokens("Tool,ANOTHER")
+        assert result == ("tool", "another")
+
+    def test_none_value(self) -> None:
+        """None returns empty tuple."""
+        result = _tool_tokens(None)
+        assert result == ()
+
+
+# Tests for _message_type
+class TestMessageType:
+    """Tests for _message_type."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _message_type(None)
+        assert result is None
+
+    def test_false_value(self) -> None:
+        """False returns None."""
+        result = _message_type(False)
+        assert result is None
+
+    def test_valid_message_type(self) -> None:
+        """Valid message type returns its value."""
+        result = _message_type("message")
+        assert result == "message"
+
+    def test_invalid_message_type(self) -> None:
+        """Invalid message type raises UsageError."""
+        with pytest.raises(click.UsageError):
+            _message_type("invalid-type")
+
+
+# Tests for _message_roles
+class TestMessageRoles:
+    """Tests for _message_roles."""
+
+    def test_dialogue_only_true(self) -> None:
+        """dialogue_only=True returns (USER, ASSISTANT)."""
+        params: dict[str, object] = {"dialogue_only": True}
+        result = _message_roles(params)
+        assert result == (Role.USER, Role.ASSISTANT)
+
+    def test_empty_params(self) -> None:
+        """Empty params returns empty tuple."""
+        result = _message_roles({})
+        assert result == ()
+
+    def test_message_role_param(self) -> None:
+        """message_role param is normalized."""
+        params: dict[str, object] = {"message_role": "user"}
+        result = _message_roles(params)
+        assert result == (Role.USER,)
+
+    def test_invalid_message_role(self) -> None:
+        """Invalid message role raises UsageError."""
+        params: dict[str, object] = {"message_role": "invalid-role"}
+        with pytest.raises(click.UsageError):
+            _message_roles(params)
+
+
+# Tests for _sort
+class TestSort:
+    """Tests for _sort."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _sort(None)
+        assert result is None
+
+    def test_false_value(self) -> None:
+        """False returns None."""
+        result = _sort(False)
+        assert result is None
+
+    def test_valid_sort_values(self) -> None:
+        """Valid sort values are returned."""
+        for sort_val in ["date", "messages", "words", "longest", "tokens", "random"]:
+            result = _sort(sort_val)
+            assert result == sort_val
+
+    def test_invalid_sort_raises_error(self) -> None:
+        """Invalid sort value raises UsageError."""
+        with pytest.raises(click.UsageError, match="sort must be one of"):
+            _sort("invalid-sort")
+
+
+# Tests for _transform
+class TestTransform:
+    """Tests for _transform."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _transform(None)
+        assert result is None
+
+    def test_false_value(self) -> None:
+        """False returns None."""
+        result = _transform(False)
+        assert result is None
+
+    def test_valid_transforms(self) -> None:
+        """Valid transform values are returned."""
+        for transform_val in ["strip-tools", "strip-thinking", "strip-all"]:
+            result = _transform(transform_val)
+            assert result == transform_val
+
+    def test_invalid_transform_raises_error(self) -> None:
+        """Invalid transform raises UsageError."""
+        with pytest.raises(click.UsageError, match="transform must be one of"):
+            _transform("invalid-transform")
+
+
+# Tests for _optional_int
+class TestOptionalInt:
+    """Tests for _optional_int."""
+
+    def test_int_value(self) -> None:
+        """Int value is returned."""
+        result = _optional_int(42)
+        assert result == 42
+
+    def test_zero_is_returned(self) -> None:
+        """Zero is returned (0 is not in false set)."""
+        result = _optional_int(0)
+        assert result == 0
+
+    def test_non_int_returns_none(self) -> None:
+        """Non-int value returns None."""
+        result = _optional_int("42")
+        assert result is None
+
+
+# Tests for _optional_str
+class TestOptionalStr:
+    """Tests for _optional_str."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _optional_str(None)
+        assert result is None
+
+    def test_string_value(self) -> None:
+        """String value is stripped."""
+        result = _optional_str("  hello  ")
+        assert result == "hello"
+
+    def test_empty_string_returns_none(self) -> None:
+        """Empty string returns None."""
+        result = _optional_str("")
+        assert result is None
+
+    def test_whitespace_string_returns_none(self) -> None:
+        """Whitespace-only string returns None."""
+        result = _optional_str("   ")
+        assert result is None
+
+
+# Tests for _limit
+class TestLimit:
+    """Tests for _limit."""
+
+    def test_positive_int(self) -> None:
+        """Positive int is returned."""
+        result = _limit({"limit": 50})
+        assert result == 50
+
+    def test_default_when_missing(self) -> None:
+        """Default 20 when limit is missing."""
+        result = _limit({})
+        assert result == 20
+
+    def test_default_when_non_positive(self) -> None:
+        """Default 20 when limit is non-positive."""
+        result = _limit({"limit": 0})
+        assert result == 20
+        result = _limit({"limit": -1})
+        assert result == 20
+
+    def test_default_when_non_int(self) -> None:
+        """Default 20 when limit is non-int."""
+        result = _limit({"limit": "50"})
+        assert result == 20
+
+
+# Tests for _offset
+class TestOffset:
+    """Tests for _offset."""
+
+    def test_positive_int(self) -> None:
+        """Positive int is returned."""
+        result = _offset({"offset": 10})
+        assert result == 10
+
+    def test_default_when_missing(self) -> None:
+        """Default 0 when offset is missing."""
+        result = _offset({})
+        assert result == 0
+
+    def test_default_when_non_positive(self) -> None:
+        """Default 0 when offset is non-positive."""
+        result = _offset({"offset": 0})
+        assert result == 0
+        result = _offset({"offset": -1})
+        assert result == 0
+
+    def test_default_when_non_int(self) -> None:
+        """Default 0 when offset is non-int."""
+        result = _offset({"offset": "10"})
+        assert result == 0
+
+
+# Tests for _optional_date_ms
+class TestOptionalDateMs:
+    """Tests for _optional_date_ms."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _optional_date_ms("since", None)
+        assert result is None
+
+    def test_false_value(self) -> None:
+        """False returns None."""
+        result = _optional_date_ms("since", False)
+        assert result is None
+
+    def test_valid_iso_date(self) -> None:
+        """Valid ISO date is parsed to milliseconds."""
+        result = _optional_date_ms("since", "2026-01-15")
+        assert isinstance(result, int)
+        assert result > 0
+
+    def test_invalid_date_raises_exception(self) -> None:
+        """Invalid date raises ClickException."""
+        with pytest.raises(click.ClickException, match="Cannot parse date"):
+            _optional_date_ms("since", "not-a-date")
+
+
+# Tests for _has_value
+class TestHasValue:
+    """Tests for _has_value."""
+
+    def test_none_is_false(self) -> None:
+        """None returns False."""
+        assert _has_value(None) is False
+
+    def test_false_is_false(self) -> None:
+        """False returns False."""
+        assert _has_value(False) is False
+
+    def test_empty_string_is_false(self) -> None:
+        """Empty string returns False."""
+        assert _has_value("") is False
+
+    def test_empty_tuple_is_false(self) -> None:
+        """Empty tuple returns False."""
+        assert _has_value(()) is False
+
+    def test_empty_list_is_false(self) -> None:
+        """Empty list returns False."""
+        assert _has_value([]) is False
+
+    def test_string_is_true(self) -> None:
+        """Non-empty string returns True."""
+        assert _has_value("value") is True
+
+    def test_zero_is_true(self) -> None:
+        """Zero returns True (0 is not in the false set)."""
+        assert _has_value(0) is True
+
+    def test_tuple_is_true(self) -> None:
+        """Non-empty tuple returns True."""
+        assert _has_value(("a",)) is True
+
+
+# Tests for _selected_fields
+class TestSelectedFields:
+    """Tests for _selected_fields."""
+
+    def test_none_value(self) -> None:
+        """None returns None."""
+        result = _selected_fields(None)
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Empty string returns None."""
+        result = _selected_fields("")
+        assert result is None
+
+    def test_single_field(self) -> None:
+        """Single field returns frozenset."""
+        result = _selected_fields("field1")
+        assert result == frozenset({"field1"})
+
+    def test_multiple_fields(self) -> None:
+        """CSV fields are parsed."""
+        result = _selected_fields("field1,field2,field3")
+        assert result == frozenset({"field1", "field2", "field3"})
+
+    def test_whitespace_stripped(self) -> None:
+        """Whitespace is stripped from each field."""
+        result = _selected_fields("  field1  ,  field2  ")
+        assert result == frozenset({"field1", "field2"})
+
+    def test_empty_fields_dropped(self) -> None:
+        """Empty fields are dropped."""
+        result = _selected_fields("field1,,field2")
+        assert result == frozenset({"field1", "field2"})
+
+    def test_whitespace_only_returns_none(self) -> None:
+        """Whitespace-only result returns None."""
+        result = _selected_fields("   ")
+        assert result is None
+
+
+# Tests for _project_payload
+class TestProjectPayload:
+    """Tests for _project_payload."""
+
+    def test_no_fields_specified(self) -> None:
+        """No fields returns copy of payload."""
+        payload: dict[str, object] = {"a": 1, "b": 2, "c": 3}
+        result = _project_payload(payload, None)
+        assert result == payload
+        assert result is not payload  # Should be a copy
+
+    def test_select_subset_of_fields(self) -> None:
+        """Selected fields are kept."""
+        payload: dict[str, object] = {"a": 1, "b": 2, "c": 3}
+        result = _project_payload(payload, "a,c")
+        assert result == {"a": 1, "c": 3}
+
+    def test_missing_fields_ignored(self) -> None:
+        """Missing fields are safely ignored."""
+        payload: dict[str, object] = {"a": 1, "b": 2}
+        result = _project_payload(payload, "a,missing")
+        assert result == {"a": 1}
+
+
+# Tests for _csv
+class TestCsv:
+    """Tests for _csv."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty string."""
+        result = _csv([])
+        assert result == ""
+
+    def test_single_row(self) -> None:
+        """Single row is formatted with header."""
+        items: list[dict[str, object]] = [{"id": "1", "name": "test"}]
+        result = _csv(items)
+        reader = csv.DictReader(io.StringIO(result))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["id"] == "1"
+        assert rows[0]["name"] == "test"
+
+    def test_multiple_rows(self) -> None:
+        """Multiple rows are formatted."""
+        items: list[dict[str, object]] = [
+            {"id": "1", "name": "test1"},
+            {"id": "2", "name": "test2"},
+        ]
+        result = _csv(items)
+        reader = csv.DictReader(io.StringIO(result))
+        rows = list(reader)
+        assert len(rows) == 2
+
+    def test_csv_contains_header(self) -> None:
+        """CSV output contains header line."""
+        items: list[dict[str, object]] = [{"key": "value"}]
+        result = _csv(items)
+        lines = [line.strip() for line in result.strip().split("\n")]
+        assert len(lines) == 2
+        assert lines[0] == "key"
+
+
+# Tests for _ellipsize
+class TestEllipsize:
+    """Tests for _ellipsize."""
+
+    def test_short_string_unchanged(self) -> None:
+        """Short string is unchanged."""
+        result = _ellipsize("hello", 10)
+        assert result == "hello"
+
+    def test_long_string_truncated(self) -> None:
+        """Long string is truncated with ellipsis."""
+        result = _ellipsize("hello world", 8)
+        assert result == "hello..."
+        assert len(result) == 8
+
+    def test_max_width_3_or_less(self) -> None:
+        """max_width <= 3 is hard slice."""
+        result = _ellipsize("hello", 3)
+        assert result == "hel"
+
+    def test_exact_length_no_truncation(self) -> None:
+        """String of exact length is not truncated."""
+        result = _ellipsize("hello", 5)
+        assert result == "hello"
+
+
+# Tests for _summary_line
+class TestSummaryLine:
+    """Tests for _summary_line."""
+
+    def test_summary_line_format(self) -> None:
+        """Summary line contains expected fields."""
+        item: dict[str, object] = {
+            "session_id": "abc123def456",
+            "title": "Test Session",
+            "created_at": "2026-01-15T10:00:00Z",
+            "updated_at": "2026-01-15T11:00:00Z",
+            "origin": "claude-code-session",
+            "message_count": 42,
+        }
+        result = _summary_line(item)
+        assert "abc123def456" in result
+        assert "2026-01-15" in result
+        assert "claude-code-session" in result
+        assert "Test Session" in result
+        assert "42" in result
+
+    def test_summary_line_missing_title(self) -> None:
+        """Missing title falls back to session_id."""
+        item: dict[str, object] = {
+            "session_id": "abc123",
+            "origin": "chatgpt-export",
+            "created_at": "2026-01-15T10:00:00Z",
+        }
+        result = _summary_line(item)
+        assert "abc123" in result
+
+
+# Tests for _hit_line
+class TestHitLine:
+    """Tests for _hit_line."""
+
+    def test_hit_line_format(self) -> None:
+        """Hit line contains expected fields."""
+        item: dict[str, object] = {
+            "rank": 1,
+            "origin": "claude-code-session",
+            "title": "Hit Title",
+            "session_id": "abc123",
+            "snippet": "...relevant text...",
+        }
+        result = _hit_line(item)
+        assert "1" in result
+        assert "claude-code-session" in result
+        assert "Hit Title" in result
+        assert "...relevant text..." in result
+
+    def test_hit_line_missing_title_uses_session_id(self) -> None:
+        """Missing title falls back to session_id."""
+        item: dict[str, object] = {
+            "rank": 2,
+            "origin": "chatgpt-export",
+            "session_id": "xyz789",
+            "snippet": "...snippet...",
+        }
+        result = _hit_line(item)
+        assert "xyz789" in result
+
+
+# Tests for _stats_by_line
+class TestStatsByLine:
+    """Tests for _stats_by_line."""
+
+    def test_stats_by_line_format(self) -> None:
+        """Stats line contains group and count."""
+        item: dict[str, object] = {"group": "claude-code", "count": 42}
+        result = _stats_by_line(item)
+        assert "claude-code" in result
+        assert "42" in result
+
+
+# Tests for _message_removed_by_transform
+class TestMessageRemovedByTransform:
+    """Tests for _message_removed_by_transform."""
+
+    def test_no_transform_keeps_message(self) -> None:
+        """transform=None keeps message."""
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=()),
+        )
+        assert _message_removed_by_transform(message, None) is False
+
+    def test_strip_tools_removes_tool_use(self) -> None:
+        """strip-tools removes message with tool_use block."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="tool_use"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-tools") is True
+
+    def test_strip_tools_removes_tool_result(self) -> None:
+        """strip-tools removes message with tool_result block."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="tool_result"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-tools") is True
+
+    def test_strip_tools_keeps_other_blocks(self) -> None:
+        """strip-tools keeps message without tool blocks."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="text"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-tools") is False
+
+    def test_strip_thinking_removes_thinking(self) -> None:
+        """strip-thinking removes message with thinking block."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="thinking"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-thinking") is True
+
+    def test_strip_thinking_keeps_other_blocks(self) -> None:
+        """strip-thinking keeps message without thinking block."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="text"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-thinking") is False
+
+    def test_strip_all_removes_tool_or_thinking(self) -> None:
+        """strip-all removes message with tool or thinking."""
+        tool_block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="tool_use"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(tool_block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-all") is True
+
+        thinking_block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="thinking"),
+        )
+        message2 = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(thinking_block,)),
+        )
+        assert _message_removed_by_transform(message2, "strip-all") is True
+
+    def test_strip_all_keeps_prose(self) -> None:
+        """strip-all keeps message with only prose."""
+        block = cast(
+            ArchiveBlockRow,
+            types.SimpleNamespace(block_type="text"),
+        )
+        message = cast(
+            ArchiveMessageRow,
+            types.SimpleNamespace(blocks=(block,)),
+        )
+        assert _message_removed_by_transform(message, "strip-all") is False
+
+
+# Tests for _decode_cursor and _build_cursor
+class TestCursorRoundtrip:
+    """Tests for cursor encoding/decoding."""
+
+    def test_decode_none_returns_none(self) -> None:
+        """_decode_cursor(None) returns None."""
+        result = _decode_cursor(None)
+        assert result is None
+
+    def test_decode_invalid_cursor_raises_error(self) -> None:
+        """Invalid cursor token raises UsageError."""
+        with pytest.raises(click.UsageError, match="invalid --cursor"):
+            _decode_cursor("invalid-cursor-token")
+
+    def test_cursor_roundtrip(self) -> None:
+        """Cursor can be built and decoded."""
+        summary = cast(
+            ArchiveSessionSummary,
+            types.SimpleNamespace(session_id="test-session-id"),
+        )
+        built_cursor = _build_cursor(summary, rank=10, retrieval_lane="dialogue")
+        assert isinstance(built_cursor, str)
+
+        decoded = _decode_cursor(built_cursor)
+        assert decoded is not None
+        assert decoded.r == 10
+        assert decoded.c == "test-session-id"
+        assert decoded.lane == "dialogue"
+
+
+# Tests for _paginate_rows
+class TestPaginateRows:
+    """Tests for _paginate_rows."""
+
+    def test_rows_within_limit(self) -> None:
+        """Rows within limit return all rows and no cursor."""
+        rows = [
+            cast(
+                ArchiveSessionSummary,
+                types.SimpleNamespace(session_id=f"session-{i}"),
+            )
+            for i in range(5)
+        ]
+        page, next_cursor = _paginate_rows(rows, limit=10, offset=0)
+        assert len(page) == 5
+        assert next_cursor is None
+
+    def test_rows_exceed_limit(self) -> None:
+        """Rows exceeding limit return limited page and cursor."""
+        rows = [
+            cast(
+                ArchiveSessionSummary,
+                types.SimpleNamespace(session_id=f"session-{i}"),
+            )
+            for i in range(30)
+        ]
+        page, next_cursor = _paginate_rows(rows, limit=10, offset=0)
+        assert len(page) == 10
+        assert next_cursor is not None
+
+    def test_empty_rows(self) -> None:
+        """Empty rows return empty page and no cursor."""
+        page, next_cursor = _paginate_rows([], limit=10, offset=0)
+        assert len(page) == 0
+        assert next_cursor is None
+
+    def test_offset_applied_to_cursor_rank(self) -> None:
+        """Offset is applied to cursor rank."""
+        rows = [
+            cast(
+                ArchiveSessionSummary,
+                types.SimpleNamespace(session_id=f"session-{i}"),
+            )
+            for i in range(30)
+        ]
+        page, next_cursor = _paginate_rows(rows, limit=10, offset=5)
+        assert len(page) == 10
+        assert next_cursor is not None
+
+        decoded = _decode_cursor(next_cursor)
+        assert decoded is not None
+        assert decoded.r == 15  # offset + len(page) = 5 + 10

--- a/tests/unit/insights/test_registry.py
+++ b/tests/unit/insights/test_registry.py
@@ -1,0 +1,580 @@
+"""Tests for polylogue.insights.registry — pure function coverage."""
+
+from __future__ import annotations
+
+import types
+from typing import Any, cast
+
+import pytest
+
+from polylogue.insights.archive import (
+    ArchiveCoverageInsightQuery,
+    SessionProfileInsight,
+    SessionProfileInsightQuery,
+)
+from polylogue.insights.archive_models import (
+    ArchiveInsightProvenance,
+)
+from polylogue.insights.registry import (
+    INSIGHT_REGISTRY,
+    InsightQueryError,
+    InsightType,
+    _attr,
+    _build_query,
+    _count_with_percentage,
+    _formatted_float,
+    _id_with_origin,
+    _list_preview,
+    _nested,
+    _nested_ms_as_seconds,
+    _source_name_origin,
+    _stringify,
+    get_insight_type,
+    insight_items_payload,
+    list_insight_types,
+    project_origin_payload,
+    register,
+    render_insight_items,
+)
+
+
+class TestProjectOriginPayload:
+    """Test project_origin_payload() — origin vocabulary projection."""
+
+    def test_scalar_passthrough(self) -> None:
+        """Non-dict/list/tuple scalars pass through unchanged."""
+        assert project_origin_payload(42) == 42
+        assert project_origin_payload("test") == "test"
+        assert project_origin_payload(None) is None
+        assert project_origin_payload(3.14) == 3.14
+
+    def test_list_recursion(self) -> None:
+        """Lists are recursed element-wise."""
+        result_list = project_origin_payload([{"source_name": "claude-code-session"}, 123])
+        assert isinstance(result_list, list)
+        assert len(result_list) == 2
+        assert result_list[0] == {"origin": "claude-code-session"}
+        assert result_list[1] == 123
+
+    def test_tuple_becomes_list(self) -> None:
+        """Tuples become lists after recursion."""
+        result = project_origin_payload(({"provider": "CLAUDE"}, "scalar"))
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_source_name_to_origin(self) -> None:
+        """Dict with source_name key → origin key."""
+        result = project_origin_payload({"source_name": "claude-code-session", "x": 1})
+        assert result == {"origin": "claude-code-session", "x": 1}
+
+    def test_provider_to_origin(self) -> None:
+        """Dict with provider key → origin key."""
+        result = project_origin_payload({"provider": "CLAUDE", "count": 5})
+        assert result == {"origin": "claude-ai-export", "count": 5}
+
+    def test_provider_coverage_projects(self) -> None:
+        """Dict with provider_coverage → origin_coverage, recursed."""
+        result = project_origin_payload({"provider_coverage": {"provider": "CLAUDE", "count": 3}})
+        assert result == {"origin_coverage": {"origin": "claude-ai-export", "count": 3}}
+
+    def test_provider_breakdown_dict_projects(self) -> None:
+        """provider_breakdown dict keys are origin-projected."""
+        result = project_origin_payload({"provider_breakdown": {"CLAUDE": 10, "CHATGPT": 5}})
+        result_dict = cast(dict[str, object], result)
+        breakdown = cast(dict[str, object], result_dict["origin_breakdown"])
+        assert isinstance(breakdown, dict)
+        assert breakdown["claude-ai-export"] == 10
+        assert breakdown["chatgpt-export"] == 5
+
+    def test_providers_with_data_to_origins_with_data(self) -> None:
+        """providers_with_data → origins_with_data."""
+        result = project_origin_payload({"providers_with_data": ["CLAUDE", "CHATGPT"]})
+        assert result == {"origins_with_data": ["CLAUDE", "CHATGPT"]}
+
+    def test_providers_without_data_to_origins_without_data(self) -> None:
+        """providers_without_data → origins_without_data."""
+        result = project_origin_payload({"providers_without_data": ["GEMINI"]})
+        assert result == {"origins_without_data": ["GEMINI"]}
+
+    def test_group_by_provider_to_origin(self) -> None:
+        """group_by == 'provider' becomes 'origin'."""
+        result = project_origin_payload({"group_by": "provider", "other": "data"})
+        result_dict = cast(dict[str, object], result)
+        assert result_dict["group_by"] == "origin"
+        assert result_dict["other"] == "data"
+
+    def test_group_by_provider_also_projects_bucket(self) -> None:
+        """When group_by was 'provider', bucket key is also origin-projected."""
+        result = project_origin_payload({"group_by": "provider", "bucket": "CLAUDE"})
+        result_dict = cast(dict[str, object], result)
+        assert result_dict["group_by"] == "origin"
+        assert result_dict["bucket"] == "claude-ai-export"
+
+    def test_group_by_other_values_unchanged(self) -> None:
+        """group_by values other than 'provider' pass through."""
+        result = project_origin_payload({"group_by": "day"})
+        result_dict = cast(dict[str, object], result)
+        assert result_dict["group_by"] == "day"
+
+    def test_nested_recursion(self) -> None:
+        """Nested structures are recursed."""
+        result = project_origin_payload(
+            {
+                "data": [{"provider": "CLAUDE"}],
+                "meta": {"source_name": "codex-session"},
+            }
+        )
+        result_dict = cast(dict[str, object], result)
+        assert result_dict["data"] == [{"origin": "claude-ai-export"}]
+        assert result_dict["meta"] == {"origin": "codex-session"}
+
+
+class TestInsightItemsPayload:
+    """Test insight_items_payload() — payload envelope contract."""
+
+    def test_empty_items_envelope(self) -> None:
+        """Empty items list returns {total: 0, json_key: []}."""
+        insight_type = get_insight_type("session_profiles")
+        result = insight_items_payload([], insight_type)
+        assert result == {"total": 0, "session_profiles": []}
+
+    def test_total_field_not_count(self) -> None:
+        """Critical contract: field is 'total', NOT 'count' (per #1007)."""
+        insight_type = get_insight_type("threads")
+        result = insight_items_payload([], insight_type)
+        assert "total" in result
+        assert "count" not in result
+
+    def test_custom_item_key(self) -> None:
+        """item_key parameter overrides default json_key."""
+        insight_type = get_insight_type("session_profiles")
+        result = insight_items_payload([], insight_type, item_key="custom_items")
+        assert "custom_items" in result
+        assert "session_profiles" not in result
+        assert result["total"] == 0
+
+    def test_items_are_serialized(self) -> None:
+        """Items are serialized via model_dump(mode='json') and origin-projected."""
+        # Build a minimal SessionProfileInsight
+        insight = SessionProfileInsight(
+            session_id="sess-123",
+            logical_session_id="logical-456",
+            source_name="claude-code-session",
+            title="Test Session",
+            provenance=ArchiveInsightProvenance(
+                materializer_version=1,
+                materialized_at="2026-01-01T00:00:00Z",
+            ),
+        )
+        insight_type = get_insight_type("session_profiles")
+        result = insight_items_payload([insight], insight_type)
+        assert result["total"] == 1
+        items_list = cast(list[dict[str, object]], result["session_profiles"])
+        assert len(items_list) == 1
+        item_dict = items_list[0]
+        # Verify origin projection happened
+        assert item_dict["origin"] == "claude-code-session"
+
+
+class TestRegistryOperations:
+    """Test register(), get_insight_type(), list_insight_types()."""
+
+    def test_list_insight_types_sorted(self) -> None:
+        """list_insight_types() returns sorted list of registered names."""
+        names = list_insight_types()
+        assert isinstance(names, list)
+        assert names == sorted(names)
+        # Verify known types are present
+        assert "session_profiles" in names
+        assert "threads" in names
+        assert "archive_coverage" in names
+
+    def test_get_insight_type_success(self) -> None:
+        """get_insight_type() returns registered InsightType by name."""
+        insight = get_insight_type("session_profiles")
+        assert insight.name == "session_profiles"
+        assert insight.display_name == "Session Profiles"
+        assert insight.json_key == "session_profiles"
+
+    def test_get_insight_type_unknown_raises_keyerror(self) -> None:
+        """get_insight_type() raises KeyError for unknown name, listing available."""
+        with pytest.raises(KeyError) as exc_info:
+            get_insight_type("nonexistent-type")
+        error_msg = str(exc_info.value)
+        assert "Unknown insight type" in error_msg
+        assert "nonexistent-type" in error_msg
+        assert "Available" in error_msg
+
+    def test_register_new_type_and_retrieve(self) -> None:
+        """register() adds to INSIGHT_REGISTRY; get_insight_type() retrieves it."""
+        # Use a unique name to avoid conflicts
+        unique_name = "test_unique_registry_type_xyz"
+        new_type = InsightType(
+            name=unique_name,
+            display_name="Unique Test Type",
+            json_key=unique_name,
+        )
+        # Clean up if it somehow exists
+        INSIGHT_REGISTRY.pop(unique_name, None)
+
+        # Register and retrieve
+        returned = register(new_type)
+        assert returned is new_type
+        assert get_insight_type(unique_name) is new_type
+        assert unique_name in list_insight_types()
+
+        # Clean up
+        INSIGHT_REGISTRY.pop(unique_name, None)
+
+
+class TestInsightTypeResolvedCliCommandName:
+    """Test InsightType.resolved_cli_command_name property."""
+
+    def test_when_cli_command_name_set(self) -> None:
+        """When cli_command_name is set, returns it."""
+        insight = InsightType(
+            name="my_type",
+            display_name="My Type",
+            json_key="my_type",
+            cli_command_name="custom-command",
+        )
+        assert insight.resolved_cli_command_name == "custom-command"
+
+    def test_when_cli_command_name_empty(self) -> None:
+        """When cli_command_name is empty, returns name with underscores → dashes."""
+        insight = InsightType(
+            name="my_insight_type",
+            display_name="My Insight Type",
+            json_key="my_insight_type",
+            cli_command_name="",
+        )
+        assert insight.resolved_cli_command_name == "my-insight-type"
+
+    def test_when_cli_command_name_not_set(self) -> None:
+        """When cli_command_name is not set (default), returns name with conversion."""
+        insight = InsightType(
+            name="another_test_name",
+            display_name="Another Test",
+            json_key="another",
+        )
+        assert insight.resolved_cli_command_name == "another-test-name"
+
+
+class TestFieldAccessors:
+    """Test field accessor factory functions."""
+
+    def _make_item(self, **attrs: object) -> object:
+        """Helper to create a test item with arbitrary attributes."""
+        return types.SimpleNamespace(**attrs)
+
+    def test_attr_basic(self) -> None:
+        """_attr() reads attribute by name."""
+        accessor = _attr("name")
+        item = self._make_item(name="Alice")
+        assert accessor(item) == "Alice"  # type: ignore[arg-type]
+
+    def test_attr_missing_uses_default(self) -> None:
+        """_attr() returns default when attribute is missing."""
+        accessor = _attr("name", default="MISSING")
+        item = self._make_item(other="value")
+        assert accessor(item) == "MISSING"  # type: ignore[arg-type]
+
+    def test_attr_none_uses_default(self) -> None:
+        """_attr() returns default when attribute is None."""
+        accessor = _attr("name", default="NULL")
+        item = self._make_item(name=None)
+        assert accessor(item) == "NULL"  # type: ignore[arg-type]
+
+    def test_attr_empty_string_uses_default(self) -> None:
+        """_attr() returns default when attribute is empty string."""
+        accessor = _attr("name", default="EMPTY")
+        item = self._make_item(name="")
+        assert accessor(item) == "EMPTY"  # type: ignore[arg-type]
+
+    def test_nested_reads_nested_attribute(self) -> None:
+        """_nested() reads item.outer.inner."""
+        accessor = _nested("data", "value")
+        data = types.SimpleNamespace(value="nested_val")
+        item = self._make_item(data=data)
+        assert accessor(item) == "nested_val"  # type: ignore[arg-type]
+
+    def test_nested_outer_none_uses_default(self) -> None:
+        """_nested() returns default when outer is None."""
+        accessor = _nested("data", "value", default="NONE")
+        item = self._make_item(data=None)
+        assert accessor(item) == "NONE"  # type: ignore[arg-type]
+
+    def test_nested_inner_missing_uses_default(self) -> None:
+        """_nested() returns default when inner is missing."""
+        accessor = _nested("data", "value", default="MISSING")
+        data = types.SimpleNamespace(other="val")
+        item = self._make_item(data=data)
+        assert accessor(item) == "MISSING"  # type: ignore[arg-type]
+
+    def test_nested_ms_as_seconds_converts(self) -> None:
+        """_nested_ms_as_seconds() converts ms to seconds (floor div 1000)."""
+        accessor = _nested_ms_as_seconds("timing", "duration_ms")
+        timing = types.SimpleNamespace(duration_ms=5000)
+        item = self._make_item(timing=timing)
+        assert accessor(item) == "5"  # type: ignore[arg-type]
+
+    def test_nested_ms_as_seconds_floor(self) -> None:
+        """_nested_ms_as_seconds() floors division."""
+        accessor = _nested_ms_as_seconds("timing", "duration_ms")
+        timing = types.SimpleNamespace(duration_ms=1234)
+        item = self._make_item(timing=timing)
+        assert accessor(item) == "1"  # type: ignore[arg-type]
+
+    def test_nested_ms_as_seconds_negative_clamped(self) -> None:
+        """_nested_ms_as_seconds() clamps negative values to 0."""
+        accessor = _nested_ms_as_seconds("timing", "duration_ms")
+        timing = types.SimpleNamespace(duration_ms=-100)
+        item = self._make_item(timing=timing)
+        assert accessor(item) == "0"  # type: ignore[arg-type]
+
+    def test_nested_ms_as_seconds_non_int_returns_default(self) -> None:
+        """_nested_ms_as_seconds() returns default for non-int values."""
+        accessor = _nested_ms_as_seconds("timing", "duration_ms", default="ERROR")
+        timing = types.SimpleNamespace(duration_ms="not_an_int")
+        item = self._make_item(timing=timing)
+        assert accessor(item) == "ERROR"  # type: ignore[arg-type]
+
+    def test_id_with_origin_canonical(self) -> None:
+        """_id_with_origin() formats 'id [origin]' with canonical origin."""
+        accessor = _id_with_origin("session_id")
+        item = self._make_item(session_id="sess-123", source_name="claude-code-session")
+        assert accessor(item) == "sess-123 [claude-code-session]"  # type: ignore[arg-type]
+
+    def test_id_with_origin_projected(self) -> None:
+        """_id_with_origin() projects provider to origin."""
+        accessor = _id_with_origin("event_id")
+        item = self._make_item(event_id="ev-456", source_name="CLAUDE")
+        result = accessor(item)  # type: ignore[arg-type]
+        assert "ev-456" in result
+        assert "claude-ai-export" in result
+
+    def test_id_with_origin_unknown_source(self) -> None:
+        """_id_with_origin() uses 'unknown-export' when source_name is unmapped."""
+        accessor = _id_with_origin("id")
+        item = self._make_item(id="test-id", source_name="nonexistent")
+        assert accessor(item) == "test-id [unknown-export]"  # type: ignore[arg-type]
+
+    def test_list_preview_basic(self) -> None:
+        """_list_preview() shows first N items joined by ', '."""
+        accessor = _list_preview("tags", limit=2)
+        item = self._make_item(tags=["tag1", "tag2", "tag3"])
+        assert accessor(item) == "tag1, tag2"  # type: ignore[arg-type]
+
+    def test_list_preview_fewer_than_limit(self) -> None:
+        """_list_preview() joins all items when fewer than limit."""
+        accessor = _list_preview("tags", limit=5)
+        item = self._make_item(tags=["a", "b"])
+        assert accessor(item) == "a, b"  # type: ignore[arg-type]
+
+    def test_list_preview_empty_list_returns_dash(self) -> None:
+        """_list_preview() returns '-' for empty list."""
+        accessor = _list_preview("tags")
+        item = self._make_item(tags=[])
+        assert accessor(item) == "-"  # type: ignore[arg-type]
+
+    def test_list_preview_tuple_works(self) -> None:
+        """_list_preview() works with tuples too."""
+        accessor = _list_preview("items", limit=2)
+        item = self._make_item(items=("x", "y", "z"))
+        assert accessor(item) == "x, y"  # type: ignore[arg-type]
+
+    def test_list_preview_non_list_stringified(self) -> None:
+        """_list_preview() stringifies non-list/tuple values."""
+        accessor = _list_preview("value")
+        item = self._make_item(value=42)
+        assert accessor(item) == "42"  # type: ignore[arg-type]
+
+    def test_formatted_float_basic(self) -> None:
+        """_formatted_float() formats with precision."""
+        accessor = _formatted_float("ratio", precision=2)
+        item = self._make_item(ratio=3.14159)
+        assert accessor(item) == "3.14"  # type: ignore[arg-type]
+
+    def test_formatted_float_int_converted(self) -> None:
+        """_formatted_float() works with int values too."""
+        accessor = _formatted_float("count", precision=1)
+        item = self._make_item(count=42)
+        assert accessor(item) == "42.0"  # type: ignore[arg-type]
+
+    def test_formatted_float_bool_returns_default(self) -> None:
+        """_formatted_float() returns default for bool values."""
+        accessor = _formatted_float("flag", default="BOOL")
+        item = self._make_item(flag=True)
+        assert accessor(item) == "BOOL"  # type: ignore[arg-type]
+
+    def test_formatted_float_non_numeric_returns_default(self) -> None:
+        """_formatted_float() returns default for non-numeric."""
+        accessor = _formatted_float("value", default="NAN")
+        item = self._make_item(value="not_a_number")
+        assert accessor(item) == "NAN"  # type: ignore[arg-type]
+
+    def test_count_with_percentage_both_present(self) -> None:
+        """_count_with_percentage() formats 'count (pct%)' when both present."""
+        accessor = _count_with_percentage("count", "percent")
+        item = self._make_item(count=50, percent=75.5)
+        assert accessor(item) == "50 (75.5%)"  # type: ignore[arg-type]
+
+    def test_count_with_percentage_count_only(self) -> None:
+        """_count_with_percentage() shows count alone if percentage missing/non-numeric."""
+        accessor = _count_with_percentage("count", "percent")
+        item = self._make_item(count=30, percent=None)
+        assert accessor(item) == "30"  # type: ignore[arg-type]
+
+    def test_count_with_percentage_count_invalid_returns_dash(self) -> None:
+        """_count_with_percentage() returns '-' if count is invalid."""
+        accessor = _count_with_percentage("count", "percent")
+        item = self._make_item(count="not_int", percent=50.0)
+        assert accessor(item) == "-"  # type: ignore[arg-type]
+
+    def test_count_with_percentage_bool_count_invalid(self) -> None:
+        """_count_with_percentage() treats bool count as invalid."""
+        accessor = _count_with_percentage("count", "percent")
+        item = self._make_item(count=True, percent=50.0)
+        assert accessor(item) == "-"  # type: ignore[arg-type]
+
+
+class TestStringify:
+    """Test _stringify() helper."""
+
+    def test_none_returns_default(self) -> None:
+        """_stringify(None) returns default."""
+        assert _stringify(None) == "-"
+        assert _stringify(None, "NULL") == "NULL"
+
+    def test_empty_string_returns_default(self) -> None:
+        """_stringify('') returns default."""
+        assert _stringify("") == "-"
+        assert _stringify("", "EMPTY") == "EMPTY"
+
+    def test_non_empty_string_returned(self) -> None:
+        """_stringify(str) returns the string."""
+        assert _stringify("hello") == "hello"
+
+    def test_other_types_stringified(self) -> None:
+        """_stringify(non-str) converts to string."""
+        assert _stringify(42) == "42"
+        assert _stringify(3.14) == "3.14"
+
+
+class TestSourceNameOrigin:
+    """Test _source_name_origin() helper."""
+
+    def test_canonical_origin_values_pass_through(self) -> None:
+        """Canonical Origin enum values pass through unchanged."""
+        assert _source_name_origin("claude-code-session") == "claude-code-session"
+        assert _source_name_origin("chatgpt-export") == "chatgpt-export"
+
+    def test_provider_enum_mapped(self) -> None:
+        """Provider enum values are mapped to origins."""
+        result = _source_name_origin("CLAUDE")
+        assert result == "claude-ai-export"
+
+    def test_empty_string_returns_unknown(self) -> None:
+        """_source_name_origin('') returns 'unknown'."""
+        assert _source_name_origin("") == "unknown"
+
+    def test_none_returns_unknown(self) -> None:
+        """_source_name_origin(None) returns 'unknown'."""
+        assert _source_name_origin(None) == "unknown"
+
+    def test_unmapped_value_returns_unknown_export(self) -> None:
+        """Unmappable values canonicalize to Provider.UNKNOWN → Origin.UNKNOWN_EXPORT."""
+        assert _source_name_origin("totally-invalid-provider") == "unknown-export"
+
+    def test_provider_string_case_insensitive(self) -> None:
+        """Provider strings are normalized (case-insensitive, alias-aware)."""
+        # "Claude" normalizes to "claude" → aliased to "claude-ai" → Origin.CLAUDE_AI_EXPORT
+        result = _source_name_origin("Claude")
+        assert result == "claude-ai-export"
+
+
+class TestRenderInsightItems:
+    """Test render_insight_items() output."""
+
+    def test_json_mode_with_empty_items(self, capsys: Any) -> None:
+        """json_mode=True with empty items emits JSON success envelope."""
+        insight_type = get_insight_type("session_profiles")
+        render_insight_items([], insight_type, json_mode=True)
+        captured = capsys.readouterr()
+        assert captured.out  # Should have output
+        # Should contain the structure from emit_success
+        assert "session_profiles" in captured.out or "total" in captured.out
+
+    def test_plain_mode_empty_items_shows_message(self, capsys: Any) -> None:
+        """json_mode=False with empty items echoes empty_message."""
+        insight_type = get_insight_type("threads")
+        render_insight_items([], insight_type, json_mode=False)
+        captured = capsys.readouterr()
+        assert insight_type.empty_message in captured.out
+
+    def test_plain_mode_with_items_shows_header_and_fields(self, capsys: Any) -> None:
+        """json_mode=False with items shows display_name, count, and field lines."""
+        # Create minimal SessionProfileInsight
+        insight = SessionProfileInsight(
+            session_id="sess-001",
+            logical_session_id="logical-001",
+            source_name="claude-code-session",
+            title="Test Session",
+            provenance=ArchiveInsightProvenance(
+                materializer_version=1,
+                materialized_at="2026-01-01T00:00:00Z",
+            ),
+        )
+        insight_type = get_insight_type("session_profiles")
+        render_insight_items([insight], insight_type, json_mode=False)
+        captured = capsys.readouterr()
+
+        # Should show display name and count
+        assert "Session Profiles: 1" in captured.out
+        # Should include some field output
+        assert "sess-001" in captured.out
+
+
+class TestBuildQuery:
+    """Test _build_query() query validation."""
+
+    def test_build_query_no_query_model_raises(self) -> None:
+        """_build_query() raises InsightQueryError when query_model is None."""
+        insight_type = InsightType(
+            name="no_query",
+            display_name="No Query",
+            json_key="no_query",
+            query_model=None,
+        )
+        with pytest.raises(InsightQueryError) as exc_info:
+            _build_query(insight_type)
+        assert "does not declare a query model" in str(exc_info.value)
+
+    def test_build_query_unknown_field_raises(self) -> None:
+        """_build_query() raises InsightQueryError for unknown query fields."""
+        insight_type = get_insight_type("session_profiles")
+        with pytest.raises(InsightQueryError) as exc_info:
+            _build_query(insight_type, unknown_field="value")
+        error_msg = str(exc_info.value)
+        assert "Unknown query field" in error_msg
+        assert "unknown_field" in error_msg
+        assert "Accepted fields" in error_msg
+
+    def test_build_query_valid_fields_succeed(self) -> None:
+        """_build_query() succeeds with valid fields."""
+
+        insight_type = get_insight_type("session_profiles")
+        query = _build_query(
+            insight_type,
+            tier="merged",
+            limit=10,
+        )
+        query_obj = cast(SessionProfileInsightQuery, query)
+        assert query_obj.tier == "merged"
+        assert query_obj.limit == 10
+
+    def test_build_query_returns_correct_type(self) -> None:
+        """_build_query() returns instance of query_model."""
+        insight_type = get_insight_type("archive_coverage")
+        query = _build_query(insight_type, group_by="day")
+        assert isinstance(query, ArchiveCoverageInsightQuery)


### PR DESCRIPTION
## Summary

Adds focused unit tests for the three production modules that
`devtools verify-test-coverage-contracts` flagged as uncovered, turning the
gate from `[BLOCK] uncovered: 3` to `All covered.`

## Problem

The coverage-contract gate (#1793) requires every production module over 150
AST statements to have a matching test file or a recorded exemption. Three
modules had neither:

- `polylogue/cli/archive_query.py` (405 lines)
- `polylogue/cli/commands/status.py` (270 lines)
- `polylogue/insights/registry.py` (158 lines)

These were the only three remaining `[BLOCK]` entries.

## Solution

Three new test files exercising each module's pure function surface with
genuine input/output assertions — no stubs, no rename-pinning:

- **`tests/unit/insights/test_registry.py`** (68 tests): `project_origin_payload`
  across every projection branch, the `total`-not-`count` envelope contract
  (#1007), register/lookup/`KeyError` paths, every field-accessor factory
  (`_attr`/`_nested`/`_nested_ms_as_seconds`/`_id_with_origin`/`_list_preview`/
  `_formatted_float`/`_count_with_percentage`/`_stringify`/`_source_name_origin`),
  `render_insight_items` in JSON and plain modes, and `InsightQueryError`.
- **`tests/unit/cli/test_archive_query.py`** (115 tests): origin/provider
  resolution, CSV/tuple/metadata tokenizers, message-type/role/sort/transform
  validators including their `click.UsageError`/`ClickException` rejections,
  limit/offset, field projection, CSV/line formatters, cursor decode +
  pagination, and transform-based message removal.
- **`tests/unit/cli/commands/test_status.py`** (86 tests): daemon-URL env
  override, byte formatting, the static facade/CLI route catalogs and
  runtime-path status, and the sqlite-probe helpers (tier version/mismatch
  detection, table/column existence, readiness counts, surface blockers)
  driven by real temp sqlite databases.

The networked/Click-entrypoint and rich-render functions are intentionally left
to integration coverage; this PR targets the pure logic the gate measures.

## Verification

```
devtools verify-test-coverage-contracts   # All covered.
devtools test tests/unit/insights/test_registry.py \
  tests/unit/cli/test_archive_query.py tests/unit/cli/commands/test_status.py   # 269 passed
mypy --strict <the three files>           # Success: no issues found in 3 source files
```

Ref #1793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CLI status command helper functions, including formatting, environment defaults, and status aggregation logic.
  * Added test suite for CLI archive query helpers, covering input parsing, output formatting, filtering, and pagination behavior.
  * Added test coverage for insights registry functionality, including payload handling, registry operations, and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->