### PR TITLE
fix(cli): rename read --view conversation to transcript (vocab policy)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -270,8 +270,8 @@ Usage: polylogue read [OPTIONS]
       timeline, tools, files, metadata, continuation
 
 Options:
-  -v, --view [summary|conversation|messages|raw|context]
-                                  What to render (summary, conversation,
+  -v, --view [summary|transcript|messages|raw|context]
+                                  What to render (summary, transcript,
                                   messages, raw, context).  [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -52,7 +52,7 @@ def _lazy_shell_complete(source: str):  # type: ignore[no-untyped-def]
 _complete_session_id = _lazy_shell_complete("session_id")
 _complete_message_type = _lazy_shell_complete("message_type")
 
-_READ_VIEWS = ("summary", "conversation", "messages", "raw", "context")
+_READ_VIEWS = ("summary", "transcript", "messages", "raw", "context")
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
 _READ_FORMATS = ("text", "markdown", "json", "ndjson", "yaml", "html", "obsidian", "org", "csv")
 
@@ -147,7 +147,7 @@ def recent_verb(
     type=click.Choice(_READ_VIEWS),
     default="summary",
     show_default=True,
-    help="What to render (summary, conversation, messages, raw, context).",
+    help="What to render (summary, transcript, messages, raw, context).",
 )
 @click.option(
     "--to",
@@ -276,7 +276,7 @@ def read_verb(
         _run_read_context(env, request, destination=destination, out_path=out_path)
         return
 
-    # summary / conversation: standard show/query path with destination routing.
+    # summary / transcript: standard show/query path with destination routing.
     if destination == "browser":
         _run_read_browser(env, request, output_format=output_format)
         return

--- a/tests/baselines/showcase/help-read.txt
+++ b/tests/baselines/showcase/help-read.txt
@@ -17,8 +17,8 @@ Usage: polylogue read [OPTIONS]
       timeline, tools, files, metadata, continuation
 
 Options:
-  -v, --view [summary|conversation|messages|raw|context]
-                                  What to render (summary, conversation,
+  -v, --view [summary|transcript|messages|raw|context]
+                                  What to render (summary, transcript,
                                   messages, raw, context).  [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]


### PR DESCRIPTION
## Summary
Rename the `read --view conversation` token to `transcript` to remove stale "conversation" vocabulary that #1863 reintroduced on public CLI surfaces, restoring the session/origin vocabulary policy from the #1810/#1852 sweep.

## Problem
#1863 shipped `read --view conversation`. The public-surface audit (`tools/cleanup/polylogue_public_surface_audit.sh`, #1852) flags `conversation` as stale schema-v1 vocabulary on both `polylogue/cli/query_verbs.py` and the generated `docs/cli-reference.md`. The audit **false-passed in CI** — the Ubuntu-image ripgrep silently mishandles the audit's `rg` invocation (the #1854/#1855 shelled-binary-in-CI fragility) — so the violation landed on master uncaught. It deterministically fails the local pre-push gate (nix ripgrep), blocking every subsequent push.

## Solution
- Rename the read view token `conversation` → `transcript` in `query_verbs.py` (`_READ_VIEWS`, help text, comment). The view has no distinct dispatch branch — it shares the summary fallthrough render path — so this is a pure token rename, no behavior change.
- Regenerate `docs/cli-reference.md` and the `help-read.txt` showcase baseline.

## Verification
- `tools/cleanup/polylogue_public_surface_audit.sh` → exit 0 (`clean (no stale schema-v1 vocabulary on public surfaces)`)
- `mypy --strict polylogue/cli/query_verbs.py` → clean
- `ruff check` → clean
- `pytest tests/unit/cli -k "help or read or view"` → 433 passed, 4 snapshots passed

## Follow-up
The CI audit's ripgrep false-pass is a real gap (CI did not catch this violation). The lint job's `rg` invocation hardening against the runner image is tracked separately (#1855 class).