### PR TITLE
fix(cli): reset --database preserves irreplaceable user.db by default (#1883)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -507,16 +507,18 @@ Usage: polylogue reset [OPTIONS]
     --source PATH      Tombstone all sessions from a source path
 
 Options:
-  --database      Delete the SQLite database
-  --blob          Delete the content-addressed blob store
-  --assets        Delete archived assets/attachments
-  --cache         Delete search indexes, schemas, and cache
-  --auth          Delete Google Drive OAuth tokens
-  --all           Reset everything
-  -y, --yes       Skip confirmation prompt
-  --session TEXT  Tombstone a specific session by ID
-  --source PATH   Tombstone all sessions from a source path
-  --help          Show this message and exit.
+  --database         Delete the rebuildable SQLite tiers (preserves user.db)
+  --include-user-db  Also delete the irreplaceable user.db tier (tags,
+                     annotations, marks, notes). Destructive.
+  --blob             Delete the content-addressed blob store
+  --assets           Delete archived assets/attachments
+  --cache            Delete search indexes, schemas, and cache
+  --auth             Delete Google Drive OAuth tokens
+  --all              Reset everything
+  -y, --yes          Skip confirmation prompt
+  --session TEXT     Tombstone a specific session by ID
+  --source PATH      Tombstone all sessions from a source path
+  --help             Show this message and exit.
 ```
 
 ## Schema

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -28,13 +28,19 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import upsert_suppression
 
-_ARCHIVE_DATABASES = (
+# Rebuildable tiers: re-acquired from source on the next ``polylogued run``.
+# Deleting these is the supported "move aside and re-ingest" reset path.
+_REBUILDABLE_ARCHIVE_DATABASES = (
     ("source database", "source.db"),
     ("index database", "index.db"),
     ("embeddings database", "embeddings.db"),
-    ("user database", "user.db"),
     ("ops database", "ops.db"),
 )
+# Irreplaceable tier: marks, annotations, corrections, tags, saved views,
+# recall packs, workspaces, blackboard notes. Nothing re-creates it, so
+# ``reset --database`` preserves it unless the operator opts in explicitly.
+_USER_ARCHIVE_DATABASE = ("user database", "user.db")
+_ARCHIVE_DATABASES = (*_REBUILDABLE_ARCHIVE_DATABASES, _USER_ARCHIVE_DATABASE)
 
 
 def _archive_root() -> Path:
@@ -53,10 +59,17 @@ def _user_db_path() -> Path:
     return _archive_root() / "user.db"
 
 
-def _archive_database_targets() -> list[tuple[str, Path]]:
+def _archive_database_targets(*, include_user_db: bool = False) -> list[tuple[str, Path]]:
+    """Resolve archive-tier files to delete for ``reset --database``.
+
+    The irreplaceable ``user.db`` tier is excluded unless ``include_user_db``
+    is set, so the default reset path drops only rebuildable tiers and never
+    silently destroys hand-authored user state (#1883).
+    """
     root = _archive_root()
+    databases = _ARCHIVE_DATABASES if include_user_db else _REBUILDABLE_ARCHIVE_DATABASES
     targets: list[tuple[str, Path]] = []
-    for name, filename in _ARCHIVE_DATABASES:
+    for name, filename in databases:
         path = root / filename
         if path.exists():
             targets.append((name, path))
@@ -65,6 +78,10 @@ def _archive_database_targets() -> list[tuple[str, Path]]:
             if sidecar.exists():
                 targets.append((f"{name} {suffix}", sidecar))
     return targets
+
+
+def _user_db_present() -> bool:
+    return _user_db_path().exists()
 
 
 def _resolve_archive_session_ids(tokens: list[str]) -> list[str]:
@@ -173,7 +190,12 @@ def _archive_session_ids_from_source(source_path: Path) -> list[str]:
 
 
 @click.command("reset")
-@click.option("--database", is_flag=True, help="Delete the SQLite database")
+@click.option("--database", is_flag=True, help="Delete the rebuildable SQLite tiers (preserves user.db)")
+@click.option(
+    "--include-user-db",
+    is_flag=True,
+    help="Also delete the irreplaceable user.db tier (tags, annotations, marks, notes). Destructive.",
+)
 @click.option("--blob", is_flag=True, help="Delete the content-addressed blob store")
 @click.option("--assets", is_flag=True, help="Delete archived assets/attachments")
 @click.option("--cache", is_flag=True, help="Delete search indexes, schemas, and cache")
@@ -192,6 +214,7 @@ def _archive_session_ids_from_source(source_path: Path) -> list[str]:
 def reset_command(
     env: AppEnv,
     database: bool,
+    include_user_db: bool,
     blob: bool,
     assets: bool,
     cache: bool,
@@ -243,7 +266,13 @@ def reset_command(
 
     targets = []
     if database:
-        targets.extend(_archive_database_targets())
+        targets.extend(_archive_database_targets(include_user_db=include_user_db))
+        if not include_user_db and _user_db_present():
+            env.ui.console.print(
+                "Preserving user.db (irreplaceable: tags, annotations, marks, saved views, "
+                "notes). Rebuildable tiers will be re-acquired on the next `polylogued run`. "
+                "Pass --include-user-db to delete user.db too."
+            )
     if blob:
         _blob_root = blob_store_root()
         if _blob_root.exists():

--- a/tests/baselines/showcase/help-reset.txt
+++ b/tests/baselines/showcase/help-reset.txt
@@ -10,13 +10,15 @@ Usage: polylogue reset [OPTIONS]
     --source PATH      Tombstone all sessions from a source path
 
 Options:
-  --database      Delete the SQLite database
-  --blob          Delete the content-addressed blob store
-  --assets        Delete archived assets/attachments
-  --cache         Delete search indexes, schemas, and cache
-  --auth          Delete Google Drive OAuth tokens
-  --all           Reset everything
-  -y, --yes       Skip confirmation prompt
-  --session TEXT  Tombstone a specific session by ID
-  --source PATH   Tombstone all sessions from a source path
-  -h, --help      Show this message and exit.
+  --database         Delete the rebuildable SQLite tiers (preserves user.db)
+  --include-user-db  Also delete the irreplaceable user.db tier (tags,
+                     annotations, marks, notes). Destructive.
+  --blob             Delete the content-addressed blob store
+  --assets           Delete archived assets/attachments
+  --cache            Delete search indexes, schemas, and cache
+  --auth             Delete Google Drive OAuth tokens
+  --all              Reset everything
+  -y, --yes          Skip confirmation prompt
+  --session TEXT     Tombstone a specific session by ID
+  --source PATH      Tombstone all sessions from a source path
+  -h, --help         Show this message and exit.

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -241,15 +241,9 @@ class TestResetCommandDeletion:
             assert not archive_db.exists()
             assert not assets_dir.exists()
 
-    def test_reset_database_deletes_all_archive_tiers_and_sidecars(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Database reset targets all archive database tier files."""
-        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
-
-        archive_root = tmp_path / "archive"
-        archive_root.mkdir()
-        paths = [
+    def _seed_archive_tiers(self, archive_root: Path) -> tuple[list[Path], Path]:
+        archive_root.mkdir(exist_ok=True)
+        rebuildable = [
             archive_root / "source.db",
             archive_root / "source.db-wal",
             archive_root / "source.db-shm",
@@ -259,21 +253,63 @@ class TestResetCommandDeletion:
             archive_root / "embeddings.db",
             archive_root / "embeddings.db-wal",
             archive_root / "embeddings.db-shm",
-            archive_root / "user.db",
             archive_root / "ops.db",
         ]
-        for path in paths:
+        user_db = archive_root / "user.db"
+        for path in [*rebuildable, user_db]:
             path.write_text("test database", encoding="utf-8")
+        return rebuildable, user_db
+
+    def test_reset_database_preserves_irreplaceable_user_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``reset --database`` deletes rebuildable tiers but PRESERVES user.db (#1883)."""
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        archive_root = tmp_path / "archive"
+        rebuildable, user_db = self._seed_archive_tiers(archive_root)
 
         with (
             patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root),
             patch("polylogue.cli.commands.reset.data_home", return_value=tmp_path),
         ):
-            runner = CliRunner()
-            result = runner.invoke(cli, ["reset", "--database", "--yes"])
+            result = CliRunner().invoke(cli, ["reset", "--database", "--yes"])
 
         assert result.exit_code == 0
-        assert all(not path.exists() for path in paths)
+        assert all(not path.exists() for path in rebuildable), "rebuildable tiers should be deleted"
+        assert user_db.exists(), "user.db is irreplaceable and must survive a plain --database reset"
+        assert "Preserving user.db" in result.output
+
+    def test_reset_database_include_user_db_deletes_everything(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``reset --database --include-user-db`` opts into deleting user.db too (#1883)."""
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        archive_root = tmp_path / "archive"
+        rebuildable, user_db = self._seed_archive_tiers(archive_root)
+
+        with (
+            patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root),
+            patch("polylogue.cli.commands.reset.data_home", return_value=tmp_path),
+        ):
+            result = CliRunner().invoke(cli, ["reset", "--database", "--include-user-db", "--yes"])
+
+        assert result.exit_code == 0
+        assert all(not path.exists() for path in [*rebuildable, user_db])
+
+    def test_reset_all_preserves_user_db_without_opt_in(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Even ``reset --all`` preserves user.db unless --include-user-db is given (#1883)."""
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        archive_root = tmp_path / "archive"
+        _rebuildable, user_db = self._seed_archive_tiers(archive_root)
+
+        with (
+            patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root),
+            patch("polylogue.cli.commands.reset.data_home", return_value=tmp_path),
+        ):
+            result = CliRunner().invoke(cli, ["reset", "--all", "--yes"])
+
+        assert result.exit_code == 0
+        assert user_db.exists(), "user.db must survive --all without an explicit --include-user-db opt-in"
 
     def test_reset_session_records_archive_suppression_and_deletes_archive_row(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
`reset --database` no longer deletes the irreplaceable `user.db` tier by default — it drops only the rebuildable tiers and requires an explicit `--include-user-db` opt-in to remove user state.

## Problem
`reset --database` deleted **all five** archive tiers, including `user.db` — the irreplaceable user tier (marks, annotations, corrections, tags, saved views, recall packs, workspaces, blackboard notes). `source.db`/`index.db`/`embeddings.db`/`ops.db` are rebuildable by re-ingest; `user.db` is not. An operator running the documented "move aside and re-ingest" reset silently lost all hand-authored state behind only a generic confirmation prompt.

## Solution
- `reset --database` now resolves only `_REBUILDABLE_ARCHIVE_DATABASES` (source/index/embeddings/ops) and preserves `user.db`, printing a notice (what was kept + how to drop it).
- New `--include-user-db` flag is the explicit opt-in to also delete `user.db`.
- The opt-in is required **even under `--all`**, so no path silently destroys irreplaceable state.

## Verification
```
devtools test tests/unit/cli/test_reset.py   # 22 passed (3 new)
devtools verify --quick   # exit 0
```
New tests pin the data-loss boundary: `--database` preserves `user.db`; `--database --include-user-db` deletes it; `--all` preserves it without the opt-in. `help-reset` baseline + `cli-reference` regenerated.

This is the data-loss-guard slice of #1883; the unified `assertions` substrate table is a follow-up slice on the same issue.

Ref #1883