### PR TITLE
chore(devtools): add release readiness gate check (#1827)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1589,6 +1589,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
+| `devtools release-readiness` | Validate the externally-presentable release gate definition. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools schema-audit` | Run committed provider schema package quality checks. |

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -162,6 +162,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
+        "release-readiness",
+        "verification",
+        "Validate the externally-presentable release gate definition.",
+        "devtools.release_readiness",
+        use_when=(
+            "Check that the release-readiness gate document, required local commands, "
+            "and release PR evidence template are still coherent before touching a release PR."
+        ),
+        examples=("devtools release-readiness", "devtools release-readiness --json"),
+    ),
+    CommandSpec(
         "test",
         "verification",
         "Run a focused pytest selection through the managed harness.",

--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -1,0 +1,130 @@
+"""Validate the externally-presentable release gate definition (#1827)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE_DOC = ROOT / "docs" / "plans" / "release-readiness-gate.md"
+
+
+@dataclass(frozen=True, slots=True)
+class GateCommand:
+    argv: tuple[str, ...]
+    required: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"argv": list(self.argv), "required": self.required, "reason": self.reason}
+
+
+REQUIRED_COMMANDS: tuple[GateCommand, ...] = (
+    GateCommand(("devtools", "release-readiness"), True, "release gate definition"),
+    GateCommand(("devtools", "verify", "--quick"), True, "static/generated baseline"),
+    GateCommand(("devtools", "verify", "--lab"), True, "verification-lab baseline"),
+    GateCommand(("devtools", "build-package"), True, "wheel/sdist/Nix package smoke"),
+    GateCommand(("devtools", "render-pages"), True, "documentation site build"),
+    GateCommand(("devtools", "verify-doc-commands"), True, "README/docs command examples"),
+)
+
+FOCUSED_COMMANDS: tuple[GateCommand, ...] = (
+    GateCommand(
+        ("devtools", "test", "tests/unit/cli/test_query_verbs_runtime.py"),
+        False,
+        "command/read surface changed",
+    ),
+    GateCommand(
+        ("devtools", "test", "tests/unit/storage/test_blackboard_facade.py"),
+        False,
+        "user assertion/KV surface changed",
+    ),
+    GateCommand(("devtools", "lab-scenario", "verify-baselines"), False, "showcase/demo baselines changed"),
+    GateCommand(("nix", "flake", "check"), False, "packaging, Nix, or dependency metadata changed"),
+)
+
+REQUIRED_DOC_HEADINGS: tuple[str, ...] = (
+    "## Gate Rule",
+    "## Required Local Commands",
+    "## Automated Gate Matrix",
+    "## Manual Release Review",
+    "## Current Status",
+    "## Release PR Body Requirements",
+)
+
+REQUIRED_RELEASE_BODY_FIELDS: tuple[str, ...] = (
+    "- Command floor:",
+    "- Machine output:",
+    "- README/demo:",
+    "- Import/demo fixture:",
+    "- Recovery/digest:",
+    "- Web/API scope:",
+    "- Packaging:",
+    "- Known caveats scoped out:",
+)
+
+
+def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
+    """Return a JSON-serializable release-gate definition report."""
+    from devtools.command_catalog import COMMANDS
+
+    errors: list[str] = []
+    text = gate_doc.read_text(encoding="utf-8") if gate_doc.exists() else ""
+    if not text:
+        errors.append(f"missing gate document: {gate_doc}")
+
+    for heading in REQUIRED_DOC_HEADINGS:
+        if heading not in text:
+            errors.append(f"gate document missing heading: {heading}")
+    for field in REQUIRED_RELEASE_BODY_FIELDS:
+        if field not in text:
+            errors.append(f"release PR template missing field: {field}")
+
+    for command in (*REQUIRED_COMMANDS, *FOCUSED_COMMANDS):
+        if command.argv[0] == "devtools" and command.argv[1] not in COMMANDS:
+            errors.append(f"unknown devtools command in release gate: {' '.join(command.argv)}")
+
+    return {
+        "ok": not errors,
+        "gate_doc": str(gate_doc.relative_to(ROOT) if gate_doc.is_relative_to(ROOT) else gate_doc),
+        "required_commands": [command.to_dict() for command in REQUIRED_COMMANDS],
+        "focused_commands": [command.to_dict() for command in FOCUSED_COMMANDS],
+        "required_release_body_fields": list(REQUIRED_RELEASE_BODY_FIELDS),
+        "errors": errors,
+    }
+
+
+def _print_human(report: dict[str, Any]) -> None:
+    status = "ok" if report["ok"] else "FAIL"
+    print(f"release-readiness: {status}")
+    print(f"gate doc: {report['gate_doc']}")
+    print("required commands:")
+    for command in report["required_commands"]:
+        print(f"  {' '.join(command['argv'])}  # {command['reason']}")
+    print("focused commands:")
+    for command in report["focused_commands"]:
+        print(f"  {' '.join(command['argv'])}  # {command['reason']}")
+    if report["errors"]:
+        print("errors:")
+        for error in report["errors"]:
+            print(f"  - {error}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit the gate-definition report as JSON.")
+    args = parser.parse_args(argv)
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_human(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -105,6 +105,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
+| `devtools release-readiness` | Validate the externally-presentable release gate definition. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools schema-audit` | Run committed provider schema package quality checks. |

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -24,6 +24,7 @@ shipped product behavior.
 Run these from a clean checkout inside the devshell:
 
 ```bash
+devtools release-readiness
 devtools verify --quick
 devtools verify --lab
 devtools build-package

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -17,7 +17,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 3082
+    loc: 3091
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -414,7 +414,7 @@ files:
     owner: archive-semantic
     reason: archive-domain semantics
   - path: polylogue/archive/semantic/content_projection.py
-    loc: 386
+    loc: 392
     target: polylogue/archive/semantic/content_projection.py
     owner: archive-semantic
     reason: archive-domain semantics
@@ -752,7 +752,7 @@ files:
     target: polylogue/cli/commands/insights.py
     owner: stable
   - path: polylogue/cli/commands/maintenance.py
-    loc: 897
+    loc: 1051
     target: polylogue/cli/commands/maintenance.py
     owner: stable
   - path: polylogue/cli/commands/paths.py
@@ -776,7 +776,7 @@ files:
     target: polylogue/cli/commands/schema.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 1190
+    loc: 1207
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -808,7 +808,7 @@ files:
     target: polylogue/cli/messages.py
     owner: stable
   - path: polylogue/cli/output_assurance.py
-    loc: 483
+    loc: 567
     target: polylogue/cli/output_assurance.py
     owner: stable
   - path: polylogue/cli/parser_diagnostics.py
@@ -852,7 +852,7 @@ files:
     target: polylogue/cli/query_stats.py
     owner: stable
   - path: polylogue/cli/query_verbs.py
-    loc: 1124
+    loc: 1144
     target: polylogue/cli/query_verbs.py
     owner: stable
   - path: polylogue/cli/root_request.py
@@ -1121,7 +1121,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 1141
+    loc: 1163
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1428,7 +1428,7 @@ files:
     target: polylogue/insights/topology.py
     owner: stable
   - path: polylogue/insights/transforms.py
-    loc: 864
+    loc: 1187
     target: polylogue/insights/transforms.py
     owner: stable
   - path: polylogue/logging.py
@@ -1493,7 +1493,7 @@ files:
     target: polylogue/mcp/__init__.py
     owner: stable
   - path: polylogue/mcp/archive_support.py
-    loc: 336
+    loc: 408
     target: polylogue/mcp/archive_support.py
     owner: stable
   - path: polylogue/mcp/cli.py
@@ -1549,7 +1549,7 @@ files:
     target: polylogue/mcp/server_support.py
     owner: stable
   - path: polylogue/mcp/server_tools.py
-    loc: 674
+    loc: 685
     target: polylogue/mcp/server_tools.py
     owner: stable
   - path: polylogue/operations/__init__.py
@@ -2535,7 +2535,7 @@ files:
     target: polylogue/sources/live/sqlite_locking.py
     owner: stable
   - path: polylogue/sources/live/watcher.py
-    loc: 648
+    loc: 649
     target: polylogue/sources/live/watcher.py
     owner: stable
   - path: polylogue/sources/parsers/antigravity.py

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -24,6 +24,7 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
     assert "regression-capture" in commands
     assert "scenario-projections" in commands
     assert "render-devtools-reference" in commands
+    assert "release-readiness" in commands
     assert "status" in commands
 
 

--- a/tests/unit/devtools/test_release_readiness.py
+++ b/tests/unit/devtools/test_release_readiness.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devtools import release_readiness
+
+
+def test_release_readiness_report_validates_committed_gate() -> None:
+    report = release_readiness.build_report()
+
+    assert report["ok"] is True
+    assert report["gate_doc"] == "docs/plans/release-readiness-gate.md"
+    assert ["devtools", "verify", "--quick"] in [command["argv"] for command in report["required_commands"]]
+    assert ["devtools", "build-package"] in [command["argv"] for command in report["required_commands"]]
+    assert "- Known caveats scoped out:" in report["required_release_body_fields"]
+    assert report["errors"] == []
+
+
+def test_release_readiness_json_cli(capsys: pytest.CaptureFixture[str]) -> None:
+    assert release_readiness.main(["--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["required_commands"][0]["argv"] == ["devtools", "release-readiness"]


### PR DESCRIPTION
## Summary
Adds a reproducible `devtools release-readiness` gate-definition check for the externally-presentable release gate.

## Problem
#1827 already has a release-readiness document, but the held release PR still needs a concrete local command that validates the gate definition itself before anyone treats a green release workflow as publish approval.

## Solution
Add `devtools.release_readiness`, register it in the devtools command catalog, and list `devtools release-readiness` in the gate's required local command sequence. The command validates that the committed gate document exists, still carries the required sections, references known devtools commands, and preserves the required release PR evidence fields. It emits both human and JSON reports. Generated devtools/agent/topology surfaces were refreshed.

Issue slice: release-readiness gate-definition command.
Files inspected: `docs/plans/release-readiness-gate.md`, `devtools/command_catalog.py`, devtools command dispatch/tests.
Files changed: `devtools/release_readiness.py`, command catalog, gate doc, generated surfaces, tests.
Old surface removed or retained: retained the held release PR policy; this does not run or merge a release.
Contracts/tests added: command report test and command discovery coverage.
Generated artifacts updated: `docs/devtools.md`, `docs/plans/topology-target.yaml`, `AGENTS.md`.
Known caveats / SPEC_MISMATCH: the command validates the gate definition and command inventory; the release PR still must run the heavy release commands explicitly.
Follow-up intentionally not included: no release publication, no #1719 merge, no web/API scope decision.

## Verification
- `uv run devtools release-readiness --json` -> `"ok": true`, `"errors": []`
- `uv run devtools test tests/unit/devtools/test_release_readiness.py tests/unit/devtools/test_devtools_main.py` -> `6 passed`
- `uv run devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

Ref #1827