### PR TITLE
test(cli): validate live output against schemas (#1849)

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -415,6 +415,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                         return
                     _emit_search(
                         page_hits,
+                        archive=archive,
                         query=similar_text or query,
                         limit=limit,
                         offset=page_offset,
@@ -529,6 +530,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 return
             _emit_search(
                 page_hits,
+                archive=archive,
                 query=similar_text or query,
                 limit=limit,
                 offset=page_offset,
@@ -1288,6 +1290,7 @@ def _emit_list(
 def _emit_search(
     hits: list[ArchiveSessionSearchHit],
     *,
+    archive: ArchiveStore,
     query: str,
     limit: int,
     offset: int,
@@ -1298,7 +1301,14 @@ def _emit_search(
     fields: str | None,
     typo_hint: str | None = None,
 ) -> None:
-    items = [_hit_payload(hit) for hit in hits]
+    items = [
+        _hit_payload(
+            hit,
+            summary=archive.read_summary(hit.session_id),
+            retrieval_lane=retrieval_lane,
+        )
+        for hit in hits
+    ]
     envelope: dict[str, object] = {
         "mode": "search",
         "origin": origin,
@@ -1524,22 +1534,27 @@ def _summary_payload(summary: ArchiveSessionSummary) -> dict[str, object]:
     )
 
 
-def _hit_payload(hit: ArchiveSessionSearchHit) -> dict[str, object]:
+def _hit_payload(
+    hit: ArchiveSessionSearchHit,
+    *,
+    summary: ArchiveSessionSummary,
+    retrieval_lane: str,
+) -> dict[str, object]:
     return cast(
         "dict[str, object]",
         model_json_document(
             SessionSearchHitPayload(
                 session=SessionSummaryPayload(
-                    id=hit.session_id,
-                    origin=hit.origin,
-                    title=hit.title or hit.session_id,
-                    message_count=0,
-                    target_ref=TargetRefPayload.session(hit.session_id),
-                    anchor=reader_anchor("session", hit.session_id),
+                    id=summary.session_id,
+                    origin=summary.origin,
+                    title=summary.title or summary.session_id,
+                    message_count=summary.message_count,
+                    target_ref=TargetRefPayload.session(summary.session_id),
+                    anchor=reader_anchor("session", summary.session_id),
                 ),
                 match=SessionSearchMatchPayload(
                     rank=hit.rank,
-                    retrieval_lane="dialogue",
+                    retrieval_lane=retrieval_lane,
                     match_surface="message",
                     target_ref=TargetRefPayload.message(session_id=hit.session_id, message_id=hit.message_id),
                     anchor=reader_anchor("message", hit.message_id),

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from contextlib import redirect_stdout
 from dataclasses import replace
 from pathlib import Path
-from typing import NoReturn, TypeVar
+from typing import NoReturn, TypeVar, cast
 from urllib.parse import quote
 
 import click
@@ -50,7 +50,15 @@ from polylogue.surfaces.payloads import (
     InvalidSearchCursorError,
     MutationResultPayload,
     SearchCursor,
+    SessionListRowPayload,
+    SessionSearchHitPayload,
+    SessionSearchMatchPayload,
+    SessionSummaryPayload,
+    TargetRefPayload,
     decode_search_cursor,
+    model_json_document,
+    reader_anchor,
+    reader_message_actions,
 )
 
 _PageRow = TypeVar("_PageRow", ArchiveSessionSummary, ArchiveSessionSearchHit)
@@ -1493,33 +1501,58 @@ def _csv(items: list[dict[str, object]]) -> str:
 
 
 def _summary_payload(summary: ArchiveSessionSummary) -> dict[str, object]:
-    return {
-        "id": summary.session_id,
-        "session_id": summary.session_id,
-        "native_id": summary.native_id,
-        "origin": summary.origin,
-        "source": summary.origin,
-        "title": summary.title,
-        "created_at": summary.created_at,
-        "updated_at": summary.updated_at,
-        "message_count": summary.message_count,
-        "word_count": summary.word_count,
-        "tags": list(summary.tags),
-    }
+    return cast(
+        "dict[str, object]",
+        model_json_document(
+            SessionListRowPayload(
+                id=summary.session_id,
+                origin=summary.origin,
+                title=summary.title or summary.session_id,
+                target_ref=TargetRefPayload.session(summary.session_id),
+                anchor=reader_anchor("session", summary.session_id),
+                created_at=summary.created_at,
+                updated_at=summary.updated_at,
+                message_count=summary.message_count,
+                messages=summary.message_count,
+                tags=summary.tags,
+                words=summary.word_count,
+                repo=summary.git_repository_url,
+                cwd_display=summary.working_directories[0] if summary.working_directories else None,
+            ),
+            exclude_none=True,
+        ),
+    )
 
 
 def _hit_payload(hit: ArchiveSessionSearchHit) -> dict[str, object]:
-    return {
-        "rank": hit.rank,
-        "id": hit.session_id,
-        "session_id": hit.session_id,
-        "block_id": hit.block_id,
-        "message_id": hit.message_id,
-        "origin": hit.origin,
-        "source": hit.origin,
-        "title": hit.title,
-        "snippet": hit.snippet,
-    }
+    return cast(
+        "dict[str, object]",
+        model_json_document(
+            SessionSearchHitPayload(
+                session=SessionSummaryPayload(
+                    id=hit.session_id,
+                    origin=hit.origin,
+                    title=hit.title or hit.session_id,
+                    message_count=0,
+                    target_ref=TargetRefPayload.session(hit.session_id),
+                    anchor=reader_anchor("session", hit.session_id),
+                ),
+                match=SessionSearchMatchPayload(
+                    rank=hit.rank,
+                    retrieval_lane="dialogue",
+                    match_surface="message",
+                    target_ref=TargetRefPayload.message(session_id=hit.session_id, message_id=hit.message_id),
+                    anchor=reader_anchor("message", hit.message_id),
+                    actions=reader_message_actions(),
+                    message_id=hit.message_id,
+                    snippet=hit.snippet,
+                    score=None,
+                    score_kind=None,
+                ),
+            ),
+            exclude_none=True,
+        ),
+    )
 
 
 def _project_session_envelope(
@@ -1665,7 +1698,7 @@ def _ellipsize(value: str, max_width: int) -> str:
 
 
 def _summary_line(item: dict[str, object]) -> str:
-    session_id = str(item["session_id"])
+    session_id = str(item["id"])
     title = _ellipsize(str(item.get("title") or session_id), 50)
     date = str(item.get("updated_at") or item.get("created_at") or "unknown")[:10]
     origin = str(item["origin"])
@@ -1674,8 +1707,12 @@ def _summary_line(item: dict[str, object]) -> str:
 
 
 def _hit_line(item: dict[str, object]) -> str:
-    title = item.get("title") or item["session_id"]
-    return f"{item['rank']}. {item['origin']}  {title}  {item['snippet']}"
+    session = item.get("session")
+    match = item.get("match")
+    if not isinstance(session, dict) or not isinstance(match, dict):
+        return str(item)
+    title = session.get("title") or session.get("id")
+    return f"{match['rank']}. {session['origin']}  {title}  {match.get('snippet') or ''}"
 
 
 def _stats_by_line(item: dict[str, object]) -> str:

--- a/tests/unit/cli/test_cli_output_schemas.py
+++ b/tests/unit/cli/test_cli_output_schemas.py
@@ -37,6 +37,37 @@ def _load_published_schema(name: str) -> dict[str, object]:
     return loaded
 
 
+def _seed_live_cli_schema_fixture(cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seed a real archive row for live CLI output-schema checks."""
+    from polylogue.storage.index import rebuild_index
+    from tests.infra.storage_records import SessionBuilder, db_setup
+
+    monkeypatch.setenv("XDG_STATE_HOME", str(cli_workspace["state_dir"]))
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(cli_workspace["archive_root"]))
+    monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+
+    db_path = db_setup(cli_workspace)
+    (
+        SessionBuilder(db_path, "schema-live-output")
+        .provider("claude-code")
+        .title("Schema Live Output")
+        .add_message(role="user", text="schema fixture needle")
+        .add_message(role="assistant", text="schema fixture response")
+        .save()
+    )
+    rebuild_index()
+
+
+def _invoke_live_cli(args: list[str]) -> str:
+    from click.testing import CliRunner
+
+    from polylogue.cli import cli
+
+    result = CliRunner().invoke(cli, ["--plain", *args])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
 @pytest.mark.parametrize("entry", SCHEMAS, ids=lambda e: e.name)
 def test_published_schema_matches_current_model(entry: object) -> None:
     """Published JSON Schema files must be in sync with the Pydantic models.
@@ -216,3 +247,73 @@ def test_ndjson_empty_rows_render_empty_string() -> None:
 
     document = StructuredRowsDocument(rows=(), csv_headers=(), csv_rows=(), text_lines=())
     assert document.render("ndjson") == ""
+
+
+def test_live_list_json_rows_validate_against_schema(
+    cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real `polylogue list --format json` rows validate against the published schema."""
+    import jsonschema
+
+    _seed_live_cli_schema_fixture(cli_workspace, monkeypatch)
+    schema = _load_published_schema("session-list-row")
+
+    payload = json.loads(_invoke_live_cli(["list", "-f", "json"]))
+    assert isinstance(payload, dict)
+    rows = payload.get("items")
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    jsonschema.validate(instance=rows[0], schema=schema)
+    assert rows[0]["title"] == "Schema Live Output"
+
+
+def test_live_list_ndjson_rows_validate_against_schema(
+    cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real `polylogue list --format ndjson` rows validate line-by-line."""
+    import jsonschema
+
+    _seed_live_cli_schema_fixture(cli_workspace, monkeypatch)
+    schema = _load_published_schema("session-list-row")
+
+    lines = [line for line in _invoke_live_cli(["list", "-f", "ndjson"]).splitlines() if line]
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    jsonschema.validate(instance=row, schema=schema)
+    assert row["title"] == "Schema Live Output"
+
+
+def test_live_search_json_rows_validate_against_schema(
+    cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real query-mode JSON rows validate against the search-hit schema."""
+    import jsonschema
+
+    _seed_live_cli_schema_fixture(cli_workspace, monkeypatch)
+    schema = _load_published_schema("session-search-hit")
+
+    payload = json.loads(_invoke_live_cli(["find", "schema", "-f", "json"]))
+    assert isinstance(payload, dict)
+    rows = payload.get("items")
+    assert isinstance(rows, list)
+    assert rows
+    jsonschema.validate(instance=rows[0], schema=schema)
+    assert rows[0]["session"]["title"] == "Schema Live Output"
+    assert rows[0]["match"]["snippet"]
+
+
+def test_live_search_ndjson_rows_validate_against_schema(
+    cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real query-mode NDJSON rows validate line-by-line against the search-hit schema."""
+    import jsonschema
+
+    _seed_live_cli_schema_fixture(cli_workspace, monkeypatch)
+    schema = _load_published_schema("session-search-hit")
+
+    lines = [line for line in _invoke_live_cli(["find", "schema", "-f", "ndjson"]).splitlines() if line]
+    assert lines
+    row = json.loads(lines[0])
+    jsonschema.validate(instance=row, schema=schema)
+    assert row["session"]["title"] == "Schema Live Output"
+    assert row["match"]["snippet"]

--- a/tests/unit/cli/test_cli_output_schemas.py
+++ b/tests/unit/cli/test_cli_output_schemas.py
@@ -299,6 +299,8 @@ def test_live_search_json_rows_validate_against_schema(
     assert rows
     jsonschema.validate(instance=rows[0], schema=schema)
     assert rows[0]["session"]["title"] == "Schema Live Output"
+    assert rows[0]["session"]["message_count"] == 2
+    assert rows[0]["match"]["retrieval_lane"] == payload["retrieval_lane"]
     assert rows[0]["match"]["snippet"]
 
 
@@ -316,4 +318,6 @@ def test_live_search_ndjson_rows_validate_against_schema(
     row = json.loads(lines[0])
     jsonschema.validate(instance=row, schema=schema)
     assert row["session"]["title"] == "Schema Live Output"
+    assert row["session"]["message_count"] == 2
+    assert row["match"]["retrieval_lane"] == "dialogue"
     assert row["match"]["snippet"]


### PR DESCRIPTION
## Summary

Routes archive-query list/search machine rows through the shared surface payload models and adds fixture-backed CLI tests proving the live JSON and NDJSON rows validate against the published output schemas.

## Problem

#1849 still had a gap between generated schema/model tests and the real CLI emitter. The published `session-list-row` and `session-search-hit` schemas described the stable payload models, but `polylogue list/find -f json|ndjson` on the archive-query path still emitted legacy flattened dictionaries. That meant downstream agents could trust a schema that the live fixture output did not actually satisfy.

## Solution

`polylogue/cli/archive_query.py` now builds list rows with `SessionListRowPayload` and search rows with `SessionSearchHitPayload`/`SessionSearchMatchPayload`, then serializes via `model_json_document`. Plain-text renderers were adjusted to read the canonical row shapes. `tests/unit/cli/test_cli_output_schemas.py` now seeds a real archive fixture through `SessionBuilder`, invokes the Click CLI, and validates live list/search JSON and NDJSON rows against `docs/schemas/cli-output/*.schema.json`.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_cli_output_schemas.py` -> `21 passed`
- `nix develop --command devtools render-cli-output-schemas --check` -> `sync OK: docs/schemas/cli-output`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- `git push` pre-push quick gate -> `exit_code: 0`

I also attempted the default `devtools verify` baseline. In this fresh worktree it required `devtools verify --seed-testmon --skip-slow`; that seed run stalled for several minutes in unrelated baseline nodes (`tests/property/test_filter_chain_laws.py` and `tests/unit/storage/test_store_ops.py`) and was terminated rather than overlap another pytest run in the same checkout.

Ref #1849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added schema validation for `polylogue list` command JSON and NDJSON outputs
  * Added schema validation for `polylogue find` command JSON and NDJSON outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->