### PR TITLE
fix(import): ingest decimal-bearing ChatGPT exports

### DIFF
--- a/polylogue/core/json.py
+++ b/polylogue/core/json.py
@@ -62,6 +62,17 @@ def json_document_list(value: object) -> JSONDocumentList:
     return documents
 
 
+def normalize_json_decimal(value: object) -> object:
+    """Recursively lower JSON parser Decimal values to JSON numbers."""
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    if isinstance(value, list):
+        return [normalize_json_decimal(item) for item in value]
+    if isinstance(value, dict):
+        return {key: normalize_json_decimal(item) for key, item in value.items()}
+    return value
+
+
 def _reject_non_finite_token(token: str) -> JSONValue:
     raise ValueError(f"invalid non-finite JSON token: {token}")
 
@@ -135,6 +146,7 @@ __all__ = [
     "json_document",
     "json_document_list",
     "loads",
+    "normalize_json_decimal",
     "require_json_document",
     "require_json_value",
 ]

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -55,7 +55,8 @@ class LoweredPayloadSpec:
 
 
 def _payload_record(value: object) -> PayloadRecord | None:
-    return value if is_json_document(value) else None
+    normalized = _normalize_json_decimal(value)
+    return normalized if is_json_document(normalized) else None
 
 
 def _payload_sequence(value: object) -> PayloadSequence | None:

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from dataclasses import dataclass
-from decimal import Decimal
 from io import BytesIO
 from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
-from polylogue.core.json import JSONDocument, JSONValue, is_json_document, is_json_value
+from polylogue.core.json import JSONDocument, JSONValue, is_json_document, is_json_value, normalize_json_decimal
 from polylogue.core.payload_coercion import optional_string
 from polylogue.logging import get_logger
 from polylogue.types import Provider
@@ -55,7 +54,7 @@ class LoweredPayloadSpec:
 
 
 def _payload_record(value: object) -> PayloadRecord | None:
-    normalized = _normalize_json_decimal(value)
+    normalized = normalize_json_decimal(value)
     return normalized if is_json_document(normalized) else None
 
 
@@ -64,21 +63,11 @@ def _payload_sequence(value: object) -> PayloadSequence | None:
         return None
     payloads: list[JSONValue] = []
     for item in value:
-        normalized = _normalize_json_decimal(item)
+        normalized = normalize_json_decimal(item)
         if not is_json_value(normalized):
             return None
         payloads.append(normalized)
     return payloads
-
-
-def _normalize_json_decimal(value: object) -> object:
-    if isinstance(value, Decimal):
-        return int(value) if value == value.to_integral_value() else float(value)
-    if isinstance(value, list):
-        return [_normalize_json_decimal(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _normalize_json_decimal(item) for key, item in value.items()}
-    return value
 
 
 def _record_messages(record: PayloadRecord) -> list[JSONValue] | None:

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -6,6 +6,7 @@ import time
 import zipfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
 from typing import IO, TypeAlias
 
@@ -125,7 +126,18 @@ class SplitPayloadBuffer:
 
 
 def _artifact_payload(value: object) -> JSONValue:
-    return value if is_json_value(value) else {}
+    normalized = _normalize_json_decimal(value)
+    return normalized if is_json_value(normalized) else {}
+
+
+def _normalize_json_decimal(value: object) -> object:
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    if isinstance(value, list):
+        return [_normalize_json_decimal(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _normalize_json_decimal(item) for key, item in value.items()}
+    return value
 
 
 def _heartbeat_label(source_path: str) -> str:

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -6,13 +6,12 @@ import time
 import zipfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from decimal import Decimal
 from pathlib import Path
 from typing import IO, TypeAlias
 
 from polylogue.archive.artifact_taxonomy import classify_artifact
 from polylogue.config import Source
-from polylogue.core.json import JSONDocument, JSONValue, is_json_value
+from polylogue.core.json import JSONDocument, JSONValue, is_json_value, normalize_json_decimal
 from polylogue.core.json import dumps_bytes as json_dumps_bytes
 from polylogue.core.metrics import read_current_rss_mb, read_peak_rss_self_mb
 from polylogue.storage.blob_store import BlobStore
@@ -126,18 +125,8 @@ class SplitPayloadBuffer:
 
 
 def _artifact_payload(value: object) -> JSONValue:
-    normalized = _normalize_json_decimal(value)
+    normalized = normalize_json_decimal(value)
     return normalized if is_json_value(normalized) else {}
-
-
-def _normalize_json_decimal(value: object) -> object:
-    if isinstance(value, Decimal):
-        return int(value) if value == value.to_integral_value() else float(value)
-    if isinstance(value, list):
-        return [_normalize_json_decimal(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _normalize_json_decimal(item) for key, item in value.items()}
-    return value
 
 
 def _heartbeat_label(source_path: str) -> str:

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -761,19 +761,19 @@ def _fts_invariant_snapshot_sync(conn: sqlite3.Connection) -> FtsInvariantSnapsh
             name="messages_fts",
             source_table_name="blocks",
             table_name="messages_fts",
-            source_sql="SELECT COUNT(*) FROM blocks WHERE NULLIF(text, '') IS NOT NULL",
+            source_sql="SELECT COUNT(*) FROM blocks WHERE search_text != ''",
             indexed_sql="SELECT COUNT(*) FROM messages_fts_docsize",
             trigger_names=_BLOCKS_FTS_TRIGGER_NAMES,
             missing_sql="""
                 SELECT COUNT(*)
                 FROM blocks AS b
                 LEFT JOIN messages_fts_docsize AS d ON d.id = b.rowid
-                WHERE NULLIF(b.text, '') IS NOT NULL AND d.id IS NULL
+                WHERE b.search_text != '' AND d.id IS NULL
             """,
             excess_sql="""
                 SELECT COUNT(*)
                 FROM messages_fts_docsize AS d
-                LEFT JOIN blocks AS b ON b.rowid = d.id AND NULLIF(b.text, '') IS NOT NULL
+                LEFT JOIN blocks AS b ON b.rowid = d.id AND b.search_text != ''
                 WHERE b.rowid IS NULL
             """,
         )

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from polylogue.sources.dispatch import _payload_sequence
+from polylogue.sources.dispatch import _payload_record, _payload_sequence, parse_payload
+from polylogue.types import Provider
 
 
 def test_payload_sequence_normalizes_streaming_decimals() -> None:
@@ -19,3 +20,30 @@ def test_payload_sequence_normalizes_streaming_decimals() -> None:
     assert isinstance(first["whole"], int)
     assert isinstance(first["fraction"], float)
     assert isinstance(items[0], int)
+
+
+def test_payload_record_normalizes_streaming_decimals_for_chatgpt_parse() -> None:
+    payload = {
+        "id": "chatgpt-decimal",
+        "title": "Decimal timestamp",
+        "create_time": Decimal("1704995846.046526"),
+        "mapping": {
+            "root": {
+                "id": "root",
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": ["hello"]},
+                },
+                "children": [],
+            }
+        },
+    }
+
+    normalized = _payload_record(payload)
+    assert normalized is not None
+    assert normalized["create_time"] == 1704995846.046526
+
+    sessions = parse_payload(Provider.CHATGPT, payload, "fallback")
+
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "chatgpt-decimal"

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import zipfile
 from collections.abc import Iterable, Mapping
+from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import IO
@@ -2161,6 +2162,57 @@ def test_iter_entry_payloads_locks_provider_after_first_detected_payload(
     assert items[1][2] >= 0.0
     assert items[2][2] == 0.0
     assert detect_calls == payloads[:2]
+
+
+def test_iter_entry_payloads_preserves_decimal_bearing_chatgpt_records() -> None:
+    payloads = [
+        {
+            "id": "chatgpt-1",
+            "title": "Decimal timestamp",
+            "create_time": Decimal("1704995846.046526"),
+            "mapping": {
+                "root": {
+                    "message": {
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["hello"]},
+                    }
+                }
+            },
+        },
+        {
+            "id": "chatgpt-2",
+            "title": "Integral timestamp",
+            "create_time": Decimal("1704995847"),
+            "mapping": {
+                "root": {
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["hi"]},
+                    }
+                }
+            },
+        },
+    ]
+
+    items = list(
+        _iter_entry_payloads(
+            BytesIO(json.dumps(payloads, default=float).encode("utf-8")),
+            stream_name="conversations-000.json",
+            provider_hint=Provider.UNKNOWN,
+        )
+    )
+
+    assert [provider for provider, _, _ in items] == [Provider.CHATGPT, Provider.CHATGPT]
+    observed_payloads = [payload for _, payload, _ in items]
+    dict_payloads: list[dict[str, JSONValue]] = []
+    for payload in observed_payloads:
+        assert isinstance(payload, dict)
+        dict_payloads.append(payload)
+    first_payload = dict_payloads[0]
+    second_payload = dict_payloads[1]
+    assert first_payload["create_time"] == 1704995846.046526
+    assert second_payload["create_time"] == 1704995847
+    assert all(isinstance(payload.get("mapping"), dict) and payload["mapping"] for payload in dict_payloads)
 
 
 def test_iter_source_raw_data_keeps_source_family_hints_for_mixed_zip_sources(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes ChatGPT account-export ZIP ingestion when streamed JSON records contain `Decimal` values from `ijson`, and fixes the FTS readiness invariant that made a correctly rebuilt search index look stale.

Closes #1870

## Problem

The dogfood archive had ChatGPT export ZIPs available but no `chatgpt-export` sessions in the archive. The daemon had excluded staged inbox copies as `unknown-export` after repeated failures. Proper investigation showed the 2026 export was not HTML-only: it contains `conversations-000.json` through `conversations-024.json` with 2,403 session-bearing ChatGPT records.

The root cause was at the ZIP acquisition boundary. `ijson` emits numeric values as `Decimal`; acquisition rejected those records as non-`JSONValue`, replaced them with `{}`, and provider detection could only classify them as `unknown`. A related operational failure surfaced after import: exact FTS readiness counted `blocks.text`, while the FTS writer and triggers index `blocks.search_text`.

## Solution

- Add shared JSON Decimal normalization in `polylogue.core.json`.
- Normalize `Decimal` values before ZIP acquisition/provider detection.
- Normalize `Decimal` values before direct parser dispatch record lowering.
- Align exact `messages_fts` readiness with the writer/trigger predicate, `blocks.search_text != ''`.
- Add focused regressions for Decimal-bearing ChatGPT records and direct ChatGPT dispatch.

Live repair/import evidence from `/realm/db/polylogue` after applying the fix locally:

- `chatgpt-export`: 2,491 indexed sessions.
- 2,424 unique normal conversation sessions from `conversations.json` / `conversations-*.json`.
- 67 real `shared_conversations.json` sessions.
- Removed 4 bogus projections from `message_feedback.json` / `user.json` created by the earlier broad live-batch attempt.
- Exact FTS check from the patched checkout: `messages_ready=True`, `3,633,598/3,633,598`, `missing=0`, `excess=0`, `duplicate=0`.

## Verification

- `devtools test tests/unit/sources/test_dispatch_payloads.py tests/unit/sources/test_source_laws.py -k 'streaming_decimals or decimal_bearing_chatgpt or locks_provider_after_first_detected_payload'`
  - `4 passed`
- `devtools test tests/unit/daemon/test_fts_readiness_fallback.py -k 'exact_coverage_counts_tool_blocks_as_indexable or falls_back_to_exact'`
  - `2 passed`
- `devtools verify --quick`
  - all quick steps passed locally
- `git push` pre-push quick gate
  - all quick steps passed again on `8c013f249980208471969acdc568f7da378dec6c`

## Operational note

The installed `polylogued.service` still uses the previous Nix-store build until this change is merged/deployed/rebuilt. The active archive data is repaired/imported; readiness from the old service can still report the pre-fix false `fts_not_fresh` result.