### PR TITLE
fix(daemon): measure FTS coverage against search_text, not display text

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -176,7 +176,12 @@ def _archive_exact_blocks_surface(conn: sqlite3.Connection) -> dict[str, int | b
             "ready": ready,
             "exact": True,
         }
-    source_rows = int(conn.execute("SELECT COUNT(*) FROM blocks WHERE text IS NOT NULL").fetchone()[0] or 0)
+    # A block is FTS-indexable iff search_text != '' — that is exactly the
+    # predicate messages_fts is populated from (storage/fts/sql.py). Counting
+    # `text IS NOT NULL` here instead undercounts the source (tool_use /
+    # tool_result blocks carry derived search_text but a NULL display text), so
+    # indexed/source could exceed 100%.
+    source_rows = int(conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0] or 0)
     docsize_exists = _table_exists(conn, "messages_fts_docsize")
     if not exists or not docsize_exists:
         return {
@@ -198,7 +203,7 @@ def _archive_exact_blocks_surface(conn: sqlite3.Connection) -> dict[str, int | b
             SELECT COUNT(*)
             FROM blocks b
             LEFT JOIN messages_fts_docsize d ON d.id = b.rowid
-            WHERE b.text IS NOT NULL
+            WHERE b.search_text != ''
               AND d.id IS NULL
             """
         ).fetchone()[0]
@@ -211,7 +216,7 @@ def _archive_exact_blocks_surface(conn: sqlite3.Connection) -> dict[str, int | b
             FROM messages_fts_docsize d
             LEFT JOIN blocks b ON b.rowid = d.id
             WHERE b.rowid IS NULL
-               OR b.text IS NULL
+               OR b.search_text = ''
             """
         ).fetchone()[0]
         or 0

--- a/tests/unit/daemon/test_fts_readiness_fallback.py
+++ b/tests/unit/daemon/test_fts_readiness_fallback.py
@@ -72,6 +72,61 @@ def test_readiness_falls_back_to_exact_when_freshness_poisoned(tmp_path: Path) -
     assert fts["coverage_exact"] is True
 
 
+def test_exact_coverage_counts_tool_blocks_as_indexable(tmp_path: Path) -> None:
+    """Exact coverage must use the FTS-population predicate (search_text != '').
+
+    A tool_use block carries a derived search_text but a NULL display text. The
+    FTS index includes it, so the exact source count must include it too —
+    otherwise indexed/source exceeds 100%.
+    """
+    db = tmp_path / "index.db"
+    initialize_archive_database(db, ArchiveTier.INDEX)
+    conn = sqlite3.connect(db)
+    try:
+        session = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="cov-tool-1",
+            title="tool coverage",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="u1",
+                    role=Role.USER,
+                    text="run the build",
+                    position=0,
+                    content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="run the build")],
+                ),
+                ParsedMessage(
+                    provider_message_id="a1",
+                    role=Role.ASSISTANT,
+                    text=None,
+                    position=1,
+                    content_blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TOOL_USE,
+                            tool_name="exec_command",
+                            tool_id="t1",
+                            tool_input={"command": "make build"},
+                        ),
+                    ],
+                ),
+            ],
+        )
+        write_parsed_session_to_archive(conn, session)
+        conn.commit()
+        text_blocks = int(conn.execute("SELECT COUNT(*) FROM blocks WHERE text IS NOT NULL").fetchone()[0])
+        search_blocks = int(conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0])
+    finally:
+        conn.close()
+
+    # The tool block makes the two predicates diverge; the exact coverage must
+    # use search_text (the FTS predicate), not text.
+    assert search_blocks > text_blocks
+
+    fts = fts_readiness_info(db, exact=True)
+    assert fts["coverage_pct"] == 100.0
+    assert fts["messages_ready"] is True
+
+
 def test_readiness_trusts_a_healthy_freshness_record_without_recompute(tmp_path: Path) -> None:
     """A trusted ready|N|N record is used directly (fast path), not recomputed."""
     db = tmp_path / "index.db"


### PR DESCRIPTION
## Summary

`polylogue status` could report **"FTS: 156.5% indexed"** over a fully-covering
index. The exact FTS-coverage computation measured the *source* row count with a
predicate (`text IS NOT NULL`) that differs from the one the index is actually
populated from (`search_text != ''`), so indexed/source exceeded 100%.

## Problem

`messages_fts` is populated from `blocks WHERE search_text != ''`
(`storage/fts/sql.py`). `tool_use` / `tool_result` blocks carry a derived
`search_text` but a `NULL` display `text`, so they are indexed but were excluded
from `_archive_exact_blocks_surface`'s source count, which used
`blocks WHERE text IS NOT NULL`. `indexed / source` then exceeded 100%. The exact
`missing` / `excess` joins used the same wrong predicate, misclassifying those
blocks too. (Surfaced via the freshness-fallback path added in #1804, but the
predicate mismatch is independent and also affects `status --exact` / health
exact probes directly.)

## Solution

`polylogue/daemon/fts_status.py` — count source rows and compute missing/excess
against `search_text != ''` / `search_text = ''`, matching the index-population
predicate. Exact coverage is now bounded at 100% and missing/excess are accurate.

## Verification

- New `test_exact_coverage_counts_tool_blocks_as_indexable`: for a session with a
  tool block, asserts `search_text`-blocks > `text`-blocks (the divergence) and
  that exact coverage is `100.0` (was 200% for that shape).
- `pytest tests/unit/daemon/test_fts_readiness_fallback.py`: 3 passed.
- `mypy --strict` clean on the changed module and test.
- Live daemon after deploying the #1804 freshness heal now reports
  `FTS: 100.0% indexed` (down from the spurious 156.5%).