### PR TITLE
test(devtools): harden release-readiness gate (#1827)

### DIFF
--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -84,8 +84,16 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
             errors.append(f"release PR template missing field: {field}")
 
     for command in (*REQUIRED_COMMANDS, *FOCUSED_COMMANDS):
+        command_text = " ".join(command.argv)
+        if command.required and command_text not in text:
+            errors.append(f"required command missing from gate document: {command_text}")
         if command.argv[0] == "devtools" and command.argv[1] not in COMMANDS:
-            errors.append(f"unknown devtools command in release gate: {' '.join(command.argv)}")
+            errors.append(f"unknown devtools command in release gate: {command_text}")
+
+    if "Satisfied:" not in text:
+        errors.append("gate document missing satisfied release-status list")
+    if "Still blocking external release claims:" not in text:
+        errors.append("gate document missing blocking release-status list")
 
     return {
         "ok": not errors,

--- a/tests/unit/devtools/test_release_readiness.py
+++ b/tests/unit/devtools/test_release_readiness.py
@@ -1,10 +1,38 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from devtools import release_readiness
+
+
+def _write_gate(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _valid_gate_text() -> str:
+    headings = "\n\n".join(release_readiness.REQUIRED_DOC_HEADINGS)
+    commands = "\n".join(" ".join(command.argv) for command in release_readiness.REQUIRED_COMMANDS)
+    fields = "\n".join(release_readiness.REQUIRED_RELEASE_BODY_FIELDS)
+    return f"""# Release Readiness Gate
+
+{headings}
+
+```bash
+{commands}
+```
+
+Satisfied:
+
+Still blocking external release claims:
+
+```text
+{fields}
+```
+"""
 
 
 def test_release_readiness_report_validates_committed_gate() -> None:
@@ -24,3 +52,23 @@ def test_release_readiness_json_cli(capsys: pytest.CaptureFixture[str]) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["required_commands"][0]["argv"] == ["devtools", "release-readiness"]
+
+
+def test_release_readiness_rejects_missing_required_command(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(gate_doc, _valid_gate_text().replace("devtools verify --lab\n", ""))
+
+    report = release_readiness.build_report(gate_doc=gate_doc)
+
+    assert report["ok"] is False
+    assert any("devtools verify --lab" in error for error in report["errors"])
+
+
+def test_release_readiness_rejects_missing_status_lists(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(gate_doc, _valid_gate_text().replace("Still blocking external release claims:\n", ""))
+
+    report = release_readiness.build_report(gate_doc=gate_doc)
+
+    assert report["ok"] is False
+    assert any("blocking release-status list" in error for error in report["errors"])


### PR DESCRIPTION
## Summary

Harden `devtools release-readiness` so it validates that the release gate document still lists every required local command and still carries both satisfied and blocking release-status sections.

## Problem

#1827 depends on a reproducible release gate, not just prose. The existing command checked headings, release PR template fields, and command inventory resolution, but it did not fail if the gate document silently stopped listing a required local command or dropped the status sections that tell the release PR what remains blocked.

## Solution

Issue slice:
- Strengthen the existing release-readiness gate definition check.

Files inspected:
- `docs/plans/release-readiness-gate.md`
- `devtools/release_readiness.py`
- `devtools/command_catalog.py`
- `tests/unit/devtools/test_release_readiness.py`
- `tests/unit/devtools/test_verify_doc_commands.py`

Files changed:
- `devtools/release_readiness.py`
- `tests/unit/devtools/test_release_readiness.py`

Old surface removed or retained:
- Retained the existing `devtools release-readiness` command and JSON report shape.
- Added stricter validation; no release workflow behavior changes.

Contracts/tests added:
- Fails if a required local command such as `devtools verify --lab` is omitted from the gate document.
- Fails if the gate loses the `Satisfied:` / `Still blocking external release claims:` status sections.

Generated artifacts updated:
- None; generated surfaces were checked and remained clean.

Verification commands and results:
- `devtools release-readiness --json` -> `ok: true`, no errors.
- `devtools test tests/unit/devtools/test_release_readiness.py tests/unit/devtools/test_command_catalog.py tests/unit/devtools/test_verify_doc_commands.py -k 'release_readiness or command_specs_have_unique_names or known_devtools_command_passes or json_mode'` -> 7 passed, 22 deselected.
- `devtools verify --quick` -> exit_code 0.
- pre-push `devtools verify --quick` -> exit_code 0.

Known caveats / SPEC_MISMATCH:
- None.

Follow-up intentionally not included:
- This does not unblock the held release PR #1719; it only makes the gate harder to drift. The remaining blockers listed in `docs/plans/release-readiness-gate.md` still apply.

Ref #1827