### PR TITLE
feat(storage): unified assertions substrate table (#1883)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/user.py
+++ b/polylogue/storage/sqlite/archive_tiers/user.py
@@ -101,6 +101,36 @@ CREATE TABLE IF NOT EXISTS blackboard_notes (
     created_at_ms    INTEGER NOT NULL,
     updated_at_ms    INTEGER NOT NULL
 ) STRICT;
+
+-- Unified evidence-linked user assertion (#1883). One table collapses the
+-- user-tier overlay mini-systems (marks/annotations/corrections/tags/
+-- saved_views/recall_packs/workspaces/blackboard_notes). Additive in this
+-- slice: the legacy tables above remain authoritative; this is the new
+-- substrate they will write through in a later slice. ``kind`` carries a
+-- closed v0 vocabulary -- see ``AssertionKind`` in user_write.py.
+CREATE TABLE IF NOT EXISTS assertions (
+    assertion_id        TEXT PRIMARY KEY,
+    scope_ref           TEXT,
+    target_ref          TEXT NOT NULL,
+    key                 TEXT,
+    kind                TEXT NOT NULL,
+    value_json          TEXT,
+    body_text           TEXT,
+    author_ref          TEXT,
+    author_kind         TEXT,
+    evidence_refs_json  TEXT,
+    status              TEXT,
+    visibility          TEXT,
+    confidence          REAL,
+    staleness_json      TEXT,
+    context_policy_json TEXT,
+    supersedes_json     TEXT,
+    created_at_ms       INTEGER NOT NULL,
+    updated_at_ms       INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_assertions_target_kind
+ON assertions(target_ref, kind);
 """
 
 __all__ = ["USER_DDL", "USER_SCHEMA_VERSION"]

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -9,8 +9,40 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
+
+
+class AssertionKind(StrEnum):
+    """Closed v0 vocabulary for ``assertions.kind`` (#1883).
+
+    The unified assertions table collapses the legacy user-tier overlays; each
+    kind below corresponds to a meaning carried by one of those mini-systems or
+    by the agent-blackboard surface. The DDL stores ``kind`` as plain ``TEXT``
+    (no CHECK) so the vocabulary can grow without a schema bump; this enum is
+    the authoritative documentation and typing aid.
+    """
+
+    MARK = "mark"
+    HIGHLIGHT = "highlight"
+    ANNOTATION = "annotation"
+    CORRECTION = "correction"
+    SUPPRESSION = "suppression"
+    TAG = "tag"
+    METADATA = "metadata"
+    SAVED_QUERY = "saved_query"
+    RECALL_PACK = "recall_pack"
+    WORKSPACE_NOTE = "workspace_note"
+    NOTE = "note"
+    DECISION = "decision"
+    LESSON = "lesson"
+    BLOCKER = "blocker"
+    HANDOFF = "handoff"
+    RUN_STATE = "run_state"
+    PROMPT_EVAL = "prompt_eval"
+    TRANSFORM_CANDIDATE = "transform_candidate"
 
 
 def _now_ms() -> int:
@@ -33,6 +65,38 @@ def _json_dumps(payload: dict[str, object] | None) -> str:
     if payload is None:
         return "{}"
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _dumps_optional(value: object | None) -> str | None:
+    """Serialize an arbitrary JSON-able value, or ``None`` when value is ``None``."""
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _loads_optional(value: object | None) -> object | None:
+    """Parse a stored JSON column back to a Python value, tolerating malformed text."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed: object = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed
+
+
+def _loads_str_list(value: object | None) -> list[str]:
+    parsed = _loads_optional(value)
+    if isinstance(parsed, list):
+        return [str(item) for item in parsed]
+    return []
+
+
+def _loads_dict_optional(value: object | None) -> dict[str, object] | None:
+    parsed = _loads_optional(value)
+    if isinstance(parsed, dict):
+        return dict(parsed)
+    return None
 
 
 def _deterministic_id(prefix: str, *parts: str) -> str:
@@ -118,6 +182,28 @@ class ArchiveBlackboardNoteEnvelope:
     target_type: str | None
     target_id: str | None
     body: str
+    created_at_ms: int
+    updated_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveAssertionEnvelope:
+    assertion_id: str
+    scope_ref: str | None
+    target_ref: str
+    key: str | None
+    kind: str
+    value: object | None
+    body_text: str | None
+    author_ref: str | None
+    author_kind: str | None
+    evidence_refs: list[str]
+    status: str | None
+    visibility: str | None
+    confidence: float | None
+    staleness: dict[str, object] | None
+    context_policy: dict[str, object] | None
+    supersedes: list[str]
     created_at_ms: int
     updated_at_ms: int
 
@@ -551,8 +637,155 @@ def read_archive_blackboard_note_envelope(conn: sqlite3.Connection, note_id: str
     )
 
 
+def upsert_assertion(
+    conn: sqlite3.Connection,
+    *,
+    assertion_id: str,
+    target_ref: str,
+    kind: str,
+    scope_ref: str | None = None,
+    key: str | None = None,
+    value: object | None = None,
+    body_text: str | None = None,
+    author_ref: str | None = None,
+    author_kind: str | None = None,
+    evidence_refs: Sequence[str] | None = None,
+    status: str | None = None,
+    visibility: str | None = None,
+    confidence: float | None = None,
+    staleness: dict[str, object] | None = None,
+    context_policy: dict[str, object] | None = None,
+    supersedes: Sequence[str] | None = None,
+    now_ms: int | None = None,
+) -> ArchiveAssertionEnvelope:
+    """Insert-or-update one assertion row keyed by caller-supplied ``assertion_id``."""
+    conn.execute("PRAGMA foreign_keys = ON")
+    timestamp = now_ms if now_ms is not None else _now_ms()
+    existing = conn.execute(
+        "SELECT created_at_ms FROM assertions WHERE assertion_id = ?",
+        (assertion_id,),
+    ).fetchone()
+    created_at_ms = int(existing[0]) if existing is not None else timestamp
+
+    evidence_refs_json = _dumps_optional(list(evidence_refs)) if evidence_refs is not None else None
+    supersedes_json = _dumps_optional(list(supersedes)) if supersedes is not None else None
+
+    conn.execute(
+        """
+        INSERT INTO assertions (
+            assertion_id, scope_ref, target_ref, key, kind, value_json, body_text,
+            author_ref, author_kind, evidence_refs_json, status, visibility, confidence,
+            staleness_json, context_policy_json, supersedes_json, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(assertion_id) DO UPDATE SET
+            scope_ref = excluded.scope_ref,
+            target_ref = excluded.target_ref,
+            key = excluded.key,
+            kind = excluded.kind,
+            value_json = excluded.value_json,
+            body_text = excluded.body_text,
+            author_ref = excluded.author_ref,
+            author_kind = excluded.author_kind,
+            evidence_refs_json = excluded.evidence_refs_json,
+            status = excluded.status,
+            visibility = excluded.visibility,
+            confidence = excluded.confidence,
+            staleness_json = excluded.staleness_json,
+            context_policy_json = excluded.context_policy_json,
+            supersedes_json = excluded.supersedes_json,
+            updated_at_ms = excluded.updated_at_ms
+        """,
+        (
+            assertion_id,
+            scope_ref,
+            target_ref,
+            key,
+            kind,
+            _dumps_optional(value),
+            body_text,
+            author_ref,
+            author_kind,
+            evidence_refs_json,
+            status,
+            visibility,
+            confidence,
+            _dumps_optional(staleness),
+            _dumps_optional(context_policy),
+            supersedes_json,
+            created_at_ms,
+            timestamp,
+        ),
+    )
+    envelope = read_assertion_envelope(conn, assertion_id)
+    assert envelope is not None
+    return envelope
+
+
+def _assertion_row_to_envelope(row: sqlite3.Row) -> ArchiveAssertionEnvelope:
+    return ArchiveAssertionEnvelope(
+        assertion_id=str(row[0]),
+        scope_ref=str(row[1]) if row[1] is not None else None,
+        target_ref=str(row[2]),
+        key=str(row[3]) if row[3] is not None else None,
+        kind=str(row[4]),
+        value=_loads_optional(row[5]),
+        body_text=str(row[6]) if row[6] is not None else None,
+        author_ref=str(row[7]) if row[7] is not None else None,
+        author_kind=str(row[8]) if row[8] is not None else None,
+        evidence_refs=_loads_str_list(row[9]),
+        status=str(row[10]) if row[10] is not None else None,
+        visibility=str(row[11]) if row[11] is not None else None,
+        confidence=float(row[12]) if row[12] is not None else None,
+        staleness=_loads_dict_optional(row[13]),
+        context_policy=_loads_dict_optional(row[14]),
+        supersedes=_loads_str_list(row[15]),
+        created_at_ms=int(row[16]),
+        updated_at_ms=int(row[17]),
+    )
+
+
+_ASSERTION_COLUMNS = (
+    "assertion_id, scope_ref, target_ref, key, kind, value_json, body_text, "
+    "author_ref, author_kind, evidence_refs_json, status, visibility, confidence, "
+    "staleness_json, context_policy_json, supersedes_json, created_at_ms, updated_at_ms"
+)
+
+
+def read_assertion_envelope(conn: sqlite3.Connection, assertion_id: str) -> ArchiveAssertionEnvelope | None:
+    """Read one assertion by id, or ``None`` when absent."""
+    row = conn.execute(
+        f"SELECT {_ASSERTION_COLUMNS} FROM assertions WHERE assertion_id = ?",
+        (assertion_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _assertion_row_to_envelope(row)
+
+
+def list_assertions_for_target(
+    conn: sqlite3.Connection,
+    target_ref: str,
+    *,
+    kind: str | None = None,
+) -> list[ArchiveAssertionEnvelope]:
+    """List assertions for one ``target_ref``, optionally filtered by ``kind``."""
+    if kind is None:
+        rows = conn.execute(
+            f"SELECT {_ASSERTION_COLUMNS} FROM assertions WHERE target_ref = ? ORDER BY created_at_ms, assertion_id",
+            (target_ref,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT {_ASSERTION_COLUMNS} FROM assertions "
+            "WHERE target_ref = ? AND kind = ? ORDER BY created_at_ms, assertion_id",
+            (target_ref, kind),
+        ).fetchall()
+    return [_assertion_row_to_envelope(row) for row in rows]
+
+
 __all__ = [
     "ArchiveAnnotationEnvelope",
+    "ArchiveAssertionEnvelope",
     "ArchiveBlackboardNoteEnvelope",
     "ArchiveSuppressionEnvelope",
     "ArchiveMarkEnvelope",
@@ -560,6 +793,8 @@ __all__ = [
     "ArchiveRecallPackEnvelope",
     "ArchiveSavedViewEnvelope",
     "ArchiveWorkspaceEnvelope",
+    "AssertionKind",
+    "list_assertions_for_target",
     "read_archive_annotation_envelope",
     "read_archive_blackboard_note_envelope",
     "read_archive_correction_envelope",
@@ -568,7 +803,9 @@ __all__ = [
     "read_archive_saved_view_envelope",
     "read_archive_suppression_envelope",
     "read_archive_workspace_envelope",
+    "read_assertion_envelope",
     "upsert_annotation",
+    "upsert_assertion",
     "upsert_blackboard_note",
     "upsert_correction",
     "upsert_mark",

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    AssertionKind,
+    list_assertions_for_target,
+    read_assertion_envelope,
+    upsert_assertion,
+)
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    initialize_archive_tier(conn, ArchiveTier.USER)
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def test_fresh_user_tier_creates_assertions_table(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        assert _table_exists(conn, "assertions")
+        # The table is purely additive: the legacy overlays still exist.
+        assert _table_exists(conn, "marks")
+        assert _table_exists(conn, "blackboard_notes")
+    finally:
+        conn.close()
+
+
+def test_assertion_round_trip_across_kinds(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        upsert_assertion(
+            conn,
+            assertion_id="a-mark",
+            target_ref="session:session-1",
+            kind=AssertionKind.MARK,
+            body_text="star this",
+            author_ref="user:sinity",
+            author_kind="human",
+            now_ms=1_700_000_000_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="a-decision",
+            target_ref="github-issue:1883",
+            kind=AssertionKind.DECISION,
+            scope_ref="workspace:polylogue",
+            key="schema-policy",
+            value={"choice": "additive", "wipe": False},
+            body_text="user.db is irreplaceable; never bump version",
+            status="active",
+            visibility="team",
+            confidence=0.92,
+            staleness={"ttl_days": 30},
+            context_policy={"inject": "on_session_start"},
+            evidence_refs=["session:session-1", "message:m-7"],
+            now_ms=1_700_000_001_000,
+        )
+
+        read_mark = read_assertion_envelope(conn, "a-mark")
+        read_decision = read_assertion_envelope(conn, "a-decision")
+        assert read_mark is not None
+        assert read_decision is not None
+
+        assert read_mark.kind == "mark"
+        assert read_mark.target_ref == "session:session-1"
+        assert read_mark.body_text == "star this"
+        assert read_mark.author_kind == "human"
+        assert read_mark.value is None
+        assert read_mark.evidence_refs == []
+        assert read_mark.created_at_ms == 1_700_000_000_000
+
+        assert read_decision.kind == "decision"
+        assert read_decision.scope_ref == "workspace:polylogue"
+        assert read_decision.key == "schema-policy"
+        assert read_decision.value == {"choice": "additive", "wipe": False}
+        assert read_decision.status == "active"
+        assert read_decision.visibility == "team"
+        assert read_decision.confidence == 0.92
+        assert read_decision.staleness == {"ttl_days": 30}
+        assert read_decision.context_policy == {"inject": "on_session_start"}
+        assert read_decision.evidence_refs == ["session:session-1", "message:m-7"]
+
+        # read of a missing assertion returns None, not a raise.
+        assert read_assertion_envelope(conn, "absent") is None
+    finally:
+        conn.close()
+
+
+def test_assertion_upsert_preserves_created_at_and_updates_fields(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        first = upsert_assertion(
+            conn,
+            assertion_id="a-1",
+            target_ref="message:m-1",
+            kind=AssertionKind.ANNOTATION,
+            body_text="initial",
+            status="draft",
+            now_ms=1_700_000_000_000,
+        )
+        second = upsert_assertion(
+            conn,
+            assertion_id="a-1",
+            target_ref="message:m-1",
+            kind=AssertionKind.ANNOTATION,
+            body_text="revised",
+            status="active",
+            now_ms=1_700_000_005_000,
+        )
+        assert first.assertion_id == second.assertion_id
+        assert second.created_at_ms == 1_700_000_000_000
+        assert second.updated_at_ms == 1_700_000_005_000
+        assert second.body_text == "revised"
+        assert second.status == "active"
+    finally:
+        conn.close()
+
+
+def test_supersession_and_status_persist(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        upsert_assertion(
+            conn,
+            assertion_id="a-old",
+            target_ref="session:session-9",
+            kind=AssertionKind.METADATA,
+            body_text="superseded",
+            status="superseded",
+            now_ms=1_700_000_000_000,
+        )
+        new = upsert_assertion(
+            conn,
+            assertion_id="a-new",
+            target_ref="session:session-9",
+            kind=AssertionKind.METADATA,
+            body_text="current",
+            status="active",
+            supersedes=["a-old"],
+            now_ms=1_700_000_001_000,
+        )
+        stored = read_assertion_envelope(conn, "a-new")
+        assert stored is not None
+        assert stored.supersedes == ["a-old"]
+        assert stored.status == "active"
+
+        old = read_assertion_envelope(conn, "a-old")
+        assert old is not None
+        assert old.status == "superseded"
+        assert old.supersedes == []
+        assert new.supersedes == ["a-old"]
+    finally:
+        conn.close()
+
+
+def test_list_assertions_filters_by_target_and_kind(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        upsert_assertion(
+            conn,
+            assertion_id="t1-tag",
+            target_ref="session:s-1",
+            kind=AssertionKind.TAG,
+            value="rust",
+            now_ms=1_700_000_000_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="t1-note",
+            target_ref="session:s-1",
+            kind=AssertionKind.NOTE,
+            body_text="note on s-1",
+            now_ms=1_700_000_001_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="t2-tag",
+            target_ref="block:b-1",
+            kind=AssertionKind.TAG,
+            value="python",
+            now_ms=1_700_000_002_000,
+        )
+
+        for_s1 = list_assertions_for_target(conn, "session:s-1")
+        assert {a.assertion_id for a in for_s1} == {"t1-tag", "t1-note"}
+        # ordered by created_at_ms
+        assert [a.assertion_id for a in for_s1] == ["t1-tag", "t1-note"]
+
+        s1_tags = list_assertions_for_target(conn, "session:s-1", kind="tag")
+        assert [a.assertion_id for a in s1_tags] == ["t1-tag"]
+
+        b1 = list_assertions_for_target(conn, "block:b-1", kind="tag")
+        assert [a.assertion_id for a in b1] == ["t2-tag"]
+
+        assert list_assertions_for_target(conn, "session:absent") == []
+    finally:
+        conn.close()
+
+
+def test_assertion_targets_various_ref_shapes(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        refs = [
+            "session:abc-123",
+            "message:abc-123:7",
+            "block:abc-123:7:2",
+            "github-issue:Sinity/polylogue#1883",
+        ]
+        for idx, ref in enumerate(refs):
+            upsert_assertion(
+                conn,
+                assertion_id=f"ref-{idx}",
+                target_ref=ref,
+                kind=AssertionKind.HANDOFF,
+                body_text=f"handoff for {ref}",
+                now_ms=1_700_000_000_000 + idx,
+            )
+        for idx, ref in enumerate(refs):
+            stored = read_assertion_envelope(conn, f"ref-{idx}")
+            assert stored is not None
+            assert stored.target_ref == ref
+    finally:
+        conn.close()
+
+
+def test_assertions_table_added_additively_without_version_bump(tmp_path: Path) -> None:
+    """A pre-existing v1 user.db lacking the table gains it on next open with no wipe."""
+    path = tmp_path / "user.db"
+    conn = _connect(path)
+    try:
+        # Seed irreplaceable user data, then simulate an older DB that predates
+        # the assertions table by dropping it. user_version stays at 1.
+        upsert_assertion(
+            conn,
+            assertion_id="seed",
+            target_ref="session:keep-me",
+            kind=AssertionKind.LESSON,
+            body_text="irreplaceable user input",
+            now_ms=1_700_000_000_000,
+        )
+        conn.execute("DROP TABLE assertions")
+        conn.commit()
+        assert not _table_exists(conn, "assertions")
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
+    finally:
+        conn.close()
+
+    # Re-open the existing v1 file and re-apply the tier DDL idempotently.
+    conn2 = sqlite3.connect(path)
+    conn2.row_factory = sqlite3.Row
+    try:
+        version_before = int(conn2.execute("PRAGMA user_version").fetchone()[0])
+        assert version_before == USER_SCHEMA_VERSION
+        # Pre-existing irreplaceable rows must survive the re-open.
+        assert _table_exists(conn2, "marks")
+
+        initialize_archive_tier(conn2, ArchiveTier.USER)
+
+        assert _table_exists(conn2, "assertions")
+        version_after = int(conn2.execute("PRAGMA user_version").fetchone()[0])
+        assert version_after == USER_SCHEMA_VERSION
+        assert USER_SCHEMA_VERSION == 1
+
+        # The freshly-added table is usable.
+        restored = upsert_assertion(
+            conn2,
+            assertion_id="post-additive",
+            target_ref="session:keep-me",
+            kind=AssertionKind.NOTE,
+            body_text="written after additive open",
+            now_ms=1_700_000_009_000,
+        )
+        assert restored.assertion_id == "post-additive"
+    finally:
+        conn2.close()


### PR DESCRIPTION
## Summary
Adds the `assertions` table — one evidence-linked overlay primitive for the user tier — plus its read/write helpers and a closed `AssertionKind` vocabulary. Additive only; existing overlay tables are untouched (write-through adapters are a later slice).

## Problem
#1883: the user tier carries a pile of parallel overlay mini-systems (marks/annotations/corrections/tags/saved_views/recall_packs/workspaces/blackboard_notes) with near-identical upsert/read skeletons. They should collapse onto one `Assertion` primitive (author/system asserts value V about target T in scope S, with evidence/status/visibility/staleness/context-policy).

## Solution
- `archive_tiers/user.py`: `CREATE TABLE IF NOT EXISTS assertions (...) STRICT` + a `(target_ref, kind)` index. **`USER_SCHEMA_VERSION` is NOT bumped** (stays 1): the user tier is irreplaceable and the runtime is fresh-only (version mismatch → wipe), so the table is added additively via `IF NOT EXISTS` — `initialize_archive_tier` re-applies the tier DDL on every valid-version open (same precedent as the `cursor_lag_samples` additive ALTER), so existing v1 `user.db` files gain the table with no wipe.
- `archive_tiers/user_write.py`: `ArchiveAssertionEnvelope` + `upsert_assertion` / `read_assertion_envelope` / `list_assertions_for_target`, mirroring the existing envelope helpers (JSON columns decoded). `AssertionKind(StrEnum)` closed v0 set (mark…transform_candidate); `kind` stored as plain TEXT (no CHECK) so the vocabulary grows without a schema bump.

## Verification
```
devtools test tests/unit/storage/test_archive_tiers_assertions.py test_archive_tiers_user_write.py   # 8 passed
devtools verify --quick   # exit 0 (mypy --strict, render-all --check, verify-topology — no drift)
```
Tests include the **additive-open proof**: a v1 `user.db` missing the table gains it via `initialize_archive_tier` with `user_version` still 1 and existing rows (`marks`) intact.

### Follow-up (same issue)
Write-through adapters (old `upsert_mark`/`annotation`/… also write an assertion row) and the read-path migration are the next #1883 slice.

Ref #1883