### PR TITLE
ci: gate public-surface vocabulary audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: uv run devtools render-all --check --skip agents
       - run: uv run ruff check polylogue/ tests/ devtools/
       - run: uv run ruff format --check polylogue/ tests/ devtools/
+      - run: bash tools/cleanup/polylogue_public_surface_audit.sh
 
   test:
     timeout-minutes: 45


### PR DESCRIPTION
## Summary

Adds the public-surface stale-vocabulary audit to the CI `lint` job so stale schema-v1 terminology cannot be reintroduced on a public surface and pass CI.

## Problem

The audit (`tools/cleanup/polylogue_public_surface_audit.sh`) landed in #1852 and runs in `devtools verify` / the pre-push hook, but **CI never invoked it**. A PR reintroducing `conversation`/`conversation_id`, `provider_meta`, or the legacy `/c/` reader route on the README, public docs, daemon web reader, API layer, or CLI would pass CI. #1850 requires the audit to run in fast CI.

## Solution

One step added to the CI `lint` job (after the ruff checks): `bash tools/cleanup/polylogue_public_surface_audit.sh`. The audit is path-aware — it excludes provider-wire parsers (`polylogue/sources/**`), internal storage/core, tests/fixtures, and historical/tombstone docs (`docs/{audits,retro,design,plans,providers}/**`) — and exits non-zero naming `file:line` + the replacement term. `ripgrep` is preinstalled on GitHub `ubuntu-latest`.

## Verification

- `devtools verify-ci-workflows` → `16 workflow files checked, no errors`
- `bash tools/cleanup/polylogue_public_surface_audit.sh` → `clean (no stale schema-v1 vocabulary on public surfaces)`

Closes #1850