### PR TITLE
test(cli): bind mutation contracts to output schemas (#1816)

### DIFF
--- a/devtools/render_cli_output_schemas.py
+++ b/devtools/render_cli_output_schemas.py
@@ -26,6 +26,8 @@ from devtools.render_support import write_if_changed
 from polylogue.surfaces.payloads import (
     MachineErrorPayload,
     MachineSuccessPayload,
+    MutationResultPayload,
+    QueryErrorPayload,
     SearchEnvelope,
     SessionListRowPayload,
     SessionNeighborCandidatePayload,
@@ -115,6 +117,23 @@ SCHEMAS: tuple[CliOutputSchema, ...] = (
         surfaces=("polylogue neighbors --format json",),
     ),
     CliOutputSchema(
+        name="mutation-result",
+        title="Mutation Result",
+        description=(
+            "Shared result envelope for CLI, MCP, API, and daemon mutation "
+            "surfaces. Used by tag, metadata, delete, and related bulk "
+            "mutation actions to report status, affected counts, and "
+            "optional session ids."
+        ),
+        model=MutationResultPayload,
+        surfaces=(
+            "polylogue find <query> then delete --dry-run",
+            "polylogue find <query> then delete --yes",
+            "MCP mutation tools",
+            "daemon mutation endpoints",
+        ),
+    ),
+    CliOutputSchema(
         name="machine-error",
         title="Machine Error Envelope",
         description=(
@@ -135,6 +154,20 @@ SCHEMAS: tuple[CliOutputSchema, ...] = (
         ),
         model=MachineSuccessPayload,
         surfaces=("polylogue * --machine (success path)",),
+    ),
+    CliOutputSchema(
+        name="query-error",
+        title="Query Error Payload",
+        description=(
+            "Shared typed error payload for daemon HTTP, MCP, and query/read "
+            "surfaces that need field-addressable machine-readable failures."
+        ),
+        model=QueryErrorPayload,
+        surfaces=(
+            "GET /api/sessions?query=... (error path)",
+            "daemon query/read error responses",
+            "MCP query/read error responses",
+        ),
     ),
 )
 

--- a/docs/schemas/cli-output/README.md
+++ b/docs/schemas/cli-output/README.md
@@ -20,5 +20,7 @@ devtools render-cli-output-schemas --check # CI sync check
 | [`session-search-hit.schema.json`](./session-search-hit.schema.json) | `polylogue --format json <query>`<br>`polylogue --format ndjson <query>` | `SessionSearchHitPayload` |
 | [`search-envelope.schema.json`](./search-envelope.schema.json) | `polylogue --format json <query>`<br>`GET /api/sessions?query=...` | `SearchEnvelope` |
 | [`session-neighbor-candidate.schema.json`](./session-neighbor-candidate.schema.json) | `polylogue neighbors --format json` | `SessionNeighborCandidatePayload` |
+| [`mutation-result.schema.json`](./mutation-result.schema.json) | `polylogue find <query> then delete --dry-run`<br>`polylogue find <query> then delete --yes`<br>`MCP mutation tools`<br>`daemon mutation endpoints` | `MutationResultPayload` |
 | [`machine-error.schema.json`](./machine-error.schema.json) | `polylogue * --machine (error path)` | `MachineErrorPayload` |
 | [`machine-success.schema.json`](./machine-success.schema.json) | `polylogue * --machine (success path)` | `MachineSuccessPayload` |
+| [`query-error.schema.json`](./query-error.schema.json) | `GET /api/sessions?query=... (error path)`<br>`daemon query/read error responses`<br>`MCP query/read error responses` | `QueryErrorPayload` |

--- a/docs/schemas/cli-output/mutation-result.schema.json
+++ b/docs/schemas/cli-output/mutation-result.schema.json
@@ -1,0 +1,171 @@
+{
+  "$id": "https://polylogue.dev/schemas/cli-output/mutation-result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Shared result envelope for CLI, MCP, API, and daemon mutation surfaces. Used by tag, metadata, delete, and related bulk mutation actions to report status, affected counts, and optional session ids.\n\nGenerated from `polylogue.surfaces.payloads.MutationResultPayload` by `devtools render-cli-output-schemas`. Do not edit by hand.",
+  "properties": {
+    "affected_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Affected Count"
+    },
+    "applied_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Applied Count"
+    },
+    "detail": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Detail"
+    },
+    "key": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Key"
+    },
+    "operation": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Operation"
+    },
+    "outcome": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Outcome"
+    },
+    "session_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Session Count"
+    },
+    "session_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Session Id"
+    },
+    "session_ids": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Session Ids"
+    },
+    "skipped_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Skipped Count"
+    },
+    "status": {
+      "title": "Status",
+      "type": "string"
+    },
+    "tag": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tag"
+    },
+    "tag_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tag Count"
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "title": "Mutation Result",
+  "type": "object",
+  "x-polylogue-cli-surfaces": [
+    "polylogue find <query> then delete --dry-run",
+    "polylogue find <query> then delete --yes",
+    "MCP mutation tools",
+    "daemon mutation endpoints"
+  ],
+  "x-polylogue-source-model": "MutationResultPayload"
+}

--- a/docs/schemas/cli-output/query-error.schema.json
+++ b/docs/schemas/cli-output/query-error.schema.json
@@ -1,0 +1,53 @@
+{
+  "$id": "https://polylogue.dev/schemas/cli-output/query-error.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Shared typed error payload for daemon HTTP, MCP, and query/read surfaces that need field-addressable machine-readable failures.\n\nGenerated from `polylogue.surfaces.payloads.QueryErrorPayload` by `devtools render-cli-output-schemas`. Do not edit by hand.",
+  "properties": {
+    "detail": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Detail"
+    },
+    "error": {
+      "title": "Error",
+      "type": "string"
+    },
+    "field": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Field"
+    },
+    "ok": {
+      "const": false,
+      "default": false,
+      "title": "Ok",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "error"
+  ],
+  "title": "Query Error Payload",
+  "type": "object",
+  "x-polylogue-cli-surfaces": [
+    "GET /api/sessions?query=... (error path)",
+    "daemon query/read error responses",
+    "MCP query/read error responses"
+  ],
+  "x-polylogue-source-model": "QueryErrorPayload"
+}

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -25,6 +25,8 @@ from polylogue.cli.commands.config import config_command
 from polylogue.cli.query_group import _split_query_mode_args
 from tests.infra.app_env import make_app_env
 
+SCHEMAS_DIR = Path("docs/schemas/cli-output")
+
 GUARD_BEHAVIOR_COVERAGE: dict[str, str] = {
     "daemon_accepts_schedule": "test_import_contract_guard_requires_daemon_acceptance",
     "dry_run_or_yes_required": "test_delete_contract_guard_refuses_plain_forceless_delete",
@@ -35,6 +37,13 @@ GUARD_BEHAVIOR_COVERAGE: dict[str, str] = {
     "single_match_unless_all": "test_delete_contract_guard_requires_all_for_multi_match",
     "single_match_unless_all_or_first": "test_mark_contract_guard_requires_all_or_first_for_multi_match",
 }
+
+
+def _load_cli_output_schema(name: str) -> dict[str, object]:
+    target = SCHEMAS_DIR / f"{name}.schema.json"
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
 
 
 def _command_paths() -> dict[tuple[str, ...], click.Command]:
@@ -137,6 +146,21 @@ def test_default_format_is_declared_for_every_contract() -> None:
     assert not invalid, f"Contracts have default_format outside formats: {invalid}"
 
 
+def test_mutation_contracts_have_published_schema() -> None:
+    """Mutation action contracts must be backed by a generated JSON Schema."""
+    from devtools.render_cli_output_schemas import SCHEMAS
+    from polylogue.surfaces.payloads import MutationResultPayload
+
+    mutation_paths = sorted(entry.path for entry in ACTION_CONTRACTS if entry.machine_envelope == "mutation")
+    assert mutation_paths == [("delete",), ("import",), ("mark",)]
+
+    schema_by_name = {entry.name: entry for entry in SCHEMAS}
+    mutation_schema = schema_by_name.get("mutation-result")
+    assert mutation_schema is not None, "mutation-result schema missing from render_cli_output_schemas.SCHEMAS"
+    assert mutation_schema.model is MutationResultPayload
+    assert (SCHEMAS_DIR / "mutation-result.schema.json").exists()
+
+
 def test_delete_contract_guard_refuses_plain_forceless_delete(workspace_env: dict[str, Path]) -> None:
     """`dry_run_or_yes_required` is enforced by the public delete CLI."""
     _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
@@ -151,6 +175,21 @@ def test_delete_contract_guard_refuses_plain_forceless_delete(workspace_env: dic
     assert payload["status"] == "aborted"
     assert payload["detail"] == "confirmation_required"
     assert payload["affected_count"] == 0
+
+
+def test_delete_contract_aborted_payload_matches_mutation_schema(workspace_env: dict[str, Path]) -> None:
+    """The destructive-action guard emits the declared mutation envelope."""
+    import jsonschema
+
+    _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
+    schema = _load_cli_output_schema("mutation-result")
+
+    runner = CliRunner()
+    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=["session-1"]):
+        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete"])
+
+    assert result.exit_code == 0, result.output
+    jsonschema.validate(instance=json.loads(result.output), schema=schema)
 
 
 def test_delete_contract_guard_allows_dry_run_preview(workspace_env: dict[str, Path]) -> None:
@@ -169,6 +208,22 @@ def test_delete_contract_guard_allows_dry_run_preview(workspace_env: dict[str, P
     assert payload["session_count"] == len(session_ids)
     assert payload["affected_count"] == 0
     assert payload["session_ids"] == session_ids
+
+
+def test_delete_contract_preview_payload_matches_mutation_schema(workspace_env: dict[str, Path]) -> None:
+    """The dry-run destructive action emits a schema-valid mutation preview."""
+    import jsonschema
+
+    _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
+    schema = _load_cli_output_schema("mutation-result")
+
+    session_ids = ["session-1", "session-2"]
+    runner = CliRunner()
+    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=session_ids):
+        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    jsonschema.validate(instance=json.loads(result.output), schema=schema)
 
 
 def test_delete_contract_guard_requires_all_for_multi_match(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/cli/test_cli_output_schemas.py
+++ b/tests/unit/cli/test_cli_output_schemas.py
@@ -85,6 +85,36 @@ def test_machine_success_payload_validates_against_schema() -> None:
     jsonschema.validate(instance=instance, schema=schema)
 
 
+def test_mutation_result_payload_validates_against_schema() -> None:
+    """A real MutationResultPayload must validate against the published schema."""
+    import jsonschema
+
+    from polylogue.surfaces.payloads import MutationResultPayload
+
+    schema = _load_published_schema("mutation-result")
+    payload = MutationResultPayload(
+        status="preview",
+        operation="delete",
+        affected_count=0,
+        session_count=2,
+        session_ids=("session-a", "session-b"),
+    )
+    instance = payload.model_dump(mode="json", exclude_none=True)
+    jsonschema.validate(instance=instance, schema=schema)
+
+
+def test_query_error_payload_validates_against_schema() -> None:
+    """A real QueryErrorPayload must validate against the published schema."""
+    import jsonschema
+
+    from polylogue.surfaces.payloads import QueryErrorPayload
+
+    schema = _load_published_schema("query-error")
+    payload = QueryErrorPayload(error="invalid_cursor", detail="cursor expired", field="cursor")
+    instance = payload.model_dump(mode="json", exclude_none=True)
+    jsonschema.validate(instance=instance, schema=schema)
+
+
 def test_session_list_row_payload_validates_against_schema() -> None:
     """SessionListRowPayload must validate against the published schema."""
     import jsonschema


### PR DESCRIPTION
## Summary

Adds generated CLI output schemas for the shared mutation and query-error payloads, then binds #1816 action-contract mutation metadata to those schemas with executable tests.

## Problem

#1816 introduced `CliActionContract.machine_envelope`, and mutation actions (`mark`, `delete`, `import`) declare the `mutation` envelope. The generated `docs/schemas/cli-output/` surface did not publish `MutationResultPayload`, and no action-contract test validated real destructive-action machine output against a generated schema. That left the mutation-envelope claim partially prose-only.

## Solution

Issue slice: contract-derived machine-output/schema drift checks for mutation/error envelopes.

Files inspected: `polylogue/cli/action_contracts.py`, `polylogue/surfaces/payloads.py`, `devtools/render_cli_output_schemas.py`, `tests/unit/cli/test_cli_action_contracts.py`, `tests/unit/cli/test_cli_output_schemas.py`.

Files changed: `devtools/render_cli_output_schemas.py`, generated `docs/schemas/cli-output/*`, and the two focused CLI schema/contract test files.

Old surface removed or retained: retained the existing generated CLI-output schema surface; expanded it with `mutation-result.schema.json` and `query-error.schema.json` rather than adding a detached manifest.

Contracts/tests added: mutation action contracts must now have a published `MutationResultPayload` schema, and delete's aborted/dry-run outputs validate against it. The schema suite also validates representative `MutationResultPayload` and `QueryErrorPayload` instances.

Generated artifacts updated: regenerated `docs/schemas/cli-output/README.md`, `mutation-result.schema.json`, and `query-error.schema.json` with `devtools render-cli-output-schemas`.

Known caveats / SPEC_MISMATCH: this does not finish all #1816 remaining work; read-view item schemas and completion/help generation remain separate coherent phases.

Follow-up intentionally not included: no command-floor expansion, no new proof/catalog layer, no release-gate closure.

## Verification

- `devtools test tests/unit/cli/test_cli_action_contracts.py tests/unit/cli/test_cli_output_schemas.py` -> 36 passed.
- `devtools render-cli-output-schemas --check` -> sync OK for `docs/schemas/cli-output`.
- `devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.
- Attempted `devtools verify`; it stopped before tests because this fresh worktree has no pytest-testmon seed (`.testmondata` / `.cache/testmon/seed.json`).

Ref #1816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new JSON schemas for mutation result and query error CLI outputs with expanded schema documentation.

* **Tests**
  * Added validation tests to verify mutation and query error outputs conform to their schema specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->