### PR TITLE
feat(storage): route saved views through assertion adapters (#1883)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -82,6 +82,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     upsert_blackboard_note,
     upsert_mark,
     upsert_recall_pack,
+    upsert_saved_view,
     upsert_workspace,
 )
 from polylogue.storage.sqlite.archive_tiers.write import (
@@ -1749,26 +1750,14 @@ class ArchiveStore:
         if not isinstance(query, dict):
             raise ValueError("query_json must encode an object")
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
-        now_ms = int(datetime.now(UTC).timestamp() * 1000)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             existing = user_conn.execute(
                 "SELECT created_at_ms FROM saved_views WHERE view_id = ?",
                 (view_id,),
             ).fetchone()
-            created_at_ms = int(existing[0]) if existing is not None else now_ms
             with user_conn:
-                user_conn.execute(
-                    """
-                    INSERT INTO saved_views (view_id, name, query_json, created_at_ms, updated_at_ms)
-                    VALUES (?, ?, ?, ?, ?)
-                    ON CONFLICT(view_id) DO UPDATE SET
-                        name = excluded.name,
-                        query_json = excluded.query_json,
-                        updated_at_ms = excluded.updated_at_ms
-                    """,
-                    (view_id, normalized_name, json.dumps(query, sort_keys=True), created_at_ms, now_ms),
-                )
+                upsert_saved_view(user_conn, normalized_name, query, view_id=view_id)
             return existing is None
         finally:
             user_conn.close()

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -408,28 +408,30 @@ def upsert_saved_view(
     name: str,
     query: dict[str, object],
     *,
+    view_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveSavedViewEnvelope:
     """Insert-or-update a saved query view keyed by name."""
     timestamp = now_ms if now_ms is not None else _now_ms()
-    view_id = _deterministic_id("view", name)
-    existing = conn.execute("SELECT created_at_ms FROM saved_views WHERE name = ?", (name,)).fetchone()
+    resolved_id = view_id or _deterministic_id("view", name)
+    existing = conn.execute("SELECT created_at_ms FROM saved_views WHERE view_id = ?", (resolved_id,)).fetchone()
     created_at_ms = int(existing[0]) if existing is not None else timestamp
 
     conn.execute(
         """
         INSERT INTO saved_views (view_id, name, query_json, created_at_ms, updated_at_ms)
         VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(name) DO UPDATE SET
+        ON CONFLICT(view_id) DO UPDATE SET
+            name = excluded.name,
             query_json = excluded.query_json,
             updated_at_ms = excluded.updated_at_ms
         """,
-        (view_id, name, _json_dumps(query), created_at_ms, timestamp),
+        (resolved_id, name, _json_dumps(query), created_at_ms, timestamp),
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.SAVED_QUERY}", name),
-        target_ref=f"saved_view:{name}",
+        assertion_id=_deterministic_id(f"assertion-{AssertionKind.SAVED_QUERY}", resolved_id),
+        target_ref=f"saved_view:{resolved_id}",
         kind=AssertionKind.SAVED_QUERY,
         key=name,
         value=query,

--- a/tests/unit/storage/test_archive_tiers_user_write.py
+++ b/tests/unit/storage/test_archive_tiers_user_write.py
@@ -207,6 +207,13 @@ def test_archive_tiers_user_write_minimal_upserts(tmp_path: Path) -> None:
     assert saved_view.created_at_ms == 1_700_000_008_000
     assert saved_view_refresh.updated_at_ms == 1_700_000_009_000
     assert refreshed_saved_view.query == {"origin": "codex-session", "limit": 20}
+    saved_view_assertions = list_assertions_for_target(
+        conn, f"saved_view:{saved_view.view_id}", kind=AssertionKind.SAVED_QUERY
+    )
+    assert len(saved_view_assertions) == 1
+    assert saved_view_assertions[0].key == "recent-codex"
+    assert saved_view_assertions[0].value == {"origin": "codex-session", "limit": 20}
+    assert saved_view_assertions[0].updated_at_ms == 1_700_000_009_000
 
     assert recall_pack.recall_pack_id == recall_pack_refresh.recall_pack_id
     assert recall_pack.created_at_ms == 1_700_000_010_000

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -167,7 +167,7 @@ async def test_user_state_mutations_write_archive_user_tier(
             """
             SELECT target_ref, kind, key, value_json
             FROM assertions
-            WHERE target_ref IN ('recall_pack:pack-v1', 'workspace:workspace-v1')
+            WHERE target_ref IN ('recall_pack:pack-v1', 'saved_view:view-v1', 'workspace:workspace-v1')
             ORDER BY target_ref
             """
         ).fetchall()
@@ -190,10 +190,12 @@ async def test_user_state_mutations_write_archive_user_tier(
     assert json.loads(workspace[2])["mode"] == "tabs"
     assert [(row[0], row[1], row[2]) for row in assertion_rows] == [
         ("recall_pack:pack-v1", "recall_pack", "Archive pack"),
+        ("saved_view:view-v1", "saved_query", "Archive view"),
         ("workspace:workspace-v1", "workspace_note", "Archive workspace"),
     ]
     assert json.loads(assertion_rows[0][3])["session_ids_json"]
-    assert json.loads(assertion_rows[1][3])["mode"] == "tabs"
+    assert json.loads(assertion_rows[1][3]) == {"query": "storage", "limit": 5}
+    assert json.loads(assertion_rows[2][3])["mode"] == "tabs"
     assert correction_row is not None
     assert correction_row[0:3] == ("session", ARCHIVE_USER_STATE_SESSION_ID, "tag_accept")
     assert json.loads(correction_row[3])["payload"] == {"tag": "archive"}


### PR DESCRIPTION
## Summary

Routes public saved-view writes through the assertion-aware user-tier helper so saved views mirror into the unified assertion substrate like the other user overlays.

## Problem

#1883 had `upsert_saved_view` writing an assertion row, but `ArchiveStore.save_view` still hand-rolled the SQL path. Public CLI/API/web saved-view writes therefore bypassed the assertion mirror.

## Solution

`upsert_saved_view` now accepts an optional stable `view_id`, preserves that id in the legacy `saved_views` row, and keys the mirrored `saved_query` assertion by `saved_view:<view_id>`. `ArchiveStore.save_view` delegates to this helper. Tests assert both helper-level and public user-state saved-view assertion parity.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_archive_tiers_user_write.py tests/unit/storage/test_user_state_contracts.py -k "minimal_upserts or user_state_mutations_write_archive_user_tier"` -> `2 passed, 5 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Issue slice:
Saved-view public write path assertion-adapter bypass.

Files inspected:
`polylogue/storage/sqlite/archive_tiers/user_write.py`, `polylogue/storage/sqlite/archive_tiers/archive.py`, `tests/unit/storage/test_archive_tiers_user_write.py`, `tests/unit/storage/test_user_state_contracts.py`.

Files changed:
`polylogue/storage/sqlite/archive_tiers/user_write.py`, `polylogue/storage/sqlite/archive_tiers/archive.py`, `tests/unit/storage/test_archive_tiers_user_write.py`, `tests/unit/storage/test_user_state_contracts.py`.

Old surface removed or retained:
Legacy `saved_views` table/read contract retained; write path now also mirrors into assertions.

Contracts/tests added:
Saved-view helper parity and public API/user-state parity for `saved_view:<view_id>` assertion rows.

Generated artifacts updated:
None.

Known caveats / SPEC_MISMATCH:
No schema change. Saved-query assertions now use stable view IDs instead of names for `target_ref` so renames do not orphan the assertion target.

Follow-up intentionally not included:
Assertion-backed delete/status transitions and legacy read-path retirement.

Ref #1883