### PR TITLE
refactor(mcp): converge MCP error payload to canonical {status,message,code} (#1818)

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -91,7 +91,11 @@ class MCPRootPayload(RootModel[TRoot], Generic[TRoot]):
 
 
 class MCPErrorPayload(SurfacePayloadModel):
-    error: str
+    # Canonical machine-error envelope core (#1818): ``status``/``code``/
+    # ``message``/``detail`` match the CLI ``MachineError`` and daemon error
+    # shapes. MCP-specific fields below are additive optional keys.
+    status: Literal["error"] = "error"
+    message: str
     code: int | str | None = None
     detail: str | None = None
     tool: str | None = None

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -157,7 +157,9 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
         except Exception as exc:
             return hooks.json_payload(
-                MCPErrorPayload(error="internal MCP resource error", code="internal_error", detail=type(exc).__name__),
+                MCPErrorPayload(
+                    message="internal MCP resource error", code="internal_error", detail=type(exc).__name__
+                ),
                 exclude_none=True,
             )
 

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -120,7 +120,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
     """
     if isinstance(exc, SchemaVersionMismatchError):
         payload = MCPErrorPayload(
-            error=str(exc),
+            message=str(exc),
             code="schema_version_mismatch",
             detail=type(exc).__name__,
             tool=fn_name,
@@ -132,7 +132,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         # vocabulary status enum + fixed command names — so forward it
         # verbatim instead of redacting to the class name (#1503 AC4).
         payload = MCPErrorPayload(
-            error=str(exc),
+            message=str(exc),
             code="embedding_retrieval_not_ready",
             detail=type(exc).__name__,
             tool=fn_name,
@@ -140,14 +140,14 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         )
     elif isinstance(exc, PolylogueError):
         payload = MCPErrorPayload(
-            error=f"{fn_name}: {type(exc).__name__}",
+            message=f"{fn_name}: {type(exc).__name__}",
             code="polylogue_error",
             detail=type(exc).__name__,
             tool=fn_name,
         )
     else:
         payload = MCPErrorPayload(
-            error=f"{fn_name}: internal error ({type(exc).__name__})",
+            message=f"{fn_name}: internal error ({type(exc).__name__})",
             code="internal_error",
             detail=type(exc).__name__,
             tool=fn_name,
@@ -208,7 +208,7 @@ async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -
 def _error_json(message: str, **extra: object) -> str:
     """Return a JSON-encoded error dict."""
     code = extra.pop("code", None)
-    return _json_payload(MCPErrorPayload(error=message, code=code, **extra), exclude_none=True)  # type: ignore[arg-type]
+    return _json_payload(MCPErrorPayload(message=message, code=code, **extra), exclude_none=True)  # type: ignore[arg-type]
 
 
 def _set_runtime_services(services: RuntimeServices | None) -> None:

--- a/tests/unit/mcp/test_aggregate_sessions.py
+++ b/tests/unit/mcp/test_aggregate_sessions.py
@@ -206,8 +206,8 @@ async def test_aggregate_with_invalid_group_by_returns_error(
         )
 
     payload = json.loads(raw)
-    assert "error" in payload
-    assert "invalid_key" in payload["error"]
+    assert "message" in payload
+    assert "invalid_key" in payload["message"]
 
 
 # ── Empty archive ────────────────────────────────────────────────────

--- a/tests/unit/mcp/test_blackboard_tools.py
+++ b/tests/unit/mcp/test_blackboard_tools.py
@@ -97,4 +97,4 @@ def test_blackboard_post_reports_invalid_kind_as_error(mcp_server: MCPServerUnde
 
     parsed = json.loads(result)
     assert parsed["is_error"] is True
-    assert "kind must be one of" in parsed["error"]
+    assert "kind must be one of" in parsed["message"]

--- a/tests/unit/mcp/test_contract_evidence.py
+++ b/tests/unit/mcp/test_contract_evidence.py
@@ -55,8 +55,9 @@ pytestmark = pytest.mark.contract
 def _structured_error(payload: str) -> dict[str, Any]:
     body = json.loads(payload)
     assert isinstance(body, dict), f"error payload is not a JSON object: {payload!r}"
+    assert body.get("status") == "error", f"missing/wrong 'status': {body}"
     assert body.get("is_error") is True, f"missing or false 'is_error': {body}"
-    assert isinstance(body.get("error"), str) and body["error"], f"missing/empty 'error': {body}"
+    assert isinstance(body.get("message"), str) and body["message"], f"missing/empty 'message': {body}"
     return body
 
 
@@ -137,7 +138,7 @@ class TestToolErrorEnvelopes:
     ) -> None:
         result = invoke_surface(mcp_server._tool_manager._tools["neighbor_candidates"].fn)
         body = _structured_error(result)
-        assert "requires id or query" in body["error"], f"unexpected error message: {body}"
+        assert "requires id or query" in body["message"], f"unexpected error message: {body}"
 
     def test_get_session_missing_returns_not_found_envelope(
         self,
@@ -343,7 +344,7 @@ class TestToolErrorEnvelopes:
             tags=["x"],
         )
         body = _structured_error(result)
-        assert "at least one session_id" in body["error"], body
+        assert "at least one session_id" in body["message"], body
 
     def test_safe_call_sanitises_exception_into_typed_payload(
         self,

--- a/tests/unit/mcp/test_correlate_session.py
+++ b/tests/unit/mcp/test_correlate_session.py
@@ -64,7 +64,7 @@ async def test_correlate_session_not_found(mcp_server: MCPServerUnderTest) -> No
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_embedding_retrieval_not_ready.py
+++ b/tests/unit/mcp/test_embedding_retrieval_not_ready.py
@@ -53,8 +53,8 @@ def test_mcp_error_json_carries_actionable_message_verbatim() -> None:
     assert payload["detail"] == "EmbeddingRetrievalNotReadyError"
     assert payload["tool"] == "search"
     assert payload["readiness_status"] == "none"
-    assert "polylogue embed status" in payload["error"]
-    assert "polylogue embed backfill" in payload["error"]
+    assert "polylogue embed status" in payload["message"]
+    assert "polylogue embed backfill" in payload["message"]
 
 
 def test_mcp_error_json_distinct_from_generic_polylogue_error() -> None:
@@ -63,9 +63,9 @@ def test_mcp_error_json_distinct_from_generic_polylogue_error() -> None:
     generic = DatabaseError("opaque internal SQL error mentioning a path")
     payload = json.loads(_exception_to_error_json("search", generic))
     assert payload["code"] == "polylogue_error"
-    assert payload["error"] == "search: DatabaseError"
+    assert payload["message"] == "search: DatabaseError"
     # The raw message is intentionally not echoed.
-    assert "opaque internal SQL error" not in payload["error"]
+    assert "opaque internal SQL error" not in payload["message"]
 
 
 def test_mcp_error_json_includes_readiness_status_for_other_states() -> None:

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -342,9 +342,11 @@ def read_server() -> MCPServerUnderTest:
 
 
 def _assert_structured_error(payload: str, *, expected_code: str | None = None) -> None:
-    """Assert payload is a structured MCPErrorPayload with is_error and code."""
+    """Assert payload is a structured MCPErrorPayload with the canonical
+    ``status``/``message`` core (#1818) plus the MCP ``is_error`` flag and code."""
     body = json.loads(payload)
-    assert "error" in body, f"missing 'error' field: {body}"
+    assert body.get("status") == "error", f"missing/wrong 'status': {body}"
+    assert "message" in body, f"missing 'message' field: {body}"
     assert body.get("is_error") is True, f"missing or false 'is_error': {body}"
     if expected_code is not None:
         assert body.get("code") == expected_code, f"expected code={expected_code}, got {body.get('code')}"

--- a/tests/unit/mcp/test_mcp_edge_cases.py
+++ b/tests/unit/mcp/test_mcp_edge_cases.py
@@ -74,8 +74,8 @@ class TestSafeCall:
         assert body["code"] == "internal_error"
         assert body["tool"] == "test_tool"
         assert body["detail"] == "RuntimeError"
-        assert "internal error" in body["error"]
-        assert "RuntimeError" in body["error"]
+        assert "internal error" in body["message"]
+        assert "RuntimeError" in body["message"]
 
     def test_traceback_not_in_output(self) -> None:
         def failing() -> str:

--- a/tests/unit/mcp/test_per_tool_contracts.py
+++ b/tests/unit/mcp/test_per_tool_contracts.py
@@ -419,7 +419,7 @@ class TestMutationToolArgumentContracts:
             return
         body = json.loads(result)
         assert body.get("is_error") is True, f"{tool_name}: missing is_error in {body}"
-        assert "error" in body, f"{tool_name}: missing error in {body}"
+        assert "message" in body, f"{tool_name}: missing error in {body}"
 
 
 # ---------------------------------------------------------------------------
@@ -595,7 +595,7 @@ class TestMutationToolIdempotency:
         # Without confirm.
         unconfirmed = json.loads(invoke_surface(fn, session_id=_CONV_ID))
         assert unconfirmed.get("is_error") is True
-        assert "error" in unconfirmed
+        assert "message" in unconfirmed
 
         # With confirm.
         confirmed = json.loads(invoke_surface(fn, session_id=_CONV_ID, confirm=True))

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -394,7 +394,7 @@ class TestResourceSurfaces:
             )
 
         result_dict = json.loads(result)
-        assert "error" in result_dict
+        assert "message" in result_dict
 
     def test_messages_resource_reads_archive_file_set(
         self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
@@ -969,8 +969,8 @@ class TestExportSessionTool:
             result = invoke_surface(mcp_server._tool_manager._tools["export_session"].fn, id="nonexistent")
 
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "not found" in parsed["error"].lower()
+        assert "message" in parsed
+        assert "not found" in parsed["message"].lower()
 
     def test_export_invalid_format_falls_back_to_markdown(
         self: object,

--- a/tests/unit/mcp/test_session_analysis_primitives.py
+++ b/tests/unit/mcp/test_session_analysis_primitives.py
@@ -120,7 +120,7 @@ async def test_compare_sessions_rejects_single_id(mcp_server: MCPServerUnderTest
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "not_found" in payload
+    assert "message" in payload or "not_found" in payload
     assert payload.get("total_found", 1) <= 1
 
 
@@ -136,7 +136,7 @@ async def test_compare_sessions_rejects_empty_input(mcp_server: MCPServerUnderTe
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
 
 
 @pytest.mark.asyncio
@@ -152,7 +152,7 @@ async def test_compare_sessions_rejects_too_many_ids(mcp_server: MCPServerUnderT
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
     assert "Too many" in str(payload)
 
 
@@ -279,7 +279,7 @@ async def test_find_similar_sessions_handles_not_found(
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
 
 
 @pytest.mark.asyncio
@@ -298,7 +298,7 @@ async def test_find_similar_sessions_rejects_invalid_dimension(
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_session_tool_timing.py
+++ b/tests/unit/mcp/test_session_tool_timing.py
@@ -93,7 +93,7 @@ async def test_session_tool_timing_not_found(
         )
 
     payload = json.loads(raw)
-    assert "error" in payload or "code" in payload
+    assert "message" in payload or "code" in payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_tag_idempotency.py
+++ b/tests/unit/mcp/test_tag_idempotency.py
@@ -79,8 +79,8 @@ class TestTagIdempotencyOutcomes:
             )
 
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "not found" in parsed["error"].lower()
+        assert "message" in parsed
+        assert "not found" in parsed["message"].lower()
 
     # ── remove_tag ───────────────────────────────────────────────────
 
@@ -132,8 +132,8 @@ class TestTagIdempotencyOutcomes:
             )
 
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "not found" in parsed["error"].lower()
+        assert "message" in parsed
+        assert "not found" in parsed["message"].lower()
 
 
 class TestBulkTagExcludesOutcome:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -464,7 +464,7 @@ class TestQueryTools:
         assert body["is_error"] is True
         assert body["tool"] == "search"
         assert body["code"] == "internal_error"
-        assert "internal error" in body["error"]
+        assert "internal error" in body["message"]
         mock_poly.search_session_hits.assert_not_called()
         mock_poly.query_sessions.assert_not_called()
 
@@ -748,8 +748,8 @@ class TestGetSessionTool:
             result = invoke_surface(mcp_server._tool_manager._tools["get_session"].fn, id="nonexistent")
 
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "not found" in parsed["error"].lower()
+        assert "message" in parsed
+        assert "not found" in parsed["message"].lower()
 
     def test_get_messages_returns_full_messages(self, tmp_path: Path, mcp_server: MCPServerUnderTest) -> None:
         long_text = "A" * 2000
@@ -1268,7 +1268,7 @@ class TestMutationTools:
             tags=["review"],
         )
 
-        assert "requires at least one session_id" in json.loads(result)["error"]
+        assert "requires at least one session_id" in json.loads(result)["message"]
 
     def test_list_tags_returns_counts(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
@@ -1351,7 +1351,7 @@ class TestMutationTools:
         )
         parsed = json.loads(result)
         assert parsed["is_error"] is True
-        assert "empty" in parsed["error"].lower()
+        assert "empty" in parsed["message"].lower()
 
     def test_set_metadata_rejects_whitespace_key(self, mcp_server: MCPServerUnderTest) -> None:
         """Whitespace-only metadata key returns structured error."""
@@ -1363,7 +1363,7 @@ class TestMutationTools:
         )
         parsed = json.loads(result)
         assert parsed["is_error"] is True
-        assert "empty" in parsed["error"].lower()
+        assert "empty" in parsed["message"].lower()
 
     def test_set_metadata_rejects_overlong_key(self, mcp_server: MCPServerUnderTest) -> None:
         """Metadata key exceeding 200 characters returns structured error."""
@@ -1375,7 +1375,7 @@ class TestMutationTools:
         )
         parsed = json.loads(result)
         assert parsed["is_error"] is True
-        assert "200" in parsed["error"]
+        assert "200" in parsed["message"]
 
     def test_delete_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         from polylogue.surfaces.payloads import MetadataMutationResult
@@ -1410,7 +1410,7 @@ class TestMutationTools:
             )
 
         parsed = json.loads(result)
-        assert "confirm=true" in parsed["error"]
+        assert "confirm=true" in parsed["message"]
         mock_poly.delete_session.assert_not_called()
 
     def test_delete_with_confirm(self, mcp_server: MCPServerUnderTest) -> None:
@@ -1484,7 +1484,7 @@ class TestMutationTools:
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_session_summary"].fn, id="nonexistent")
 
-        assert "not found" in json.loads(result)["error"].lower()
+        assert "not found" in json.loads(result)["message"].lower()
 
     def test_session_tree_returns_envelope(self, simple_session: Session, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -131,7 +131,7 @@ def test_tool_returns_valid_response_envelope(tool_name: str, kwargs: dict[str, 
     # the stdio loop). We only fail when the response is not valid JSON.
     if body.get("is_error") is True:
         # Must have at least an error message.
-        assert body.get("error") is not None, f"{tool_name}: error response missing error string"
+        assert body.get("message") is not None, f"{tool_name}: error response missing error string"
         # internal_error (with or without explicit code) is acceptable —
         # it means the safety net caught a tool-body exception.
         # Other structured errors (schema_version_mismatch, not_found) are also fine.

--- a/tests/unit/mcp/test_tool_error_isolation.py
+++ b/tests/unit/mcp/test_tool_error_isolation.py
@@ -53,7 +53,7 @@ class TestSchemaVersionMismatchSurface:
         assert body["current_version"] == 16
         assert body["expected_version"] == 9
         assert body["detail"] == "SchemaVersionMismatchError"
-        assert "schema version 16" in cast(str, body["error"])
+        assert "schema version 16" in cast(str, body["message"])
 
     @pytest.mark.asyncio
     async def test_async_safe_call_returns_schema_version_mismatch_payload(self) -> None:
@@ -84,8 +84,8 @@ class TestTopLevelIsolation:
         assert body["detail"] == "RuntimeError"
         # The exception class name MUST appear so the operator can see
         # what failed; the raw message MUST NOT.
-        assert "RuntimeError" in cast(str, body["error"])
-        assert "oops" not in cast(str, body["error"])
+        assert "RuntimeError" in cast(str, body["message"])
+        assert "oops" not in cast(str, body["message"])
 
     @pytest.mark.asyncio
     async def test_async_safe_call_swallows_arbitrary_exception(self) -> None:
@@ -96,7 +96,7 @@ class TestTopLevelIsolation:
         assert body["code"] == "internal_error"
         assert body["tool"] == "list_sessions"
         assert body["detail"] == "ValueError"
-        assert "inner failure" not in cast(str, body["error"])
+        assert "inner failure" not in cast(str, body["message"])
 
     @pytest.mark.asyncio
     async def test_async_safe_call_does_not_reraise(self) -> None:

--- a/tests/unit/mcp/test_user_state_tools.py
+++ b/tests/unit/mcp/test_user_state_tools.py
@@ -80,7 +80,7 @@ def test_add_mark_rejects_unknown_type(mcp_server: MCPServerUnderTest) -> None:
 
     parsed = json.loads(result)
     assert parsed["is_error"] is True
-    assert "star, pin, archive" in parsed["error"]
+    assert "star, pin, archive" in parsed["message"]
 
 
 def test_remove_mark_reports_missing_mark(mcp_server: MCPServerUnderTest) -> None:
@@ -116,7 +116,7 @@ def test_remove_mark_rejects_unknown_type(mcp_server: MCPServerUnderTest) -> Non
 
     parsed = json.loads(result)
     assert parsed["is_error"] is True
-    assert "star, pin, archive" in parsed["error"]
+    assert "star, pin, archive" in parsed["message"]
 
 
 def test_add_mark_accepts_message_target(mcp_server: MCPServerUnderTest) -> None:
@@ -281,7 +281,7 @@ def test_save_saved_view_rejects_unknown_query_param(mcp_server: MCPServerUnderT
 
     parsed = json.loads(result)
     assert parsed["is_error"] is True
-    assert "SessionQuerySpec" in parsed["error"]
+    assert "SessionQuerySpec" in parsed["message"]
     assert "not_a_filter" in parsed["detail"]
 
 


### PR DESCRIPTION
## Summary
Aligns `MCPErrorPayload` to the canonical machine-error envelope (`{status:"error", message, code, detail?}`, matching the CLI `MachineError` shape), part of #1818's single machine-output contract.

## Problem
Three surfaces diverged: CLI `{status,code,message}`, daemon `{ok,error,detail}`, MCP `{error,code,detail,is_error}`. The MCP error core (`error` field, no `status`) was the outlier on the read/tool surface.

## Solution
`mcp/payloads.py`: `MCPErrorPayload` now emits `status:"error"` and `message` (was `error`), keeping MCP-specific fields (`tool`, `session_id`, schema-version fields, `is_error`) as additive optional keys. All 6 emitters updated (`server_support.py` ×5 incl. the shared `_error_json` used by ~70 tool call sites, `server_resources.py` ×1). 16 `tests/unit/mcp/` files updated to the new shape; the two structured-error contract helpers now also pin `status == "error"`.

## Verification
```
devtools test <16 affected mcp test files>   # 478 passed
devtools verify --quick   # exit 0 (ruff/mypy/render-all --check)
```
No witness/gate fixture needed regen (none pins the error payload shape). No cross-surface (cli/daemon) edits required.

Ref #1818