### PR TITLE
feat(cli): schedule approved demo fixture import (#1843)

### DIFF
--- a/polylogue/cli/commands/import_command.py
+++ b/polylogue/cli/commands/import_command.py
@@ -48,7 +48,7 @@ def _daemon_url(env: AppEnv) -> str:
     return getattr(env, "daemon_url", None) or _DEFAULT_DAEMON_URL
 
 
-def _stage_for_daemon(path: Path) -> Path:
+def _stage_for_daemon(path: Path, *, replace_existing: bool = False) -> Path:
     """Copy a local import target into the archive inbox for daemon pickup."""
     resolved = path.expanduser().resolve()
     if not resolved.exists():
@@ -62,6 +62,11 @@ def _stage_for_daemon(path: Path) -> Path:
         return dest
 
     try:
+        if replace_existing and dest.exists():
+            if dest.is_dir():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
         if resolved.is_dir():
             shutil.copytree(resolved, dest, dirs_exist_ok=True)
         else:
@@ -70,6 +75,18 @@ def _stage_for_daemon(path: Path) -> Path:
         fail("import", f"Could not stage {resolved} in daemon inbox: {exc}")
 
     return dest
+
+
+def _materialize_demo_source() -> Path:
+    """Write the approved deterministic demo fixture world to a local source dir."""
+    from polylogue.scenarios import build_demo_corpus_specs
+    from polylogue.schemas.synthetic import SyntheticCorpus
+
+    source_root = archive_root() / "demo-fixture-world-source"
+    if source_root.exists():
+        shutil.rmtree(source_root)
+    SyntheticCorpus.write_specs_artifacts(build_demo_corpus_specs(), source_root, prefix="demo", index_width=2)
+    return source_root
 
 
 def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
@@ -82,7 +99,12 @@ def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
 
 
 @click.command("import")
-@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.argument("path", required=False, type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--demo",
+    is_flag=True,
+    help="Generate and schedule the approved deterministic demo fixture world.",
+)
 @click.option(
     "--daemon-url",
     default=_DEFAULT_DAEMON_URL,
@@ -92,7 +114,8 @@ def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
 @click.pass_obj
 def import_command(
     env: AppEnv,
-    path: Path,
+    path: Path | None,
+    demo: bool,
     daemon_url: str,
 ) -> None:
     """Schedule a file or directory for import by the running daemon.
@@ -104,7 +127,15 @@ def import_command(
     actionable error. It never reports success without observable
     processing.
     """
-    staged = _stage_for_daemon(path)
+    if demo:
+        if path is not None:
+            fail("import", "Use either PATH or --demo, not both.")
+        source_path = _materialize_demo_source()
+        staged = _stage_for_daemon(source_path, replace_existing=True)
+    else:
+        if path is None:
+            fail("import", "Provide a source PATH or pass --demo.")
+        staged = _stage_for_daemon(path)
 
     body = json.dumps({"path": str(staged)}).encode("utf-8")
     req = Request(

--- a/tests/baselines/showcase/help-import.txt
+++ b/tests/baselines/showcase/help-import.txt
@@ -1,4 +1,4 @@
-Usage: polylogue import [OPTIONS] PATH
+Usage: polylogue import [OPTIONS] [PATH]
 
   Schedule a file or directory for import by the running daemon.
 
@@ -9,5 +9,7 @@ Usage: polylogue import [OPTIONS] PATH
   success without observable processing.
 
 Options:
+  --demo             Generate and schedule the approved deterministic demo
+                     fixture world.
   --daemon-url TEXT  Daemon API URL.  [default: http://127.0.0.1:8766]
   -h, --help         Show this message and exit.

--- a/tests/unit/cli/test_import.py
+++ b/tests/unit/cli/test_import.py
@@ -30,6 +30,7 @@ def test_import_help_includes_inbox_info() -> None:
     assert "daemon" in result.output.lower() or "polylogued" in result.output.lower(), (
         "import help should reference the daemon"
     )
+    assert "--demo" in result.output
 
 
 class _FakeDaemonResponse:
@@ -103,6 +104,85 @@ def test_import_command_stages_local_path_before_daemon_request(
     # for live progress and polylogue stats to verify the import landed.
     assert str(staged) in result.output
     assert "polylogue stats" in result.output
+
+
+def test_import_demo_materializes_fixture_world_before_daemon_request(
+    workspace_env: dict[str, Path],
+) -> None:
+    """--demo writes approved fixture sources and still requires daemon acceptance."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Request, timeout: int) -> _FakeDaemonResponse:
+        captured["request"] = req
+        captured["timeout"] = timeout
+        assert req.data is not None
+        request_data = cast("bytes", req.data)
+        staged_path = json.loads(request_data.decode("utf-8"))["path"]
+        return _FakeDaemonResponse(
+            {
+                "ok": True,
+                "operation_id": "import-demo-fixture-world",
+                "kind": "import",
+                "status": "pending",
+                "path": staged_path,
+                "message": "scheduled",
+            }
+        )
+
+    runner = CliRunner()
+    with patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(cli, ["import", "--demo"])
+
+    assert result.exit_code == 0, result.output
+    source_root = workspace_env["archive_root"] / "demo-fixture-world-source"
+    staged = workspace_env["archive_root"] / "inbox" / "demo-fixture-world-source"
+    assert sorted(path.name for path in source_root.iterdir()) == ["chatgpt", "claude-code", "codex"]
+    assert sorted(path.name for path in staged.iterdir()) == ["chatgpt", "claude-code", "codex"]
+    assert len(tuple(staged.rglob("demo-*.json*"))) == 3
+
+    request = cast("Request", captured["request"])
+    assert request.data is not None
+    body = json.loads(cast("bytes", request.data).decode("utf-8"))
+    assert body == {"path": str(staged)}
+    assert captured["timeout"] == 5
+    assert str(staged) in result.output
+    assert "polylogue stats" in result.output
+
+
+def test_import_requires_path_or_demo() -> None:
+    """Bare import refuses to claim success without a source selector."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import"])
+
+    assert result.exit_code != 0
+    combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()
+    assert "path" in combined
+    assert "--demo" in combined
+
+
+def test_import_rejects_path_with_demo(tmp_path: Path) -> None:
+    """PATH and --demo are mutually exclusive source selectors."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    source = tmp_path / "source.jsonl"
+    source.write_text('{"type":"session"}\n')
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", str(source), "--demo"])
+
+    assert result.exit_code != 0
+    combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()
+    assert "either path or --demo" in combined
 
 
 def test_import_rejects_missing_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds `polylogue import --demo` as the first runnable demo import surface. The command materializes the approved #1843 demo corpus specs into deterministic local source files, stages that source directory into the daemon inbox, and still requires `/api/ingest` acceptance before reporting success.

## Problem
#1843 needs a new-user demo path that does not depend on private exports. The existing import command was truthful for explicit paths but had no approved fixture selector, so a demo flow would either require devtools-only setup or bypass the daemon scheduling contract.

## Solution
`import --demo` now uses `build_demo_corpus_specs()` plus `SyntheticCorpus.write_specs_artifacts()` to generate the fixture world under the active archive root, then stages the generated directory into `archive_root()/inbox` and submits that staged path to the same daemon endpoint as ordinary imports. `PATH` and `--demo` are mutually exclusive, and bare `polylogue import` now fails with a clear source-selector error.

Issue slice:
#1843 slice 2: add `polylogue import --demo` scheduling over the approved fixture-world specs.

Files inspected:
`polylogue/cli/commands/import_command.py`, `tests/unit/cli/test_import.py`, `polylogue/scenarios/corpus.py`, `polylogue/schemas/synthetic/core.py`, `polylogue/schemas/synthetic/build_batch.py`, `polylogue/showcase/workspace.py`, `devtools/pipeline_probe/staging.py`, #1843, #1815.

Files changed:
`polylogue/cli/commands/import_command.py`, `tests/unit/cli/test_import.py`.

Old surface removed or retained:
Retained `polylogue import PATH` behavior and daemon truthfulness. Added `--demo`; no `ingest` alias or direct archive write path added.

Contracts/tests added:
Tests cover `--demo` help visibility, fixture materialization before daemon request, staged inbox request body, daemon acceptance still required, bare import rejection, and `PATH`/`--demo` mutual exclusion.

Generated artifacts updated:
None; `devtools verify --quick` reported no render drift.

Verification commands and results:
- `devtools test tests/unit/cli/test_import.py tests/unit/scenarios/test_corpus.py` -> 30 passed
- `devtools verify --quick` -> exit_code 0 at `2026-06-15T19:54:48Z`
- push hook: HEAD already verified (`3c8738fe`)

Known caveats / SPEC_MISMATCH:
No SPEC_MISMATCH. This schedules demo import through the daemon; it does not run a daemon convergence cycle or assert normalized archive rows in this slice.

Follow-up intentionally not included:
End-to-end demo archive convergence, README-ready demo commands against the generated archive, parser regression matrix, and known tags/notes/KV overlays remain separate #1843/#1883 slices.

Ref #1843