### PR TITLE
fix(cli): refuse forceless delete in machine mode without prompting (#1818)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1584,6 +1584,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
 | `devtools evidence-dashboard` | Render the pytest-first evidence dashboard or a changed-path trace. |
+| `devtools ingest-amplification-probe` | Measure deterministic per-tier ingest write amplification on a synthetic fixture (#1851). |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -1208,6 +1208,24 @@ def _emit_delete(
         )
         return
     if not force:
+        # Machine/non-interactive surfaces must never block on an interactive
+        # confirmation prompt (#1818 P6). The delete verb always emits a JSON
+        # MutationResultPayload, so in plain mode (``--format`` machine output,
+        # a non-TTY pipe, or ``POLYLOGUE_FORCE_PLAIN``) we refuse without
+        # prompting and emit a parseable ``aborted`` envelope that names the
+        # required flag, mirroring the reset command's plain-mode guard rather
+        # than relying on the generic plain-prompt SystemExit.
+        if env.ui.plain:
+            click.echo(
+                MutationResultPayload(
+                    status="aborted",
+                    operation="delete",
+                    session_count=count,
+                    affected_count=0,
+                    detail="confirmation_required",
+                ).to_json(exclude_none=True)
+            )
+            return
         click.echo(f"About to delete {count} session(s):", err=True)
         for session_id in session_ids[:5]:
             click.echo(f"  - {session_id}", err=True)

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import types
 from typing import cast
+from unittest.mock import MagicMock
 
 import click
 import pytest
@@ -17,6 +19,7 @@ from polylogue.cli.archive_query import (
     _csv_tokens,
     _decode_cursor,
     _ellipsize,
+    _emit_delete,
     _has_value,
     _hit_line,
     _limit,
@@ -891,3 +894,67 @@ class TestPaginateRows:
         decoded = _decode_cursor(next_cursor)
         assert decoded is not None
         assert decoded.r == 15  # offset + len(page) = 5 + 10
+
+
+class TestEmitDeleteMachineModeNoPrompt:
+    """`_emit_delete` must never block on an interactive prompt in machine mode (#1818 P6).
+
+    The delete verb always emits a JSON MutationResultPayload. In plain mode
+    (machine output, non-TTY pipe, or POLYLOGUE_FORCE_PLAIN) it must refuse a
+    forceless delete with a parseable ``aborted`` envelope rather than calling
+    ``env.ui.confirm`` (which would prompt on a TTY or SystemExit on a pipe).
+    """
+
+    @staticmethod
+    def _env(*, plain: bool) -> MagicMock:
+        env = MagicMock()
+        env.ui.plain = plain
+        env.ui.confirm = MagicMock()
+        return env
+
+    @staticmethod
+    def _archive() -> MagicMock:
+        archive = MagicMock()
+        archive.delete_sessions = MagicMock(return_value=0)
+        return archive
+
+    def test_plain_forceless_delete_aborts_without_prompt(self, capsys: pytest.CaptureFixture[str]) -> None:
+        env = self._env(plain=True)
+        archive = self._archive()
+
+        _emit_delete(env, archive, ("s1", "s2"), params={"force": False, "dry_run": False})
+
+        env.ui.confirm.assert_not_called()
+        archive.delete_sessions.assert_not_called()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "aborted"
+        assert payload["operation"] == "delete"
+        assert payload["detail"] == "confirmation_required"
+        assert payload["session_count"] == 2
+        assert payload["affected_count"] == 0
+
+    def test_plain_forced_delete_proceeds_without_prompt(self, capsys: pytest.CaptureFixture[str]) -> None:
+        env = self._env(plain=True)
+        archive = self._archive()
+        archive.delete_sessions.return_value = 2
+
+        _emit_delete(env, archive, ("s1", "s2"), params={"force": True, "dry_run": False})
+
+        env.ui.confirm.assert_not_called()
+        archive.delete_sessions.assert_called_once_with(("s1", "s2"))
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "deleted"
+        assert payload["affected_count"] == 2
+
+    def test_interactive_forceless_delete_still_prompts(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Human interactive use (non-plain) must keep the confirmation prompt.
+        env = self._env(plain=False)
+        env.ui.confirm.return_value = False
+        archive = self._archive()
+
+        _emit_delete(env, archive, ("s1", "s2"), params={"force": False, "dry_run": False})
+
+        env.ui.confirm.assert_called_once()
+        archive.delete_sessions.assert_not_called()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "aborted"


### PR DESCRIPTION
## Summary

Closes the last #1818 machine-output gap (P6): the `delete` verb's output is
always a JSON `MutationResultPayload`, yet a forceless delete (no `--yes`/`--force`)
called `env.ui.confirm`, mixing an interactive prompt into machine output.

## Problem

`delete` never threads `--format`; its result is unconditionally a JSON payload.
But the forceless path called `env.ui.confirm`, so:
- **Plain + TTY stdin** (e.g. `POLYLOGUE_FORCE_PLAIN=1` automation): `confirm`
  falls through to a blocking `input()` prompt — a prompt interleaved into JSON.
- **Non-TTY pipe**: `confirm` raises → `SystemExit(1)` with a human notice on
  stderr and **empty stdout** — no parseable envelope.

`reset` already guarded this (plain-mode early return); `delete` did not. Audit
of all `polylogue/cli/` confirm sites (table in the lane report) confirmed
`delete` was the only reachable machine-mode gap; `reset` is already guarded,
`query_actions.py` confirm sites are orphaned (no production caller), and
`embed` has no machine surface.

## Solution

`_emit_delete` (`polylogue/cli/archive_query.py`) now guards the confirm block on
`env.ui.plain`: in plain mode without force it emits
`MutationResultPayload(status="aborted", operation="delete", session_count=N,
affected_count=0, detail="confirmation_required")` and returns — no prompt, no
hang, parseable JSON. Interactive (non-plain) use keeps the prompt; `delete --yes`
still deletes without prompting.

Also regenerates `AGENTS.md` to pick up the `#1851 ingest-amplification-probe`
devtools-reference row that had drifted on master (separate chore commit).

## Verification

- `devtools test tests/unit/cli/test_archive_query.py` → **114 passed**
  (incl. new `TestEmitDeleteMachineModeNoPrompt`: plain+forceless → aborted/no
  prompt; plain+force → deletes; non-plain+forceless → prompt preserved).
- `devtools verify --quick` → green (format, lint, mypy, render-all --check).

Ref #1818