### PR TITLE
fix(daemon): preserve inbox import suffixes (#1843)

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -46,7 +46,7 @@ from polylogue.daemon.status import daemon_status_payload, format_daemon_status_
 from polylogue.logging import configure_logging, get_logger
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
-from polylogue.sources.live.watcher import default_sources
+from polylogue.sources.live.watcher import INBOX_SOURCE_SUFFIXES, default_sources
 
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
@@ -91,6 +91,28 @@ def _enable_faulthandler_if_supported() -> None:
     """Enable faulthandler when stderr exposes a real file descriptor."""
     with contextlib.suppress(Exception):
         faulthandler.enable()
+
+
+def _watch_sources_from_roots(roots: tuple[Path, ...]) -> tuple[WatchSource, ...]:
+    """Build watch sources for explicit daemon roots.
+
+    An explicit ``--root`` normally means a JSONL session tree. The archive
+    inbox is different: ``polylogue import`` stages approved exports there,
+    including ChatGPT ``.json`` files and zipped takeouts, so an isolated
+    daemon pointed at that inbox must keep the same suffix contract as the
+    default inbox source.
+    """
+    if not roots:
+        return default_sources()
+
+    from polylogue.paths import archive_root
+
+    inbox_root = (archive_root() / "inbox").resolve(strict=False)
+    sources: list[WatchSource] = []
+    for root in roots:
+        suffixes = INBOX_SOURCE_SUFFIXES if root.resolve(strict=False) == inbox_root else (".jsonl",)
+        sources.append(WatchSource(name=root.name, root=root, suffixes=suffixes))
+    return tuple(sources)
 
 
 def _active_index_db_path() -> Path:
@@ -1068,7 +1090,7 @@ def run_command(
 
     atexit.register(_cleanup_pidfile)
 
-    sources = tuple(WatchSource(name=p.name, root=p) for p in roots) if roots else default_sources()
+    sources = _watch_sources_from_roots(roots)
     components = []
     if enable_watch:
         components.append(f"watch={len(sources)} source(s)")
@@ -1120,7 +1142,7 @@ def run_command(
     help="Quiet-period (seconds) before parsing a modified file.",
 )
 def watch_command(roots: tuple[Path, ...], debounce_s: float) -> None:
-    sources = tuple(WatchSource(name=p.name, root=p) for p in roots) if roots else default_sources()
+    sources = _watch_sources_from_roots(roots)
 
     click.echo(
         f"Watching {len(sources)} source(s); debounce={debounce_s}s. Ctrl-C to stop.",

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -35,6 +35,7 @@ logger = get_logger(__name__)
 _PARSER_FINGERPRINT = "live-batched-v2"
 _CATCH_UP_MAX_BATCH_FILES = 50
 _CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
+INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson")
 
 
 @dataclass(frozen=True, slots=True)
@@ -606,7 +607,7 @@ def default_sources() -> tuple[WatchSource, ...]:
         WatchSource(name="antigravity", root=antigravity_path(), suffixes=(".metadata.json",)),
         # #1683: inbox accepts archive, zip, and json-line formats so that
         # GDPR exports (typically .zip) and raw .json dumps are observed.
-        WatchSource(name="inbox", root=archive_root() / "inbox", suffixes=(".jsonl", ".zip", ".json", ".ndjson")),
+        WatchSource(name="inbox", root=archive_root() / "inbox", suffixes=INBOX_SOURCE_SUFFIXES),
         WatchSource(name="hooks", root=hooks_sidecar_dir()),
     )
 

--- a/tests/integration/test_demo_daemon_convergence.py
+++ b/tests/integration/test_demo_daemon_convergence.py
@@ -1,15 +1,9 @@
-"""Live-daemon scheduling harness for ``polylogue import --demo`` (#1843).
+"""Live-daemon convergence harness for ``polylogue import --demo`` (#1843).
 
 This test covers the real scheduling chain:
 
 ``polylogue import --demo`` -> daemon ``/api/ingest`` acceptance -> staged
-demo fixture in the archive inbox.
-
-SPEC_MISMATCH: the attempted full convergence assertion showed that the
-current live daemon path converges only 2 of the 3 generated demo sessions
-from this fixture world when driven through filesystem watch events. Keep this
-test at the accepted-operation boundary until the daemon scheduling path has a
-deterministic operation-to-worker handoff for staged directories.
+demo fixture in the archive inbox -> live daemon convergence.
 """
 
 from __future__ import annotations
@@ -18,6 +12,7 @@ import asyncio
 import contextlib
 import os
 import socket
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -27,6 +22,27 @@ from urllib.request import urlopen
 import pytest
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+EXPECTED_DEMO_SESSIONS = (
+    (
+        "chatgpt-export:dc13ca54-0bba-4298-a38f-09068c2ef2c5",
+        "chatgpt-export",
+        "dc13ca54-0bba-4298-a38f-09068c2ef2c5",
+        3,
+    ),
+    (
+        "claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6",
+        "claude-code-session",
+        "63705dcc-f3e5-4378-8118-8bc21e53bbb6",
+        10,
+    ),
+    (
+        "codex-session:demo-00",
+        "codex-session",
+        "demo-00",
+        6,
+    ),
+)
 
 
 def _free_local_port() -> int:
@@ -74,11 +90,66 @@ def _run_import_demo(daemon_url: str, env: dict[str, str]) -> subprocess.Complet
     )
 
 
-async def test_import_demo_is_accepted_by_live_daemon_scheduling_path(
+def _session_rows(archive_root: Path) -> tuple[tuple[object, ...], ...]:
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        rows = conn.execute(
+            """
+            SELECT session_id, origin, native_id, message_count
+            FROM sessions
+            ORDER BY origin, native_id
+            """
+        ).fetchall()
+    return tuple(tuple(row) for row in rows)
+
+
+def _message_count(archive_root: Path) -> int:
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+
+
+async def _wait_for_demo_archive(
+    archive_root: Path,
+    *,
+    daemon_log: Path,
+    timeout_s: float = 20.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    last_error: BaseException | None = None
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            if _session_rows(archive_root) == EXPECTED_DEMO_SESSIONS and _message_count(archive_root) == 19:
+                return
+        except (OSError, sqlite3.Error) as exc:
+            last_error = exc
+        await asyncio.sleep(0.1)
+
+    log_text = daemon_log.read_text(encoding="utf-8", errors="replace") if daemon_log.exists() else "<missing>"
+    try:
+        rows = _session_rows(archive_root)
+        messages = _message_count(archive_root)
+    except (OSError, sqlite3.Error):
+        rows = ()
+        messages = -1
+    raise AssertionError(
+        "demo import did not converge through live daemon path: "
+        f"sessions={len(rows)} messages={messages} rows={rows!r} "
+        f"last_error={last_error!r}\ndaemon log:\n{log_text}"
+    )
+
+
+def _assert_demo_searchable(archive_root: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with ArchiveStore.open_existing(archive_root, read_only=True) as archive:
+        hits = archive.search_summaries("pytest", limit=5)
+    assert "claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6" in {hit.session_id for hit in hits}
+
+
+async def test_import_demo_converges_through_live_daemon_path(
     workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``polylogue import --demo`` reaches a real daemon accepted operation."""
+    """``polylogue import --demo`` reaches and converges through a real daemon."""
     from polylogue.core.degraded import clear_degraded
 
     clear_degraded()
@@ -126,6 +197,11 @@ async def test_import_demo_is_accepted_by_live_daemon_scheduling_path(
             staged = inbox / "demo-fixture-world-source"
             assert sorted(path.name for path in staged.iterdir()) == ["chatgpt", "claude-code", "codex"]
             assert len(tuple(staged.rglob("demo-*.json*"))) == 3
+
+            await _wait_for_demo_archive(archive_root, daemon_log=daemon_log)
+            assert _session_rows(archive_root) == EXPECTED_DEMO_SESSIONS
+            assert _message_count(archive_root) == 19
+            _assert_demo_searchable(archive_root)
             assert daemon.poll() is None
         finally:
             daemon.terminate()

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -384,6 +384,21 @@ def test_polylogued_watch_builds_sources_from_roots(tmp_path: Path) -> None:
     assert "Watching 2 source(s); debounce=2.0s" in result.stderr
 
 
+def test_explicit_archive_inbox_root_keeps_import_suffixes(workspace_env: dict[str, Path]) -> None:
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.sources.live.watcher import INBOX_SOURCE_SUFFIXES
+
+    inbox = workspace_env["archive_root"] / "inbox"
+    ordinary = workspace_env["archive_root"] / "ordinary-jsonl-root"
+
+    sources = daemon_cli._watch_sources_from_roots((inbox, ordinary))
+
+    assert sources == (
+        WatchSource(name="inbox", root=inbox, suffixes=INBOX_SOURCE_SUFFIXES),
+        WatchSource(name="ordinary-jsonl-root", root=ordinary, suffixes=(".jsonl",)),
+    )
+
+
 def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     from polylogue.daemon import cli as daemon_cli
 


### PR DESCRIPTION
## Summary

Fixes the live-daemon demo convergence gap by preserving the inbox import suffix set for explicit archive inbox roots.

## Problem

The #1950 harness proved `polylogue import --demo` could schedule through the live daemon, but full convergence stopped at 2 of 3 demo sessions. The daemon was watching the explicit inbox root with the default `WatchSource` suffix set of only `.jsonl`, so the staged ChatGPT `demo-00.json` fixture was ignored while the two `.jsonl` demo fixtures converged.

## Solution

`polylogue/sources/live/watcher.py` now exposes the inbox import suffix tuple, and `polylogue/daemon/cli.py` uses it when an explicit root resolves to the active archive inbox. The demo daemon integration test is promoted to assert all 3 sessions, 19 messages, and searchable demo content. A daemon CLI unit test pins the explicit-inbox suffix behavior.

## Verification

- `devtools test tests/integration/test_demo_daemon_convergence.py` -> 1 passed
- `devtools test tests/unit/daemon/test_daemon_cli.py -k 'explicit_archive_inbox_root or polylogued_watch_builds_sources_from_roots'` -> 2 passed, 31 deselected
- `devtools verify --quick` -> exit_code 0

Closes the live daemon convergence gap in #1843.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved daemon file watching configuration to more efficiently handle multiple file formats (.jsonl, .zip, .json, .ndjson)

* **Tests**
  * Enhanced integration tests to verify complete end-to-end daemon convergence and archive searchability
  * Expanded unit test coverage for daemon configuration and source handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->