### PR TITLE
feat(cli): expose recovery digest as a read view (#1880)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -263,6 +263,7 @@ Usage: polylogue read [OPTIONS]
       polylogue find id:abc then read --view context --related-limit 5
       polylogue find 'cost tracking' then read --view context-pack --max-sessions 5
       polylogue read --view context-pack --project-repo github.com/Sinity/polylogue --since 2026-01-01
+      polylogue find id:abc then read --view recovery
       polylogue find id:abc then read --view neighbors --window-hours 48
       polylogue --latest read --view neighbors --format json
       polylogue find id:abc then read --view correlation --since-hours 4
@@ -272,10 +273,11 @@ Usage: polylogue read [OPTIONS]
       timeline, tools, files, metadata, continuation
 
 Options:
-  -v, --view [summary|transcript|messages|raw|context|context-pack|neighbors|correlation]
+  -v, --view [summary|transcript|messages|raw|context|context-pack|recovery|neighbors|correlation]
                                   What to render (summary, transcript,
                                   messages, raw, context, context-pack,
-                                  neighbors, correlation).  [default: summary]
+                                  recovery, neighbors, correlation).
+                                  [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
   -f, --format [text|markdown|json|ndjson|yaml|html|obsidian|org|csv]

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -393,10 +393,11 @@ def read_verb(
         return
 
     if view == "recovery":
+        effective_format = output_format or request.params.get("output_format")
         _run_read_recovery(
             env,
             session_id=session_id,
-            output_format=output_format,
+            output_format=effective_format if isinstance(effective_format, str) else None,
             destination=destination,
             out_path=out_path,
         )

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -53,7 +53,17 @@ def _lazy_shell_complete(source: str):  # type: ignore[no-untyped-def]
 _complete_session_id = _lazy_shell_complete("session_id")
 _complete_message_type = _lazy_shell_complete("message_type")
 
-_READ_VIEWS = ("summary", "transcript", "messages", "raw", "context", "context-pack", "neighbors", "correlation")
+_READ_VIEWS = (
+    "summary",
+    "transcript",
+    "messages",
+    "raw",
+    "context",
+    "context-pack",
+    "recovery",
+    "neighbors",
+    "correlation",
+)
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
 _READ_FORMATS = ("text", "markdown", "json", "ndjson", "yaml", "html", "obsidian", "org", "csv")
 
@@ -148,7 +158,9 @@ def recent_verb(
     type=click.Choice(_READ_VIEWS),
     default="summary",
     show_default=True,
-    help="What to render (summary, transcript, messages, raw, context, context-pack, neighbors, correlation).",
+    help=(
+        "What to render (summary, transcript, messages, raw, context, context-pack, recovery, neighbors, correlation)."
+    ),
 )
 @click.option(
     "--to",
@@ -297,6 +309,7 @@ def read_verb(
         polylogue find id:abc then read --view context --related-limit 5
         polylogue find 'cost tracking' then read --view context-pack --max-sessions 5
         polylogue read --view context-pack --project-repo github.com/Sinity/polylogue --since 2026-01-01
+        polylogue find id:abc then read --view recovery
         polylogue find id:abc then read --view neighbors --window-hours 48
         polylogue --latest read --view neighbors --format json
         polylogue find id:abc then read --view correlation --since-hours 4
@@ -376,6 +389,16 @@ def read_verb(
             max_sessions=max_sessions,
             max_messages=max_messages,
             no_redact=no_redact,
+        )
+        return
+
+    if view == "recovery":
+        _run_read_recovery(
+            env,
+            session_id=session_id,
+            output_format=output_format,
+            destination=destination,
+            out_path=out_path,
         )
         return
 
@@ -602,6 +625,34 @@ def _run_read_context(
         raise click.UsageError("read --view context requires a session ID (use --id, id:prefix, or --latest).")
     preamble = run_context_compose(env, session_id=session_id, related_limit=max(1, related_limit))
     _deliver_content(env, preamble + "\n", destination=destination, out_path=out_path)
+
+
+def _run_read_recovery(
+    env: AppEnv,
+    *,
+    session_id: str | None,
+    output_format: str | None,
+    destination: str,
+    out_path: str | None,
+) -> None:
+    """Render the deterministic recovery digest for one archived session (#1880)."""
+    from polylogue.api.sync.bridge import run_coroutine_sync
+    from polylogue.cli.shared.helper_support import fail
+    from polylogue.cli.shared.machine_errors import success
+    from polylogue.insights.transforms import compile_recovery_digest
+    from polylogue.surfaces.payloads import model_json_document
+
+    if session_id is None:
+        fail("read", "read --view recovery requires a session ID (use --id, id:prefix, or --latest).")
+    session = run_coroutine_sync(env.polylogue.get_session(session_id))
+    if session is None:
+        fail("read", f"Session not found: {session_id}")
+    digest = compile_recovery_digest(session)
+    if output_format == "json":
+        payload = success({"recovery": model_json_document(digest, exclude_none=True)}).to_json()
+        _deliver_content(env, payload + "\n", destination=destination, out_path=out_path)
+        return
+    _deliver_content(env, digest.resume_markdown, destination=destination, out_path=out_path)
 
 
 def _neighbor_score_label(score: float) -> str:

--- a/tests/baselines/showcase/help-read.txt
+++ b/tests/baselines/showcase/help-read.txt
@@ -14,6 +14,7 @@ Usage: polylogue read [OPTIONS]
       polylogue find id:abc then read --view context --related-limit 5
       polylogue find 'cost tracking' then read --view context-pack --max-sessions 5
       polylogue read --view context-pack --project-repo github.com/Sinity/polylogue --since 2026-01-01
+      polylogue find id:abc then read --view recovery
       polylogue find id:abc then read --view neighbors --window-hours 48
       polylogue --latest read --view neighbors --format json
       polylogue find id:abc then read --view correlation --since-hours 4
@@ -23,10 +24,11 @@ Usage: polylogue read [OPTIONS]
       timeline, tools, files, metadata, continuation
 
 Options:
-  -v, --view [summary|transcript|messages|raw|context|context-pack|neighbors|correlation]
+  -v, --view [summary|transcript|messages|raw|context|context-pack|recovery|neighbors|correlation]
                                   What to render (summary, transcript,
                                   messages, raw, context, context-pack,
-                                  neighbors, correlation).  [default: summary]
+                                  recovery, neighbors, correlation).
+                                  [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
   -f, --format [text|markdown|json|ndjson|yaml|html|obsidian|org|csv]

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -252,6 +252,31 @@ def test_read_view_recovery_json_uses_success_envelope(capsys: pytest.CaptureFix
     assert '"recovery"' in output
 
 
+def test_read_view_recovery_honors_root_json_format() -> None:
+    """Root --json applies to recovery output when the verb has no local format."""
+    _, child = _context_pair(params={"conv_id": "codex-session:abc123", "output_format": "json"}, query_terms=())
+    child.obj.polylogue = SimpleNamespace()
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    async def get_session(session_id: str) -> SimpleNamespace:
+        return SimpleNamespace(id=session_id)
+
+    child.obj.polylogue.get_session = get_session
+    digest = SimpleNamespace(resume_markdown="# Resume\n")
+
+    with (
+        patch("polylogue.insights.transforms.compile_recovery_digest", return_value=digest),
+        patch("polylogue.surfaces.payloads.model_json_document", return_value={"session_id": "codex-session:abc123"}),
+        patch("polylogue.cli.query_verbs._deliver_content") as deliver,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="recovery", output_format=None))
+
+    content = deliver.call_args.args[1]
+    assert '"status": "ok"' in content
+    assert '"recovery"' in content
+
+
 def test_read_view_recovery_requires_session_id() -> None:
     env = SimpleNamespace(polylogue=SimpleNamespace())
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 import click
@@ -8,6 +9,7 @@ import pytest
 
 from polylogue.cli import query_verbs
 from polylogue.cli.root_request import RootModeRequest
+from polylogue.cli.shared.types import AppEnv
 
 
 def _context_pair(
@@ -197,6 +199,70 @@ def test_read_verb_context_pack_invokes_pack_view() -> None:
     pack.assert_called_once()
     assert pack.call_args.kwargs["query"] == "cost"
     assert pack.call_args.kwargs["max_sessions"] == 3
+
+
+def test_read_verb_recovery_compiles_digest() -> None:
+    """read --view recovery renders the deterministic recovery digest (#1880)."""
+    _, child = _context_pair(params={"conv_id": "codex-session:abc123"}, query_terms=())
+    child.obj.polylogue = SimpleNamespace()
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    async def get_session(session_id: str) -> SimpleNamespace:
+        return SimpleNamespace(id=session_id)
+
+    child.obj.polylogue.get_session = get_session
+    digest = SimpleNamespace(resume_markdown="# Resume: demo\n")
+
+    with (
+        patch("polylogue.insights.transforms.compile_recovery_digest", return_value=digest) as compile_digest,
+        patch("polylogue.cli.query_verbs._deliver_content") as deliver,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="recovery"))
+
+    compile_digest.assert_called_once()
+    assert compile_digest.call_args.args[0].id == "codex-session:abc123"
+    deliver.assert_called_once_with(child.obj, "# Resume: demo\n", destination="terminal", out_path=None)
+
+
+def test_read_view_recovery_json_uses_success_envelope(capsys: pytest.CaptureFixture[str]) -> None:
+    """The recovery read view exposes the typed digest under the machine envelope."""
+
+    class _API:
+        async def get_session(self, session_id: str) -> SimpleNamespace:
+            return SimpleNamespace(id=session_id)
+
+    env = SimpleNamespace(polylogue=_API())
+    digest = SimpleNamespace(resume_markdown="# Resume\n")
+
+    with (
+        patch("polylogue.insights.transforms.compile_recovery_digest", return_value=digest),
+        patch("polylogue.surfaces.payloads.model_json_document", return_value={"session_id": "s1"}),
+    ):
+        query_verbs._run_read_recovery(
+            cast(AppEnv, env),
+            session_id="s1",
+            output_format="json",
+            destination="terminal",
+            out_path=None,
+        )
+
+    output = capsys.readouterr().out
+    assert '"status": "ok"' in output
+    assert '"recovery"' in output
+
+
+def test_read_view_recovery_requires_session_id() -> None:
+    env = SimpleNamespace(polylogue=SimpleNamespace())
+
+    with pytest.raises(SystemExit):
+        query_verbs._run_read_recovery(
+            cast(AppEnv, env),
+            session_id=None,
+            output_format=None,
+            destination="terminal",
+            out_path=None,
+        )
 
 
 def test_resolve_target_session_id_uses_explicit_conv_id() -> None:


### PR DESCRIPTION
## Summary

Adds `read --view recovery`, an on-demand CLI surface over the existing deterministic recovery digest transform. Text/markdown output renders the successor-session resume bundle, while `--format json` emits the typed digest inside the standard machine success envelope.

## Problem

#1880 already landed the recovery transform registry, structural digest, RunState extraction, subagent report extraction, and handler-specific tool summaries. The transform was still only accessible from code/tests, so operators had no query-first way to ask an archived session for its compact recovery image.

## Solution

- Add `recovery` to the `read --view` choices and generated CLI reference.
- Resolve the target session through the existing read-verb session-id path.
- Fetch the hydrated session with `Polylogue.get_session()` and compile it with `compile_recovery_digest()`.
- Deliver `digest.resume_markdown` for text/markdown output.
- Deliver `{status: ok, result: {recovery: ...}}` for JSON output.

This PR intentionally does not persist transform outputs or promote decision candidates into assertions. Those remain #1880/#1883 follow-up slices.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_verbs_runtime.py -k "recovery or context_pack or summary"` — 5 passed.
- `nix develop --command devtools render-all` — regenerated CLI docs.
- `nix develop --command devtools verify --quick` — exit_code 0.
- Pre-push `devtools verify --quick` — exit_code 0.

Ref #1880