### PR TITLE
fix(scenarios): keep demo fixture tool paths relative (#1843)

### DIFF
--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -124,7 +124,7 @@ def _tool_use_blocks(provider: str, index: int) -> list[JSONValue]:
             "type": "tool_use",
             "id": read_id,
             "name": "Read",
-            "input": {"file_path": f"/tmp/polylogue/generated-{index:04d}.jsonl"},
+            "input": {"file_path": f"fixtures/generated-{index:04d}.jsonl"},
         },
         {
             "type": "tool_use",

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -193,7 +193,10 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
 
 
 def test_build_demo_corpus_specs_materializes_with_synthetic_generator(tmp_path: Path) -> None:
+    from polylogue.config import Source
     from polylogue.schemas.synthetic import SyntheticCorpus
+    from polylogue.sources import iter_source_sessions
+    from polylogue.types import BlockType
 
     written = SyntheticCorpus.write_specs_artifacts(
         build_demo_corpus_specs(),
@@ -206,6 +209,34 @@ def test_build_demo_corpus_specs_materializes_with_synthetic_generator(tmp_path:
         "chatgpt/demo-00.json",
         "claude-code/demo-00.jsonl",
         "codex/demo-00.jsonl",
+    )
+
+    raw_text = "\n".join(path.read_text(encoding="utf-8") for batch in written for path in batch.files)
+    assert "/tmp/" not in raw_text
+    assert "/tmp/polylogue" not in raw_text
+
+    parsed = tuple(
+        session
+        for batch in written
+        for path in batch.files
+        for session in iter_source_sessions(Source(name="demo", path=path))
+    )
+    assert tuple(str(session.source_name) for session in parsed) == ("chatgpt", "claude-code", "codex")
+    assert all(session.provider_session_id for session in parsed)
+    assert all(session.messages for session in parsed)
+
+    tool_inputs = tuple(
+        block.tool_input
+        for session in parsed
+        for message in session.messages
+        for block in message.blocks
+        if block.type is BlockType.TOOL_USE and isinstance(block.tool_input, dict)
+    )
+    assert tool_inputs
+    assert all(
+        not str(tool_input.get("file_path", "")).startswith("/")
+        for tool_input in tool_inputs
+        if "file_path" in tool_input
     )
 
 


### PR DESCRIPTION
## Summary
Keeps the approved demo fixture world free of host-shaped absolute tool paths. The shared synthetic `tool-heavy` style now emits relative `fixtures/generated-*.jsonl` paths, and the demo corpus test now materializes and parses the generated demo files while rejecting `/tmp` path leakage.

## Problem
#1843 explicitly requires approved demo fixtures to avoid private data and host-specific absolute paths. The newly-landed demo specs use the existing `tool-heavy` style for Claude Code and Codex agent-style sessions, but that style emitted `/tmp/polylogue/generated-*.jsonl` in Read tool inputs.

## Solution
Change the synthetic tool-heavy Read path to `fixtures/generated-*.jsonl`. Extend `test_build_demo_corpus_specs_materializes_with_synthetic_generator` so it now proves the generated demo files:

- materialize to ChatGPT, Claude Code, and Codex source files;
- contain no `/tmp/` or `/tmp/polylogue` raw text;
- parse back through `iter_source_sessions` as `chatgpt`, `claude-code`, and `codex` sessions;
- preserve non-empty provider session IDs/messages;
- keep tool `file_path` values relative.

## Verification
- `devtools test tests/unit/scenarios/test_corpus.py` -> 19 passed
- `devtools verify --quick` -> exit_code 0
- push hook reran `devtools verify --quick` at `2026-06-15T20:10:13Z` -> exit_code 0

Ref #1843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synthetic data generation to use consistent fixture files instead of temporary paths.
* **Tests**
  * Enhanced validation of generated artifacts to ensure they don't contain system-specific temporary paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->