### PR TITLE
feat(web): consume component readiness in status strip (#1832)

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1500,6 +1500,7 @@ def _daemon_component_readiness(
     *,
     component_state: ComponentState,
     fts_readiness: FTSReadiness,
+    insight_freshness: InsightFreshness,
     embedding_readiness: EmbeddingReadiness,
     archive_storage: ArchiveStorageStatus,
     live_ingest_attempts: LiveIngestAttemptSummary,
@@ -1517,6 +1518,7 @@ def _daemon_component_readiness(
             scope="daemon",
         ).to_dict(),
         "search": _component_from_fts_readiness(fts_readiness).to_dict(),
+        "session_profiles": _component_from_insight_freshness(insight_freshness).to_dict(),
         "embeddings": _component_from_daemon_embedding_readiness(embedding_readiness).to_dict(),
         "archive_storage": _component_from_archive_storage(archive_storage).to_dict(),
         "daemon_ingest": _component_from_live_ingest(live_ingest_attempts).to_dict(),
@@ -1557,6 +1559,37 @@ def _component_from_fts_readiness(readiness: FTSReadiness) -> ComponentReadiness
             "coverage_pct": readiness.coverage_pct,
         },
         repair_hint=None if readiness.messages_ready else "polylogue maintenance run --target dangling_fts",
+    )
+
+
+def _component_from_insight_freshness(freshness: InsightFreshness) -> ComponentReadiness:
+    total = freshness.total_sessions
+    with_profiles = freshness.sessions_with_profiles
+    if total <= 0:
+        state = CapabilityReadinessState.MISSING
+        summary = "no sessions"
+    elif with_profiles >= total:
+        state = CapabilityReadinessState.READY
+        summary = "ready"
+    elif with_profiles > 0:
+        state = CapabilityReadinessState.DEGRADED
+        summary = "partial"
+    else:
+        state = CapabilityReadinessState.STALE
+        summary = "profiles missing"
+    return ComponentReadiness(
+        component="session_profiles",
+        scope="insights",
+        state=state,
+        summary=summary,
+        counts={
+            "sessions_with_profiles": with_profiles,
+            "total_sessions": total,
+            "missing_profiles": max(0, total - with_profiles),
+        },
+        repair_hint=None
+        if state is CapabilityReadinessState.READY
+        else "polylogue maintenance preview --scope derived",
     )
 
 
@@ -1752,6 +1785,11 @@ def build_daemon_status(
         ),
     )
 
+    insight_freshness = InsightFreshness(
+        sessions_with_profiles=_safe_int(freshness.get("sessions_with_profiles", 0)),
+        total_sessions=_safe_int(freshness.get("total_sessions", 0)),
+    )
+
     return DaemonStatus(
         raw_parse_failures=_safe_int(raw_failures.get("parse_failures", 0)),
         raw_validation_failures=_safe_int(raw_failures.get("validation_failures", 0)),
@@ -1773,15 +1811,13 @@ def build_daemon_status(
         blob_dir_size_bytes=_blob_size_info(),
         disk_free_bytes=_safe_int(db_info.get("disk_free_bytes", 0)),
         fts_readiness=fts_readiness,
-        insight_freshness=InsightFreshness(
-            sessions_with_profiles=_safe_int(freshness.get("sessions_with_profiles", 0)),
-            total_sessions=_safe_int(freshness.get("total_sessions", 0)),
-        ),
+        insight_freshness=insight_freshness,
         embedding_readiness=embedding_readiness,
         archive_storage=storage_info,
         component_readiness=_daemon_component_readiness(
             component_state=component_state,
             fts_readiness=fts_readiness,
+            insight_freshness=insight_freshness,
             embedding_readiness=embedding_readiness,
             archive_storage=storage_info,
             live_ingest_attempts=live_ingest_attempts,

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -551,7 +551,10 @@ function renderComponentReadinessChip(el, label, component) {
 
 function renderFtsChip(component, fts) {
   var el = document.getElementById('status-fts');
-  if (renderComponentReadinessChip(el, 'FTS', component)) return;
+  if (component && component.state !== 'unknown') {
+    renderComponentReadinessChip(el, 'FTS', component);
+    return;
+  }
   var msgReady = !!fts.messages_ready;
   var indexed = Number(fts.message_indexed_count || 0);
   var indexable = Number(fts.message_indexable_count || 0);

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -246,6 +246,7 @@ __ATTACHMENT_CSS__
     <span class="chip" id="status-db">--</span>
     <span class="spacer"></span>
     <span class="chip" id="status-fts" title="FTS readiness">FTS: --</span>
+    <span class="chip" id="status-semantic" title="Semantic readiness">semantic: --</span>
     <span class="chip" id="status-insights" title="Session insight freshness" style="display:none">insights: --</span>
     <span class="chip" id="status-ingest" style="display:none">live</span>
     <span class="chip" id="status-live" title="Realtime channel">live: --</span>
@@ -499,16 +500,13 @@ async function loadStatus() {
   }
   try {
     var s = await fetchJSON('/api/status');
+    var readiness = s.component_readiness || {};
     document.getElementById('status-convs').textContent = (s.total_sessions || 0).toLocaleString() + ' convs';
     document.getElementById('status-msgs').textContent = (s.total_messages || 0).toLocaleString() + ' msgs';
-    renderFtsChip(s.fts_readiness || {});
+    renderFtsChip(readiness.search || null, s.fts_readiness || {});
+    renderSemanticChip(readiness.embeddings || null);
     renderInsightChip(s.insight_freshness || {});
-    var ingestEl = document.getElementById('status-ingest');
-    if (s.live && s.live.existing_source_count > 0) {
-      ingestEl.style.display = '';
-      ingestEl.textContent = 'live: ' + s.live.existing_source_count + ' srcs';
-      setChipQuality(ingestEl, 'canonical');
-    } else { ingestEl.style.display = 'none'; }
+    renderIngestChip(readiness.daemon_ingest || null, s.live || {});
   } catch(e) {}
 }
 
@@ -520,8 +518,40 @@ function setChipQuality(el, quality) {
   if (quality) el.classList.add('q-' + quality);
 }
 
-function renderFtsChip(fts) {
+function readinessQuality(state) {
+  if (state === 'ready') return 'canonical';
+  if (state === 'stale') return 'stale';
+  if (state === 'rebuilding' || state === 'degraded') return 'partial';
+  if (state === 'poisoned') return 'redacted';
+  if (state === 'missing' || state === 'blocked') return 'unavailable';
+  return 'unavailable';
+}
+
+function readinessLabel(state) {
+  if (state === 'ready') return 'ok';
+  if (state === 'rebuilding') return 'rebuilding';
+  if (state === 'stale') return 'stale';
+  if (state === 'degraded') return 'degraded';
+  if (state === 'missing') return 'missing';
+  if (state === 'blocked') return 'blocked';
+  if (state === 'poisoned') return 'poisoned';
+  return 'unknown';
+}
+
+function renderComponentReadinessChip(el, label, component) {
+  if (!el || !component) return false;
+  var state = component.state || 'unknown';
+  el.textContent = label + ': ' + readinessLabel(state);
+  setChipQuality(el, readinessQuality(state));
+  var caveats = component.caveats || [];
+  var summary = component.summary || state;
+  el.title = label + ' readiness: ' + summary + (caveats.length ? ' (' + caveats.join(', ') + ')' : '');
+  return true;
+}
+
+function renderFtsChip(component, fts) {
   var el = document.getElementById('status-fts');
+  if (renderComponentReadinessChip(el, 'FTS', component)) return;
   var msgReady = !!fts.messages_ready;
   var indexed = Number(fts.message_indexed_count || 0);
   var indexable = Number(fts.message_indexable_count || 0);
@@ -535,6 +565,11 @@ function renderFtsChip(fts) {
   setChipQuality(el, quality);
 }
 
+function renderSemanticChip(component) {
+  var el = document.getElementById('status-semantic');
+  renderComponentReadinessChip(el, 'semantic', component);
+}
+
 function renderInsightChip(freshness) {
   var el = document.getElementById('status-insights');
   var total = freshness.total_sessions || 0;
@@ -544,6 +579,20 @@ function renderInsightChip(freshness) {
   if (withProfiles >= total) { el.textContent = 'insights: ok'; setChipQuality(el, 'canonical'); }
   else if (withProfiles > 0) { el.textContent = 'insights: ' + withProfiles + '/' + total; setChipQuality(el, 'partial'); }
   else { el.textContent = 'insights: stale'; setChipQuality(el, 'stale'); }
+}
+
+function renderIngestChip(component, live) {
+  var el = document.getElementById('status-ingest');
+  if (component) {
+    el.style.display = '';
+    renderComponentReadinessChip(el, 'ingest', component);
+    return;
+  }
+  if (live && live.existing_source_count > 0) {
+    el.style.display = '';
+    el.textContent = 'live: ' + live.existing_source_count + ' srcs';
+    setChipQuality(el, 'canonical');
+  } else { el.style.display = 'none'; }
 }
 
 function renderSidebarState(kind, msg) {

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -505,7 +505,7 @@ async function loadStatus() {
     document.getElementById('status-msgs').textContent = (s.total_messages || 0).toLocaleString() + ' msgs';
     renderFtsChip(readiness.search || null, s.fts_readiness || {});
     renderSemanticChip(readiness.embeddings || null);
-    renderInsightChip(s.insight_freshness || {});
+    renderInsightChip(readiness.session_profiles || null, s.insight_freshness || {});
     renderIngestChip(readiness.daemon_ingest || null, s.live || {});
   } catch(e) {}
 }
@@ -570,8 +570,13 @@ function renderSemanticChip(component) {
   renderComponentReadinessChip(el, 'semantic', component);
 }
 
-function renderInsightChip(freshness) {
+function renderInsightChip(component, freshness) {
   var el = document.getElementById('status-insights');
+  if (component) {
+    el.style.display = '';
+    renderComponentReadinessChip(el, 'insights', component);
+    return;
+  }
   var total = freshness.total_sessions || 0;
   var withProfiles = freshness.sessions_with_profiles || 0;
   if (total <= 0) { el.style.display = 'none'; return; }

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -165,7 +165,10 @@ def test_daemon_status_payload_maps_component_readiness(tmp_path: Path) -> None:
                 "coverage_pct": 40.0,
             },
         ),
-        patch("polylogue.daemon.status._insight_freshness_info", return_value={}),
+        patch(
+            "polylogue.daemon.status._insight_freshness_info",
+            return_value={"sessions_with_profiles": 7, "total_sessions": 10},
+        ),
         patch(
             "polylogue.daemon.status.embedding_readiness_info",
             return_value={
@@ -187,10 +190,12 @@ def test_daemon_status_payload_maps_component_readiness(tmp_path: Path) -> None:
     readiness = payload["component_readiness"]
     assert isinstance(readiness, dict)
     search = readiness["search"]
+    session_profiles = readiness["session_profiles"]
     embeddings = readiness["embeddings"]
     api = readiness["daemon_api"]
     ingest = readiness["daemon_ingest"]
     assert isinstance(search, dict)
+    assert isinstance(session_profiles, dict)
     assert isinstance(embeddings, dict)
     assert isinstance(api, dict)
     assert isinstance(ingest, dict)
@@ -198,6 +203,12 @@ def test_daemon_status_payload_maps_component_readiness(tmp_path: Path) -> None:
     assert search["state"] == "stale"
     assert search_counts["message_indexed_count"] == 4
     assert search["repair_hint"] == "polylogue maintenance run --target dangling_fts"
+    profile_counts = cast(dict[str, object], session_profiles["counts"])
+    assert session_profiles["state"] == "degraded"
+    assert session_profiles["scope"] == "insights"
+    assert profile_counts["sessions_with_profiles"] == 7
+    assert profile_counts["missing_profiles"] == 3
+    assert session_profiles["repair_hint"] == "polylogue maintenance preview --scope derived"
     assert embeddings["state"] == "stale"
     assert embeddings["scope"] == "semantic"
     assert embeddings["repair_hint"] == "polylogue embed backfill"

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1272,11 +1272,24 @@ class TestReaderInformability:
         ):
             assert f".chip.{quality}" in body, f"web shell missing MK3 chip-quality class {quality!r}"
 
-    def test_fts_chip_renders_tri_state_not_binary(self, workspace_env: dict[str, Path]) -> None:
-        """``renderFtsChip`` must distinguish ok / partial / unavailable
-        rather than collapsing partial readiness into the ok bucket. The
-        prior code rendered ``messages_ready ? 'ok' : '--'`` which hides
-        partial message FTS readiness entirely.
+    def test_status_strip_consumes_component_readiness(self, workspace_env: dict[str, Path]) -> None:
+        """The web shell status strip should consume the canonical #1832
+        component readiness map instead of recomputing product state from
+        legacy daemon fields. Legacy FTS rendering remains as fallback for
+        old/status-snapshot payloads.
+        """
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        assert "var readiness = s.component_readiness || {};" in body
+        assert "renderFtsChip(readiness.search || null, s.fts_readiness || {})" in body
+        assert "renderSemanticChip(readiness.embeddings || null)" in body
+        assert "renderIngestChip(readiness.daemon_ingest || null, s.live || {})" in body
+        assert "function renderComponentReadinessChip(" in body
+        assert "function readinessQuality(" in body
+
+    def test_fts_chip_keeps_legacy_tri_state_fallback(self, workspace_env: dict[str, Path]) -> None:
+        """``renderFtsChip`` must still distinguish ok / partial /
+        unavailable when an older payload lacks ``component_readiness``.
         """
         with _running_server(workspace_env) as (_, base_url):
             _, _, body = _get_text(base_url, "/")
@@ -1284,6 +1297,20 @@ class TestReaderInformability:
         assert "'FTS: ok'" in body
         assert "'FTS: partial'" in body
         assert "'FTS: unavailable'" in body
+
+    def test_semantic_and_ingest_readiness_chips_render_present(self, workspace_env: dict[str, Path]) -> None:
+        """Semantic and ingest state have first-class status-strip chips fed
+        by ``component_readiness.embeddings`` and
+        ``component_readiness.daemon_ingest``.
+        """
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        assert 'id="status-semantic"' in body
+        assert 'id="status-ingest"' in body
+        assert "function renderSemanticChip(" in body
+        assert "function renderIngestChip(" in body
+        assert "'semantic'" in body
+        assert "'ingest'" in body
 
     def test_insight_freshness_chip_render_present(self, workspace_env: dict[str, Path]) -> None:
         """Session insight freshness gets its own status-strip chip so

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1295,6 +1295,7 @@ class TestReaderInformability:
         with _running_server(workspace_env) as (_, base_url):
             _, _, body = _get_text(base_url, "/")
         assert "function renderFtsChip(" in body
+        assert "component && component.state !== 'unknown'" in body
         assert "'FTS: ok'" in body
         assert "'FTS: partial'" in body
         assert "'FTS: unavailable'" in body

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1283,6 +1283,7 @@ class TestReaderInformability:
         assert "var readiness = s.component_readiness || {};" in body
         assert "renderFtsChip(readiness.search || null, s.fts_readiness || {})" in body
         assert "renderSemanticChip(readiness.embeddings || null)" in body
+        assert "renderInsightChip(readiness.session_profiles || null, s.insight_freshness || {})" in body
         assert "renderIngestChip(readiness.daemon_ingest || null, s.live || {})" in body
         assert "function renderComponentReadinessChip(" in body
         assert "function readinessQuality(" in body
@@ -1312,14 +1313,15 @@ class TestReaderInformability:
         assert "'semantic'" in body
         assert "'ingest'" in body
 
-    def test_insight_freshness_chip_render_present(self, workspace_env: dict[str, Path]) -> None:
-        """Session insight freshness gets its own status-strip chip so
-        operators can tell whether session profiles are computed, partial,
-        or stale without opening the inspector."""
+    def test_insight_freshness_chip_keeps_legacy_fallback(self, workspace_env: dict[str, Path]) -> None:
+        """Session insight freshness gets its own status-strip chip. It now
+        prefers ``component_readiness.session_profiles`` and keeps the
+        previous freshness-payload fallback for old status snapshots."""
         with _running_server(workspace_env) as (_, base_url):
             _, _, body = _get_text(base_url, "/")
         assert "function renderInsightChip(" in body
         assert 'id="status-insights"' in body
+        assert "renderComponentReadinessChip(el, 'insights', component)" in body
         assert "'insights: ok'" in body
         assert "'insights: stale'" in body
 


### PR DESCRIPTION
## Summary

Route the daemon web shell status strip through the shared `ComponentReadiness` vocabulary added for #1832. The reader now consumes `/api/status.component_readiness.search`, `.session_profiles`, `.embeddings`, and `.daemon_ingest` for the FTS, insights, semantic, and ingest chips while retaining legacy fallbacks for older cached or minimal status payloads.

## Problem

The daemon/API status payload already exposes canonical component readiness, and MCP readiness now does the same. The browser shell still recomputed product readiness directly from legacy `fts_readiness`, `insight_freshness`, `embedding_readiness`, and `live` fragments, leaving the web UI as a parallel interpretation of status state.

## Solution

`polylogue/daemon/status.py` now maps bounded session-profile freshness into `component_readiness.session_profiles`. `polylogue/daemon/web_shell.py` reads `component_readiness` once in `loadStatus`, maps canonical readiness states to the existing MK3 chip-quality classes, and renders search, insights, semantic, and ingest chips from the shared DTO. The old FTS/insight/live render paths stay as fallback behavior instead of being removed from request-safe snapshots.

## Verification

- `uv run devtools test tests/unit/daemon/test_daemon_status.py::test_daemon_status_payload_maps_component_readiness` -> 1 passed.
- `uv run devtools test tests/unit/daemon/test_web_reader.py -k 'status_strip_consumes_component_readiness or fts_chip_keeps_legacy_tri_state_fallback or semantic_and_ingest_readiness_chips_render_present or insight_freshness_chip_keeps_legacy_fallback'` -> 4 passed, 73 deselected.
- `uv run devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.

## #1832 PR handoff checklist

Issue slice: web status-strip consumption of canonical component readiness plus session-profile freshness projection.
Files inspected: `polylogue/daemon/status.py`, `polylogue/daemon/status_snapshot.py`, `polylogue/daemon/web_shell.py`, `tests/unit/daemon/test_daemon_status.py`, `tests/unit/daemon/test_daemon_http_contracts.py`, `tests/unit/daemon/test_web_reader.py`.
Files changed: `polylogue/daemon/status.py`, `polylogue/daemon/web_shell.py`, `tests/unit/daemon/test_daemon_status.py`, `tests/unit/daemon/test_web_reader.py`.
Old surface removed or retained: retained legacy `fts_readiness`, `insight_freshness`, and `live` fallbacks for older/minimal status payloads; the primary route now uses `component_readiness`.
Contracts/tests added: daemon status contract for `component_readiness.session_profiles`; source-level web-reader contract asserting `component_readiness` drives search, insights, semantic, and ingest chips while legacy FTS/insight fallbacks remain.
Generated artifacts updated: none; `render-all --check` was clean.
Verification commands and results: see Verification above.
Known caveats / SPEC_MISMATCH: none for this phase.
Follow-up intentionally not included: fixture archive readiness-state matrix and transform/assertion readiness entries remain separate #1832/#1880/#1883 work.

Closes no issue; progresses #1832.
