### PR TITLE
fix(cli): reject --sample with mutating verbs instead of silently ignoring it

### DIFF
--- a/polylogue/cli/verb_cardinality.py
+++ b/polylogue/cli/verb_cardinality.py
@@ -80,6 +80,20 @@ def resolve_session_ids_for_verb(env: AppEnv, request: RootModeRequest) -> list[
     """
     from polylogue.api.sync.bridge import run_coroutine_sync
 
+    # ``--sample`` is a display-window operation (random subset applied during
+    # result windowing); the verb resolution path deliberately resolves the
+    # COMPLETE matched set so the cardinality guard and the mutation act on the
+    # same rows. Honoring ``--sample`` here would mean a destructive verb
+    # silently operated on the full match while the operator believed the blast
+    # radius was capped at N — so reject the combination instead of ignoring it.
+    if request.query_spec().sample is not None:
+        raise click.UsageError(
+            "Root query does not combine --sample with a mutating verb "
+            "(delete/mark): these operate on the complete matched set, so "
+            "--sample would be silently ignored. Narrow the query (e.g. an "
+            "id:/since: filter) to scope the blast radius explicitly."
+        )
+
     return run_coroutine_sync(_async_resolve_ids(env, request))
 
 

--- a/tests/unit/cli/test_verb_cardinality.py
+++ b/tests/unit/cli/test_verb_cardinality.py
@@ -406,6 +406,59 @@ class TestDeleteVerbCardinality:
 
 
 # ---------------------------------------------------------------------------
+# resolve_session_ids_for_verb — --sample is rejected, never silently ignored
+# ---------------------------------------------------------------------------
+
+
+class TestSampleRejectedForMutatingVerbs:
+    """``--sample`` must not silently widen a mutating verb's blast radius.
+
+    ``--sample N`` is a display-window random subset; the verb resolution path
+    deliberately resolves the COMPLETE matched set. Honoring it would mean a
+    destructive ``delete``/``mark`` operated on every match while the operator
+    believed only N rows were in scope. The shared resolver rejects the
+    combination up front rather than ignoring it.
+    """
+
+    def test_resolver_rejects_sample(self) -> None:
+        from polylogue.cli.verb_cardinality import resolve_session_ids_for_verb
+
+        request = RootModeRequest.from_params({"sample": 5})
+        assert request.query_spec().sample == 5
+
+        with patch("polylogue.api.sync.bridge.run_coroutine_sync") as mock_run:
+            with pytest.raises(click.UsageError, match="--sample"):
+                resolve_session_ids_for_verb(cast(object, MagicMock()), request)  # type: ignore[arg-type]
+
+        # The guard fires before any DB resolution.
+        mock_run.assert_not_called()
+
+    def test_resolver_allows_absent_sample(self) -> None:
+        """Without --sample the resolver proceeds to the async DB path."""
+        from polylogue.cli.verb_cardinality import resolve_session_ids_for_verb
+
+        request = RootModeRequest.from_params({})
+        assert request.query_spec().sample is None
+
+        with (
+            # _async_resolve_ids is stubbed so no coroutine is created and the
+            # MagicMock env is never dereferenced for real DB work.
+            patch(
+                "polylogue.cli.verb_cardinality._async_resolve_ids",
+                new=lambda env, request: object(),
+            ),
+            patch(
+                "polylogue.api.sync.bridge.run_coroutine_sync",
+                return_value=["id1"],
+            ) as mock_run,
+        ):
+            result = resolve_session_ids_for_verb(cast(object, MagicMock()), request)  # type: ignore[arg-type]
+
+        assert result == ["id1"]
+        mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # analyze_verb — no cardinality restriction
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
`find QUERY --sample N then delete` / `then mark` silently ignored `--sample` and operated on the **complete** matched set. The shared verb resolver now rejects the combination with a `UsageError` rather than ignoring it.

## Problem
`resolve_session_ids_for_verb` deliberately resolves the **full** matched set so the cardinality guard and the mutation act on the same rows (this is the #1873 invariant). `--sample N` is a *display-window* random subset applied later in query sorting (`archive/query/sorting.py`), never in the verb-resolution path. Result: `find big-query --sample 3 then delete --yes --all` deleted **every** match while the operator believed the blast radius was capped at 3 rows — a data-loss footgun. Both dry-run and real delete ignored it identically (so the preview/delete sets still matched), but the silent-ignore itself is the bug.

There was no guard for this: the existing `--sample` guards reject combining it with `--cursor`, stats, and search-terms, but not with a following mutating verb.

## Solution
`resolve_session_ids_for_verb` (the single seam shared by `delete`, `delete --dry-run`, and `mark`) raises a `UsageError` when the request carries `--sample`, consistent with the existing `--sample` guard family. The message points the operator at narrowing the query (`id:`/`since:`) to scope the blast radius explicitly.

## Verification
```
devtools test tests/unit/cli/test_verb_cardinality.py   # 33 passed (2 new)
ruff check + mypy --strict polylogue/cli/verb_cardinality.py tests/...  # clean
```
New tests: resolver rejects `--sample` before any DB resolution; resolver proceeds normally when `--sample` is absent.

Found during a coordinator verification sweep of analysis-flagged hazards.