### PR TITLE
chore(ci): batch GitHub Action maintenance bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --extra dev --frozen
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.decide.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - name: Install dependencies (frozen lockfile)

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - name: Install dev dependencies (frozen lockfile)
@@ -259,7 +259,7 @@ jobs:
         with:
           name: distribution-artifacts
           path: dist/
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: "3.13"
       - name: Generate CycloneDX SBOM from built wheel
@@ -307,7 +307,7 @@ jobs:
       - name: List artifacts about to be signed and published
         run: ls -la dist/
       - name: Sign wheel + sdist with Sigstore (keyless OIDC)
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
           inputs: |
             ./dist/*.whl
@@ -350,7 +350,7 @@ jobs:
       - name: List artifacts about to be signed and published
         run: ls -la dist/
       - name: Sign wheel + sdist with Sigstore (keyless OIDC)
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
           inputs: |
             ./dist/*.whl
@@ -389,7 +389,7 @@ jobs:
       - name: List artifacts about to be signed and published
         run: ls -la dist/
       - name: Sign wheel + sdist with Sigstore (keyless OIDC)
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
           inputs: |
             ./dist/*.whl


### PR DESCRIPTION
## Summary

Batches the remaining GitHub Action maintenance bumps that were opened separately by Dependabot after `actions/checkout@v6` landed.

## Problem

The standalone Dependabot PRs for `astral-sh/setup-uv`, `docker/login-action`, and `sigstore/gh-action-sigstore-python` conflicted after #1917 updated the same workflow blocks. Keeping them separate burns CI/review cycles for version-only maintenance.

## Solution

Updates:

- `astral-sh/setup-uv`: `v8.1.0` -> `v8.2.0`
- `docker/login-action`: `v3` -> `v4`
- `sigstore/gh-action-sigstore-python`: `v3.0.0` -> `v3.4.0`

## Verification

- `nix develop --command devtools render-pages` -> rebuilt `.cache/site`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Supersedes #1918.
Supersedes #1919.
Supersedes #1920.