### PR TITLE
fix(daemon): repair fresh-archive ingest dropping sessions + false 0% FTS

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -295,6 +295,17 @@ def _archive_readiness_payload(conn: sqlite3.Connection, *, exact: bool) -> dict
     if not _table_exists(conn, "blocks") and not _table_exists(conn, "messages_fts"):
         return None
     blocks = _archive_exact_blocks_surface(conn) if exact else _archive_blocks_surface(conn)
+    effective_exact = exact
+    if not exact and blocks.get("freshness_state") == UNKNOWN:
+        # The durable freshness cache is untrusted: the recorded state is
+        # "ready" but the counts are the poisoned 0/0 shape while the source
+        # actually has rows. This happens after a fresh-archive bootstrap, where
+        # daemon startup legitimately recorded ready|0|0 over an empty archive
+        # and trigger-maintained ingest then populated the index without ever
+        # triggering a rebuild that refreshes the counts. Recompute exact counts
+        # so coverage reflects the populated index instead of reporting 0%.
+        blocks = _archive_exact_blocks_surface(conn)
+        effective_exact = True
     block_source_rows = _payload_int(blocks, "source_rows")
     block_indexed_rows = _payload_int(blocks, "indexed_rows")
     invariant_ready = bool(blocks["ready"])
@@ -311,7 +322,7 @@ def _archive_readiness_payload(conn: sqlite3.Connection, *, exact: bool) -> dict
             if block_source_rows > 0
             else (100.0 if invariant_ready else 0.0)
         ),
-        "coverage_exact": exact,
+        "coverage_exact": effective_exact,
         "surfaces": {"messages_fts": blocks},
     }
 

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1660,11 +1660,16 @@ def _write_repo_edges(conn: sqlite3.Connection, session_id: str, session: Parsed
             INSERT INTO repos (origin_url, root_path, repo_name, first_seen_at_ms, last_seen_at_ms)
             VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(origin_url, root_path) DO UPDATE SET
-                repo_name = COALESCE(excluded.repo_name, repos.repo_name),
+                repo_name = COALESCE(NULLIF(excluded.repo_name, ''), repos.repo_name),
                 first_seen_at_ms = MIN(repos.first_seen_at_ms, excluded.first_seen_at_ms),
                 last_seen_at_ms = MAX(repos.last_seen_at_ms, excluded.last_seen_at_ms)
             """,
-            (origin_url, root_path, repo_name, observed_at_ms or 0, observed_at_ms or 0),
+            # repos.repo_name is NOT NULL DEFAULT ''. _repo_name() returns None
+            # when no name can be derived (e.g. a session whose cwd is "/" or
+            # "."): insert the schema's empty-string sentinel instead of NULL so
+            # the session is not dropped, while the NULLIF above keeps a later
+            # re-ingest from clobbering a previously-derived name with ''.
+            (origin_url, root_path, repo_name or "", observed_at_ms or 0, observed_at_ms or 0),
         )
         conn.execute(
             """

--- a/tests/unit/daemon/test_fts_readiness_fallback.py
+++ b/tests/unit/daemon/test_fts_readiness_fallback.py
@@ -1,0 +1,98 @@
+"""FTS readiness recomputes exact coverage when the freshness cache is poisoned.
+
+On a fresh archive, daemon startup legitimately records ``messages_fts|ready|0|0``
+over an empty index. Trigger-maintained ingest then populates the index without
+ever triggering a rebuild that refreshes those counts, leaving the durable
+freshness row as the untrusted ``ready|0|0`` shape. Read surfaces (``status``,
+``/healthz``, ``/metrics``) funnel through ``fts_readiness_info`` and must report
+the real coverage instead of dividing 0/0 and showing 0% over a populated index.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+from polylogue.archive.message.roles import Role
+from polylogue.daemon.fts_status import fts_readiness_info
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.fts.freshness import record_fts_surface_state_sync
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.types import BlockType, Provider
+
+
+def _populated_index(db: Path) -> None:
+    initialize_archive_database(db, ArchiveTier.INDEX)
+    conn = sqlite3.connect(db)
+    try:
+        session = ParsedSession(
+            source_name=Provider.CLAUDE_CODE,
+            provider_session_id="fts-cov-1",
+            title="coverage probe",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="u1",
+                    role=Role.USER,
+                    text="searchable content here",
+                    position=0,
+                    content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="searchable content here")],
+                ),
+            ],
+        )
+        write_parsed_session_to_archive(conn, session)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_readiness_falls_back_to_exact_when_freshness_poisoned(tmp_path: Path) -> None:
+    db = tmp_path / "index.db"
+    _populated_index(db)
+
+    # Poison the durable freshness cache with the empty-archive ready|0|0 shape.
+    conn = sqlite3.connect(db)
+    try:
+        record_fts_surface_state_sync(conn, surface="messages_fts", state="ready", source_rows=0, indexed_rows=0)
+        conn.commit()
+    finally:
+        conn.close()
+
+    fts = fts_readiness_info(db, exact=False)
+
+    indexable = int(cast(int, fts["message_indexable_count"]))
+    indexed = int(cast(int, fts["message_indexed_count"]))
+    assert indexable > 0
+    assert indexed == indexable
+    assert fts["coverage_pct"] == 100.0
+    assert fts["messages_ready"] is True
+    # The fallback recomputed exact counts rather than trusting the cache.
+    assert fts["coverage_exact"] is True
+
+
+def test_readiness_trusts_a_healthy_freshness_record_without_recompute(tmp_path: Path) -> None:
+    """A trusted ready|N|N record is used directly (fast path), not recomputed."""
+    db = tmp_path / "index.db"
+    _populated_index(db)
+
+    conn = sqlite3.connect(db)
+    try:
+        indexed = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
+        record_fts_surface_state_sync(
+            conn,
+            surface="messages_fts",
+            state="ready",
+            source_rows=indexed,
+            indexed_rows=indexed,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    fts = fts_readiness_info(db, exact=False)
+
+    assert fts["messages_ready"] is True
+    assert fts["coverage_pct"] == 100.0
+    assert fts["coverage_exact"] is False

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -115,6 +115,41 @@ def test_archive_tiers_writer_materializes_codex_session(tmp_path: Path) -> None
     assert search_archive_blocks(conn, "focused") == ["codex-session:codex-session-1:u1:0"]
 
 
+def test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name(tmp_path: Path) -> None:
+    """A session whose only working directory is "/" must still ingest.
+
+    ``_repo_name`` returns None when no name can be derived from the cwd (e.g.
+    "/" or "."), but ``repos.repo_name`` is ``NOT NULL``. Passing the None
+    through crashed the write with an IntegrityError, silently dropping the
+    session and retrying it forever. The writer must persist the empty-string
+    sentinel instead and keep the session.
+    """
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="root-cwd-1",
+        title="Session started at filesystem root",
+        working_directories=["/"],
+        messages=[
+            ParsedMessage(
+                provider_message_id="u1",
+                role=Role.USER,
+                text="hello from root",
+                position=0,
+                content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="hello from root")],
+            ),
+        ],
+    )
+
+    # Must not raise sqlite3.IntegrityError on repos.repo_name NOT NULL.
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    repos = [dict(row) for row in conn.execute("SELECT root_path, repo_name FROM repos").fetchall()]
+    assert {"root_path": "/", "repo_name": ""} in repos
+    envelope = read_archive_session_envelope(conn, session_id)
+    assert len(envelope.messages) == 1
+
+
 def test_archive_tiers_writer_preserves_chatgpt_branch_variants(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(


### PR DESCRIPTION
## Summary

Two soundness bugs that only manifest during a **fresh-archive catch-up** (the
exact situation when re-ingesting the full corpus from source), both found while
combing the live deployment for breakage. One silently drops real sessions; the
other makes `status` lie about FTS coverage. Each is a small, isolated fix with
a regression test.

## Problem

**1. Sessions with `cwd="/"` are silently dropped (data loss).**
`_write_repo_edges` passed `_repo_name()`'s `None` result straight into
`repos.repo_name`, which is `TEXT NOT NULL DEFAULT ''`. `_repo_name` returns
`None` whenever no name can be derived from the working directory — notably when
a session's cwd is `/` or `.`. The explicit `NULL` violates the NOT NULL
constraint (the column `DEFAULT` only applies to *omitted* columns), raising
`sqlite3.IntegrityError`. The daemon batch-ingest path catches and logs this as
`archive full ingest failed`, so the session is dropped and re-queued **forever**.
Observed live: a real Claude Code session (`c9385a99…`, cwd `/`) failed on every
catch-up retry cycle.

**2. `status` reports "FTS: 0.0% indexed" over a populated, working index.**
On a fresh archive, daemon startup legitimately records `messages_fts|ready|0|0`
over the empty index. Trigger-maintained ingest then populates the index, but
the durable freshness counts are only refreshed by a *rebuild* — which
steady-state ingest never triggers (doc_count stays equal to the block count, so
no repair fires). The record stays at the untrusted `ready|0|0` shape. The reader
correctly distrusts it (→ `UNKNOWN`), so the non-exact readiness path honestly
computes `0/0 = 0%`. Search itself works fine; the stale writer cache, not the
display, is wrong. All read surfaces (`status`, `/healthz`, `/metrics`, the
status snapshot) funnel through `fts_readiness_info`, so all showed 0%.

## Solution

- **`storage/sqlite/archive_tiers/write.py`** — insert `repo_name or ""` (the
  schema's empty-string sentinel) instead of `None`, and change the upsert to
  `COALESCE(NULLIF(excluded.repo_name, ''), repos.repo_name)` so a later
  re-ingest that *can* derive a real name still wins while an empty one never
  clobbers a known name.
- **`daemon/fts_status.py`** — in `_archive_readiness_payload`, when the
  non-exact freshness read resolves to `UNKNOWN`, recompute via
  `_archive_exact_blocks_surface`. The exact recompute runs only while the cache
  is untrusted; a trusted `ready|N|N` record still takes the fast path.

These are the *read/write* fixes for the symptoms. The deeper "durable freshness
counts are never refreshed by steady-state ingest" gap is mitigated here
(read-side fallback keeps every surface truthful; the record also self-heals on
daemon restart and on the next search-readiness check) and is a candidate
follow-up if a fast-path-always-truthful writer is wanted.

## Verification

- Reproduced the live data-loss failure against the offending session file:
  before → `IntegrityError: NOT NULL constraint failed: repos.repo_name`; after →
  writes `session_id=claude-code-session:c9385a99-…` with a `repos` row
  (`repo_name=''`).
- New `tests/unit/storage/test_archive_tiers_write.py::test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name`.
- New `tests/unit/daemon/test_fts_readiness_fallback.py` (2 tests): poisoned
  `ready|0|0` over a populated index → 100% via non-exact `fts_readiness_info`;
  healthy `ready|N|N` stays on the fast path (`coverage_exact=False`).
- `pytest` the 3 new tests: passed. Full `test_archive_tiers_write.py`: 23 passed.
- `mypy --strict` clean on `write.py`, `fts_status.py`, and the new test.
- `devtools verify --quick` (pre-push): exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of full-text search readiness reporting by recomputing coverage metrics when cached data is unreliable.
  * Enhanced repository name handling in archives to prevent unintended data overwriting with empty values.

* **Tests**
  * Added unit tests for FTS readiness fallback behavior and archive tier writing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->