### PR TITLE
feat(demo): seed deterministic user overlays (#1843)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ the running daemon to ingest them. The command is asynchronous: `status` shows
 daemon/archive health, while `stats` and search/read commands are meaningful
 after daemon convergence. The current deterministic archive evidence is the
 in-process fixture evidence in [docs/generate.md](docs/generate.md), including
-the expected `pytest` search hit.
+the expected `pytest` search hit and user-tier overlay evidence for the
+`pytest-triage` tag, mark, note, saved query, and typed assertions.
 
 ## Developer tools
 

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -64,6 +64,11 @@ The test suite uses the same `SyntheticCorpus` infrastructure through shared fix
 
 `polylogue import --demo` uses the named `build_demo_corpus_specs()` fixture
 world so README examples and release checks can run without private exports.
+After that archive has converged, the repository-level
+`seed_demo_user_overlays()` fixture attaches deterministic user-tier overlays
+to the same sessions for release evidence: a `pytest-triage` tag, a starred
+README example mark, a session-scoped blackboard note, a saved query, and
+typed assertions in `user.db`.
 
 ## README Demo Evidence
 
@@ -79,8 +84,11 @@ same `build_demo_corpus_specs()` artifacts, converges them in process with
   `claude-code/demo-00.jsonl`, `codex/demo-00.jsonl`);
 - `polylogue` full-text search for `pytest` is backed by the Claude Code demo
   session;
+- deterministic user overlays are stored in `user.db`: the `pytest-triage`
+  tag, session mark, blackboard note, saved query, and typed tag/decision
+  assertions all target the Claude Code demo session;
 - repeating convergence is idempotent for raw sessions, sessions, messages,
-  and blocks.
+  blocks, and user overlay assertions.
 
 SPEC_MISMATCH: the README command transcript exercises the shipped
 daemon-backed scheduling surface, while the convergence evidence above uses

--- a/polylogue/scenarios/__init__.py
+++ b/polylogue/scenarios/__init__.py
@@ -10,11 +10,16 @@ from .cli_surfaces import (
     build_cli_surface_memory_budget_variants,
 )
 from .corpus import (
+    DEMO_CHATGPT_SESSION_ID,
+    DEMO_CLAUDE_CODE_SESSION_ID,
+    DEMO_CODEX_SESSION_ID,
+    DEMO_SESSION_IDS,
     CorpusProfile,
     CorpusRequest,
     CorpusScenario,
     CorpusSourceKind,
     CorpusSpec,
+    DemoUserOverlayResult,
     build_corpus_scenarios,
     build_default_corpus_specs,
     build_demo_corpus_specs,
@@ -22,6 +27,7 @@ from .corpus import (
     flatten_corpus_specs,
     resolve_corpus_scenarios,
     resolve_corpus_specs,
+    seed_demo_user_overlays,
 )
 from .executable import ExecutableScenario
 from .execution import (
@@ -81,6 +87,7 @@ __all__ = [
     "classification_label",
     "build_default_corpus_specs",
     "build_demo_corpus_specs",
+    "seed_demo_user_overlays",
     "build_corpus_scenarios",
     "build_inferred_corpus_specs",
     "build_cli_surface_exercises",
@@ -101,6 +108,11 @@ __all__ = [
     "CorpusSourceKind",
     "CorpusScenario",
     "CorpusSpec",
+    "DEMO_CLAUDE_CODE_SESSION_ID",
+    "DEMO_CODEX_SESSION_ID",
+    "DEMO_CHATGPT_SESSION_ID",
+    "DEMO_SESSION_IDS",
+    "DemoUserOverlayResult",
     "compile_projection_entries",
     "dispatch_execution",
     "dispatch_runner_execution",

--- a/polylogue/scenarios/corpus.py
+++ b/polylogue/scenarios/corpus.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.insights.authored_payloads import (
@@ -46,6 +48,26 @@ class CorpusSourceKind(str, Enum):
 
 
 DEMO_CORPUS_SEED = 1843
+DEMO_CHATGPT_SESSION_ID = "chatgpt-export:dc13ca54-0bba-4298-a38f-09068c2ef2c5"
+DEMO_CLAUDE_CODE_SESSION_ID = "claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6"
+DEMO_CODEX_SESSION_ID = "codex-session:demo-00"
+DEMO_SESSION_IDS = (
+    DEMO_CHATGPT_SESSION_ID,
+    DEMO_CLAUDE_CODE_SESSION_ID,
+    DEMO_CODEX_SESSION_ID,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DemoUserOverlayResult:
+    """Deterministic user-tier overlay rows seeded for the approved demo world."""
+
+    session_ids: tuple[str, ...]
+    tag: str
+    mark_id: str
+    note_id: str
+    saved_view_id: str
+    assertion_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -558,6 +580,116 @@ def build_demo_corpus_specs(
             origin=origin,
             tags=tags,
         ),
+    )
+
+
+def seed_demo_user_overlays(
+    archive_root: Path,
+    *,
+    now_ms: int = 1_700_000_200_000,
+) -> DemoUserOverlayResult:
+    """Seed deterministic user-tier overlays for the approved demo archive.
+
+    ``polylogue import --demo`` is an asynchronous daemon scheduling command,
+    so it cannot synchronously attach overlays to sessions it has not converged
+    yet. This helper is the executable fixture contract for README/release
+    evidence after the demo archive has converged.
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import (
+        AssertionKind,
+        list_assertions_for_target,
+        upsert_assertion,
+        upsert_blackboard_note,
+        upsert_mark,
+        upsert_saved_view,
+    )
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        resolved_session_ids = tuple(archive.resolve_session_id(session_id) for session_id in DEMO_SESSION_IDS)
+        archive.add_user_tags((DEMO_CLAUDE_CODE_SESSION_ID,), ("pytest-triage",))
+
+    user_db_path = archive_root / "user.db"
+    initialize_archive_database(user_db_path, ArchiveTier.USER)
+    conn = sqlite3.connect(user_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        mark = upsert_mark(
+            conn,
+            "session",
+            DEMO_CLAUDE_CODE_SESSION_ID,
+            "star",
+            label="README search example",
+            metadata={"demo": True, "query": "pytest"},
+            now_ms=now_ms,
+        )
+        note = upsert_blackboard_note(
+            conn,
+            "The demo pytest session is the approved fixture for search, read, and assertion overlays.",
+            target_type="session",
+            target_id=DEMO_CLAUDE_CODE_SESSION_ID,
+            note_id="demo-note:pytest-triage",
+            author_ref="demo-fixture-world",
+            author_kind="fixture",
+            evidence_refs=(f"session:{DEMO_CLAUDE_CODE_SESSION_ID}",),
+            context_policy={"inject": False, "demo": True},
+            now_ms=now_ms + 1_000,
+        )
+        saved_view = upsert_saved_view(
+            conn,
+            "demo-pytest-triage",
+            {"query": "pytest", "origin": "claude-code-session", "limit": 5},
+            view_id="demo-view:pytest-triage",
+            now_ms=now_ms + 2_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="demo-assertion:tag:pytest-triage",
+            target_ref=f"session:{DEMO_CLAUDE_CODE_SESSION_ID}",
+            key="pytest-triage",
+            kind=AssertionKind.TAG,
+            value={"tag": "pytest-triage", "source": "demo-fixture-world"},
+            body_text="Demo session tag used by README search examples.",
+            author_ref="demo-fixture-world",
+            author_kind="fixture",
+            evidence_refs=(f"session:{DEMO_CLAUDE_CODE_SESSION_ID}",),
+            status="active",
+            visibility="public",
+            context_policy={"inject": False, "demo": True},
+            now_ms=now_ms + 3_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="demo-assertion:decision:pytest-triage",
+            target_ref=f"session:{DEMO_CLAUDE_CODE_SESSION_ID}",
+            key="pytest-triage",
+            kind=AssertionKind.DECISION,
+            value={"decision": "use-demo-fixture", "query": "pytest"},
+            body_text="Use the Claude Code demo session as the stable pytest triage example.",
+            author_ref="demo-fixture-world",
+            author_kind="fixture",
+            evidence_refs=(f"session:{DEMO_CLAUDE_CODE_SESSION_ID}",),
+            status="active",
+            visibility="public",
+            confidence=1.0,
+            context_policy={"inject": False, "demo": True},
+            now_ms=now_ms + 4_000,
+        )
+        assertions = list_assertions_for_target(conn, f"session:{DEMO_CLAUDE_CODE_SESSION_ID}")
+        conn.commit()
+    finally:
+        conn.close()
+
+    return DemoUserOverlayResult(
+        session_ids=resolved_session_ids,
+        tag="pytest-triage",
+        mark_id=mark.mark_id,
+        note_id=note.note_id,
+        saved_view_id=saved_view.view_id,
+        assertion_ids=tuple(dict.fromkeys(assertion.assertion_id for assertion in assertions)),
     )
 
 

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -7,6 +7,10 @@ import pytest
 
 from polylogue.core.json import JSONDocument
 from polylogue.scenarios import (
+    DEMO_CHATGPT_SESSION_ID,
+    DEMO_CLAUDE_CODE_SESSION_ID,
+    DEMO_CODEX_SESSION_ID,
+    DEMO_SESSION_IDS,
     CorpusProfile,
     CorpusRequest,
     CorpusScenario,
@@ -177,6 +181,11 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
     specs = build_demo_corpus_specs()
 
     assert tuple(spec.provider for spec in specs) == ("chatgpt", "claude-code", "codex")
+    assert DEMO_SESSION_IDS == (
+        DEMO_CHATGPT_SESSION_ID,
+        DEMO_CLAUDE_CODE_SESSION_ID,
+        DEMO_CODEX_SESSION_ID,
+    )
     assert tuple(spec.style for spec in specs) == (
         "showcase",
         "tool-heavy",

--- a/tests/unit/scenarios/test_demo_archive_convergence.py
+++ b/tests/unit/scenarios/test_demo_archive_convergence.py
@@ -8,9 +8,14 @@ import pytest
 
 from polylogue.config import Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
-from polylogue.scenarios import build_demo_corpus_specs
+from polylogue.scenarios import (
+    DEMO_CLAUDE_CODE_SESSION_ID,
+    build_demo_corpus_specs,
+    seed_demo_user_overlays,
+)
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, list_assertions_for_target
 
 EXPECTED_DEMO_SESSIONS = (
     (
@@ -78,6 +83,20 @@ def _raw_source_paths(archive_root: Path) -> tuple[str, ...]:
     return tuple(str(row["source_path"]) for row in rows)
 
 
+def _user_overlay_rows(archive_root: Path) -> tuple[tuple[str, str, str | None, object | None, str | None], ...]:
+    with _connect(archive_root / "user.db") as conn:
+        rows = conn.execute(
+            """
+            SELECT assertion_id, kind, key, value_json, body_text
+            FROM assertions
+            ORDER BY assertion_id
+            """
+        ).fetchall()
+    return tuple(
+        (str(row["assertion_id"]), str(row["kind"]), row["key"], row["value_json"], row["body_text"]) for row in rows
+    )
+
+
 def _stored_text_values(archive_root: Path) -> Iterable[str]:
     with _connect(archive_root / "index.db") as conn:
         for table, columns in (
@@ -132,11 +151,46 @@ async def test_demo_fixture_world_converges_into_deterministic_archive(
     assert all(not Path(path).is_absolute() for path in _raw_source_paths(archive_root))
     assert all(fragment not in value for value in stored_values for fragment in forbidden_fragments)
 
+    overlay = seed_demo_user_overlays(archive_root)
+    assert overlay.session_ids == tuple(row[0] for row in EXPECTED_DEMO_SESSIONS)
+    assert overlay.tag == "pytest-triage"
+    assert overlay.note_id == "demo-note:pytest-triage"
+    assert overlay.saved_view_id == "demo-view:pytest-triage"
+
+    with _connect(archive_root / "user.db") as conn:
+        session_tags = conn.execute(
+            "SELECT tag, tag_source FROM session_tags WHERE session_id = ?",
+            (DEMO_CLAUDE_CODE_SESSION_ID,),
+        ).fetchall()
+        assertions = list_assertions_for_target(conn, f"session:{DEMO_CLAUDE_CODE_SESSION_ID}")
+
+    assert tuple((row["tag"], row["tag_source"]) for row in session_tags) == (("pytest-triage", "user"),)
+    assert {assertion.kind for assertion in assertions} == {
+        AssertionKind.MARK,
+        AssertionKind.NOTE,
+        AssertionKind.TAG,
+        AssertionKind.DECISION,
+    }
+    assert {
+        assertion.key for assertion in assertions if assertion.kind in {AssertionKind.TAG, AssertionKind.DECISION}
+    } == {"pytest-triage"}
+    fixture_assertions = [assertion for assertion in assertions if assertion.author_kind == "fixture"]
+    assert fixture_assertions
+    assert all(assertion.context_policy == {"demo": True, "inject": False} for assertion in fixture_assertions)
+    assert all(assertion.author_kind in {"fixture", "user"} for assertion in assertions)
+    assert all("/tmp/" not in str(value) for row in _user_overlay_rows(archive_root) for value in row if value)
+
+    overlay_rows_before = _user_overlay_rows(archive_root)
+    overlay_again = seed_demo_user_overlays(archive_root)
+    assert overlay_again == overlay
+    assert _user_overlay_rows(archive_root) == overlay_rows_before
+
     before_counts = {
         "raw_sessions": _row_count(archive_root / "source.db", "raw_sessions"),
         "sessions": _row_count(archive_root / "index.db", "sessions"),
         "messages": _row_count(archive_root / "index.db", "messages"),
         "blocks": _row_count(archive_root / "index.db", "blocks"),
+        "assertions": _row_count(archive_root / "user.db", "assertions"),
     }
 
     repeat = await parse_sources_archive(archive_root, sources)
@@ -148,4 +202,5 @@ async def test_demo_fixture_world_converges_into_deterministic_archive(
         "sessions": _row_count(archive_root / "index.db", "sessions"),
         "messages": _row_count(archive_root / "index.db", "messages"),
         "blocks": _row_count(archive_root / "index.db", "blocks"),
+        "assertions": _row_count(archive_root / "user.db", "assertions"),
     } == before_counts


### PR DESCRIPTION
## Summary

Adds deterministic user-tier overlay evidence for the approved demo archive. After the existing `build_demo_corpus_specs()` archive convergence path stores the three demo sessions, `seed_demo_user_overlays()` attaches a `pytest-triage` tag, README example mark, blackboard note, saved query, and typed tag/decision assertions to the Claude Code demo session.

## Problem

#1843's demo fixture world had deterministic source/index convergence evidence, but the remaining known tags/notes/KV overlay requirement was still unrepresented after the #1883 assertion substrate landed. Public docs could show search/read examples, but there was no private-data-free evidence that the demo archive also exercises `user.db` overlays and assertion rows.

## Solution

`polylogue.scenarios.corpus` now exposes the fixed approved demo session IDs plus `seed_demo_user_overlays(archive_root)`. The helper intentionally runs after archive convergence rather than changing `polylogue import --demo`, because import is an asynchronous daemon scheduling command and cannot synchronously attach overlays to sessions that may not exist yet. The demo convergence test now proves deterministic user overlays, assertion kinds, idempotent reseeding, and no private path leakage. README and `docs/generate.md` describe the shipped evidence without changing the import command contract.

## Verification

- `nix develop --command devtools test tests/unit/scenarios/test_corpus.py tests/unit/scenarios/test_demo_archive_convergence.py` -> `20 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`
- `git push` pre-push quick gate -> `exit_code 0`

## PR handoff checklist

Issue slice: #1843 known tags/notes/KV overlays for the approved demo fixture world after #1883.
Files inspected: `polylogue/scenarios/corpus.py`, `polylogue/scenarios/__init__.py`, `tests/unit/scenarios/test_corpus.py`, `tests/unit/scenarios/test_demo_archive_convergence.py`, `polylogue/storage/sqlite/archive_tiers/user_write.py`, `README.md`, `docs/generate.md`.
Files changed: `polylogue/scenarios/corpus.py`, `polylogue/scenarios/__init__.py`, `tests/unit/scenarios/test_corpus.py`, `tests/unit/scenarios/test_demo_archive_convergence.py`, `README.md`, `docs/generate.md`.
Old surface removed or retained: retained `polylogue import --demo` as asynchronous daemon scheduling; added repository fixture evidence after convergence.
Contracts/tests added: demo session ID constants; `seed_demo_user_overlays()`; assertions for tag, mark, note, saved query, typed assertions, idempotency, and private-path hygiene.
Generated artifacts updated: none; `devtools render-all --check` stayed clean.
Verification commands and results: listed above.
Known caveats / SPEC_MISMATCH: `polylogue import --demo` still schedules daemon ingest; it does not synchronously seed overlays. Overlay seeding is repository evidence after convergence.
Follow-up intentionally not included: a public CLI/API command for seeding demo overlays, if wanted, should be designed as a separate user-facing surface rather than hidden inside import scheduling.

Ref #1843