### PR TITLE
test(status): cover readiness state matrix (#1832)

### DIFF
--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -564,6 +564,74 @@ class TestNoArchiveStatus:
         assert transforms["summary"] == "no sessions"
         assert transforms["repair_hint"] == "polylogue import --demo"
 
+    def test_direct_status_json_covers_component_readiness_state_matrix(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        env = _make_app_env()
+        db_anchor = tmp_path / "index.db"
+        initialize_archive_database(db_anchor, ArchiveTier.INDEX)
+        archive_readiness = {
+            "checked": True,
+            "counts": {"session_count": 0},
+            "surfaces": {
+                "archive_sessions": {
+                    "ready": True,
+                    "blockers": [],
+                    "evidence": {"session_count": 0},
+                },
+                "search": {
+                    "ready": False,
+                    "blockers": ["messages_fts_row_mismatch"],
+                    "evidence": {"text_block_count": 10, "messages_fts_count": 8},
+                },
+                "session_profiles": {
+                    "ready": False,
+                    "blockers": [],
+                    "evidence": {"profile_row_count": 1, "missing_profile_row_count": 1},
+                },
+            },
+        }
+        embedding_payload = {
+            "config_enabled": False,
+            "has_voyage_api_key": False,
+            "status": "disabled",
+            "total_sessions": 0,
+            "embedded_sessions": 0,
+            "embedded_messages": 0,
+            "pending_sessions": 0,
+            "stale_messages": 0,
+            "failure_count": 0,
+            "freshness_status": "disabled",
+            "retrieval_ready": False,
+            "next_action": {"code": "enable", "command": "polylogue embed enable"},
+        }
+
+        with (
+            patch("polylogue.paths.db_path", return_value=db_anchor),
+            patch("polylogue.paths.archive_root", return_value=tmp_path),
+            patch("polylogue.cli.commands.status._archive_readiness_status", return_value=archive_readiness),
+            patch(
+                "polylogue.storage.embeddings.status_payload.embedding_status_payload",
+                return_value=embedding_payload,
+            ),
+        ):
+            _show_direct_json(env)
+
+        components = json.loads(_combined_calls(env))["component_readiness"]
+        assert components["archive_sessions"]["state"] == "ready"
+        assert components["search"]["state"] == "stale"
+        assert components["search"]["caveats"] == ["messages_fts_row_mismatch"]
+        assert components["search"]["repair_hint"] == "polylogue maintenance run --target dangling_fts"
+        assert components["session_profiles"]["state"] == "degraded"
+        assert components["session_profiles"]["counts"] == {
+            "profile_row_count": 1,
+            "missing_profile_row_count": 1,
+        }
+        assert components["embeddings"]["state"] == "missing"
+        assert components["assertions"]["state"] == "missing"
+        assert components["transforms"]["state"] == "missing"
+
     def test_direct_status_json_blocks_transforms_when_archive_readiness_fails(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Add a direct-status JSON fixture that proves the shared `component_readiness` payload can carry ready, stale, degraded, and missing states together.

## Problem

#1832 had landed the shared DTO and several projections, but the issue still called for fixture coverage over ready/missing/stale/degraded status states. Existing tests covered individual adapters and selected direct-status paths, but not a single status payload demonstrating the state vocabulary across multiple component families.

## Solution

Issue slice:
- Fixture readiness-state matrix for direct `polylogue status --format json` component readiness.

Files inspected:
- `polylogue/readiness/capability.py`
- `polylogue/cli/commands/status.py`
- `tests/unit/core/test_readiness_capability.py`
- `tests/unit/cli/test_status.py`

Files changed:
- `tests/unit/cli/test_status.py`

Old surface removed or retained:
- Retained the existing status surface and legacy payload fields.
- Added only additive contract coverage for the canonical component map.

Contracts/tests added:
- New status JSON fixture covers:
  - `archive_sessions` -> `ready`
  - `search` -> `stale` with blocker caveat and repair hint
  - `session_profiles` -> `degraded` with counts
  - `embeddings`, `assertions`, and `transforms` -> `missing`

Generated artifacts updated:
- None.

Verification commands and results:
- `devtools test tests/unit/cli/test_status.py -k 'component_readiness or archive_surface or embeddings_component or missing_assertions or blocks_transforms'` -> 7 passed, 23 deselected.
- `devtools verify --quick` -> exit_code 0.
- pre-push `devtools verify --quick` -> exit_code 0.

Known caveats / SPEC_MISMATCH:
- None. This is coverage for an already-exposed payload, not new runtime behavior.

Follow-up intentionally not included:
- Broader MCP/web readiness convergence remains separate #1832 work.
- Generated command/action contract coverage remains #1816.

Ref #1832