### PR TITLE
feat(storage): read user overlays through assertions (#1883)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -85,6 +85,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     assertion_id_for_recall_pack,
     assertion_id_for_saved_view,
     assertion_id_for_workspace,
+    list_archive_blackboard_note_envelopes,
     mark_assertion_status,
     upsert_annotation,
     upsert_assertion,
@@ -2199,37 +2200,16 @@ class ArchiveStore:
     def list_blackboard_notes(self, *, limit: int | None = None) -> list[ArchiveBlackboardNoteEnvelope]:
         """List blackboard notes from archive user.db, newest first.
 
-        Returns raw envelopes; structured-field decoding (kind/title/scope) is a
-        presentation concern handled by ``polylogue.archive.blackboard``.
+        Mirrored assertion rows own note body/timestamps for write-through
+        notes; legacy rows still provide stable note ids and target fields.
+        Structured-field decoding (kind/title/scope) is a presentation concern
+        handled by ``polylogue.archive.blackboard``.
         """
         if not self.user_db_path.exists():
             return []
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            row = user_conn.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='blackboard_notes' LIMIT 1"
-            ).fetchone()
-            if row is None:
-                return []
-            sql = (
-                "SELECT note_id, target_type, target_id, body, created_at_ms, updated_at_ms "
-                "FROM blackboard_notes ORDER BY created_at_ms DESC, note_id DESC"
-            )
-            params: tuple[object, ...] = ()
-            if limit is not None and limit > 0:
-                sql += " LIMIT ?"
-                params = (limit,)
-            return [
-                ArchiveBlackboardNoteEnvelope(
-                    note_id=str(record[0]),
-                    target_type=record[1],
-                    target_id=record[2],
-                    body=str(record[3]),
-                    created_at_ms=int(record[4]),
-                    updated_at_ms=int(record[5]),
-                )
-                for record in user_conn.execute(sql, params).fetchall()
-            ]
+            return list_archive_blackboard_note_envelopes(user_conn, limit=limit)
         finally:
             user_conn.close()
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 
 
 class AssertionKind(StrEnum):
@@ -113,6 +114,11 @@ def assertion_id_for_mark(target_type: str, target_id: str, mark_type: str) -> s
     return _deterministic_id(f"assertion-{AssertionKind.MARK}", mark_id)
 
 
+def assertion_id_for_suppression(session_id: str) -> str:
+    """Return the mirrored assertion id for one legacy suppression row."""
+    return _deterministic_id(f"assertion-{AssertionKind.SUPPRESSION}", session_id)
+
+
 def assertion_id_for_annotation(annotation_id: str) -> str:
     """Return the mirrored assertion id for one legacy annotation row."""
     return _deterministic_id(f"assertion-{AssertionKind.ANNOTATION}", annotation_id)
@@ -136,6 +142,11 @@ def assertion_id_for_recall_pack(recall_pack_id: str) -> str:
 def assertion_id_for_workspace(workspace_id: str) -> str:
     """Return the mirrored assertion id for one legacy workspace row."""
     return _deterministic_id(f"assertion-{AssertionKind.WORKSPACE_NOTE}", workspace_id)
+
+
+def assertion_id_for_blackboard_note(note_id: str) -> str:
+    """Return the mirrored assertion id for one legacy blackboard note row."""
+    return _deterministic_id(f"assertion-{AssertionKind.NOTE}", note_id)
 
 
 def _target_ref(target_type: str | None, target_id: str | None) -> str | None:
@@ -282,7 +293,7 @@ def upsert_suppression(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.SUPPRESSION}", session_id),
+        assertion_id=assertion_id_for_suppression(session_id),
         target_ref=session_id,
         kind=AssertionKind.SUPPRESSION,
         value={"mode": mode},
@@ -590,7 +601,7 @@ def upsert_blackboard_note(
     )
     upsert_assertion(
         conn,
-        assertion_id=_deterministic_id(f"assertion-{AssertionKind.NOTE}", resolved_id),
+        assertion_id=assertion_id_for_blackboard_note(resolved_id),
         target_ref=_target_ref(target_type, target_id) or resolved_id,
         kind=AssertionKind.NOTE,
         body_text=body,
@@ -615,12 +626,16 @@ def read_archive_suppression_envelope(conn: sqlite3.Connection, session_id: str)
     ).fetchone()
     if row is None:
         raise KeyError(session_id)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_suppression(session_id))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveSuppressionEnvelope(
         session_id=str(row[0]),
-        reason=str(row[1]) if row[1] is not None else None,
-        mode=str(row[2]),
-        created_at_ms=int(row[3]),
-        updated_at_ms=int(row[4]),
+        reason=assertion.body_text if assertion is not None else str(row[1]) if row[1] is not None else None,
+        mode=str(assertion_value.get("mode"))
+        if assertion_value is not None and "mode" in assertion_value
+        else str(row[2]),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
     )
 
 
@@ -635,15 +650,19 @@ def read_archive_mark_envelope(conn: sqlite3.Connection, mark_id: str) -> Archiv
     ).fetchone()
     if row is None:
         raise KeyError(mark_id)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_mark(str(row[1]), str(row[2]), str(row[3])))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveMarkEnvelope(
         mark_id=str(row[0]),
         target_type=str(row[1]),
         target_id=str(row[2]),
         mark_type=str(row[3]),
-        label=str(row[4]) if row[4] is not None else None,
-        created_at_ms=int(row[5]),
-        updated_at_ms=int(row[6]),
-        metadata=_read_payload_text(row[7] if isinstance(row[7], str) else None),
+        label=assertion.body_text if assertion is not None else str(row[4]) if row[4] is not None else None,
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[5]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[6]),
+        metadata=assertion_value
+        if assertion_value is not None
+        else _read_payload_text(row[7] if isinstance(row[7], str) else None),
     )
 
 
@@ -658,13 +677,14 @@ def read_archive_annotation_envelope(conn: sqlite3.Connection, annotation_id: st
     ).fetchone()
     if row is None:
         raise KeyError(annotation_id)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_annotation(annotation_id))
     return ArchiveAnnotationEnvelope(
         annotation_id=str(row[0]),
         target_type=str(row[1]),
         target_id=str(row[2]),
-        body=str(row[3]),
-        created_at_ms=int(row[4]),
-        updated_at_ms=int(row[5]),
+        body=assertion.body_text if assertion is not None and assertion.body_text is not None else str(row[3]),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[4]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[5]),
     )
 
 
@@ -682,14 +702,18 @@ def read_archive_correction_envelope(
     ).fetchone()
     if row is None:
         raise KeyError(correction_id)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_correction(correction_id))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveCorrectionEnvelope(
         correction_id=str(row[0]),
         target_type=str(row[1]),
         target_id=str(row[2]),
         correction_type=str(row[3]),
-        payload=_read_payload_text(row[4] if isinstance(row[4], str) else None),
-        created_at_ms=int(row[5]),
-        updated_at_ms=int(row[6]),
+        payload=assertion_value
+        if assertion_value is not None
+        else _read_payload_text(row[4] if isinstance(row[4], str) else None),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[5]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[6]),
     )
 
 
@@ -704,12 +728,16 @@ def read_archive_saved_view_envelope(conn: sqlite3.Connection, name: str) -> Arc
     ).fetchone()
     if row is None:
         raise KeyError(name)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_saved_view(str(row[0])))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveSavedViewEnvelope(
         view_id=str(row[0]),
         name=str(row[1]),
-        query=_read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=int(row[3]),
-        updated_at_ms=int(row[4]),
+        query=assertion_value
+        if assertion_value is not None
+        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
     )
 
 
@@ -724,12 +752,16 @@ def read_archive_recall_pack_envelope(conn: sqlite3.Connection, recall_pack_id: 
     ).fetchone()
     if row is None:
         raise KeyError(recall_pack_id)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_recall_pack(recall_pack_id))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveRecallPackEnvelope(
         recall_pack_id=str(row[0]),
         name=str(row[1]),
-        payload=_read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=int(row[3]),
-        updated_at_ms=int(row[4]),
+        payload=assertion_value
+        if assertion_value is not None
+        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
     )
 
 
@@ -744,12 +776,47 @@ def read_archive_workspace_envelope(conn: sqlite3.Connection, name: str) -> Arch
     ).fetchone()
     if row is None:
         raise KeyError(name)
+    assertion = _read_mirrored_assertion(conn, assertion_id_for_workspace(str(row[0])))
+    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveWorkspaceEnvelope(
         workspace_id=str(row[0]),
         name=str(row[1]),
-        settings=_read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=int(row[3]),
-        updated_at_ms=int(row[4]),
+        settings=assertion_value
+        if assertion_value is not None
+        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _read_mirrored_assertion(conn: sqlite3.Connection, assertion_id: str) -> ArchiveAssertionEnvelope | None:
+    if not _table_exists(conn, "assertions"):
+        return None
+    return read_assertion_envelope(conn, assertion_id)
+
+
+def _blackboard_envelope_from_legacy_row(
+    row: sqlite3.Row | tuple[Any, ...],
+    assertion: ArchiveAssertionEnvelope | None = None,
+) -> ArchiveBlackboardNoteEnvelope:
+    """Project one legacy note row, preferring mirrored assertion content."""
+    return ArchiveBlackboardNoteEnvelope(
+        note_id=str(row[0]),
+        target_type=str(row[1]) if row[1] is not None else None,
+        target_id=str(row[2]) if row[2] is not None else None,
+        body=assertion.body_text if assertion is not None and assertion.body_text is not None else str(row[3]),
+        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[4]),
+        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[5]),
     )
 
 
@@ -764,14 +831,64 @@ def read_archive_blackboard_note_envelope(conn: sqlite3.Connection, note_id: str
     ).fetchone()
     if row is None:
         raise KeyError(note_id)
-    return ArchiveBlackboardNoteEnvelope(
-        note_id=str(row[0]),
-        target_type=str(row[1]) if row[1] is not None else None,
-        target_id=str(row[2]) if row[2] is not None else None,
-        body=str(row[3]),
-        created_at_ms=int(row[4]),
-        updated_at_ms=int(row[5]),
+    assertion = (
+        read_assertion_envelope(conn, assertion_id_for_blackboard_note(note_id))
+        if _table_exists(conn, "assertions")
+        else None
     )
+    return _blackboard_envelope_from_legacy_row(row, assertion)
+
+
+def list_archive_blackboard_note_envelopes(
+    conn: sqlite3.Connection,
+    *,
+    limit: int | None = None,
+) -> list[ArchiveBlackboardNoteEnvelope]:
+    """List blackboard notes through mirrored assertions with legacy fallback.
+
+    The assertion row owns the note body and timestamps for write-through notes.
+    The legacy row still owns the public ``note_id`` and target fields until the
+    assertion model grows a first-class blackboard note identity.
+    """
+    if not _table_exists(conn, "blackboard_notes"):
+        return []
+
+    legacy_rows = conn.execute(
+        """
+        SELECT note_id, target_type, target_id, body, created_at_ms, updated_at_ms
+        FROM blackboard_notes
+        """
+    ).fetchall()
+    if not legacy_rows:
+        return []
+
+    legacy_by_assertion_id = {assertion_id_for_blackboard_note(str(row[0])): row for row in legacy_rows}
+    seen_note_ids: set[str] = set()
+    envelopes: list[ArchiveBlackboardNoteEnvelope] = []
+
+    if _table_exists(conn, "assertions"):
+        assertion_rows = conn.execute(
+            f"SELECT {_ASSERTION_COLUMNS} FROM assertions WHERE kind = ? ORDER BY created_at_ms DESC, assertion_id DESC",
+            (AssertionKind.NOTE,),
+        ).fetchall()
+        for assertion_row in assertion_rows:
+            assertion = _assertion_row_to_envelope(assertion_row)
+            legacy_row = legacy_by_assertion_id.get(assertion.assertion_id)
+            if legacy_row is None:
+                continue
+            envelope = _blackboard_envelope_from_legacy_row(legacy_row, assertion)
+            envelopes.append(envelope)
+            seen_note_ids.add(envelope.note_id)
+
+    for legacy_row in legacy_rows:
+        note_id = str(legacy_row[0])
+        if note_id not in seen_note_ids:
+            envelopes.append(_blackboard_envelope_from_legacy_row(legacy_row))
+
+    envelopes.sort(key=lambda envelope: (envelope.created_at_ms, envelope.note_id), reverse=True)
+    if limit is not None and limit > 0:
+        return envelopes[:limit]
+    return envelopes
 
 
 def upsert_assertion(
@@ -952,11 +1069,14 @@ __all__ = [
     "ArchiveWorkspaceEnvelope",
     "AssertionKind",
     "assertion_id_for_annotation",
+    "assertion_id_for_blackboard_note",
     "assertion_id_for_correction",
     "assertion_id_for_mark",
     "assertion_id_for_recall_pack",
     "assertion_id_for_saved_view",
+    "assertion_id_for_suppression",
     "assertion_id_for_workspace",
+    "list_archive_blackboard_note_envelopes",
     "list_assertions_for_target",
     "mark_assertion_status",
     "read_archive_annotation_envelope",

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -630,7 +630,11 @@ def read_archive_suppression_envelope(conn: sqlite3.Connection, session_id: str)
     assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
     return ArchiveSuppressionEnvelope(
         session_id=str(row[0]),
-        reason=assertion.body_text if assertion is not None else str(row[1]) if row[1] is not None else None,
+        reason=assertion.body_text
+        if assertion is not None and assertion.body_text is not None
+        else str(row[1])
+        if row[1] is not None
+        else None,
         mode=str(assertion_value.get("mode"))
         if assertion_value is not None and "mode" in assertion_value
         else str(row[2]),

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -9,14 +9,34 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     AssertionKind,
+    assertion_id_for_annotation,
+    assertion_id_for_blackboard_note,
+    assertion_id_for_correction,
+    assertion_id_for_mark,
+    assertion_id_for_recall_pack,
+    assertion_id_for_saved_view,
+    assertion_id_for_suppression,
+    assertion_id_for_workspace,
+    list_archive_blackboard_note_envelopes,
     list_assertions_for_target,
+    read_archive_annotation_envelope,
+    read_archive_blackboard_note_envelope,
+    read_archive_correction_envelope,
+    read_archive_mark_envelope,
+    read_archive_recall_pack_envelope,
+    read_archive_saved_view_envelope,
+    read_archive_suppression_envelope,
+    read_archive_workspace_envelope,
     read_assertion_envelope,
     upsert_annotation,
+    upsert_assertion,
     upsert_blackboard_note,
     upsert_correction,
     upsert_mark,
+    upsert_recall_pack,
     upsert_saved_view,
     upsert_suppression,
+    upsert_workspace,
 )
 
 
@@ -204,6 +224,179 @@ def test_blackboard_note_assertion_metadata_is_preserved(tmp_path: Path) -> None
     assert env.evidence_refs == ["message:m1", "block:m1:2"]
     assert env.staleness == {"expires_after_days": 14}
     assert env.context_policy == {"inject": False}
+
+
+def test_user_overlay_reads_prefer_assertion_mirrors(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    suppression = upsert_suppression(conn, "session-2", "legacy reason", mode="hide", now_ms=1_700_000_034_000)
+    mark = upsert_mark(
+        conn,
+        "session",
+        "session-1",
+        "star",
+        label="legacy label",
+        metadata={"scope": "legacy"},
+        now_ms=1_700_000_034_000,
+    )
+    annotation = upsert_annotation(conn, "message", "msg-1", "legacy body", now_ms=1_700_000_034_000)
+    correction = upsert_correction(
+        conn,
+        "insight",
+        "session-1",
+        "tag_reject",
+        {"tag": "legacy"},
+        now_ms=1_700_000_034_000,
+    )
+    saved_view = upsert_saved_view(conn, "recent", {"limit": 10}, now_ms=1_700_000_034_000)
+    recall_pack = upsert_recall_pack(conn, "handoff", {"sessions": ["legacy"]}, now_ms=1_700_000_034_000)
+    workspace = upsert_workspace(conn, "main", {"repo": "legacy"}, now_ms=1_700_000_034_000)
+
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_suppression(suppression.session_id),
+        target_ref=suppression.session_id,
+        kind=AssertionKind.SUPPRESSION,
+        value={"mode": "freeze"},
+        body_text="asserted reason",
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_mark(mark.target_type, mark.target_id, mark.mark_type),
+        target_ref="session:session-1",
+        kind=AssertionKind.MARK,
+        key=mark.mark_type,
+        value={"scope": "asserted"},
+        body_text="asserted label",
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_annotation(annotation.annotation_id),
+        target_ref="message:msg-1",
+        kind=AssertionKind.ANNOTATION,
+        body_text="asserted annotation",
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_correction(correction.correction_id),
+        target_ref="insight:session-1",
+        kind=AssertionKind.CORRECTION,
+        key=correction.correction_type,
+        value={"tag": "asserted"},
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_saved_view(saved_view.view_id),
+        target_ref=f"saved_view:{saved_view.view_id}",
+        kind=AssertionKind.SAVED_QUERY,
+        key=saved_view.name,
+        value={"limit": 20},
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_recall_pack(recall_pack.recall_pack_id),
+        target_ref=f"recall_pack:{recall_pack.recall_pack_id}",
+        kind=AssertionKind.RECALL_PACK,
+        key=recall_pack.name,
+        value={"sessions": ["asserted"]},
+        body_text=recall_pack.name,
+        now_ms=1_700_000_035_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_workspace(workspace.workspace_id),
+        target_ref=f"workspace:{workspace.workspace_id}",
+        kind=AssertionKind.WORKSPACE_NOTE,
+        key=workspace.name,
+        value={"repo": "asserted"},
+        body_text=workspace.name,
+        now_ms=1_700_000_035_000,
+    )
+
+    suppression_read = read_archive_suppression_envelope(conn, suppression.session_id)
+    mark_read = read_archive_mark_envelope(conn, mark.mark_id)
+    annotation_read = read_archive_annotation_envelope(conn, annotation.annotation_id)
+    correction_read = read_archive_correction_envelope(conn, correction.correction_id)
+    saved_view_read = read_archive_saved_view_envelope(conn, saved_view.name)
+    recall_pack_read = read_archive_recall_pack_envelope(conn, recall_pack.recall_pack_id)
+    workspace_read = read_archive_workspace_envelope(conn, workspace.name)
+
+    assert suppression_read.reason == "asserted reason"
+    assert suppression_read.mode == "freeze"
+    assert mark_read.mark_id == mark.mark_id
+    assert mark_read.label == "asserted label"
+    assert mark_read.metadata == {"scope": "asserted"}
+    assert annotation_read.body == "asserted annotation"
+    assert correction_read.payload == {"tag": "asserted"}
+    assert saved_view_read.query == {"limit": 20}
+    assert recall_pack_read.payload == {"sessions": ["asserted"]}
+    assert workspace_read.settings == {"repo": "asserted"}
+    assert workspace_read.updated_at_ms == 1_700_000_035_000
+
+
+def test_blackboard_note_read_prefers_assertion_mirror(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    note = upsert_blackboard_note(conn, "legacy body", note_id="note-1", now_ms=1_700_000_034_000)
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_blackboard_note(note.note_id),
+        target_ref=note.note_id,
+        kind=AssertionKind.NOTE,
+        body_text="[decision] asserted title\n\nassertion body",
+        now_ms=1_700_000_035_000,
+    )
+
+    envelope = read_archive_blackboard_note_envelope(conn, note.note_id)
+
+    assert envelope.note_id == note.note_id
+    assert envelope.target_type is None
+    assert envelope.target_id is None
+    assert envelope.body == "[decision] asserted title\n\nassertion body"
+    assert envelope.created_at_ms == 1_700_000_034_000
+    assert envelope.updated_at_ms == 1_700_000_035_000
+
+
+def test_blackboard_note_list_is_assertion_backed_with_legacy_fallback(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    mirrored = upsert_blackboard_note(
+        conn,
+        "legacy mirrored body",
+        note_id="note-mirrored",
+        target_type="session",
+        target_id="session-1",
+        now_ms=1_700_000_036_000,
+    )
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_blackboard_note(mirrored.note_id),
+        target_ref="session:session-1",
+        kind=AssertionKind.NOTE,
+        body_text="[finding] assertion title\n\nassertion body",
+        now_ms=1_700_000_037_000,
+    )
+    conn.execute(
+        """
+        INSERT INTO blackboard_notes (note_id, target_type, target_id, body, created_at_ms, updated_at_ms)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("note-legacy", None, None, "[question] legacy title\n\nlegacy body", 1_700_000_038_000, 1_700_000_038_000),
+    )
+
+    notes = list_archive_blackboard_note_envelopes(conn)
+
+    assert [note.note_id for note in notes] == ["note-legacy", "note-mirrored"]
+    assert notes[0].body == "[question] legacy title\n\nlegacy body"
+    assert notes[1].target_type == "session"
+    assert notes[1].target_id == "session-1"
+    assert notes[1].body == "[finding] assertion title\n\nassertion body"
+    assert notes[1].updated_at_ms == 1_700_000_037_000
 
 
 def test_suppression_write_through_mirrors_assertion(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -339,6 +339,26 @@ def test_user_overlay_reads_prefer_assertion_mirrors(tmp_path: Path) -> None:
     assert workspace_read.updated_at_ms == 1_700_000_035_000
 
 
+def test_suppression_read_preserves_legacy_reason_when_assertion_body_is_absent(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    suppression = upsert_suppression(conn, "session-2", "legacy reason", mode="hide", now_ms=1_700_000_034_000)
+    upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_suppression(suppression.session_id),
+        target_ref=suppression.session_id,
+        kind=AssertionKind.SUPPRESSION,
+        value={"mode": "freeze"},
+        body_text=None,
+        now_ms=1_700_000_035_000,
+    )
+
+    suppression_read = read_archive_suppression_envelope(conn, suppression.session_id)
+
+    assert suppression_read.reason == "legacy reason"
+    assert suppression_read.mode == "freeze"
+
+
 def test_blackboard_note_read_prefers_assertion_mirror(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 

--- a/tests/unit/storage/test_blackboard_facade.py
+++ b/tests/unit/storage/test_blackboard_facade.py
@@ -13,7 +13,12 @@ from pathlib import Path
 import pytest
 
 from polylogue.api import Polylogue
-from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, list_assertions_for_target
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    AssertionKind,
+    assertion_id_for_blackboard_note,
+    list_assertions_for_target,
+    upsert_assertion,
+)
 from tests.infra.storage_records import db_setup
 
 
@@ -67,6 +72,42 @@ async def test_post_mirrors_agent_metadata_into_assertion(workspace_env: dict[st
     assert assertion.evidence_refs == ["message:m1", "block:m1:2"]
     assert assertion.staleness == {"expires_after_days": 7}
     assert assertion.context_policy == {"inject": False}
+
+
+@pytest.mark.asyncio
+async def test_list_decodes_assertion_backed_blackboard_body(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        posted = await poly.post_blackboard_note(
+            kind="finding",
+            title="legacy title",
+            content="legacy body",
+            scope_repo="polylogue",
+        )
+
+    conn = sqlite3.connect(workspace_env["archive_root"] / "user.db")
+    try:
+        conn.row_factory = sqlite3.Row
+        upsert_assertion(
+            conn,
+            assertion_id=assertion_id_for_blackboard_note(posted.note_id),
+            target_ref=posted.note_id,
+            kind=AssertionKind.NOTE,
+            body_text="[decision] asserted title\n\nassertion body\n\nscope_repo: polylogue",
+            now_ms=1_700_000_000_000,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        notes = await poly.list_blackboard_notes()
+
+    assert [note.note_id for note in notes] == [posted.note_id]
+    assert notes[0].kind == "decision"
+    assert notes[0].title == "asserted title"
+    assert notes[0].content == "assertion body"
+    assert notes[0].scope_repo == "polylogue"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Moves user-overlay read parity forward by reading mirrored assertion rows for overlay metadata and routing blackboard list/read behavior through the assertion-backed adapter while preserving the public blackboard output shape.

## Problem

#1883 write-through work made marks, annotations, corrections, saved views, recall/workspace data, and blackboard notes mirror into assertion rows, but read paths could still bypass that substrate. #1839 specifically needed blackboard/sidecar notes to become evidence-bearing without breaking existing note IDs and public list output.

## Solution

Adds assertion-backed user-overlay readers in the user tier, gives mirrored assertion rows stable named IDs, and adapts `ArchiveStore.list_blackboard_notes()` to decode blackboard rows through the assertion-backed envelope. Focused tests cover overlay parity and the blackboard facade path.

The phase intentionally keeps legacy blackboard rows as the source of public `note_id` and target identity. Assertion-only blackboard notes are not exposed yet because the assertion row does not currently carry a first-class public blackboard note identity.

## Verification

- `uv run devtools test tests/unit/storage/test_archive_tiers_assertion_write_through.py tests/unit/storage/test_blackboard_facade.py` → `17 passed`
- `uv run devtools verify --quick` → `exit_code: 0`

Ref #1883
Ref #1839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Blackboard notes now use a more consistent storage mechanism with improved data deduplication and integrity handling.
  * Enhanced note retrieval and listing with better support for legacy data compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->