### PR TITLE
test(storage): prove blob GC combines safety gates (#1830)

### DIFF
--- a/tests/unit/storage/test_blob_gc_lease_recovery.py
+++ b/tests/unit/storage/test_blob_gc_lease_recovery.py
@@ -30,6 +30,7 @@ from polylogue.storage.blob_gc import (
     sweep_orphaned_blob_leases,
 )
 from polylogue.storage.sqlite.connection_profile import open_connection
+from tests.infra.frozen_clock import FrozenClock
 
 
 @pytest.fixture
@@ -208,7 +209,12 @@ def test_gc_age_gate_respects_previous_generation(db_path: Path, tmp_path: Path)
     assert not (blob_dir / blob_hash[:2] / blob_hash[2:]).exists()
 
 
-def test_gc_combines_reference_lease_and_generation_guards(db_path: Path, tmp_path: Path) -> None:
+def test_gc_combines_reference_lease_and_generation_guards(
+    db_path: Path,
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    frozen_clock: FrozenClock,
+) -> None:
     """One GC pass applies all #1830 safety gates before reclaiming.
 
     A generation-safe GC pass must keep referenced blobs, in-flight leased
@@ -224,7 +230,7 @@ def test_gc_combines_reference_lease_and_generation_guards(db_path: Path, tmp_pa
     generation_young_hash = "cc" + "3" * 62
     orphan_hash = "dd" + "4" * 62
 
-    now = int(time.time())
+    now = int(frozen_clock.time())
     completed_at_ms = (now - 1000) * 1000
     conn = open_connection(db_path)
     try:
@@ -247,6 +253,7 @@ def test_gc_combines_reference_lease_and_generation_guards(db_path: Path, tmp_pa
     acquire_blob_leases(db_path, [leased_hash], "op-in-flight")
     _make_blob(blob_dir, referenced_hash, age_s=1200)
     _make_blob(blob_dir, leased_hash, age_s=1200)
+    assert MIN_AGE_S + 10 < 1000  # guard the generation-young premise
     _make_blob(blob_dir, generation_young_hash, age_s=MIN_AGE_S + 10)
     _make_blob(blob_dir, orphan_hash, age_s=1200)
 

--- a/tests/unit/storage/test_blob_gc_lease_recovery.py
+++ b/tests/unit/storage/test_blob_gc_lease_recovery.py
@@ -206,3 +206,70 @@ def test_gc_age_gate_respects_previous_generation(db_path: Path, tmp_path: Path)
     deleted = run_blob_gc(db_path, blob_dir)
     assert deleted == 1
     assert not (blob_dir / blob_hash[:2] / blob_hash[2:]).exists()
+
+
+def test_gc_combines_reference_lease_and_generation_guards(db_path: Path, tmp_path: Path) -> None:
+    """One GC pass applies all #1830 safety gates before reclaiming.
+
+    A generation-safe GC pass must keep referenced blobs, in-flight leased
+    blobs, and blobs newer than the previous completed generation while still
+    reclaiming old unreferenced blobs in the same run. This is the executable
+    proof for the combined backup/GC safety story rather than independent
+    unit checks for each predicate.
+    """
+    blob_dir = tmp_path / "blobs"
+    blob_dir.mkdir()
+    referenced_hash = "aa" + "1" * 62
+    leased_hash = "bb" + "2" * 62
+    generation_young_hash = "cc" + "3" * 62
+    orphan_hash = "dd" + "4" * 62
+
+    now = int(time.time())
+    completed_at_ms = (now - 1000) * 1000
+    conn = open_connection(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO gc_generations "
+            "(generation_id, started_at_ms, completed_at_ms, reclaimed_count, reclaimed_bytes) "
+            "VALUES (?, ?, ?, 0, 0)",
+            ("gen-boundary", completed_at_ms, completed_at_ms),
+        )
+        conn.execute(
+            "INSERT INTO blob_refs "
+            "(blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms) "
+            "VALUES (?, 'ref-1', 'raw_payload', 'source.jsonl', 4, ?)",
+            (bytes.fromhex(referenced_hash), completed_at_ms),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    acquire_blob_leases(db_path, [leased_hash], "op-in-flight")
+    _make_blob(blob_dir, referenced_hash, age_s=1200)
+    _make_blob(blob_dir, leased_hash, age_s=1200)
+    _make_blob(blob_dir, generation_young_hash, age_s=MIN_AGE_S + 10)
+    _make_blob(blob_dir, orphan_hash, age_s=1200)
+
+    deleted = run_blob_gc(db_path, blob_dir, max_batch=10)
+
+    assert deleted == 1
+    assert (blob_dir / referenced_hash[:2] / referenced_hash[2:]).exists()
+    assert (blob_dir / leased_hash[:2] / leased_hash[2:]).exists()
+    assert (blob_dir / generation_young_hash[:2] / generation_young_hash[2:]).exists()
+    assert not (blob_dir / orphan_hash[:2] / orphan_hash[2:]).exists()
+
+    conn = open_connection(db_path)
+    try:
+        rows = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT reclaimed_count, reclaimed_bytes FROM gc_generations ORDER BY started_at_ms DESC LIMIT 1"
+            ).fetchall()
+        ]
+        pending = conn.execute("SELECT COUNT(*) FROM pending_blob_refs WHERE operation_id = 'op-in-flight'").fetchone()
+    finally:
+        conn.close()
+
+    assert rows == [(1, 4)]
+    assert pending is not None
+    assert pending[0] == 1


### PR DESCRIPTION
## Summary

Adds an integrated blob-GC contract test for #1830 proving one GC pass applies the reference, active-lease, and previous-generation age guards together before reclaiming an old orphan blob.

## Problem

The backup/GC issue now has docs, backup planning, profiles, and benchmark registration, but the generation-safe GC proof was still mostly distributed across independent tests: one test for generation age, one for lease protection, one for reference protection. That made the operator-facing claim weaker than the actual safety boundary: production GC must combine all predicates in the same pass.

## Solution

`tests/unit/storage/test_blob_gc_lease_recovery.py` now seeds a real split archive with:

- a previous completed GC generation;
- a blob referenced through `blob_refs`;
- a blob protected by an active `pending_blob_refs` lease;
- an unreferenced blob younger than the previous generation boundary;
- an old unreferenced blob eligible for reclamation.

The test asserts GC deletes only the eligible orphan, preserves the referenced/leased/generation-young blobs, records the reclaim count/bytes, and keeps the active lease row intact.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_blob_gc_lease_recovery.py` -> 6 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.
- Attempted `nix develop --command devtools verify --seed-testmon --skip-slow` in the fresh worktree. Static gates passed, but the pytest seed run was terminated after 957s with seed-testmon still running, so the default testmon baseline was not usable for this one-file proof.

## Issue handoff checklist

Issue slice: generation-safe blob GC proof.
Files inspected: `polylogue/storage/blob_gc.py`, `polylogue/storage/sqlite/archive_tiers/source.py`, `tests/unit/storage/test_blob_gc.py`, `tests/unit/storage/test_blob_gc_concurrency.py`, `tests/unit/storage/test_blob_gc_lease_recovery.py`, `tests/unit/storage/test_blob_store_contracts.py`, #1830, #1849.
Files changed: `tests/unit/storage/test_blob_gc_lease_recovery.py`.
Old surface removed or retained: no public surface changed; this is test coverage for the existing GC contract.
Contracts/tests added: integrated split-archive GC safety test combining reference, lease, generation-age, and reclaim-counter assertions.
Generated artifacts updated: none.
Verification commands and results: listed above.
Known caveats / SPEC_MISMATCH: default testmon seed was not usable in the fresh worktree because it exceeded 15 minutes and was terminated; focused and quick gates were clean.
Follow-up intentionally not included: GC dry-run/report CLI expansion and restore-plan dry-run fixture remain separate #1830 work; action-contract/output-schema test generation remains #1849/#1816/#1818 work.

Ref #1830
Ref #1849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test validating blob garbage collection with multiple blob states (referenced, leased, generation-young, and orphaned).
  * Verifies only orphaned blobs are reclaimed while others remain preserved on disk.
  * Confirms proper tracking of reclaimed blob metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->