### PR TITLE
feat(cli): expose recovery report presets (#1880)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -305,6 +305,8 @@ Options:
                                   (--view correlation).
   --related-limit INTEGER         Number of related sessions to include
                                   (--view context).  [default: 5]
+  --report [continue|blame]       Render a recovery report preset (--view
+                                  recovery): continue or blame.
   --project-path TEXT             Filter by cwd prefix pattern (--view
                                   context-pack).
   --project-repo TEXT             Filter by git repo URL or name (--view

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from polylogue.insights.export_bundles import InsightExportBundleRequest, InsightExportBundleResult
     from polylogue.insights.readiness import InsightReadinessQuery, InsightReadinessReport
     from polylogue.insights.resume import ResumeBrief, ResumeCandidate
-    from polylogue.insights.transforms import RecoveryDigest
+    from polylogue.insights.transforms import RecoveryDigest, RecoveryReportPreset
     from polylogue.operations import ArchiveStats
     from polylogue.protocols import ProgressCallback, SessionQueryRuntimeStore
     from polylogue.readiness import ReadinessReport
@@ -1084,6 +1084,13 @@ class PolylogueArchiveMixin:
         if session is None:
             return None
         return compile_recovery_digest(session)
+
+    async def recovery_report(self, session_id: str, preset: RecoveryReportPreset) -> str | None:
+        """Render one deterministic recovery report preset for a session."""
+        digest = await self.recovery_digest(session_id)
+        if digest is None:
+            return None
+        return digest.report_markdown(preset)
 
     async def get_sessions(
         self,

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -7,7 +7,7 @@ a specific action on the matched sessions.
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import click
 
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from polylogue.archive.session.domain_models import Session, SessionSummary
     from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
     from polylogue.cli.root_request import RootModeRequest
+    from polylogue.insights.transforms import RecoveryReportPreset
 
 from polylogue.cli.click_option_groups import _LazyChoice
 from polylogue.cli.shared.types import AppEnv
@@ -66,6 +67,7 @@ _READ_VIEWS = (
 )
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
 _READ_FORMATS = ("text", "markdown", "json", "ndjson", "yaml", "html", "obsidian", "org", "csv")
+_RECOVERY_REPORT_PRESETS = ("continue", "blame")
 
 
 @click.command("list")
@@ -235,6 +237,13 @@ def recent_verb(
     show_default=True,
     help="Number of related sessions to include (--view context).",
 )
+@click.option(
+    "--report",
+    "recovery_report",
+    type=click.Choice(_RECOVERY_REPORT_PRESETS),
+    default=None,
+    help="Render a recovery report preset (--view recovery): continue or blame.",
+)
 @click.option("--project-path", default=None, help="Filter by cwd prefix pattern (--view context-pack).")
 @click.option("--project-repo", default=None, help="Filter by git repo URL or name (--view context-pack).")
 @click.option("--since", default=None, help="Start date, ISO 8601 (--view context-pack).")
@@ -277,6 +286,7 @@ def read_verb(
     github_api: bool,
     otlp: bool,
     related_limit: int,
+    recovery_report: str | None,
     project_path: str | None,
     project_repo: str | None,
     since: str | None,
@@ -398,6 +408,7 @@ def read_verb(
             env,
             session_id=session_id,
             output_format=effective_format if isinstance(effective_format, str) else None,
+            report=recovery_report,
             destination=destination,
             out_path=out_path,
         )
@@ -633,6 +644,7 @@ def _run_read_recovery(
     *,
     session_id: str | None,
     output_format: str | None,
+    report: str | None = None,
     destination: str,
     out_path: str | None,
 ) -> None:
@@ -649,6 +661,14 @@ def _run_read_recovery(
     if session is None:
         fail("read", f"Session not found: {session_id}")
     digest = compile_recovery_digest(session)
+    if report is not None:
+        _deliver_content(
+            env,
+            digest.report_markdown(cast("RecoveryReportPreset", report)),
+            destination=destination,
+            out_path=out_path,
+        )
+        return
     if output_format == "json":
         payload = success({"recovery": model_json_document(digest, exclude_none=True)}).to_json()
         _deliver_content(env, payload + "\n", destination=destination, out_path=out_path)

--- a/tests/baselines/showcase/help-read.txt
+++ b/tests/baselines/showcase/help-read.txt
@@ -56,6 +56,8 @@ Options:
                                   (--view correlation).
   --related-limit INTEGER         Number of related sessions to include
                                   (--view context).  [default: 5]
+  --report [continue|blame]       Render a recovery report preset (--view
+                                  recovery): continue or blame.
   --project-path TEXT             Filter by cwd prefix pattern (--view
                                   context-pack).
   --project-repo TEXT             Filter by git repo URL or name (--view

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -197,6 +197,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "delete_annotation",
         "list_annotations",
         "neighbor_candidates",
+        "recovery_report",
         "find_resume_candidates",
         "export_insight_bundle",
         "parse_file",
@@ -645,6 +646,27 @@ async def test_recovery_digest_compiles_seeded_session(tmp_path: Path) -> None:
         await archive.close()
 
 
+async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) -> None:
+    """``recovery_report`` exposes deterministic preset markdown with evidence refs."""
+    archive = _archive(tmp_path)
+    db_path = archive.config.archive_root / "index.db"
+    await _seed_two_sessions(db_path)
+    try:
+        continue_report = await archive.recovery_report("claude-ai-export:conv-alpha", "continue")
+        blame_report = await archive.recovery_report("claude-ai-export:conv-alpha", "blame")
+
+        assert continue_report is not None
+        assert blame_report is not None
+        assert continue_report.startswith("# Continue: Alpha")
+        assert blame_report.startswith("# Blame: Alpha")
+        assert continue_report != blame_report
+        assert "[evidence:" in continue_report
+        assert "[evidence:" in blame_report
+        assert await archive.recovery_report("nonexistent", "continue") is None
+    finally:
+        await archive.close()
+
+
 async def test_get_actions_derives_from_archive_blocks(tmp_path: Path) -> None:
     """``get_actions`` derives tool invocations from content blocks.
 
@@ -769,6 +791,7 @@ async def test_get_session_returns_none_for_unknown_id(tmp_path: Path) -> None:
         assert await archive.get_session("nonexistent") is None
         assert await archive.get_session_summary("nonexistent") is None
         assert await archive.get_session_profile_insight("nonexistent") is None
+        assert await archive.recovery_report("nonexistent", "continue") is None
     finally:
         await archive.close()
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -119,6 +119,7 @@ def _read_verb_kwargs(**overrides: object) -> dict[str, object]:
         "github_api": True,
         "otlp": False,
         "related_limit": 5,
+        "recovery_report": None,
         "project_path": None,
         "project_repo": None,
         "since": None,
@@ -225,6 +226,74 @@ def test_read_verb_recovery_compiles_digest() -> None:
     deliver.assert_called_once_with(child.obj, "# Resume: demo\n", destination="terminal", out_path=None)
 
 
+def test_read_verb_recovery_default_ignores_report_renderer() -> None:
+    """Default recovery view stays the existing resume bundle, not a preset report."""
+    _, child = _context_pair(params={"conv_id": "codex-session:abc123"}, query_terms=())
+    child.obj.polylogue = SimpleNamespace()
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    async def get_session(session_id: str) -> SimpleNamespace:
+        return SimpleNamespace(id=session_id)
+
+    child.obj.polylogue.get_session = get_session
+    digest = SimpleNamespace(
+        resume_markdown="# Resume: demo\n",
+        report_markdown=lambda preset: f"# {preset.title()}: demo [evidence: E1]\n",
+    )
+
+    with (
+        patch("polylogue.insights.transforms.compile_recovery_digest", return_value=digest),
+        patch("polylogue.cli.query_verbs._deliver_content") as deliver,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="recovery"))
+
+    deliver.assert_called_once_with(child.obj, "# Resume: demo\n", destination="terminal", out_path=None)
+
+
+def test_read_verb_recovery_report_selector_renders_presets() -> None:
+    """read --view recovery --report exposes distinct continue/blame reports."""
+    _, child = _context_pair(params={"conv_id": "codex-session:abc123"}, query_terms=())
+    child.obj.polylogue = SimpleNamespace()
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    async def get_session(session_id: str) -> SimpleNamespace:
+        return SimpleNamespace(id=session_id)
+
+    child.obj.polylogue.get_session = get_session
+    reports = {
+        "continue": "# Continue: demo [evidence: E1]\n",
+        "blame": "# Blame: demo [evidence: E2]\n",
+    }
+    digest = SimpleNamespace(
+        resume_markdown="# Resume: demo\n",
+        report_markdown=lambda preset: reports[preset],
+    )
+
+    with (
+        patch("polylogue.insights.transforms.compile_recovery_digest", return_value=digest),
+        patch("polylogue.cli.query_verbs._deliver_content") as deliver,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="recovery", recovery_report="continue"))
+        wrapped(child, **_read_verb_kwargs(view="recovery", recovery_report="blame"))
+
+    continue_report = deliver.call_args_list[0].args[1]
+    blame_report = deliver.call_args_list[1].args[1]
+    assert continue_report.startswith("# Continue:")
+    assert blame_report.startswith("# Blame:")
+    assert continue_report != blame_report
+    assert "[evidence: E1]" in continue_report
+    assert "[evidence: E2]" in blame_report
+
+
+def test_read_verb_recovery_report_selector_rejects_unknown() -> None:
+    option = next(param for param in query_verbs.read_verb.params if param.name == "recovery_report")
+
+    with pytest.raises(click.BadParameter, match="'incident' is not one of 'continue', 'blame'"):
+        option.type.convert("incident", option, click.Context(query_verbs.read_verb))
+
+
 def test_read_view_recovery_json_uses_success_envelope(capsys: pytest.CaptureFixture[str]) -> None:
     """The recovery read view exposes the typed digest under the machine envelope."""
 
@@ -243,6 +312,7 @@ def test_read_view_recovery_json_uses_success_envelope(capsys: pytest.CaptureFix
             cast(AppEnv, env),
             session_id="s1",
             output_format="json",
+            report=None,
             destination="terminal",
             out_path=None,
         )
@@ -285,6 +355,7 @@ def test_read_view_recovery_requires_session_id() -> None:
             cast(AppEnv, env),
             session_id=None,
             output_format=None,
+            report=None,
             destination="terminal",
             out_path=None,
         )


### PR DESCRIPTION
## Summary
Exposes the recovery `continue` and `blame` report presets through the existing recovery read/API surfaces.

## Problem
#1945 added deterministic report preset rendering on `RecoveryDigest`, but users and API callers still had no selector to request those preset views from the existing recovery surface.

## Solution
Added `read --view recovery --report continue|blame`, preserving the default recovery read output and JSON digest envelope. Added `Polylogue.recovery_report(session_id, preset)` for library callers, returning rendered markdown or `None` for a missing session. Invalid report preset input is rejected through the Click choice.

Issue slice: CLI/API wiring for report preset selectors.
Files inspected: recovery read view, Python API facade, recovery digest transform tests.
Files changed: `polylogue/cli/query_verbs.py`, `polylogue/api/archive.py`, `tests/unit/cli/test_query_verbs_runtime.py`, `tests/unit/api/test_facade_contracts.py`, `docs/cli-reference.md`.
Old surface removed or retained: retained default recovery read behavior and JSON envelope.
Contracts/tests added: default recovery output unchanged, distinct continue/blame reports with evidence refs, invalid preset rejection, API report rendering, missing-session `None`.
Generated artifacts updated: CLI reference.
Known caveats / SPEC_MISMATCH: no SPEC_MISMATCH.
Follow-up intentionally not included: persisted outputs, topology-aware subagent links, and #1883 KV policy.

## Verification
- `devtools test tests/unit/cli/test_query_verbs_runtime.py tests/unit/api/test_facade_contracts.py -k 'recovery or no_undiscovered_async_methods or method_has_typed_signature or get_session_returns_none'` -> 116 passed, 83 deselected.
- `devtools verify --quick` -> exit_code 0.

Ref #1880