### PR TITLE
feat(transforms): add recovery report presets (#1880)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -34,6 +34,7 @@ ForensicClaimKind = Literal[
     "event",
     "decision_candidate",
 ]
+RecoveryReportPreset = Literal["continue", "blame"]
 
 _ISSUE_RE = re.compile(r"(?:issues/|issue\s+|closed\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
 _PR_RE = re.compile(r"(?:pull/|PR\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
@@ -237,6 +238,11 @@ class RecoveryDigest(ArchiveInsightModel):
             raise ValueError("RecoveryDigest requires at least one raw ref")
         return self
 
+    def report_markdown(self, preset: RecoveryReportPreset) -> str:
+        """Render a deterministic evidence-linked recovery report preset."""
+
+        return render_recovery_report(self, preset=preset)
+
 
 class TransformDescriptor(ArchiveInsightModel):
     transform_id: str
@@ -383,6 +389,199 @@ def render_resume_bundle(
     lines.extend(["", "## Evidence"])
     lines.append("Raw refs are available on every extracted event/tool/decision record.")
     return "\n".join(lines).strip() + "\n"
+
+
+def render_recovery_report(digest: RecoveryDigest, *, preset: RecoveryReportPreset) -> str:
+    """Render a deterministic recovery report preset from a compiled digest."""
+
+    if preset == "continue":
+        return _render_continue_report(digest)
+    if preset == "blame":
+        return _render_blame_report(digest)
+    raise ValueError(f"unsupported recovery report preset: {preset}")
+
+
+def _render_continue_report(digest: RecoveryDigest) -> str:
+    session_refs = digest.raw_refs
+    lines = [
+        f"# Continue: {digest.title or digest.session_id}{_evidence_suffix(digest, session_refs)}",
+        "",
+        "## Session",
+        f"- session_id: {digest.session_id}{_evidence_suffix(digest, session_refs)}",
+        f"- origin: {digest.transform.source_origin}{_evidence_suffix(digest, session_refs)}",
+        f"- messages: {digest.size_metrics.message_count}{_evidence_suffix(digest, session_refs)}",
+    ]
+    lines.extend(["", "## Boot Packet"])
+    if digest.run_state is None:
+        lines.append(f"- run_state: none extracted{_evidence_suffix(digest, session_refs)}")
+    else:
+        if digest.run_state.goal:
+            lines.append(f"- goal: {digest.run_state.goal}{_evidence_suffix(digest, digest.run_state.raw_refs)}")
+        lines.extend(
+            f"- done: {item}{_evidence_suffix(digest, digest.run_state.raw_refs)}" for item in digest.run_state.done[:8]
+        )
+        lines.extend(
+            f"- in_flight: {item}{_evidence_suffix(digest, digest.run_state.raw_refs)}"
+            for item in digest.run_state.in_flight[:8]
+        )
+        lines.extend(
+            f"- blocker: {item}{_evidence_suffix(digest, digest.run_state.raw_refs)}"
+            for item in digest.run_state.blockers[:8]
+        )
+        lines.extend(
+            f"- next: {item}{_evidence_suffix(digest, digest.run_state.raw_refs)}"
+            for item in digest.run_state.next_actions[:8]
+        )
+    lines.extend(["", "## Recent Events"])
+    if digest.events:
+        lines.extend(
+            f"- {event.kind}: {event.summary}{_evidence_suffix(digest, event.raw_refs)}" for event in digest.events[:10]
+        )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Subagent Reports"])
+    if digest.subagent_reports:
+        for report in digest.subagent_reports[:8]:
+            prompt = f" — {report.prompt}" if report.prompt else ""
+            lines.append(f"- {report.subagent_type}{prompt}{_evidence_suffix(digest, report.raw_refs)}")
+            if report.final_report_preview:
+                lines.append(f"  report: {report.final_report_preview}{_evidence_suffix(digest, report.raw_refs)}")
+            for caveat in report.caveats[:4]:
+                lines.append(f"  caveat: {caveat}{_evidence_suffix(digest, report.raw_refs)}")
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Useful Tools"])
+    if digest.tool_summaries:
+        for tool in digest.tool_summaries[:10]:
+            command = f" — {tool.command}" if tool.command else ""
+            lines.append(
+                f"- {tool.tool_name} [{tool.handler_kind}] ({tool.status}){command}"
+                f"{_evidence_suffix(digest, tool.raw_refs)}"
+            )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Candidate Decisions"])
+    if digest.decision_candidates:
+        lines.extend(
+            f"- {candidate.kind}: {candidate.text}{_evidence_suffix(digest, candidate.raw_refs)}"
+            for candidate in digest.decision_candidates[:10]
+        )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Evidence Index"])
+    lines.extend(_render_evidence_index_lines(digest, limit=12))
+    return "\n".join(lines).strip() + "\n"
+
+
+def _render_blame_report(digest: RecoveryDigest) -> str:
+    session_refs = digest.raw_refs
+    lines = [
+        f"# Blame: {digest.title or digest.session_id}{_evidence_suffix(digest, session_refs)}",
+        "",
+        "## Forensic Summary",
+        f"- session_id: {digest.session_id}{_evidence_suffix(digest, session_refs)}",
+        f"- transform: {digest.transform.transform_id} v{digest.transform.transform_version}"
+        f"{_evidence_suffix(digest, session_refs)}",
+        f"- extracted_claims: {digest.forensic_index.claim_count}{_evidence_suffix(digest, session_refs)}",
+        f"- evidence_locations: {len(digest.forensic_index.entries)}{_evidence_suffix(digest, session_refs)}",
+        "",
+        "## Checks And Tests",
+    ]
+    check_events = [
+        event for event in digest.events if event.kind in {"check_passed", "check_failed", "test_passed", "test_failed"}
+    ]
+    if check_events:
+        lines.extend(
+            f"- {event.kind}: {event.summary}{_evidence_suffix(digest, event.raw_refs)}" for event in check_events
+        )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## GitHub Events"])
+    github_events = [event for event in digest.events if event.kind in {"pr_opened", "pr_merged", "issue_closed"}]
+    if github_events:
+        lines.extend(
+            f"- {event.kind}: {event.summary}{_evidence_suffix(digest, event.raw_refs)}" for event in github_events
+        )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Tool Envelopes"])
+    if digest.tool_summaries:
+        for tool in digest.tool_summaries:
+            command = f" — {tool.command}" if tool.command else ""
+            lines.append(
+                f"- {tool.tool_name} [{tool.handler_kind}] status={tool.status} lines={tool.line_count}{command}"
+                f"{_evidence_suffix(digest, tool.raw_refs)}"
+            )
+            if tool.output_preview:
+                lines.append(f"  output: {tool.output_preview}{_evidence_suffix(digest, tool.raw_refs)}")
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Subagent Evidence"])
+    if digest.subagent_reports:
+        for report in digest.subagent_reports:
+            lines.append(
+                f"- {report.subagent_type}: {report.final_report_preview or report.prompt}"
+                f"{_evidence_suffix(digest, report.raw_refs)}"
+            )
+            for caveat in report.caveats:
+                lines.append(f"  caveat: {caveat}{_evidence_suffix(digest, report.raw_refs)}")
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Decision Candidates"])
+    if digest.decision_candidates:
+        lines.extend(
+            f"- {candidate.kind}: {candidate.text}{_evidence_suffix(digest, candidate.raw_refs)}"
+            for candidate in digest.decision_candidates
+        )
+    else:
+        lines.append(f"- none extracted{_evidence_suffix(digest, session_refs)}")
+    lines.extend(["", "## Evidence Timeline"])
+    lines.extend(_render_evidence_index_lines(digest, limit=None))
+    return "\n".join(lines).strip() + "\n"
+
+
+def _render_evidence_index_lines(digest: RecoveryDigest, *, limit: int | None) -> list[str]:
+    entries = digest.forensic_index.entries if limit is None else digest.forensic_index.entries[:limit]
+    if not entries:
+        return [f"- none extracted{_evidence_suffix(digest, digest.raw_refs)}"]
+    lines = []
+    for entry in entries:
+        location = _raw_location(entry.raw_ref)
+        preview = f" preview={entry.raw_ref.preview!r}" if entry.raw_ref.preview else ""
+        lines.append(
+            f"- evidence_id: {entry.evidence_id}; raw: {location}; claims: {', '.join(entry.claim_labels)}"
+            f"{preview}{_evidence_suffix(digest, (entry.raw_ref,))}"
+        )
+    if limit is not None and len(digest.forensic_index.entries) > limit:
+        lines.append(
+            f"- truncated: {len(digest.forensic_index.entries) - limit} more{_evidence_suffix(digest, digest.raw_refs)}"
+        )
+    return lines
+
+
+def _raw_location(ref: TransformRawRef) -> str:
+    parts: list[str] = [ref.ref_kind]
+    if ref.message_id is not None:
+        parts.append(f"message={ref.message_id}")
+    if ref.block_index is not None:
+        parts.append(f"block={ref.block_index}")
+    return " ".join(parts)
+
+
+def _evidence_suffix(digest: RecoveryDigest, refs: Sequence[TransformRawRef]) -> str:
+    evidence_ids = _evidence_ids_for_refs(digest, refs)
+    if not evidence_ids:
+        evidence_ids = tuple(_evidence_id(ref) for ref in refs)
+    return f" [evidence: {', '.join(evidence_ids)}]"
+
+
+def _evidence_ids_for_refs(digest: RecoveryDigest, refs: Sequence[TransformRawRef]) -> tuple[str, ...]:
+    evidence_ids_by_key = {_raw_ref_key(entry.raw_ref): entry.evidence_id for entry in digest.forensic_index.entries}
+    result: list[str] = []
+    for ref in refs:
+        evidence_id = evidence_ids_by_key.get(_raw_ref_key(ref), _evidence_id(ref))
+        _append_unique(result, evidence_id)
+    return tuple(result)
 
 
 def _build_forensic_index(
@@ -974,6 +1173,7 @@ __all__ = [
     "ForensicIndexEntry",
     "RecoveryDigest",
     "RecoveryEvent",
+    "RecoveryReportPreset",
     "RecoverySizeMetrics",
     "RunStateSummary",
     "SubagentReport",
@@ -982,5 +1182,6 @@ __all__ = [
     "TransformMetadata",
     "TransformRawRef",
     "compile_recovery_digest",
+    "render_recovery_report",
     "render_resume_bundle",
 ]

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -18,6 +18,7 @@ from polylogue.insights.transforms import (
     ToolSummary,
     TransformRawRef,
     compile_recovery_digest,
+    render_recovery_report,
 )
 from polylogue.types import SessionId
 
@@ -235,6 +236,52 @@ def test_forensic_index_groups_claims_by_raw_ref() -> None:
     assert any(label.startswith("event:issue_closed:") for label in merged_event_entry.claim_labels)
 
     assert digest.forensic_index.claim_count > len(digest.forensic_index.entries)
+
+
+def test_continue_report_renders_successor_boot_packet_with_evidence_refs() -> None:
+    digest = compile_recovery_digest(_session())
+
+    report = digest.report_markdown("continue")
+
+    assert report.startswith("# Continue: Ship the backlog [evidence: codex-session:demo]")
+    assert "## Boot Packet" in report
+    assert "- goal: burn down the backlog [evidence: codex-session:demo::m1]" in report
+    assert "- next: merge PR #1911 [evidence: codex-session:demo::m1]" in report
+    assert "- pr_opened: PR #1911 opened [evidence: codex-session:demo::m2]" in report
+    assert "Explore — Map the transform surface and report caveats. [evidence: codex-session:demo::m3::0" in report
+    assert "Bash [test] (ok) — devtools verify --quick [evidence: codex-session:demo::m2::0" in report
+    assert "## Evidence Index" in report
+    assert "evidence_id: codex-session:demo::m2::0; raw: block message=m2 block=0" in report
+    _assert_report_claim_lines_are_evidence_linked(report)
+
+
+def test_blame_report_renders_forensic_evidence_report_with_raw_refs() -> None:
+    digest = compile_recovery_digest(_session())
+
+    report = render_recovery_report(digest, preset="blame")
+
+    assert report.startswith("# Blame: Ship the backlog [evidence: codex-session:demo]")
+    assert "## Forensic Summary" in report
+    assert f"- extracted_claims: {digest.forensic_index.claim_count} [evidence: codex-session:demo]" in report
+    assert "- check_passed: ruff check passed [evidence: codex-session:demo::m2]" in report
+    assert "- test_passed: 20 tests passed [evidence: codex-session:demo::m2]" in report
+    assert "- issue_closed: Issue #1818 closed [evidence: codex-session:demo::m3]" in report
+    assert "- Bash [test] status=ok lines=3 — devtools verify --quick [evidence: codex-session:demo::m2::0" in report
+    assert "output: ruff check ... ok 20 passed in 50.28s" in report
+    assert "## Evidence Timeline" in report
+    assert "raw: message message=m1" in report
+    assert "claims: run_state, event:pr_merged:0, decision:run_state:0, decision:run_state:1" in report
+    _assert_report_claim_lines_are_evidence_linked(report)
+
+
+def _assert_report_claim_lines_are_evidence_linked(report: str) -> None:
+    for line in report.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("##"):
+            continue
+        assert "[evidence: " in line, line
 
 
 def test_github_cli_and_failed_check_events_are_extracted() -> None:


### PR DESCRIPTION
## Summary
Adds deterministic `continue` and `blame` recovery report presets over `RecoveryDigest`.

## Problem
#1880 needs compiled recovery views to feed successor-session and forensic report use cases. The digest had structured raw refs and a forensic index, but no preset renderer for the two immediate product reads: continuation and blame/evidence review.

## Solution
Added recovery report preset support and `RecoveryDigest.report_markdown()`. The `continue` preset renders the successor boot packet, while `blame` renders a forensic evidence report using the raw-ref index so claims stay linked to evidence. No LLM summarization or persistence is introduced.

Issue slice: pure transform report presets for `continue` and `blame`.
Files inspected: `polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`.
Files changed: `polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`, `docs/topology-status.md`.
Old surface removed or retained: retained existing resume markdown and recovery read/API surfaces.
Contracts/tests added: report preset rendering and evidence-link assertions.
Generated artifacts updated: topology status.
Known caveats / SPEC_MISMATCH: no SPEC_MISMATCH; this is pure transform rendering, not CLI/API wiring or persisted output storage.
Follow-up intentionally not included: topology-aware subagent links, persisted recovery outputs, CLI/API report preset selectors, and #1883 KV policy.

## Verification
- `devtools test tests/unit/insights/test_transforms.py` -> 10 passed.
- `devtools verify --quick` -> exit_code 0.

Ref #1880