### PR TITLE
test(devtools): smoke benchmark artifact compare (#1849)

### DIFF
--- a/tests/unit/devtools/test_benchmark_campaign.py
+++ b/tests/unit/devtools/test_benchmark_campaign.py
@@ -5,13 +5,14 @@ from pathlib import Path
 from types import TracebackType
 from typing import Literal
 
-from pytest import MonkeyPatch
+from pytest import CaptureFixture, MonkeyPatch
 
 from devtools.benchmark_campaign import (
     CampaignResult,
     Regression,
     _compare_results,
     compare_artifacts,
+    main,
     render_index,
     run_campaign,
 )
@@ -48,6 +49,31 @@ def _benchmark_record(fullname: str, mean: float) -> BenchmarkStatRecord:
         "rounds": 1,
         "ops": (1.0 / mean) if mean > 0 else None,
     }
+
+
+def _campaign_result(*, description: str, commit: str, mean: float) -> CampaignResult:
+    return CampaignResult(
+        campaign="search-filters",
+        description=description,
+        commit=commit,
+        worktree_dirty=False,
+        created_at="2026-04-11T00:00:00+00:00",
+        workspace="/tmp/workspace",
+        command=["pytest"],
+        tests=["tests/benchmarks/test_search_filters.py"],
+        notes=[],
+        benchmark_count=1,
+        runtime_seconds=1.0,
+        exit_code=0,
+        machine_info={},
+        benchmarks=[_benchmark_record("bench.query", mean)],
+        slowest=[],
+        compare_to=None,
+        warn_pct=10.0,
+        fail_pct=20.0,
+        regressions=[],
+        worst_regression_pct=None,
+    )
 
 
 def test_compare_results_orders_regressions_by_worst_delta() -> None:
@@ -138,6 +164,30 @@ def test_compare_artifacts_fails_when_threshold_is_exceeded(tmp_path: Path) -> N
     candidate_path.write_text(json.dumps(candidate.__dict__), encoding="utf-8")
 
     assert compare_artifacts(baseline_path, candidate_path, 20.0) == 1
+
+
+def test_compare_command_reports_expected_delta(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    """#1849: benchmark artifact comparison has an executable smoke fixture.
+
+    The public operator command must read two durable campaign artifacts,
+    report the overlapping benchmark delta, and return failure only when the
+    configured threshold is exceeded.
+    """
+    baseline = _campaign_result(description="baseline", commit="a" * 40, mean=1.0)
+    candidate = _campaign_result(description="candidate", commit="b" * 40, mean=1.15)
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    baseline_path.write_text(json.dumps(baseline.__dict__), encoding="utf-8")
+    candidate_path.write_text(json.dumps(candidate.__dict__), encoding="utf-8")
+
+    assert main(["compare", str(baseline_path), str(candidate_path), "--fail-pct", "20.0"]) == 0
+    out = capsys.readouterr().out
+    assert "Comparing candidate.json against baseline.json:" in out
+    assert "bench.query: 15.00% (1.000000s -> 1.150000s)" in out
+
+    assert main(["compare", str(baseline_path), str(candidate_path), "--fail-pct", "10.0"]) == 1
+    out = capsys.readouterr().out
+    assert "FAIL: worst regression 15.00% exceeds 10.00%" in out
 
 
 def test_render_index_lists_saved_artifacts(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Adds a command-level smoke test for benchmark artifact comparison so #1849 has executable coverage that durable benchmark artifacts can be compared and produce expected regression deltas.

## Problem

`devtools benchmark-campaign compare` is part of the evidence-first benchmark artifact story, but coverage focused on the internal threshold helper. The public command path did not have a fixture proving that two saved campaign artifacts produce the expected delta output and fail only when the configured threshold is exceeded.

## Solution

`tests/unit/devtools/test_benchmark_campaign.py` now builds tiny baseline/candidate `CampaignResult` artifacts and exercises `main(["compare", ...])` directly. The smoke asserts:

- the command prints the artifact names being compared;
- the overlapping benchmark reports the expected `15.00%` delta and means;
- the command exits cleanly under a `20%` fail threshold;
- the command exits with failure under a `10%` fail threshold.

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_benchmark_campaign.py` -> 13 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.

## Issue handoff checklist

Issue slice: benchmark compare smoke.
Files inspected: `devtools/benchmark_campaign.py`, `devtools/benchmark_results.py`, `tests/unit/devtools/test_benchmark_campaign.py`, `tests/unit/devtools/test_benchmark_campaigns.py`, `docs/test-quality-workflows.md`, #1849, #1830.
Files changed: `tests/unit/devtools/test_benchmark_campaign.py`.
Old surface removed or retained: retained existing `benchmark-campaign compare` command; this PR adds executable coverage for it.
Contracts/tests added: command-level compare fixture covering durable artifact read, expected delta reporting, and threshold pass/fail behavior.
Generated artifacts updated: none.
Verification commands and results: listed above.
Known caveats / SPEC_MISMATCH: none.
Follow-up intentionally not included: generated action-contract tests, machine-output JSON/NDJSON fixture validation, and broader import/search benchmark artifacts remain separate #1849 work.

Ref #1849