### PR TITLE
feat(status): expose embedding component readiness (#1832)

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -246,6 +246,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "rebuild_index": ("archive_routed", "index", "rebuilds messages_fts from index.db"),
     "rebuild_insights": ("archive_routed", "index", "rebuilds insight tables"),
     "record_correction": ("archive_routed", "user", "writes corrections through user.db"),
+    "recovery_digest": ("archive_routed", "index", "builds recovery digests from archive-routed session reads"),
     "remove_mark": ("archive_routed", "user", "writes user marks through user.db"),
     "remove_tag": ("archive_routed", "user", "writes user tags through user.db"),
     "resume_brief": ("archive_routed", "index", "builds resume briefs from archive-routed reads"),
@@ -901,6 +902,7 @@ def _show_direct_json(env: AppEnv) -> None:
         "archive_facade_routes": _archive_facade_route_status(),
         "archive_cli_routes": _archive_cli_route_status(),
         "archive_runtime_paths": _archive_runtime_path_status(),
+        "component_readiness": _direct_component_readiness(env),
         "next_action": diag.next_action,
         "diagnostic": diagnostic_payload(diag),
     }
@@ -918,6 +920,21 @@ def _show_direct_json(env: AppEnv) -> None:
         except Exception as exc:
             payload["error"] = str(exc)
     env.ui.console.print(json.dumps(payload, indent=2, default=str))
+
+
+def _direct_component_readiness(env: AppEnv) -> dict[str, Any]:
+    """Return additive component readiness for direct status JSON."""
+    components: dict[str, Any] = {}
+    try:
+        from polylogue.readiness.capability import component_from_embedding_payload
+        from polylogue.storage.embeddings.status_payload import embedding_status_payload
+
+        embedding_payload = embedding_status_payload(env, include_retrieval_bands=False)
+        embedding = component_from_embedding_payload(embedding_payload)
+        components[embedding.component] = embedding.to_dict()
+    except Exception:
+        pass
+    return components
 
 
 def _render_diagnostic(env: AppEnv, diag: Any) -> None:

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -405,6 +405,52 @@ class TestNoArchiveStatus:
             "ops.db",
         ]
 
+    def test_direct_status_json_maps_embeddings_component_readiness(self, tmp_path: Path) -> None:
+        env = _make_app_env()
+        db_anchor = tmp_path / "index.db"
+        initialize_archive_database(db_anchor, ArchiveTier.INDEX)
+        embedding_payload = {
+            "config_enabled": True,
+            "has_voyage_api_key": True,
+            "status": "partial",
+            "total_sessions": 3,
+            "embedded_sessions": 2,
+            "embedded_messages": 20,
+            "pending_sessions": 1,
+            "stale_messages": 4,
+            "failure_count": 0,
+            "freshness_status": "stale",
+            "retrieval_ready": True,
+            "next_action": {
+                "code": "refresh_stale",
+                "command": "polylogue embed backfill --max-sessions 10",
+                "reason": "Existing vectors are stale for at least one message.",
+            },
+        }
+
+        with (
+            patch("polylogue.paths.db_path", return_value=db_anchor),
+            patch("polylogue.paths.archive_root", return_value=tmp_path),
+            patch(
+                "polylogue.storage.embeddings.status_payload.embedding_status_payload",
+                return_value=embedding_payload,
+            ),
+        ):
+            _show_direct_json(env)
+
+        payload = json.loads(_combined_calls(env))
+        readiness = payload["component_readiness"]["embeddings"]
+        assert readiness["component"] == "embeddings"
+        assert readiness["scope"] == "semantic"
+        assert readiness["state"] == "stale"
+        assert readiness["summary"] == "partial"
+        assert readiness["counts"]["total_sessions"] == 3
+        assert readiness["counts"]["embedded_sessions"] == 2
+        assert readiness["counts"]["stale_messages"] == 4
+        assert readiness["counts"]["retrieval_ready"] is True
+        assert readiness["caveats"] == []
+        assert readiness["repair_hint"] == "polylogue embed backfill --max-sessions 10"
+
     def test_direct_status_uses_active_archive_root(self, tmp_path: Path) -> None:
         env = _make_app_env()
         db_anchor = tmp_path / "custom.sqlite"


### PR DESCRIPTION
## Summary

Adds an additive component-readiness map to `polylogue status --format json` so readiness consumers can inspect embedding coverage through the shared capability-readiness vocabulary instead of scraping prose.

## Problem

#1832 introduced the shared readiness contract, but `polylogue status --format json` still exposed embedding state only through its older status payload. That left the operator-facing status command without a direct path to the new component vocabulary.

## Solution

`polylogue/cli/commands/status.py` now maps the existing embedding status payload into `component_readiness.embeddings` using the shared readiness helper. The existing status route catalog also names the recovery digest surface so the route inventory stays aligned with current read surfaces. `tests/unit/cli/test_status.py` covers stale embedding readiness, caveats, counts, and repair hints.

## Verification

- `devtools test tests/unit/cli/test_status.py tests/unit/cli/test_json_envelope_contract.py::TestStatusJsonContract` -> 28 passed
- `devtools verify --quick` -> exit_code 0

Ref #1832