### PR TITLE
fix(cli): messages --format ndjson emits JSON-per-line, not markdown (#1818)

### DIFF
--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -61,25 +61,35 @@ def run_messages(
 
             fmt = output_format or "markdown"
 
+            def _message_document(m: object) -> dict[str, object]:
+                return {
+                    "id": str(m.id),  # type: ignore[attr-defined]
+                    "role": str(m.role),  # type: ignore[attr-defined]
+                    "message_type": str(m.message_type.value),  # type: ignore[attr-defined]
+                    "text": m.text or "",  # type: ignore[attr-defined]
+                }
+
             if fmt == "json":
                 import json as _json
 
+                # Finite machine-output contract (#1818): one JSON value.
                 payload = {
                     "session_id": session_id,
-                    "messages": [
-                        {
-                            "id": str(m.id),
-                            "role": str(m.role),
-                            "message_type": str(m.message_type.value),
-                            "text": m.text or "",
-                        }
-                        for m in messages
-                    ],
+                    "messages": [_message_document(m) for m in messages],
                     "total": total,
                     "limit": limit,
                     "offset": offset,
                 }
                 env.ui.print(_json.dumps(payload, indent=2))
+            elif fmt == "ndjson":
+                import json as _json
+
+                # Streaming machine-output contract (#1818): one JSON document
+                # per line. Each line is self-contained, carrying session_id so
+                # downstream consumers do not need an out-of-band envelope.
+                for m in messages:
+                    line = {"session_id": session_id, **_message_document(m)}
+                    env.ui.print(_json.dumps(line))
             else:
                 for msg in messages:
                     role = str(msg.role)

--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import cast
 
+import click
+
 from polylogue.api.archive import SessionNotFoundError
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.message.roles import MessageRoleFilter, normalize_message_roles
@@ -80,16 +82,22 @@ def run_messages(
                     "limit": limit,
                     "offset": offset,
                 }
-                env.ui.print(_json.dumps(payload, indent=2))
+                # Machine output goes through click.echo (raw stdout), NOT
+                # env.ui.print: the Rich console defaults markup=True and would
+                # interpret/strip bracket sequences like "[bold]" inside message
+                # text, corrupting the exact bytes json.dumps produced (#1818).
+                click.echo(_json.dumps(payload, indent=2))
             elif fmt == "ndjson":
                 import json as _json
 
                 # Streaming machine-output contract (#1818): one JSON document
                 # per line. Each line is self-contained, carrying session_id so
                 # downstream consumers do not need an out-of-band envelope.
+                # Raw click.echo (not env.ui.print) so Rich markup never mangles
+                # message text inside the JSON document.
                 for m in messages:
                     line = {"session_id": session_id, **_message_document(m)}
-                    env.ui.print(_json.dumps(line))
+                    click.echo(_json.dumps(line))
             else:
                 for msg in messages:
                     role = str(msg.role)

--- a/tests/unit/cli/test_messages.py
+++ b/tests/unit/cli/test_messages.py
@@ -6,6 +6,8 @@ from types import TracebackType
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.cli.messages import run_messages, run_raw
 from polylogue.cli.root_request import RootModeRequest
@@ -93,7 +95,7 @@ def _request(tmp_path: Path) -> RootModeRequest:
     )
 
 
-def test_run_messages_emits_json_and_passes_projection(tmp_path: Path) -> None:
+def test_run_messages_emits_json_and_passes_projection(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     env = _env()
     api = _FakeApi(
         messages_result=(
@@ -123,7 +125,7 @@ def test_run_messages_emits_json_and_passes_projection(tmp_path: Path) -> None:
             output_format="json",
         )
 
-    payload = json.loads(_ui_print(env).call_args.args[0])
+    payload = json.loads(capsys.readouterr().out)
     assert payload["messages"][0]["text"] == "hello"
     assert api.messages_kwargs["session_id"] == "conv-1"
     assert api.messages_kwargs["message_role"] == ("user",)
@@ -135,13 +137,15 @@ def test_run_messages_emits_json_and_passes_projection(tmp_path: Path) -> None:
     assert projection.include_tool_calls is False
 
 
-def test_run_messages_json_is_single_finite_document(tmp_path: Path) -> None:
+def test_run_messages_json_is_single_finite_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """`read --view messages --format json` emits one finite JSON value (#1818)."""
     env = _env()
     api = _FakeApi(
         messages_result=(
             [
-                {"id": "m1", "role": "user", "message_type": "message", "text": "first"},
+                # Rich-markup-like text must survive byte-for-byte: machine output
+                # goes through raw click.echo, not the markup-interpreting console.
+                {"id": "m1", "role": "user", "message_type": "message", "text": "[bold]first[/bold]"},
                 {"id": "m2", "role": "assistant", "message_type": "message", "text": "second"},
             ],
             2,
@@ -151,22 +155,22 @@ def test_run_messages_json_is_single_finite_document(tmp_path: Path) -> None:
     with patch("polylogue.api.Polylogue.open", return_value=api):
         run_messages(env, _request(tmp_path), session_id="conv-1", output_format="json")
 
-    # Exactly one print, and it parses as a single finite JSON value.
-    assert _ui_print(env).call_count == 1
-    raw = _ui_print(env).call_args.args[0]
-    payload = json.loads(raw)  # single json.loads must succeed (finite)
+    # Output is a single finite JSON value on stdout (one json.loads succeeds).
+    payload = json.loads(capsys.readouterr().out)
     assert payload["session_id"] == "conv-1"
-    assert [m["text"] for m in payload["messages"]] == ["first", "second"]
+    assert [m["text"] for m in payload["messages"]] == ["[bold]first[/bold]", "second"]
     assert payload["total"] == 2
 
 
-def test_run_messages_ndjson_emits_one_json_document_per_line(tmp_path: Path) -> None:
+def test_run_messages_ndjson_emits_one_json_document_per_line(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """`--format ndjson` streams one parseable JSON document per message (#1818)."""
     env = _env()
     api = _FakeApi(
         messages_result=(
             [
-                {"id": "m1", "role": "user", "message_type": "message", "text": "first"},
+                {"id": "m1", "role": "user", "message_type": "message", "text": "[bold]first[/bold]"},
                 {"id": "m2", "role": "assistant", "message_type": "message", "text": "second"},
             ],
             2,
@@ -176,10 +180,11 @@ def test_run_messages_ndjson_emits_one_json_document_per_line(tmp_path: Path) ->
     with patch("polylogue.api.Polylogue.open", return_value=api):
         run_messages(env, _request(tmp_path), session_id="conv-1", output_format="ndjson")
 
-    lines = [call.args[0] for call in _ui_print(env).call_args_list]
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
     assert len(lines) == 2
     docs = [json.loads(line) for line in lines]  # each line parses independently
-    assert [d["text"] for d in docs] == ["first", "second"]
+    # Rich markup in text survives byte-for-byte (raw click.echo, no console markup).
+    assert [d["text"] for d in docs] == ["[bold]first[/bold]", "second"]
     assert all(d["session_id"] == "conv-1" for d in docs)
 
 

--- a/tests/unit/cli/test_messages.py
+++ b/tests/unit/cli/test_messages.py
@@ -135,6 +135,54 @@ def test_run_messages_emits_json_and_passes_projection(tmp_path: Path) -> None:
     assert projection.include_tool_calls is False
 
 
+def test_run_messages_json_is_single_finite_document(tmp_path: Path) -> None:
+    """`read --view messages --format json` emits one finite JSON value (#1818)."""
+    env = _env()
+    api = _FakeApi(
+        messages_result=(
+            [
+                {"id": "m1", "role": "user", "message_type": "message", "text": "first"},
+                {"id": "m2", "role": "assistant", "message_type": "message", "text": "second"},
+            ],
+            2,
+        )
+    )
+
+    with patch("polylogue.api.Polylogue.open", return_value=api):
+        run_messages(env, _request(tmp_path), session_id="conv-1", output_format="json")
+
+    # Exactly one print, and it parses as a single finite JSON value.
+    assert _ui_print(env).call_count == 1
+    raw = _ui_print(env).call_args.args[0]
+    payload = json.loads(raw)  # single json.loads must succeed (finite)
+    assert payload["session_id"] == "conv-1"
+    assert [m["text"] for m in payload["messages"]] == ["first", "second"]
+    assert payload["total"] == 2
+
+
+def test_run_messages_ndjson_emits_one_json_document_per_line(tmp_path: Path) -> None:
+    """`--format ndjson` streams one parseable JSON document per message (#1818)."""
+    env = _env()
+    api = _FakeApi(
+        messages_result=(
+            [
+                {"id": "m1", "role": "user", "message_type": "message", "text": "first"},
+                {"id": "m2", "role": "assistant", "message_type": "message", "text": "second"},
+            ],
+            2,
+        )
+    )
+
+    with patch("polylogue.api.Polylogue.open", return_value=api):
+        run_messages(env, _request(tmp_path), session_id="conv-1", output_format="ndjson")
+
+    lines = [call.args[0] for call in _ui_print(env).call_args_list]
+    assert len(lines) == 2
+    docs = [json.loads(line) for line in lines]  # each line parses independently
+    assert [d["text"] for d in docs] == ["first", "second"]
+    assert all(d["session_id"] == "conv-1" for d in docs)
+
+
 def test_run_messages_markdown_and_not_found_paths(tmp_path: Path) -> None:
     env = _env()
     api = _FakeApi(messages_result=([{"role": "assistant", "message_type": "message", "text": "x" * 501}], 1))


### PR DESCRIPTION
## Summary
`read --view messages --format ndjson` emitted human markdown lines instead of JSON; it now emits one self-contained JSON document per line, matching the repo-wide ndjson contract (#1818 finiteness).

## Problem
#1818 requires `--format json` → a single finite JSON value; `--format ndjson` → one JSON document per line. Investigating the reported "messages --format json emits N documents" violation: it did **not** reproduce — the json path (`cli/messages.py:run_messages`) already emits one finite envelope `{session_id, messages:[...], total, limit, offset}` parseable by a single `json.loads`. But the **ndjson** side of the same view was broken: it fell through to the `else:` markdown branch (`[role type] text` lines), not JSON at all, contradicting the format help and `query_output.py`'s ndjson definition.

## Solution
`cli/messages.py`: added an explicit `elif fmt == "ndjson":` branch emitting one JSON document per message (each line self-contained with `session_id`), factoring the per-message dict into `_message_document()` shared by the json and ndjson branches. The finite-json envelope is unchanged; non-JSON formats untouched.

## Verification
```
devtools test tests/unit/cli/test_messages.py   # 5 passed (2 new)
devtools verify --quick   # exit 0 (ruff/mypy/render-all --check)
```
New tests pin both halves of the contract: json parses as one finite document; ndjson yields N independently-parseable lines.

Ref #1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format ndjson` option for streaming one JSON object per message line with session identifiers included.

* **Bug Fixes**
  * JSON output format now emits raw JSON directly to stdout for improved output handling.

* **Tests**
  * Enhanced test coverage for JSON and NDJSON output formats with stdout capture assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->