### PR TITLE
feat(maintenance): report blob GC dry-runs (#1830)

### DIFF
--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `267`
+- scenario projections: `268`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
-  - exercise: `160`
+  - exercise: `161`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -400,6 +400,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-maintenance-archive-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance archive-plan help |
 | `exercise` | `help-maintenance-archive-read` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance archive-read help |
 | `exercise` | `help-maintenance-backup-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance backup-plan help |
+| `exercise` | `help-maintenance-blob-gc` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance blob-gc help |
 | `exercise` | `help-maintenance-gc-history` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance gc-history help |
 | `exercise` | `help-maintenance-plan` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance plan help |
 | `exercise` | `help-maintenance-preview` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | maintenance preview help |

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -23,7 +23,7 @@ from polylogue.maintenance.replay import ReplayProgress, execute_replay
 from polylogue.maintenance.scope import MaintenanceScopeFilter
 from polylogue.maintenance.targets import MAINTENANCE_TARGET_NAMES, build_maintenance_target_catalog
 from polylogue.paths import archive_file_set_root_for_paths, archive_root, blob_store_root, db_path, render_root
-from polylogue.storage.blob_gc import read_gc_history
+from polylogue.storage.blob_gc import read_gc_history, run_blob_gc_report
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveInitBlockedError,
@@ -833,6 +833,76 @@ def preview_command(
                 f"  {item.reason.value:>20s}  count={item.count:>10,}  fraction={fraction_pct:>5.1f}%  {item.detail}"
             )
         click.echo("")
+
+
+@maintenance_group.command("blob-gc")
+@click.option(
+    "--max-batch",
+    type=int,
+    default=100,
+    show_default=True,
+    help="Maximum number of eligible blobs to delete or preview.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Actually delete eligible blobs. Without this flag the command is a dry-run preview.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_gc_command(max_batch: int, yes: bool, output_format: str) -> None:
+    """Preview or run lease-safe blob garbage collection.
+
+    The default is a dry-run report. Pass ``--yes`` to reclaim eligible blobs.
+    """
+    configure_logging()
+    config = Config(
+        archive_root=archive_root(),
+        render_root=render_root(),
+        sources=[],
+    )
+    result = run_blob_gc_report(
+        config.db_path,
+        blob_store_root(),
+        max_batch=max_batch,
+        dry_run=not yes,
+    )
+    payload = {
+        "ok": True,
+        "mode": "blob_gc",
+        "mutates": bool(yes),
+        **result.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    action = "would delete" if result.dry_run else "deleted"
+    affected = result.would_delete_count if result.dry_run else result.deleted_count
+    click.echo("Blob GC dry-run" if result.dry_run else "Blob GC")
+    click.echo(f"Archive DB: {result.db_path}")
+    click.echo(f"Blob root:  {result.blob_dir}")
+    click.echo(f"Candidates: {result.candidate_count:,}")
+    click.echo(f"Inspected:  {result.inspected_count:,}")
+    click.echo(f"Result:     {action} {affected:,} blob(s)")
+    click.echo(
+        "Skipped:    "
+        f"referenced={result.skipped_referenced:,} "
+        f"leased={result.skipped_leased:,} "
+        f"missing={result.skipped_missing:,} "
+        f"unlink_error={result.skipped_unlink_error:,}"
+    )
+    if not result.dry_run:
+        click.echo(f"Reclaimed:  {result.reclaimed_bytes:,} byte(s)")
+        if result.generation_id is not None:
+            click.echo(f"Generation: {result.generation_id}")
 
 
 @maintenance_group.command("gc-history")

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -51,6 +51,48 @@ class GCRunEvidence:
     max_batch: int = 0
 
 
+@dataclass
+class BlobGCResult:
+    """Machine-readable summary of one blob-GC pass."""
+
+    db_path: str
+    blob_dir: str
+    dry_run: bool
+    max_batch: int
+    candidate_count: int = 0
+    inspected_count: int = 0
+    would_delete_count: int = 0
+    deleted_count: int = 0
+    reclaimed_bytes: int = 0
+    skipped_referenced: int = 0
+    skipped_leased: int = 0
+    skipped_missing: int = 0
+    skipped_unlink_error: int = 0
+    generation_id: str | None = None
+    generation_written: bool = False
+    older_than_s: float = 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "db_path": self.db_path,
+            "blob_dir": self.blob_dir,
+            "dry_run": self.dry_run,
+            "max_batch": self.max_batch,
+            "candidate_count": self.candidate_count,
+            "inspected_count": self.inspected_count,
+            "would_delete_count": self.would_delete_count,
+            "deleted_count": self.deleted_count,
+            "reclaimed_bytes": self.reclaimed_bytes,
+            "skipped_referenced": self.skipped_referenced,
+            "skipped_leased": self.skipped_leased,
+            "skipped_missing": self.skipped_missing,
+            "skipped_unlink_error": self.skipped_unlink_error,
+            "generation_id": self.generation_id,
+            "generation_written": self.generation_written,
+            "older_than_s": self.older_than_s,
+        }
+
+
 # Minimum age in seconds for a blob to be eligible for deletion.
 # Provides defense-in-depth against clockskew and delayed lease writes
 # beyond the lease-based safety mechanism.
@@ -306,12 +348,35 @@ def run_blob_gc(
     pre-existing partial cleanup) bumps ``skipped_missing`` in the
     persisted evidence record and is NOT counted as a deletion (#1190).
     """
+    result = run_blob_gc_report(db_path, blob_dir, max_batch=max_batch, dry_run=dry_run)
+    return result.would_delete_count if dry_run else result.deleted_count
+
+
+def run_blob_gc_report(
+    db_path: str | Path,
+    blob_dir: str | Path,
+    max_batch: int = 100,
+    *,
+    dry_run: bool = False,
+) -> BlobGCResult:
+    """Run blob GC and return an operator-facing report.
+
+    ``run_blob_gc`` remains the compatibility API returning only the affected
+    count. This report form exposes the same pass as machine-readable counts
+    for CLI dry-runs and maintenance logs.
+    """
     blob_path = Path(blob_dir)
+    db_path_obj = Path(db_path)
+    report = BlobGCResult(
+        db_path=str(db_path_obj),
+        blob_dir=str(blob_path),
+        dry_run=dry_run,
+        max_batch=int(max_batch),
+    )
     if not blob_path.is_dir():
         logger.debug("Blob directory %s does not exist, skipping GC", blob_dir)
-        return 0
+        return report
 
-    db_path_obj = Path(db_path)
     source_db_path: Path | None = db_path_obj.with_name("source.db")
     if source_db_path == db_path_obj:
         source_db_path = None
@@ -337,9 +402,11 @@ def run_blob_gc(
         if prev_completed_at is not None:
             since_prev_generation = time.time() - prev_completed_at
             older_than = max(older_than, since_prev_generation)
+        report.older_than_s = older_than
         candidates = _candidate_blobs(blob_path, older_than=older_than)
+        report.candidate_count = len(candidates)
         if not candidates:
-            return 0
+            return report
 
         evidence = GCRunEvidence(dry_run=dry_run, max_batch=max_batch)
         deleted = 0
@@ -415,7 +482,13 @@ def run_blob_gc(
                 evidence.skipped_leased,
                 evidence.skipped_missing,
             )
-            return deleted
+            report.inspected_count = evidence.inspected
+            report.would_delete_count = evidence.deleted
+            report.skipped_referenced = evidence.skipped_referenced
+            report.skipped_leased = evidence.skipped_leased
+            report.skipped_missing = evidence.skipped_missing
+            report.skipped_unlink_error = evidence.skipped_unlink_error
+            return report
 
         # Record the completed generation with typed reclaim counters. The
         # per-skip tally stays an in-memory log aggregate; the durable record is
@@ -437,7 +510,16 @@ def run_blob_gc(
                 generation_id,
             )
 
-        return deleted
+        report.generation_id = generation_id
+        report.generation_written = True
+        report.inspected_count = evidence.inspected
+        report.reclaimed_bytes = reclaimed_bytes
+        report.deleted_count = deleted
+        report.skipped_referenced = evidence.skipped_referenced
+        report.skipped_leased = evidence.skipped_leased
+        report.skipped_missing = evidence.skipped_missing
+        report.skipped_unlink_error = evidence.skipped_unlink_error
+        return report
     except Exception:
         conn.rollback()
         raise
@@ -545,6 +627,7 @@ def release_operation_leases(
 
 
 __all__ = [
+    "BlobGCResult",
     "MIN_AGE_S",
     "ORPHAN_LEASE_MAX_AGE_S",
     "GCHistoryRow",
@@ -553,5 +636,6 @@ __all__ = [
     "read_gc_history",
     "release_operation_leases",
     "run_blob_gc",
+    "run_blob_gc_report",
     "sweep_orphaned_blob_leases",
 ]

--- a/tests/baselines/showcase/help-maintenance-blob-gc.txt
+++ b/tests/baselines/showcase/help-maintenance-blob-gc.txt
@@ -1,0 +1,13 @@
+Usage: polylogue maintenance blob-gc [OPTIONS]
+
+  Preview or run lease-safe blob garbage collection.
+
+  The default is a dry-run report. Pass ``--yes`` to reclaim eligible blobs.
+
+Options:
+  --max-batch INTEGER           Maximum number of eligible blobs to delete or
+                                preview.  [default: 100]
+  --yes                         Actually delete eligible blobs. Without this
+                                flag the command is a dry-run preview.
+  --output-format [plain|json]  Output format.  [default: plain]
+  -h, --help                    Show this message and exit.

--- a/tests/baselines/showcase/help-maintenance.txt
+++ b/tests/baselines/showcase/help-maintenance.txt
@@ -10,6 +10,7 @@ Commands:
   archive-plan  Inspect readiness for the archive file set.
   archive-read  Read index sessions from the archive.
   backup-plan   Inspect archive backup boundaries without copying data.
+  blob-gc       Preview or run lease-safe blob garbage collection.
   gc-history    Show recent blob-GC passes recorded in ``gc_generations``.
   plan          Dry-run summary: show what would be rebuilt without...
   preview       Staleness inventory by model and scope.

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands import maintenance
+from polylogue.storage.blob_gc import read_gc_history
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveInitResult,
@@ -30,6 +32,16 @@ def _stage_uninitialized_archive(cli_workspace: dict[str, Path]) -> None:
     archive_root = cli_workspace["archive_root"]
     for name in _ARCHIVE_TIERS:
         (archive_root / name).unlink(missing_ok=True)
+
+
+def _write_gc_candidate(cli_workspace: dict[str, Path], blob_hash: str) -> Path:
+    blob_root = cli_workspace["data_root"] / "polylogue" / "blob"
+    path = blob_root / blob_hash[:2] / blob_hash[2:]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"gc candidate")
+    old_epoch_s = 946684800
+    os.utime(path, (old_epoch_s, old_epoch_s))
+    return path
 
 
 def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
@@ -163,6 +175,83 @@ def test_backup_plan_cli_renders_plain_summary(
     assert "Archive backup plan" in result.output
     assert "source.db: critical policy=back_up present" in result.output
     assert "full_evidence:" in result.output
+
+
+def test_blob_gc_cli_dry_run_reports_without_deleting(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    blob_hash = "aa" + "1" * 62
+    candidate = _write_gc_candidate(cli_workspace, blob_hash)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "blob-gc", "--max-batch", "5", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["mode"] == "blob_gc"
+    assert payload["mutates"] is False
+    assert payload["dry_run"] is True
+    assert payload["candidate_count"] == 1
+    assert payload["inspected_count"] == 1
+    assert payload["would_delete_count"] == 1
+    assert payload["deleted_count"] == 0
+    assert payload["generation_written"] is False
+    assert candidate.exists(), "dry-run must not delete the candidate"
+    assert read_gc_history(cli_workspace["archive_root"] / "index.db", limit=1) == []
+
+
+def test_blob_gc_cli_plain_preview_names_skip_counts(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    _write_gc_candidate(cli_workspace, "bb" + "2" * 62)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "blob-gc", "--max-batch", "5"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Blob GC dry-run" in result.output
+    assert "Candidates: 1" in result.output
+    assert "Result:     would delete 1 blob(s)" in result.output
+    assert "referenced=0 leased=0 missing=0 unlink_error=0" in result.output
+
+
+def test_blob_gc_cli_yes_deletes_and_records_generation(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    blob_hash = "cc" + "3" * 62
+    candidate = _write_gc_candidate(cli_workspace, blob_hash)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "maintenance", "blob-gc", "--yes", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mutates"] is True
+    assert payload["dry_run"] is False
+    assert payload["would_delete_count"] == 0
+    assert payload["deleted_count"] == 1
+    assert payload["reclaimed_bytes"] == len(b"gc candidate")
+    assert payload["generation_written"] is True
+    assert str(payload["generation_id"]).startswith("gc-")
+    assert not candidate.exists()
+
+    history = read_gc_history(cli_workspace["archive_root"] / "index.db", limit=1)
+    assert len(history) == 1
+    assert history[0].generation_id == payload["generation_id"]
+    assert history[0].reclaimed_count == 1
 
 
 def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary

Adds an operator-facing `polylogue maintenance blob-gc` surface for #1830. The command previews by default, only deletes with `--yes`, and emits both plain and JSON reports with candidate, inspected, skip, would-delete/deleted, reclaim, and generation fields.

## Problem

#1830 had backup boundary docs, named backup profiles, benchmark registration, and generation-safe GC proof coverage, but the remaining operator gap was that blob GC dry-runs existed only as a low-level integer return from `run_blob_gc(..., dry_run=True)`. Operators could not get a structured report before deleting blobs.

## Solution

- Added `BlobGCResult` and `run_blob_gc_report(...)` in `polylogue/storage/blob_gc.py`, preserving the existing `run_blob_gc(...) -> int` compatibility API.
- Added `polylogue maintenance blob-gc` with dry-run default and `--yes` as the mutation path.
- Added CLI tests proving JSON dry-run does not delete or consume a generation, plain preview exposes skip counts, and `--yes` deletes an eligible blob and records a generation.
- Refreshed the generated help baseline and test-quality workflow catalog for the new maintenance command.

This is one coherent #1830 phase: GC preview/report execution. It does not change backup profile semantics or expand into a separate restore redesign.

## Verification

```text
nix develop --command devtools test tests/unit/cli/test_archive_maintenance_cli.py tests/unit/storage/test_blob_gc.py tests/unit/storage/test_blob_gc_lease_recovery.py -k 'blob_gc or run_blob_gc'
-> 30 passed, 10 deselected

nix develop --command devtools lab-scenario verify-baselines
-> Ran 77 exercises; All baselines match.

nix develop --command devtools verify --quick
-> exit_code 0

git push pre-push quick gate
-> exit_code 0 on 28a9be59
```

`nix develop --command devtools verify` was attempted, but this fresh worktree has no pytest-testmon seed:

```text
verify: pytest-testmon is not seeded; run `devtools verify --seed-testmon` to create .testmondata and .cache/testmon/seed.json before using the default affected-test path.
```
