### PR TITLE
feat(mcp): expose readiness component map (#1832)

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from pydantic import RootModel
 from typing_extensions import TypedDict
@@ -36,6 +36,7 @@ from polylogue.mcp.context_pack import (
 from polylogue.mcp.context_pack import (
     ContextPackUnresolvedWork as MCPContextPackUnresolvedWork,
 )
+from polylogue.readiness import component_from_outcome_check
 from polylogue.surfaces.payloads import (
     MutationResultPayload,
     SearchCursor,
@@ -870,6 +871,7 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
     checks: list[MCPReadinessCheckPayload]
     summary: str | dict[str, int]
     source: str | None = None
+    component_readiness: dict[str, Any] | None = None
 
     @classmethod
     def from_report(
@@ -879,6 +881,7 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
         include_counts: bool,
         include_detail: bool,
         include_cached: bool,
+        include_component_readiness: bool = True,
     ) -> MCPReadinessReportPayload:
         return cls(
             checks=[
@@ -891,6 +894,12 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
             ],
             summary=report.summary,
             source=_extract_readiness_source(report) if include_cached else None,
+            component_readiness={
+                check.name: component_from_outcome_check(check, scope="mcp_readiness").to_dict()
+                for check in report.checks
+            }
+            if include_component_readiness
+            else None,
         )
 
 

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -477,13 +477,20 @@ class TestResourceSurfaces:
         assert parsed == {"feature": 10, "bug": 5}
 
     def test_readiness_resource(self: object, mcp_server: MCPServerUnderTest) -> None:
-        mock_check = MagicMock()
-        mock_check.name = "database"
-        mock_check.status.value = "ok"
+        from polylogue.core.outcomes import OutcomeCheck, OutcomeStatus
 
         mock_report = MagicMock()
-        mock_report.checks = [mock_check]
-        mock_report.summary = "All systems operational"
+        mock_report.checks = [
+            OutcomeCheck("database", OutcomeStatus.OK, summary="DB reachable", count=1),
+            OutcomeCheck(
+                "index",
+                OutcomeStatus.WARNING,
+                summary="messages FTS stale",
+                count=2,
+                details=["messages_fts_row_mismatch"],
+            ),
+        ]
+        mock_report.summary = {"ok": 1, "warning": 1, "error": 0}
 
         with (
             patch("polylogue.mcp.server._get_config") as mock_get_config,
@@ -495,8 +502,16 @@ class TestResourceSurfaces:
             result = invoke_surface(mcp_server._resource_manager._resources["polylogue://readiness"].fn)
 
         parsed = json.loads(result)
-        assert len(parsed["checks"]) == 1
-        assert parsed["summary"] == "All systems operational"
+        assert len(parsed["checks"]) == 2
+        assert parsed["summary"] == {"ok": 1, "warning": 1, "error": 0}
+        assert parsed["checks"][0] == {"name": "database", "status": "ok"}
+        component_readiness = parsed["component_readiness"]
+        assert component_readiness["database"]["component"] == "database"
+        assert component_readiness["database"]["scope"] == "mcp_readiness"
+        assert component_readiness["database"]["state"] == "ready"
+        assert component_readiness["database"]["counts"] == {"count": 1}
+        assert component_readiness["index"]["state"] == "degraded"
+        assert component_readiness["index"]["caveats"] == ["messages_fts_row_mismatch"]
 
 
 class TestArchiveGenericToolSurfaces:


### PR DESCRIPTION
## Summary
Add canonical `component_readiness` output to the MCP `polylogue://readiness` resource while preserving its existing `checks` and `summary` fields.

## Problem
#1832 is converging status/readiness surfaces onto the shared `ComponentReadiness` vocabulary. CLI status, daemon status, archive surface readiness, and MCP embedding readiness already expose canonical component readiness, but the general MCP readiness resource still returned only the legacy readiness report shape.

## Solution
`MCPReadinessReportPayload.from_report(...)` now builds a `component_readiness` map from each `ReadinessReport` check using the shared `component_from_outcome_check(...)` adapter. The map is additive and keyed by check name, so existing MCP clients can keep reading `checks`/`summary` while newer consumers use the canonical readiness DTO.

## Verification
- `uv run devtools test tests/unit/mcp/test_server_surfaces.py -k readiness_resource` -> 1 passed, 58 deselected
- `uv run devtools test tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_embedding_status_tool.py -q` -> 63 passed
- `uv run devtools verify --quick` -> exit_code 0
- pre-push `devtools verify --quick` -> exit_code 0

Ref #1832