### PR TITLE
docs: complete demo analyze transcript (#1843)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,14 +259,16 @@ polylogue status
 polylogue stats
 polylogue "pytest" list --limit 5
 polylogue find "pytest" then read --view messages
+polylogue find "pytest" then analyze --facets
 ```
 
 `polylogue import --demo` writes only approved synthetic source files and asks
 the running daemon to ingest them. The command is asynchronous: `status` shows
-daemon/archive health, while `stats` and search/read commands are meaningful
-after daemon convergence. The current deterministic archive evidence is the
-in-process fixture evidence in [docs/generate.md](docs/generate.md), including
-the expected `pytest` search hit and user-tier overlay evidence for the
+daemon/archive health, while `stats` and search/read/analyze commands are
+meaningful after daemon convergence. The current deterministic archive
+evidence is the in-process fixture evidence in
+[docs/generate.md](docs/generate.md), including the expected `pytest` search
+hit and user-tier overlay evidence for the
 `pytest-triage` tag, mark, note, saved query, and typed assertions.
 
 ## Developer tools

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -29,6 +29,7 @@ polylogue status
 polylogue stats
 polylogue "pytest" list --limit 5
 polylogue find "pytest" then read --view messages
+polylogue find "pytest" then analyze --facets
 
 # Repository verification-lab scenarios
 devtools lab-scenario run archive-smoke --tier 0
@@ -40,7 +41,7 @@ archive build. It materializes approved fixture sources under the configured
 archive root, stages them into the daemon inbox, and reports success only after
 the daemon accepts scheduling. Until the running daemon converges the staged
 source, `polylogue status` may show an empty or in-progress archive and
-search/read examples can legitimately return no rows.
+search/read/analyze examples can legitimately return no rows.
 
 ## How It Works
 
@@ -92,7 +93,7 @@ same `build_demo_corpus_specs()` artifacts, converges them in process with
 
 SPEC_MISMATCH: the README command transcript exercises the shipped
 daemon-backed scheduling surface, while the convergence evidence above uses
-the in-process archive parser. The documented search/read examples are
+the in-process archive parser. The documented search/read/analyze examples are
 therefore truthful after daemon convergence, but `polylogue import --demo`
 itself does not synchronously prove the archive contains those rows.
 


### PR DESCRIPTION
## Summary
Complete #1843's README-ready demo transcript by adding the missing `analyze` example alongside the existing demo import, status, stats, search, and read commands.

## Problem
The #1843 acceptance criteria require the demo archive to support search/read/analyze examples. The current README and `docs/generate.md` transcript showed search and read after daemon convergence, but not an analyze command. Closing the issue without this would leave a literal AC gap.

## Solution
Add `polylogue find "pytest" then analyze --facets` to both the README quick transcript and the detailed generate/demo page. Update the async import caveat so it consistently says search/read/analyze examples become meaningful after daemon convergence.

### AC matrix

| AC | Current state |
| --- | --- |
| A new user can run demo import from a clean checkout. | Satisfied by `polylogue import --demo` in `polylogue/cli/commands/import_command.py`; tested by `tests/unit/cli/test_import.py`; documented in `README.md` and `docs/generate.md`. |
| Demo archive supports search/read/analyze examples. | Satisfied here: README/docs now show `polylogue "pytest" list`, `polylogue find "pytest" then read --view messages`, and `polylogue find "pytest" then analyze --facets`. The archive-level `pytest` search/read evidence is pinned by `tests/unit/scenarios/test_demo_archive_convergence.py`; analyze is the registered aggregate verb over the matched result set. |
| Fixture world is committed and documented. | Satisfied by `build_demo_corpus_specs()` and docs in `docs/generate.md`; prior PRs #1934, #1935, #1936, #1937, #1940, #1943, #1950, #1953, and #1975 recorded the fixture, live daemon path, convergence proof, and overlay evidence. |
| Tests validate demo output without relying on dev machine state. | Satisfied by isolated archive/config roots in the demo import and convergence tests; #1975 additionally proves deterministic user overlays and private-path hygiene. |
| No private data / no host-specific absolute paths. | Satisfied by the relative fixture-path tests and convergence assertions in `tests/unit/scenarios/test_corpus.py` and `tests/unit/scenarios/test_demo_archive_convergence.py`. |
| Known tags/notes/KV once #1883 lands. | Satisfied by #1975: `seed_demo_user_overlays()` stores the `pytest-triage` tag, mark, blackboard note, saved query, and typed tag/decision assertions in `user.db` after convergence. |

### Explicit decisions

`polylogue import --demo` remains asynchronous daemon scheduling. It does not synchronously seed user overlays because the target sessions may not exist yet. Overlay seeding stays as deterministic repository/release evidence after convergence, as documented by #1975.

## Verification
- `nix develop --command devtools verify-doc-commands` -> `99 doc files scanned, no stale commands`.
- `nix develop --command devtools verify --quick` -> `exit_code 0`.
- Pre-push `devtools verify --quick` -> `exit_code 0`.

Closes #1843