### PR TITLE
feat(query): execute near:id:<ref> session-seeded similarity (#1842)

### DIFF
--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -54,32 +54,56 @@ def _provider_for_origin(origin: str) -> Provider:
     return _ORIGIN_TO_PROVIDER.get(origin, Provider.UNKNOWN)
 
 
-def _reject_unexecutable_session_seed(plan: SessionQueryPlan) -> None:
-    """Fail typed for ``near:id:<ref>`` until session-seeded vectors are wired.
+def _session_seed_scored(
+    plan: SessionQueryPlan,
+    *,
+    config: Config | None,
+    archive_root: Path,
+    pool: int,
+) -> list[tuple[str, float]]:
+    """Resolve a ``near:id:<ref>`` plan to vector-ranked ``(message_id, distance)``.
 
-    ``similar_session_id`` carries the intent "rank sessions by vector
-    similarity to a stored session's embeddings". Executing it requires a
-    storage primitive that does not exist yet: ``VectorProvider`` only exposes
-    ``query(text, limit)`` (which re-embeds a text string), with no way to fetch
-    a session's stored ``message_embeddings`` and vector-search against them.
-
-    Until that primitive lands, the plan compiles and round-trips (so surfaces
-    and completion already know the field), but executing it raises a typed
-    error here instead of silently broadening to an unfiltered listing — which
-    is what every execution branch below would otherwise do, because none of
-    them inspect ``similar_session_id``.
+    Unlike the text-semantic leg, a session seed is an explicit request to rank by
+    a *stored* session's embeddings; there is no text query to fall back to. When
+    the request cannot be honored — no vector backend is available, or the seed
+    session has no stored embeddings — this raises a typed ``ExpressionCompileError``
+    on the ``near`` field rather than degrading to an unfiltered or silently-empty
+    listing. The returned hits already exclude the seed session's own messages
+    (enforced by ``VectorProvider.query_by_session``).
     """
-    if plan.similar_session_id is None:
-        return
     from polylogue.archive.query.expression import ExpressionCompileError
+    from polylogue.storage.search_providers import create_vector_provider
+    from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError
 
-    raise ExpressionCompileError(
-        "near:id: session-seeded similarity is not executable yet — it needs a "
-        "VectorProvider primitive that vector-searches a stored session's "
-        'embeddings (see issue #1842). Use near:"text" for text-seeded '
-        "similarity in the meantime.",
-        field="near",
-    )
+    seed = plan.similar_session_id
+    assert seed is not None
+    vector_provider = plan.vector_provider
+    if vector_provider is None and config is not None:
+        vector_provider = create_vector_provider(config, db_path=archive_root / "embeddings.db")
+    if vector_provider is None:
+        raise ExpressionCompileError(
+            "near:id: session-seeded similarity needs a configured vector backend "
+            "(sqlite-vec plus an embedded archive); none is available for this archive.",
+            field="near",
+        )
+    try:
+        return vector_provider.query_by_session(seed, limit=pool)
+    except SqliteVecError as exc:
+        raise ExpressionCompileError(str(exc), field="near") from exc
+
+
+def _session_seed_hits(
+    plan: SessionQueryPlan,
+    archive: ArchiveStore,
+    *,
+    config: Config | None,
+    archive_root: Path,
+) -> list[ArchiveSessionSearchHit]:
+    """Resolve a session-seeded plan to filtered session-level hits."""
+    limit = plan.limit if plan.limit is not None else 50
+    pool = max(limit + plan.offset, limit) * 3
+    scored = _session_seed_scored(plan, config=config, archive_root=archive_root, pool=pool)
+    return archive.semantic_summaries(scored, limit=pool, offset=0, **_plan_filter_kwargs(plan))
 
 
 def _parse_archive_datetime(value: str | None) -> datetime | None:
@@ -310,11 +334,14 @@ def _archive_summaries(
     archive_root: Path,
     default_limit: int,
 ) -> list[ArchiveSessionSummary]:
-    _reject_unexecutable_session_seed(plan)
     filter_kwargs = _plan_filter_kwargs(plan)
     limit = _fetch_limit(plan, default=default_limit)
     sort = plan.sort
     reverse = plan.reverse
+
+    if plan.similar_session_id is not None:
+        hits = _session_seed_hits(plan, archive, config=config, archive_root=archive_root)
+        return _summaries_from_hits(archive, hits)
 
     if plan.similar_text is not None or plan.retrieval_lane in {"semantic", "hybrid"}:
         hits = _semantic_hits(plan, archive, config=config, archive_root=archive_root)
@@ -422,8 +449,12 @@ async def count_archive(
     archive_root: Path,
     config: Config | None,
 ) -> int:
-    _reject_unexecutable_session_seed(plan)
-    if not plan.has_post_filters() and plan.similar_text is None and plan.retrieval_lane not in {"semantic", "hybrid"}:
+    if (
+        not plan.has_post_filters()
+        and plan.similar_text is None
+        and plan.similar_session_id is None
+        and plan.retrieval_lane not in {"semantic", "hybrid"}
+    ):
         filter_kwargs = _plan_filter_kwargs(plan)
         query_text = _plan_text_query(plan)
         with _open_archive(archive_root) as archive:
@@ -464,12 +495,17 @@ def archive_search_hits(
     """
     from polylogue.storage.search_providers import create_vector_provider, reciprocal_rank_fusion
 
-    _reject_unexecutable_session_seed(plan)
     text = plan.similar_text or _plan_text_query(plan) or ""
     limit = plan.limit if plan.limit is not None else default_limit
     offset = plan.offset
     filter_kwargs = _plan_filter_kwargs(plan)
     with _open_archive(archive_root) as archive:
+        if plan.similar_session_id is not None:
+            pool = max(limit + offset, limit) * 3
+            scored = _session_seed_scored(plan, config=config, archive_root=archive_root, pool=pool)
+            semantic_hits = archive.semantic_summaries(scored, limit=pool, offset=0, **filter_kwargs)
+            return _pair_hits(archive, semantic_hits[offset : offset + limit]), "semantic"
+
         if plan.similar_text is None and plan.retrieval_lane in {"auto", "dialogue"}:
             hits = archive.search_summaries(
                 text,

--- a/polylogue/archive/query/plan_execution.py
+++ b/polylogue/archive/query/plan_execution.py
@@ -16,6 +16,27 @@ if TYPE_CHECKING:
     from polylogue.protocols import SessionQueryRuntimeStore
 
 
+def _reject_session_seed_on_repository_path(plan: SessionQueryPlan) -> None:
+    """Fail typed for ``near:id:<ref>`` on the repository runtime store path.
+
+    Session-seeded similarity executes through the archive query path
+    (``archive_execution`` / ``search_hits``), which reads the seed session's
+    stored vectors via ``VectorProvider.query_by_session``. The repository runtime
+    store exposes only text-seeded ``search_similar``; it has no session-seeded
+    vector primitive. Rather than silently broadening to an unfiltered listing,
+    reject typed and point at the executable path.
+    """
+    if plan.similar_session_id is None:
+        return
+    from polylogue.archive.query.expression import ExpressionCompileError
+
+    raise ExpressionCompileError(
+        "near:id: session-seeded similarity executes through the archive query path, "
+        "not the repository runtime store, which has no session-seeded vector primitive.",
+        field="near",
+    )
+
+
 def _plan_sort_is_rank_first(plan: SessionQueryPlan) -> bool:
     """Return True when the plan's effective sort is rank-first.
 
@@ -29,9 +50,7 @@ async def list_for_plan(
     plan: SessionQueryPlan,
     repository: SessionQueryRuntimeStore,
 ) -> list[Session]:
-    from polylogue.archive.query.archive_execution import _reject_unexecutable_session_seed
-
-    _reject_unexecutable_session_seed(plan)
+    _reject_session_seed_on_repository_path(plan)
     if plan.similar_text:
         candidates = await repository.search_similar(
             plan.similar_text,
@@ -55,9 +74,7 @@ async def list_summaries_for_plan(
     plan: SessionQueryPlan,
     repository: SessionQueryRuntimeStore,
 ) -> list[SessionSummary]:
-    from polylogue.archive.query.archive_execution import _reject_unexecutable_session_seed
-
-    _reject_unexecutable_session_seed(plan)
+    _reject_session_seed_on_repository_path(plan)
     can_use_action_stats = await plan.can_use_action_stats_with(repository)
     uses_action_read_model = plan._uses_action_read_model()
     if not plan.can_use_summaries() and not uses_action_read_model:

--- a/polylogue/archive/query/search_hits.py
+++ b/polylogue/archive/query/search_hits.py
@@ -230,7 +230,7 @@ def default_score_kind(retrieval_lane: str) -> str | None:
 
 
 def plan_has_search_hit_evidence(plan: SessionQueryPlan) -> bool:
-    return bool(plan.fts_terms or plan.similar_text)
+    return bool(plan.fts_terms or plan.similar_text or plan.similar_session_id)
 
 
 async def search_hits_for_plan(
@@ -243,20 +243,15 @@ async def search_hits_for_plan(
     hits carry FTS snippets, semantic/hybrid lanes resolve through the
     vector provider, and hybrid preserves per-lane RRF rank contributions.
     """
-    # A session-seeded plan (near:id:) carries no FTS/text evidence, so it would
-    # otherwise fall through plan_has_search_hit_evidence() and silently return
-    # no hits. Reject it typed instead — execution support is not wired yet
-    # (#1842), and silent emptiness is exactly the failure the guard prevents on
-    # every other execution entry point.
-    from polylogue.archive.query.archive_execution import _reject_unexecutable_session_seed
-
-    _reject_unexecutable_session_seed(plan)
-
     if not plan_has_search_hit_evidence(plan):
         return []
 
+    # A session-seeded plan (near:id:) carries no FTS/text evidence; its evidence is
+    # the seed session's stored vectors, resolved by archive_search_hits through the
+    # vector provider. It must bypass the text-query gate below (which would treat an
+    # empty query string as "no hits") and fail typed if it cannot execute.
     query_text = plan.similar_text or plan_search_query_text(plan)
-    if not query_text:
+    if not query_text and plan.similar_session_id is None:
         return []
 
     from polylogue.archive.query.archive_execution import archive_search_hits
@@ -272,7 +267,7 @@ async def search_hits_for_plan(
         config=config,
         default_limit=plan.limit or search_limit(plan),
     )
-    query_terms = (query_text,)
+    query_terms = (query_text,) if query_text else ()
     terms = search_terms(query_terms)
     hits: list[SessionSearchHit] = []
     for rank, (native_hit, summary) in enumerate(paired, start=1):

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -72,6 +72,18 @@ class VectorProvider(Protocol):
         """Synchronously return ranked ``(message_id, distance)`` search results."""
         ...
 
+    def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+        """Rank messages by similarity to a stored session's own embeddings.
+
+        Reads ``session_id``'s already-materialized message vectors and KNN-searches
+        them against the store, returning ranked ``(message_id, distance)`` hits with
+        the seed session's own messages excluded (so the seed never ranks against
+        itself). No re-embedding occurs — only stored vectors are read. Raises a typed
+        error when the seed session has no stored embeddings, never silently returning
+        an empty or unfiltered result.
+        """
+        ...
+
 
 @runtime_checkable
 class ProgressCallback(Protocol):

--- a/polylogue/storage/search_providers/sqlite_vec_queries.py
+++ b/polylogue/storage/search_providers/sqlite_vec_queries.py
@@ -157,6 +157,7 @@ class SqliteVecQueryMixin:
 
         conn = self._get_connection()
         try:
+            seed_rows: list[sqlite3.Row] = []
             try:
                 seed_rows = conn.execute(
                     "SELECT message_id, embedding FROM message_embeddings WHERE session_id = ?",

--- a/polylogue/storage/search_providers/sqlite_vec_queries.py
+++ b/polylogue/storage/search_providers/sqlite_vec_queries.py
@@ -11,6 +11,12 @@ from polylogue.storage.embeddings.embedding_stats import read_embedding_stats_sy
 from polylogue.storage.runtime import MessageRecord
 from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError, _serialize_f32, logger
 
+# Per-seed-message neighbor fanout used to grow the candidate pool before
+# deduplicating to messages. Bounds the number of MATCH queries issued for a
+# large seed session to a fixed, representative sample (mirrors
+# ``polylogue.daemon.similarity._PER_MESSAGE_K``).
+_SESSION_SEED_FANOUT = 20
+
 
 class SqliteVecQueryMixin:
     """Vector upsert/query/stat operations."""
@@ -131,6 +137,62 @@ class SqliteVecQueryMixin:
                 (query_embedding, limit),
             ).fetchall()
             return [(row["message_id"], row["distance"]) for row in rows]
+        finally:
+            conn.close()
+
+    def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+        """Rank messages by similarity to a stored session's own embeddings.
+
+        Fetches every stored vector for ``session_id`` and KNN-searches a bounded,
+        representative sample of them against the store. Hits belonging to the seed
+        session itself are dropped so the seed never ranks against its own messages;
+        each surviving message keeps its closest (smallest) distance across the seed
+        vectors. Returns ranked ``(message_id, distance)`` ascending by distance.
+
+        Raises :class:`SqliteVecError` when the seed session has no stored
+        embeddings (including when the vector table does not exist yet) so the caller
+        fails typed rather than returning an empty/unfiltered listing.
+        """
+        self._ensure_vec_available()
+
+        conn = self._get_connection()
+        try:
+            try:
+                seed_rows = conn.execute(
+                    "SELECT message_id, embedding FROM message_embeddings WHERE session_id = ?",
+                    (session_id,),
+                ).fetchall()
+            except sqlite3.OperationalError as exc:
+                raise SqliteVecError(f"session {session_id!r} has no stored embeddings: {exc}") from exc
+            if not seed_rows:
+                raise SqliteVecError(
+                    f"session {session_id!r} has no stored message embeddings; cannot run session-seeded similarity"
+                )
+
+            k = max(limit, 1)
+            best_distance: dict[str, float] = {}
+            for seed_row in seed_rows[:_SESSION_SEED_FANOUT]:
+                embedding_blob = bytes(seed_row["embedding"])
+                neighbors = conn.execute(
+                    """
+                    SELECT message_id, session_id, distance
+                    FROM message_embeddings
+                    WHERE embedding MATCH ?
+                      AND k = ?
+                    ORDER BY distance
+                    """,
+                    (embedding_blob, k),
+                ).fetchall()
+                for neighbor in neighbors:
+                    if str(neighbor["session_id"]) == session_id:
+                        continue
+                    message_id = str(neighbor["message_id"])
+                    distance = float(neighbor["distance"])
+                    if message_id not in best_distance or distance < best_distance[message_id]:
+                        best_distance[message_id] = distance
+
+            ranked = sorted(best_distance.items(), key=lambda item: (item[1], item[0]))
+            return ranked[:limit]
         finally:
             conn.close()
 

--- a/tests/unit/archive/test_near_session_seed_execution.py
+++ b/tests/unit/archive/test_near_session_seed_execution.py
@@ -1,64 +1,215 @@
-"""Execution-guard tests for ``near:id:<ref>`` session-seeded similarity (#1842).
+"""Execution tests for ``near:id:<ref>`` session-seeded similarity (#1842).
 
 The compiler accepts ``near:id:<ref>`` and threads it into
-``SessionQuerySpec.similar_session_id`` / ``SessionQueryPlan.similar_session_id``
-so surfaces and completion already know the field. Executing it requires a
-storage primitive that does not exist yet (a ``VectorProvider`` lookup that
-vector-searches a stored session's embeddings rather than re-embedding text).
-
-Until that primitive lands, execution must fail *typed* rather than silently
-broaden to an unfiltered listing — no execution branch inspects
-``similar_session_id``, so without the guard the plan would degrade into "list
-everything". These tests pin that guard.
+``SessionQueryPlan.similar_session_id`` (#1899). This module pins the *execution*
+of that field: a session-seeded plan reads the seed session's stored embeddings,
+KNN-searches them, excludes the seed itself, and aggregates to session-level hits
+ranked by similarity. When the request cannot be honored (no vector backend, or a
+seed with no stored embeddings) execution fails *typed* — never a silent empty or
+unfiltered listing.
 """
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 
-from polylogue.archive.query.archive_execution import _reject_unexecutable_session_seed
+from polylogue.archive.query.archive_execution import list_summaries_archive
 from polylogue.archive.query.expression import ExpressionCompileError, compile_expression
 from polylogue.archive.query.plan import SessionQueryPlan
-from polylogue.archive.query.search_hits import search_hits_for_plan
-from polylogue.config import Config
+from polylogue.archive.query.search_hits import plan_has_search_hit_evidence, search_hits_for_plan
+from polylogue.config import Config, Source
+from polylogue.core.enums import Origin
+from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.embedding_write import upsert_message_embedding
+from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.types import Provider
+from tests.infra.storage_records import SessionBuilder
 
 
-def test_guard_passes_through_plain_plan() -> None:
-    # No session seed → no-op.
-    _reject_unexecutable_session_seed(SessionQueryPlan())
-    _reject_unexecutable_session_seed(SessionQueryPlan(similar_text="hello"))
+def _unit_vector(*, axis0: float, axis1: float) -> list[float]:
+    vec = [0.0] * EMBEDDING_DIMENSION
+    vec[0] = axis0
+    vec[1] = axis1
+    return vec
 
 
-def test_guard_rejects_session_seed_typed() -> None:
-    plan = SessionQueryPlan(similar_session_id="abc123")
-    with pytest.raises(ExpressionCompileError) as excinfo:
-        _reject_unexecutable_session_seed(plan)
-    assert excinfo.value.field == "near"
-    assert "not executable yet" in str(excinfo.value)
+def _build_index(db_path: Path) -> None:
+    for session_key, text in (
+        ("conv-seed", "alpha seed session"),
+        ("conv-near", "alpha near neighbor"),
+        ("conv-far", "zeta unrelated topic"),
+        ("conv-unembedded", "no vectors here"),
+    ):
+        (
+            SessionBuilder(db_path, session_key)
+            .provider(Provider.CODEX.value)
+            .title(session_key)
+            .updated_at("2026-04-22T12:00:00+00:00")
+            .add_message("m1", role="user", text=text)
+            .save()
+        )
 
 
-def test_compiled_near_id_plan_is_rejected_at_execution() -> None:
-    # End-to-end: a compiled `near:id:` query reaches the guard with the seed set.
-    plan = compile_expression("near:id:abc123").to_plan()
-    assert plan.similar_session_id == "abc123"
-    with pytest.raises(ExpressionCompileError):
-        _reject_unexecutable_session_seed(plan)
+def _message_rows(db_path: Path) -> dict[str, tuple[str, str]]:
+    """Return ``{session_key_suffix: (session_id, message_id)}`` from the index."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT message_id, session_id FROM messages").fetchall()
+    finally:
+        conn.close()
+    mapping: dict[str, tuple[str, str]] = {}
+    for row in rows:
+        session_id = str(row["session_id"])
+        message_id = str(row["message_id"])
+        for suffix in ("seed", "near", "far", "unembedded"):
+            if f"conv-{suffix}" in session_id:
+                mapping[suffix] = (session_id, message_id)
+    return mapping
 
 
-async def test_search_hits_for_plan_rejects_session_seed_not_silently_empty(tmp_path: Path) -> None:
-    """search_hits_for_plan must reject near:id: typed, not return [] (Codex #1899).
+@pytest.fixture
+def seeded_archive(tmp_path: Path) -> tuple[Path, Config, dict[str, tuple[str, str]]]:
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    render_root = tmp_path / "render"
+    render_root.mkdir(parents=True, exist_ok=True)
+    db_path = archive_root / "index.db"
 
-    This path checks plan_has_search_hit_evidence() first; a session-seeded plan
-    has no FTS/text evidence, so without the guard it silently returned no hits.
-    """
-    plan = compile_expression("near:id:abc123").to_plan()
+    _build_index(db_path)
+    mapping = _message_rows(db_path)
+
+    embeddings_db = archive_root / "embeddings.db"
+    conn = sqlite3.connect(embeddings_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        initialize_archive_tier(conn, ArchiveTier.EMBEDDINGS)
+    except sqlite3.OperationalError as exc:
+        if "vec0" in str(exc) or "sqlite-vec" in str(exc):
+            pytest.skip("sqlite-vec extension is unavailable")
+        raise
+    vectors = {
+        "seed": _unit_vector(axis0=1.0, axis1=0.0),
+        "near": _unit_vector(axis0=0.99, axis1=0.141),
+        "far": _unit_vector(axis0=0.0, axis1=1.0),
+    }
+    for suffix, vector in vectors.items():
+        session_id, message_id = mapping[suffix]
+        upsert_message_embedding(
+            conn,
+            message_id=message_id,
+            session_id=session_id,
+            origin=Origin.CODEX_SESSION,
+            embedding=vector,
+            model="voyage-4",
+            embedded_at_ms=1_767_225_700_000,
+            content_hash=b"x" * 32,
+        )
+    conn.close()
+
     config = Config(
-        archive_root=tmp_path,
-        render_root=tmp_path / "render",
-        sources=[],
-        db_path=tmp_path / "index.db",
+        archive_root=archive_root,
+        render_root=render_root,
+        sources=[Source(name="test", path=tmp_path / "inbox")],
+        db_path=db_path,
     )
+    return archive_root, config, mapping
+
+
+def _provider(archive_root: Path) -> SqliteVecProvider:
+    provider = SqliteVecProvider(
+        voyage_key="test-key",
+        db_path=archive_root / "embeddings.db",
+        model="voyage-4",
+    )
+    provider.dimension = EMBEDDING_DIMENSION
+    provider._vec_available = None
+    return provider
+
+
+async def test_near_id_returns_similar_sessions_excluding_seed(
+    seeded_archive: tuple[Path, Config, dict[str, tuple[str, str]]],
+) -> None:
+    archive_root, config, mapping = seeded_archive
+    seed_id = mapping["seed"][0]
+    near_id = mapping["near"][0]
+    far_id = mapping["far"][0]
+
+    plan = SessionQueryPlan(similar_session_id=seed_id, vector_provider=_provider(archive_root))
+    summaries = await list_summaries_archive(plan, archive_root=archive_root, config=config)
+
+    result_ids = [str(summary.id) for summary in summaries]
+    # The seed session is excluded from its own similarity results.
+    assert seed_id not in result_ids
+    # Both other embedded sessions surface, the near neighbor ahead of the far one.
+    assert near_id in result_ids
+    assert far_id in result_ids
+    assert result_ids.index(near_id) < result_ids.index(far_id)
+
+
+async def test_near_id_seed_without_embeddings_fails_typed(
+    seeded_archive: tuple[Path, Config, dict[str, tuple[str, str]]],
+) -> None:
+    archive_root, config, mapping = seeded_archive
+    unembedded_id = mapping["unembedded"][0]
+
+    plan = SessionQueryPlan(similar_session_id=unembedded_id, vector_provider=_provider(archive_root))
+    with pytest.raises(ExpressionCompileError) as excinfo:
+        await list_summaries_archive(plan, archive_root=archive_root, config=config)
+    assert excinfo.value.field == "near"
+
+
+async def test_near_id_without_vector_backend_fails_typed(
+    seeded_archive: tuple[Path, Config, dict[str, tuple[str, str]]],
+) -> None:
+    archive_root, config, mapping = seeded_archive
+    seed_id = mapping["seed"][0]
+
+    # No vector provider on the plan and no Voyage key in config -> no backend can
+    # be constructed. This must fail typed rather than broaden to a full listing.
+    plan = SessionQueryPlan(similar_session_id=seed_id)
+    with pytest.raises(ExpressionCompileError) as excinfo:
+        await list_summaries_archive(plan, archive_root=archive_root, config=config)
+    assert excinfo.value.field == "near"
+
+
+async def test_search_hits_for_plan_resolves_session_seed(
+    seeded_archive: tuple[Path, Config, dict[str, tuple[str, str]]],
+) -> None:
+    archive_root, config, mapping = seeded_archive
+    seed_id = mapping["seed"][0]
+    near_id = mapping["near"][0]
+
+    plan = SessionQueryPlan(similar_session_id=seed_id, vector_provider=_provider(archive_root), limit=5)
+    hits = await search_hits_for_plan(plan, config)
+
+    result_ids = [hit.session_id for hit in hits]
+    assert seed_id not in result_ids
+    assert near_id in result_ids
+    assert all(hit.retrieval_lane == "semantic" for hit in hits)
+
+
+async def test_search_hits_for_plan_session_seed_no_backend_fails_typed(
+    seeded_archive: tuple[Path, Config, dict[str, tuple[str, str]]],
+) -> None:
+    _archive_root, config, mapping = seeded_archive
+    seed_id = mapping["seed"][0]
+
+    plan = SessionQueryPlan(similar_session_id=seed_id)
     with pytest.raises(ExpressionCompileError):
         await search_hits_for_plan(plan, config)
+
+
+def test_session_seed_counts_as_search_hit_evidence() -> None:
+    assert plan_has_search_hit_evidence(SessionQueryPlan(similar_session_id="abc123")) is True
+    assert plan_has_search_hit_evidence(SessionQueryPlan()) is False
+
+
+def test_compiled_near_id_threads_session_seed() -> None:
+    plan = compile_expression("near:id:abc123").to_plan()
+    assert plan.similar_session_id == "abc123"

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -54,6 +54,9 @@ class _FakeV1VectorProvider:
     def query(self, text: str, limit: int = 10) -> list[tuple[str, float]]:
         return []
 
+    def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+        return []
+
     def _get_embeddings(self, texts: list[str], input_type: str = "document") -> list[list[float]]:
         self.texts.extend(texts)
         return [[0.01] * 1024 for _ in texts]

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -1810,6 +1810,9 @@ class _VectorSpy:
         self.query_calls.append((text, limit))
         return [("msg-1", 0.125)]
 
+    def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+        return [("msg-1", 0.125)]
+
     def upsert(self, session_id: str, messages: list[MessageRecord]) -> None:
         self.upsert_calls.append((session_id, messages))
 

--- a/tests/unit/storage/test_vec_session_seed.py
+++ b/tests/unit/storage/test_vec_session_seed.py
@@ -1,0 +1,97 @@
+"""Storage-primitive contracts for ``VectorProvider.query_by_session`` (#1842).
+
+``query_by_session`` powers ``near:id:<ref>`` session-seeded similarity: it reads
+a stored session's own vectors and KNN-searches them against the store, excluding
+the seed session's own messages. These tests pin the primitive directly against a
+real archive-shaped ``embeddings.db`` so the exclusion and no-embedding contracts
+fail here rather than silently at the query surface.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Origin
+from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
+from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.embedding_write import upsert_message_embedding
+from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _unit_vector(*, axis0: float, axis1: float) -> list[float]:
+    """Build a 1024-dim vector concentrated on the first two axes."""
+    vec = [0.0] * EMBEDDING_DIMENSION
+    vec[0] = axis0
+    vec[1] = axis1
+    return vec
+
+
+@pytest.fixture
+def embeddings_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "embeddings.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        initialize_archive_tier(conn, ArchiveTier.EMBEDDINGS)
+    except sqlite3.OperationalError as exc:
+        if "vec0" in str(exc) or "sqlite-vec" in str(exc):
+            pytest.skip("sqlite-vec extension is unavailable")
+        raise
+    # Session A (seed): two messages on the x-axis.
+    # Session B: very close to A (small angle) -> small L2 distance.
+    # Session C: orthogonal to A -> large L2 distance.
+    seeds = [
+        ("sess-A", "sess-A:m1", _unit_vector(axis0=1.0, axis1=0.0)),
+        ("sess-A", "sess-A:m2", _unit_vector(axis0=0.999, axis1=0.045)),
+        ("sess-B", "sess-B:m1", _unit_vector(axis0=0.99, axis1=0.141)),
+        ("sess-C", "sess-C:m1", _unit_vector(axis0=0.0, axis1=1.0)),
+    ]
+    for session_id, message_id, vector in seeds:
+        upsert_message_embedding(
+            conn,
+            message_id=message_id,
+            session_id=session_id,
+            origin=Origin.CODEX_SESSION,
+            embedding=vector,
+            model="voyage-4",
+            embedded_at_ms=1_767_225_700_000,
+            content_hash=b"x" * 32,
+        )
+    conn.close()
+    return db_path
+
+
+def _provider(db_path: Path) -> SqliteVecProvider:
+    provider = SqliteVecProvider(voyage_key="test-key", db_path=db_path, model="voyage-4")
+    provider.dimension = EMBEDDING_DIMENSION
+    provider._vec_available = None
+    return provider
+
+
+def test_query_by_session_excludes_seed_and_ranks_by_similarity(embeddings_db: Path) -> None:
+    provider = _provider(embeddings_db)
+
+    hits = provider.query_by_session("sess-A", limit=10)
+
+    returned_ids = [message_id for message_id, _distance in hits]
+    # The seed session's own messages never appear.
+    assert all(not message_id.startswith("sess-A:") for message_id in returned_ids)
+    # Both other sessions' messages surface, B (closer) ahead of C (orthogonal).
+    assert "sess-B:m1" in returned_ids
+    assert "sess-C:m1" in returned_ids
+    assert returned_ids.index("sess-B:m1") < returned_ids.index("sess-C:m1")
+    # Distances are non-decreasing (ascending similarity ranking).
+    distances = [distance for _id, distance in hits]
+    assert distances == sorted(distances)
+
+
+def test_query_by_session_raises_typed_when_seed_has_no_embeddings(embeddings_db: Path) -> None:
+    provider = _provider(embeddings_db)
+
+    with pytest.raises(SqliteVecError):
+        provider.query_by_session("sess-unembedded", limit=10)

--- a/tests/unit/test_protocol_conformance.py
+++ b/tests/unit/test_protocol_conformance.py
@@ -40,6 +40,10 @@ class _VectorStub:
         del text, limit
         return []
 
+    def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+        del session_id, limit
+        return []
+
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary
Wires `near:id:<ref>` to actually return sessions similar to a seed session by its **stored** embedding, replacing the typed-rejection guard from the plumbing PR (#1899). Completes the operator's "both" decision for #1842 PR-3b.

## Solution
- `protocols.py`: `VectorProvider.query_by_session(session_id, limit) -> list[tuple[str, float]]`.
- `storage/search_providers/sqlite_vec_queries.py`: implemented on `SqliteVecQueryMixin` — reads the seed's stored vectors (`message_embeddings`), KNN-searches a bounded fan-out via vec0 `embedding MATCH`, **excludes the seed's own messages**, returns min-distance per surviving message. No re-embedding / no API call (mirrors `daemon/similarity.py`). Missing embeddings/table → typed `SqliteVecError`.
- `archive/query/{archive_execution,search_hits}.py`: removed `_reject_unexecutable_session_seed`; session-seeded plans route through the vector path on the archive list/search-hit surfaces; no backend → `ExpressionCompileError(field="near")`.
- `archive/query/plan_execution.py`: the repository runtime path has no session-seeded vector primitive, so it fails **typed** (points at the archive path) rather than silently listing — an honest, documented non-execution. Production CLI/MCP/API/filters use the archive path, which executes; `list_for_plan` is test-only.

## Verification
```
devtools test test_vec_session_seed test_near_session_seed_execution   # 9 passed
devtools test test_protocol_conformance test_query_search_runtime test_query_expression   # 154 passed
devtools test test_embedding_contracts test_store_ops test_protocol_conformance   # 89 passed
devtools verify --quick   # exit 0
```
Tests run end-to-end over a seeded `index.db` + real `embeddings.db`: `near:id:<seed>` returns similar sessions (near before far), excludes the seed, and fails typed on an unembedded seed / missing backend.

### Follow-up
Repository-path execution (`storage/repository/` session-seeded vector primitive) — out of scope here; the archive path covers all production surfaces.

Closes #1842 PR-3b (near:id:).

Ref #1842