### PR TITLE
fix(mcp): apply projection flags to message reads (#1825)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1066,7 +1066,6 @@ class PolylogueArchiveMixin:
         *,
         content_projection: ContentProjectionSpec | None = None,
     ) -> Session | None:
-        del content_projection
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
@@ -1074,7 +1073,10 @@ class PolylogueArchiveMixin:
                 resolved_id = archive.resolve_session_id(session_id)
             except KeyError:
                 return None
-            return _archive_session_to_session(archive.read_session(resolved_id))
+            session = _archive_session_to_session(archive.read_session(resolved_id))
+            if content_projection is None or not content_projection.filters_content():
+                return session
+            return session.with_content_projection(content_projection)
 
     async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:
         """Compile one session into the deterministic recovery digest transform."""
@@ -1136,7 +1138,6 @@ class PolylogueArchiveMixin:
         limit: int | None = None,
         content_projection: ContentProjectionSpec | None = None,
     ) -> list[Session]:
-        del content_projection
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
@@ -1144,7 +1145,10 @@ class PolylogueArchiveMixin:
                 origin=origin,
                 limit=50 if limit is None else limit,
             )
-            return [_archive_session_to_session(archive.read_session(summary.session_id)) for summary in summaries]
+            sessions = [_archive_session_to_session(archive.read_session(summary.session_id)) for summary in summaries]
+            if content_projection is None or not content_projection.filters_content():
+                return sessions
+            return [session.with_content_projection(content_projection) for session in sessions]
 
     async def list_summaries(
         self,
@@ -1796,8 +1800,7 @@ class PolylogueArchiveMixin:
 
         Raises ``SessionNotFoundError`` if the session does not exist.
         """
-        del content_projection
-        session = await self.get_session(session_id)
+        session = await self.get_session(session_id, content_projection=content_projection)
         if session is None:
             raise SessionNotFoundError(session_id)
         messages = [
@@ -1817,12 +1820,11 @@ class PolylogueArchiveMixin:
         content_projection: ContentProjectionSpec | None = None,
     ) -> dict[str, list[Message]]:
         """Return messages for many sessions using one archive batch read."""
-        del content_projection
         since_ms = _archive_query_date_ms("since", since)
         until_ms = _archive_query_date_ms("until", until)
         rows: dict[str, list[Message]] = {}
         for session_id in session_ids:
-            session = await self.get_session(session_id)
+            session = await self.get_session(session_id, content_projection=content_projection)
             if session is None:
                 continue
             rows[str(session.id)] = [

--- a/polylogue/archive/semantic/content_projection.py
+++ b/polylogue/archive/semantic/content_projection.py
@@ -237,16 +237,7 @@ def _segments_from_text(message: Message) -> list[_Segment]:
     if message.is_context_dump or message.is_protocol_artifact or message.is_system:
         return [_Segment(ContentKind.SYSTEM_NOISE, text)]
 
-    segments: list[_Segment] = []
-    cursor = 0
-    for match in _CODE_FENCE_PATTERN.finditer(text):
-        segments.extend(_segments_from_noncode_text(text[cursor : match.start()]))
-        code = (match.group("code") or "").strip()
-        if code:
-            segments.append(_Segment(ContentKind.CODE, code))
-        cursor = match.end()
-    segments.extend(_segments_from_noncode_text(text[cursor:]))
-
+    segments = _segments_from_inline_text(text)
     if segments:
         return segments
 
@@ -262,6 +253,8 @@ def _text_block_segments(block: Mapping[str, object]) -> list[_Segment]:
     if text is None:
         return [_Segment(ContentKind.PROSE, None, block=dict(block))]
     if not text.lstrip().startswith("<system-reminder>"):
+        if "```" in text or "<thinking>" in text or "<antml:thinking>" in text:
+            return _segments_from_inline_text(text)
         return [_Segment(ContentKind.PROSE, text, block=dict(block))]
     cleaned = strip_leading_system_reminders(text)
     if not cleaned:
@@ -297,6 +290,19 @@ def _segments_from_noncode_text(text: str) -> list[_Segment]:
     tail = text[cursor:].strip()
     if tail:
         segments.append(_Segment(ContentKind.PROSE, tail))
+    return segments
+
+
+def _segments_from_inline_text(text: str) -> list[_Segment]:
+    segments: list[_Segment] = []
+    cursor = 0
+    for match in _CODE_FENCE_PATTERN.finditer(text):
+        segments.extend(_segments_from_noncode_text(text[cursor : match.start()]))
+        code = (match.group("code") or "").strip()
+        if code:
+            segments.append(_Segment(ContentKind.CODE, code))
+        cursor = match.end()
+    segments.extend(_segments_from_noncode_text(text[cursor:]))
     return segments
 
 

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 
     from polylogue.archive.blackboard import BlackboardNote
     from polylogue.archive.query.spec import SessionQuerySpec
+    from polylogue.archive.semantic.content_projection import ContentProjectionSpec
     from polylogue.config import Config
     from polylogue.mcp.payloads import (
         MCPBlackboardNotePayload,
@@ -28,7 +30,7 @@ if TYPE_CHECKING:
         ArchiveSessionSummary,
         ArchiveStore,
     )
-    from polylogue.storage.sqlite.archive_tiers.write import ArchiveMessageRow, ArchiveSessionEnvelope
+    from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
     from polylogue.surfaces.payloads import SearchEnvelope, SessionSearchHitPayload
 
 
@@ -153,6 +155,73 @@ def blackboard_note_payload(note: BlackboardNote) -> MCPBlackboardNotePayload:
     )
 
 
+def _project_text_block(text: str | None, projection: ContentProjectionSpec) -> str | None:
+    if text is None:
+        return None
+    if (
+        projection.include_prose
+        and projection.include_code
+        and projection.include_reasoning
+        and projection.include_system_noise
+    ):
+        return text
+    from polylogue.archive.message.models import Message
+    from polylogue.archive.message.roles import Role
+    from polylogue.archive.semantic.content_projection import project_message_content
+
+    projected = project_message_content(
+        [Message(id="archive-block", role=Role.ASSISTANT, text=text, blocks=[])],
+        projection,
+    )
+    if not projected:
+        return None
+    return projected[0].text
+
+
+def _project_archive_message(
+    message: ArchiveMessageRow,
+    projection: ContentProjectionSpec | None,
+) -> ArchiveMessageRow | None:
+    if projection is None or projection.is_default():
+        return message
+    tool_semantics = {
+        block.tool_id: block.semantic_type
+        for block in message.blocks
+        if block.block_type == "tool_use" and block.tool_id and block.semantic_type
+    }
+    blocks: list[ArchiveBlockRow] = []
+    for block in message.blocks:
+        if block.block_type == "thinking" and not projection.include_reasoning:
+            continue
+        if block.block_type == "code" and not projection.include_code:
+            continue
+        if block.block_type == "tool_use" and not projection.include_tool_calls:
+            continue
+        if block.block_type == "tool_result":
+            semantic_type = tool_semantics.get(block.tool_id or "", block.semantic_type or "")
+            if semantic_type == "file_read" and not (projection.include_file_reads and projection.include_tool_outputs):
+                continue
+            if semantic_type != "file_read" and not projection.include_tool_outputs:
+                continue
+        if block.block_type in {"image", "document", "file"} and not projection.include_attachments:
+            continue
+        if block.block_type == "text":
+            text = _project_text_block(block.text, projection)
+            if text is None:
+                continue
+            blocks.append(replace(block, text=text))
+            continue
+        if (
+            block.block_type not in {"thinking", "code", "tool_use", "tool_result", "image", "document", "file"}
+            and not projection.include_prose
+        ):
+            continue
+        blocks.append(block)
+    if not blocks and projection.filters_content():
+        return None
+    return replace(message, blocks=tuple(blocks))
+
+
 def archive_message_payload(message: ArchiveMessageRow, *, session_id: str) -> MCPMessagePayload:
     """Project one archive message into the generic MCP message shape."""
     from polylogue.mcp.payloads import MCPMessagePayload
@@ -254,6 +323,7 @@ def archive_messages_payload(
     *,
     roles: Sequence[str] = (),
     message_type: str | None = None,
+    content_projection: ContentProjectionSpec | None = None,
     limit: int,
     offset: int,
 ) -> MCPMessagesListPayload:
@@ -262,10 +332,12 @@ def archive_messages_payload(
 
     role_filter = frozenset(roles)
     messages = [
-        message
+        projected
         for message in session.messages
         if (not role_filter or message.role in role_filter)
         and (message_type is None or message.message_type == message_type)
+        for projected in (_project_archive_message(message, content_projection),)
+        if projected is not None
     ]
     page = messages[offset : offset + limit]
     return MCPMessagesListPayload(

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.enums import Origin
 from polylogue.core.sources import provider_from_origin
 from polylogue.mcp.archive_support import (
@@ -593,6 +594,15 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             normalized_message_type = (
                 validate_message_type_filter(message_type).value if message_type is not None else None
             )
+            projection = ContentProjectionSpec.from_params(
+                {
+                    "no_code_blocks": no_code_blocks,
+                    "no_tool_calls": no_tool_calls,
+                    "no_tool_outputs": no_tool_outputs,
+                    "no_file_reads": no_file_reads,
+                    "prose_only": prose_only,
+                }
+            )
             config = hooks.get_config()
             with ArchiveStore.open_existing(active_archive_root(config) or config.archive_root) as archive:
                 try:
@@ -605,6 +615,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                         session,
                         roles=tuple(str(role) for role in roles),
                         message_type=normalized_message_type,
+                        content_projection=projection,
                         limit=hooks.clamp_limit(limit),
                         offset=max(0, offset),
                     )

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -806,6 +806,40 @@ async def test_get_messages_paginated_raises_for_unknown_id(tmp_path: Path) -> N
         await archive.close()
 
 
+async def test_get_messages_paginated_applies_content_projection(tmp_path: Path) -> None:
+    """Message reads honor the same content projection as session reads."""
+    from polylogue.archive.semantic.content_projection import ContentProjectionSpec
+
+    archive = _archive(tmp_path)
+    body = "Alpha\n\n```python\nprint('x')\n```\n\nOmega"
+    with ArchiveStore(tmp_path) as archive_db:
+        session_id = archive_db.write_parsed(
+            ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id="projected-messages",
+                title="Projected messages",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="projected-m1",
+                        role=Role.ASSISTANT,
+                        text=body,
+                        blocks=[],
+                    )
+                ],
+            )
+        )
+    try:
+        messages, total = await archive.get_messages_paginated(
+            session_id,
+            content_projection=ContentProjectionSpec.prose_only(),
+        )
+    finally:
+        await archive.close()
+
+    assert total == 1
+    assert messages[0].text == "Alpha\n\nOmega"
+
+
 # ---------------------------------------------------------------------------
 # 7. Required-arg validation
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -891,19 +891,12 @@ class TestPromptSurfaces:
 
 
 class TestExportSessionTool:
-    def test_get_messages_tool_native_content_projection_is_not_applied(
+    def test_get_messages_tool_applies_native_content_projection(
         self: object,
         mcp_server: MCPServerUnderTest,
         tmp_path: Path,
     ) -> None:
-        """PROD GAP: the archive ``get_messages`` path builds the content
-        projection request but never applies it — ``archive_messages_payload``
-        joins all block text verbatim. So ``no_code_blocks=True`` does NOT strip
-        fenced code on the archive store. This test pins the *current* archive
-        contract (text returned verbatim) so the divergence is visible and the
-        gap is tracked; the previous behavior stripped code via
-        ``content_projection``.
-        """
+        """Archive-backed MCP messages honor the shared projection flags."""
         body = "Alpha\n\n```python\nprint('x')\n```\n\nOmega"
         archive_root = tmp_path / "archive"
         with ArchiveStore(archive_root) as archive:
@@ -935,8 +928,8 @@ class TestExportSessionTool:
             )
 
         payload = json.loads(result)
-        # Native path returns the code fence intact (projection not applied).
-        assert payload["messages"][0]["text"] == body
+        assert payload["messages"][0]["text"] == "Alpha\n\nOmega"
+        assert "```" not in payload["messages"][0]["content_blocks"][0]["text"]
 
     def test_export_markdown(self: object, simple_session: Session, mcp_server: MCPServerUnderTest) -> None:
         with (


### PR DESCRIPTION
## Summary

Fixes a concrete MCP/Python API read-parity gap: archive-backed message reads accepted projection flags such as `no_code_blocks` and `prose_only`, but the read paths dropped the projection before building message payloads.

## Problem

`get_messages` on MCP had a test documenting a `PROD GAP`: the archive path joined block text verbatim, so `no_code_blocks=True` did not strip fenced code. The Python API facade had the same shape: `get_session`, `list_sessions`, `get_messages_paginated`, and `bulk_get_messages` accepted `content_projection` but discarded it. That violated #1825's requirement that MCP/Python API remain thin views over shared read contracts.

## Solution

- Apply `ContentProjectionSpec` in `Polylogue.get_session`, `list_sessions`, `get_messages_paginated`, and `bulk_get_messages`.
- Thread MCP `get_messages` projection flags into `archive_messages_payload`.
- Project archive message rows before MCP payload serialization, including inline fenced-code/thinking segmentation for text blocks.
- Replace the prior MCP `PROD GAP` test with the expected projection behavior and add Python API facade coverage for projected message pagination.

## #1825 PR handoff checklist

Issue slice: MCP/Python API message read projection parity over the shared content projection contract.

Files inspected: `polylogue/mcp/server_tools.py`, `polylogue/mcp/archive_support.py`, `polylogue/api/archive.py`, `polylogue/archive/semantic/content_projection.py`, `tests/unit/mcp/test_server_surfaces.py`, `tests/unit/api/test_facade_contracts.py`, issue #1825 comments.

Files changed: `polylogue/mcp/server_tools.py`, `polylogue/mcp/archive_support.py`, `polylogue/api/archive.py`, `polylogue/archive/semantic/content_projection.py`, `tests/unit/mcp/test_server_surfaces.py`, `tests/unit/api/test_facade_contracts.py`.

Old surface removed or retained: retained public MCP/API flags; removed the documented behavior gap where flags were accepted but ignored.

Contracts/tests added: MCP archive-backed `get_messages` now asserts `no_code_blocks` strips fenced code; Python API `get_messages_paginated` now asserts `ContentProjectionSpec.prose_only()` is applied.

Generated artifacts updated: none.

Verification commands and results:

- `uv run devtools test tests/unit/mcp/test_server_surfaces.py -k 'get_messages_tool_applies_native_content_projection or get_messages_tool_reads_archive_file_set or session_to_full_dict_applies_projection'` -> 3 passed, 56 deselected
- `uv run devtools test tests/unit/api/test_facade_contracts.py -k 'get_messages_paginated_applies_content_projection or get_messages_paginated_raises_for_unknown_id'` -> 2 passed, 179 deselected
- `uv run devtools verify --quick` -> exit_code 0
- pre-push `devtools verify --quick` -> exit_code 0

Known caveats / SPEC_MISMATCH: this does not slim the MCP tool list or converge error envelopes; the issue comments already assign those to post-#1842 review and #1818 respectively.

Follow-up intentionally not included: broad CLI/MCP/API parity matrix for mutation/error/status surfaces; this PR is the bounded message-read projection slice.

Ref #1825