### PR TITLE
feat: wire query-expression compiler into MCP search and /api/sessions (#1860)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -29,7 +29,7 @@ Clause forms:
 
 Cross-field OR (``(a origin:x OR origin:y)``) and nested parentheses across
 different fields are **rejected loudly** — they require a boolean-tree spec
-that is tracked in issue #1858.  Unknown fields also fail loudly.
+that is tracked in issue #1812.  Unknown fields also fail loudly.
 
 Field registry
 --------------
@@ -102,7 +102,7 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
         "example": "repo:polylogue",
     },
     "origin": {
-        "description": "Filter by session origin (provider source)",
+        "description": "Filter by session origin",
         "spec_field": "origins",
         "negatable": "yes",
         "example": "origin:claude-code-session",
@@ -372,7 +372,7 @@ def _lex(expression: str) -> list[_LexToken]:
             raise ExpressionCompileError(
                 "cross-field OR parentheses are not supported; express as separate queries "
                 "or use field:(a|b|c) for in-field OR. "
-                "Boolean-tree queries are tracked in issue #1858.",
+                "Boolean-tree queries are tracked in issue #1812.",
                 field=None,
             )
 
@@ -739,7 +739,7 @@ def compile_expression(expression: str) -> SessionQuerySpec:
         raise ExpressionCompileError(
             "cross-field OR is not supported in this version; express as separate queries "
             "or use field:(a|b|c) for in-field OR. "
-            "Boolean-tree queries are tracked in issue #1858.",
+            "Boolean-tree queries are tracked in issue #1812.",
             field=None,
         )
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -1278,16 +1278,24 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         limit: int,
         offset: int,
     ) -> object:
+        from polylogue.archive.query.expression import compile_expression_into
         from polylogue.archive.query.spec import SessionQuerySpec
 
-        spec = SessionQuerySpec.from_params(
-            {**query_params, "limit": limit, "offset": offset},
-        )
-        query_text = query_params.get("query") or query_params.get("contains")
+        # Build the flag-derived base spec (all params except the free-text
+        # query string), then route the query string through the shared
+        # expression compiler so structured clauses like
+        # ``origin:codex has:paste since:7d`` resolve to the correct spec
+        # fields rather than being passed as literal FTS terms (#1860).
+        query_str = str(query_params.get("query") or "").strip()
+        base_params = {k: v for k, v in query_params.items() if k != "query"}
+        base = SessionQuerySpec.from_params({**base_params, "limit": limit, "offset": offset})
+        spec = compile_expression_into(query_str, base) if query_str else base
 
-        # When search terms are present, return ranked result envelope with
-        # per-hit match evidence instead of plain row dicts.
-        if query_text and not query_params.get("similar_text"):
+        # Route to the ranked search path when the compiled spec carries FTS
+        # or vector terms; use the plain list path otherwise (including for
+        # pure-DSL queries whose clauses only set structured fields with no
+        # FTS text, e.g. ``origin:codex has:paste``).
+        if spec.query_terms or spec.contains_terms:
             return await self._do_search_list(poly, spec, limit, offset)
 
         # A pure vector-only request (similar_text, no FTS term) must surface
@@ -1296,7 +1304,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # vector provider (raising the typed readiness error when embeddings
         # are not ready), which daemon_safe_handler maps to its 409 status
         # instead of falling through to a generic ValueError (#1749).
-        if query_params.get("similar_text"):
+        if spec.similar_text:
             return await self._do_search_list(poly, spec, limit, offset)
 
         filter_obj = spec.build_filter(poly.config)
@@ -1385,33 +1393,106 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         limit: int,
         offset: int,
     ) -> object:
+        from polylogue.archive.query.expression import compile_expression
+        from polylogue.archive.query.search_hits import search_query_text
         from polylogue.archive.query.spec import parse_query_date
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
-        query = self._get_param(params, "query") or self._get_param(params, "contains") or ""
-        origin, origins = _archive_origin_filter(params)
-        tags = _archive_tag_filter(params)
+        # Compile the free-text query string through the shared expression
+        # compiler so DSL clauses like ``origin:codex has:paste since:7d``
+        # map to the correct ArchiveStore filter arguments rather than being
+        # passed as literal FTS text (#1860).
+        query_str = self._get_param(params, "query") or self._get_param(params, "contains") or ""
+        if query_str:
+            spec = compile_expression(query_str)
+            # Bare words / quoted phrases become the FTS query; field clauses
+            # (origin:, tag:, since:, etc.) become structured filter args.
+            fts_query = search_query_text(spec.query_terms + spec.contains_terms)
+        else:
+            spec = None
+            fts_query = ""
+
+        # HTTP-param-based origin/tag filters — still honoured for backwards
+        # compatibility with callers passing ``?origin=...`` or ``?tag=...``
+        # as separate query-string parameters.
+        _, http_origins = _archive_origin_filter(params)
+        http_tags = _archive_tag_filter(params)
+
+        # Merge DSL-compiled spec filters with HTTP-param-based filters.
+        origins = tuple(dict.fromkeys((spec.origins if spec else ()) + http_origins))
+        excluded_origins = spec.excluded_origins if spec else ()
+        tags = tuple(dict.fromkeys((spec.tags if spec else ()) + http_tags))
+        excluded_tags = spec.excluded_tags if spec else ()
+        origin = origins[0] if len(origins) == 1 else None
+
+        # Date filters: DSL spec takes precedence over bare HTTP params.
+        since_str = (spec.since if spec else None) or self._get_param(params, "since")
+        until_str = (spec.until if spec else None) or self._get_param(params, "until")
         # parse_query_date raises QuerySpecError (a PolylogueError carrying
         # http_status_code=400) for unparseable dates; daemon_safe_handler maps
         # it to the QueryErrorPayload-shaped 400 the other surfaces return.
-        since_dt = parse_query_date("since", self._get_param(params, "since"))
-        until_dt = parse_query_date("until", self._get_param(params, "until"))
+        since_dt = parse_query_date("since", since_str)
+        until_dt = parse_query_date("until", until_str)
         since_ms = _archive_datetime_to_ms(since_dt)
         until_ms = _archive_datetime_to_ms(until_dt)
+
+        # Remaining structured filters come directly from the compiled spec.
+        has_paste = spec.filter_has_paste if spec else False
+        has_tool_use = spec.filter_has_tool_use if spec else False
+        has_thinking = spec.filter_has_thinking if spec else False
+        repo_names = spec.repo_names if spec else ()
+        has_types = spec.has_types if spec else ()
+        tool_terms = spec.tool_terms if spec else ()
+        excluded_tool_terms = spec.excluded_tool_terms if spec else ()
+        action_terms = spec.action_terms if spec else ()
+        excluded_action_terms = spec.excluded_action_terms if spec else ()
+        action_sequence = spec.action_sequence if spec else ()
+        action_text_terms = spec.action_text_terms if spec else ()
+        referenced_paths = spec.referenced_path if spec else ()
+        cwd_prefix = spec.cwd_prefix if spec else None
+        title = spec.title if spec else None
+        min_messages = spec.min_messages if spec else None
+        max_messages = spec.max_messages if spec else None
+        min_words = spec.min_words if spec else None
+
+        # Shared filter kwargs forwarded to every ArchiveStore call.
+        _filter_kw: dict[str, object] = {
+            "origin": origin,
+            "origins": origins,
+            "excluded_origins": excluded_origins,
+            "tags": tags,
+            "excluded_tags": excluded_tags,
+            "repo_names": repo_names,
+            "has_types": has_types,
+            "has_tool_use": has_tool_use,
+            "has_thinking": has_thinking,
+            "has_paste": has_paste,
+            "tool_terms": tool_terms,
+            "excluded_tool_terms": excluded_tool_terms,
+            "action_terms": action_terms,
+            "excluded_action_terms": excluded_action_terms,
+            "action_sequence": action_sequence,
+            "action_text_terms": action_text_terms,
+            "referenced_paths": referenced_paths,
+            "cwd_prefix": cwd_prefix,
+            "title": title,
+            "min_messages": min_messages,
+            "max_messages": max_messages,
+            "min_words": min_words,
+            "since_ms": since_ms,
+            "until_ms": until_ms,
+        }
+
         with ArchiveStore.open_existing(archive_root) as archive:
-            if query:
+            if fts_query:
                 hits = archive.search_summaries(
-                    query,
+                    fts_query,
                     limit=limit,
                     offset=offset,
-                    origin=origin,
-                    origins=origins,
-                    tags=tags,
-                    since_ms=since_ms,
-                    until_ms=until_ms,
+                    **_filter_kw,  # type: ignore[arg-type]
                 )
                 payload: dict[str, object] = {
-                    "query": query,
+                    "query": fts_query,
                     "retrieval_lane": "dialogue",
                     "ranking_policy": "mixed-bm25-rrf-vector",
                     "ranking_policy_version": "1",
@@ -1426,24 +1507,18 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     # miss instead of rendering a bare empty list.
                     from polylogue.surfaces.payloads import QueryMissDiagnosticsPayload
 
-                    archive_count = archive.count_sessions(
-                        origin=origin,
-                        origins=origins,
-                        tags=tags,
-                        since_ms=since_ms,
-                        until_ms=until_ms,
-                    )
+                    archive_count = archive.count_sessions(**_filter_kw)  # type: ignore[arg-type]
                     filters = tuple(
                         label
                         for label in (
-                            f"query={query!r}",
+                            f"query={fts_query!r}",
                             f"origin={origin}" if origin else None,
                             f"tags={list(tags)}" if tags else None,
                         )
                         if label is not None
                     )
                     payload["diagnostics"] = QueryMissDiagnosticsPayload(
-                        message=f"No sessions matched {query!r}.",
+                        message=f"No sessions matched {fts_query!r}.",
                         filters=filters,
                         reasons=(),
                         archive_session_count=archive_count,
@@ -1452,19 +1527,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             summaries = archive.list_summaries(
                 limit=limit,
                 offset=offset,
-                origin=origin,
-                origins=origins,
-                tags=tags,
-                since_ms=since_ms,
-                until_ms=until_ms,
+                **_filter_kw,  # type: ignore[arg-type]
             )
-            total = archive.count_sessions(
-                origin=origin,
-                origins=origins,
-                tags=tags,
-                since_ms=since_ms,
-                until_ms=until_ms,
-            )
+            total = archive.count_sessions(**_filter_kw)  # type: ignore[arg-type]
             return {
                 "items": [self._archive_summary_payload(summary) for summary in summaries],
                 "total": total,

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -39,11 +39,29 @@ def normalize_query_params(params: Mapping[str, object]) -> dict[str, object]:
 
 
 def build_query_spec(**params: object) -> SessionQuerySpec:
-    """Build a SessionQuerySpec from MCP-facing query kwargs."""
+    """Build a SessionQuerySpec from MCP-facing query kwargs.
+
+    When a ``query`` string is present it is routed through the shared
+    query-expression compiler (:func:`~polylogue.archive.query.expression.compile_expression_into`)
+    so structured clauses such as ``origin:codex has:paste since:7d`` map to
+    the correct spec fields, mirroring the CLI bare-query path in
+    :meth:`~polylogue.cli.root_request.RootModeRequest.query_spec`.
+    """
     normalized = normalize_query_params(params)
     if normalized.get("message_type") is not None:
         normalized["message_type"] = validate_message_type_filter(normalized["message_type"]).value
-    return SessionQuerySpec.from_params(normalized)
+
+    # Extract the free-text query string for compiler routing.
+    # ``from_params`` would treat it as a literal FTS term; the compiler
+    # resolves field clauses to the appropriate spec fields first.
+    query_str = str(normalized.pop("query", None) or "").strip()
+    base = SessionQuerySpec.from_params(normalized)
+    if not query_str:
+        return base
+
+    from polylogue.archive.query.expression import compile_expression_into
+
+    return compile_expression_into(query_str, base)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -272,7 +272,7 @@ class TestRejection:
             compile_expression("repo:polylogue OR repo:sinex")
 
     def test_cross_field_or_mentions_follow_up_issue(self) -> None:
-        with pytest.raises(ExpressionCompileError, match="1858"):
+        with pytest.raises(ExpressionCompileError, match="1812"):
             compile_expression("repo:polylogue OR origin:claude-code-session")
 
     def test_unknown_origin_raises(self) -> None:
@@ -483,3 +483,144 @@ class TestFieldRegistry:
         for field, info in EXPRESSION_FIELD_REGISTRY.items():
             assert "description" in info, f"{field} missing description"
             assert info["description"], f"{field} has empty description"
+
+    def test_origin_description_has_no_provider_source_wording(self) -> None:
+        """Regression: origin field description must not use 'provider source' (#1861)."""
+        desc = EXPRESSION_FIELD_REGISTRY["origin"]["description"]
+        assert "provider source" not in desc, "origin description must not use 'provider source' wording; got: " + repr(
+            desc
+        )
+
+    def test_cross_field_or_error_cites_1812(self) -> None:
+        """Regression: cross-field OR error must cite issue #1812, not #1858 (#1861)."""
+        with pytest.raises(ExpressionCompileError, match="1812"):
+            compile_expression("repo:x OR origin:y")
+
+
+# ---------------------------------------------------------------------------
+# MCP surface wiring (#1860)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPWiring:
+    """build_query_spec routes free-text query through the shared compiler."""
+
+    def test_bare_words_preserved_as_fts(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        spec = build_query_spec(query="json envelope")
+        # Bare words must end up in query_terms (FTS), not in structured fields.
+        assert spec.query_terms == ("json", "envelope")
+
+    def test_dsl_origin_clause_compiled(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        spec = build_query_spec(query="origin:claude-code-session")
+        assert spec.origins == ("claude-code-session",)
+        # Must NOT go to FTS query_terms.
+        assert not any("origin" in t for t in spec.query_terms)
+
+    def test_dsl_has_paste_compiled(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        spec = build_query_spec(query="has:paste")
+        assert spec.filter_has_paste is True
+        assert spec.query_terms == ()
+
+    def test_dsl_flags_merged_with_base_params(self) -> None:
+        """DSL expression merges additively with flag-derived base spec."""
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        # Simulate: MCP caller passes both a structured 'tag' param and a DSL
+        # expression in 'query'.
+        spec = build_query_spec(query="origin:codex-session", tag="review")
+        assert spec.origins == ("codex-session",)
+        assert spec.tags == ("review",)
+
+    def test_unknown_field_raises(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        with pytest.raises(ExpressionCompileError, match="unknown query field"):
+            build_query_spec(query="nosuchfield:value")
+
+    def test_cross_field_or_raises(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        with pytest.raises(ExpressionCompileError, match="cross-field OR"):
+            build_query_spec(query="repo:x OR origin:y")
+
+    def test_none_query_returns_base_spec(self) -> None:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        spec = build_query_spec(query=None, tag="review")
+        # With no query expression, must still apply the flag-derived filters.
+        assert spec.tags == ("review",)
+        assert spec.query_terms == ()
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface parity (#1860 / #1812)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSurfaceParity:
+    """Same DSL expression → same SessionQuerySpec on all three surfaces.
+
+    CLI path:   RootModeRequest.query_spec()
+    MCP path:   build_query_spec(query=...)
+    Daemon path: compile_expression_into(query_str, base_spec)  (same function)
+
+    Because all three surfaces ultimately call compile_expression_into, these
+    tests verify that the compiler is wired symmetrically and that no surface
+    silently re-parses the expression through its own ad-hoc logic.
+    """
+
+    _EXPRESSION = "origin:claude-code-session has:paste repo:polylogue"
+
+    def _cli_spec(self) -> SessionQuerySpec:
+        from polylogue.cli.root_request import RootModeRequest
+
+        # CLI receives the expression as individual shell-split tokens.
+        request = RootModeRequest(
+            params={},
+            query_terms=tuple(self._EXPRESSION.split()),
+        )
+        return request.query_spec()
+
+    def _mcp_spec(self) -> SessionQuerySpec:
+        from polylogue.mcp.query_contracts import build_query_spec
+
+        return build_query_spec(query=self._EXPRESSION)
+
+    def _daemon_spec(self) -> SessionQuerySpec:
+        # The daemon path: compile_expression_into(query_str, base_spec).
+        # Reproduce the same logic as _do_list with no extra flag-based params.
+        base = SessionQuerySpec()
+        return compile_expression_into(self._EXPRESSION, base)
+
+    def test_cli_and_mcp_origins_match(self) -> None:
+        assert self._cli_spec().origins == self._mcp_spec().origins
+
+    def test_cli_and_daemon_origins_match(self) -> None:
+        assert self._cli_spec().origins == self._daemon_spec().origins
+
+    def test_cli_and_mcp_has_paste_match(self) -> None:
+        assert self._cli_spec().filter_has_paste == self._mcp_spec().filter_has_paste
+
+    def test_cli_and_daemon_has_paste_match(self) -> None:
+        assert self._cli_spec().filter_has_paste == self._daemon_spec().filter_has_paste
+
+    def test_cli_and_mcp_repo_names_match(self) -> None:
+        assert self._cli_spec().repo_names == self._mcp_spec().repo_names
+
+    def test_cli_and_daemon_repo_names_match(self) -> None:
+        assert self._cli_spec().repo_names == self._daemon_spec().repo_names
+
+    def test_all_three_query_terms_are_empty(self) -> None:
+        """Pure DSL expression (no bare words) → query_terms empty on all surfaces."""
+        cli_spec = self._cli_spec()
+        mcp_spec = self._mcp_spec()
+        daemon_spec = self._daemon_spec()
+        assert cli_spec.query_terms == ()
+        assert mcp_spec.query_terms == ()
+        assert daemon_spec.query_terms == ()


### PR DESCRIPTION
## Summary

Wire the query-expression compiler (landed in #1861) into the MCP search tool and daemon `/api/sessions` HTTP endpoint so all three surfaces — CLI, MCP, and HTTP — compile free-text query expressions through the same `compile_expression_into` function and field registry. Also applies two docstring corrections from the #1861 review.

## Problem

After #1861 landed the shared expression compiler, the MCP `build_query_spec()` function and the daemon `_do_list` / `_do_archive_list_sessions` paths still passed raw query strings through `SessionQuerySpec.from_params()`, which treats the entire string as a literal FTS term. A query like `origin:codex has:paste since:7d` worked on the CLI but would be sent as-is to FTS on MCP and HTTP surfaces, breaking the CLI/web/MCP parity AC for #1812. Two `expression.py` docstring issues were also identified in the #1861 review:

- Issue reference in cross-field OR error messages cited #1858 instead of the correct tracking issue #1812.
- The `EXPRESSION_FIELD_REGISTRY["origin"]` description used "provider source" wording contrary to the source-origin vocabulary policy.

## Solution

**`polylogue/archive/query/expression.py`** — Two docstring corrections:
- Replace `#1858` → `#1812` in the module docstring and both cross-field OR error messages.
- Fix origin field description: `"Filter by session origin (provider source)"` → `"Filter by session origin"`.

**`polylogue/mcp/query_contracts.py`** — `build_query_spec()` now:
1. Pops the `query` string before calling `from_params()` on the remainder.
2. Calls `compile_expression_into(query_str, base)` when a query string is present.
This mirrors the CLI `RootModeRequest.query_spec()` pattern exactly. `MCPSessionQueryRequest.build_spec()` inherits the fix automatically.

**`polylogue/daemon/http.py`** — Two paths wired:
- `_do_list` (Polylogue API path): extracts `query` from `query_params`, builds flag-derived `base` from the rest, then calls `compile_expression_into(query_str, base)`. Routes to `_do_search_list` only when `spec.query_terms` or `spec.contains_terms` are non-empty, so pure-DSL queries (`origin:codex has:paste`) correctly use the filtered list path instead of the search path.
- `_do_archive_list_sessions` (ArchiveStore path, active when `index.db` exists): compiles the query expression; uses `search_query_text(spec.query_terms + spec.contains_terms)` as the FTS string; passes the full set of compiled spec filters (origins, tags, has_paste, repo_names, tool_terms, action_terms, since_ms, until_ms, …) to all three `ArchiveStore` calls via a shared `_filter_kw` dict — replacing the previous minimal set that only forwarded (origin, origins, tags, since_ms, until_ms). HTTP-param-based `?origin=` and `?tag=` filters remain honoured for backwards compatibility and are merged with the DSL-compiled values.

**`tests/unit/cli/test_query_expression.py`** — New test classes added:
- `TestFieldRegistry`: two regression tests for the #1861 corrections (no "provider source", cites #1812).
- `TestMCPWiring`: bare-word preservation, DSL clause compilation, flag+expression merge, unknown-field rejection, cross-field OR rejection, `None` query handling — all through `build_query_spec()`.
- `TestCrossSurfaceParity`: same multi-clause expression (`origin:claude-code-session has:paste repo:polylogue`) compiled via CLI `RootModeRequest.query_spec()`, MCP `build_query_spec()`, and `compile_expression_into()` (daemon logic) — asserts identical `origins`, `filter_has_paste`, `repo_names`, and empty `query_terms` on all three paths.

## Verification

```
nix develop --command mypy polylogue/  # 826 files, no issues
nix develop --command ruff check polylogue/ tests/unit/cli/test_query_expression.py  # clean
nix develop --command ruff format --check  # clean
nix develop --command devtools test tests/unit/cli/test_query_expression.py  # 92 passed
nix develop --command devtools test tests/unit/mcp/test_query_tool_schema_derivation.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_mcp_edge_cases.py  # 88 passed
nix develop --command devtools test tests/unit/daemon/test_daemon_http.py tests/unit/daemon/test_daemon_http_contracts.py tests/unit/daemon/test_web_reader.py tests/unit/daemon/test_web_shell_endpoint_contracts.py  # 127 passed
nix develop --command devtools verify --quick  # exit 0, all 15 gates green
```

Pre-push hook passed (all 15 static gates green before push).

**Pre-existing failures not caused by this PR:**
- `test_fts_readiness_rejects_zero_count_ready_freshness_when_source_has_rows` — fails on master before and after this diff (`KeyError: 'messages_fts'`).

**Intentionally not in scope:**
- `_do_facets` daemon path (uses `from_params` on query params without a `query` string route — the facets endpoint does not expose a free-text query surface today).
- `user_state_http.py` `handle_save_view` — validates a JSON dict body, not a DSL string; no change needed.

Closes #1860
Ref #1812