### PR TITLE
docs: prune stale media surface wording (#1848)

### DIFF
--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -12,12 +12,12 @@ sample data, and timestamps all change between renders, producing large diffs
 that carry no semantic signal and date the documentation badly.
 
 When such media is needed (for a release, a blog post, the website), it is
-rendered on demand from the same showcase exercises and seeded environments
-that back the test suite:
+rendered on demand from the same demo fixtures and verification-lab
+environments that back the test suite:
 
-- `polylogue/showcase/` produces deterministic demo workspaces.
-- `polylogue generate` + `polylogue qa --only exercises` reproduce the
-  scenarios used in any rendered capture.
+- deterministic demo workspaces provide safe, synthetic session data;
+- verification-lab exercise baselines reproduce the scenarios used in any
+  rendered capture;
 - `devtools render-readme-media` re-renders the diagrams committed here
   from their Mermaid sources.
 
@@ -53,14 +53,14 @@ explicitly excluded:
 - No README content currently references screenshots or terminal recordings.
 - A committed asset without a `--check`-style freshness gate is dead weight
   the manifest cannot honestly claim coverage over.
-- The showcase + qa workflows already provide reproducible demo output,
-  which is the source of truth when capture is actually needed.
+- Demo fixtures plus verification-lab baselines already provide reproducible
+  output, which is the source of truth when capture is actually needed.
 
 If a future README change introduces a screenshot or VHS tape, the asset
 must arrive together with:
 
-1. A render script that regenerates it deterministically from a showcase
-   exercise or seeded environment.
+1. A render script that regenerates it deterministically from a demo fixture
+   or verification-lab environment.
 2. A `--check` mode that fails when the committed asset diverges from the
    freshly rendered output (the pattern used by `render-readme-media`).
 3. A new row in `docs/plans/docs-media-coverage.yaml` pointing at that

--- a/tests/unit/devtools/test_public_surface_audit.py
+++ b/tests/unit/devtools/test_public_surface_audit.py
@@ -123,6 +123,16 @@ def test_audit_fails_on_stale_product_wording_in_public_docs(
     assert replacement in result.stderr
 
 
+def test_audit_scans_docs_media_readme_as_product_docs(tmp_path: Path) -> None:
+    _seed_minimal_tree(tmp_path)
+    (tmp_path / "docs" / "media").mkdir()
+    (tmp_path / "docs" / "media" / "README.md").write_text("Render screenshots from the showcase product UI.\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "docs/media/README.md" in result.stderr
+    assert "demo fixture or verification-lab baseline" in result.stderr
+
+
 def test_audit_allows_showcase_wording_in_devtools_docs(tmp_path: Path) -> None:
     """Verification-lab docs can still name internal showcase baselines."""
     _seed_minimal_tree(tmp_path)

--- a/tools/cleanup/polylogue_public_surface_audit.sh
+++ b/tools/cleanup/polylogue_public_surface_audit.sh
@@ -72,6 +72,7 @@ PRODUCT_DOC_GLOBS=(
   "docs/security.md"
   "docs/maintenance.md"
   "docs/archive-backup.md"
+  "docs/media/README.md"
 )
 
 # Path prefixes excluded from scanning even when matched by a public glob:


### PR DESCRIPTION
## Summary

Removes stale showcase/QA product wording from the public media documentation and extends the public-surface audit so `docs/media/README.md` is covered by the same product-doc rules as README/getting-started style docs.

## Problem

#1848 already had a public product wording audit, but `docs/media/README.md` was outside the product-doc scan even though it is release-facing documentation. It still framed capture generation around showcase/QA workflows instead of demo fixtures and verification-lab baselines.

## Solution

`docs/media/README.md` now describes media capture inputs as demo fixtures and verification-lab environments. The public-surface audit now scans `docs/media/README.md`, and the audit tests include a regression proving stale showcase product wording fails on that path while devtools/internal verification-lab wording remains allowed.

## Verification

- `uv run devtools test tests/unit/devtools/test_public_surface_audit.py` → 13 passed
- `bash tools/cleanup/polylogue_public_surface_audit.sh` → clean
- `uv run devtools verify --quick` → exit_code 0