### PR TITLE
docs(internals): note topology regen when adding a module

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -78,6 +78,12 @@ storage in `storage/insights/session/`. Wire rebuild logic and register in
 Run `devtools render-all` to update the generated catalog in
 `docs/devtools.md`.
 
+**Adding any new module/file under `polylogue/`**: regenerate the topology
+projection or `verify-topology` and `render-all --check` will fail on the new
+path. Run `devtools build-topology-projection && devtools render-topology-status`
+and commit the updated `docs/plans/topology-target.yaml` and
+`docs/topology-status.md` alongside the code.
+
 ## Schema Versioning Model
 
 Polylogue has no in-place schema upgrade chain. The runtime knows exactly one


### PR DESCRIPTION
## Summary

Documents that adding any new module under `polylogue/` requires regenerating the topology projection.

## Problem

Adding a new file changes the realized tree, so `verify-topology` and `render-all --check` fail until `docs/plans/topology-target.yaml` / `docs/topology-status.md` are regenerated. The internals.md "Extension Points" section listed adding a provider/filter/CLI-command/insight/devtools-command but not this cross-cutting step — a discoverable-only gotcha (hit while landing #1812's new `expression.py`).

## Solution

Add an "Adding any new module/file" entry recording the `devtools build-topology-projection && devtools render-topology-status` fix and that both generated docs must be committed with the code.

## Verification

- pre-push `devtools verify --quick` (render-all --check incl. AGENTS.md, verify-topology) — green.