### PR TITLE
feat(status): expose archive surface readiness components (#1832)

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -30,6 +30,27 @@ _ARCHIVE_TIER_TARGETS: tuple[str, ...] = (
     "ops.db",
 )
 
+_ARCHIVE_COMPONENT_SCOPES: dict[str, str] = {
+    "archive_sessions": "archive",
+    "raw_artifacts": "source",
+    "search": "lexical",
+    "session_profiles": "insights",
+    "timeline_work_events": "insights",
+    "timeline_phases": "insights",
+    "threads": "insights",
+    "tool_usage": "actions",
+    "latency_profiles": "insights",
+}
+
+_ARCHIVE_COMPONENT_REPAIR_HINTS: dict[str, str] = {
+    "search": "polylogue maintenance run --target dangling_fts",
+    "session_profiles": "polylogue maintenance run --target session_insights",
+    "timeline_work_events": "polylogue maintenance run --target session_insights",
+    "timeline_phases": "polylogue maintenance run --target session_insights",
+    "threads": "polylogue maintenance run --target session_insights",
+    "latency_profiles": "polylogue maintenance run --target session_insights",
+}
+
 
 def _default_daemon_url() -> str:
     """Resolve the default daemon URL.
@@ -931,15 +952,18 @@ def _direct_component_readiness(env: AppEnv, *, archive_readiness: dict[str, Any
             from polylogue.readiness.capability import component_from_archive_surface
 
             surfaces = archive_readiness.get("surfaces") or {}
-            search_surface = surfaces.get("search") if isinstance(surfaces, dict) else None
-            if isinstance(search_surface, dict):
-                search = component_from_archive_surface(
-                    "search",
-                    search_surface,
-                    scope="lexical",
-                    repair_hint="polylogue maintenance run --target dangling_fts",
-                )
-                components[search.component] = search.to_dict()
+            if isinstance(surfaces, dict):
+                for component, scope in _ARCHIVE_COMPONENT_SCOPES.items():
+                    surface = surfaces.get(component)
+                    if not isinstance(surface, dict):
+                        continue
+                    readiness = component_from_archive_surface(
+                        component,
+                        surface,
+                        scope=scope,
+                        repair_hint=_ARCHIVE_COMPONENT_REPAIR_HINTS.get(component),
+                    )
+                    components[readiness.component] = readiness.to_dict()
         except Exception:
             pass
     try:

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -451,18 +451,33 @@ class TestNoArchiveStatus:
         assert readiness["caveats"] == []
         assert readiness["repair_hint"] == "polylogue embed backfill --max-sessions 10"
 
-    def test_direct_status_json_maps_search_component_readiness(self, tmp_path: Path) -> None:
+    def test_direct_status_json_maps_archive_surface_component_readiness(self, tmp_path: Path) -> None:
         env = _make_app_env()
         db_anchor = tmp_path / "index.db"
         initialize_archive_database(db_anchor, ArchiveTier.INDEX)
         archive_readiness = {
             "checked": True,
             "surfaces": {
+                "archive_sessions": {
+                    "ready": True,
+                    "blockers": [],
+                    "evidence": {"session_count": 3, "message_count": 19},
+                },
                 "search": {
                     "ready": False,
                     "blockers": ["messages_fts_row_mismatch"],
                     "evidence": {"text_block_count": 10, "messages_fts_count": 8},
-                }
+                },
+                "session_profiles": {
+                    "ready": False,
+                    "blockers": ["missing_session_profile_materialization"],
+                    "evidence": {
+                        "profile_row_count": 2,
+                        "missing_profile_row_count": 0,
+                        "missing_materialization_count": 1,
+                    },
+                },
+                "tool_usage": {"ready": True, "blockers": [], "evidence": {"action_count": 4}},
             },
         }
 
@@ -475,14 +490,27 @@ class TestNoArchiveStatus:
             _show_direct_json(env)
 
         payload = json.loads(_combined_calls(env))
-        readiness = payload["component_readiness"]["search"]
+        components = payload["component_readiness"]
+        archive = components["archive_sessions"]
+        readiness = components["search"]
+        profiles = components["session_profiles"]
+        tool_usage = components["tool_usage"]
         assert payload["archive_readiness"] == archive_readiness
+        assert archive["component"] == "archive_sessions"
+        assert archive["scope"] == "archive"
+        assert archive["state"] == "ready"
+        assert archive["counts"] == {"session_count": 3, "message_count": 19}
         assert readiness["component"] == "search"
         assert readiness["scope"] == "lexical"
         assert readiness["state"] == "stale"
         assert readiness["counts"] == {"text_block_count": 10, "messages_fts_count": 8}
         assert readiness["caveats"] == ["messages_fts_row_mismatch"]
         assert readiness["repair_hint"] == "polylogue maintenance run --target dangling_fts"
+        assert profiles["scope"] == "insights"
+        assert profiles["state"] == "stale"
+        assert profiles["repair_hint"] == "polylogue maintenance run --target session_insights"
+        assert tool_usage["scope"] == "actions"
+        assert tool_usage["counts"] == {"action_count": 4}
 
     def test_direct_status_uses_active_archive_root(self, tmp_path: Path) -> None:
         env = _make_app_env()


### PR DESCRIPTION
## Summary
Expands `polylogue status --format json` so every direct archive-readiness surface is also available as a canonical `ComponentReadiness` entry.

## Problem
#1956 added `component_readiness.search`, but the direct status JSON still left the rest of `archive_readiness.surfaces` only in the older surface-specific shape. #1832 wants status payloads to converge on one readiness vocabulary without breaking existing consumers.

## Solution
Replace the search-only projection with a small surface map that converts archive sessions, raw artifacts, lexical search, session profiles, timeline work events, phases, threads, tool usage, and latency profiles into `component_readiness`. Scope labels distinguish archive/source/lexical/insights/actions, and existing maintenance repair hints are attached where available. The legacy `archive_readiness` payload remains unchanged.

Issue slice: route direct archive surfaces through `ComponentReadiness`.
Files inspected: `polylogue/cli/commands/status.py`, `polylogue/readiness/capability.py`, status tests.
Files changed: status JSON component projection and tests.
Old surface removed or retained: retained `archive_readiness`; added canonical component projections.
Contracts/tests added: direct status JSON test now covers archive, lexical, insights, and action components.
Generated artifacts updated: none.
Known caveats / SPEC_MISMATCH: none.
Follow-up intentionally not included: daemon/web/MCP status convergence and other readiness source families remain open under #1832.

## Verification
- `uv run devtools test tests/unit/cli/test_status.py -k "archive_surface_component or embeddings_component"` -> `2 passed, 25 deselected`
- `uv run devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

Ref #1832