### PR TITLE
fix: audit nits — test-helper connection leak + cloud-agent --no-api docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1044,6 +1044,12 @@ storage in `storage/insights/session/`. Wire rebuild logic and register in
 Run `devtools render-all` to update the generated catalog in
 `docs/devtools.md`.
 
+**Adding any new module/file under `polylogue/`**: regenerate the topology
+projection or `verify-topology` and `render-all --check` will fail on the new
+path. Run `devtools build-topology-projection && devtools render-topology-status`
+and commit the updated `docs/plans/topology-target.yaml` and
+`docs/topology-status.md` alongside the code.
+
 ## Schema Versioning Model
 
 Polylogue has no in-place schema upgrade chain. The runtime knows exactly one
@@ -1676,7 +1682,7 @@ See also: `2026-05-27_Build_Plan.md` §D (Cloud agent enablement).
 | `uv run mypy polylogue`                       | yes       | Type check.                                                 |
 | `uv run devtools verify`                      | yes       | Slow. Prefer scoped invocations during iteration.           |
 | `uv run devtools render-all --check`          | yes       | Generated-file drift check (also runs in CI).               |
-| `polylogued run --no-api`                     | yes\*     | \*Only against synthetic fixtures in `/tmp/polylogue-archive`. |
+| `polylogued run --no-api --no-watch --no-browser-capture` | yes\*     | \*Only against synthetic fixtures in `/tmp/polylogue-archive`. `--no-api` alone is insufficient; you must also disable live watch and browser capture for a truly inert sandbox. |
 | Real archive imports (`~/.claude/projects/…`) | NO        | Never upload personal corpus into a managed sandbox.        |
 | Browser-capture flows                         | NO        | Needs interactive cookies; relocated to ethereal host.      |
 | Any `/realm/data/...` path                    | NO        | Not mounted in cloud sandboxes; would resolve to nothing.   |

--- a/docs/cloud-agents.md
+++ b/docs/cloud-agents.md
@@ -25,7 +25,7 @@ See also: `2026-05-27_Build_Plan.md` §D (Cloud agent enablement).
 | `uv run mypy polylogue`                       | yes       | Type check.                                                 |
 | `uv run devtools verify`                      | yes       | Slow. Prefer scoped invocations during iteration.           |
 | `uv run devtools render-all --check`          | yes       | Generated-file drift check (also runs in CI).               |
-| `polylogued run --no-api`                     | yes\*     | \*Only against synthetic fixtures in `/tmp/polylogue-archive`. |
+| `polylogued run --no-api --no-watch --no-browser-capture` | yes\*     | \*Only against synthetic fixtures in `/tmp/polylogue-archive`. `--no-api` alone is insufficient; you must also disable live watch and browser capture for a truly inert sandbox. |
 | Real archive imports (`~/.claude/projects/…`) | NO        | Never upload personal corpus into a managed sandbox.        |
 | Browser-capture flows                         | NO        | Needs interactive cookies; relocated to ethereal host.      |
 | Any `/realm/data/...` path                    | NO        | Not mounted in cloud sandboxes; would resolve to nothing.   |

--- a/tests/integration/test_live_write_amplification.py
+++ b/tests/integration/test_live_write_amplification.py
@@ -46,8 +46,10 @@ def _checkpoint_truncate(db: Path) -> None:
         return
     try:
         conn = sqlite3.connect(str(db))
-        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        conn.close()
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            conn.close()
     except sqlite3.Error:
         pass
 


### PR DESCRIPTION
## Summary
Fixed two code-review audit findings: a connection-leak in a test helper and clarified cloud-agent sandbox documentation to specify all required daemon flags.

## Problem
1. Test helper `_checkpoint_truncate` in `tests/integration/test_live_write_amplification.py` opened a SQLite connection but could leak if `execute()` raised an exception.
2. The `docs/cloud-agents.md` documentation incorrectly implied that `--no-api` alone provides sandbox isolation, but live filesystem watch and browser capture remain enabled by default.

## Solution
1. Wrapped the connection's execute call in a try/finally block so `conn.close()` always runs, even on error.
2. Updated cloud-agents documentation to clarify that a truly inert sandbox requires `--no-api --no-watch --no-browser-capture` (verified flag names from `polylogue/daemon/cli.py`).

## Verification
- `devtools render-all --check` passes (generated files in sync)
- `devtools verify --quick` passes (format, lint, mypy)
- Test helper parses without errors
- All pre-push verification gates pass (18.4s total)

From the 2026-06-14 bot-review audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cloud-agent documentation with a more complete inert sandbox command including flags for disabling live watch and browser capture.
  * Added requirement to regenerate topology projections when introducing new modules and commit updated artifacts.

* **Bug Fixes**
  * Improved connection cleanup in WAL checkpoint operations to ensure proper resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->