### PR TITLE
refactor: session/origin vocabulary sweep + public-surface static audit (#1810)

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -414,6 +414,10 @@ def build_verify_steps(
                 ("verify-lane-assertions", _devtools_cmd("verify-lane-assertions")),
                 ("verify-test-infra-currency", _devtools_cmd("verify-test-infra-currency")),
                 ("verify-test-clock-hygiene", _devtools_cmd("verify-test-clock-hygiene")),
+                (
+                    "public-surface-audit",
+                    ["bash", str(ROOT / "tools" / "cleanup" / "polylogue_public_surface_audit.sh")],
+                ),
             ]
         )
 

--- a/docs/visual-evidence.md
+++ b/docs/visual-evidence.md
@@ -41,12 +41,12 @@ operator-facing wrapper for the visual/DOM lane.
 | Reader state | Artefact id | Routes exercised |
 |---|---|---|
 | List / search | `polylogue.local_reader.search` | `/`, `/api/sessions`, `/api/sessions?query=...`, `/api/facets`, `/api/facets?origin=...`, `/api/facets?query=...` |
-| Detail / session | `polylogue.local_reader.session` | `/c/{id}`, `/api/sessions/{id}`, `/api/sessions/{id}/messages`, `/api/sessions/{id}/raw` |
+| Detail / session | `polylogue.local_reader.session` | `/s/{id}`, `/api/sessions/{id}`, `/api/sessions/{id}/messages`, `/api/sessions/{id}/raw` |
 | Stack workspace | `polylogue.local_reader.workspace.stack` | `/w/stack?ids=...`, `/api/stack?ids=...` |
 | Compare workspace | `polylogue.local_reader.workspace.compare` | `/w/compare?left=...&right=...&align=prompt`, `/api/compare?left=...&right=...&align=prompt` |
 | Empty archive | — | `/api/sessions`, `/api/facets` |
 | Degraded FTS | `polylogue.local_reader.degraded` | `/api/sessions?query=...` with message FTS absent |
-| Privacy boundary | — | `/`, `/c/{id}`, `/api/facets`, `/api/sessions`, `/api/sessions/{id}`, `/api/sessions/{id}/messages` (auditing for absolute local paths) |
+| Privacy boundary | — | `/`, `/s/{id}`, `/api/facets`, `/api/sessions`, `/api/sessions/{id}`, `/api/sessions/{id}/messages` (auditing for absolute local paths) |
 | Auth boundary | — | `/api/sessions` with/without `Authorization: Bearer ...` |
 
 The artefact ids match the names referenced in the design packs and in #848 so
@@ -56,7 +56,7 @@ palette screenshots under `docs/design/mk3/screens/`.
 
 ## What the lane checks
 
-- **Page structure.** The HTML payloads at `/`, `/c/{id}`, and `/w/{mode}` contain the region
+- **Page structure.** The HTML payloads at `/`, `/s/{id}`, and `/w/{mode}` contain the region
   hooks (`renderSidebarState`, `renderSessions`, `renderFacets`,
   `renderMain`, `renderWorkspaceToolbar`, `renderStackWorkspace`,
   `renderCompareWorkspace`, `renderInspector`) the JS bundle hydrates. A regression

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -758,7 +758,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # Web shell is the only unauthenticated endpoint (localhost only).
         if (
             path == [""]
-            or (len(path) == 2 and path[0] == "c" and bool(path[1]))
+            or (len(path) == 2 and path[0] == "s" and bool(path[1]))
             or (len(path) == 2 and path[0] == "w" and path[1] in workspace_routes.WORKSPACE_SHELL_MODES)
         ):
             self._serve_web_shell()

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -386,15 +386,15 @@ function annotationsFor(sessionId) {
   return state.annotations[sessionId] || [];
 }
 
-function getConvIdFromURL() {
-  var m = window.location.pathname.match(/^\/c\/(.+)$/);
+function getSessionIdFromURL() {
+  var m = window.location.pathname.match(/^\/s\/(.+)$/);
   return m ? decodeURIComponent(m[1]) : null;
 }
 __WORKSPACE_JS__
 window.addEventListener('popstate', function() {
   var route = getWorkspaceRouteFromURL();
   if (route) { loadWorkspaceRoute(route, false); return; }
-  var cid = getConvIdFromURL();
+  var cid = getSessionIdFromURL();
   if (cid) selectSession(cid, false);
   else { state.mode = 'single'; state.selected = null; state.selectedRaw = null; renderMain(); renderInspector(); renderSessions(); }
 });
@@ -1437,7 +1437,7 @@ document.getElementById('inspector-tabs').addEventListener('click', function(e) 
 loadSessions().then(function() {
   var route = getWorkspaceRouteFromURL();
   if (route) { loadWorkspaceRoute(route, false); return; }
-  var cid = getConvIdFromURL();
+  var cid = getSessionIdFromURL();
   if (cid) selectSession(cid, false);
 });
 loadFacets();

--- a/polylogue/daemon/web_shell_attachments.py
+++ b/polylogue/daemon/web_shell_attachments.py
@@ -373,7 +373,7 @@ function _polyAttachmentLibraryRender() {
   var html = order.map(function(cid) {
     var g = groups[cid];
     var rows = g.items.map(function(it) {
-      var href = '/c/' + encodeURIComponent(cid);
+      var href = '/s/' + encodeURIComponent(cid);
       if (it.message_anchor) href += '#' + encodeURIComponent(it.message_anchor);
       var sizeStr = _polyFormatBytes(it.size_bytes);
       var meta = [];
@@ -391,7 +391,7 @@ function _polyAttachmentLibraryRender() {
     return ''
       + '<div class="att-group">'
       +   '<div class="att-group-title">'
-      +     '<a href="/c/' + encodeURIComponent(cid) + '">'
+      +     '<a href="/s/' + encodeURIComponent(cid) + '">'
       +     (g.title || cid).replace(/[<&]/g, function(c) { return c === '<' ? '&lt;' : '&amp;'; })
       +     '</a>'
       +     '<span class="att-origin">' + (g.origin || '') + '</span>'

--- a/polylogue/daemon/web_shell_paste.py
+++ b/polylogue/daemon/web_shell_paste.py
@@ -538,7 +538,7 @@ function _polyPasteBrowserRender(items) {
   var html = order.map(function(cid) {
     var g = groups[cid];
     var rows = g.items.map(function(it) {
-      var href = '/c/' + encodeURIComponent(cid) + '#' + encodeURIComponent(it.message_anchor);
+      var href = '/s/' + encodeURIComponent(cid) + '#' + encodeURIComponent(it.message_anchor);
       var badges = '';
       if (it.has_diff) badges += '<span class="pb-badge pb-diff">diff</span>';
       var spanCount = (it.paste_spans || []).length;
@@ -553,7 +553,7 @@ function _polyPasteBrowserRender(items) {
     return ''
       + '<div class="pb-group">'
       +   '<div class="pb-group-title">'
-      +     '<a href="/c/' + encodeURIComponent(cid) + '">'
+      +     '<a href="/s/' + encodeURIComponent(cid) + '">'
       +     (g.title || cid).replace(/[<&]/g, function(c) { return c === '<' ? '&lt;' : '&amp;'; })
       +     '</a>'
       +     '<span class="pb-origin">' + (g.origin || '') + '</span>'

--- a/polylogue/daemon/web_shell_similar.py
+++ b/polylogue/daemon/web_shell_similar.py
@@ -153,7 +153,7 @@ function openSimilarHit(sessionId) {
     loadWorkspaceRoute({mode: 'single', id: sessionId}, true).catch(function() {});
     return;
   }
-  window.location.hash = '#/c/' + encodeURIComponent(sessionId);
+  window.location.hash = '#/s/' + encodeURIComponent(sessionId);
 }
 """
 

--- a/polylogue/daemon/web_shell_workspace.py
+++ b/polylogue/daemon/web_shell_workspace.py
@@ -100,7 +100,7 @@ function getWorkspaceRouteFromURL() {
 
 function pushSingleURL(convId) {
   if (convId) {
-    var url = '/c/' + encodeURIComponent(convId);
+    var url = '/s/' + encodeURIComponent(convId);
     if (window.location.pathname + window.location.search !== url) history.pushState({}, '', url);
   } else {
     if (window.location.pathname + window.location.search !== '/') history.pushState({}, '', '/');

--- a/tests/unit/daemon/test_maintenance_endpoints.py
+++ b/tests/unit/daemon/test_maintenance_endpoints.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class MockServer:
-    auth_token = None
+    auth_token: str | None = None
     api_host = "127.0.0.1"
 
 

--- a/tests/unit/daemon/test_schema_preflight.py
+++ b/tests/unit/daemon/test_schema_preflight.py
@@ -230,8 +230,8 @@ async def test_ingest_files_short_circuits_when_degraded(tmp_path: Path) -> None
 
     class _StubPolylogue:
         archive_root = tmp_path
-        backend = None
-        config = None
+        backend: object | None = None
+        config: object | None = None
 
     sources_root = type(
         "SourceRoot",
@@ -342,8 +342,8 @@ async def test_ingest_files_short_circuits_under_burst_after_degraded(
 
     class _StubPolylogue:
         archive_root = tmp_path
-        backend = None
-        config = None
+        backend: object | None = None
+        config: object | None = None
 
     sources_root = type("SourceRoot", (), {"name": "claude-code", "root": tmp_path})()
     processor = LiveBatchProcessor(
@@ -381,8 +381,8 @@ async def test_live_batch_marks_structural_database_error_degraded(
 
     class _StubPolylogue:
         archive_root = tmp_path
-        backend = None
-        config = None
+        backend: object | None = None
+        config: object | None = None
 
     sources_root = type("SourceRoot", (), {"name": "claude-code", "root": tmp_path})()
     processor = LiveBatchProcessor(

--- a/tests/unit/daemon/test_similarity_endpoint.py
+++ b/tests/unit/daemon/test_similarity_endpoint.py
@@ -148,7 +148,7 @@ def _disable_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class _Cfg:
         embedding_enabled = False
-        voyage_api_key = None
+        voyage_api_key: str | None = None
 
     monkeypatch.setattr(similarity_mod, "load_polylogue_config", lambda: _Cfg())
 
@@ -263,7 +263,7 @@ class TestSimilarPayloadStates:
 
         class _Cfg:
             embedding_enabled = True
-            voyage_api_key = None
+            voyage_api_key: str | None = None
 
         monkeypatch.setattr(similarity_mod, "load_polylogue_config", lambda: _Cfg())
         session_id = _seed_archive_session("c1")

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -571,6 +571,21 @@ class TestReaderWorkspaceRoutes:
         assert compare_status == 200
         assert "renderCompareWorkspace" in compare_body
 
+    def test_session_deep_link_route_serves_web_shell(self, workspace_env: dict[str, Path]) -> None:
+        """The session reader deep link is ``/s/{session_id}`` (schema-v1 vocabulary)."""
+        with _running_server(workspace_env) as (_, base_url):
+            status, content_type, body = _get_text(base_url, "/s/claude-code-session:c1")
+        assert status == 200
+        assert "text/html" in content_type
+        assert "<title>Polylogue</title>" in body
+        assert "getSessionIdFromURL" in body
+
+    def test_legacy_conversation_route_is_gone(self, workspace_env: dict[str, Path]) -> None:
+        """The stale ``/c/{conversation_id}`` route must not resolve — no compat alias."""
+        with _running_server(workspace_env) as (_, base_url):
+            status, _, _ = _get_text(base_url, "/c/claude-code-session:c1")
+        assert status == 404
+
     def test_archive_file_set_stack_route_from_archive_tiers(
         self,
         workspace_env: dict[str, Path],

--- a/tests/unit/devtools/test_public_surface_audit.py
+++ b/tests/unit/devtools/test_public_surface_audit.py
@@ -1,0 +1,98 @@
+"""Tests for the public-surface stale-vocabulary audit (#1850).
+
+The audit (``tools/cleanup/polylogue_public_surface_audit.sh``) fails when
+stale schema-v1 vocabulary (``conversation`` / ``conversation_id`` /
+``provider_meta`` / the legacy ``/c/{id}`` reader route) reappears on a public
+surface, while allowing it in provider-wire parsers, internal storage/core,
+tests, and historical/tombstone docs.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AUDIT_SCRIPT = REPO_ROOT / "tools" / "cleanup" / "polylogue_public_surface_audit.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep (rg) not available")
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    # The script anchors its scan to its own location's repo root, so a seeded
+    # tree must invoke the *copied* script under ``root`` (not the canonical one).
+    script = root / "tools" / "cleanup" / AUDIT_SCRIPT.name
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_audit_script_exists_and_is_executable() -> None:
+    assert AUDIT_SCRIPT.is_file(), "audit script must exist at the issue-specified path"
+
+
+def test_audit_passes_on_current_tree() -> None:
+    """The live repository must be clean of stale public-surface vocabulary."""
+    result = _run(REPO_ROOT)
+    assert result.returncode == 0, f"audit unexpectedly failed:\n{result.stderr}"
+    assert "clean" in result.stdout
+
+
+def _seed_minimal_tree(root: Path) -> None:
+    """Create the directory shape the audit scans plus the script itself."""
+    (root / "tools" / "cleanup").mkdir(parents=True)
+    shutil.copy(AUDIT_SCRIPT, root / "tools" / "cleanup" / AUDIT_SCRIPT.name)
+    (root / "docs").mkdir()
+    (root / "polylogue" / "daemon").mkdir(parents=True)
+    (root / "polylogue" / "sources" / "parsers").mkdir(parents=True)
+
+
+def test_audit_fails_on_stale_conversation_id_in_public_doc(tmp_path: Path) -> None:
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "docs" / "api.md").write_text("Fetch via `conversation_id` query param.\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "conversation_id" in result.stderr
+    assert "session_id" in result.stderr  # replacement guidance is named
+
+
+def test_audit_fails_on_legacy_route_literal(tmp_path: Path) -> None:
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "polylogue" / "daemon" / "web.py").write_text("href = '/c/' + sid\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "/s/{session_id}" in result.stderr
+
+
+def test_audit_fails_on_provider_meta_in_public_surface(tmp_path: Path) -> None:
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "docs" / "schema.md").write_text("The `provider_meta` field carries vendor data.\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "provider_meta" in result.stderr
+
+
+def test_audit_allows_stale_terms_in_provider_wire_parsers(tmp_path: Path) -> None:
+    """Provider-wire parsers read external vendor field names verbatim."""
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "polylogue" / "sources" / "parsers" / "vendor.py").write_text(
+        "conv_id = payload.get('conversation_id')\nprovider_meta = payload.get('provider_meta')\n"
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, f"provider-wire paths must be allowlisted:\n{result.stderr}"
+
+
+def test_audit_honors_inline_allow_marker(tmp_path: Path) -> None:
+    """A policed line may opt out when it documents an external vendor format."""
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "docs" / "providers-note.md").write_text(
+        "Antigravity stores `conversation` blobs.  <!-- polylogue-audit: allow external antigravity format -->\n"
+    )
+    result = _run(tmp_path)
+    assert result.returncode == 0, f"inline allow marker must suppress the hit:\n{result.stderr}"

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -191,7 +191,7 @@ def test_reader_compare_workspace_dom_evidence(reader_workspace: ReaderWorkspace
 
 def test_reader_session_deeplink_and_detail_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
     with running_reader_server(reader_workspace) as (_, base_url):
-        status, content_type, shell = get_text(base_url, f"/c/{READER_C1}")
+        status, content_type, shell = get_text(base_url, f"/s/{READER_C1}")
         detail = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}"))
         messages = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/messages"))
         raw = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/raw"))
@@ -250,7 +250,7 @@ def test_reader_session_deeplink_and_detail_evidence(reader_workspace: ReaderWor
     write_evidence_manifest(
         tmp_path / "reader-session-dom-evidence.json",
         artifact_id="polylogue.local_reader.session",
-        route=f"/c/{READER_C1}",
+        route=f"/s/{READER_C1}",
         fixture_id="reader-visual-synthetic-v1",
         checks=checks,
     )
@@ -307,7 +307,7 @@ def test_reader_cost_panel_evidence(reader_workspace: ReaderWorkspace, tmp_path:
       so the panel is reachable through the inspector tab strip.
     """
     with running_reader_server(reader_workspace) as (_, base_url):
-        status, content_type, shell = get_text(base_url, f"/c/{READER_C1}")
+        status, content_type, shell = get_text(base_url, f"/s/{READER_C1}")
         known_cost = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/cost"))
         unknown_status, _, unknown_body = get_text(base_url, "/api/sessions/does-not-exist/cost")
 
@@ -378,7 +378,7 @@ def test_reader_insights_browser_evidence(reader_workspace: ReaderWorkspace, tmp
       the readiness chip CSS classes.
     """
     with running_reader_server(reader_workspace) as (_, base_url):
-        status, content_type, shell = get_text(base_url, f"/c/{READER_C1}")
+        status, content_type, shell = get_text(base_url, f"/s/{READER_C1}")
         known = cast(dict[str, object], get_json(base_url, f"/api/insights/sessions/{READER_C1}"))
         subset = cast(
             dict[str, object],

--- a/tools/cleanup/polylogue_public_surface_audit.sh
+++ b/tools/cleanup/polylogue_public_surface_audit.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Polylogue public-surface stale-vocabulary audit (#1850 / #1810 / #1835).
+#
+# Polylogue's public schema-v1 vocabulary is `session` and `origin`. The terms
+# `conversation` / `conversation_id` and the field `provider_meta`, plus the
+# legacy reader route `/c/{conversation_id}`, are stale and must not reappear on
+# any *public surface*: the README, hand-authored (non-historical) docs, the
+# daemon web reader (routes + HTML), the JSON-RPC/HTTP API layer, and the CLI.
+#
+# This audit is path-aware. It does NOT police:
+#   - provider-wire parsers that read external vendor payloads verbatim
+#     (`polylogue/sources/**`) — those field names mirror the vendor's own JSON;
+#   - the internal storage/core/schema layer where the `provider`/`provider_meta`
+#     identifiers are deferred internal renames behind origin<->provider boundary
+#     translation (tracked debt; public API already speaks `origin`);
+#   - tests, fixtures, and synthetic wire builders (incl. stale-term rejection
+#     tests, which must mention the stale term on purpose);
+#   - historical/tombstone docs (audits, retros, design canvases, plans).
+#
+# It deliberately does NOT police the bare word `provider`: the deep
+# `provider` -> `origin` internal rename is schema-migration-scale work tracked
+# separately (Ref #1835). Only the unambiguous stale tokens below are failed.
+#
+# Failing output names the exact file:line and the replacement term. A single
+# line inside a policed path may opt out with a trailing
+# `# polylogue-audit: allow <reason>` marker when it legitimately documents an
+# external vendor format.
+#
+# Exit 0 = clean; exit 1 = stale terms found; exit 2 = misuse.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "polylogue-public-surface-audit: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+# Public surfaces the audit scans. A leading slash anchors the glob to the repo
+# root (the root README only; nested component READMEs are their own surface).
+PUBLIC_GLOBS=(
+  "/README.md"
+  "docs/**/*.md"
+  "polylogue/daemon/**/*.py"
+  "polylogue/api/**/*.py"
+  "polylogue/cli/**/*.py"
+)
+
+# Path prefixes excluded from scanning even when matched by a public glob:
+#   - historical/tombstone docs that intentionally preserve old vocabulary;
+#   - docs/providers/** documents external vendor wire formats and the deferred
+#     internal `provider_meta` field (Ref #1790), so it is provider-wire, not
+#     stale Polylogue vocabulary.
+EXCLUDE_GLOBS=(
+  "docs/audits/**"
+  "docs/retro/**"
+  "docs/design/**"
+  "docs/plans/**"
+  "docs/providers/**"
+)
+
+# Stale token => human-readable replacement guidance.
+# Each entry is "REGEX|||REPLACEMENT".
+declare -a RULES=(
+  '\bconversation_id\b|||session_id (schema-v1 identifier)'
+  '\bconversationId\b|||sessionId (schema-v1 identifier)'
+  '\bconversation\b|||session (schema-v1 vocabulary)'
+  '\bprovider_meta\b|||origin-typed fields (Ref #1790; provider_meta is stale)'
+  "['\"\`]/c/|||/s/{session_id} reader route"
+)
+
+rg_args=()
+for g in "${PUBLIC_GLOBS[@]}"; do rg_args+=(--glob "$g"); done
+for g in "${EXCLUDE_GLOBS[@]}"; do rg_args+=(--glob "!$g"); done
+
+status=0
+for rule in "${RULES[@]}"; do
+  pattern="${rule%%|||*}"
+  replacement="${rule##*|||}"
+  # --no-heading line-oriented output: path:line:text
+  while IFS= read -r hit; do
+    # Honor inline opt-out marker for legitimate external-vendor-format docs.
+    # Comment syntax is irrelevant (``#``, ``//``, ``<!-- -->`` all work).
+    case "$hit" in
+      *"polylogue-audit: allow"*) continue ;;
+    esac
+    if [ "$status" -eq 0 ]; then
+      echo "Stale schema-v1 vocabulary found on public surfaces:" >&2
+      echo >&2
+      status=1
+    fi
+    echo "  $hit" >&2
+    echo "    -> replace with: $replacement" >&2
+  done < <(rg --no-heading --line-number --color never "${rg_args[@]}" -e "$pattern" 2>/dev/null || true)
+done
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "Public Polylogue vocabulary is 'session' and 'origin'. Stale terms are" >&2
+  echo "allowed only in provider-wire parsers, internal storage/core, tests," >&2
+  echo "and historical/tombstone docs. See tools/cleanup/$(basename "${BASH_SOURCE[0]}")." >&2
+  exit 1
+fi
+
+echo "polylogue-public-surface-audit: clean (no stale schema-v1 vocabulary on public surfaces)"
+exit 0


### PR DESCRIPTION
## Summary

Coherent first slice of the schema-v1 session/origin terminology sweep: renames the stale `/c/{conversation_id}` HTML reader route to `/s/{session_id}` across the daemon web shell, and adds a path-aware static audit (`tools/cleanup/polylogue_public_surface_audit.sh`, #1850) that fails CI when stale schema-v1 vocabulary reappears on a public surface. This is intentionally **partial** — see Deferred below; it is being merged as the first reviewable slice so the branch can clear the worktree for follow-up work from clean master.

## Problem

Schema-v1 fixed Polylogue's public vocabulary to `session` and `origin`, but the daemon still served the legacy `/c/{conversation_id}` reader route (JS regex, link construction, and HTTP dispatch), and nothing prevented stale `conversation`/`conversation_id`/`provider_meta` terms or the dead route from reappearing on public surfaces (README, hand-authored docs, web reader, API, CLI). The audit on `origin/master` finds 8 public-surface hits (the `/c/` reader route in `web_shell*.py` plus 3 stale `/c/{id}` references in `docs/visual-evidence.md`).

## Solution

- **Route rename** (`polylogue/daemon/http.py`, `web_shell*.py`): `/c/{id}` → `/s/{id}`; `getConvIdFromURL` → `getSessionIdFromURL`; all link/href/pushState/hash sites updated. No compatibility alias (pre-release, single-user — delete+replace).
- **Static audit** (`tools/cleanup/polylogue_public_surface_audit.sh`, #1850): ripgrep-based, path-aware. Fails on `conversation`/`conversation_id`/`conversationId`/`provider_meta`/`/c/` literals in public surfaces (root README, non-historical docs, daemon web, API, CLI), names each `file:line` with replacement guidance. Allowlists provider-wire parsers (`polylogue/sources/**`), internal storage/core/schema, tests, historical/tombstone docs (`audits`/`retro`/`design`/`plans`), and `docs/providers/**` (external wire notes). Supports an inline `polylogue-audit: allow <reason>` marker. Deliberately does **not** police bare `provider` (deferred internal rename) or `blocks` (#1791). Wired into the `devtools verify --quick` non-pytest gate set.
- **Doc fix** (`docs/visual-evidence.md`): `/c/{id}` → `/s/{id}` (stale after the route rename).
- **Tests**: positive/negative route tests (`/s/{id}` serves the shell; `/c/{id}` is 404, no alias); audit tests (clean tree passes; `conversation_id`/legacy-route/`provider_meta` fail; provider-wire allowlist; inline-allow marker).
- **Inherited fix** (`fix(tests):` commit): annotated 9 pre-existing `var-annotated` mypy errors in three daemon test stub classes that were red on `master` and blocked the pre-push gate. Not part of the sweep; zero behavior change.

## Verification

```
tools/cleanup/polylogue_public_surface_audit.sh   # origin/master: 8 hits → branch: clean (0)
devtools verify --quick                            # 15/15 gates exit 0 (incl. new public-surface-audit; mypy now 0 errors)
pytest tests/unit/devtools/test_public_surface_audit.py   # 7 passed
pytest tests/unit/daemon/test_web_reader.py -k "session_deep_link or legacy_conversation"   # 2 passed
```

Baseline before this branch: `devtools verify --quick` was 13/14 (mypy red with 9 inherited errors). Final: 15/15 green.

### Before / after stale terms (public surfaces)

| Surface | master | branch |
|---|---|---|
| `/c/` reader route literals (`polylogue/` py) | 1 dispatch + JS/link sites | 0 |
| `/c/{id}` in `docs/visual-evidence.md` | 3 | 0 |
| audit verdict | FAIL (8 hits) | CLEAN |

## Deferred (next agent, from clean master)

- **Deep `provider` → `origin` internal rename** (~6024 hits in storage/query/schema behind `origin↔provider` boundary translation). Schema-migration-scale; public JSON/query API already speaks `origin`. Audit allowlists these paths. Ref #1835.
- **`provider_meta` restructure** into typed origin-specific fields. Field is used in ~40 internal files; the audit only polices it on public text surfaces. (#1790 does not resolve to an issue in this repo — GraphQL 404 — so its plan could not be consulted.)
- **`content_blocks` → `blocks`** (#1791) — separate ~133-file mechanical rename with its own plan; out of session/origin scope. Audit does not police `blocks`.
- **#1835 broader items** not in this slice: removing stale root command names from docs/help (`show`/`open`/`messages`/`raw`/`export`/`bulk-export`/`recent`/`count`/`stats`), the fate of `polylogue/rendering/*` and `polylogue/templates/*`, and proof/QA/showcase confidence-language cleanup.
- **`browser-extension/README.md`** generic/external-product `conversation` prose (anchored out of the README glob; separate component surface).

Ref #1810 #1835 #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added public surface audit tool to verify consistency of public-facing documentation and API references.

* **Updates**
  * Web reader session routes changed from `/c/{id}` to `/s/{id}`.
  * Documentation updated to reflect new route structure.
  * Legacy conversation routes now return HTTP 404.

* **Tests**
  * Added verification tests for new session deep-link routes.
  * Added comprehensive public surface audit test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->