### PR TITLE
fix(ci): revive dead mutation-testing job and enforce kill-rate thresholds

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   mutate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v8.1.0
@@ -16,14 +16,45 @@ jobs:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
       - run: uv pip install mutmut
-      - name: Run rotating module subset
+      - name: Run rotating campaign group
+        # Rotate a curated core over four weekly groups so every group runs at
+        # least once per month (#1733 AC1/AC5). These are real campaign names
+        # from the authored scenario catalog (`devtools mutmut-campaign list`) —
+        # the previous job invoked `run --module <path>`, an interface that does
+        # not exist, so `|| true` silently swallowed the argparse error and the
+        # job ran no mutation testing at all.
+        #
+        # The run is best-effort: surviving mutants and timeouts are expected and
+        # must not fail the step (the kill-rate gate below is the hard contract).
+        # A fresh CI checkout has no prior artifacts, so each run only produces an
+        # artifact for its group's campaigns under .local/mutation-campaigns/.
+        continue-on-error: true
         run: |
-          modules=(
-            polylogue/core/hashing.py
-            polylogue/core/timestamps.py
-            polylogue/archive/message/paste_detection.py
-            polylogue/insights/confidence.py
+          groups=(
+            "json models schema-core schema-validation"
+            "filters fts5 hybrid cli-query"
+            "pipeline pipeline-services sources-parse source-detection"
+            "repository storage repair-core daemon-http"
           )
-          idx=$(( $(date +%U) % ${#modules[@]} ))
-          echo "Running mutation campaign for: ${modules[$idx]}"
-          uv run devtools mutmut-campaign run --module "${modules[$idx]}" || true
+          idx=$(( $(date +%U) % ${#groups[@]} ))
+          echo "Running mutation campaign group $idx: ${groups[$idx]}"
+          for campaign in ${groups[$idx]}; do
+            echo "::group::mutmut-campaign run $campaign"
+            uv run devtools mutmut-campaign run "$campaign" || echo "campaign $campaign exited non-zero (survivors/timeout)"
+            echo "::endgroup::"
+          done
+      - name: Enforce kill-rate thresholds on fresh campaigns
+        # Hard gate (#1733 AC3): every campaign that produced a fresh artifact
+        # above must clear its min_kill_rate floor (per-entry, else the manifest
+        # default_min_kill_rate). --enforce-kill-rate without --strict only checks
+        # fresh campaigns, so campaigns whose group did not run this week are
+        # ignored rather than flagged missing in the artifact-less CI checkout.
+        run: uv run python -m devtools.verify_mutation_freshness --enforce-kill-rate
+      - name: Upload campaign artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-campaign-artifacts
+          path: .local/mutation-campaigns/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/devtools/verify_mutation_freshness.py
+++ b/devtools/verify_mutation_freshness.py
@@ -39,6 +39,12 @@ ROOT = _get_root()
 MANIFEST = ROOT / "docs" / "plans" / "campaign-coverage.yaml"
 DEFAULT_FRESHNESS_DAYS = 60
 DEFAULT_ARTIFACT_GLOB = ".local/mutation-campaigns/{name}/*.json"
+# Conservative kill-rate floor (#1733 AC2/AC3). Mutation kill rates for
+# well-tested modules sit well above this; 0.5 flags a genuinely under-killed
+# module without false-alarming on a healthy campaign. Ratchet up per-entry in
+# the manifest as real run data accrues. Only enforced under --enforce-kill-rate
+# and only against fresh campaigns (those that actually have a recent artifact).
+DEFAULT_MIN_KILL_RATE = 0.5
 
 
 @dataclass(frozen=True)
@@ -52,6 +58,7 @@ class CampaignFreshness:
     newest_created_at: str | None
     newest_age_days: float | None
     kill_rate: float | None
+    min_kill_rate: float | None
     counts: dict[str, int]
     state: str  # "fresh" | "stale" | "missing" | "inactive"
 
@@ -63,6 +70,19 @@ def _coerce_int(value: object, default: int) -> int:
         return value
     if isinstance(value, str) and value.strip().isdigit():
         return int(value)
+    return default
+
+
+def _coerce_float(value: object, default: float | None) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return default
     return default
 
 
@@ -113,10 +133,12 @@ def assess_campaign(
     repo_root: Path,
     now: datetime,
     default_freshness_days: int,
+    default_min_kill_rate: float | None = None,
 ) -> CampaignFreshness:
     name = str(entry["name"])
     status = str(entry.get("status", "active"))
     freshness_days = _coerce_int(entry.get("freshness_days"), default_freshness_days)
+    min_kill_rate = _coerce_float(entry.get("min_kill_rate"), default_min_kill_rate)
     glob = _entry_glob(entry)
     artifacts = _resolve_artifacts(repo_root, glob)
     if status != "active":
@@ -130,6 +152,7 @@ def assess_campaign(
             newest_created_at=None,
             newest_age_days=None,
             kill_rate=None,
+            min_kill_rate=min_kill_rate,
             counts={},
             state="inactive",
         )
@@ -144,6 +167,7 @@ def assess_campaign(
             newest_created_at=None,
             newest_age_days=None,
             kill_rate=None,
+            min_kill_rate=min_kill_rate,
             counts={},
             state="missing",
         )
@@ -170,6 +194,7 @@ def assess_campaign(
         newest_created_at=created_at,
         newest_age_days=age,
         kill_rate=_kill_rate(counts),
+        min_kill_rate=min_kill_rate,
         counts=counts,
         state=state,
     )
@@ -216,6 +241,23 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exit non-zero when any campaign is missing or stale. Default is soft (always exit 0).",
     )
+    parser.add_argument(
+        "--enforce-kill-rate",
+        action="store_true",
+        help=(
+            "Exit non-zero when a fresh campaign's kill rate is below its "
+            "min_kill_rate threshold (per-entry, else --default-min-kill-rate)."
+        ),
+    )
+    parser.add_argument(
+        "--default-min-kill-rate",
+        type=float,
+        default=None,
+        help=(
+            "Kill-rate floor for entries without min_kill_rate. Defaults to the "
+            f"manifest's top-level default_min_kill_rate, else {DEFAULT_MIN_KILL_RATE}."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit a JSON report instead of human output.")
     args = parser.parse_args(argv)
 
@@ -225,6 +267,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{args.yaml}: missing or invalid mutation_campaigns list", file=sys.stderr)
         return 2
 
+    default_min_kill_rate = (
+        args.default_min_kill_rate
+        if args.default_min_kill_rate is not None
+        else _coerce_float(manifest.get("default_min_kill_rate"), DEFAULT_MIN_KILL_RATE)
+    )
+
     now = datetime.now(UTC)
     assessments = [
         assess_campaign(
@@ -232,6 +280,7 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=ROOT,
             now=now,
             default_freshness_days=args.default_freshness_days,
+            default_min_kill_rate=default_min_kill_rate,
         )
         for entry in entries
         if isinstance(entry, dict) and "name" in entry
@@ -244,8 +293,11 @@ def main(argv: list[str] | None = None) -> int:
     stale = [a for a in assessments if a.state == "stale"]
     fresh = [a for a in assessments if a.state == "fresh"]
     inactive = [a for a in assessments if a.state == "inactive"]
+    below_threshold = [
+        a for a in fresh if a.kill_rate is not None and a.min_kill_rate is not None and a.kill_rate < a.min_kill_rate
+    ]
 
-    blocking = args.strict and (bool(missing) or bool(stale))
+    blocking = (args.strict and (bool(missing) or bool(stale))) or (args.enforce_kill_rate and bool(below_threshold))
 
     if args.json:
         json.dump(
@@ -253,15 +305,19 @@ def main(argv: list[str] | None = None) -> int:
                 "blocking": blocking,
                 "strict": bool(args.strict),
                 "default_freshness_days": args.default_freshness_days,
+                "enforce_kill_rate": bool(args.enforce_kill_rate),
+                "default_min_kill_rate": default_min_kill_rate,
                 "counts": {
                     "registered": len(assessments),
                     "fresh": len(fresh),
                     "stale": len(stale),
                     "missing": len(missing),
                     "inactive": len(inactive),
+                    "below_kill_threshold": len(below_threshold),
                     "orphan_artifact_names": len(orphan_names),
                 },
                 "campaigns": [a.__dict__ for a in assessments],
+                "below_kill_threshold": [a.name for a in below_threshold],
                 "orphan_artifact_names": orphan_names,
             },
             sys.stdout,
@@ -285,6 +341,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"{prefix} stale: {a.name} "
                 f"newest={a.newest_artifact} "
                 f"age={a.newest_age_days:.1f}d (budget {a.freshness_days}d)"
+            )
+        kill_prefix = "[BLOCK]" if args.enforce_kill_rate else "[warn]"
+        for a in below_threshold:
+            assert a.kill_rate is not None and a.min_kill_rate is not None
+            print(
+                f"{kill_prefix} kill rate below threshold: {a.name} "
+                f"kill={a.kill_rate * 100:.1f}% (floor {a.min_kill_rate * 100:.1f}%)"
             )
         if orphan_names:
             print(f"[warn] orphan artifact directories (not in manifest): {len(orphan_names)}")

--- a/docs/plans/campaign-coverage.yaml
+++ b/docs/plans/campaign-coverage.yaml
@@ -14,10 +14,21 @@
 #                     Defaults to .local/mutation-campaigns/<name>/*.json when
 #                     unset. Resolved by mutmut_campaign.default_artifact_paths
 #                     and the freshness lint.
+#   min_kill_rate   — per-entry kill-rate floor (0..1) enforced by
+#                     verify-mutation-freshness --enforce-kill-rate against a
+#                     fresh campaign's latest artifact. Overrides the top-level
+#                     default_min_kill_rate below. Ratchet up as real run data
+#                     accrues; only fresh campaigns (with a recent artifact) are
+#                     checked, so the gate never fails on a campaign that simply
+#                     has not been run.
 #
-# Updated 2026-05-19 — mutation-campaign discipline scaffolding for #1304.
+# Updated 2026-06-09 — kill-rate threshold enforcement wired for #1733.
 
 description: Mutation and benchmark campaign registry with covered paths, test targets, and freshness budgets.
+
+# Conservative floor applied to every active campaign unless its entry overrides
+# it with min_kill_rate. Enforced by the weekly mutation CI job (#1733).
+default_min_kill_rate: 0.5
 
 mutation_campaigns:
   - name: cli-query

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -200,6 +200,7 @@ class MutationCampaignEntry(BaseModel):
     status: str = "active"
     freshness_days: int | None = None
     artifact_glob: str | None = None
+    min_kill_rate: float | None = None
 
     VALID_STATUSES: ClassVar[frozenset[str]] = frozenset({"active", "inactive", "draft", "archived"})
 
@@ -215,6 +216,13 @@ class MutationCampaignEntry(BaseModel):
     def _check_freshness(cls, v: int | None) -> int | None:
         if v is not None and v <= 0:
             raise ValueError(f"freshness_days must be positive, got {v!r}")
+        return v
+
+    @field_validator("min_kill_rate")
+    @classmethod
+    def _check_min_kill_rate(cls, v: float | None) -> float | None:
+        if v is not None and not (0.0 <= v <= 1.0):
+            raise ValueError(f"min_kill_rate must be within [0, 1], got {v!r}")
         return v
 
 
@@ -251,8 +259,16 @@ class CampaignCoverageManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     description: str | None = None
+    default_min_kill_rate: float | None = None
     mutation_campaigns: list[MutationCampaignEntry] = Field(default_factory=list)
     benchmark_campaigns: list[BenchmarkCampaignEntry] = Field(default_factory=list)
+
+    @field_validator("default_min_kill_rate")
+    @classmethod
+    def _check_default_min_kill_rate(cls, v: float | None) -> float | None:
+        if v is not None and not (0.0 <= v <= 1.0):
+            raise ValueError(f"default_min_kill_rate must be within [0, 1], got {v!r}")
+        return v
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/unit/devtools/test_verify_mutation_freshness.py
+++ b/tests/unit/devtools/test_verify_mutation_freshness.py
@@ -163,6 +163,115 @@ def test_main_strict_passes_when_fresh(
     assert rc == 0
 
 
+def test_assess_campaign_carries_min_kill_rate_threshold(tmp_path: Path) -> None:
+    """A fresh campaign records its threshold (per-entry overrides the default)."""
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    _write_artifact(tmp_path, "filters", created_at=now - timedelta(days=1))
+    result = verify_mutation_freshness.assess_campaign(
+        {"name": "filters", "status": "active", "min_kill_rate": 0.8},
+        repo_root=tmp_path,
+        now=now,
+        default_freshness_days=60,
+        default_min_kill_rate=0.5,
+    )
+    assert result.min_kill_rate == pytest.approx(0.8)  # per-entry override wins
+    assert result.kill_rate == pytest.approx(0.7)
+
+
+def test_enforce_kill_rate_blocks_fresh_campaign_below_floor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--enforce-kill-rate fails when a fresh campaign is below its floor."""
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [{"name": "filters", "status": "active", "min_kill_rate": 0.9}],
+    )
+    # kill rate 7/(7+3) = 0.70, below the 0.90 floor.
+    _write_artifact(tmp_path, "filters", created_at=datetime(2099, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--enforce-kill-rate"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[BLOCK] kill rate below threshold: filters" in out
+    assert "blocking=True" in out
+
+
+def test_enforce_kill_rate_passes_when_above_floor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--enforce-kill-rate passes when the fresh campaign clears its floor."""
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [{"name": "filters", "status": "active", "min_kill_rate": 0.5}],
+    )
+    _write_artifact(tmp_path, "filters", created_at=datetime(2099, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--enforce-kill-rate"])
+    assert rc == 0
+
+
+def test_enforce_kill_rate_ignores_missing_campaigns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A campaign with no artifact is missing, not below-threshold — not blocked.
+
+    This is the CI contract: a fresh checkout has artifacts only for the
+    just-run group, so --enforce-kill-rate (without --strict) must not flag the
+    artifact-less campaigns.
+    """
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [
+            {"name": "filters", "status": "active", "min_kill_rate": 0.9},
+            {"name": "fts5", "status": "active", "min_kill_rate": 0.9},
+        ],
+    )
+    # Only filters has an artifact, and it clears the floor.
+    _write_artifact(
+        tmp_path,
+        "filters",
+        created_at=datetime(2099, 1, 1, tzinfo=UTC),
+        counts={"killed": 19, "survived": 1},
+    )
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--enforce-kill-rate"])
+    assert rc == 0
+
+
+def test_enforce_kill_rate_uses_manifest_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A campaign without its own min_kill_rate inherits the manifest default."""
+    import yaml
+
+    manifest = tmp_path / "campaign-coverage.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "description": "test",
+                "default_min_kill_rate": 0.9,
+                "mutation_campaigns": [{"name": "filters", "status": "active"}],
+            },
+            sort_keys=False,
+        )
+    )
+    _write_artifact(tmp_path, "filters", created_at=datetime(2099, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--enforce-kill-rate"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "kill rate below threshold: filters" in out
+
+
 def test_committed_manifest_lint_soft_is_clean() -> None:
     """The committed manifest passes the lint in soft mode."""
     rc = verify_mutation_freshness.main([])


### PR DESCRIPTION
## Summary

Revives the weekly Mutation Testing workflow — which had been running **no
mutation testing at all** — and adds a hard kill-rate threshold gate.

## Problem

The job invoked `devtools mutmut-campaign run --module <path>`, but `run` takes
a campaign *name* (`choices=sorted(CAMPAIGNS)`), not a `--module` path. Every
invocation hit an argparse error that the trailing `|| true` silently swallowed,
so the workflow has been green-and-empty since #1733 added it. None of #1733's
enforcement acceptance criteria were realized: no thresholds manifest, no
kill-rate gate, no freshness wiring that actually runs.

## Solution

- **Rewrite `.github/workflows/mutation-testing.yml`**: rotate a curated core of
  real campaign names over four weekly groups (each group runs ≥ monthly), run
  each campaign best-effort (`continue-on-error` — survivors/timeouts no longer
  fail the step), then enforce kill-rate thresholds as the hard gate, and upload
  artifacts.
- **Add `--enforce-kill-rate` to `devtools/verify_mutation_freshness.py`**: fails
  when a *fresh* campaign's kill rate is below its `min_kill_rate` floor
  (per-entry → manifest `default_min_kill_rate` → 0.5). It only checks fresh
  campaigns, so a fresh CI checkout — which holds artifacts only for the week's
  group — never flags the artifact-less campaigns. (Artifacts live under
  gitignored `.local/`, so a whole-manifest `--strict` freshness gate cannot run
  in CI; `--enforce-kill-rate` is the CI-appropriate contract.)
- **Declare `default_min_kill_rate: 0.5`** in `docs/plans/campaign-coverage.yaml`
  and document the per-entry `min_kill_rate` override.
- **Extend the Pydantic manifest models** (`CampaignCoverageManifest`,
  `MutationCampaignEntry`) with the new fields, range-validated to `[0, 1]`, so
  `verify-manifests` (`extra="forbid"`) accepts them.

#1733 AC2 named `docs/plans/mutation-thresholds.yaml`; this realizes it as fields
on the existing `campaign-coverage.yaml` registry instead of a second parallel
manifest, keeping one source of truth for mutation-campaign metadata.

## Verification

```
devtools test tests/unit/devtools/test_verify_mutation_freshness.py   # 16 passed
devtools verify-manifests        # manifest consistency checks passed
devtools verify-ci-workflows     # 16 workflow files checked, no errors
python -m devtools.verify_mutation_freshness --enforce-kill-rate   # exit 0 (no artifacts → none fresh)
mypy --strict devtools/verify_mutation_freshness.py polylogue/verification/manifests/models.py \
  tests/unit/devtools/test_verify_mutation_freshness.py   # clean
```

Five new tests cover: threshold carried per-entry (override beats default),
below-floor fresh campaign blocks, above-floor passes, missing campaigns are
ignored (the CI contract), and manifest `default_min_kill_rate` inheritance.

Ref #1733