### PR TITLE
test: stabilize devtools verify --all under xdist load

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -438,18 +438,43 @@ def build_verify_steps(
             "--json-report-omit=collectors,log,streams,warnings",
             f"--json-report-file={PYTEST_REPORT_PATH}",
         ]
-        if skip_slow:
-            pytest_cmd.extend(["-m", f"not slow and {scale_marker_expr}"])
-        else:
-            pytest_cmd.extend(["-m", scale_marker_expr])
+        base_marker = f"not slow and {scale_marker_expr}" if skip_slow else scale_marker_expr
         if seed_testmon:
-            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")])
+            pytest_cmd.extend(
+                ["-m", base_marker, "--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")]
+            )
             steps.append(("pytest seed-testmon", pytest_cmd))
         elif full_pytest:
-            pytest_cmd.extend(_pytest_worker_args(default="16"))
-            steps.append(("pytest full", pytest_cmd))
+            # #1775: the full diagnostic runs as two lanes. The bulk lane keeps
+            # xdist parallelism but deselects wall-clock-bound tests; the
+            # isolated lane reruns those (``load_sensitive``/``tui`` — timing
+            # budgets, loopback-socket timeouts, TUI render timing) single-
+            # process with a stable order, so worker contention can no longer
+            # flake them. Both lanes are correctness blockers; the split only
+            # removes the scheduling jitter that made ``--all`` an unreliable
+            # completion gate.
+            bulk_cmd = [
+                *pytest_cmd,
+                "-m",
+                f"({base_marker}) and not load_sensitive and not tui",
+                *_pytest_worker_args(default="16"),
+            ]
+            steps.append(("pytest full (parallel)", bulk_cmd))
+
+            def _isolated_report_arg(arg: str) -> str:
+                # Keep the bulk lane's canonical report artifacts intact for
+                # _compare_against_last; the isolated lane writes its own files.
+                if arg.startswith("--junitxml="):
+                    return f"--junitxml={_report_dir}/verify-latest-isolated.xml"
+                if arg.startswith("--json-report-file="):
+                    return f"--json-report-file={PYTEST_REPORT_DIR / 'last-pytest-isolated.json'}"
+                return arg
+
+            isolated_cmd = [_isolated_report_arg(arg) for arg in pytest_cmd]
+            isolated_cmd.extend(["-m", f"({base_marker}) and (load_sensitive or tui)", "-p", "no:randomly", "-n", "0"])
+            steps.append(("pytest load-sensitive (isolated)", isolated_cmd))
         else:
-            pytest_cmd.extend(["--testmon", *_pytest_worker_args(default="0")])
+            pytest_cmd.extend(["-m", base_marker, "--testmon", *_pytest_worker_args(default="0")])
             pytest_cmd.append("--testmon-forceselect")
             steps.append(("pytest testmon", pytest_cmd))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ markers = [
     "chaos: marks ingestion hostility, interruption, and chronology tests",
     "live: marks operator-run live archive validation lanes",
     "xdist_group(group_name): distribute parametrized tests within a file across workers (#1026)",
+    "load_sensitive: wall-clock-bound tests (timing budgets, loopback sockets) routed into the isolated single-process lane of `devtools verify --all` so xdist worker contention cannot flake them (#1775)",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning:dateparser",  # dateparser strptime deprecation (external)

--- a/tests/benchmarks/test_fts_trigger_amplification.py
+++ b/tests/benchmarks/test_fts_trigger_amplification.py
@@ -56,6 +56,7 @@ def _timed_insert(conn: sqlite3.Connection, message_id: str, session_id: str, po
 
 
 @pytest.mark.slow
+@pytest.mark.load_sensitive
 def test_messages_fts_trigger_growth_is_subquadratic(tmp_path: Path) -> None:
     """Insert 200 blocks incrementally; per-block time must not grow linearly."""
     from tests.infra.storage_records import SessionBuilder
@@ -95,6 +96,7 @@ def test_messages_fts_trigger_growth_is_subquadratic(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.load_sensitive
 def test_content_blocks_batch_insert_is_linear(tmp_path: Path) -> None:
     """Bulk-inserting N blocks scales linearly — comparison baseline."""
     from tests.infra.storage_records import SessionBuilder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,11 @@ _HYPOTHESIS_DB = DirectoryBasedExampleDatabase(_HYPOTHESIS_HOME / "examples")
 settings.register_profile(
     "ci",
     max_examples=5 if os.environ.get("POLYLOGUE_CI") else 30,
+    # deadline=None: per-example wall time is dominated by xdist scheduling
+    # jitter under `-n 16`, not algorithmic cost, so a deadline only produces
+    # load-dependent flakes (#1775). Real perf regressions are caught by the
+    # dedicated TestPerformanceBudget / benchmark tests, not Hypothesis timing.
+    deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
     database=_HYPOTHESIS_DB,
 )
@@ -157,7 +162,13 @@ settings.register_profile(
 settings.register_profile(
     "default",
     max_examples=100,
-    suppress_health_check=[HealthCheck.differing_executors],
+    # deadline=None + suppress too_slow: see the ci profile note (#1775). The
+    # property tests in test_schema_privacy / test_null_guard_properties /
+    # test_machine_contract have no per-test deadline override and previously
+    # inherited Hypothesis's 200ms default, which DB- and subprocess-touching
+    # examples blow past under full-suite worker contention.
+    deadline=None,
+    suppress_health_check=[HealthCheck.differing_executors, HealthCheck.too_slow],
     database=_HYPOTHESIS_DB,
 )
 # "verify" profile: fast bounded-example pass for routine devtools verify cycles.

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1161,6 +1161,7 @@ class TestSharedQueryPayloads:
         assert d["time_range"]["min"] == "2024-01-01"
 
 
+@pytest.mark.load_sensitive
 class TestQueryNoResultsDiagnosticPath:
     """Cross-surface contract: one filtered query → diagnostics path."""
 

--- a/tests/unit/storage/test_scale.py
+++ b/tests/unit/storage/test_scale.py
@@ -179,6 +179,7 @@ class TestLargeInputRoundTrip:
 
 
 @pytest.mark.slow
+@pytest.mark.load_sensitive
 class TestPerformanceBudget:
     """Performance budget tests — each asserts a timing SLA.
 


### PR DESCRIPTION
## Summary

`devtools verify --all` is now a reliable completion gate: a parallel bulk lane
plus an isolated single-process lane for wall-clock-bound tests, with the
Hypothesis profiles calibrated so per-example timing no longer flakes under
xdist worker contention.

## Problem

`devtools verify --all` ran the whole non-integration suite in one `-n 16`
xdist pool. Load-sensitive tests failed intermittently while exact reruns of
the failed nodes passed (#1775). Two physical causes:

- **Hypothesis deadlines:** property tests in `test_schema_privacy`,
  `test_null_guard_properties`, and `test_machine_contract` had no per-test
  deadline override, so they inherited Hypothesis's implicit 200ms deadline.
  Under 16-worker contention, per-example wall time is dominated by scheduling
  jitter, not algorithmic cost, and blows past 200ms.
- **Wall-clock budgets/timeouts:** `TestPerformanceBudget`, the FTS-trigger
  amplification timing tests, the daemon web-reader loopback-socket diagnostic
  test, and the TUI render tests measure elapsed wall time that balloons under
  worker pressure.

## Solution

1. **Hypothesis `default`/`ci` profiles** set `deadline=None` and suppress
   `HealthCheck.too_slow`. Real perf regressions are caught by the dedicated
   `TestPerformanceBudget` / benchmark tests, not Hypothesis per-example
   timing. Global fix — future property tests can't regress into the same
   load-dependent deadline flake.

2. **`load_sensitive` marker** on the wall-clock-bound classes. `verify --all`
   now runs two lanes:
   - **bulk** (`-n 16`): `... and not load_sensitive and not tui`
   - **isolated** (`-n 0 -p no:randomly`): `... and (load_sensitive or tui)`,
     single-process with a stable order. Writes its own report artifacts so
     the bulk lane's `_compare_against_last` regression signal is preserved.

   Both lanes are correctness blockers; the split only removes scheduling
   jitter. Step names (`pytest full (parallel)` / `pytest load-sensitive
   (isolated)`) make the timing-sensitive lane explicit (AC5).

## Verification

- `build_verify_steps(full_pytest=True)` emits the two expected lanes with the
  correct `-m` expressions and worker counts.
- Lane partition: 25 isolated-lane tests (load_sensitive + tui), named flaky
  perf/socket tests captured, **zero overlap** with the bulk lane, marker
  registered (no `PytestUnknownMarkWarning`).
- Isolated lane single-process: `24 passed, 10532 deselected in 27.25s`.
- Previously-flaky property tests under the new profile: `3 passed in 2.15s`.
- `mypy --strict devtools/verify.py`: clean. `devtools render-all --check`: no
  committed-doc drift. Pre-push static gate: all green.

Closes #1775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined test execution strategy to isolate performance-sensitive tests in a dedicated single-process lane, preventing resource contention.
  * Enhanced Hypothesis testing configuration to improve test reliability and remove timing constraints.
  * Improved categorization of slow and resource-intensive tests for more efficient test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->