### PR TITLE
ci: raise test job timeout 45→90 min so the test gate can complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,12 @@ jobs:
       - run: bash tools/cleanup/polylogue_public_surface_audit.sh
 
   test:
-    timeout-minutes: 45
+    # The full non-integration suite runs single-process under coverage
+    # instrumentation across three Python versions; 45 min was on the edge and
+    # legs were being cut mid-run (reported as "cancelled"), so the test gate
+    # could never go green. 90 min gives headroom; passing runs cost their
+    # actual ~45-50 min regardless of the ceiling.
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Raise the CI `test` job `timeout-minutes` from 45 to 90.

## Problem
The full non-integration suite runs single-process under coverage instrumentation across three Python versions. Test legs were being cut at exactly 45:00 (surfaced as "cancelled" in the checks UI), so the `test` gate could never report green — recent PRs merged on the other required checks alone, with no real test signal. The 45-min ceiling was simply too tight for the suite's actual ~45–50 min runtime.

## Solution
`.github/workflows/ci.yml`: `test.timeout-minutes: 45 → 90`. Passing runs still cost only their actual ~45–50 min; the higher ceiling only bounds a genuine hang. (A follow-up could parallelise `coverage-gate` with xdist to cut wall-clock, but that risks `load_sensitive` flakiness and is out of scope here.)

## Verification
ci.yml-only change; `lint`/`typecheck`/`nix`/`showcase-verify` are unaffected. The effect is observable on this PR's own `test` legs, which now have headroom to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)