### PR TITLE
refactor(cli): converge mutation output onto MutationResultPayload (#1818)

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -48,6 +48,7 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.surfaces.payloads import (
     SEARCH_CURSOR_VERSION,
     InvalidSearchCursorError,
+    MutationResultPayload,
     SearchCursor,
     decode_search_cursor,
 )
@@ -1144,7 +1145,9 @@ def _emit_stats_by(
 
 
 def _emit_mutation(changed: int, *, operation: str) -> None:
-    click.echo(json.dumps({"mode": "mutation", "operation": operation, "changed": changed}, indent=2))
+    click.echo(
+        MutationResultPayload(status="ok", operation=operation, affected_count=changed).to_json(exclude_none=True)
+    )
 
 
 def _emit_user_mutations(
@@ -1165,12 +1168,16 @@ def _emit_user_mutations(
     if set(changes) == {"metadata"}:
         _emit_mutation(changes["metadata"], operation="set_meta")
         return
+    # Combined tag+metadata mutation: ``tag_count`` carries the number of
+    # sessions that had a tag added, ``applied_count`` the number that had
+    # metadata set (the two halves of the former ``changed`` dict).
     click.echo(
-        json.dumps(
-            {"mode": "mutation", "operation": "mutate", "changed": changes},
-            indent=2,
-            sort_keys=True,
-        )
+        MutationResultPayload(
+            status="ok",
+            operation="mutate",
+            tag_count=changes.get("tags"),
+            applied_count=changes.get("metadata"),
+        ).to_json(exclude_none=True)
     )
 
 
@@ -1181,21 +1188,23 @@ def _emit_delete(
     force = bool(params.get("force"))
     count = len(session_ids)
     if count == 0:
-        click.echo(json.dumps({"mode": "mutation", "operation": "delete", "matched": 0, "deleted": 0}, indent=2))
+        click.echo(
+            MutationResultPayload(status="ok", operation="delete", session_count=0, affected_count=0).to_json(
+                exclude_none=True
+            )
+        )
         return
     if dry_run:
+        # ``session_count`` = matched, ``affected_count`` = deleted (0 in a
+        # preview); ``session_ids`` enumerates the sessions that would be deleted.
         click.echo(
-            json.dumps(
-                {
-                    "mode": "mutation",
-                    "operation": "delete",
-                    "dry_run": True,
-                    "matched": count,
-                    "deleted": 0,
-                    "session_ids": list(session_ids),
-                },
-                indent=2,
-            )
+            MutationResultPayload(
+                status="preview",
+                operation="delete",
+                session_count=count,
+                affected_count=0,
+                session_ids=tuple(session_ids),
+            ).to_json(exclude_none=True)
         )
         return
     if not force:
@@ -1206,24 +1215,20 @@ def _emit_delete(
             click.echo(f"  ... and {count - 5} more", err=True)
         if not env.ui.confirm("Proceed?", default=False):
             click.echo(
-                json.dumps(
-                    {
-                        "mode": "mutation",
-                        "operation": "delete",
-                        "matched": count,
-                        "deleted": 0,
-                        "aborted": True,
-                    },
-                    indent=2,
-                )
+                MutationResultPayload(
+                    status="aborted", operation="delete", session_count=count, affected_count=0
+                ).to_json(exclude_none=True)
             )
             return
     deleted = archive.delete_sessions(session_ids)
+    # ``session_count`` = matched, ``affected_count`` = sessions actually deleted.
     click.echo(
-        json.dumps(
-            {"mode": "mutation", "operation": "delete", "matched": count, "deleted": deleted},
-            indent=2,
-        )
+        MutationResultPayload(
+            status="deleted" if deleted else "ok",
+            operation="delete",
+            session_count=count,
+            affected_count=deleted,
+        ).to_json(exclude_none=True)
     )
 
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1271,7 +1271,9 @@ class MutationResultPayload(SurfacePayloadModel):
     """
 
     status: str
-    """``ok``, ``deleted``, ``not_found``, ``unchanged``, or ``partial``."""
+    """``ok``, ``deleted``, ``not_found``, ``unchanged``, or ``partial``. The CLI
+    bulk-delete surface additionally emits ``preview`` (dry-run) and ``aborted``
+    (operator declined the confirmation prompt)."""
 
     session_id: str | None = None
     detail: str | None = None
@@ -1288,6 +1290,14 @@ class MutationResultPayload(SurfacePayloadModel):
     session_count: int | None = None
     tag_count: int | None = None
     applied_count: int | None = None
+    operation: str | None = None
+    """CLI bulk-mutation discriminator: ``add_tag``, ``set_meta``, ``mutate``, or
+    ``delete``. ``None`` for the single-session MCP/daemon surfaces, whose
+    operation is implied by the calling tool/endpoint."""
+    session_ids: tuple[str, ...] | None = None
+    """Session ids enumerated by a CLI bulk operation (e.g. the delete dry-run
+    preview lists the sessions that *would* be deleted). ``None`` for
+    single-session surfaces, which carry the lone id in ``session_id``."""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -707,7 +707,7 @@ def test_async_execute_query_archive_outputs_stats(
             {
                 "archive": True,
                 "stats_only": True,
-                "provider": "codex",
+                "origin": "codex-session",
                 "tag": "archive",
                 "output_format": "json",
             },
@@ -899,8 +899,8 @@ def test_async_execute_query_archive_search_maps_provider_to_origin(
             {
                 "archive": True,
                 "query": ("needle",),
-                "provider": "codex",
-                "exclude_provider": "chatgpt",
+                "origin": "codex-session",
+                "exclude_origin": "chatgpt-export",
                 "tag": "review,archive",
                 "exclude_tag": "archived",
                 "repo": "polylogue",
@@ -970,7 +970,7 @@ def test_async_execute_query_archive_filters_multiple_providers(
             env,
             {
                 "archive": True,
-                "provider": "codex,chatgpt",
+                "origin": "codex-session,chatgpt-export",
                 "output_format": "json",
             },
         )

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -1741,9 +1741,9 @@ def test_async_execute_query_archive_adds_tags_to_session(
     )
 
     assert json.loads(capsys.readouterr().out) == {
-        "mode": "mutation",
+        "status": "ok",
         "operation": "add_tag",
-        "changed": 2,
+        "affected_count": 2,
     }
 
 
@@ -1792,10 +1792,10 @@ def test_async_execute_query_archive_deletes_session_by_id(
     )
 
     assert json.loads(capsys.readouterr().out) == {
-        "mode": "mutation",
+        "status": "deleted",
         "operation": "delete",
-        "matched": 1,
-        "deleted": 1,
+        "session_count": 1,
+        "affected_count": 1,
     }
 
 
@@ -1844,9 +1844,9 @@ def test_async_execute_query_archive_sets_session_metadata(
     )
 
     assert json.loads(capsys.readouterr().out) == {
-        "mode": "mutation",
+        "status": "ok",
         "operation": "set_meta",
-        "changed": 1,
+        "affected_count": 1,
     }
 
 
@@ -1894,9 +1894,9 @@ def test_async_execute_query_archive_delete_dry_run_does_not_delete(
     )
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["dry_run"] is True
-    assert payload["matched"] == 1
-    assert payload["deleted"] == 0
+    assert payload["status"] == "preview"
+    assert payload["session_count"] == 1
+    assert payload["affected_count"] == 0
     assert payload["session_ids"] == ["codex-session:native-1"]
 
 

--- a/tests/unit/cli/test_verb_cardinality.py
+++ b/tests/unit/cli/test_verb_cardinality.py
@@ -707,9 +707,9 @@ class TestDeleteCardinalityLargeNonMocked:
         # 2. Dry-run preview set: must equal the guard set (the #1873 bug previewed
         #    only the first page while --yes --all deleted everything).
         preview = self._invoke_delete(env, dry_run=True, yes_flag=False, all_flag=False)
-        assert preview["dry_run"] is True
-        assert preview["matched"] == self.COUNT
-        assert preview["deleted"] == 0
+        assert preview["status"] == "preview"
+        assert preview["session_count"] == self.COUNT
+        assert preview["affected_count"] == 0
         preview_ids = preview["session_ids"]
         assert isinstance(preview_ids, list)
         assert set(preview_ids) == set(guard), "dry-run preview set diverges from the guard set"
@@ -719,8 +719,10 @@ class TestDeleteCardinalityLargeNonMocked:
 
         # 3. Deleted set: --yes --all removes the entire matched set.
         result = self._invoke_delete(env, dry_run=False, yes_flag=True, all_flag=True)
-        assert result["matched"] == self.COUNT
-        assert result["deleted"] == self.COUNT, f"delete truncated to {result['deleted']} (expected {self.COUNT})"
+        assert result["session_count"] == self.COUNT
+        assert result["affected_count"] == self.COUNT, (
+            f"delete truncated to {result['affected_count']} (expected {self.COUNT})"
+        )
 
         # The archive no longer matches the query: deleted set == guard set.
         assert resolve_session_ids_for_verb(env, request) == []


### PR DESCRIPTION
## Summary
Converges the CLI's 6 ad-hoc `{mode:"mutation",...}` JSON outputs onto the shared typed `MutationResultPayload` (the contract MCP and the daemon already use), completing #1818 P4. Also fixes 3 unrelated master-red tests (see below).

## Problem
The CLI emitted hand-rolled mutation dicts (`archive_query.py`), diverging from the `MutationResultPayload` MCP/daemon use — #1818 wants one machine-output mutation contract.

## Solution (option A — additive)
- `surfaces/payloads.py`: `MutationResultPayload` gains two optional fields, both default `None` so MCP/daemon `exclude_none=True` dumps are **byte-unchanged** (no mcp/daemon call site touched): `operation: str | None` (bulk-mutation discriminator) and `session_ids: tuple[str,...] | None` (dry-run enumeration). `status` docstring notes the new `preview`/`aborted` CLI values.
- `cli/archive_query.py`: all 6 sites build `MutationResultPayload` and emit `.to_json(exclude_none=True)` (one finite JSON value). Mappings: `changed→affected_count`, `matched→session_count`, `deleted→affected_count`, `dry_run/aborted→status`, combined tag+meta → `tag_count`+`applied_count` (documented inline).

## Bundled fix (master-red, #1810 regression)
3 tests in `test_query_exec_laws.py` were left red on master by the #1810 provider sweep (#1901) — they fed `{provider: codex}` expecting origin mapping that was intentionally removed; PR CI missed it (test job is PR-skipped). Their inputs are updated to `origin`/`exclude_origin`. Bundled here because this PR already edits that file (avoids a conflict).

## Verification
```
devtools test test_query_exec_laws test_verb_cardinality   # 99 passed (3 ex-red now green)
devtools verify --quick   # exit 0
```
No snapshots/baselines pin the mutation shape (confirmed).

Ref #1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mutation operations now support additional status indicators for dry-run previews and user-aborted confirmations.

* **Refactor**
  * Standardized response format for mutation and deletion operations.
  * Updated archive filtering parameters to use `origin` instead of `provider`.

* **Tests**
  * Updated test suite to match revised operation response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->