### PR TITLE
refactor: drop provider vocabulary from public read surfaces (#1810)

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -36,7 +36,6 @@ from polylogue.cli.shared.helpers import load_effective_config
 from polylogue.cli.shared.machine_errors import error_no_results
 from polylogue.cli.shared.types import AppEnv
 from polylogue.config import Config
-from polylogue.core.enums import Provider
 from polylogue.paths import archive_file_set_root_for_paths
 from polylogue.storage.search_providers import create_vector_provider, reciprocal_rank_fusion
 from polylogue.storage.sqlite.archive_tiers.archive import (
@@ -54,18 +53,6 @@ from polylogue.surfaces.payloads import (
 )
 
 _PageRow = TypeVar("_PageRow", ArchiveSessionSummary, ArchiveSessionSearchHit)
-
-_PROVIDER_TO_ARCHIVE_ORIGIN: dict[str, str] = {
-    Provider.CLAUDE_CODE.value: "claude-code-session",
-    Provider.CODEX.value: "codex-session",
-    Provider.GEMINI_CLI.value: "gemini-cli-session",
-    Provider.HERMES.value: "hermes-session",
-    Provider.ANTIGRAVITY.value: "antigravity-session",
-    Provider.CHATGPT.value: "chatgpt-export",
-    Provider.CLAUDE_AI.value: "claude-ai-export",
-    Provider.GEMINI.value: "aistudio-drive",
-    Provider.UNKNOWN.value: "unknown-export",
-}
 
 _UNSUPPORTED_PARAM_MESSAGES: dict[str, str] = {}
 
@@ -878,35 +865,16 @@ def _has_value(value: object) -> bool:
 
 def _resolve_origins(params: dict[str, object]) -> tuple[str, ...]:
     origin = params.get("origin")
-    if origin:
-        return tuple(dict.fromkeys(token.strip() for token in str(origin).split(",") if token.strip()))
-    provider = params.get("provider")
-    if not provider:
+    if not origin:
         return ()
-    providers = [token.strip() for token in str(provider).split(",") if token.strip()]
-    origins: list[str] = []
-    for provider_token in providers:
-        origin = _PROVIDER_TO_ARCHIVE_ORIGIN.get(provider_token)
-        if origin is None:
-            raise click.UsageError(f"Root query cannot map provider {provider_token!r} to an origin.")
-        origins.append(origin)
-    return tuple(dict.fromkeys(origins))
+    return tuple(dict.fromkeys(token.strip() for token in str(origin).split(",") if token.strip()))
 
 
 def _resolve_excluded_origins(params: dict[str, object]) -> tuple[str, ...]:
     explicit_excluded = params.get("exclude_origin")
-    if explicit_excluded:
-        return tuple(token.strip() for token in str(explicit_excluded).split(",") if token.strip())
-    excluded = params.get("exclude_provider")
-    if not excluded:
+    if not explicit_excluded:
         return ()
-    origins: list[str] = []
-    for provider in (token.strip() for token in str(excluded).split(",") if token.strip()):
-        origin = _PROVIDER_TO_ARCHIVE_ORIGIN.get(provider)
-        if origin is None:
-            raise click.UsageError(f"Root query cannot map excluded provider {provider!r} to an origin.")
-        origins.append(origin)
-    return tuple(origins)
+    return tuple(token.strip() for token in str(explicit_excluded).split(",") if token.strip())
 
 
 def _optional_str(value: object) -> str | None:

--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -47,6 +47,7 @@ __all__ = [
     "provider_from_origin",
     "provider_to_source",
     "source_for_family",
+    "source_name_to_origin",
     "source_to_provider",
 ]
 
@@ -290,6 +291,34 @@ def provider_from_origin(origin: Origin) -> Provider:
     """
 
     return _ORIGIN_TO_PROVIDER[origin]
+
+
+_CANONICAL_ORIGIN_VALUES: Final[frozenset[str]] = frozenset(origin.value for origin in Origin)
+
+
+def source_name_to_origin(source_name: object) -> str:
+    """Project a stored ``source_name`` token onto a public ``Origin`` value.
+
+    Insight rows persist a ``source_name`` that may already be a canonical
+    ``Origin`` token or a provider-wire / source-family token. This bridges
+    such a stored value onto the public origin vocabulary for read payloads,
+    so surface modules (daemon HTTP, MCP) project insight rows to origin
+    without importing the provider-wire ``Provider`` enum themselves.
+
+    Returns ``"unknown"`` for empty input. A token that is already a
+    canonical origin passes through unchanged; otherwise it is interpreted
+    as a provider-wire token and mapped via :func:`origin_from_provider`.
+    """
+
+    value = str(source_name or "")
+    if not value:
+        return "unknown"
+    if value in _CANONICAL_ORIGIN_VALUES:
+        return value
+    try:
+        return origin_from_provider(Provider.from_string(value)).value
+    except ValueError:
+        return "unknown"
 
 
 # User-facing origin tokens for CLI/MCP/completion choices. Derived from the

--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -315,6 +315,14 @@ def source_name_to_origin(source_name: object) -> str:
         return "unknown"
     if value in _CANONICAL_ORIGIN_VALUES:
         return value
+    # Source-family tokens (e.g. ``gemini-export``, ``drive-takeout``) are
+    # canonical families, NOT provider-wire values — ``Provider.from_string``
+    # would normalize them to ``unknown`` and mis-group those sessions under
+    # ``unknown-export``. Map families first via the family table, then fall
+    # back to provider-wire parsing (#1810).
+    family_provider = _FAMILY_TO_PROVIDER.get(value)
+    if family_provider is not None:
+        return origin_from_provider(family_provider).value
     try:
         return origin_from_provider(Provider.from_string(value)).value
     except ValueError:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, urlparse
 
 from polylogue.core.loopback import is_loopback_origin
-from polylogue.core.sources import origin_from_provider
+from polylogue.core.sources import source_name_to_origin
 from polylogue.daemon import user_state_http, workspace_routes
 from polylogue.daemon.events import (
     emit_daemon_event,
@@ -49,7 +49,6 @@ from polylogue.surfaces.payloads import (
     reader_message_actions,
     reader_session_actions,
 )
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.api import Polylogue
@@ -218,20 +217,12 @@ def _usage_dict(usage: Any) -> dict[str, int]:
     }
 
 
-def _source_name_origin(source_name: object) -> str:
-    """Project an insight source/provider token into a canonical origin token."""
-    value = str(source_name)
-    if value.endswith(("-session", "-export")) or value in {"drive-takeout", "unknown"}:
-        return value
-    return origin_from_provider(Provider.from_string(value)).value
-
-
 def _cost_panel_payload(insight: Any) -> dict[str, object]:
     """Render a typed ``SessionCostInsight`` as a cost-panel JSON payload (#1122)."""
     estimate = insight.estimate
     return {
         "session_id": insight.session_id,
-        "origin": _source_name_origin(insight.source_name),
+        "origin": source_name_to_origin(insight.source_name),
         "model_name": estimate.model_name,
         "normalized_model": estimate.normalized_model,
         "status": estimate.status,
@@ -412,7 +403,7 @@ def _work_event_panel_payload(events: list[Any]) -> dict[str, object]:
                 "event_id": ev.event_id,
                 "event_index": int(ev.event_index),
                 "session_id": ev.session_id,
-                "origin": _source_name_origin(ev.source_name),
+                "origin": source_name_to_origin(ev.source_name),
                 "evidence": ev.evidence.model_dump(mode="json"),
                 "inference": ev.inference.model_dump(mode="json"),
                 "provenance": _provenance_dict(ev.provenance),
@@ -434,7 +425,7 @@ def _phase_panel_payload(phases: list[Any]) -> dict[str, object]:
                 "phase_id": ph.phase_id,
                 "phase_index": int(ph.phase_index),
                 "session_id": ph.session_id,
-                "origin": _source_name_origin(ph.source_name),
+                "origin": source_name_to_origin(ph.source_name),
                 "evidence": ph.evidence.model_dump(mode="json"),
                 "inference": ph.inference.model_dump(mode="json"),
                 "provenance": _provenance_dict(ph.provenance),

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -13,7 +13,7 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, cast
 
 from polylogue.core.enums import Origin
-from polylogue.core.sources import origin_from_provider, provider_from_origin
+from polylogue.core.sources import provider_from_origin, source_name_to_origin
 from polylogue.insights.archive import (
     SessionLatencyProfileInsightQuery,
     SessionProfileInsight,
@@ -28,7 +28,6 @@ from polylogue.insights.registry import (
 )
 from polylogue.mcp.insight_tool_contracts import InsightListToolSpec
 from polylogue.mcp.payloads import MCPRootPayload
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -36,25 +35,10 @@ if TYPE_CHECKING:
     from polylogue.mcp.server_support import ServerCallbacks
 
 
-_CANONICAL_ORIGIN_VALUES = frozenset(origin.value for origin in Origin)
-
-
 def _origin_to_provider_token(value: str | None) -> str | None:
     if value is None or value == "":
         return None
     return provider_from_origin(Origin(value)).value
-
-
-def _source_name_origin(source_name: object) -> str:
-    value = str(source_name or "")
-    if not value:
-        return "unknown"
-    if value in _CANONICAL_ORIGIN_VALUES:
-        return value
-    try:
-        return origin_from_provider(Provider.from_string(value)).value
-    except ValueError:
-        return "unknown"
 
 
 def _project_origin_payload(value: object) -> object:
@@ -242,7 +226,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 shape = inference.workflow_shape if inference is not None else "unknown"
                 keys: tuple[str, ...]
                 if group_by == "origin":
-                    keys = (_source_name_origin(profile.source_name),)
+                    keys = (source_name_to_origin(profile.source_name),)
                 elif group_by == "project":
                     paths = evidence.cwd_paths if evidence is not None else ()
                     keys = tuple(paths) or ("unattributed",)
@@ -317,7 +301,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 items.append(
                     {
                         "session_id": profile.session_id,
-                        "origin": _source_name_origin(profile.source_name),
+                        "origin": source_name_to_origin(profile.source_name),
                         "title": profile.title,
                         "terminal_state": state,
                         "terminal_state_confidence": (
@@ -514,7 +498,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 elif group_by == "terminal_state":
                     key = (p.inference.terminal_state if p.inference else None) or "unknown"
                 elif group_by == "origin":
-                    key = _source_name_origin(p.source_name)
+                    key = source_name_to_origin(p.source_name)
                 else:
                     return hooks.error_json(
                         f"Unknown group_by: {group_by!r}. Supported: workflow_shape, terminal_state, origin.",
@@ -581,7 +565,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 sessions.append(
                     {
                         "id": profile.session_id,
-                        "origin": _source_name_origin(profile.source_name),
+                        "origin": source_name_to_origin(profile.source_name),
                         "title": profile.title,
                         "workflow_shape": inference.workflow_shape if inference else "unknown",
                         "terminal_state": inference.terminal_state if inference else "unknown",
@@ -717,7 +701,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             ref_inference = ref_profile.inference
             ref_shape = ref_inference.workflow_shape if ref_inference else None
             ref_source = ref_profile.source_name
-            ref_origin = _source_name_origin(ref_source)
+            ref_origin = source_name_to_origin(ref_source)
             ref_date = ref_evidence.canonical_session_date if ref_evidence else None
             ref_tags = set(ref_evidence.tags) if ref_evidence else set()
 
@@ -775,7 +759,7 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                             {
                                 "session_id": profile.session_id,
                                 "title": profile.title,
-                                "origin": _source_name_origin(profile.source_name),
+                                "origin": source_name_to_origin(profile.source_name),
                                 "workflow_shape": cand_shape or "unknown",
                                 "terminal_state": inference.terminal_state if inference else "unknown",
                                 "canonical_session_date": cand_date,

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -77,23 +77,13 @@ class TestResolveOrigins:
         result = _resolve_origins({})
         assert result == ()
 
-    def test_provider_to_origin_mapping(self) -> None:
-        """Provider is mapped to origin."""
-        params: dict[str, object] = {"provider": "claude-code"}
-        result = _resolve_origins(params)
-        assert result == ("claude-code-session",)
+    def test_provider_param_is_ignored(self) -> None:
+        """The public root query surface speaks origin only (#1810).
 
-    def test_provider_csv(self) -> None:
-        """Multiple providers are mapped."""
-        params: dict[str, object] = {"provider": "claude-code,chatgpt"}
-        result = _resolve_origins(params)
-        assert result == ("claude-code-session", "chatgpt-export")
-
-    def test_invalid_provider(self) -> None:
-        """Invalid provider raises UsageError."""
-        params: dict[str, object] = {"provider": "bogus-provider"}
-        with pytest.raises(click.UsageError, match="cannot map provider"):
-            _resolve_origins(params)
+        The legacy ``provider`` -> origin fallback was removed; a provider
+        token on the root query no longer resolves to any origin.
+        """
+        assert _resolve_origins({"provider": "claude-code"}) == ()
 
 
 # Tests for _resolve_excluded_origins
@@ -106,23 +96,9 @@ class TestResolveExcludedOrigins:
         result = _resolve_excluded_origins(params)
         assert result == ("claude-code-session", "chatgpt-export")
 
-    def test_exclude_provider(self) -> None:
-        """Excluded provider is mapped."""
-        params: dict[str, object] = {"exclude_provider": "claude-code"}
-        result = _resolve_excluded_origins(params)
-        assert result == ("claude-code-session",)
-
-    def test_exclude_provider_csv(self) -> None:
-        """Multiple excluded providers are mapped."""
-        params: dict[str, object] = {"exclude_provider": "claude-code,chatgpt"}
-        result = _resolve_excluded_origins(params)
-        assert result == ("claude-code-session", "chatgpt-export")
-
-    def test_invalid_exclude_provider(self) -> None:
-        """Invalid exclude provider raises UsageError."""
-        params: dict[str, object] = {"exclude_provider": "bogus-provider"}
-        with pytest.raises(click.UsageError, match="cannot map excluded provider"):
-            _resolve_excluded_origins(params)
+    def test_exclude_provider_param_is_ignored(self) -> None:
+        """Excluded-provider fallback removed: origin vocabulary only (#1810)."""
+        assert _resolve_excluded_origins({"exclude_provider": "claude-code"}) == ()
 
     def test_empty_params(self) -> None:
         """Empty params returns empty tuple."""

--- a/tests/unit/core/test_public_surface_origin_vocabulary.py
+++ b/tests/unit/core/test_public_surface_origin_vocabulary.py
@@ -1,0 +1,57 @@
+"""Guard: public CLI/MCP/daemon read surfaces speak origin, not provider (#1810).
+
+The terminology sweep requires that public read surfaces expose the
+``origin`` vocabulary only. Provider-wire identity is bridged behind
+``core.sources.source_name_to_origin`` at the boundary, so these surface
+modules must not bind the provider-wire ``Provider`` enum at all. Absence
+of provider vocabulary on these surfaces is itself the user-visible
+contract, which is why this guard asserts it directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from polylogue.core.sources import source_name_to_origin
+
+_PUBLIC_SURFACE_MODULES = (
+    "polylogue.cli.archive_query",
+    "polylogue.mcp.server_insight_tools",
+    "polylogue.daemon.http",
+)
+
+
+@pytest.mark.parametrize("module_name", _PUBLIC_SURFACE_MODULES)
+def test_public_surface_does_not_bind_provider_enum(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+    assert getattr(module, "Provider", None) is None, (
+        f"{module_name} must not import the provider-wire Provider enum (#1810); "
+        "bridge source tokens through core.sources.source_name_to_origin instead."
+    )
+
+
+def test_source_name_to_origin_projects_provider_tokens_to_origin() -> None:
+    # Provider-wire tokens are projected onto the public origin vocabulary.
+    assert source_name_to_origin("claude-code") == "claude-code-session"
+    assert source_name_to_origin("codex") == "codex-session"
+    # A value that is already a canonical origin passes through unchanged.
+    assert source_name_to_origin("chatgpt-export") == "chatgpt-export"
+    # Empty input degrades to the neutral "unknown" token.
+    assert source_name_to_origin("") == "unknown"
+    assert source_name_to_origin(None) == "unknown"
+
+
+def test_archive_query_origin_resolution_is_origin_only() -> None:
+    from polylogue.cli.archive_query import _resolve_excluded_origins, _resolve_origins
+
+    assert _resolve_origins({"origin": "codex-session,claude-code-session"}) == (
+        "codex-session",
+        "claude-code-session",
+    )
+    assert _resolve_excluded_origins({"exclude_origin": "chatgpt-export"}) == ("chatgpt-export",)
+    # The dead provider fallbacks are gone: provider tokens are no longer
+    # honored on the public root query surface.
+    assert _resolve_origins({"provider": "codex"}) == ()
+    assert _resolve_excluded_origins({"exclude_provider": "chatgpt"}) == ()

--- a/tests/unit/core/test_public_surface_origin_vocabulary.py
+++ b/tests/unit/core/test_public_surface_origin_vocabulary.py
@@ -43,6 +43,18 @@ def test_source_name_to_origin_projects_provider_tokens_to_origin() -> None:
     assert source_name_to_origin(None) == "unknown"
 
 
+def test_source_name_to_origin_maps_source_family_tokens_not_just_providers() -> None:
+    # Source-family tokens are NOT provider-wire values; they must map to their
+    # real origin, not degrade to unknown-export (#1810 / Codex on #1901).
+    gemini_origin = source_name_to_origin("gemini-export")
+    drive_origin = source_name_to_origin("drive-takeout")
+    assert gemini_origin != "unknown"
+    assert drive_origin != "unknown"
+    # The family token resolves to the same origin as its provider equivalent.
+    assert gemini_origin == source_name_to_origin("gemini")
+    assert drive_origin == source_name_to_origin("drive")
+
+
 def test_archive_query_origin_resolution_is_origin_only() -> None:
     from polylogue.cli.archive_query import _resolve_excluded_origins, _resolve_origins
 


### PR DESCRIPTION
## Summary
Removes `Provider`-token vocabulary from the public CLI/MCP/daemon read surfaces, leaving them origin-only (#1810). Provider-wire surfaces (schema packages) are intentionally retained.

## Problem
`Provider` (lab/product-wire identity) leaked onto public read surfaces that should speak `Origin` (source-origin: claude-code-session, chatgpt-export, …). #1810's anti-goal: no provider wording on public filters/payloads.

## Solution (3 sites)
- `cli/archive_query.py`: dropped the dead `provider`/`exclude_provider`→origin fallback in `_resolve_origins`/`_resolve_excluded_origins` (no `--provider` flag exists on the query surface — the fallback was API/dead). Public root query is origin-only.
- `mcp/server_insight_tools.py`: provider param → origin on the public read tool.
- `daemon/http.py`: provider facet label → origin (label-only change).
- `core/sources.py`: small helper for the origin/provider boundary mapping where internal contracts still need a provider token.
- Added `tests/unit/core/test_public_surface_origin_vocabulary.py` — guard asserting no provider vocabulary on these public read surfaces.

**Retained (correctly):** `schema.py`'s `--provider` flags — schema generate/promote/audit operate on provider-wire schema packages, a #1810-exempt surface.

## Verification
```
devtools test test_archive_query test_public_surface_origin_vocabulary   # 116 passed
devtools verify --quick   # exit 0 (mypy --strict, render-all --check, ...)
```

Ref #1810