### PR TITLE
feat(storage): mark deleted overlays in assertions (#1883)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -78,7 +78,16 @@ from polylogue.storage.sqlite.archive_tiers.source_write import (
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     ArchiveBlackboardNoteEnvelope,
+    AssertionKind,
+    assertion_id_for_annotation,
+    assertion_id_for_correction,
+    assertion_id_for_mark,
+    assertion_id_for_recall_pack,
+    assertion_id_for_saved_view,
+    assertion_id_for_workspace,
+    mark_assertion_status,
     upsert_annotation,
+    upsert_assertion,
     upsert_blackboard_note,
     upsert_mark,
     upsert_recall_pack,
@@ -1593,7 +1602,14 @@ class ArchiveStore:
                     """,
                     (storage_target_type, target_id, mark_type),
                 )
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted:
+                    mark_assertion_status(
+                        user_conn,
+                        assertion_id_for_mark(storage_target_type, target_id, mark_type),
+                        "deleted",
+                    )
+                return deleted
         finally:
             user_conn.close()
 
@@ -1737,7 +1753,10 @@ class ArchiveStore:
         try:
             with user_conn:
                 cursor = user_conn.execute("DELETE FROM annotations WHERE annotation_id = ?", (annotation_id,))
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted:
+                    mark_assertion_status(user_conn, assertion_id_for_annotation(annotation_id), "deleted")
+                return deleted
         finally:
             user_conn.close()
 
@@ -1810,7 +1829,10 @@ class ArchiveStore:
         try:
             with user_conn:
                 cursor = user_conn.execute("DELETE FROM saved_views WHERE view_id = ?", (view_id,))
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted:
+                    mark_assertion_status(user_conn, assertion_id_for_saved_view(view_id), "deleted")
+                return deleted
         finally:
             user_conn.close()
 
@@ -1893,7 +1915,10 @@ class ArchiveStore:
         try:
             with user_conn:
                 cursor = user_conn.execute("DELETE FROM recall_packs WHERE recall_pack_id = ?", (pack_id,))
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted:
+                    mark_assertion_status(user_conn, assertion_id_for_recall_pack(pack_id), "deleted")
+                return deleted
         finally:
             user_conn.close()
 
@@ -1982,7 +2007,10 @@ class ArchiveStore:
         try:
             with user_conn:
                 cursor = user_conn.execute("DELETE FROM workspaces WHERE workspace_id = ?", (workspace_id,))
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted:
+                    mark_assertion_status(user_conn, assertion_id_for_workspace(workspace_id), "deleted")
+                return deleted
         finally:
             user_conn.close()
 
@@ -2032,6 +2060,17 @@ class ArchiveStore:
                         now_ms,
                     ),
                 )
+                upsert_assertion(
+                    user_conn,
+                    assertion_id=assertion_id_for_correction(correction_id),
+                    target_ref=f"insight:{resolved_session_id}",
+                    kind=AssertionKind.CORRECTION,
+                    key=correction_kind.value,
+                    value=stored_payload,
+                    body_text=note,
+                    author_kind="user",
+                    now_ms=now_ms,
+                )
         finally:
             user_conn.close()
         listed = self.list_corrections(session_id=resolved_session_id, kind=correction_kind.value)
@@ -2077,6 +2116,14 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
+                row = user_conn.execute(
+                    """
+                    SELECT correction_id
+                    FROM corrections
+                    WHERE target_type = 'session' AND target_id = ? AND correction_type = ?
+                    """,
+                    (resolved_session_id, correction_kind.value),
+                ).fetchone()
                 cursor = user_conn.execute(
                     """
                     DELETE FROM corrections
@@ -2084,7 +2131,10 @@ class ArchiveStore:
                     """,
                     (resolved_session_id, correction_kind.value),
                 )
-                return int(cursor.rowcount) > 0
+                deleted = int(cursor.rowcount) > 0
+                if deleted and row is not None:
+                    mark_assertion_status(user_conn, assertion_id_for_correction(str(row[0])), "deleted")
+                return deleted
         finally:
             user_conn.close()
 
@@ -2096,11 +2146,19 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
+                rows = user_conn.execute(
+                    "SELECT correction_id FROM corrections WHERE target_type = 'session' AND target_id = ?",
+                    (resolved_session_id,),
+                ).fetchall()
                 cursor = user_conn.execute(
                     "DELETE FROM corrections WHERE target_type = 'session' AND target_id = ?",
                     (resolved_session_id,),
                 )
-                return max(int(cursor.rowcount), 0)
+                deleted_count = max(int(cursor.rowcount), 0)
+                if deleted_count:
+                    for row in rows:
+                        mark_assertion_status(user_conn, assertion_id_for_correction(str(row[0])), "deleted")
+                return deleted_count
         finally:
             user_conn.close()
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -107,6 +107,37 @@ def _deterministic_id(prefix: str, *parts: str) -> str:
     return f"{prefix}:{digest.hexdigest()}"
 
 
+def assertion_id_for_mark(target_type: str, target_id: str, mark_type: str) -> str:
+    """Return the mirrored assertion id for one legacy mark row."""
+    mark_id = _deterministic_id("mark", target_type, target_id, mark_type)
+    return _deterministic_id(f"assertion-{AssertionKind.MARK}", mark_id)
+
+
+def assertion_id_for_annotation(annotation_id: str) -> str:
+    """Return the mirrored assertion id for one legacy annotation row."""
+    return _deterministic_id(f"assertion-{AssertionKind.ANNOTATION}", annotation_id)
+
+
+def assertion_id_for_correction(correction_id: str) -> str:
+    """Return the mirrored assertion id for one legacy correction row."""
+    return _deterministic_id(f"assertion-{AssertionKind.CORRECTION}", correction_id)
+
+
+def assertion_id_for_saved_view(view_id: str) -> str:
+    """Return the mirrored assertion id for one legacy saved-view row."""
+    return _deterministic_id(f"assertion-{AssertionKind.SAVED_QUERY}", view_id)
+
+
+def assertion_id_for_recall_pack(recall_pack_id: str) -> str:
+    """Return the mirrored assertion id for one legacy recall-pack row."""
+    return _deterministic_id(f"assertion-{AssertionKind.RECALL_PACK}", recall_pack_id)
+
+
+def assertion_id_for_workspace(workspace_id: str) -> str:
+    """Return the mirrored assertion id for one legacy workspace row."""
+    return _deterministic_id(f"assertion-{AssertionKind.WORKSPACE_NOTE}", workspace_id)
+
+
 def _target_ref(target_type: str | None, target_id: str | None) -> str | None:
     """Compose the assertions ``target_ref`` from a legacy ``(type, id)`` pair.
 
@@ -298,7 +329,7 @@ def upsert_mark(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.MARK}", mark_id),
+        assertion_id=assertion_id_for_mark(target_type, target_id, mark_type),
         target_ref=f"{target_type}:{target_id}",
         kind=AssertionKind.MARK,
         key=mark_type,
@@ -341,7 +372,7 @@ def upsert_annotation(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.ANNOTATION}", resolved_id),
+        assertion_id=assertion_id_for_annotation(resolved_id),
         target_ref=f"{target_type}:{target_id}",
         kind=AssertionKind.ANNOTATION,
         body_text=body,
@@ -392,7 +423,7 @@ def upsert_correction(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.CORRECTION}", correction_id),
+        assertion_id=assertion_id_for_correction(correction_id),
         target_ref=f"{target_type}:{target_id}",
         kind=AssertionKind.CORRECTION,
         key=correction_type,
@@ -430,7 +461,7 @@ def upsert_saved_view(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.SAVED_QUERY}", resolved_id),
+        assertion_id=assertion_id_for_saved_view(resolved_id),
         target_ref=f"saved_view:{resolved_id}",
         kind=AssertionKind.SAVED_QUERY,
         key=name,
@@ -471,7 +502,7 @@ def upsert_recall_pack(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.RECALL_PACK}", resolved_id),
+        assertion_id=assertion_id_for_recall_pack(resolved_id),
         target_ref=f"recall_pack:{resolved_id}",
         kind=AssertionKind.RECALL_PACK,
         key=name,
@@ -510,7 +541,7 @@ def upsert_workspace(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.WORKSPACE_NOTE}", resolved_id),
+        assertion_id=assertion_id_for_workspace(resolved_id),
         target_ref=f"workspace:{resolved_id}",
         kind=AssertionKind.WORKSPACE_NOTE,
         key=name,
@@ -818,6 +849,26 @@ def upsert_assertion(
     return envelope
 
 
+def mark_assertion_status(
+    conn: sqlite3.Connection,
+    assertion_id: str,
+    status: str,
+    *,
+    now_ms: int | None = None,
+) -> bool:
+    """Update one assertion status without deleting its evidence row."""
+    timestamp = now_ms if now_ms is not None else _now_ms()
+    cursor = conn.execute(
+        """
+        UPDATE assertions
+        SET status = ?, updated_at_ms = ?
+        WHERE assertion_id = ?
+        """,
+        (status, timestamp, assertion_id),
+    )
+    return int(cursor.rowcount) > 0
+
+
 def _assertion_row_to_envelope(row: sqlite3.Row) -> ArchiveAssertionEnvelope:
     return ArchiveAssertionEnvelope(
         assertion_id=str(row[0]),
@@ -891,7 +942,14 @@ __all__ = [
     "ArchiveSavedViewEnvelope",
     "ArchiveWorkspaceEnvelope",
     "AssertionKind",
+    "assertion_id_for_annotation",
+    "assertion_id_for_correction",
+    "assertion_id_for_mark",
+    "assertion_id_for_recall_pack",
+    "assertion_id_for_saved_view",
+    "assertion_id_for_workspace",
     "list_assertions_for_target",
+    "mark_assertion_status",
     "read_archive_annotation_envelope",
     "read_archive_blackboard_note_envelope",
     "read_archive_correction_envelope",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -2462,8 +2462,21 @@ async def test_archive_tiers_api_marks_and_annotations_write_user_tier(tmp_path:
         with sqlite3.connect(tmp_path / "user.db") as conn:
             mark_count = conn.execute("SELECT COUNT(*) FROM marks").fetchone()[0]
             annotation_count = conn.execute("SELECT COUNT(*) FROM annotations").fetchone()[0]
+            assertion_statuses = conn.execute(
+                """
+                SELECT kind, key, status
+                FROM assertions
+                WHERE target_ref = ?
+                ORDER BY kind, key
+                """,
+                (f"session:{session_id}",),
+            ).fetchall()
         assert mark_count == 0
         assert annotation_count == 0
+        assert assertion_statuses == [
+            ("annotation", None, "deleted"),
+            ("mark", "star", "deleted"),
+        ]
     finally:
         await archive.close()
 
@@ -2563,6 +2576,19 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
             assert conn.execute("SELECT COUNT(*) FROM saved_views").fetchone()[0] == 0
             assert conn.execute("SELECT COUNT(*) FROM recall_packs").fetchone()[0] == 0
             assert conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0] == 0
+            assertion_statuses = conn.execute(
+                """
+                SELECT target_ref, kind, status
+                FROM assertions
+                WHERE target_ref IN ('saved_view:view-v1', 'recall_pack:pack-v1', 'workspace:workspace-v1')
+                ORDER BY target_ref
+                """
+            ).fetchall()
+        assert assertion_statuses == [
+            ("recall_pack:pack-v1", "recall_pack", "deleted"),
+            ("saved_view:view-v1", "saved_query", "deleted"),
+            ("workspace:workspace-v1", "workspace_note", "deleted"),
+        ]
     finally:
         await archive.close()
 
@@ -2621,6 +2647,19 @@ async def test_archive_tiers_api_corrections_write_user_tier(tmp_path: Path) -> 
 
         with sqlite3.connect(tmp_path / "user.db") as conn:
             assert conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0] == 0
+            assertion_statuses = conn.execute(
+                """
+                SELECT key, status, json_extract(value_json, '$.payload.tag'), json_extract(value_json, '$.payload.summary')
+                FROM assertions
+                WHERE target_ref = ? AND kind = 'correction'
+                ORDER BY key
+                """,
+                (f"insight:{session_id}",),
+            ).fetchall()
+        assert assertion_statuses == [
+            ("summary_override", "deleted", None, "replacement"),
+            ("tag_accept", "deleted", "archive-updated", None),
+        ]
     finally:
         await archive.close()
 

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -201,16 +201,16 @@ def test_suppression_write_through_mirrors_assertion(tmp_path: Path) -> None:
 def test_saved_view_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    upsert_saved_view(conn, "recent", {"limit": 10}, now_ms=1_700_000_050_000)
+    saved_view = upsert_saved_view(conn, "recent", {"limit": 10}, now_ms=1_700_000_050_000)
     assert conn.execute("SELECT 1 FROM saved_views WHERE name = ?", ("recent",)).fetchone() is not None
 
-    mirrored = list_assertions_for_target(conn, "saved_view:recent", kind=AssertionKind.SAVED_QUERY)
+    mirrored = list_assertions_for_target(conn, f"saved_view:{saved_view.view_id}", kind=AssertionKind.SAVED_QUERY)
     assert len(mirrored) == 1
     assert mirrored[0].key == "recent"
     assert mirrored[0].value == {"limit": 10}
 
     upsert_saved_view(conn, "recent", {"limit": 20}, now_ms=1_700_000_051_000)
-    again = list_assertions_for_target(conn, "saved_view:recent", kind=AssertionKind.SAVED_QUERY)
+    again = list_assertions_for_target(conn, f"saved_view:{saved_view.view_id}", kind=AssertionKind.SAVED_QUERY)
     assert len(again) == 1
     assert again[0].assertion_id == mirrored[0].assertion_id
     assert again[0].value == {"limit": 20}


### PR DESCRIPTION
## Summary

Legacy user-overlay delete paths now preserve their mirrored assertion rows and mark them `status=deleted` after a successful delete. Public learning corrections also write through to insight-scoped correction assertions, so correction deletes and clears can transition the assertion mirror instead of leaving no lifecycle evidence.

## Problem

#1883 had landed the assertions table plus write-through rows for marks, annotations, saved views, recall packs, workspaces, and helper-level corrections. The remaining lifecycle gap was deletes: the legacy table row disappeared, but the assertion mirror stayed apparently live. The public `record_correction` path also bypassed assertion write-through, so correction delete/status transitions had nothing to update.

## Solution

- Added typed deterministic assertion-id helpers in `polylogue/storage/sqlite/archive_tiers/user_write.py` so upsert and delete paths share the same identity derivation.
- Added `mark_assertion_status` to update assertion lifecycle state without deleting the evidence row.
- Wired successful public deletes for marks, annotations, saved views, recall packs, workspaces, single corrections, and correction clears to mark matching assertion rows as `deleted`.
- Mirrored public learning corrections into `AssertionKind.CORRECTION` rows scoped to `insight:<session_id>`.
- Fixed the saved-view write-through test to use the returned deterministic `view_id` as the assertion target.

## Verification

- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k "archive_tiers_api_marks_and_annotations_write_user_tier or archive_tiers_api_reader_artifacts_write_user_tier or archive_tiers_api_corrections_write_user_tier"` — 3 passed.
- `nix develop --command devtools test tests/unit/storage/test_archive_tiers_assertions.py tests/unit/storage/test_archive_tiers_assertion_write_through.py tests/unit/storage/test_archive_tiers_user_write.py` — 15 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.
- Pre-push `devtools verify --quick` — exit_code 0.

Ref #1883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced operation tracking with comprehensive assertion ledger for user actions
  * System now records status updates when marks, annotations, saved views, recall packs, and workspaces are deleted
  * Corrections and correction deletions are now tracked in the assertion ledger

* **Tests**
  * Expanded test coverage to validate assertion ledger entries for deleted entities and corrections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->