### PR TITLE
feat(insights): parse run state into recovery digests (#1880)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -33,6 +33,10 @@ _TEST_FAIL_RE = re.compile(r"\b(?P<count>\d+)\s+failed\b", re.IGNORECASE)
 _CHECK_PASS_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_. -]+)\s+\.\.\.\s+ok\b")
 _DECISION_RE = re.compile(r"\b(decision|decided|choose|chosen):?\s+(?P<text>.+)", re.IGNORECASE)
 _STATUS_HEADING_RE = re.compile(r"^\s*(goal|done|in flight|blockers?|next):\s*(?P<text>.+)$", re.IGNORECASE)
+_RUNSTATE_SECTION_RE = re.compile(
+    r"^\s*(goal|done|in flight|blockers?|next(?: action)?s?):\s*(?P<text>.*)$",
+    re.IGNORECASE,
+)
 
 
 def _utc_now_iso() -> str:
@@ -72,6 +76,7 @@ class RecoverySizeMetrics(ArchiveInsightModel):
     message_count: int
     tool_summary_count: int
     subagent_report_count: int
+    run_state_count: int
     event_count: int
     decision_candidate_count: int
 
@@ -114,6 +119,23 @@ class SubagentReport(ArchiveInsightModel):
         return self
 
 
+class RunStateSummary(ArchiveInsightModel):
+    goal: str | None = None
+    done: tuple[str, ...] = ()
+    in_flight: tuple[str, ...] = ()
+    blockers: tuple[str, ...] = ()
+    next_actions: tuple[str, ...] = ()
+    raw_refs: tuple[TransformRawRef, ...]
+
+    @model_validator(mode="after")
+    def _requires_content_and_raw_refs(self) -> RunStateSummary:
+        if not self.raw_refs:
+            raise ValueError("RunStateSummary requires at least one raw ref")
+        if not any((self.goal, self.done, self.in_flight, self.blockers, self.next_actions)):
+            raise ValueError("RunStateSummary requires at least one parsed field")
+        return self
+
+
 class RecoveryEvent(ArchiveInsightModel):
     kind: Literal["pr_opened", "pr_merged", "issue_closed", "check_passed", "test_passed", "test_failed"]
     summary: str
@@ -148,6 +170,7 @@ class RecoveryDigest(ArchiveInsightModel):
     role_counts: dict[str, int] = Field(default_factory=dict)
     tool_summaries: tuple[ToolSummary, ...] = ()
     subagent_reports: tuple[SubagentReport, ...] = ()
+    run_state: RunStateSummary | None = None
     events: tuple[RecoveryEvent, ...] = ()
     decision_candidates: tuple[DecisionCandidate, ...] = ()
     resume_markdown: str
@@ -192,6 +215,7 @@ def compile_recovery_digest(session: Session) -> RecoveryDigest:
     )
     tool_summaries = tuple(_extract_tool_summaries(session, messages))
     subagent_reports = tuple(_extract_subagent_reports(session, messages))
+    run_state = _extract_run_state(session, messages)
     events = tuple(_extract_events(session, messages))
     decisions = tuple(_extract_decision_candidates(session, messages))
     role_counts = dict(Counter(_role_value(message) for message in messages))
@@ -201,6 +225,7 @@ def compile_recovery_digest(session: Session) -> RecoveryDigest:
         session=session,
         tool_summaries=tool_summaries,
         subagent_reports=subagent_reports,
+        run_state=run_state,
         events=events,
         decisions=decisions,
     )
@@ -221,12 +246,14 @@ def compile_recovery_digest(session: Session) -> RecoveryDigest:
             message_count=len(messages),
             tool_summary_count=len(tool_summaries),
             subagent_report_count=len(subagent_reports),
+            run_state_count=1 if run_state is not None else 0,
             event_count=len(events),
             decision_candidate_count=len(decisions),
         ),
         role_counts=role_counts,
         tool_summaries=tool_summaries,
         subagent_reports=subagent_reports,
+        run_state=run_state,
         events=events,
         decision_candidates=decisions,
         resume_markdown=resume_markdown,
@@ -239,6 +266,7 @@ def render_resume_bundle(
     session: Session,
     tool_summaries: Sequence[ToolSummary],
     subagent_reports: Sequence[SubagentReport],
+    run_state: RunStateSummary | None,
     events: Sequence[RecoveryEvent],
     decisions: Sequence[DecisionCandidate],
 ) -> str:
@@ -267,6 +295,16 @@ def render_resume_bundle(
             lines.append(f"  - report: {report.final_report_preview}")
     if not subagent_reports:
         lines.append("- none extracted")
+    lines.extend(["", "## Run State"])
+    if run_state is None:
+        lines.append("- none extracted")
+    else:
+        if run_state.goal:
+            lines.append(f"- goal: {run_state.goal}")
+        lines.extend(f"- done: {item}" for item in run_state.done[:8])
+        lines.extend(f"- in_flight: {item}" for item in run_state.in_flight[:8])
+        lines.extend(f"- blocker: {item}" for item in run_state.blockers[:8])
+        lines.extend(f"- next: {item}" for item in run_state.next_actions[:8])
     lines.extend(["", "## Tools"])
     for tool in tool_summaries[:8]:
         command = f" — {tool.command}" if tool.command else ""
@@ -365,6 +403,117 @@ def _extract_events(session: Session, messages: Sequence[Message]) -> Iterable[R
                     continue
                 seen.add(key)
                 yield event
+
+
+def _extract_run_state(session: Session, messages: Sequence[Message]) -> RunStateSummary | None:
+    goal: str | None = None
+    done: list[str] = []
+    in_flight: list[str] = []
+    blockers: list[str] = []
+    next_actions: list[str] = []
+    refs: list[TransformRawRef] = []
+
+    for message in messages:
+        parsed = _parse_run_state_text(message.text or "")
+        if parsed is None:
+            continue
+        parsed_goal, parsed_done, parsed_in_flight, parsed_blockers, parsed_next = parsed
+        if parsed_goal:
+            goal = parsed_goal
+        _extend_unique(done, parsed_done)
+        _extend_unique(in_flight, parsed_in_flight)
+        _extend_unique(blockers, parsed_blockers)
+        _extend_unique(next_actions, parsed_next)
+        refs.append(_message_ref(session, message))
+
+    if not refs:
+        return None
+    return RunStateSummary(
+        goal=goal,
+        done=tuple(done),
+        in_flight=tuple(in_flight),
+        blockers=tuple(blockers),
+        next_actions=tuple(next_actions),
+        raw_refs=tuple(refs),
+    )
+
+
+def _parse_run_state_text(
+    text: str,
+) -> tuple[str | None, list[str], list[str], list[str], list[str]] | None:
+    goal: str | None = None
+    done: list[str] = []
+    in_flight: list[str] = []
+    blockers: list[str] = []
+    next_actions: list[str] = []
+    current_section: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            current_section = None
+            continue
+        heading = _RUNSTATE_SECTION_RE.match(line)
+        if heading is not None:
+            current_section = _run_state_section_key(heading.group(1))
+            value = _clean_run_state_item(heading.group("text"))
+            if value:
+                if current_section == "goal":
+                    goal = value
+                elif current_section == "done":
+                    done.append(value)
+                elif current_section == "in_flight":
+                    in_flight.append(value)
+                elif current_section == "blockers":
+                    blockers.append(value)
+                elif current_section == "next":
+                    next_actions.append(value)
+            continue
+        if current_section is None:
+            continue
+        value = _clean_run_state_item(line)
+        if not value:
+            continue
+        if current_section == "goal":
+            goal = value if goal is None else f"{goal}; {value}"
+        elif current_section == "done":
+            done.append(value)
+        elif current_section == "in_flight":
+            in_flight.append(value)
+        elif current_section == "blockers":
+            blockers.append(value)
+        elif current_section == "next":
+            next_actions.append(value)
+
+    if not any((goal, done, in_flight, blockers, next_actions)):
+        return None
+    return goal, done, in_flight, blockers, next_actions
+
+
+def _run_state_section_key(value: str) -> Literal["goal", "done", "in_flight", "blockers", "next"]:
+    normalized = value.lower().strip()
+    if normalized == "goal":
+        return "goal"
+    if normalized == "done":
+        return "done"
+    if normalized == "in flight":
+        return "in_flight"
+    if normalized.startswith("blocker"):
+        return "blockers"
+    return "next"
+
+
+def _clean_run_state_item(value: str) -> str:
+    return _preview(value.strip().lstrip("-*").strip(), limit=240)
+
+
+def _extend_unique(target: list[str], values: Iterable[str]) -> None:
+    seen = set(target)
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        target.append(value)
 
 
 def _events_from_text(text: str, ref: TransformRawRef) -> Iterable[RecoveryEvent]:
@@ -611,6 +760,7 @@ __all__ = [
     "RecoveryDigest",
     "RecoveryEvent",
     "RecoverySizeMetrics",
+    "RunStateSummary",
     "SubagentReport",
     "ToolSummary",
     "TransformDescriptor",

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -12,6 +12,7 @@ from polylogue.insights.transforms import (
     RECOVERY_TRANSFORM,
     TRANSFORM_REGISTRY,
     RecoveryEvent,
+    RunStateSummary,
     SubagentReport,
     ToolSummary,
     TransformRawRef,
@@ -32,7 +33,17 @@ def _session() -> Session:
                 Message(
                     id="m1",
                     role=Role.USER,
-                    text="Goal: burn down the backlog\nNext: merge PR #1911",
+                    text=(
+                        "Goal: burn down the backlog\n"
+                        "Done:\n"
+                        "- #1910 merged\n"
+                        "- #1818 closed\n"
+                        "In flight:\n"
+                        "- #1913 CI\n"
+                        "Blockers:\n"
+                        "- none\n"
+                        "Next: merge PR #1911"
+                    ),
                 ),
                 Message(
                     id="m2",
@@ -96,6 +107,7 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert digest.transform.input_session_id == "codex-session:demo"
     assert digest.size_metrics.message_count == 3
     assert digest.size_metrics.subagent_report_count == 1
+    assert digest.size_metrics.run_state_count == 1
     assert digest.size_metrics.raw_bytes > digest.size_metrics.resume_bundle_bytes
     assert digest.size_metrics.resume_to_raw_ratio < 1
     assert digest.role_counts == {"user": 1, "assistant": 2}
@@ -117,6 +129,14 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert subagent.caveats == ("Caveat: storage persistence not included.",)
     assert {ref.ref_kind for ref in subagent.raw_refs} == {"block"}
 
+    assert digest.run_state is not None
+    assert digest.run_state.goal == "burn down the backlog"
+    assert digest.run_state.done == ("#1910 merged", "#1818 closed")
+    assert digest.run_state.in_flight == ("#1913 CI",)
+    assert digest.run_state.blockers == ("none",)
+    assert digest.run_state.next_actions == ("merge PR #1911",)
+    assert digest.run_state.raw_refs[0].message_id == "m1"
+
     event_summaries = {event.summary for event in digest.events}
     assert "PR #1911 opened" in event_summaries
     assert "PR #1910 merged" in event_summaries
@@ -133,6 +153,9 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert "feature/demo" in digest.resume_markdown
     assert "## Subagents" in digest.resume_markdown
     assert "Explore — Map the transform surface and report caveats." in digest.resume_markdown
+    assert "## Run State" in digest.resume_markdown
+    assert "- done: #1910 merged" in digest.resume_markdown
+    assert "- next: merge PR #1911" in digest.resume_markdown
     assert "Raw refs are available" in digest.resume_markdown
 
 
@@ -146,6 +169,9 @@ def test_every_extracted_claim_carries_raw_refs() -> None:
     for report in digest.subagent_reports:
         assert report.raw_refs
         assert all(ref.session_id == digest.session_id for ref in report.raw_refs)
+    assert digest.run_state is not None
+    assert digest.run_state.raw_refs
+    assert all(ref.session_id == digest.session_id for ref in digest.run_state.raw_refs)
     for event in digest.events:
         assert event.raw_refs
         assert all(ref.session_id == digest.session_id for ref in event.raw_refs)
@@ -159,6 +185,8 @@ def test_claim_models_reject_missing_raw_refs() -> None:
         ToolSummary(tool_name="Bash", raw_refs=())
     with pytest.raises(ValidationError):
         SubagentReport(raw_refs=())
+    with pytest.raises(ValidationError):
+        RunStateSummary(raw_refs=())
     with pytest.raises(ValidationError):
         RecoveryEvent(kind="test_passed", summary="1 tests passed", raw_refs=())
 


### PR DESCRIPTION
## Summary

Adds structured RunState extraction to the deterministic recovery digest so continuation packets can carry explicit operator state alongside tools, subagents, events, and decision candidates.

## Problem

#1880's recovery digest path could extract generic `Goal:` / `Next:` lines only as flat decision candidates. That loses the useful continuation shape from recaps and RunState notes: what is done, what is in flight, blockers, and the next action list.

## Solution

`polylogue/insights/transforms.py` now includes a typed `RunStateSummary` with raw message refs, parses `Goal`, `Done`, `In flight`, `Blockers`, and `Next` sections deterministically, counts the extraction in `RecoverySizeMetrics`, attaches it to `RecoveryDigest`, and renders it into the resume bundle before generic tools/events. `tests/unit/insights/test_transforms.py` pins multi-line section parsing, evidence refs, metric counts, and validation failures for missing refs.

## Verification

- `nix develop --command devtools test tests/unit/insights/test_transforms.py` -> `6 passed in 0.74s`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Ref #1880