### PR TITLE
docs: fix stale SessionFilter(repo) examples in library-api.md (#1841)

### DIFF
--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -14,21 +14,33 @@ The public Python surface is split into:
 ## Basic Usage
 
 ```python
-from polylogue.archive.filter.filters import SessionFilter
-from polylogue.storage.repository import SessionRepository
-from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+import asyncio
 
-backend = SQLiteBackend()
-repo = SessionRepository(backend=backend)
+from polylogue import Polylogue
 
-# Search
-results = await SessionFilter(repo).contains("error").provider("claude-ai").list()
-for conv in results:
-    print(f"{conv.id}: {conv.display_title}")
 
-# Single session
-conv = await SessionFilter(repo).id("abc123").first()
+async def main() -> None:
+    async with Polylogue.open() as archive:
+        # Full-text search (returns list[Session])
+        results = await archive.repository.search("error", limit=10)
+        for session in results:
+            print(f"{session.id}: {session.display_title}")
+
+        # Fluent filter by origin (lazy; terminals are async)
+        recent = await archive.filter().origin("claude-ai-export").limit(10).list_summaries()
+        for summary in recent:
+            print(f"{summary.id}: {summary.display_title}")
+
+        # Single session by id prefix
+        session = await archive.get_session("abc123")
+
+
+asyncio.run(main())
 ```
+
+`Polylogue.open()` is the async context manager; `archive.repository` is a
+`SessionRepository` and `archive.filter()` returns a `SessionFilter` already
+bound to the active archive — never construct `SessionFilter` directly.
 
 ## Precise Module Imports
 
@@ -137,53 +149,57 @@ Archive coverage and archive debt are public insights too:
 
 ## Filter Chain API
 
+All examples below assume an open archive, where `archive.filter()` yields a
+fresh `SessionFilter` bound to the active archive:
+
 ```python
-# Chainable, lazy evaluation (terminals are async)
-results = await (SessionFilter(repo)
-    .contains("error")
-    .contains("python")             # AND
-    .provider("claude-ai", "chatgpt")  # OR
-    .since("2025-01-01")
-    .has("thinking")
-    .limit(10)
-    .list())                        # Terminal: await list(), first(), count(), delete()
+async with Polylogue.open() as archive:
+    # Chainable, lazy evaluation (terminals are async)
+    results = await (archive.filter()
+        .contains("error")
+        .contains("python")                          # AND
+        .origin("claude-ai-export", "chatgpt-export")  # OR
+        .since("2025-01-01")
+        .has("thinking")
+        .limit(10)
+        .list())                        # Terminal: await list(), first(), count(), delete()
 
-# Exclusion filters
-results = await (SessionFilter(repo)
-    .contains("error")
-    .exclude_text("warning")
-    .exclude_provider("gemini")
-    .exclude_tag("archived")
-    .list())
+    # Exclusion filters
+    results = await (archive.filter()
+        .contains("error")
+        .exclude_text("warning")
+        .exclude_origin("gemini-cli-session")
+        .exclude_tag("archived")
+        .list())
 
-# Lightweight summaries (no message loading)
-summaries = await (SessionFilter(repo)
-    .provider("claude-ai")
-    .since("2025-01-01")
-    .list_summaries())              # Returns SessionSummary (no messages)
+    # Lightweight summaries (no message loading)
+    summaries = await (archive.filter()
+        .origin("claude-ai-export")
+        .since("2025-01-01")
+        .list_summaries())              # Returns SessionSummary (no messages)
 
-# Check if summaries are sufficient
-f = SessionFilter(repo).provider("claude-ai")
-if f.can_use_summaries():
-    results = f.list_summaries()    # Fast path
-else:
-    results = f.list()              # Loads full sessions
+    # Check if summaries are sufficient
+    f = archive.filter().origin("claude-ai-export")
+    if f.can_use_summaries():
+        results = await f.list_summaries()  # Fast path
+    else:
+        results = await f.list()            # Loads full sessions
 
-# Custom predicates
-results = await (SessionFilter(repo)
-    .where(lambda c: len(c.messages) > 50)
-    .list())
+    # Custom predicates
+    results = await (archive.filter()
+        .where(lambda c: len(c.messages) > 50)
+        .list())
 
-# Sorting and sampling
-results = await (SessionFilter(repo)
-    .sort("tokens")
-    .reverse()
-    .sample(10)
-    .list())
+    # Sorting and sampling
+    results = await (archive.filter()
+        .sort("tokens")
+        .reverse()
+        .sample(10)
+        .list())
 
-# Session structure filters
-roots = await SessionFilter(repo).is_root().list()
-continuations = await SessionFilter(repo).is_continuation().list()
+    # Session structure filters
+    roots = await archive.filter().is_root().list()
+    continuations = await archive.filter().is_continuation().list()
 ```
 
 ## Available Filter Methods
@@ -192,18 +208,17 @@ continuations = await SessionFilter(repo).is_continuation().list()
 |--------|-------------|
 | `.contains(text)` | FTS term (chainable = AND) |
 | `.exclude_text(text)` | Exclude FTS term |
-| `.provider(*names)` | Include providers |
-| `.exclude_provider(*names)` | Exclude providers |
+| `.origin(*names)` | Include origins (e.g. `claude-ai-export`, `chatgpt-export`) |
+| `.exclude_origin(*names)` | Exclude origins |
+| `.repo(*names)` | Require repository names |
 | `.tag(*tags)` | Include tags |
 | `.exclude_tag(*tags)` | Exclude tags |
-| `.referenced_path(*terms)` | Require touched-path substrings |
+| `.referenced_path(pattern)` | Require a touched-path substring |
+| `.cwd_prefix(prefix)` | Require a working-directory prefix |
 | `.action(*kinds)` | Require semantic action kinds |
 | `.exclude_action(*kinds)` | Exclude semantic action kinds |
 | `.tool(*names)` | Require normalized tool names |
 | `.exclude_tool(*names)` | Exclude normalized tool names |
-| `.action_sequence(*kinds)` | Require ordered semantic action subsequence |
-| `.action_text(*terms)` | Require text inside normalized action evidence |
-| `.retrieval_lane(name)` | Choose retrieval lane: `auto`, `dialogue`, `actions`, `hybrid` |
 | `.has(*types)` | Content types: `thinking`, `tools`, `summary`, `attachments` |
 | `.title(pattern)` | Title contains pattern |
 | `.id(prefix)` | ID prefix match |
@@ -230,7 +245,6 @@ continuations = await SessionFilter(repo).is_continuation().list()
 | `.first()` | Execute and return first match or `None` |
 | `.count()` | Execute and return count (uses SQL fast path when possible) |
 | `.delete()` | Delete matching sessions (returns count deleted) |
-| `.pick()` | Interactive picker (TTY) or first match (non-TTY) |
 | `.can_use_summaries()` | Check if `list_summaries()` is valid for current filters |
 
 ## Ingestion
@@ -261,7 +275,7 @@ async def main():
         stats, recent, claude = await asyncio.gather(
             archive.stats(),
             archive.list_sessions(limit=10),
-            archive.list_sessions(provider="claude-ai"),
+            archive.list_sessions(origin="claude-ai-export"),
         )
 
         print(f"Total: {stats.session_count} sessions")
@@ -279,7 +293,7 @@ async def main():
         result = await archive.parse_file("chatgpt_export.json")
 
         # Fluent filter (terminals are async)
-        convs = await archive.filter().provider("claude-ai").contains("error").limit(10).list()
+        convs = await archive.filter().origin("claude-ai-export").contains("error").limit(10).list()
 
         # Rebuild search index
         await archive.rebuild_index()
@@ -293,7 +307,7 @@ asyncio.run(main())
 |--------|-------------|
 | `get_session(id)` | Get single session by ID |
 | `get_sessions(ids)` | Parallel batch fetch (5-10x faster) |
-| `list_sessions(provider, limit)` | List with optional filtering |
+| `list_sessions(origin, limit)` | List with optional filtering |
 | `search(query, limit, source, since)` | Search returning evidence snippets; text matches report message evidence and Drive/Gemini `provider_id` / `id` / `fileId` / `driveId` attachment-id matches report attachment evidence |
 | `parse_file(path, source_name)` | Parse a single export file |
 | `parse_sources(sources, download_assets)` | Parse from configured sources |
@@ -307,7 +321,7 @@ asyncio.run(main())
 | `list_session_latency_profile_insights(query)` | List durable session-latency insights |
 | `find_stuck_session_latency_profile_insights(query)` | List sessions with stuck tool starts |
 | `list_session_work_event_insights(query)` | List durable work-event insights |
-| `list_work_thread_insights(query)` | List durable work-thread insights |
+| `list_thread_insights(query)` | List durable work-thread insights |
 | `list_session_tag_rollup_insights(query)` | List durable tag-rollup insights |
 | `list_archive_coverage_insights(query)` | List provider, day, or week archive coverage insights |
 | `list_tool_usage_insights(query)` | Per-provider tool usage with explicit coverage gaps |


### PR DESCRIPTION
## Summary
Rewrites `docs/library-api.md` so every Python example uses a real, runnable public API. The old examples used `SessionFilter(repo)` (positional repository), which never worked — `SessionFilter.__init__` is keyword-only (`archive_root=...`).

## Solution
- `SessionFilter(repo).contains(...)` → `archive.repository.search(...)` / `archive.filter()....list_summaries()` under `async with Polylogue.open() as archive:`.
- `.provider()`/`.exclude_provider()` → `.origin()`/`.exclude_origin()`; `list_sessions(provider=…)` → `origin=…`.
- Fixed latent bugs: missing `await` on `list`/`list_summaries`; removed nonexistent builder methods (`.retrieval_lane`, `.action_sequence`, `.action_text`, `.pick`); corrected `.referenced_path(pattern)` arity; `list_work_thread_insights` → `list_thread_insights`.

`library-api.md` is hand-maintained (not generated — `docs_surface.py` only lists it in a README table).

## Verification
Every code block was run end-to-end against a fresh archive (no exceptions). `devtools verify-doc-commands` clean ("97 doc files scanned, no stale commands"). `devtools verify --quick` exit 0.

Surfaced while fixing the README (#1903); same stale form. Ref #1841