### PR TITLE
fix(antigravity): flag fragmented brain-metadata sessions degraded

### DIFF
--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -240,7 +240,23 @@ def parse_markdown_export_payload(payload: JSONDocument, fallback_id: str) -> Pa
     return parse_markdown_export(_string(payload.get("markdown")) or "", summary)
 
 
+BRAIN_METADATA_FRAGMENT_FLAG = "degraded:brain-metadata-fragment"
+
+
 def parse_brain_metadata(payload: JSONDocument, source_path: Path, fallback_id: str) -> ParsedSession:
+    """Parse a single Antigravity brain-artifact metadata file into a session.
+
+    Each ``*.metadata.json`` file becomes its own session whose
+    ``provider_session_id`` is ``{parent_dir}:{artifact_name}``.  Because one
+    logical work session typically produces many artifacts, this path fragments
+    a single conversation into N single-message sessions — one per artifact.
+
+    The session is flagged ``degraded:brain-metadata-fragment`` (written as an
+    auto-tag at ingest time) so it can be excluded from primary session counts
+    and insight rollups.  The underlying cause and the viable fix paths
+    (aggregate by parent-dir key, or prefer the language-server export) are
+    tracked in GitHub issue #1764.
+    """
     artifact_path = _artifact_path_for_metadata(source_path)
     session_id = artifact_path.parent.name if artifact_path.parent.name else fallback_id
     artifact_name = artifact_path.name if artifact_path.name else fallback_id
@@ -269,6 +285,7 @@ def parse_brain_metadata(payload: JSONDocument, source_path: Path, fallback_id: 
             )
         ],
         active_leaf_message_provider_id=f"{composed_session_id}:artifact",
+        ingest_flags=[BRAIN_METADATA_FRAGMENT_FLAG],
     )
 
 
@@ -443,6 +460,7 @@ __all__ = [
     "AntigravityExportError",
     "AntigravityLanguageServerClient",
     "AntigravityPartialExportError",
+    "BRAIN_METADATA_FRAGMENT_FLAG",
     "discover_language_server",
     "iter_language_server_exports",
     "looks_like_brain_metadata",

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -201,6 +201,13 @@ class ParsedSession(BaseModel):
     # pin a session to an exact commit instead of the looser "session_date
     # +/- N hours" window. Empty string treated as None.
     git_commit_hash: str | None = None
+    # Parser-level ingest flags that the storage layer persists as auto-tags
+    # (tag_source='auto', method='parser') during write_parsed_session_to_archive.
+    # Parsers set these to communicate structural quality issues without requiring
+    # new storage columns — the existing session_tags table (index.db) absorbs them.
+    # Example: ["degraded:brain-metadata-fragment"] for Antigravity brain-artifact
+    # fallback sessions that fragment one work session into N single-message sessions.
+    ingest_flags: list[str] = Field(default_factory=list)
 
     @field_validator("source_name", mode="before")
     @classmethod

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -281,7 +281,33 @@ def write_parsed_session_to_archive(
         _write_reported_costs(conn, session_id, session)
         _refresh_session_counts(conn, session_id)
         _resolve_session_graph(conn, session_id, native_id, origin.value)
+        if session.ingest_flags:
+            _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
     return session_id
+
+
+def _write_ingest_flag_tags(conn: sqlite3.Connection, session_id: str, flags: list[str]) -> None:
+    """Write parser-level ingest flags as auto-tags in the same transaction.
+
+    Each flag is lowercased and written as ``(session_id, flag, 'auto')`` with
+    ``method='parser'``.  Duplicate flags on re-ingest are silently skipped
+    (``ON CONFLICT DO NOTHING``) so repeated ingest of the same session is
+    idempotent.  Called from inside the ``with conn:`` block of
+    ``write_parsed_session_to_archive`` so the tag rows are committed atomically
+    with the session row they reference.
+    """
+    for raw_flag in flags:
+        normalized = raw_flag.strip().lower()
+        if not normalized:
+            continue
+        conn.execute(
+            """
+            INSERT INTO session_tags (session_id, tag, tag_source, method)
+            VALUES (?, ?, 'auto', 'parser')
+            ON CONFLICT(session_id, tag, tag_source) DO NOTHING
+            """,
+            (session_id, normalized),
+        )
 
 
 def _clear_session_projection_rows(conn: sqlite3.Connection, session_id: str) -> None:

--- a/tests/unit/sources/parsers/test_antigravity.py
+++ b/tests/unit/sources/parsers/test_antigravity.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from polylogue.archive.message.roles import Role
 from polylogue.core.json import JSONDocument
 from polylogue.sources.parsers.antigravity import (
+    BRAIN_METADATA_FRAGMENT_FLAG,
     AntigravitySessionSummary,
     looks_like_brain_metadata,
     parse_brain_metadata,
@@ -115,3 +116,56 @@ def test_parse_brain_metadata_marks_missing_artifact(tmp_path: Path) -> None:
 
     assert session.provider_session_id == "session-2:missing.md"
     assert session.messages[0].text == "Missing body"
+
+
+# ---------------------------------------------------------------------------
+# Regression: brain-metadata fragmentation degraded flag (#1764)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_brain_metadata_sets_degraded_ingest_flag(tmp_path: Path) -> None:
+    """Brain-metadata sessions are flagged degraded:brain-metadata-fragment.
+
+    Each *.metadata.json artifact becomes its own single-message session,
+    fragmenting one work session into N sessions.  The ingest_flags field
+    carries the degraded marker so it is written as an auto-tag at storage
+    time and can be excluded from primary session counts and insight rollups.
+    """
+    session_dir = tmp_path / "brain" / "session-abc"
+    session_dir.mkdir(parents=True)
+    artifact_path = session_dir / "output.md"
+    artifact_path.write_text("# Output\n\nSome result.\n", encoding="utf-8")
+    metadata_path = session_dir / "output.md.metadata.json"
+    payload: JSONDocument = {
+        "artifactType": "ARTIFACT_TYPE_OTHER",
+        "summary": "Output",
+        "updatedAt": "2026-04-01T10:00:00Z",
+    }
+
+    session = parse_brain_metadata(payload, metadata_path, "fallback")
+
+    assert BRAIN_METADATA_FRAGMENT_FLAG in session.ingest_flags, (
+        f"Expected {BRAIN_METADATA_FRAGMENT_FLAG!r} in ingest_flags, got {session.ingest_flags!r}"
+    )
+
+
+def test_parse_markdown_export_has_no_degraded_flag() -> None:
+    """Language-server export sessions are whole transcripts — not fragmented.
+
+    Markdown export sessions must NOT carry the brain-metadata fragment flag;
+    they represent complete work sessions and must not be excluded from primary
+    views by the same filter that suppresses brain-metadata fragments.
+    """
+    markdown = "### User Input\n\nRun checks.\n\n### Planner Response\n\nDone.\n"
+    summary = AntigravitySessionSummary(
+        cascade_id="cascade-clean",
+        title="Clean session",
+        last_modified_time="2026-04-01T12:00:00Z",
+    )
+
+    session = parse_markdown_export(markdown, summary)
+
+    assert BRAIN_METADATA_FRAGMENT_FLAG not in session.ingest_flags, (
+        f"Markdown export session must not carry {BRAIN_METADATA_FRAGMENT_FLAG!r}, "
+        f"got ingest_flags={session.ingest_flags!r}"
+    )

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1323,3 +1323,98 @@ def test_agent_policy_absent_when_no_events(tmp_path: Path) -> None:
     )
     session_id = write_parsed_session_to_archive(conn, session)
     assert read_session_agent_policies(conn, session_id) == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: ingest_flags written as auto-tags at write time (#1764)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_flags_written_as_auto_tags(tmp_path: Path) -> None:
+    """ParsedSession.ingest_flags are persisted as auto-tags during write.
+
+    The storage layer calls _write_ingest_flag_tags inside the same transaction
+    as the session row, so the tags are always present when the session is
+    readable.  This is the durable persistence path for parser-level quality
+    flags (e.g. ``degraded:brain-metadata-fragment`` for Antigravity brain-
+    artifact fallback sessions, issue #1764).
+    """
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="flagged-session",
+        title="Flagged session",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                text="artifact body",
+                position=0,
+                content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="artifact body")],
+            ),
+        ],
+        ingest_flags=["degraded:brain-metadata-fragment"],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    tags = read_session_tags(conn, session_id=session_id, tag_source="auto")
+    assert "degraded:brain-metadata-fragment" in tags, (
+        f"Expected degraded:brain-metadata-fragment auto-tag, got: {list(tags)}"
+    )
+    tag = tags["degraded:brain-metadata-fragment"]
+    assert isinstance(tag, ArchiveSessionTag)
+    assert tag.tag_source == "auto"
+    assert tag.method == "parser"
+
+
+def test_ingest_flags_empty_writes_no_auto_tags(tmp_path: Path) -> None:
+    """Sessions with no ingest_flags do not gain spurious auto-tags."""
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="clean-session",
+        title="Clean session",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                text="hello",
+                position=0,
+                content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="hello")],
+            ),
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    auto_tags = read_session_tags(conn, session_id=session_id, tag_source="auto")
+    assert auto_tags == {}, f"Expected no auto-tags for clean session, got: {list(auto_tags)}"
+
+
+def test_ingest_flags_re_ingest_is_idempotent(tmp_path: Path) -> None:
+    """Re-ingesting a session with ingest_flags does not duplicate auto-tags."""
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="re-ingest-session",
+        title="Re-ingest test",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                text="body",
+                position=0,
+                content_blocks=[ParsedContentBlock(type=BlockType.TEXT, text="body")],
+            ),
+        ],
+        ingest_flags=["degraded:brain-metadata-fragment"],
+    )
+
+    write_parsed_session_to_archive(conn, session)
+    write_parsed_session_to_archive(conn, session)
+
+    auto_tags = read_session_tags(conn, session_id=write_parsed_session_to_archive(conn, session), tag_source="auto")
+    assert len(auto_tags) == 1, (
+        f"Expected exactly one auto-tag after re-ingest, got {len(auto_tags)}: {list(auto_tags)}"
+    )


### PR DESCRIPTION
## Summary

Implements the v1 AC from #1764: flags fragmented brain-metadata sessions as
`degraded:brain-metadata-fragment` so they are excludable from primary session
counts and insight rollups.  Uses `ParsedSession.ingest_flags` — a new in-memory
field that the storage layer drains into auto-tags at write time — so **no schema
version bump is required**.

## Problem

Antigravity's brain-metadata fallback path builds a composite
`provider_session_id` of `{parent_dir}:{artifact_name}` per `*.metadata.json`
file.  Under the v1 identity law every artifact becomes its own single-message
session.  One logical work session shatters into N sessions, polluting session
counts and insight rollups silently.

## Solution

Three touch-points, no schema change:

**`polylogue/sources/parsers/base_models.py`** — adds `ingest_flags: list[str]`
to `ParsedSession`.  Parsers set flags to communicate structural quality issues;
the storage layer writes them as `(auto, parser)` session_tags.  Default: empty
list (all other parsers are unaffected).

**`polylogue/sources/parsers/antigravity.py`** — `parse_brain_metadata` sets
`ingest_flags=["degraded:brain-metadata-fragment"]`.  Exports `BRAIN_METADATA_FRAGMENT_FLAG`
constant for use in filters and tests.

**`polylogue/storage/sqlite/archive_tiers/write.py`** — `_write_ingest_flag_tags`
helper writes each flag as a `session_tags` row (`tag_source='auto'`,
`method='parser'`) inside the same `with conn:` block as the session row.  The
`session_tags` table in `index.db` already supports `tag_source='auto'`; no new
column or version bump needed.

Also records the two investigation findings as an issue comment:
- **Grouping key**: `artifact_path.parent.name` is a reliable per-session directory
  key → option A (aggregate) is viable.
- **Language-server availability**: binary is Nix/install-dependent, not
  universally available → option C requires a fallback; brain-metadata path
  remains necessary.

## Verification

```
# Format + lint
nix develop /realm/project/polylogue --command ruff format <touched files>
nix develop /realm/project/polylogue --command ruff check <touched files>
# → 0 issues

# Types
nix develop /realm/project/polylogue --command mypy <touched files>
# → Success: no issues found in 5 source files

# Parser-level regression tests (6 pass)
devtools test tests/unit/sources/parsers/test_antigravity.py -v
# → 6 passed in 0.69s

# Storage roundtrip tests (3 new pass)
devtools test tests/unit/storage/test_archive_tiers_write.py -k "ingest_flag" -v
# → 3 passed in 0.74s

# Broader sources regression (1332 pass)
devtools test tests/unit/sources/ -v
# → 1332 passed in 52.46s

# Full quick gate (all 15 checks green)
git push  # pre-push hook ran devtools verify --quick
# → exit 0, 30.42s total
```

Closes #1764