### PR TITLE
feat(api): expose recovery digest transform (#1880)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from polylogue.insights.export_bundles import InsightExportBundleRequest, InsightExportBundleResult
     from polylogue.insights.readiness import InsightReadinessQuery, InsightReadinessReport
     from polylogue.insights.resume import ResumeBrief, ResumeCandidate
+    from polylogue.insights.transforms import RecoveryDigest
     from polylogue.operations import ArchiveStats
     from polylogue.protocols import ProgressCallback, SessionQueryRuntimeStore
     from polylogue.readiness import ReadinessReport
@@ -1074,6 +1075,15 @@ class PolylogueArchiveMixin:
             except KeyError:
                 return None
             return _archive_session_to_session(archive.read_session(resolved_id))
+
+    async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:
+        """Compile one session into the deterministic recovery digest transform."""
+        from polylogue.insights.transforms import compile_recovery_digest
+
+        session = await self.get_session(session_id)
+        if session is None:
+            return None
+        return compile_recovery_digest(session)
 
     async def get_sessions(
         self,

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -70,6 +70,7 @@ READ_BY_ID_NONE_METHODS: frozenset[str] = frozenset(
         "get_session_profile_record",
         "get_session_latency_profile_insight",
         "resume_brief",
+        "recovery_digest",
     }
 )
 
@@ -621,6 +622,25 @@ async def test_get_session_returns_typed_object(tmp_path: Path) -> None:
         assert conv is not None
         assert isinstance(conv, Session)
         assert conv.title == "Alpha"
+    finally:
+        await archive.close()
+
+
+async def test_recovery_digest_compiles_seeded_session(tmp_path: Path) -> None:
+    """``recovery_digest`` exposes the deterministic transform surface (#1880)."""
+    archive = _archive(tmp_path)
+    db_path = archive.config.archive_root / "index.db"
+    await _seed_two_sessions(db_path)
+    try:
+        digest = await archive.recovery_digest("claude-ai-export:conv-alpha")
+
+        assert digest is not None
+        assert digest.session_id == "claude-ai-export:conv-alpha"
+        assert digest.transform.transform_id == "recovery_digest_v0"
+        assert digest.transform.input_session_id == "claude-ai-export:conv-alpha"
+        assert digest.resume_markdown.startswith("# Resume: Alpha")
+        assert digest.raw_refs
+        assert await archive.recovery_digest("nonexistent") is None
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Adds a Python API facade for the deterministic recovery digest transform. `Polylogue.recovery_digest(session_id)` now compiles the same on-demand recovery digest used by the CLI read view and returns `None` for missing sessions.

## Problem

#1880 is moving transform outputs toward first-class digest surfaces. The CLI read view exposes the recovery digest for operators, but library callers still had to import the transform internals and manually fetch sessions.

## Solution

`polylogue/api/archive.py` now exposes `recovery_digest()` as a thin facade over `get_session()` plus `compile_recovery_digest()`. The facade intentionally does not persist transform output or promote anything into the assertion substrate; that remains a separate #1880/#1883 policy decision.

## Verification

- `devtools test tests/unit/api/test_facade_contracts.py -k "recovery_digest or get_session_returns_none_for_unknown_id or no_undiscovered_async_methods"` — 4 passed.
- `devtools verify --quick` — exit_code 0.