### PR TITLE
test(cli): publish read message output schemas (#1816)

### DIFF
--- a/devtools/render_cli_output_schemas.py
+++ b/devtools/render_cli_output_schemas.py
@@ -30,6 +30,8 @@ from polylogue.surfaces.payloads import (
     QueryErrorPayload,
     SearchEnvelope,
     SessionListRowPayload,
+    SessionMessageRowPayload,
+    SessionMessagesResponsePayload,
     SessionNeighborCandidatePayload,
     SessionSearchHitPayload,
     SessionSummaryPayload,
@@ -75,6 +77,26 @@ SCHEMAS: tuple[CliOutputSchema, ...] = (
             "polylogue stats --format json (rows)",
             "polylogue select --format json",
         ),
+    ),
+    CliOutputSchema(
+        name="session-message-row",
+        title="Session Message Row",
+        description=(
+            "One message row emitted by `polylogue read --view messages --format ndjson` "
+            "and embedded inside the finite messages response."
+        ),
+        model=SessionMessageRowPayload,
+        surfaces=(
+            "polylogue read --view messages --format ndjson",
+            "polylogue read --view messages --format json (messages[])",
+        ),
+    ),
+    CliOutputSchema(
+        name="session-messages-response",
+        title="Session Messages Response",
+        description=("Finite response for `polylogue read --view messages --format json`."),
+        model=SessionMessagesResponsePayload,
+        surfaces=("polylogue read --view messages --format json",),
     ),
     CliOutputSchema(
         name="session-search-hit",

--- a/docs/schemas/cli-output/README.md
+++ b/docs/schemas/cli-output/README.md
@@ -17,6 +17,8 @@ devtools render-cli-output-schemas --check # CI sync check
 | --- | --- | --- |
 | [`session-list-row.schema.json`](./session-list-row.schema.json) | `polylogue list --format json`<br>`polylogue list --format ndjson`<br>`polylogue list --format yaml` | `SessionListRowPayload` |
 | [`session-summary.schema.json`](./session-summary.schema.json) | `polylogue stats --format json (rows)`<br>`polylogue select --format json` | `SessionSummaryPayload` |
+| [`session-message-row.schema.json`](./session-message-row.schema.json) | `polylogue read --view messages --format ndjson`<br>`polylogue read --view messages --format json (messages[])` | `SessionMessageRowPayload` |
+| [`session-messages-response.schema.json`](./session-messages-response.schema.json) | `polylogue read --view messages --format json` | `SessionMessagesResponsePayload` |
 | [`session-search-hit.schema.json`](./session-search-hit.schema.json) | `polylogue --format json <query>`<br>`polylogue --format ndjson <query>` | `SessionSearchHitPayload` |
 | [`search-envelope.schema.json`](./search-envelope.schema.json) | `polylogue --format json <query>`<br>`GET /api/sessions?query=...` | `SearchEnvelope` |
 | [`session-neighbor-candidate.schema.json`](./session-neighbor-candidate.schema.json) | `polylogue neighbors --format json` | `SessionNeighborCandidatePayload` |

--- a/docs/schemas/cli-output/session-message-row.schema.json
+++ b/docs/schemas/cli-output/session-message-row.schema.json
@@ -1,0 +1,338 @@
+{
+  "$defs": {
+    "ReaderActionAvailabilityPayload": {
+      "additionalProperties": false,
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "properties": {
+        "disabled_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Disabled Reason"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "title": "ReaderActionAvailabilityPayload",
+      "type": "object"
+    },
+    "TargetRefPayload": {
+      "additionalProperties": false,
+      "description": "Stable reader target reference for selectable archive objects.",
+      "properties": {
+        "block_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Block Index"
+        },
+        "identity_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identity Key"
+        },
+        "message_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message Id"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
+        "target_id": {
+          "title": "Target Id",
+          "type": "string"
+        },
+        "target_type": {
+          "enum": [
+            "session",
+            "message"
+          ],
+          "title": "Target Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_type",
+        "target_id"
+      ],
+      "title": "TargetRefPayload",
+      "type": "object"
+    }
+  },
+  "$id": "https://polylogue.dev/schemas/cli-output/session-message-row.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One message row emitted by `polylogue read --view messages --format ndjson` and embedded inside the finite messages response.\n\nGenerated from `polylogue.surfaces.payloads.SessionMessageRowPayload` by `devtools render-cli-output-schemas`. Do not edit by hand.",
+  "properties": {
+    "actions": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ReaderActionAvailabilityPayload"
+      },
+      "title": "Actions",
+      "type": "object"
+    },
+    "anchor": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Anchor"
+    },
+    "attachment_refs": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Attachment Refs",
+      "type": "array"
+    },
+    "branch_index": {
+      "default": 0,
+      "title": "Branch Index",
+      "type": "integer"
+    },
+    "cache_read_tokens": {
+      "default": 0,
+      "title": "Cache Read Tokens",
+      "type": "integer"
+    },
+    "cache_write_tokens": {
+      "default": 0,
+      "title": "Cache Write Tokens",
+      "type": "integer"
+    },
+    "content_blocks": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Content Blocks",
+      "type": "array"
+    },
+    "has_paste": {
+      "default": false,
+      "title": "Has Paste",
+      "type": "boolean"
+    },
+    "has_thinking": {
+      "default": false,
+      "title": "Has Thinking",
+      "type": "boolean"
+    },
+    "has_tool_use": {
+      "default": false,
+      "title": "Has Tool Use",
+      "type": "boolean"
+    },
+    "id": {
+      "title": "Id",
+      "type": "string"
+    },
+    "input_tokens": {
+      "default": 0,
+      "title": "Input Tokens",
+      "type": "integer"
+    },
+    "message_type": {
+      "default": "message",
+      "title": "Message Type",
+      "type": "string"
+    },
+    "model_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Name"
+    },
+    "output_tokens": {
+      "default": 0,
+      "title": "Output Tokens",
+      "type": "integer"
+    },
+    "parent_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Parent Id"
+    },
+    "paste_boundary_state": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Paste Boundary State"
+    },
+    "raw_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Raw Id"
+    },
+    "role": {
+      "title": "Role",
+      "type": "string"
+    },
+    "session_id": {
+      "title": "Session Id",
+      "type": "string"
+    },
+    "source_path": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Path"
+    },
+    "target_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TargetRefPayload"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "text": {
+      "title": "Text",
+      "type": "string"
+    },
+    "timestamp": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timestamp"
+    }
+  },
+  "required": [
+    "id",
+    "role",
+    "text",
+    "session_id"
+  ],
+  "title": "Session Message Row",
+  "type": "object",
+  "x-polylogue-cli-surfaces": [
+    "polylogue read --view messages --format ndjson",
+    "polylogue read --view messages --format json (messages[])"
+  ],
+  "x-polylogue-source-model": "SessionMessageRowPayload"
+}

--- a/docs/schemas/cli-output/session-messages-response.schema.json
+++ b/docs/schemas/cli-output/session-messages-response.schema.json
@@ -1,0 +1,375 @@
+{
+  "$defs": {
+    "ReaderActionAvailabilityPayload": {
+      "additionalProperties": false,
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "properties": {
+        "disabled_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Disabled Reason"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "title": "ReaderActionAvailabilityPayload",
+      "type": "object"
+    },
+    "SessionMessageRowPayload": {
+      "additionalProperties": false,
+      "description": "One `read --view messages` machine-output row.",
+      "properties": {
+        "actions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ReaderActionAvailabilityPayload"
+          },
+          "title": "Actions",
+          "type": "object"
+        },
+        "anchor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Anchor"
+        },
+        "attachment_refs": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Attachment Refs",
+          "type": "array"
+        },
+        "branch_index": {
+          "default": 0,
+          "title": "Branch Index",
+          "type": "integer"
+        },
+        "cache_read_tokens": {
+          "default": 0,
+          "title": "Cache Read Tokens",
+          "type": "integer"
+        },
+        "cache_write_tokens": {
+          "default": 0,
+          "title": "Cache Write Tokens",
+          "type": "integer"
+        },
+        "content_blocks": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Content Blocks",
+          "type": "array"
+        },
+        "has_paste": {
+          "default": false,
+          "title": "Has Paste",
+          "type": "boolean"
+        },
+        "has_thinking": {
+          "default": false,
+          "title": "Has Thinking",
+          "type": "boolean"
+        },
+        "has_tool_use": {
+          "default": false,
+          "title": "Has Tool Use",
+          "type": "boolean"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "input_tokens": {
+          "default": 0,
+          "title": "Input Tokens",
+          "type": "integer"
+        },
+        "message_type": {
+          "default": "message",
+          "title": "Message Type",
+          "type": "string"
+        },
+        "model_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model Name"
+        },
+        "output_tokens": {
+          "default": 0,
+          "title": "Output Tokens",
+          "type": "integer"
+        },
+        "parent_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Id"
+        },
+        "paste_boundary_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Paste Boundary State"
+        },
+        "raw_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Id"
+        },
+        "role": {
+          "title": "Role",
+          "type": "string"
+        },
+        "session_id": {
+          "title": "Session Id",
+          "type": "string"
+        },
+        "source_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Path"
+        },
+        "target_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TargetRefPayload"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Timestamp"
+        }
+      },
+      "required": [
+        "id",
+        "role",
+        "text",
+        "session_id"
+      ],
+      "title": "SessionMessageRowPayload",
+      "type": "object"
+    },
+    "TargetRefPayload": {
+      "additionalProperties": false,
+      "description": "Stable reader target reference for selectable archive objects.",
+      "properties": {
+        "block_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Block Index"
+        },
+        "identity_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identity Key"
+        },
+        "message_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message Id"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
+        "target_id": {
+          "title": "Target Id",
+          "type": "string"
+        },
+        "target_type": {
+          "enum": [
+            "session",
+            "message"
+          ],
+          "title": "Target Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_type",
+        "target_id"
+      ],
+      "title": "TargetRefPayload",
+      "type": "object"
+    }
+  },
+  "$id": "https://polylogue.dev/schemas/cli-output/session-messages-response.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Finite response for `polylogue read --view messages --format json`.\n\nGenerated from `polylogue.surfaces.payloads.SessionMessagesResponsePayload` by `devtools render-cli-output-schemas`. Do not edit by hand.",
+  "properties": {
+    "limit": {
+      "title": "Limit",
+      "type": "integer"
+    },
+    "messages": {
+      "items": {
+        "$ref": "#/$defs/SessionMessageRowPayload"
+      },
+      "title": "Messages",
+      "type": "array"
+    },
+    "offset": {
+      "title": "Offset",
+      "type": "integer"
+    },
+    "session_id": {
+      "title": "Session Id",
+      "type": "string"
+    },
+    "total": {
+      "title": "Total",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "session_id",
+    "messages",
+    "total",
+    "limit",
+    "offset"
+  ],
+  "title": "Session Messages Response",
+  "type": "object",
+  "x-polylogue-cli-surfaces": [
+    "polylogue read --view messages --format json"
+  ],
+  "x-polylogue-source-model": "SessionMessagesResponsePayload"
+}

--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -14,6 +14,11 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 from polylogue.config import Config
 from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
+from polylogue.surfaces.payloads import (
+    SessionMessageRowPayload,
+    SessionMessagesResponsePayload,
+    model_json_document,
+)
 
 
 def run_messages(
@@ -64,24 +69,30 @@ def run_messages(
             fmt = output_format or "markdown"
 
             def _message_document(m: object) -> dict[str, object]:
-                return {
-                    "id": str(m.id),  # type: ignore[attr-defined]
-                    "role": str(m.role),  # type: ignore[attr-defined]
-                    "message_type": str(m.message_type.value),  # type: ignore[attr-defined]
-                    "text": m.text or "",  # type: ignore[attr-defined]
-                }
+                return cast(
+                    "dict[str, object]",
+                    model_json_document(
+                        SessionMessageRowPayload.from_message(m, session_id=session_id),  # type: ignore[arg-type]
+                        exclude_none=True,
+                    ),
+                )
 
             if fmt == "json":
                 import json as _json
 
                 # Finite machine-output contract (#1818): one JSON value.
-                payload = {
-                    "session_id": session_id,
-                    "messages": [_message_document(m) for m in messages],
-                    "total": total,
-                    "limit": limit,
-                    "offset": offset,
-                }
+                payload = model_json_document(
+                    SessionMessagesResponsePayload(
+                        session_id=session_id,
+                        messages=tuple(
+                            SessionMessageRowPayload.from_message(m, session_id=session_id) for m in messages
+                        ),
+                        total=total,
+                        limit=limit,
+                        offset=offset,
+                    ),
+                    exclude_none=True,
+                )
                 # Machine output goes through click.echo (raw stdout), NOT
                 # env.ui.print: the Rich console defaults markup=True and would
                 # interpret/strip bracket sequences like "[bold]" inside message

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -362,6 +362,32 @@ class SessionMessagePayload(SurfacePayloadModel):
         )
 
 
+class SessionMessageRowPayload(SessionMessagePayload):
+    """One `read --view messages` machine-output row."""
+
+    session_id: str
+
+    @classmethod
+    def from_message(
+        cls,
+        message: Message,
+        *,
+        session_id: object | None = None,
+        raw_id: str | None = None,
+        source_path: str | None = None,
+    ) -> SessionMessageRowPayload:
+        if session_id is None:
+            msg_id = getattr(message, "id", "<unknown>")
+            raise ValueError(f"SessionMessageRowPayload requires session_id for message {msg_id}")
+        base = SessionMessagePayload.from_message(
+            message,
+            session_id=session_id,
+            raw_id=raw_id,
+            source_path=source_path,
+        )
+        return cls(session_id=str(session_id), **base.model_dump())
+
+
 class SessionSummaryPayload(SurfacePayloadModel):
     """Compact session summary payload used by MCP/search surfaces."""
 
@@ -1121,6 +1147,16 @@ class SessionDetailResponse(SurfacePayloadModel):
     session: SessionDetailPayload
 
 
+class SessionMessagesResponsePayload(SurfacePayloadModel):
+    """Finite `read --view messages --format json` response."""
+
+    session_id: str
+    messages: tuple[SessionMessageRowPayload, ...]
+    total: int
+    limit: int
+    offset: int
+
+
 class FacetTimeRange(SurfacePayloadModel):
     """Time range boundary for facet results."""
 
@@ -1357,6 +1393,8 @@ __all__ = [
     "SessionFlagsPayload",
     "SessionListResponse",
     "SessionListRowPayload",
+    "SessionMessageRowPayload",
+    "SessionMessagesResponsePayload",
     "SessionMessagePayload",
     "ContextPreamble",
     "ContextPreambleBlackboardNote",

--- a/tests/unit/cli/test_messages.py
+++ b/tests/unit/cli/test_messages.py
@@ -14,6 +14,14 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 from polylogue.config import Config
 
+SCHEMAS_DIR = Path("docs/schemas/cli-output")
+
+
+def _load_schema(name: str) -> dict[str, object]:
+    loaded = json.loads((SCHEMAS_DIR / f"{name}.schema.json").read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
 
 class _FakeApi:
     def __init__(
@@ -48,10 +56,31 @@ class _FakeApi:
             raise SessionNotFoundError("missing")
         msgs, total = self.messages_result
         # Convert dicts to fake objects with attribute access for Message compat
+        defaults: dict[str, object] = {
+            "blocks": [],
+            "parent_id": None,
+            "timestamp": None,
+            "attachments": (),
+            "branch_index": 0,
+            "has_paste": False,
+            "has_tool_use": False,
+            "has_thinking": False,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "model_name": None,
+        }
         objs = (
             [
                 type(
-                    "_FakeMsg", (), {**m, "message_type": type("_FakeMT", (), {"value": m.get("message_type", "")})()}
+                    "_FakeMsg",
+                    (),
+                    {
+                        **defaults,
+                        **m,
+                        "message_type": type("_FakeMT", (), {"value": m.get("message_type", "")})(),
+                    },
                 )()
                 for m in msgs
             ]
@@ -139,6 +168,8 @@ def test_run_messages_emits_json_and_passes_projection(tmp_path: Path, capsys: p
 
 def test_run_messages_json_is_single_finite_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """`read --view messages --format json` emits one finite JSON value (#1818)."""
+    import jsonschema
+
     env = _env()
     api = _FakeApi(
         messages_result=(
@@ -157,6 +188,7 @@ def test_run_messages_json_is_single_finite_document(tmp_path: Path, capsys: pyt
 
     # Output is a single finite JSON value on stdout (one json.loads succeeds).
     payload = json.loads(capsys.readouterr().out)
+    jsonschema.validate(instance=payload, schema=_load_schema("session-messages-response"))
     assert payload["session_id"] == "conv-1"
     assert [m["text"] for m in payload["messages"]] == ["[bold]first[/bold]", "second"]
     assert payload["total"] == 2
@@ -166,6 +198,8 @@ def test_run_messages_ndjson_emits_one_json_document_per_line(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """`--format ndjson` streams one parseable JSON document per message (#1818)."""
+    import jsonschema
+
     env = _env()
     api = _FakeApi(
         messages_result=(
@@ -183,6 +217,9 @@ def test_run_messages_ndjson_emits_one_json_document_per_line(
     lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
     assert len(lines) == 2
     docs = [json.loads(line) for line in lines]  # each line parses independently
+    schema = _load_schema("session-message-row")
+    for doc in docs:
+        jsonschema.validate(instance=doc, schema=schema)
     # Rich markup in text survives byte-for-byte (raw click.echo, no console markup).
     assert [d["text"] for d in docs] == ["[bold]first[/bold]", "second"]
     assert all(d["session_id"] == "conv-1" for d in docs)


### PR DESCRIPTION
## Summary

Publishes schema-backed machine-output contracts for `read --view messages` and routes the message JSON/NDJSON emitter through typed payload models.

## Problem

#1816 had generated schemas for list/search/mutation/error surfaces, but the messages read view still built ad hoc dictionaries. That left `read --view messages --format json` and `--format ndjson` outside the code-coupled schema contract even though they are stable machine-readable read surfaces.

## Solution

Adds `SessionMessageRowPayload` and `SessionMessagesResponsePayload`, registers generated `session-message-row` and `session-messages-response` schemas, and updates `run_messages` to serialize JSON/NDJSON through those models. The existing message tests now validate the finite JSON response and each NDJSON line against the generated schemas.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_messages.py tests/unit/cli/test_cli_output_schemas.py` -> `28 passed`
- `nix develop --command devtools render-cli-output-schemas --check` -> `sync OK: docs/schemas/cli-output`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- `git push` pre-push quick gate -> `exit_code: 0`

Ref #1816