### PR TITLE
perf(daemon): targeted FTS repair in archive convergence, not full rebuild (#1851)

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -969,6 +969,29 @@ def _archive_rebuild_messages_fts(conn: sqlite3.Connection) -> None:
     rebuild_fts_index_sync(conn)
 
 
+def _archive_repair_sessions_fts(conn: sqlite3.Connection, session_ids: Sequence[str]) -> None:
+    """Repair ``messages_fts`` for just the changed sessions (#1851).
+
+    The archive FTS convergence paths previously called the full
+    ``_archive_rebuild_messages_fts`` (delete-all + re-insert every message row)
+    on every batch, so a single small append re-indexed the entire corpus —
+    ~14 MiB of writes regardless of payload size. When the source path resolves
+    to known session ids we instead delete+reinsert only those sessions' FTS
+    rows (the same targeted primitive the legacy monolith path used), and mark
+    the surface ready. Full rebuild remains the fallback when scope is unknown.
+    """
+    ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
+    if not ids:
+        _archive_rebuild_messages_fts(conn)
+        return
+    if not _table_exists(conn, "messages_fts"):
+        return
+    from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
+
+    repair_message_fts_index_sync(conn, ids)
+    _mark_message_fts_ready_after_targeted_repair(conn)
+
+
 def _archive_fts_check(db_path: Path, path: Path) -> bool:
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
@@ -986,9 +1009,9 @@ def _archive_fts_execute(db_path: Path, path: Path) -> bool:
         conn = sqlite3.connect(db_path, timeout=30.0)
         try:
             session_ids = _schema_archive_session_ids_for_source_path(conn, path)
-            _archive_rebuild_messages_fts(conn)
+            _archive_repair_sessions_fts(conn, session_ids)
             conn.commit()
-            logger.info("fts: archive rebuilt messages_fts sessions=%d", len(session_ids))
+            logger.info("fts: archive repaired messages_fts sessions=%d", len(session_ids))
             return not _archive_fts_needs_repair(conn, session_ids or None)
         finally:
             conn.close()
@@ -1021,9 +1044,9 @@ def _archive_fts_execute_many(db_path: Path, paths: Sequence[Path]) -> bool:
         try:
             by_path = _schema_archive_session_ids_for_source_paths(conn, paths)
             session_ids = list(dict.fromkeys(session_id for ids in by_path.values() for session_id in ids))
-            _archive_rebuild_messages_fts(conn)
+            _archive_repair_sessions_fts(conn, session_ids)
             conn.commit()
-            logger.info("fts: archive batch rebuilt messages_fts paths=%d sessions=%d", len(paths), len(session_ids))
+            logger.info("fts: archive batch repaired messages_fts paths=%d sessions=%d", len(paths), len(session_ids))
             return not _archive_fts_needs_repair(conn, session_ids or None)
         finally:
             conn.close()
@@ -1051,9 +1074,9 @@ def _archive_fts_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> 
             ids = _archive_existing_session_ids(conn, session_ids)
             if not ids:
                 return True
-            _archive_rebuild_messages_fts(conn)
+            _archive_repair_sessions_fts(conn, ids)
             conn.commit()
-            logger.info("fts: archive rebuilt messages_fts session debt sessions=%d", len(ids))
+            logger.info("fts: archive repaired messages_fts session debt sessions=%d", len(ids))
             return not _archive_fts_needs_repair(conn, ids)
         finally:
             conn.close()

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -222,6 +222,60 @@ def test_fts_stage_repairs_archive_when_db_anchor_exists(tmp_path: Path) -> None
         assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == 1
 
 
+def test_fts_stage_uses_targeted_repair_not_full_rebuild(tmp_path: Path) -> None:
+    """#1851: an archive FTS batch repairs only the changed sessions.
+
+    The convergence FTS stage previously called the full corpus rebuild
+    (delete-all + re-insert every message row) on every batch, so a single
+    small append re-indexed everything (~14 MiB regardless of payload). With a
+    known source-path → session mapping it must take the targeted delete+insert
+    path instead, while leaving ``messages_fts`` complete.
+    """
+    from unittest import mock
+
+    import polylogue.storage.fts.fts_lifecycle as fts_lc
+
+    archive_db = tmp_path / "index.db"
+    archive_db.touch()
+    source_path = tmp_path / "codex.jsonl"
+    _seed_minimal_archive(archive_db, source_path)
+
+    stage = make_fts_stage(tmp_path / "index.db")
+
+    with (
+        mock.patch.object(
+            fts_lc, "repair_message_fts_index_sync", wraps=fts_lc.repair_message_fts_index_sync
+        ) as targeted,
+        mock.patch.object(fts_lc, "rebuild_fts_index_sync", wraps=fts_lc.rebuild_fts_index_sync) as full_rebuild,
+    ):
+        assert stage.execute(source_path) is True
+
+    targeted.assert_called_once()
+    full_rebuild.assert_not_called()
+    with sqlite3.connect(archive_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == 1
+
+
+def test_archive_repair_sessions_fts_falls_back_to_full_rebuild_without_ids(tmp_path: Path) -> None:
+    """When scope is unknown (no session ids), the full rebuild is the fallback."""
+    from unittest import mock
+
+    import polylogue.storage.fts.fts_lifecycle as fts_lc
+
+    archive_db = tmp_path / "index.db"
+    archive_db.touch()
+    source_path = tmp_path / "codex.jsonl"
+    _seed_minimal_archive(archive_db, source_path)
+
+    with (
+        sqlite3.connect(archive_db) as conn,
+        mock.patch.object(fts_lc, "rebuild_fts_index_sync", wraps=fts_lc.rebuild_fts_index_sync) as full_rebuild,
+    ):
+        stages._archive_repair_sessions_fts(conn, [])
+
+    full_rebuild.assert_called_once()
+
+
 def test_insights_stage_materializes_archive_profiles_from_archive_tiers(tmp_path: Path) -> None:
     archive_db = tmp_path / "index.db"
     source_path = tmp_path / "codex.jsonl"


### PR DESCRIPTION
## Summary
Kills the live-ingest write amplification: the archive FTS convergence paths now repair only the changed sessions' `messages_fts` rows instead of re-indexing the entire corpus on every batch.

## Problem
`_archive_fts_execute` / `_archive_fts_execute_many` / `_archive_fts_execute_sessions` (the split-file archive runtime path) computed the changed `session_ids` for a source path, then **ignored them** and called `_archive_rebuild_messages_fts` → `rebuild_fts_index_sync` — a full delete-all + re-insert of *every* message row in the corpus. A one-message append re-indexed the whole FTS index → ~14 MiB of writes per batch regardless of payload (~1000× amplification for small appends). The legacy monolith path already did targeted repair (`_repair_changed_session_fts`); the archive path never got the equivalent.

## Solution
`_archive_repair_sessions_fts(conn, session_ids)` uses the existing targeted primitive `repair_message_fts_index_sync` (per-session delete+insert of `messages_fts` rows) and `_mark_message_fts_ready_after_targeted_repair`, falling back to the full rebuild only when scope is unknown (no ids). All three archive FTS execute paths route through it.

Correctness preserved: `_archive_fts_needs_repair` returns False after targeted repair (index complete for the changed sessions), readiness/freshness state is updated through the existing helper, and the unknown-scope fallback keeps the full-rebuild behavior. No durability/raw-evidence change.

## Verification
```
devtools test tests/unit/daemon/test_convergence_stages.py   # 28 passed (2 new)
devtools test test_fts_global_repair test_fts5 test_fts_repair_sql   # green
devtools verify --quick   # exit 0
```
New tests: `test_fts_stage_uses_targeted_repair_not_full_rebuild` (spies that the targeted primitive is called and `rebuild_fts_index_sync` is **not**, while `messages_fts` stays complete) and `test_archive_repair_sessions_fts_falls_back_to_full_rebuild_without_ids`. One unrelated `status --json` subprocess test flaked only in a mixed-file batch (passes isolated + in-file; pre-existing #1878-class cross-test stdout pollution).

---
```text
Issue slice: #1851 slice 5 (concrete write reduction) + regression tests
Files inspected: daemon/convergence_stages.py, storage/fts/fts_lifecycle.py, daemon/health.py, pipeline/services/indexing.py
Files changed: daemon/convergence_stages.py, tests/unit/daemon/test_convergence_stages.py
Old surface removed or retained: full-rebuild retained as unknown-scope fallback; targeted repair added for known scope
Contracts/tests added: targeted-path-taken assertion; unknown-scope fallback; messages_fts completeness
Generated artifacts updated: none (internal daemon logic, no CLI/doc surface)
Verification commands and results: see above — 28 passed, verify --quick exit 0
Known caveats / SPEC_MISMATCH: amplification source attributed by code, not yet by a committed byte-measurement artifact
Follow-up intentionally not included: slices 1-2/4 — deterministic fixture + page/WAL byte attribution + a benchmark-campaign artifact for before/after comparison across PRs
```

Ref #1851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Full-Text Search index repair efficiency by performing targeted repairs on affected sessions instead of full index rebuilds when session scope is available. Full index rebuilds remain available as a fallback for unscoped repairs.

* **Tests**
  * Added unit tests to verify Full-Text Search repair behavior and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->