### PR TITLE
docs: define release readiness gate (#1827)

### DIFF
--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -74,6 +74,11 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
         "docs/test-quality-workflows.md",
         "Generated validation lanes, mutation campaigns, and benchmark campaigns.",
     ),
+    DocsEntry(
+        "Release Readiness Gate",
+        "docs/plans/release-readiness-gate.md",
+        "Externally-presentable release gate, required checks, and release PR evidence contract.",
+    ),
 )
 
 REPO_GUIDE_ENTRIES: tuple[DocsEntry, ...] = (

--- a/devtools/render_docs_surface.py
+++ b/devtools/render_docs_surface.py
@@ -107,7 +107,7 @@ def build_docs_readme(
             "",
             _render_named_table(
                 docs_by_title,
-                ("Developer Tools", "Test Quality Workflows"),
+                ("Developer Tools", "Test Quality Workflows", "Release Readiness Gate"),
                 from_dir="docs",
             ),
             "",

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Use this map when you need the complete repository documentation surface. The to
 |----------|-------------|
 | [Developer Tools](devtools.md) | `devtools` guide for generated surfaces, validation, and repo hygiene. |
 | [Test Quality Workflows](test-quality-workflows.md) | Generated validation lanes, mutation campaigns, and benchmark campaigns. |
+| [Release Readiness Gate](plans/release-readiness-gate.md) | Externally-presentable release gate, required checks, and release PR evidence contract. |
 
 ## Contributor Workflow
 

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -1,0 +1,117 @@
+# Release Readiness Gate
+
+Issue: #1827.
+
+This gate decides whether Polylogue is externally presentable enough to merge a
+release PR. A green release workflow is not sufficient: the release must be
+installable, demoable without private data, and truthful about shipped command,
+read, import, and output surfaces.
+
+## Gate Rule
+
+The release PR remains held unless every required item below is either:
+
+- `satisfied`, with a PR/check/document citation; or
+- `scoped out`, with release notes that explicitly avoid claiming the missing
+  capability.
+
+Do not use release pressure to force unrelated architecture work. Design-frontier
+issues can stay open when the README and release notes do not advertise them as
+shipped product behavior.
+
+## Required Local Commands
+
+Run these from a clean checkout inside the devshell:
+
+```bash
+devtools verify --quick
+devtools verify --lab
+devtools build-package
+devtools render-pages
+devtools verify-doc-commands
+```
+
+Add focused commands for changed release surfaces:
+
+```bash
+devtools test tests/unit/cli/test_query_verbs_runtime.py
+devtools test tests/unit/storage/test_blackboard_facade.py
+devtools lab-scenario verify-baselines
+```
+
+If packaging, Nix, or dependency metadata changed, also run:
+
+```bash
+nix flake check
+```
+
+## Automated Gate Matrix
+
+| Area | Required Evidence | Current Owner |
+| --- | --- | --- |
+| Command floor | Final public command tree has no stale command aliases or undocumented examples. | #1842 |
+| Machine output | JSON is finite, NDJSON is streaming, mutation/error envelopes are typed, and machine-output prompts do not block. | #1818, #1816 |
+| README commands | README examples resolve against live commands and do not cite stale APIs. | #1841 |
+| Import/demo | Public import vocabulary is stable and demo mode has deterministic private-data-free fixtures. | #1815, #1843 |
+| Recovery/digest | Agent-session recovery views are available only to the extent claimed by README/release notes. | #1880 |
+| Assertion/user state | User-tier note/assertion data is preserved and reset/delete flows are guarded. | #1883, #1839 |
+| Public vocabulary | Public surfaces use session/origin vocabulary; provider/conversation terms are raw-source or historical only. | #1810 |
+| Web/API | Any advertised web/API surface has stable DTOs, auth posture, and route vocabulary. | #1847, #1846 |
+| Static/docs surface | Generated docs, pages, media, and topology status are current. | #1848, #1849 |
+| CI reliability | Known benchmark/test flakes are resolved or explicitly excluded from the release gate with rationale. | #1878 |
+| Packaging | Wheel/sdist/Nix package expose only supported runtime entrypoints. | `devtools build-package`, `nix flake check` |
+
+## Manual Release Review
+
+Before merging a release PR, record the answers in the PR body:
+
+| Question | Required Answer |
+| --- | --- |
+| What can a new user run first? | Exact command sequence, including archive root/demo root. |
+| Does the sequence touch private archives? | No, unless the user supplied an explicit source path. |
+| Which origins are advertised? | Only origins with current parser/import/read evidence. |
+| Which features are deliberately not shipped? | Listed in release notes, with open issue refs. |
+| What irreversible publication happens? | PyPI/GHCR/tag behavior stated before merge. |
+| Which local gates ran? | Exact commands and key pass/fail line. |
+
+## Current Status
+
+Satisfied:
+
+- #1810 public session/origin vocabulary sweep is closed.
+- #1818 machine-output concrete violations are closed.
+- #1841 README cockpit is landed and command examples are checked by
+  `verify-doc-commands`.
+- #1878 benchmark convergence flake is closed.
+- #1880 has recovery digest registry, extraction, CLI read view, Python API
+  facade, and GitHub/check event extraction slices.
+- #1883 has the assertions table, write-through adapters, delete/status
+  transitions, reset user.db guard, and blackboard assertion metadata slices.
+
+Still blocking external release claims:
+
+- #1843 demo fixture world and `import --demo` are not landed.
+- #1816 generated action-contract replacement is not landed.
+- #1847/#1846 web/API release scope is not settled.
+- #1848/#1849 static/docs/proof pruning is not settled.
+- #1880 persisted transform outputs and `continue`/`blame` report presets are
+  not landed; do not advertise them as shipped.
+
+## Release PR Body Requirements
+
+Use this section in the release PR:
+
+```text
+Release gate:
+- Command floor:
+- Machine output:
+- README/demo:
+- Import/demo fixture:
+- Recovery/digest:
+- Web/API scope:
+- Packaging:
+- Known caveats scoped out:
+
+Verification:
+- <command> — <key output line>
+```


### PR DESCRIPTION
## Summary

Adds a durable release-readiness gate for externally presentable Polylogue releases and links it from the generated docs map.

## Problem

The held release PR needs a concrete gate that distinguishes green release automation from product readiness. Without a written gate, release decisions depend on chat context and can accidentally advertise unfinished demo/import/web/recovery surfaces.

## Solution

`docs/plans/release-readiness-gate.md` defines the gate rule, required local commands, automated and manual review matrices, current satisfied blockers, remaining release-scope blockers, and the release PR body evidence contract. The docs surface registry and renderer now include it under Verification and Quality.

## Verification

- `devtools verify-doc-commands` — 98 doc files scanned, no stale commands.
- `devtools render-all --check` — OK.
- `devtools verify --quick` — exit_code 0.