### PR TITLE
refactor(daemon): converge HTTP error responses onto QueryErrorPayload (#1818)

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -694,8 +694,20 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(raw)
 
-    def _send_error(self, status: HTTPStatus, code: str) -> None:
-        self._send_json(status, {"ok": False, "error": code})
+    def _send_error(self, status: HTTPStatus, code: str, detail: str | None = None) -> None:
+        """Emit the canonical daemon error envelope.
+
+        Every daemon error response shares one machine-output contract
+        (#1818): ``{"ok": false, "error": <code>, "detail": <str|null>,
+        "field": <str|null>}``, produced by ``QueryErrorPayload`` so the
+        decorator path, the cursor-rejection path, and ad-hoc 4xx sites all
+        serialize identically. Health/status payloads use a different,
+        deliberately separate shape and do not route through here.
+        """
+        self._send_json(
+            status,
+            QueryErrorPayload(error=code, detail=detail).model_dump(mode="json"),
+        )
 
     def _parse_path(self) -> tuple[list[str], dict[str, list[str]]]:
         parsed = urlparse(self.path)
@@ -1374,7 +1386,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 offset=offset,
             )
         except InvalidSearchCursorError as exc:
-            return {"ok": False, "error": "invalid_cursor", "detail": str(exc)}
+            return QueryErrorPayload(error="invalid_cursor", detail=str(exc)).model_dump(mode="json")
         return envelope.model_dump(mode="json")
 
     def _do_archive_list_sessions(

--- a/tests/unit/daemon/test_daemon_http_contracts.py
+++ b/tests/unit/daemon/test_daemon_http_contracts.py
@@ -675,3 +675,69 @@ class TestOperationSpecContract:
             seen[name] = seen.get(name, 0) + 1
         duplicates = {name: count for name, count in seen.items() if count > 1}
         assert not duplicates, f"duplicate operation names in catalog: {duplicates}"
+
+
+# ---------------------------------------------------------------------------
+# Error-envelope convergence (#1818)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorEnvelopeContract:
+    """Every genuine daemon error response shares one machine-output shape.
+
+    ``_send_error`` is the single helper for daemon error responses; it emits
+    ``{"ok": False, "error": <code>, "detail": <str|null>, "field": <str|null>}``
+    through the shared ``QueryErrorPayload``, identical to the
+    ``daemon_safe_handler`` decorator and the cursor-rejection path. Health and
+    status payloads use a deliberately separate shape (``status`` / ``alerts`` /
+    ``quick_check`` keys) and must NOT be routed through this helper.
+    """
+
+    def test_send_error_emits_canonical_envelope(self) -> None:
+        handler = _make_handler("GET", "/api/status")
+        send_json = MagicMock()
+        handler._send_json = send_json  # type: ignore[method-assign]
+        handler._send_error(HTTPStatus.NOT_FOUND, "not_found")
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.NOT_FOUND
+        assert payload == {"ok": False, "error": "not_found", "detail": None, "field": None}
+
+    def test_send_error_includes_detail_when_provided(self) -> None:
+        handler = _make_handler("GET", "/api/status")
+        send_json = MagicMock()
+        handler._send_json = send_json  # type: ignore[method-assign]
+        handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_cursor", "bad anchor")
+        _, payload = send_json.call_args.args
+        assert payload == {
+            "ok": False,
+            "error": "invalid_cursor",
+            "detail": "bad anchor",
+            "field": None,
+        }
+
+    def test_do_options_error_routes_through_canonical_envelope(self) -> None:
+        """A representative real error site (405 on OPTIONS) carries the shape."""
+        handler = _make_handler("OPTIONS", "/api/status")
+        send_json = MagicMock()
+        handler._send_json = send_json  # type: ignore[method-assign]
+        handler.do_OPTIONS()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.METHOD_NOT_ALLOWED
+        assert payload["ok"] is False
+        assert payload["error"] == "method_not_allowed"
+        assert payload["detail"] is None
+
+    def test_health_payload_is_not_an_error_envelope(self) -> None:
+        """Health/status sites keep their own shape and never go through _send_error.
+
+        The healthz unhealthy/error bodies carry ``status``/``alerts`` keys, not
+        an ``error`` code — that separation is intentional (#1818) and must hold.
+        """
+        from polylogue.surfaces.payloads import QueryErrorPayload
+
+        # The canonical error envelope never carries health-status keys.
+        error_keys = set(QueryErrorPayload(error="x").model_dump(mode="json"))
+        assert error_keys == {"ok", "error", "detail", "field"}
+        assert "status" not in error_keys
+        assert "alerts" not in error_keys
+        assert "quick_check" not in error_keys


### PR DESCRIPTION
## Summary
Routes the daemon's straggler HTTP error responses through the already-canonical `QueryErrorPayload` (`{ok:false, error, detail, field}`), so every genuine daemon error serializes identically (#1818 P1). Health/status bodies are intentionally left as their own contract.

## Problem
The daemon had three error shapes: `daemon_safe_handler` already emitted the canonical `QueryErrorPayload`, but `_send_error` emitted `{ok:false, error}` (no detail) and the cursor-rejection site hand-built `{ok:false, error, detail}`.

## Solution (daemon/http.py only)
- `_send_error(status, code, detail=None)` now emits `QueryErrorPayload`; its ~30 existing `(status, code)` call sites are unchanged (`detail` defaults to None).
- The cursor-rejection site uses `QueryErrorPayload(...)` instead of a hand-built dict — byte-identical to the decorator path.
- **Left unchanged**: healthz/`/api/health` bodies use `status`/`alerts`/`quick_check` deliberately — a separate health contract, not errors.

## Verification
```
devtools test test_daemon_http_contracts + all _send_error-touching daemon tests   # 293 + 233 passed
devtools verify --quick   # exit 0
```
New `TestErrorEnvelopeContract` pins the canonical shape, detail-when-provided, a real 405 error site, and the error-vs-health key separation.

Ref #1818