### PR TITLE
docs: document demo import path (#1843)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,17 +239,17 @@ nix run github:Sinity/polylogue -- --help
 
 ### Synthetic demo data
 
-To explore features without importing real exports, the verification lab seeds
-a synthetic archive from `polylogue.scenarios`:
+To explore features without importing real exports, schedule the approved
+deterministic demo fixture world:
 
 ```bash
-devtools lab-scenario run archive-smoke --tier 0
-devtools lab-scenario verify-baselines
+polylogue import --demo
 ```
 
-`devtools` is the repository control-plane CLI (it ships in source checkouts
-and the Nix package). See [docs/generate.md](docs/generate.md) for the
-synthetic-corpus generator.
+The command writes only approved synthetic source files and then uses the same
+daemon-backed import path as ordinary source imports. See
+[docs/generate.md](docs/generate.md) for the synthetic-corpus generator and
+verification-lab workflows.
 
 ## Developer tools
 

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -4,12 +4,19 @@
 
 Polylogue includes a built-in synthetic data generator for exploring features without importing real session data.
 
-Synthetic generation is available through the `polylogue.scenarios` module and the test infrastructure. Use `devtools lab-scenario` for demo workspace seeding and verification-lab exercises.
+For users, the supported entrypoint is `polylogue import --demo`: it generates
+the approved deterministic fixture world and schedules it through the same
+daemon-backed import path as ordinary source imports. For tests and repository
+verification, the same generator is available through `polylogue.scenarios`,
+shared fixtures, and `devtools lab-scenario`.
 
 ## Quick Start
 
 ```bash
-# Lab scenario with synthetic data
+# User-facing demo source import
+polylogue import --demo
+
+# Repository verification-lab scenarios
 devtools lab-scenario run archive-smoke --tier 0
 devtools lab-scenario verify-baselines
 ```
@@ -33,6 +40,9 @@ The test suite uses the same `SyntheticCorpus` infrastructure through shared fix
 - `seeded_db` — A pre-populated database for integration tests
 - `synthetic_source` — A temporary source directory with generated files
 - `raw_synthetic_samples` — Raw session data for unit tests
+
+`polylogue import --demo` uses the named `build_demo_corpus_specs()` fixture
+world so README examples and release checks can run without private exports.
 
 ---
 

--- a/docs/plans/import-demo-terminology-floor.md
+++ b/docs/plans/import-demo-terminology-floor.md
@@ -9,7 +9,12 @@ Internal daemon and pipeline code may still use ingestion words for background p
 Current floor: `build_demo_corpus_specs()` declares the deterministic approved
 demo fixture-world contract used by the release gate. It covers ChatGPT normal
 chat plus Claude Code and Codex coding-agent-style sessions with fixed seeds.
+`polylogue import --demo` materializes that fixture world and schedules it
+through the daemon-backed import path.
 
-Remaining work: materialize those demo corpus specs behind `polylogue import --demo`, parser regression pack for advertised origins, truthful import operation status, early unsupported-shape classification, and stale public vocabulary audit.
+Remaining work: end-to-end demo archive convergence evidence, README-ready
+commands against the generated demo archive, parser regression pack for
+advertised origins, truthful import operation status, early unsupported-shape
+classification, and stale public vocabulary audit.
 
 Acceptance: public examples use import/session/origin; demo mode never touches the real archive or configured source roots; parser outputs expose normalized terms; import status is visible in CLI status and web home.

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -87,10 +87,13 @@ Satisfied:
   facade, and GitHub/check event extraction slices.
 - #1883 has the assertions table, write-through adapters, delete/status
   transitions, reset user.db guard, and blackboard assertion metadata slices.
+- #1843 has deterministic demo corpus specs and the `polylogue import --demo`
+  scheduling surface.
 
 Still blocking external release claims:
 
-- #1843 demo fixture world and `import --demo` are not landed.
+- #1843 still needs end-to-end demo archive convergence evidence and
+  README-ready commands against the generated demo archive.
 - #1816 generated action-contract replacement is not landed.
 - #1847/#1846 web/API release scope is not settled.
 - #1848/#1849 static/docs/proof pruning is not settled.


### PR DESCRIPTION
## Summary
Updates the public docs after `polylogue import --demo` landed. README and `docs/generate.md` now point users at the demo import command, while keeping `devtools lab-scenario` framed as repository verification tooling. The release-readiness and import-demo floor notes now distinguish the landed scheduling surface from the remaining end-to-end demo archive evidence.

## Problem
After #1935, the command existed but docs still described devtools lab scenarios as the demo path and the release gate still said `import --demo` was not landed. That made the release gate stale immediately after the demo import slice merged.

## Solution
Document `polylogue import --demo` as the user-facing demo source import path, keep the synthetic generator details in `docs/generate.md`, and update gate/planning docs to leave only the actual remaining #1843 work: end-to-end demo archive convergence and README-ready commands against the generated archive.

## Verification
- `devtools verify-doc-commands` -> 98 doc files scanned, no stale commands
- `devtools render-all --check` -> OK
- `devtools verify --quick` -> exit_code 0 at `2026-06-15T20:05:05Z`
- push hook: HEAD already verified (`a50ed0da`)

Ref #1843
Ref #1827