### PR TITLE
feat(storage): mirror recall packs and workspaces into assertions (#1883)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -81,6 +81,8 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     upsert_annotation,
     upsert_blackboard_note,
     upsert_mark,
+    upsert_recall_pack,
+    upsert_workspace,
 )
 from polylogue.storage.sqlite.archive_tiers.write import (
     ArchiveInsightMaterialization,
@@ -1837,26 +1839,14 @@ class ArchiveStore:
         payload = dict(payload)
         payload["session_ids_json"] = session_ids_json
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
-        now_ms = int(datetime.now(UTC).timestamp() * 1000)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             existing = user_conn.execute(
                 "SELECT created_at_ms FROM recall_packs WHERE recall_pack_id = ?",
                 (pack_id,),
             ).fetchone()
-            created_at_ms = int(existing[0]) if existing is not None else now_ms
             with user_conn:
-                user_conn.execute(
-                    """
-                    INSERT INTO recall_packs (recall_pack_id, name, payload_json, created_at_ms, updated_at_ms)
-                    VALUES (?, ?, ?, ?, ?)
-                    ON CONFLICT(recall_pack_id) DO UPDATE SET
-                        name = excluded.name,
-                        payload_json = excluded.payload_json,
-                        updated_at_ms = excluded.updated_at_ms
-                    """,
-                    (pack_id, label, json.dumps(payload, sort_keys=True), created_at_ms, now_ms),
-                )
+                upsert_recall_pack(user_conn, label, payload, recall_pack_id=pack_id)
             return existing is None
         finally:
             user_conn.close()
@@ -1929,33 +1919,21 @@ class ArchiveStore:
         active_target_json: str,
     ) -> bool:
         """Create or update one reader workspace in archive user.db."""
-        settings = {
+        settings: dict[str, object] = {
             "mode": mode,
             "open_targets_json": open_targets_json,
             "layout_json": layout_json,
             "active_target_json": active_target_json,
         }
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
-        now_ms = int(datetime.now(UTC).timestamp() * 1000)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             existing = user_conn.execute(
                 "SELECT created_at_ms FROM workspaces WHERE workspace_id = ?",
                 (workspace_id,),
             ).fetchone()
-            created_at_ms = int(existing[0]) if existing is not None else now_ms
             with user_conn:
-                user_conn.execute(
-                    """
-                    INSERT INTO workspaces (workspace_id, name, settings_json, created_at_ms, updated_at_ms)
-                    VALUES (?, ?, ?, ?, ?)
-                    ON CONFLICT(workspace_id) DO UPDATE SET
-                        name = excluded.name,
-                        settings_json = excluded.settings_json,
-                        updated_at_ms = excluded.updated_at_ms
-                    """,
-                    (workspace_id, name, json.dumps(settings, sort_keys=True), created_at_ms, now_ms),
-                )
+                upsert_workspace(user_conn, name, settings, workspace_id=workspace_id)
             return existing is None
         finally:
             user_conn.close()

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -467,6 +467,17 @@ def upsert_recall_pack(
         """,
         (resolved_id, name, _json_dumps(payload), created_at_ms, timestamp),
     )
+    upsert_assertion(
+        conn,
+        assertion_id=_deterministic_id(f"assertion-{AssertionKind.RECALL_PACK}", resolved_id),
+        target_ref=f"recall_pack:{resolved_id}",
+        kind=AssertionKind.RECALL_PACK,
+        key=name,
+        value=payload,
+        body_text=name,
+        author_kind="user",
+        now_ms=timestamp,
+    )
     return read_archive_recall_pack_envelope(conn, resolved_id)
 
 
@@ -475,23 +486,36 @@ def upsert_workspace(
     name: str,
     settings: dict[str, object],
     *,
+    workspace_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveWorkspaceEnvelope:
     """Insert-or-update one workspace keyed by name."""
     timestamp = now_ms if now_ms is not None else _now_ms()
-    workspace_id = _deterministic_id("workspace", name)
-    existing = conn.execute("SELECT created_at_ms FROM workspaces WHERE name = ?", (name,)).fetchone()
+    resolved_id = workspace_id or _deterministic_id("workspace", name)
+    existing = conn.execute("SELECT created_at_ms FROM workspaces WHERE workspace_id = ?", (resolved_id,)).fetchone()
     created_at_ms = int(existing[0]) if existing is not None else timestamp
 
     conn.execute(
         """
         INSERT INTO workspaces (workspace_id, name, settings_json, created_at_ms, updated_at_ms)
         VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(name) DO UPDATE SET
+        ON CONFLICT(workspace_id) DO UPDATE SET
+            name = excluded.name,
             settings_json = excluded.settings_json,
             updated_at_ms = excluded.updated_at_ms
         """,
-        (workspace_id, name, _json_dumps(settings), created_at_ms, timestamp),
+        (resolved_id, name, _json_dumps(settings), created_at_ms, timestamp),
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=_deterministic_id(f"assertion-{AssertionKind.WORKSPACE_NOTE}", resolved_id),
+        target_ref=f"workspace:{resolved_id}",
+        kind=AssertionKind.WORKSPACE_NOTE,
+        key=name,
+        value=settings,
+        body_text=name,
+        author_kind="user",
+        now_ms=timestamp,
     )
     return read_archive_workspace_envelope(conn, name)
 

--- a/tests/unit/storage/test_archive_tiers_user_write.py
+++ b/tests/unit/storage/test_archive_tiers_user_write.py
@@ -14,6 +14,8 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     ArchiveSavedViewEnvelope,
     ArchiveSuppressionEnvelope,
     ArchiveWorkspaceEnvelope,
+    AssertionKind,
+    list_assertions_for_target,
     read_archive_annotation_envelope,
     read_archive_blackboard_note_envelope,
     read_archive_correction_envelope,
@@ -210,11 +212,23 @@ def test_archive_tiers_user_write_minimal_upserts(tmp_path: Path) -> None:
     assert recall_pack.created_at_ms == 1_700_000_010_000
     assert recall_pack_refresh.updated_at_ms == 1_700_000_011_000
     assert refreshed_recall_pack.payload == {"session_ids": ["session-1", "session-2"]}
+    recall_pack_assertions = list_assertions_for_target(conn, "recall_pack:pack-1", kind=AssertionKind.RECALL_PACK)
+    assert len(recall_pack_assertions) == 1
+    assert recall_pack_assertions[0].key == "launch-pack"
+    assert recall_pack_assertions[0].value == {"session_ids": ["session-1", "session-2"]}
+    assert recall_pack_assertions[0].updated_at_ms == 1_700_000_011_000
 
     assert workspace.workspace_id == workspace_refresh.workspace_id
     assert workspace.created_at_ms == 1_700_000_012_000
     assert workspace_refresh.updated_at_ms == 1_700_000_013_000
     assert refreshed_workspace.settings == {"root": "/realm/project/polylogue", "branch": "feature"}
+    workspace_assertions = list_assertions_for_target(
+        conn, f"workspace:{workspace.workspace_id}", kind=AssertionKind.WORKSPACE_NOTE
+    )
+    assert len(workspace_assertions) == 1
+    assert workspace_assertions[0].key == "polylogue"
+    assert workspace_assertions[0].value == {"root": "/realm/project/polylogue", "branch": "feature"}
+    assert workspace_assertions[0].updated_at_ms == 1_700_000_013_000
 
     assert blackboard_note.note_id == blackboard_note_refresh.note_id
     assert blackboard_note.created_at_ms == 1_700_000_014_000

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -163,6 +163,14 @@ async def test_user_state_mutations_write_archive_user_tier(
         workspace = conn.execute(
             "SELECT workspace_id, name, settings_json FROM workspaces WHERE workspace_id = 'workspace-v1'"
         ).fetchone()
+        assertion_rows = conn.execute(
+            """
+            SELECT target_ref, kind, key, value_json
+            FROM assertions
+            WHERE target_ref IN ('recall_pack:pack-v1', 'workspace:workspace-v1')
+            ORDER BY target_ref
+            """
+        ).fetchall()
         correction_row = conn.execute(
             "SELECT target_type, target_id, correction_type, payload_json FROM corrections"
         ).fetchone()
@@ -180,6 +188,12 @@ async def test_user_state_mutations_write_archive_user_tier(
     assert workspace is not None
     assert workspace[0:2] == ("workspace-v1", "Archive workspace")
     assert json.loads(workspace[2])["mode"] == "tabs"
+    assert [(row[0], row[1], row[2]) for row in assertion_rows] == [
+        ("recall_pack:pack-v1", "recall_pack", "Archive pack"),
+        ("workspace:workspace-v1", "workspace_note", "Archive workspace"),
+    ]
+    assert json.loads(assertion_rows[0][3])["session_ids_json"]
+    assert json.loads(assertion_rows[1][3])["mode"] == "tabs"
     assert correction_row is not None
     assert correction_row[0:3] == ("session", ARCHIVE_USER_STATE_SESSION_ID, "tag_accept")
     assert json.loads(correction_row[3])["payload"] == {"tag": "archive"}


### PR DESCRIPTION
## Summary

Extends the unified assertion substrate write-through coverage to recall packs and reader workspaces, including the public `ArchiveStore` write paths.

## Problem

#1883 had landed the assertion table and several write-through adapters, but recall packs and workspaces still wrote only their legacy user-tier tables. That meant new overlay surfaces could continue bypassing the unified evidence-linked assertion substrate.

## Solution

`upsert_recall_pack` now mirrors rows into `AssertionKind.RECALL_PACK` entries keyed by `recall_pack:<id>`. `upsert_workspace` now accepts an optional stable `workspace_id`, mirrors rows into `AssertionKind.WORKSPACE_NOTE` entries keyed by `workspace:<id>`, and preserves existing workspace read/update behavior. `ArchiveStore.save_recall_pack` and `save_workspace` now route through those helpers instead of hand-rolled SQL. Tests pin helper-level parity and the public user-state mutation path.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_archive_tiers_user_write.py tests/unit/storage/test_user_state_contracts.py -k "minimal_upserts or user_state_mutations_write_archive_user_tier or recall_pack_items_resolve or reader_workspaces"` -> `4 passed, 3 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Issue slice:
Recall-pack/workspace assertion write-through gap after the table + first adapters landed.

Files inspected:
`polylogue/storage/sqlite/archive_tiers/user.py`, `polylogue/storage/sqlite/archive_tiers/user_write.py`, `polylogue/storage/sqlite/archive_tiers/archive.py`, `tests/unit/storage/test_archive_tiers_assertions.py`, `tests/unit/storage/test_archive_tiers_user_write.py`, `tests/unit/storage/test_user_state_contracts.py`.

Files changed:
`polylogue/storage/sqlite/archive_tiers/user_write.py`, `polylogue/storage/sqlite/archive_tiers/archive.py`, `tests/unit/storage/test_archive_tiers_user_write.py`, `tests/unit/storage/test_user_state_contracts.py`.

Old surface removed or retained:
Legacy recall-pack/workspace tables and read contracts retained; write paths now also mirror into assertions.

Contracts/tests added:
Helper-level assertion parity for recall packs/workspaces and public user-state mutation parity for `ArchiveStore`/API calls.

Generated artifacts updated:
None.

Known caveats / SPEC_MISMATCH:
No schema change. `workspace_note` is the existing v0 assertion kind for workspace-scoped authored state; this PR does not introduce a new `workspace` kind.

Follow-up intentionally not included:
Read-path retirement of legacy overlay tables, assertion-backed deletes/status transitions, and #1880 transform-candidate promotion policy.

Ref #1883