### PR TITLE
refactor(cli): rename ingest command to import (#1815)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1044,6 +1044,12 @@ storage in `storage/insights/session/`. Wire rebuild logic and register in
 Run `devtools render-all` to update the generated catalog in
 `docs/devtools.md`.
 
+**Adding any new module/file under `polylogue/`**: regenerate the topology
+projection or `verify-topology` and `render-all --check` will fail on the new
+path. Run `devtools build-topology-projection && devtools render-topology-status`
+and commit the updated `docs/plans/topology-target.yaml` and
+`docs/topology-status.md` alongside the code.
+
 ## Schema Versioning Model
 
 Polylogue has no in-place schema upgrade chain. The runtime knows exactly one

--- a/docs/cli-audit.md
+++ b/docs/cli-audit.md
@@ -35,7 +35,7 @@ Registered in `polylogue/cli/click_command_registration.py`.
 | `commands` | Meta | **Keep** | Discoverability tool. Delivered in #1717. |
 | `status` | Diagnostics | **Keep** | Daemon and archive status. One of the most-used commands. |
 | `doctor` | Archive Mgmt | **Keep (rename)** | Currently registered as `doctor` (internal name `check`). Align on `doctor` everywhere — `check` is a Polylogue legacy artifact. Update `commands` listing to say `doctor`. |
-| `ingest` | Archive Mgmt | **Keep** | Import from configured sources. Clear intent. |
+| `import` | Archive Mgmt | **Keep** | Import from configured sources. Clear intent. |
 | `backup` | Archive Mgmt | **Keep** | Timestamped archive backup. Clear intent. |
 | `reset` | Archive Mgmt | **Keep** | Reset archive state. Destructive but clearly named. |
 | `maintenance` | Archive Mgmt | **Keep** | Preview and run maintenance backfill. Subcommands: `gc-history`, `plan`, `preview`, `run`, `status`. `maintenance run` overlaps with `doctor` conceptually — `doctor` is health check, `maintenance run` is repair/recompute. Distinction is subtle but real. |
@@ -176,7 +176,7 @@ Every intent maps to exactly one verb. This table is the decision record.
 | Open in external viewer | `open` | `open` | Already standard. |
 | View raw/debug data | `raw` | `raw`, `insights audit` | `audit` could become `raw` but its report shape is distinct. |
 | Check health/status | `status` | `status`, `doctor`, `insights status`, `maintenance status`, `embed status` | `status` = read-only snapshot. `doctor` = active health check + repair (distinct). Keep both. |
-| Ingest/import data | `ingest` | `ingest` | Already standard. |
+| Ingest/import data | `import` | `import` | Already standard. |
 | Export data | `export` | `export`, `bulk-export`, `insights export` | Merge `bulk-export` into `export bulk`. Keep `insights export` as distinct surface. |
 | Create/initialize | `init` | `init` | Already standard. |
 | Configure | `config` | `config`, `auth`, `completions` | These are distinct enough to stay separate. |
@@ -353,7 +353,7 @@ broken JSON output. 78 commands are covered as of 2026-05-28.
 | `recent` hardcodes invalid sort field | `recent_verb` passes `sort="updated_at"` which is rejected by `SessionQuerySpec`. The `--json` test excludes `recent` until this is fixed. | Pre-existing |
 | `count` has no `--format` flag | The `count` verb always emits a bare integer; there is no way to request a JSON envelope. | #1689 |
 | Deeply-nested groups (`user-state`, `blackboard`) don't dispatch through lazy wrappers | Commands registered as `_LazyCommand` but implemented as Click groups don't dispatch subcommands through the lazy wrapper. | #1725 |
-| No `--json` test for mutation commands | `delete`, `reset`, `ingest`, `backup` are excluded from the parametrized test because they modify state. They should still accept `--json`/`--machine` without crashing. | #1689 |
+| No `--json` test for mutation commands | `delete`, `reset`, `import`, `backup` are excluded from the parametrized test because they modify state. They should still accept `--json`/`--machine` without crashing. | #1689 |
 
 ### Commands Without JSON Support
 
@@ -385,6 +385,6 @@ regenerate after changing a Pydantic model that feeds a CLI output surface.
 ## Related Issues
 
 - [#1625](https://github.com/Sinity/polylogue/issues/1625) — `insights coverage|debt|...` hang with no output
-- [#1679](https://github.com/Sinity/polylogue/issues/1679) — `ingest` suggests `status` which shows wrong info
+- [#1679](https://github.com/Sinity/polylogue/issues/1679) — `import` suggests `status` which shows wrong info
 - [#1689](https://github.com/Sinity/polylogue/issues/1689) — generalized `--json` output
 - [#1680](https://github.com/Sinity/polylogue/issues/1680) — `recent`/`resume` commands (landed)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -184,7 +184,7 @@ Commands:
   embed              Enable, preflight, and backfill the embedding pipeline.
   facets
   feedback           Record learning corrections for derived insights.
-  ingest             Import sessions from configured sources.
+  import             Import sessions from configured sources.
   init               Detect chat sources and write a starter polylogue.toml.
   insights           Rebuild and inspect derived session insights.
   list               List matched sessions.
@@ -611,12 +611,12 @@ Published JSON Schemas live under [`docs/schemas/cli-output/`](./schemas/cli-out
 | `dashboard` | no | yes | yes | no | — | Side-effect command; opens local dashboard. |
 | `status` | yes | yes | yes | no | — | Daemon and archive status; --json flag emits structured payload. |
 
-### Family: `ingest`
+### Family: `import`
 
 | Command | JSON contract | Snapshot | `--plain` | NDJSON | Schema | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | `embed` | yes | yes | yes | no | — | Embedding pipeline status; --json emits structured progress. |
-| `ingest` | yes | yes | yes | no | — | --machine emits success/error envelope per ingest run. |
+| `import` | yes | yes | yes | no | — | --machine emits success/error envelope per import run. |
 
 ### Family: `config`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ same directory tree.
 ## Input Conventions
 
 - `polylogued run` watches configured source roots and owns ingestion.
-- Use `polylogue ingest PATH` to ask the running daemon to ingest an explicit
+- Use `polylogue import PATH` to ask the running daemon to import an explicit
   file or directory.
 - Directory names are for organization only; providers are detected from content.
 - Supported source formats include `.json`, `.jsonl`, and `.zip`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,10 +102,10 @@ Polylogue auto-discovers these directories:
 ```
 
 Custom watch roots can be given to the daemon with `--root`. For an explicit
-one-time ingest request, keep the daemon running and use:
+one-time import request, keep the daemon running and use:
 
 ```bash
-polylogue ingest /path/to/exports
+polylogue import /path/to/exports
 ```
 
 ## Next steps

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -33,7 +33,7 @@ A maintenance operation is distinguished from three adjacent things:
 
 | Surface | What it does | When you reach for it |
 | --- | --- | --- |
-| **Ingest** (`polylogued`, `polylogue ingest PATH`) | Daemon acquires source payloads, parses provider records, writes archive rows, and advances derived models *for the new rows*. `polylogue ingest PATH` asks the running daemon to schedule an explicit file or directory. | You have new exports/sessions to import. |
+| **Import** (`polylogued`, `polylogue import PATH`) | Daemon acquires source payloads, parses provider records, writes archive rows, and advances derived models *for the new rows*. `polylogue import PATH` asks the running daemon to schedule an explicit file or directory. | You have new exports/sessions to import. |
 | **Daemon convergence** (`polylogued` inline loops) | Performs the same operations as ingest plus the lightweight maintenance loop (WAL checkpoint every 5 min, FTS convergence every 10 min, heartbeat, health checks). | The daemon is running. You do nothing. |
 | **Maintenance** (`polylogue maintenance ...`) | Rebuilds derived state and prunes archive debt over already-ingested rows. Read-only by default; mutations are explicit. | A derived model is stale or missing for old rows that the daemon's small inline windows will not pick up. |
 | **Reset** (`polylogue reset`) | Deletes data: the SQLite database, the blob store, attachments, cache, OAuth tokens, or named sessions (soft-delete via tombstones). | The data itself is wrong or unwanted, not just a derived projection of it. |
@@ -448,8 +448,8 @@ curl -sf "http://127.0.0.1:8765/api/raw_artifacts/<artifact_id>" | jq .
 
 # 4. If the artifact is malformed at the source layer (truncated
 #    JSONL, missing required field), the fix is upstream — fix the
-#    source file, then ask the running daemon to re-ingest it:
-polylogue ingest <path-to-source>
+#    source file, then ask the running daemon to import it:
+polylogue import <path-to-source>
 
 # 5. If the artifact is fine but the parser rejects it, the fix is
 #    in the parser. File an issue with the provider and artifact details.
@@ -497,9 +497,9 @@ restic restore latest --target / --include /path/to/archive_root/blob
 
 # 5. If the blob is gone for good, the session referencing it
 #    cannot be exported. Tombstone it so it stops blocking exports
-#    and re-ingest from the original source if available:
+#    and import from the original source if available:
 polylogue reset --session <conv_id>
-polylogue ingest <path-to-source>
+polylogue import <path-to-source>
 
 # 6. After recovery, GC the orphan references that point at the
 #    now-missing blobs.

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -660,7 +660,7 @@ files:
     target: polylogue/cli/click_app.py
     owner: stable
   - path: polylogue/cli/click_command_registration.py
-    loc: 189
+    loc: 191
     target: polylogue/cli/click_command_registration.py
     owner: stable
   - path: polylogue/cli/click_option_groups.py
@@ -743,9 +743,9 @@ files:
     loc: 182
     target: polylogue/cli/commands/feedback.py
     owner: stable
-  - path: polylogue/cli/commands/ingest.py
+  - path: polylogue/cli/commands/import_command.py
     loc: 159
-    target: polylogue/cli/commands/ingest.py
+    target: polylogue/cli/commands/import_command.py
     owner: stable
   - path: polylogue/cli/commands/init.py
     loc: 233
@@ -1038,7 +1038,7 @@ files:
     owner: core-primitive
     reason: core primitive
   - path: polylogue/core/json.py
-    loc: 140
+    loc: 152
     target: polylogue/core/json.py
     owner: core-primitive
     reason: core primitive
@@ -1205,7 +1205,7 @@ files:
     target: polylogue/daemon/healthz.py
     owner: stable
   - path: polylogue/daemon/http.py
-    loc: 2571
+    loc: 2636
     target: polylogue/daemon/http.py
     owner: stable
   - path: polylogue/daemon/live_ingest_attempt_models.py
@@ -1517,7 +1517,7 @@ files:
     target: polylogue/mcp/payloads.py
     owner: stable
   - path: polylogue/mcp/query_contracts.py
-    loc: 227
+    loc: 245
     target: polylogue/mcp/query_contracts.py
     owner: stable
   - path: polylogue/mcp/server.py
@@ -2423,7 +2423,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 684
+    loc: 674
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -2672,7 +2672,7 @@ files:
     target: polylogue/sources/source_acquisition.py
     owner: stable
   - path: polylogue/sources/source_acquisition_components.py
-    loc: 436
+    loc: 437
     target: polylogue/sources/source_acquisition_components.py
     owner: stable
   - path: polylogue/sources/source_parsing.py

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -377,7 +377,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-feedback-clear` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | feedback clear help |
 | `exercise` | `help-feedback-list` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | feedback list help |
 | `exercise` | `help-feedback-record` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | feedback record help |
-| `exercise` | `help-ingest` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | ingest help |
+| `exercise` | `help-import` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | import help |
 | `exercise` | `help-init` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | init help |
 | `exercise` | `help-insights` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights help |
 | `exercise` | `help-insights-audit` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights audit help |

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -98,7 +98,7 @@ _SHORT_HELP: dict[str, str] = {
     "diagnostics": "Temporal session diagnostics",
     "embed": "Enable, preflight, and backfill the embedding pipeline.",
     "feedback": "Record learning corrections for derived insights.",
-    "ingest": "Import sessions from configured sources.",
+    "import_command": "Import sessions from configured sources.",
     "init": "Detect chat sources and write a starter polylogue.toml.",
     "insights": "Rebuild and inspect derived session insights.",
     "maintenance": "Preview and run maintenance backfill operations.",
@@ -116,6 +116,7 @@ _SHORT_HELP: dict[str, str] = {
 
 _COMMAND_NAMES: dict[str, str] = {
     "check": "doctor",
+    "import_command": "import",
 }
 
 _GROUP_ATTRS: dict[str, str] = {
@@ -131,6 +132,7 @@ _GROUP_ATTRS: dict[str, str] = {
 }
 
 _COMMAND_ATTRS: dict[str, str] = {
+    "import_command": "import_command",
     "resume_candidates": "resume_candidates_command",
 }
 
@@ -156,7 +158,7 @@ ROOT_COMMANDS: tuple[click.Command, ...] = (
     _L("cost"),
     _L("reset"),
     _L("status"),
-    _L("ingest"),
+    _L("import_command"),
     _L("init"),
     _L("auth"),
     _L("completions"),

--- a/polylogue/cli/commands/commands.py
+++ b/polylogue/cli/commands/commands.py
@@ -8,7 +8,7 @@ from polylogue.cli.shared.types import AppEnv
 
 _COMMAND_CATEGORIES: dict[str, tuple[str, ...]] = {
     "Query & Search": ("list", "count", "stats", "read", "recent"),
-    "Archive Management": ("ingest", "check", "reset", "backup", "maintenance"),
+    "Archive Management": ("import", "check", "reset", "backup", "maintenance"),
     "Insights & Analytics": ("insights", "facets", "correlate", "neighbors", "resume"),
     "User-State Objects": ("user-state", "blackboard", "tags", "feedback"),
     "Context & Sessions": ("context", "context-pack"),

--- a/polylogue/cli/commands/import_command.py
+++ b/polylogue/cli/commands/import_command.py
@@ -1,8 +1,8 @@
-"""Ingest command — schedule source files for ingestion via the daemon.
+"""import command — schedule source files for import via the daemon.
 
 Truthfulness contract (#1264 / #869 slice C):
 
-* ``polylogue ingest PATH`` either really stages the file into the daemon
+* ``polylogue import PATH`` either really stages the file into the daemon
   inbox **and** confirms the daemon accepted scheduling, or it fails with
   an actionable message. There is no silent success path.
 
@@ -49,10 +49,10 @@ def _daemon_url(env: AppEnv) -> str:
 
 
 def _stage_for_daemon(path: Path) -> Path:
-    """Copy a local ingest target into the archive inbox for daemon pickup."""
+    """Copy a local import target into the archive inbox for daemon pickup."""
     resolved = path.expanduser().resolve()
     if not resolved.exists():
-        fail("ingest", f"Path does not exist: {resolved}")
+        fail("import", f"Path does not exist: {resolved}")
 
     inbox = archive_root() / "inbox"
     inbox.mkdir(parents=True, exist_ok=True)
@@ -67,7 +67,7 @@ def _stage_for_daemon(path: Path) -> Path:
         else:
             shutil.copy2(resolved, dest)
     except OSError as exc:
-        fail("ingest", f"Could not stage {resolved} in daemon inbox: {exc}")
+        fail("import", f"Could not stage {resolved} in daemon inbox: {exc}")
 
     return dest
 
@@ -81,7 +81,7 @@ def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
     )
 
 
-@click.command("ingest")
+@click.command("import")
 @click.argument("path", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--daemon-url",
@@ -90,12 +90,12 @@ def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
     help="Daemon API URL.",
 )
 @click.pass_obj
-def ingest_command(
+def import_command(
     env: AppEnv,
     path: Path,
     daemon_url: str,
 ) -> None:
-    """Schedule a file or directory for ingestion by the running daemon.
+    """Schedule a file or directory for import by the running daemon.
 
     Stages PATH into the archive inbox and asks the running polylogued
     daemon to schedule it for processing. The command is truthful: it
@@ -122,26 +122,26 @@ def ingest_command(
         # code so the operator knows it's a contract problem, not a
         # transport problem.
         fail(
-            "ingest",
+            "import",
             f"Daemon at {daemon_url} rejected /api/ingest with HTTP {exc.code}: {exc.reason}.\n"
             "  Check the daemon log for the cause; the staged inbox file was "
             f"left in place at {staged}.",
         )
     except URLError as exc:
-        fail("ingest", _daemon_unreachable_message(daemon_url, str(exc.reason)))
+        fail("import", _daemon_unreachable_message(daemon_url, str(exc.reason)))
     except OSError as exc:
-        fail("ingest", _daemon_unreachable_message(daemon_url, str(exc)))
+        fail("import", _daemon_unreachable_message(daemon_url, str(exc)))
 
     operation = ImportOperation.from_dict(raw)
 
     if operation.status in ("failed", "error"):
-        fail("ingest", operation.error or operation.message or "Unknown error")
+        fail("import", operation.error or operation.message or "Unknown error")
 
     if operation.status not in _ACCEPTED_STATUSES:
         # The daemon returned something we don't recognize as accepted
         # *or* failed. Refuse to fabricate success.
         fail(
-            "ingest",
+            "import",
             f"Daemon returned unexpected status {operation.status!r}; refusing to claim success.",
         )
 
@@ -156,4 +156,4 @@ def ingest_command(
     )
 
 
-__all__ = ["ingest_command"]
+__all__ = ["import_command"]

--- a/polylogue/cli/output_assurance.py
+++ b/polylogue/cli/output_assurance.py
@@ -52,7 +52,7 @@ DAEMON_FAMILY = "daemon"
 CONFIG_FAMILY = "config"
 MAINTENANCE_FAMILY = "maintenance"
 SHELL_FAMILY = "shell"
-INGEST_FAMILY = "ingest"
+INGEST_FAMILY = "import"
 
 
 # Every primary subcommand of `polylogue` declares its assurance posture
@@ -259,13 +259,13 @@ ASSURANCE_REGISTRY: tuple[OutputAssurance, ...] = (
         notes="Side-effect command; opens local dashboard.",
     ),
     OutputAssurance(
-        command="ingest",
+        command="import",
         family=INGEST_FAMILY,
         json_contract=True,
         snapshot=True,
         plain=True,
         streaming=False,
-        notes="--machine emits success/error envelope per ingest run.",
+        notes="--machine emits success/error envelope per import run.",
     ),
     OutputAssurance(
         command="embed",

--- a/tests/baselines/showcase/help-import.txt
+++ b/tests/baselines/showcase/help-import.txt
@@ -1,6 +1,6 @@
-Usage: polylogue ingest [OPTIONS] PATH
+Usage: polylogue import [OPTIONS] PATH
 
-  Schedule a file or directory for ingestion by the running daemon.
+  Schedule a file or directory for import by the running daemon.
 
   Stages PATH into the archive inbox and asks the running polylogued daemon to
   schedule it for processing. The command is truthful: it either confirms the

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -173,7 +173,7 @@ Commands:
   embed              Enable, preflight, and backfill the embedding pipeline.
   facets
   feedback           Record learning corrections for derived insights.
-  ingest             Import sessions from configured sources.
+  import             Import sessions from configured sources.
   init               Detect chat sources and write a starter polylogue.toml.
   insights           Rebuild and inspect derived session insights.
   list               List matched sessions.

--- a/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
@@ -171,7 +171,7 @@
     embed              Enable, preflight, and backfill the embedding pipeline.
     facets
     feedback           Record learning corrections for derived insights.
-    ingest             Import sessions from configured sources.
+    import             Import sessions from configured sources.
     init               Detect chat sources and write a starter polylogue.toml.
     insights           Rebuild and inspect derived session insights.
     list               List matched sessions.

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -239,7 +239,7 @@
     embed              Enable, preflight, and backfill the embedding pipeline.
     facets
     feedback           Record learning corrections for derived insights.
-    ingest             Import sessions from configured sources.
+    import             Import sessions from configured sources.
     init               Detect chat sources and write a starter polylogue.toml.
     insights           Rebuild and inspect derived session insights.
     list               List matched sessions.
@@ -516,7 +516,7 @@
     facets
     feedback           Record learning corrections for derived
    insights.
-    ingest             Import sessions from configured sources
+    import             Import sessions from configured sources
   .
     init               Detect chat sources and write a starter
    polylogue.toml.
@@ -711,7 +711,7 @@
     embed              Enable, preflight, and backfill the embedding pipeline.
     facets
     feedback           Record learning corrections for derived insights.
-    ingest             Import sessions from configured sources.
+    import             Import sessions from configured sources.
     init               Detect chat sources and write a starter polylogue.toml.
     insights           Rebuild and inspect derived session insights.
     list               List matched sessions.

--- a/tests/unit/cli/test_cli_error_boundaries.py
+++ b/tests/unit/cli/test_cli_error_boundaries.py
@@ -32,7 +32,7 @@ SUBCOMMANDS = [
     "auth",
     "completions",
     "dashboard",
-    "ingest",
+    "import",
     "schema",
     "tags",
     "list",
@@ -132,8 +132,8 @@ class TestInvalidDates:
 
 class TestNonexistentPaths:
     def test_nonexistent_source_path(self, runner: CliRunner) -> None:
-        """Non-existent ingest path should not produce traceback."""
-        result = runner.invoke(cli, ["ingest", "/nonexistent/path"])
+        """Non-existent import path should not produce traceback."""
+        result = runner.invoke(cli, ["import", "/nonexistent/path"])
         assert TRACEBACK_SENTINEL not in result.output
 
     def test_nonexistent_output_path(self, runner: CliRunner, workspace_env: Mapping[str, Path]) -> None:

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -523,7 +523,7 @@ class TestCliMetadata:
 
         result = cli_runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
-        for command in ("doctor", "ingest", "tags", "list", "count", "stats"):
+        for command in ("doctor", "import", "tags", "list", "count", "stats"):
             assert command in result.output
         assert result.output.count("Commands:") == 1
 
@@ -534,7 +534,7 @@ class TestCliMetadata:
             "doctor",
             "reset",
             "status",
-            "ingest",
+            "import",
             "init",
             "auth",
             "backup",

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -220,7 +220,7 @@ _PLAIN_COMMANDS: tuple[tuple[str, ...], ...] = (
     ("diagnostics", "tools"),
     ("diagnostics", "turns"),
     ("doctor",),
-    ("ingest",),
+    ("import",),
     ("insights",),
     ("insights", "analytics"),
     ("insights", "cost-rollups"),

--- a/tests/unit/cli/test_exit_code_contracts.py
+++ b/tests/unit/cli/test_exit_code_contracts.py
@@ -52,7 +52,7 @@ class TestSuccessExitCode:
         "cmd",
         [
             "doctor",
-            "ingest",
+            "import",
             "schema",
             "tags",
             "list",

--- a/tests/unit/cli/test_import.py
+++ b/tests/unit/cli/test_import.py
@@ -1,4 +1,4 @@
-"""Tests for polylogue ingest truthfulness (#869 / #1264)."""
+"""Tests for polylogue import truthfulness (#869 / #1264)."""
 
 from __future__ import annotations
 
@@ -10,25 +10,25 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request
 
 
-def test_ingest_command_registered() -> None:
-    """ingest command must be available in the CLI group."""
+def test_import_command_registered() -> None:
+    """import command must be available in the CLI group."""
     from polylogue.cli.click_app import cli
 
     commands = {name for name in cli.commands if not name.startswith("_")}
-    assert "ingest" in commands, "ingest command not registered"
+    assert "import" in commands, "import command not registered"
 
 
-def test_ingest_help_includes_inbox_info() -> None:
-    """ingest --help should document that files are staged for daemon processing."""
+def test_import_help_includes_inbox_info() -> None:
+    """import --help should document that files are staged for daemon processing."""
     from click.testing import CliRunner
 
     from polylogue.cli.click_app import cli
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["ingest", "--help"])
+    result = runner.invoke(cli, ["import", "--help"])
     assert result.exit_code == 0
     assert "daemon" in result.output.lower() or "polylogued" in result.output.lower(), (
-        "ingest help should reference the daemon"
+        "import help should reference the daemon"
     )
 
 
@@ -46,7 +46,7 @@ class _FakeDaemonResponse:
         return json.dumps(self._payload).encode("utf-8")
 
 
-def test_ingest_command_stages_local_path_before_daemon_request(
+def test_import_command_stages_local_path_before_daemon_request(
     workspace_env: dict[str, Path],
     tmp_path: Path,
 ) -> None:
@@ -69,7 +69,7 @@ def test_ingest_command_stages_local_path_before_daemon_request(
         return _FakeDaemonResponse(
             {
                 "ok": True,
-                "operation_id": "ingest-source.jsonl",
+                "operation_id": "import-source.jsonl",
                 "kind": "import",
                 "status": "pending",
                 "path": staged_path,
@@ -78,10 +78,10 @@ def test_ingest_command_stages_local_path_before_daemon_request(
         )
 
     runner = CliRunner()
-    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
         result = runner.invoke(
             cli,
-            ["ingest", str(source), "--daemon-url", "http://127.0.0.1:8766"],
+            ["import", str(source), "--daemon-url", "http://127.0.0.1:8766"],
         )
 
     assert result.exit_code == 0, result.output
@@ -105,7 +105,7 @@ def test_ingest_command_stages_local_path_before_daemon_request(
     assert "polylogue stats" in result.output
 
 
-def test_ingest_rejects_missing_path(tmp_path: Path) -> None:
+def test_import_rejects_missing_path(tmp_path: Path) -> None:
     """A path that does not exist is rejected by Click before any daemon call."""
     from click.testing import CliRunner
 
@@ -113,14 +113,14 @@ def test_ingest_rejects_missing_path(tmp_path: Path) -> None:
 
     missing = tmp_path / "does-not-exist.jsonl"
     runner = CliRunner()
-    result = runner.invoke(cli, ["ingest", str(missing)])
+    result = runner.invoke(cli, ["import", str(missing)])
 
     assert result.exit_code != 0
     # Click's standard "Path 'X' does not exist" or equivalent.
     assert "does not exist" in result.output.lower() or "no such" in result.output.lower()
 
 
-def test_ingest_rejects_when_daemon_unreachable(
+def test_import_rejects_when_daemon_unreachable(
     workspace_env: dict[str, Path],
     tmp_path: Path,
 ) -> None:
@@ -136,10 +136,10 @@ def test_ingest_rejects_when_daemon_unreachable(
         raise URLError("Connection refused")
 
     runner = CliRunner()
-    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
         result = runner.invoke(
             cli,
-            ["ingest", str(source), "--daemon-url", "http://127.0.0.1:65535"],
+            ["import", str(source), "--daemon-url", "http://127.0.0.1:65535"],
         )
 
     assert result.exit_code != 0
@@ -149,7 +149,7 @@ def test_ingest_rejects_when_daemon_unreachable(
     assert "127.0.0.1:65535" in combined
 
 
-def test_ingest_surfaces_http_error_with_staged_path(
+def test_import_surfaces_http_error_with_staged_path(
     workspace_env: dict[str, Path],
     tmp_path: Path,
 ) -> None:
@@ -171,8 +171,8 @@ def test_ingest_surfaces_http_error_with_staged_path(
         )
 
     runner = CliRunner()
-    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
-        result = runner.invoke(cli, ["ingest", str(source)])
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(cli, ["import", str(source)])
 
     assert result.exit_code != 0
     staged = workspace_env["archive_root"] / "inbox" / source.name
@@ -181,7 +181,7 @@ def test_ingest_surfaces_http_error_with_staged_path(
     assert str(staged).lower() in combined
 
 
-def test_ingest_refuses_unrecognized_daemon_status(
+def test_import_refuses_unrecognized_daemon_status(
     workspace_env: dict[str, Path],
     tmp_path: Path,
 ) -> None:
@@ -197,7 +197,7 @@ def test_ingest_refuses_unrecognized_daemon_status(
         return _FakeDaemonResponse(
             {
                 "ok": True,
-                "operation_id": "ingest-source.jsonl",
+                "operation_id": "import-source.jsonl",
                 "kind": "import",
                 "status": "mystery_status",
                 "path": "/somewhere",
@@ -206,15 +206,15 @@ def test_ingest_refuses_unrecognized_daemon_status(
         )
 
     runner = CliRunner()
-    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
-        result = runner.invoke(cli, ["ingest", str(source)])
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(cli, ["import", str(source)])
 
     assert result.exit_code != 0
     combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()
     assert "mystery_status" in combined
 
 
-def test_ingest_surfaces_daemon_failure_status(
+def test_import_surfaces_daemon_failure_status(
     workspace_env: dict[str, Path],
     tmp_path: Path,
 ) -> None:
@@ -230,7 +230,7 @@ def test_ingest_surfaces_daemon_failure_status(
         return _FakeDaemonResponse(
             {
                 "ok": False,
-                "operation_id": "ingest-source.jsonl",
+                "operation_id": "import-source.jsonl",
                 "kind": "import",
                 "status": "failed",
                 "error": "inbox locked by another operation",
@@ -238,8 +238,8 @@ def test_ingest_surfaces_daemon_failure_status(
         )
 
     runner = CliRunner()
-    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
-        result = runner.invoke(cli, ["ingest", str(source)])
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(cli, ["import", str(source)])
 
     assert result.exit_code != 0
     combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()

--- a/tests/unit/cli/test_json_output.py
+++ b/tests/unit/cli/test_json_output.py
@@ -71,7 +71,7 @@ def _looks_like_json_output(text: str) -> bool:
 #
 # Commands intentionally excluded:
 #   - delete, reset        → destructive
-#   - ingest               → requires source config, modifies archive
+#   - import               → requires source config, modifies archive
 #   - tutorial, auth, init → interactive or requires external service
 #   - dashboard, open      → side effect (opens browser)
 #   - backup               → creates backup file; needs populated archive
@@ -127,7 +127,7 @@ _COMMANDS: list[tuple[list[str], bool]] = [
 _EXCLUDED: list[str] = [
     "delete (destructive)",
     "reset (destructive)",
-    "ingest (requires source config, modifies archive)",
+    "import (requires source config, modifies archive)",
     "tutorial (interactive)",
     "auth (interactive, requires external service)",
     "init (interactive, writes config)",

--- a/tests/unit/cli/test_output_contracts.py
+++ b/tests/unit/cli/test_output_contracts.py
@@ -39,7 +39,7 @@ def test_config_show_toml_output() -> None:
     assert "[" in output  # TOML section headers
 
 
-def test_ingest_missing_path_error() -> None:
-    """ingest with nonexistent path returns non-zero and error message."""
-    exit_code, output = _invoke("ingest", "/nonexistent/path/12345")
+def test_import_missing_path_error() -> None:
+    """import with nonexistent path returns non-zero and error message."""
+    exit_code, output = _invoke("import", "/nonexistent/path/12345")
     assert exit_code != 0

--- a/tests/unit/cli/test_stdout_stderr_split.py
+++ b/tests/unit/cli/test_stdout_stderr_split.py
@@ -48,7 +48,7 @@ _ALL_COMMANDS: tuple[tuple[str, ...], ...] = (
     ("diagnostics", "tools"),
     ("diagnostics", "turns"),
     ("doctor",),
-    ("ingest",),
+    ("import",),
     ("insights",),
     ("insights", "audit"),
     ("insights", "cost-rollups"),

--- a/tests/unit/security/test_sentinel_env_leak.py
+++ b/tests/unit/security/test_sentinel_env_leak.py
@@ -56,7 +56,7 @@ _COMMANDS_TO_PROBE: tuple[tuple[str, ...], ...] = (
     ("count", "--definitely-not-a-flag"),
     ("auth", "--help"),
     ("schema", "--help"),
-    ("ingest", "--help"),
+    ("import", "--help"),
     ("tags", "--help"),
 )
 


### PR DESCRIPTION
## Summary

Renames the public CLI command `polylogue ingest` → `polylogue import`. No backwards-compat alias. This is the first slice of #1815.

## Problem

The command was named `ingest` — a pipeline/daemon internal verb — while its user-facing role is to schedule a file for import. The mismatch violated the vocabulary policy (#1815) and caused confusion for new users expecting `polylogue import`.

## Solution

- Deleted `polylogue/cli/commands/ingest.py`; new module is `polylogue/cli/commands/import_command.py` (module can't be named `import.py` — Python keyword)
- Click command name string changed from `"ingest"` to `"import"` in the `@click.command` decorator
- `click_command_registration.py`: module key changed to `"import_command"`, display name to `"import"`
- `commands.py`: command group listing updated
- `output_assurance.py`: `INGEST_FAMILY` constant value updated to `"import"`
- Help text updated: "Schedule a file or directory for **import** by the running daemon" vs. previous "ingestion" wording
- Tests: `test_ingest.py` replaced by `test_import.py`; all invocations updated to `"import"`
- Docs (getting-started.md, configuration.md, maintenance.md, cli-audit.md): `polylogue ingest` command invocations → `polylogue import`
- Snapshots updated: syrupy help/terminal snapshots and showcase baselines (help-ingest.txt → help-import.txt, help-main.txt)
- Generated surfaces regenerated: cli-reference.md, AGENTS.md, topology-target.yaml, test-quality-workflows.md

**Internal vocabulary preserved**: `pipeline/ingest_support.py`, `pipeline/services/ingest_batch.py`, `live_ingest_attempt`, daemon `/api/ingest` endpoint, `live-ingest` log terminology — all unchanged. Those are not public command vocabulary.

## Deferred to later #1815 slices

- `provider_meta` field elimination
- `provider`/`conversation` → `origin`/`session` terminology sweep
- Parser regression pack
- Demo mode additions

## Verification

```
# Command renamed correctly
nix develop --command polylogue import --help
# → "Usage: polylogue import [OPTIONS] PATH"

# Old name is gone (falls through to query mode, not an error)
nix develop --command polylogue ingest --help
# → shows root usage (no ingest subcommand)

# mypy clean
nix develop --command mypy polylogue/cli/commands/import_command.py polylogue/cli/click_command_registration.py
# → Success: no issues found in 2 source files

# Topology clean
nix develop --command devtools verify-topology
# → realized=827 declared=827 blocking=False

# Generated surfaces all in sync
nix develop --command devtools render-all --check
# → all 8 checks: sync OK

# All showcase baselines match
POLYLOGUE_FORCE_PLAIN=1 nix develop --command devtools lab-scenario verify-baselines
# → Ran 81 exercises / All baselines match.

# CLI tests pass
nix develop --command devtools test -k "import or ingest" tests/unit/cli/
# → 23 passed, 1732 deselected

# Full pre-push gate (run on git push)
# → 15/15 checks green: ruff format, ruff check, mypy, render-all,
#   verify-topology, verify-layering, verify-closure-matrix,
#   verify-schema-roundtrip, verify-manifests, verify-ci-workflows,
#   verify-doc-commands, verify-lane-assertions, verify-test-infra-currency,
#   verify-test-clock-hygiene, public-surface-audit
```

Ref #1815