### PR TITLE
test(docs): audit stale public product wording (#1848)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ polylogue find "pytest" then read --view messages
 `polylogue import --demo` writes only approved synthetic source files and asks
 the running daemon to ingest them. The command is asynchronous: `status` shows
 daemon/archive health, while `stats` and search/read commands are meaningful
-after daemon convergence. The current deterministic archive proof is the
+after daemon convergence. The current deterministic archive evidence is the
 in-process fixture evidence in [docs/generate.md](docs/generate.md), including
 the expected `pytest` search hit.
 

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -88,7 +88,7 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
 
 REPO_GUIDE_ENTRIES: tuple[DocsEntry, ...] = (
     DocsEntry("Contributing", "CONTRIBUTING.md", "Branching, issues, PRs, squash-merge history, and repo policy."),
-    DocsEntry("Testing", "TESTING.md", "Baseline test matrix, protected surfaces, and QA entrypoints."),
+    DocsEntry("Testing", "TESTING.md", "Baseline test matrix, protected surfaces, and verification entrypoints."),
     DocsEntry("Agent Guide", "CLAUDE.md", "Agent memory and working rules."),
 )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,5 +43,5 @@ Use this map when you need the complete repository documentation surface. The to
 | Document | Description |
 |----------|-------------|
 | [Contributing](../CONTRIBUTING.md) | Branching, issues, PRs, squash-merge history, and repo policy. |
-| [Testing](../TESTING.md) | Baseline test matrix, protected surfaces, and QA entrypoints. |
+| [Testing](../TESTING.md) | Baseline test matrix, protected surfaces, and verification entrypoints. |
 | [Agent Guide](../CLAUDE.md) | Agent memory and working rules. |

--- a/tests/unit/devtools/test_public_surface_audit.py
+++ b/tests/unit/devtools/test_public_surface_audit.py
@@ -1,10 +1,14 @@
-"""Tests for the public-surface stale-vocabulary audit (#1850).
+"""Tests for the public-surface stale-vocabulary audit (#1850 / #1848).
 
 The audit (``tools/cleanup/polylogue_public_surface_audit.sh``) fails when
 stale schema-v1 vocabulary (``conversation`` / ``conversation_id`` /
 ``provider_meta`` / the legacy ``/c/{id}`` reader route) reappears on a public
 surface, while allowing it in provider-wire parsers, internal storage/core,
 tests, and historical/tombstone docs.
+
+It also rejects stale proof/QA/showcase/static-site product wording from the
+README/getting-started style public docs while allowing those terms in
+devtools/test-quality internals.
 """
 
 from __future__ import annotations
@@ -96,3 +100,32 @@ def test_audit_honors_inline_allow_marker(tmp_path: Path) -> None:
     )
     result = _run(tmp_path)
     assert result.returncode == 0, f"inline allow marker must suppress the hit:\n{result.stderr}"
+
+
+@pytest.mark.parametrize(
+    ("needle", "replacement"),
+    [
+        ("The current deterministic archive proof is complete.", "evidence or verification result"),
+        ("QA entrypoints are documented here.", "verification or test workflow"),
+        ("Use the showcase product UI.", "demo fixture or verification-lab baseline"),
+        ("Publish the static site as the product UI.", "read/export output or documentation site"),
+    ],
+)
+def test_audit_fails_on_stale_product_wording_in_public_docs(
+    tmp_path: Path,
+    needle: str,
+    replacement: str,
+) -> None:
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "README.md").write_text(needle + "\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert replacement in result.stderr
+
+
+def test_audit_allows_showcase_wording_in_devtools_docs(tmp_path: Path) -> None:
+    """Verification-lab docs can still name internal showcase baselines."""
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "docs" / "devtools.md").write_text("Run showcase baseline checks in the verification lab.\n")
+    result = _run(tmp_path)
+    assert result.returncode == 0, f"devtools internals must be outside product wording audit:\n{result.stderr}"

--- a/tools/cleanup/polylogue_public_surface_audit.sh
+++ b/tools/cleanup/polylogue_public_surface_audit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Polylogue public-surface stale-vocabulary audit (#1850 / #1810 / #1835).
+# Polylogue public-surface stale-vocabulary audit (#1850 / #1810 / #1835 / #1848).
 #
 # Polylogue's public schema-v1 vocabulary is `session` and `origin`. The terms
 # `conversation` / `conversation_id` and the field `provider_meta`, plus the
@@ -26,6 +26,12 @@
 # `# polylogue-audit: allow <reason>` marker when it legitimately documents an
 # external vendor format.
 #
+# #1848 adds a narrower product-docs audit for stale proof/QA/showcase/static
+# product language. Verification-lab, generated-test, devtools, internals, and
+# architecture docs may still use those words for internal machinery; the public
+# getting-started/README surface should talk in terms of evidence,
+# verification, demos, and read/export outputs instead.
+#
 # Exit 0 = clean; exit 1 = stale terms found; exit 2 = misuse.
 
 set -euo pipefail
@@ -46,6 +52,26 @@ PUBLIC_GLOBS=(
   "polylogue/daemon/**/*.py"
   "polylogue/api/**/*.py"
   "polylogue/cli/**/*.py"
+)
+
+PRODUCT_DOC_GLOBS=(
+  "/README.md"
+  "docs/README.md"
+  "docs/getting-started.md"
+  "docs/onboarding.md"
+  "docs/installation.md"
+  "docs/configuration.md"
+  "docs/release.md"
+  "docs/cloud-agents.md"
+  "docs/export.md"
+  "docs/generate.md"
+  "docs/mcp-integration.md"
+  "docs/library-api.md"
+  "docs/search.md"
+  "docs/browser-capture.md"
+  "docs/security.md"
+  "docs/maintenance.md"
+  "docs/archive-backup.md"
 )
 
 # Path prefixes excluded from scanning even when matched by a public glob:
@@ -69,6 +95,14 @@ declare -a RULES=(
   '\bconversation\b|||session (schema-v1 vocabulary)'
   '\bprovider_meta\b|||origin-typed fields (Ref #1790; provider_meta is stale)'
   "['\"\`]/c/|||/s/{session_id} reader route"
+)
+
+declare -a PRODUCT_RULES=(
+  '\bproof\b|||evidence or verification result (#1848)'
+  '\bwitness\b|||fixture, evidence, or contract test (#1848)'
+  '\bQA\b|||verification or test workflow (#1848)'
+  '\bshowcase\b|||demo fixture or verification-lab baseline (#1848)'
+  '\bstatic[- ]site\b|\bstatic site\b|||read/export output or documentation site (#1848)'
 )
 
 rg_args=()
@@ -96,13 +130,35 @@ for rule in "${RULES[@]}"; do
   done < <(rg --no-heading --line-number --color never "${rg_args[@]}" -e "$pattern" 2>/dev/null || true)
 done
 
+product_rg_args=()
+for g in "${PRODUCT_DOC_GLOBS[@]}"; do product_rg_args+=(--glob "$g"); done
+for rule in "${PRODUCT_RULES[@]}"; do
+  pattern="${rule%%|||*}"
+  replacement="${rule##*|||}"
+  while IFS= read -r hit; do
+    case "$hit" in
+      *"polylogue-audit: allow"*) continue ;;
+    esac
+    if [ "$status" -eq 0 ]; then
+      echo "Stale public product-surface wording found:" >&2
+      echo >&2
+      status=1
+    fi
+    echo "  $hit" >&2
+    echo "    -> replace with: $replacement" >&2
+  done < <(rg --no-heading --line-number --color never "${product_rg_args[@]}" -e "$pattern" 2>/dev/null || true)
+done
+
 if [ "$status" -ne 0 ]; then
   echo >&2
-  echo "Public Polylogue vocabulary is 'session' and 'origin'. Stale terms are" >&2
-  echo "allowed only in provider-wire parsers, internal storage/core, tests," >&2
-  echo "and historical/tombstone docs. See tools/cleanup/$(basename "${BASH_SOURCE[0]}")." >&2
+  echo "Public Polylogue vocabulary is 'session' and 'origin'; public product" >&2
+  echo "docs should describe evidence/verification/demo/read-export surfaces," >&2
+  echo "not stale proof/witness/QA/showcase/static-site product layers." >&2
+  echo "Provider-wire parsers, internal storage/core, tests, generated quality" >&2
+  echo "references, and historical/tombstone docs are outside this public audit." >&2
+  echo "See tools/cleanup/$(basename "${BASH_SOURCE[0]}")." >&2
   exit 1
 fi
 
-echo "polylogue-public-surface-audit: clean (no stale schema-v1 vocabulary on public surfaces)"
+echo "polylogue-public-surface-audit: clean (no stale public vocabulary/product wording)"
 exit 0


### PR DESCRIPTION
## Summary
Adds a #1848 product-doc wording layer to the existing public-surface audit and removes the current product-facing stale wording hits from README surfaces.

## Problem
The repository already blocked stale schema-v1 public vocabulary, but #1848 also needs old proof/witness/QA/showcase/static-site language to stay out of external-facing product docs. Internal verification-lab and devtools documents still need those words for their actual machinery.

## Solution
Extend `tools/cleanup/polylogue_public_surface_audit.sh` with a narrow `PRODUCT_DOC_GLOBS` scan and replacement guidance for stale product wording. Keep devtools, internals, architecture, generated test-quality, and historical docs outside that product-doc rule set. Update the README wording from archive proof to archive evidence, update the docs map from QA entrypoints to verification entrypoints, and refresh `docs/README.md` via `uv run devtools render-docs-surface`.

## Verification
- `bash tools/cleanup/polylogue_public_surface_audit.sh` -> `polylogue-public-surface-audit: clean (no stale public vocabulary/product wording)`
- `uv run devtools test tests/unit/devtools/test_public_surface_audit.py` -> `12 passed`
- `uv run devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

Ref #1848