### PR TITLE
feat(maintenance): add archive backup plan surface (#1830)

### DIFF
--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `5`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `264`
+- scenario projections: `265`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `5`
-  - exercise: `159`
+  - exercise: `160`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -395,6 +395,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-maintenance-archive-init` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance archive-init help |
 | `exercise` | `help-maintenance-archive-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance archive-plan help |
 | `exercise` | `help-maintenance-archive-read` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance archive-read help |
+| `exercise` | `help-maintenance-backup-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance backup-plan help |
 | `exercise` | `help-maintenance-gc-history` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance gc-history help |
 | `exercise` | `help-maintenance-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance plan help |
 | `exercise` | `help-maintenance-preview` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance preview help |

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -22,7 +22,7 @@ from polylogue.maintenance.registry import MaintenanceOperationRegistry, Operati
 from polylogue.maintenance.replay import ReplayProgress, execute_replay
 from polylogue.maintenance.scope import MaintenanceScopeFilter
 from polylogue.maintenance.targets import MAINTENANCE_TARGET_NAMES, build_maintenance_target_catalog
-from polylogue.paths import archive_file_set_root_for_paths, archive_root, db_path, render_root
+from polylogue.paths import archive_file_set_root_for_paths, archive_root, blob_store_root, db_path, render_root
 from polylogue.storage.blob_gc import read_gc_history
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
@@ -386,7 +386,7 @@ def _backup_plan_payload(root: Path) -> dict[str, Any]:
             }
         )
 
-    blob_root = root / "blob"
+    blob_root = blob_store_root()
     return {
         "ok": True,
         "mode": "backup_plan",

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -31,6 +31,63 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     initialize_archive_tier_files_from_plan,
 )
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitPlan, build_archive_init_plan
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_BACKUP_POLICIES: dict[ArchiveTier, dict[str, object]] = {
+    ArchiveTier.SOURCE: {
+        "backup_class": "critical",
+        "policy": "back_up",
+        "restore_role": "raw acquisition evidence and rebuild root",
+    },
+    ArchiveTier.INDEX: {
+        "backup_class": "warm_cache",
+        "policy": "optional_full_evidence",
+        "restore_role": "parsed sessions, search indexes, graph rows, and derived read models",
+    },
+    ArchiveTier.EMBEDDINGS: {
+        "backup_class": "expensive_rebuild",
+        "policy": "back_up_when_present",
+        "restore_role": "vector rows and embedding catch-up state",
+    },
+    ArchiveTier.USER: {
+        "backup_class": "critical",
+        "policy": "always_back_up",
+        "restore_role": "human and agent overlays",
+    },
+    ArchiveTier.OPS: {
+        "backup_class": "diagnostic",
+        "policy": "diagnostics_only",
+        "restore_role": "daemon cursors, convergence debt, and runtime telemetry",
+    },
+}
+
+_BACKUP_PROFILES: tuple[dict[str, object], ...] = (
+    {
+        "name": "full_evidence",
+        "include": ["source.db", "index.db", "embeddings.db", "user.db", "blob/", "ops.db optional"],
+        "exclude": ["*-wal after checkpoint", "*-shm after checkpoint"],
+        "use_case": "fastest complete restore with raw evidence, read models, vectors, and overlays",
+    },
+    {
+        "name": "user_overlays",
+        "include": ["user.db", "user-owned referenced blobs"],
+        "exclude": ["index.db", "ops.db", "rebuildable derived models"],
+        "use_case": "protect irreplaceable human and agent state before resets or schema rebuilds",
+    },
+    {
+        "name": "rebuildable_cache_exclude",
+        "include": ["source.db", "user.db", "blob/", "embeddings.db optional"],
+        "exclude": ["index.db", "ops.db", "derived/cache artifacts"],
+        "use_case": "smaller backup that can rebuild parsed and indexed data locally",
+    },
+    {
+        "name": "diagnostics_bundle",
+        "include": ["ops.db", "backup-plan json", "daemon-workload-probe json", "logs", "readonly status outputs"],
+        "exclude": ["private raw blobs unless explicitly needed"],
+        "use_case": "incident triage without over-sharing archive contents",
+    },
+)
 
 
 def _build_scope_filter(
@@ -271,6 +328,103 @@ def _archive_plan_payload(plan: ArchiveInitPlan) -> dict[str, object]:
             for tier_plan in plan.tiers
         ],
     }
+
+
+@maintenance_group.command("backup-plan")
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def backup_plan_command(output_format: str) -> None:
+    """Inspect archive backup boundaries without copying data.
+
+    Reports the backup class and presence of each archive tier, blob-store
+    boundary, and the named backup profiles documented for operators.
+    """
+    root = archive_root()
+    payload = _backup_plan_payload(root)
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_backup_plain_plan(payload)
+
+
+def _backup_plan_payload(root: Path) -> dict[str, Any]:
+    tier_payloads = []
+    wal_warnings: list[str] = []
+    for tier in ArchiveTier:
+        spec = ARCHIVE_TIER_SPECS[tier]
+        path = root / spec.filename
+        wal_path = path.with_name(f"{path.name}-wal")
+        shm_path = path.with_name(f"{path.name}-shm")
+        wal_present = wal_path.exists()
+        if wal_present:
+            wal_warnings.append(f"{spec.filename}-wal is present; checkpoint before copying {spec.filename}")
+        policy = _BACKUP_POLICIES[tier]
+        tier_payloads.append(
+            {
+                "tier": tier.value,
+                "filename": spec.filename,
+                "path": str(path),
+                "present": path.exists(),
+                "size_bytes": path.stat().st_size if path.exists() else None,
+                "durability": spec.durability,
+                "expected_user_version": spec.version,
+                "backup_required": spec.backup_required,
+                "backup_class": policy["backup_class"],
+                "backup_policy": policy["policy"],
+                "restore_role": policy["restore_role"],
+                "wal_present": wal_present,
+                "shm_present": shm_path.exists(),
+                "checkpoint_recommended": wal_present,
+            }
+        )
+
+    blob_root = root / "blob"
+    return {
+        "ok": True,
+        "mode": "backup_plan",
+        "archive_root": str(root),
+        "tiers": tier_payloads,
+        "blob_store": {
+            "path": str(blob_root),
+            "present": blob_root.exists(),
+            "backup_policy": "back_up_referenced_blobs_with_source_and_user_tiers",
+            "gc_safety_boundary": "source.db raw references plus pending_blob_refs leases are authoritative",
+        },
+        "profiles": list(_BACKUP_PROFILES),
+        "warnings": wal_warnings,
+        "mutates": False,
+    }
+
+
+def _render_backup_plain_plan(payload: dict[str, Any]) -> None:
+    click.echo("Archive backup plan")
+    click.echo(f"Archive root: {payload['archive_root']}")
+    click.echo("")
+    click.echo("Tiers:")
+    for tier in payload["tiers"]:
+        assert isinstance(tier, dict)
+        status = "present" if tier["present"] else "missing"
+        checkpoint = " checkpoint-before-copy" if tier["checkpoint_recommended"] else ""
+        click.echo(f"  {tier['filename']}: {tier['backup_class']} policy={tier['backup_policy']} {status}{checkpoint}")
+    click.echo("")
+    click.echo("Profiles:")
+    for profile in payload["profiles"]:
+        assert isinstance(profile, dict)
+        click.echo(f"  {profile['name']}: {profile['use_case']}")
+    warnings = payload["warnings"]
+    if warnings:
+        click.echo("")
+        click.echo("Warnings:")
+        for warning in warnings:
+            click.echo(f"  {warning}")
 
 
 @maintenance_group.command("archive-read")

--- a/tests/baselines/showcase/help-maintenance-backup-plan.txt
+++ b/tests/baselines/showcase/help-maintenance-backup-plan.txt
@@ -1,0 +1,10 @@
+Usage: polylogue maintenance backup-plan [OPTIONS]
+
+  Inspect archive backup boundaries without copying data.
+
+  Reports the backup class and presence of each archive tier, blob-store
+  boundary, and the named backup profiles documented for operators.
+
+Options:
+  --output-format [plain|json]  Output format.  [default: plain]
+  -h, --help                    Show this message and exit.

--- a/tests/baselines/showcase/help-maintenance.txt
+++ b/tests/baselines/showcase/help-maintenance.txt
@@ -9,6 +9,7 @@ Commands:
   archive-init  Initialize the archive file set after explicit confirmation.
   archive-plan  Inspect readiness for the archive file set.
   archive-read  Read index sessions from the archive.
+  backup-plan   Inspect archive backup boundaries without copying data.
   gc-history    Show recent blob-GC passes recorded in ``gc_generations``.
   plan          Dry-run summary: show what would be rebuilt without...
   preview       Staleness inventory by model and scope.

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -88,6 +88,82 @@ def test_archive_plan_cli_surfaces_existing_target_blocker(
     assert any("source target already exists" in blocker for blocker in payload["blockers"])
 
 
+def test_backup_plan_cli_reports_backup_profiles_and_tier_boundaries(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "backup-plan", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["mode"] == "backup_plan"
+    assert payload["mutates"] is False
+    assert payload["archive_root"] == str(cli_workspace["archive_root"])
+
+    tiers = {tier["tier"]: tier for tier in payload["tiers"]}
+    assert tiers["source"]["backup_class"] == "critical"
+    assert tiers["source"]["backup_required"] is True
+    assert tiers["index"]["backup_class"] == "warm_cache"
+    assert tiers["index"]["backup_required"] is False
+    assert tiers["embeddings"]["backup_policy"] == "back_up_when_present"
+    assert tiers["user"]["backup_policy"] == "always_back_up"
+    assert tiers["ops"]["backup_policy"] == "diagnostics_only"
+    assert all(tier["present"] is True for tier in tiers.values())
+
+    profiles = {profile["name"] for profile in payload["profiles"]}
+    assert profiles == {
+        "full_evidence",
+        "user_overlays",
+        "rebuildable_cache_exclude",
+        "diagnostics_bundle",
+    }
+    assert payload["blob_store"]["backup_policy"] == "back_up_referenced_blobs_with_source_and_user_tiers"
+
+
+def test_backup_plan_cli_surfaces_missing_tiers_and_wal_checkpoint_warning(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    archive_root = cli_workspace["archive_root"]
+    (archive_root / "index.db").unlink()
+    (archive_root / "user.db-wal").write_text("pending", encoding="utf-8")
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "backup-plan", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    tiers = {tier["tier"]: tier for tier in payload["tiers"]}
+    assert tiers["index"]["present"] is False
+    assert tiers["user"]["wal_present"] is True
+    assert tiers["user"]["checkpoint_recommended"] is True
+    assert payload["warnings"] == ["user.db-wal is present; checkpoint before copying user.db"]
+
+
+def test_backup_plan_cli_renders_plain_summary(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "backup-plan"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Archive backup plan" in result.output
+    assert "source.db: critical policy=back_up present" in result.output
+    assert "full_evidence:" in result.output
+
+
 def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
     _stage_uninitialized_archive(cli_workspace)
     result = cli_runner.invoke(

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -122,6 +122,7 @@ def test_backup_plan_cli_reports_backup_profiles_and_tier_boundaries(
         "rebuildable_cache_exclude",
         "diagnostics_bundle",
     }
+    assert payload["blob_store"]["path"] == str(cli_workspace["data_root"] / "polylogue" / "blob")
     assert payload["blob_store"]["backup_policy"] == "back_up_referenced_blobs_with_source_and_user_tiers"
 
 


### PR DESCRIPTION
## Summary

Adds a read-only `polylogue maintenance backup-plan` operator surface that turns the archive backup boundaries from #1948 into machine-readable tier and profile data.

## Problem

#1948 documented the tier backup classes, profiles, and blob-GC safety boundary, but operators still had to read prose or infer from `archive-plan`. `archive-plan` is an initialization planner; it does not directly answer which existing tiers belong in full, overlay-only, rebuildable-cache, or diagnostic backups.

## Solution

`polylogue/cli/commands/maintenance.py` now exposes `maintenance backup-plan` with plain and JSON output. The JSON payload reports each tier path, presence, size, expected version, backup class/policy, WAL checkpoint warnings, the blob-store safety boundary, and the four named backup profiles. `tests/unit/cli/test_archive_maintenance_cli.py` covers JSON tier/profile output, missing-tier plus WAL warning behavior, and the plain summary. `docs/test-quality-workflows.md` is regenerated for the new generated help exercise.

## Verification

- `devtools test tests/unit/cli/test_archive_maintenance_cli.py -k 'backup_plan or archive_plan'` -> 5 passed, 5 deselected
- `devtools render-pages && devtools verify --quick` -> exit_code 0

Ref #1830