### PR TITLE
ci: install ripgrep before public-surface audit in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - run: uv run devtools render-all --check --skip agents
       - run: uv run ruff check polylogue/ tests/ devtools/
       - run: uv run ruff format --check polylogue/ tests/ devtools/
+      - name: Install ripgrep (public-surface audit dependency)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
       - run: bash tools/cleanup/polylogue_public_surface_audit.sh
 
   test:


### PR DESCRIPTION
## Summary

Fixes the red `lint` job on master: install `ripgrep` in the CI lint job before the public-surface audit step added in #1854.

## Problem

#1854 added `bash tools/cleanup/polylogue_public_surface_audit.sh` to the CI `lint` job. The audit shells out to `rg` (ripgrep), which is not on the `uv`/`ubuntu-latest` lint runner's PATH, so the step exited 2 (`ripgrep is required`) and master's lint job went red. The audit was validated locally inside the nix devshell — where `rg` is always present — which masked the CI-environment gap.

## Solution

Install ripgrep via apt in the lint job, immediately before the audit step.

## Verification

- `devtools verify-ci-workflows` → `16 workflow files checked, no errors`

Ref #1850