### PR TITLE
feat(transforms): expose subagent spawn refs (#1880)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -162,6 +162,9 @@ class ToolSummary(ArchiveInsightModel):
 
 class SubagentReport(ArchiveInsightModel):
     subagent_type: str = "unknown"
+    tool_id: str | None = None
+    task_id: str | None = None
+    child_session_id: str | None = None
     prompt: str = ""
     final_report_preview: str = ""
     pr_refs: tuple[str, ...] = ()
@@ -449,6 +452,9 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
     for entry in subagent_entries[:8]:
         prompt = f" — {entry.text}" if entry.text else ""
         lines.append(f"- {entry.label}{prompt}")
+        refs = _subagent_metadata_line(entry.metadata)
+        if refs:
+            lines.append(f"  - refs: {refs}")
         report = entry.metadata.get("report", "")
         if report:
             lines.append(f"  - report: {report}")
@@ -520,11 +526,14 @@ def _work_packet_entries(
             evidence_refs=_to_evidence_refs(event.raw_refs),
         )
     for report in subagent_reports:
+        metadata = _subagent_report_metadata(report)
+        if report.final_report_preview:
+            metadata["report"] = report.final_report_preview
         yield RecoveryWorkPacketEntry(
             section="subagents",
             label=report.subagent_type,
             text=report.prompt,
-            metadata={"report": report.final_report_preview},
+            metadata=metadata,
             evidence_refs=_to_evidence_refs(report.raw_refs),
         )
     if run_state is not None:
@@ -621,7 +630,10 @@ def _render_continue_report(digest: RecoveryDigest) -> str:
     if digest.subagent_reports:
         for report in digest.subagent_reports[:8]:
             prompt = f" — {report.prompt}" if report.prompt else ""
-            lines.append(f"- {report.subagent_type}{prompt}{_evidence_suffix(digest, report.raw_refs)}")
+            lines.append(
+                f"- {report.subagent_type}{_subagent_link_suffix(report)}{prompt}"
+                f"{_evidence_suffix(digest, report.raw_refs)}"
+            )
             if report.final_report_preview:
                 lines.append(f"  report: {report.final_report_preview}{_evidence_suffix(digest, report.raw_refs)}")
             for caveat in report.caveats[:4]:
@@ -698,7 +710,8 @@ def _render_blame_report(digest: RecoveryDigest) -> str:
     if digest.subagent_reports:
         for report in digest.subagent_reports:
             lines.append(
-                f"- {report.subagent_type}: {report.final_report_preview or report.prompt}"
+                f"- {report.subagent_type}{_subagent_link_suffix(report)}: "
+                f"{report.final_report_preview or report.prompt}"
                 f"{_evidence_suffix(digest, report.raw_refs)}"
             )
             for caveat in report.caveats:
@@ -901,6 +914,9 @@ def _extract_subagent_reports(session: Session, messages: Sequence[Message]) -> 
             result_text = _block_text(result_block or {})
             yield SubagentReport(
                 subagent_type=_subagent_type(block),
+                tool_id=tool_id,
+                task_id=_subagent_task_id(block),
+                child_session_id=_subagent_child_session_id(block, result_text),
                 prompt=_subagent_prompt(block),
                 final_report_preview=_preview(result_text, limit=320),
                 pr_refs=tuple(_number_refs(_PR_RE, result_text)),
@@ -1225,6 +1241,55 @@ def _subagent_prompt(block: Mapping[str, object]) -> str:
         if value:
             return _preview(value, limit=240)
     return ""
+
+
+def _subagent_task_id(block: Mapping[str, object]) -> str | None:
+    tool_input = block.get("tool_input") or block.get("input")
+    if isinstance(tool_input, Mapping):
+        return _optional_text(tool_input.get("taskId") or tool_input.get("task_id"))
+    return None
+
+
+def _subagent_child_session_id(block: Mapping[str, object], result_text: str) -> str | None:
+    tool_input = block.get("tool_input") or block.get("input")
+    if isinstance(tool_input, Mapping):
+        for key in ("child_session_id", "subagent_session_id", "agent_session_id", "sessionId", "session_id"):
+            value = _optional_text(tool_input.get(key))
+            if value:
+                return value
+    return _subagent_child_session_id_from_text(result_text)
+
+
+def _subagent_child_session_id_from_text(text: str) -> str | None:
+    for line in text.splitlines():
+        if "session" not in line.lower():
+            continue
+        for token in line.replace("=", " ").split():
+            cleaned = token.strip("`'\"(),")
+            if cleaned.startswith(("claude-code-session:", "codex-session:", "gemini-cli-session:")):
+                return cleaned
+    return None
+
+
+def _subagent_report_metadata(report: SubagentReport) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    if report.tool_id:
+        metadata["tool_id"] = report.tool_id
+    if report.task_id:
+        metadata["task_id"] = report.task_id
+    if report.child_session_id:
+        metadata["child_session_id"] = report.child_session_id
+    return metadata
+
+
+def _subagent_metadata_line(metadata: Mapping[str, str]) -> str:
+    parts = [f"{key}={metadata[key]}" for key in ("tool_id", "task_id", "child_session_id") if metadata.get(key)]
+    return ", ".join(parts)
+
+
+def _subagent_link_suffix(report: SubagentReport) -> str:
+    refs = _subagent_metadata_line(_subagent_report_metadata(report))
+    return f" [{refs}]" if refs else ""
 
 
 def _number_refs(pattern: re.Pattern[str], text: str) -> Iterable[str]:

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -88,6 +88,8 @@ def _session() -> Session:
                             "name": "Task",
                             "tool_input": {
                                 "subagent_type": "Explore",
+                                "taskId": "task-42",
+                                "child_session_id": "codex-session:child-42",
                                 "prompt": "Map the transform surface and report caveats.",
                             },
                         },
@@ -146,6 +148,9 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert len(digest.subagent_reports) == 1
     subagent = digest.subagent_reports[0]
     assert subagent.subagent_type == "Explore"
+    assert subagent.tool_id == "tool-2"
+    assert subagent.task_id == "task-42"
+    assert subagent.child_session_id == "codex-session:child-42"
     assert subagent.prompt == "Map the transform surface and report caveats."
     assert "Subagent done" in subagent.final_report_preview
     assert subagent.pr_refs == ("#1912",)
@@ -177,6 +182,7 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert "feature/demo" in digest.resume_markdown
     assert "## Subagents" in digest.resume_markdown
     assert "Explore — Map the transform surface and report caveats." in digest.resume_markdown
+    assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in digest.resume_markdown
     assert "## Run State" in digest.resume_markdown
     assert "- done: #1910 merged" in digest.resume_markdown
     assert "- next: merge PR #1911" in digest.resume_markdown
@@ -269,6 +275,7 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
     assert any(ref.format() == "codex-session:demo::m2::0" for entry in packet.entries for ref in entry.evidence_refs)
     assert "# Resume: Ship the backlog" in rendered
     assert "- pr_opened: PR #1911 opened" in rendered
+    assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in rendered
     assert "- Bash [test] (ok) — devtools verify --quick" in rendered
 
 
@@ -282,7 +289,10 @@ def test_continue_report_renders_successor_boot_packet_with_evidence_refs() -> N
     assert "- goal: burn down the backlog [evidence: codex-session:demo::m1]" in report
     assert "- next: merge PR #1911 [evidence: codex-session:demo::m1]" in report
     assert "- pr_opened: PR #1911 opened [evidence: codex-session:demo::m2]" in report
-    assert "Explore — Map the transform surface and report caveats. [evidence: codex-session:demo::m3::0" in report
+    assert (
+        "Explore [tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42] "
+        "— Map the transform surface and report caveats. [evidence: codex-session:demo::m3::0"
+    ) in report
     assert "Bash [test] (ok) — devtools verify --quick [evidence: codex-session:demo::m2::0" in report
     assert "## Evidence Index" in report
     assert "evidence_id: codex-session:demo::m2::0; raw: block message=m2 block=0" in report
@@ -302,6 +312,7 @@ def test_blame_report_renders_forensic_evidence_report_with_raw_refs() -> None:
     assert "- issue_closed: Issue #1818 closed [evidence: codex-session:demo::m3]" in report
     assert "- Bash [test] status=ok lines=3 — devtools verify --quick [evidence: codex-session:demo::m2::0" in report
     assert "output: ruff check ... ok 20 passed in 50.28s" in report
+    assert "Explore [tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42]:" in report
     assert "## Evidence Timeline" in report
     assert "raw: message message=m1" in report
     assert "claims: run_state, event:pr_merged:0, decision:run_state:0, decision:run_state:1" in report


### PR DESCRIPTION
## Summary

Adds durable subagent spawn/link refs to recovery digest reports. `SubagentReport` now carries the Task `tool_id`, optional `task_id`, and optional child/subagent session id when the raw Task block or result text exposes one, and the resume/work-packet/continue/blame renderers show those refs.

## Problem

#1880 recovery reports extracted subagent prompts and final reports, but successor agents still had to infer which Task invocation or child session a report belonged to. That weakens the recovery view precisely where subagents are most likely to contain important delegated work.

## Solution

The transform layer stays storage-free: it does not query archive topology or claim resolved lineage. Instead it preserves the durable identifiers already present in raw Task evidence:

- `tool_id` from the Task tool call/result pair;
- `task_id` from `taskId` / `task_id` Task input fields;
- `child_session_id` from explicit Task input session fields or provider-prefixed session ids in result text.

Those refs are carried in `SubagentReport`, work-packet metadata, and the rendered recovery reports so later topology/API layers can resolve them when archive data is available.

## Verification

- `uv run devtools test tests/unit/insights/test_transforms.py` -> `12 passed`
- `uv run devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

## #1880 PR handoff checklist

Issue slice: topology-aware subagent refs, storage-free v0. This records spawn/link identifiers from Task evidence; it does not perform archive topology resolution.

Files inspected: `polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`, `polylogue/archive/session/domain_models.py`, `polylogue/insights/topology.py`, `polylogue/pipeline/semantic_metadata.py`, issue #1880.

Files changed: `polylogue/insights/transforms.py`, `tests/unit/insights/test_transforms.py`.

Old surface removed or retained: retained. Existing subagent report fields and recovery report shapes continue to render; refs are additive.

Contracts/tests added: subagent reports extract `tool_id`, `task_id`, and `child_session_id`; resume/work-packet/continue/blame reports render these refs while every claim remains evidence-linked.

Generated artifacts updated: none; quick gate reports no generated drift.

Verification commands and results: see Verification section above.

Known caveats / SPEC_MISMATCH: no resolved topology lookup happens here because the transform input is only a hydrated `Session`. This PR records link refs for later API/storage resolution.

Follow-up intentionally not included: persisted recovery outputs and archive-level topology resolution from child session rows.

Refs #1880
