### PR TITLE
feat(storage): preserve blackboard assertion metadata (#1839)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2984,12 +2984,19 @@ class PolylogueArchiveMixin:
         scope_issue: int | None = None,
         scope_path: str | None = None,
         related_sessions: tuple[str, ...] = (),
+        author_ref: str | None = None,
+        author_kind: str = "user",
+        evidence_refs: tuple[str, ...] = (),
+        staleness: dict[str, object] | None = None,
+        context_policy: dict[str, object] | None = None,
     ) -> BlackboardNote:
         """Post a note to the persistent agent blackboard (#1697).
 
         ``kind`` must be one of :data:`BLACKBOARD_KINDS`; raises ``ValueError``
         otherwise. The structured fields are encoded into the stored body and a
-        fresh note id is allocated, so each call appends a distinct note.
+        fresh note id is allocated, so each call appends a distinct note. The
+        optional assertion metadata fields are mirrored only into the unified
+        assertion row (#1839/#1883), preserving the legacy blackboard row shape.
         """
         from polylogue.archive.blackboard import (
             BLACKBOARD_KINDS,
@@ -3017,6 +3024,11 @@ class PolylogueArchiveMixin:
                 target_type=target_type,
                 target_id=scope_session,
                 note_id=note_id,
+                author_ref=author_ref,
+                author_kind=author_kind,
+                evidence_refs=evidence_refs,
+                staleness=staleness,
+                context_policy=context_policy,
             )
         return decode_blackboard_note(
             note_id=envelope.note_id,

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -145,12 +145,18 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         scope_issue: int | None = None,
         scope_path: str | None = None,
         related_sessions: list[str] | None = None,
+        author_ref: str | None = None,
+        author_kind: str = "agent",
+        evidence_refs: list[str] | None = None,
+        staleness: dict[str, object] | None = None,
+        context_policy: dict[str, object] | None = None,
     ) -> str:
         """Post a note to the persistent agent blackboard (#1697).
 
         ``kind`` must be one of finding/blocker/decision/handoff/question/
         observation. Optional scope fields (repo/session/issue/path) and
-        related session ids are recorded with the note.
+        related session ids are recorded with the note. Assertion metadata is
+        mirrored into the unified assertion row for agent-written notes.
         """
 
         async def run() -> str:
@@ -165,6 +171,11 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     scope_issue=scope_issue,
                     scope_path=scope_path,
                     related_sessions=tuple(related_sessions or ()),
+                    author_ref=author_ref,
+                    author_kind=author_kind,
+                    evidence_refs=tuple(evidence_refs or ()),
+                    staleness=staleness,
+                    context_policy=context_policy,
                 )
             except ValueError as exc:
                 return hooks.error_json(str(exc))

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2169,6 +2169,11 @@ class ArchiveStore:
         target_type: str | None = None,
         target_id: str | None = None,
         note_id: str | None = None,
+        author_ref: str | None = None,
+        author_kind: str = "user",
+        evidence_refs: tuple[str, ...] = (),
+        staleness: dict[str, object] | None = None,
+        context_policy: dict[str, object] | None = None,
     ) -> ArchiveBlackboardNoteEnvelope:
         """Insert-or-update one blackboard note in archive user.db."""
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
@@ -2180,6 +2185,11 @@ class ArchiveStore:
                 target_type=target_type,
                 target_id=target_id,
                 note_id=note_id,
+                author_ref=author_ref,
+                author_kind=author_kind,
+                evidence_refs=evidence_refs,
+                staleness=staleness,
+                context_policy=context_policy,
             )
             user_conn.commit()
             return envelope

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -560,6 +560,11 @@ def upsert_blackboard_note(
     target_type: str | None = None,
     target_id: str | None = None,
     note_id: str | None = None,
+    author_ref: str | None = None,
+    author_kind: str = "user",
+    evidence_refs: Sequence[str] | None = None,
+    staleness: dict[str, object] | None = None,
+    context_policy: dict[str, object] | None = None,
     now_ms: int | None = None,
 ) -> ArchiveBlackboardNoteEnvelope:
     """Insert-or-update one blackboard note, optionally scoped to an archive target."""
@@ -589,7 +594,11 @@ def upsert_blackboard_note(
         target_ref=_target_ref(target_type, target_id) or resolved_id,
         kind=AssertionKind.NOTE,
         body_text=body,
-        author_kind="user",
+        author_ref=author_ref,
+        author_kind=author_kind,
+        evidence_refs=evidence_refs,
+        staleness=staleness,
+        context_policy=context_policy,
         now_ms=timestamp,
     )
     return read_archive_blackboard_note_envelope(conn, resolved_id)

--- a/tests/unit/mcp/test_blackboard_tools.py
+++ b/tests/unit/mcp/test_blackboard_tools.py
@@ -65,6 +65,11 @@ def test_blackboard_post_passes_fields_and_returns_note(mcp_server: MCPServerUnd
             content="MCP tools remain",
             scope_repo="polylogue",
             related_sessions=["claude-code:abc"],
+            author_ref="agent:codex-session:abc",
+            author_kind="agent",
+            evidence_refs=["message:m1", "block:m1:2"],
+            staleness={"expires_after_days": 7},
+            context_policy={"inject": False},
         )
 
     parsed = json.loads(result)
@@ -79,6 +84,11 @@ def test_blackboard_post_passes_fields_and_returns_note(mcp_server: MCPServerUnd
         scope_issue=None,
         scope_path=None,
         related_sessions=("claude-code:abc",),
+        author_ref="agent:codex-session:abc",
+        author_kind="agent",
+        evidence_refs=("message:m1", "block:m1:2"),
+        staleness={"expires_after_days": 7},
+        context_policy={"inject": False},
     )
 
 

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -180,6 +180,32 @@ def test_blackboard_note_write_through_scoped_and_unscoped(tmp_path: Path) -> No
     assert len(list_assertions_for_target(conn, "session:session-9", kind=AssertionKind.NOTE)) == 1
 
 
+def test_blackboard_note_assertion_metadata_is_preserved(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    upsert_blackboard_note(
+        conn,
+        "agent finding",
+        target_type="session",
+        target_id="session-9",
+        author_ref="agent:codex-session:abc",
+        author_kind="agent",
+        evidence_refs=("message:m1", "block:m1:2"),
+        staleness={"expires_after_days": 14},
+        context_policy={"inject": False},
+        now_ms=1_700_000_033_000,
+    )
+
+    mirrored = list_assertions_for_target(conn, "session:session-9", kind=AssertionKind.NOTE)
+    assert len(mirrored) == 1
+    env = mirrored[0]
+    assert env.author_ref == "agent:codex-session:abc"
+    assert env.author_kind == "agent"
+    assert env.evidence_refs == ["message:m1", "block:m1:2"]
+    assert env.staleness == {"expires_after_days": 14}
+    assert env.context_policy == {"inject": False}
+
+
 def test_suppression_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 

--- a/tests/unit/storage/test_blackboard_facade.py
+++ b/tests/unit/storage/test_blackboard_facade.py
@@ -7,11 +7,13 @@ facade with structured decoding and filters applied.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 
 from polylogue.api import Polylogue
+from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, list_assertions_for_target
 from tests.infra.storage_records import db_setup
 
 
@@ -33,6 +35,38 @@ async def test_post_then_list_round_trips_through_user_db(workspace_env: dict[st
         assert [n.note_id for n in notes] == [posted.note_id]
         assert notes[0].title == "FTS unicode61 only"
         assert notes[0].content == "No porter stemmer compiled in this build."
+
+
+@pytest.mark.asyncio
+async def test_post_mirrors_agent_metadata_into_assertion(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        await poly.post_blackboard_note(
+            kind="handoff",
+            title="resume here",
+            content="Merge the green PR.",
+            scope_session="codex-session:abc",
+            author_ref="agent:codex-session:abc",
+            author_kind="agent",
+            evidence_refs=("message:m1", "block:m1:2"),
+            staleness={"expires_after_days": 7},
+            context_policy={"inject": False},
+        )
+
+    conn = sqlite3.connect(workspace_env["archive_root"] / "user.db")
+    try:
+        conn.row_factory = sqlite3.Row
+        assertions = list_assertions_for_target(conn, "session:codex-session:abc", kind=AssertionKind.NOTE)
+    finally:
+        conn.close()
+
+    assert len(assertions) == 1
+    assertion = assertions[0]
+    assert assertion.author_ref == "agent:codex-session:abc"
+    assert assertion.author_kind == "agent"
+    assert assertion.evidence_refs == ["message:m1", "block:m1:2"]
+    assert assertion.staleness == {"expires_after_days": 7}
+    assert assertion.context_policy == {"inject": False}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Extends blackboard note write-through into the unified assertion substrate with optional assertion metadata: `author_ref`, `author_kind`, `evidence_refs`, `staleness`, and `context_policy`.

## Problem

#1839 is folded under #1883, but the existing blackboard write-through only mirrored body text into `AssertionKind.NOTE`. Agent-written notes still had no way to carry evidence refs, author identity, staleness, or context-injection policy through the public blackboard path.

## Solution

`upsert_blackboard_note`, `ArchiveStore.post_blackboard_note`, and `Polylogue.post_blackboard_note` now accept optional assertion metadata and pass it only to the mirrored assertion row. The legacy `blackboard_notes` row shape and existing callers remain unchanged.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_assertion_write_through.py` — 8 passed.
- `devtools test tests/unit/storage/test_blackboard_facade.py tests/unit/api/test_facade_contracts.py -k "blackboard or no_undiscovered_async_methods"` — 8 passed.
- `devtools verify --quick` — exit_code 0.