### PR TITLE
fix(daemon): stop ingest failures from ArchiveStore's 5s busy_timeout under write contention

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1146,8 +1146,21 @@ class LiveBatchProcessor:
                         result.session_ids.append(session_id)
                         result.session_count += 1
                         result.message_count += len(session.messages)
-                except Exception:
-                    logger.warning("live.watcher: archive full ingest failed for %s", record.source_path, exc_info=True)
+                except Exception as exc:
+                    if isinstance(exc, sqlite3.OperationalError) and is_transient_sqlite_lock(exc):
+                        logger.debug(
+                            "live.watcher: archive full ingest deferred for %s (retryable lock); will retry: %s",
+                            record.source_path,
+                            exc,
+                        )
+                    else:
+                        logger.warning(
+                            "live.watcher: archive full ingest failed for %s: %s: %s",
+                            record.source_path,
+                            type(exc).__name__,
+                            exc,
+                            exc_info=True,
+                        )
         return result
 
     def _extract_zip_member_records(

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -96,6 +96,10 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     upsert_session_tag,
     write_parsed_session_to_archive,
 )
+from polylogue.storage.sqlite.connection_profile import (
+    READ_CONNECTION_PRAGMA_STATEMENTS,
+    WRITE_CONNECTION_PRAGMA_STATEMENTS,
+)
 from polylogue.storage.sqlite.queries.tool_usage import ToolUsageProviderCoverageRow, ToolUsageRow
 from polylogue.types import SessionId
 
@@ -155,10 +159,21 @@ class ArchiveStore:
             initialize_active_archive_root(archive_root)
         if read_only:
             self._conn = sqlite3.connect(f"file:{self.index_db_path}?mode=ro", uri=True)
+            pragma_statements = READ_CONNECTION_PRAGMA_STATEMENTS
         else:
             self._conn = sqlite3.connect(self.index_db_path)
+            pragma_statements = WRITE_CONNECTION_PRAGMA_STATEMENTS
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA foreign_keys = ON")
+        # Apply the canonical connection profile rather than a bare connection.
+        # A bare sqlite3.connect defaults to a 5s busy_timeout with no WAL
+        # tuning; under daemon write contention (live ingest and convergence
+        # stages both writing index.db) that window is exceeded and ingest
+        # writes fail with "database is locked", marking files failed and
+        # collapsing throughput. The write profile raises busy_timeout to 30s so
+        # writers queue instead of failing (docs/internals.md: SQLite tuning is
+        # profile-driven, not backend-local).
+        for statement in pragma_statements:
+            self._conn.execute(statement)
         self._user_tier_attached = False
         self._tags_relation = "session_tags"
         self._attach_user_tier_if_present()

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -115,6 +115,25 @@ def test_archive_tiers_writer_materializes_codex_session(tmp_path: Path) -> None
     assert search_archive_blocks(conn, "focused") == ["codex-session:codex-session-1:u1:0"]
 
 
+def test_archive_store_connection_applies_canonical_profile(tmp_path: Path) -> None:
+    """ArchiveStore must apply the write/read connection profile, not a bare connect.
+
+    A bare sqlite3.connect defaults to a 5s busy_timeout with no WAL tuning.
+    Under daemon write contention (live ingest vs convergence both writing
+    index.db) that window is exceeded and ingest fails with "database is
+    locked". The write profile raises busy_timeout to 30s so writers queue.
+    """
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with ArchiveStore(tmp_path, initialize=True, read_only=False) as archive:
+        assert int(archive._conn.execute("PRAGMA busy_timeout").fetchone()[0]) == 30_000
+        assert str(archive._conn.execute("PRAGMA journal_mode").fetchone()[0]).lower() == "wal"
+
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        assert int(archive._conn.execute("PRAGMA busy_timeout").fetchone()[0]) == 1_000
+        assert int(archive._conn.execute("PRAGMA query_only").fetchone()[0]) == 1
+
+
 def test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name(tmp_path: Path) -> None:
     """A session whose only working directory is "/" must still ingest.
 


### PR DESCRIPTION
## Summary

During a full re-ingest, the daemon accumulated **148+ "archive full ingest
failed" files** and throughput collapsed to **~0.1 files/s**. Root cause:
`ArchiveStore` opened `index.db` with a **bare `sqlite3.connect`** (5s default
busy_timeout, no WAL tuning) instead of the canonical connection profile. Under
write contention between live ingest and the convergence stages, the 5s ceiling
was exceeded and ingest writes failed with `database is locked`. Two commits:
the connection-profile fix (the cure) and an error-visibility fix (so the
failure is diagnosable and transient locks are classified, not screamed).

## Problem

`ArchiveStore.__init__` did `self._conn = sqlite3.connect(self.index_db_path)`
+ `PRAGMA foreign_keys = ON` only. Python's default busy_timeout is **5s**.
`ArchiveStore` is the daemon's live-ingest write path, and the convergence
stages (insight materialization draining 100 debt items/cycle, FTS rebuilds)
hold the `index.db` write lock far longer than 5s. The ingest writer hit the
ceiling → `sqlite3.OperationalError: database is locked` → caught by the
per-record handler as "archive full ingest failed" → file marked failed and
re-queued. This snowballed (148+ failed files, retry churn, ~0.1 files/s) and
directly violated the documented invariant *"SQLite read/write tuning is
profile-driven, not backend-local"* (`docs/internals.md`).

The failures were **undiagnosable from logs**: the per-record handler logged
with `exc_info=True`, but the daemon's structlog config drops the traceback, so
a transient lock looked identical to a real defect and neither showed the error
text. The root cause had to be reproduced offline.

## Solution

- **`storage/sqlite/archive_tiers/archive.py`** — apply
  `WRITE_CONNECTION_PRAGMA_STATEMENTS` (read-write) or
  `READ_CONNECTION_PRAGMA_STATEMENTS` (read-only): busy_timeout **30s**, WAL,
  `synchronous=NORMAL`, cache/mmap sizing, `wal_autocheckpoint`,
  `journal_size_limit`, and `query_only` on reads. Writers now queue for the
  lock and succeed instead of failing.
- **`sources/live/batch.py`** — classify the per-record exception: a transient
  SQLite lock logs at debug as a retryable deferral (the failed-file scheduler
  retries it); any other exception logs at warning with
  `type(exc).__name__: exc` embedded so the real error survives exc_info
  stripping.

The convergence stages still hold the write lock for up to ~20s during heavy
materialization, so individual ingest writes can now *wait* that long — a
throughput characteristic, not a failure. Shortening those convergence
transactions is a follow-up optimization, separate from this correctness fix.

## Verification

- Reproduced the exact failing write against the **live archive** while the
  daemon ran: **before** → `sqlite3.OperationalError: database is locked`;
  **after** → `busy_timeout=30000`, the write waits 21.2s then succeeds.
- Restarted the daemon over the same catch-up corpus: **0 hard ingest failures**
  (previously 148+ and growing); remaining "scheduling failed" lines are
  carryover retries of prior-run failures that now succeed.
- New `test_archive_store_connection_applies_canonical_profile` pins
  busy_timeout=30000 + WAL on write, 1000 + query_only on read.
- `mypy --strict` clean on `archive.py` and `batch.py`; full
  `tests/unit/storage/test_archive_tiers_write.py` 24 passed;
  `devtools verify --quick` (pre-push) passed.

## Follow-up

- The bare-`sqlite3.connect` pattern also appears on the per-tier source/user
  connections in `ArchiveStore`; those are single-writer paths today but should
  also route through the profile for the same invariant.
- Convergence write-transaction duration (~20s lock holds) is the remaining
  throughput limiter and warrants smaller commit batches.