### PR TITLE
feat(transforms): extract GitHub event failures (#1880)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -27,10 +27,15 @@ RECOVERY_TRANSFORM_VERSION = 1
 
 _ISSUE_RE = re.compile(r"(?:issues/|issue\s+|closed\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
 _PR_RE = re.compile(r"(?:pull/|PR\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
+_CREATED_PR_RE = re.compile(
+    r"\b(?:created|opened)\s+(?:pull\s+request|PR)\s+#?(?P<number>\d{3,6})\b",
+    re.IGNORECASE,
+)
 _MERGED_RE = re.compile(r"\bMERGED\s+#(?P<number>\d{3,6})\b", re.IGNORECASE)
 _TEST_PASS_RE = re.compile(r"\b(?P<count>\d+)\s+passed\b", re.IGNORECASE)
 _TEST_FAIL_RE = re.compile(r"\b(?P<count>\d+)\s+failed\b", re.IGNORECASE)
-_CHECK_PASS_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_. -]+)\s+\.\.\.\s+ok\b")
+_CHECK_PASS_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_.() -]+)\s+\.\.\.\s+ok\b")
+_CHECK_FAIL_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_.() -]+)\s+\.\.\.\s+(?:FAIL|FAILED|failure)\b", re.IGNORECASE)
 _DECISION_RE = re.compile(r"\b(decision|decided|choose|chosen):?\s+(?P<text>.+)", re.IGNORECASE)
 _STATUS_HEADING_RE = re.compile(r"^\s*(goal|done|in flight|blockers?|next):\s*(?P<text>.+)$", re.IGNORECASE)
 _RUNSTATE_SECTION_RE = re.compile(
@@ -143,7 +148,15 @@ class RunStateSummary(ArchiveInsightModel):
 
 
 class RecoveryEvent(ArchiveInsightModel):
-    kind: Literal["pr_opened", "pr_merged", "issue_closed", "check_passed", "test_passed", "test_failed"]
+    kind: Literal[
+        "pr_opened",
+        "pr_merged",
+        "issue_closed",
+        "check_passed",
+        "check_failed",
+        "test_passed",
+        "test_failed",
+    ]
     summary: str
     raw_refs: tuple[TransformRawRef, ...]
 
@@ -536,6 +549,13 @@ def _events_from_text(text: str, ref: TransformRawRef) -> Iterable[RecoveryEvent
         yield RecoveryEvent(kind="pr_merged", summary=f"PR #{number} merged", raw_refs=(ref,))
     for line in text.splitlines():
         lowered = line.lower()
+        created_pr_match = _CREATED_PR_RE.search(line)
+        if created_pr_match is not None:
+            yield RecoveryEvent(
+                kind="pr_opened",
+                summary=f"PR #{created_pr_match.group('number')} opened",
+                raw_refs=(ref,),
+            )
         if "pull/" in lowered or "pr " in lowered:
             pr_match = _PR_RE.search(line)
             if pr_match is not None:
@@ -571,6 +591,13 @@ def _events_from_text(text: str, ref: TransformRawRef) -> Iterable[RecoveryEvent
             yield RecoveryEvent(
                 kind="check_passed",
                 summary=f"{check_match.group('name').strip()} passed",
+                raw_refs=(ref,),
+            )
+        failed_check_match = _CHECK_FAIL_RE.search(line)
+        if failed_check_match:
+            yield RecoveryEvent(
+                kind="check_failed",
+                summary=f"{failed_check_match.group('name').strip()} failed",
                 raw_refs=(ref,),
             )
 

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -203,6 +203,30 @@ def test_every_extracted_claim_carries_raw_refs() -> None:
         assert all(ref.session_id == digest.session_id for ref in candidate.raw_refs)
 
 
+def test_github_cli_and_failed_check_events_are_extracted() -> None:
+    session = Session(
+        id=SessionId("codex-session:github-events"),
+        origin=Origin.CODEX_SESSION,
+        title="GitHub event extraction",
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="m-gh",
+                    role=Role.ASSISTANT,
+                    text=("✓ Created pull request #1930\nshowcase-verify ... FAILED (2.3s)\nAnalyze (python) ... ok"),
+                )
+            ]
+        ),
+    )
+
+    digest = compile_recovery_digest(session)
+    events = {(event.kind, event.summary) for event in digest.events}
+
+    assert ("pr_opened", "PR #1930 opened") in events
+    assert ("check_failed", "showcase-verify failed") in events
+    assert ("check_passed", "Analyze (python) passed") in events
+
+
 def test_claim_models_reject_missing_raw_refs() -> None:
     with pytest.raises(ValidationError):
         ToolSummary(tool_name="Bash", raw_refs=())


### PR DESCRIPTION
## Summary

Broadens the recovery digest's deterministic event extraction for GitHub-heavy agent sessions. The digest now recognizes common `gh pr create` output (`Created pull request #N`) and failed check lines (`name ... FAILED`) as typed recovery events.

## Problem

#1880's recovery views are intended to be successor-session boot packets. They already captured some PR merges and passing checks, but common red-check and PR-creation evidence was missed unless it matched a narrow URL/`PR` token pattern.

## Solution

`polylogue/insights/transforms.py` adds deterministic regexes for PR creation and failed check lines, extends `RecoveryEvent.kind` with `check_failed`, and keeps every extracted event evidence-linked through existing raw refs. Unit coverage pins PR-created, check-failed, and parenthesized check-name pass cases.

## Verification

- `devtools test tests/unit/insights/test_transforms.py` — 7 passed.
- `devtools verify --quick` — exit_code 0.