### PR TITLE
feat(insights): classify recovery tool envelopes (#1880)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -91,8 +91,14 @@ class ToolSummary(ArchiveInsightModel):
     tool_name: str
     tool_id: str | None = None
     command: str | None = None
+    handler_kind: Literal["shell", "file_read", "github", "git", "test", "generic"] = "generic"
     status: Literal["ok", "failed", "unknown"] = "unknown"
+    line_count: int = 0
     output_preview: str = ""
+    pr_refs: tuple[str, ...] = ()
+    issue_refs: tuple[str, ...] = ()
+    test_evidence: tuple[str, ...] = ()
+    file_refs: tuple[str, ...] = ()
     raw_refs: tuple[TransformRawRef, ...]
 
     @model_validator(mode="after")
@@ -308,7 +314,7 @@ def render_resume_bundle(
     lines.extend(["", "## Tools"])
     for tool in tool_summaries[:8]:
         command = f" — {tool.command}" if tool.command else ""
-        lines.append(f"- {tool.tool_name} ({tool.status}){command}")
+        lines.append(f"- {tool.tool_name} [{tool.handler_kind}] ({tool.status}){command}")
     if not tool_summaries:
         lines.append("- none extracted")
     lines.extend(["", "## Candidate Decisions / Run State"])
@@ -345,12 +351,20 @@ def _extract_tool_summaries(session: Session, messages: Sequence[Message]) -> It
             if result_ref is not None:
                 refs.append(result_ref)
             output_text = _block_text(result_block or {})
+            tool_name = _tool_name(block)
+            command = _tool_command(block)
             yield ToolSummary(
-                tool_name=_tool_name(block),
+                tool_name=tool_name,
                 tool_id=tool_id,
-                command=_tool_command(block),
+                command=command,
+                handler_kind=_tool_handler_kind(tool_name=tool_name, command=command, output_text=output_text),
                 status=_tool_status(output_text),
+                line_count=_line_count(output_text),
                 output_preview=_preview(output_text),
+                pr_refs=tuple(_number_refs(_PR_RE, output_text)),
+                issue_refs=tuple(_number_refs(_ISSUE_RE, output_text)),
+                test_evidence=tuple(_test_evidence(output_text)),
+                file_refs=tuple(_tool_file_refs(tool_name=tool_name, command=command, output_text=output_text)),
                 raw_refs=tuple(refs),
             )
 
@@ -726,6 +740,60 @@ def _tool_status(output_text: str) -> Literal["ok", "failed", "unknown"]:
     if "exit code 1" in lowered or "failed" in lowered or "traceback" in lowered:
         return "failed"
     return "unknown"
+
+
+def _tool_handler_kind(
+    *,
+    tool_name: str,
+    command: str | None,
+    output_text: str,
+) -> Literal["shell", "file_read", "github", "git", "test", "generic"]:
+    name = tool_name.lower()
+    command_text = command or ""
+    command_lower = command_text.lower()
+    if name in {"read", "read_file"}:
+        return "file_read"
+    if command_lower.startswith("git "):
+        return "git"
+    if command_lower.startswith("gh "):
+        return "github"
+    if _looks_like_test_output(command_lower, output_text):
+        return "test"
+    if "github.com/" in output_text.lower():
+        return "github"
+    if name in {"bash", "shell", "exec_command"}:
+        return "shell"
+    return "generic"
+
+
+def _looks_like_test_output(command_lower: str, output_text: str) -> bool:
+    if any(token in command_lower for token in ("pytest", "devtools test", "devtools verify", "ruff ", "mypy")):
+        return True
+    return any(
+        (_TEST_PASS_RE.search(output_text), _TEST_FAIL_RE.search(output_text), _CHECK_PASS_RE.search(output_text))
+    )
+
+
+def _line_count(text: str) -> int:
+    if not text:
+        return 0
+    return len(text.splitlines())
+
+
+def _tool_file_refs(
+    *,
+    tool_name: str,
+    command: str | None,
+    output_text: str,
+) -> Iterable[str]:
+    if tool_name.lower() in {"read", "read_file"} and command:
+        yield command
+        return
+    for value in (command or "", output_text):
+        for token in value.split():
+            cleaned = token.strip("`'\"(),:")
+            if "/" in cleaned and not cleaned.startswith(("http://", "https://")):
+                yield cleaned
 
 
 def _block_text(block: Mapping[str, object]) -> str:

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -759,8 +759,6 @@ def _tool_handler_kind(
         return "github"
     if _looks_like_test_output(command_lower, output_text):
         return "test"
-    if "github.com/" in output_text.lower():
-        return "github"
     if name in {"bash", "shell", "exec_command"}:
         return "shell"
     return "generic"

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -61,6 +61,17 @@ def _session() -> Session:
                             "tool_id": "tool-1",
                             "text": "ruff check ... ok\n20 passed in 50.28s\nhttps://github.com/Sinity/polylogue/pull/1911",
                         },
+                        {
+                            "type": "tool_use",
+                            "id": "tool-read",
+                            "name": "Read",
+                            "tool_input": {"file_path": "polylogue/insights/transforms.py"},
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-read",
+                            "text": "class ToolSummary\nhandler_kind: Literal",
+                        },
                     ],
                 ),
                 Message(
@@ -112,12 +123,22 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert digest.size_metrics.resume_to_raw_ratio < 1
     assert digest.role_counts == {"user": 1, "assistant": 2}
 
-    assert len(digest.tool_summaries) == 1
-    tool = digest.tool_summaries[0]
+    assert len(digest.tool_summaries) == 2
+    tool = next(item for item in digest.tool_summaries if item.tool_name == "Bash")
     assert tool.tool_name == "Bash"
     assert tool.command == "devtools verify --quick"
+    assert tool.handler_kind == "test"
     assert tool.status == "ok"
+    assert tool.line_count == 3
+    assert tool.pr_refs == ("#1911",)
+    assert tool.test_evidence == ("ruff check ... ok", "20 passed in 50.28s")
     assert {ref.ref_kind for ref in tool.raw_refs} == {"block"}
+
+    read_tool = next(item for item in digest.tool_summaries if item.tool_name == "Read")
+    assert read_tool.handler_kind == "file_read"
+    assert read_tool.command == "polylogue/insights/transforms.py"
+    assert read_tool.line_count == 2
+    assert read_tool.file_refs == ("polylogue/insights/transforms.py",)
 
     assert len(digest.subagent_reports) == 1
     subagent = digest.subagent_reports[0]
@@ -156,6 +177,8 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert "## Run State" in digest.resume_markdown
     assert "- done: #1910 merged" in digest.resume_markdown
     assert "- next: merge PR #1911" in digest.resume_markdown
+    assert "Bash [test]" in digest.resume_markdown
+    assert "Read [file_read]" in digest.resume_markdown
     assert "Raw refs are available" in digest.resume_markdown
 
 


### PR DESCRIPTION
## Summary

Adds handler-specific metadata to recovery digest tool summaries so successor sessions can distinguish tests, file reads, GitHub/git commands, and generic shell output without reading full raw tool blocks.

## Problem

#1880's generic `ToolSummary` exposed a command, status, and preview, but did not preserve enough structured recovery cues for common coding-agent tools. A successor prompt needs to know which outputs were tests, which files were read, and which PR/issue/test refs were observed.

## Solution

`ToolSummary` now carries `handler_kind`, output `line_count`, PR/issue refs, test evidence, and file refs. Extraction classifies `Read`, `git`, `gh`, test-like commands/output, shell commands, and generic tools deterministically. The resume bundle renders the handler kind, and tests pin Bash test-output plus Read file-output envelopes with raw refs still attached.

## Verification

- `nix develop --command devtools test tests/unit/insights/test_transforms.py` -> `6 passed in 0.74s`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Issue slice:
Handler-specific tool-result envelopes for the v0 recovery digest.

Files inspected:
`polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`.

Files changed:
`polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`.

Old surface removed or retained:
Generic tool summaries retained; new fields are additive.

Contracts/tests added:
Pinned handler kind, line count, PR refs, test evidence, file refs, and resume rendering for Bash/Read examples.

Generated artifacts updated:
None.

Known caveats / SPEC_MISMATCH:
No SPEC_MISMATCH. Classification is deterministic and intentionally shallow; unknown tools remain `generic` with preview/raw refs.

Follow-up intentionally not included:
Persisted transform outputs, CLI/API/read surfaces, full `polylogue continue`/`blame` presets, and richer handler parsers for every tool result shape.

Ref #1880