### PR TITLE
test(contracts): derive mutation guards from operation specs (#1849)

### DIFF
--- a/polylogue/operations/__init__.py
+++ b/polylogue/operations/__init__.py
@@ -24,6 +24,7 @@ from .specs import (
     OperationCatalog,
     OperationKind,
     OperationSpec,
+    SafetyGuard,
     build_declared_operation_catalog,
     build_runtime_operation_catalog,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "OperationSpec",
     "OperationStatus",
     "RawFailureSample",
+    "SafetyGuard",
     "bounded_failure_samples",
     "build_declared_operation_catalog",
     "build_runtime_operation_catalog",

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -617,6 +617,8 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         code_refs=(
             "polylogue.storage.repository.archive.writes.sessions.delete_session_via_backend",
             "polylogue.api.archive.PolylogueArchiveMixin.delete_session",
+            "polylogue.cli.query_verbs.delete_verb",
+            "polylogue.cli.archive_query._emit_delete",
             "polylogue.mcp.server_mutation_tools.delete_session",
         ),
         surfaces=("facade", "cli", "mcp", "daemon"),

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -24,6 +24,9 @@ must check:
   Destructive → explicit_dry_run_evidence, confirmed_before_execute
 """
 
+SafetyGuard = Literal["write_role_required", "confirmed_before_execute", "explicit_dry_run_evidence"]
+"""Declared safety guard that a mutating operation's public surfaces must enforce."""
+
 
 class OperationKind(str, Enum):
     """High-level operation class over runtime artifacts."""
@@ -56,6 +59,7 @@ class OperationSpec:
     previewable: bool = False
     idempotent: bool = True
     effects: tuple[Effect, ...] = ()
+    safety_guards: tuple[SafetyGuard, ...] = ()
 
     def to_dict(self) -> JSONDocument:
         return json_document(
@@ -72,6 +76,7 @@ class OperationSpec:
                 "previewable": self.previewable,
                 "idempotent": self.idempotent,
                 "effects": list(self.effects),
+                "safety_guards": list(self.safety_guards),
             }
         )
 
@@ -537,6 +542,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
     ),
     OperationSpec(
         name="mutate-remove-tag",
@@ -553,6 +559,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
     ),
     OperationSpec(
         name="mutate-bulk-tag-sessions",
@@ -566,6 +573,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
     ),
     OperationSpec(
         name="mutate-set-metadata",
@@ -583,6 +591,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
     ),
     OperationSpec(
         name="mutate-delete-metadata",
@@ -596,6 +605,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
     ),
     OperationSpec(
         name="mutate-delete-session",
@@ -614,6 +624,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         previewable=False,
         idempotent=True,
         effects=("DbRead", "DbWrite", "Destructive"),
+        safety_guards=("write_role_required", "confirmed_before_execute", "explicit_dry_run_evidence"),
     ),
     OperationSpec(
         name="project-archive-readiness",
@@ -810,4 +821,5 @@ __all__ = [
     "OperationKind",
     "OperationSpec",
     "RUNTIME_OPERATION_SPECS",
+    "SafetyGuard",
 ]

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -43,6 +43,7 @@ from polylogue.cli.archive_query import (
     _transform,
     _tuple_tokens,
 )
+from polylogue.operations import OperationSpec, build_runtime_operation_catalog
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary
 from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow
 
@@ -637,7 +638,7 @@ class TestSummaryLine:
     def test_summary_line_format(self) -> None:
         """Summary line contains expected fields."""
         item: dict[str, object] = {
-            "session_id": "abc123def456",
+            "id": "abc123def456",
             "title": "Test Session",
             "created_at": "2026-01-15T10:00:00Z",
             "updated_at": "2026-01-15T11:00:00Z",
@@ -654,7 +655,7 @@ class TestSummaryLine:
     def test_summary_line_missing_title(self) -> None:
         """Missing title falls back to session_id."""
         item: dict[str, object] = {
-            "session_id": "abc123",
+            "id": "abc123",
             "origin": "chatgpt-export",
             "created_at": "2026-01-15T10:00:00Z",
         }
@@ -906,6 +907,10 @@ class TestEmitDeleteMachineModeNoPrompt:
     """
 
     @staticmethod
+    def _delete_spec() -> OperationSpec:
+        return build_runtime_operation_catalog().by_name()["mutate-delete-session"]
+
+    @staticmethod
     def _env(*, plain: bool) -> MagicMock:
         env = MagicMock()
         env.ui.plain = plain
@@ -919,6 +924,11 @@ class TestEmitDeleteMachineModeNoPrompt:
         return archive
 
     def test_plain_forceless_delete_aborts_without_prompt(self, capsys: pytest.CaptureFixture[str]) -> None:
+        spec = self._delete_spec()
+        assert "Destructive" in spec.effects
+        assert "confirmed_before_execute" in spec.safety_guards
+        assert "cli" in spec.surfaces
+
         env = self._env(plain=True)
         archive = self._archive()
 
@@ -932,6 +942,24 @@ class TestEmitDeleteMachineModeNoPrompt:
         assert payload["detail"] == "confirmation_required"
         assert payload["session_count"] == 2
         assert payload["affected_count"] == 0
+
+    def test_dry_run_evidence_lists_matched_sessions(self, capsys: pytest.CaptureFixture[str]) -> None:
+        spec = self._delete_spec()
+        assert "explicit_dry_run_evidence" in spec.safety_guards
+
+        env = self._env(plain=True)
+        archive = self._archive()
+
+        _emit_delete(env, archive, ("s1", "s2"), params={"force": False, "dry_run": True})
+
+        env.ui.confirm.assert_not_called()
+        archive.delete_sessions.assert_not_called()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "preview"
+        assert payload["operation"] == "delete"
+        assert payload["session_count"] == 2
+        assert payload["affected_count"] == 0
+        assert payload["session_ids"] == ["s1", "s2"]
 
     def test_plain_forced_delete_proceeds_without_prompt(self, capsys: pytest.CaptureFixture[str]) -> None:
         env = self._env(plain=True)

--- a/tests/unit/daemon/test_daemon_http_contracts.py
+++ b/tests/unit/daemon/test_daemon_http_contracts.py
@@ -614,6 +614,7 @@ _DECLARED_NAME_RE = re.compile(r"^[a-z][a-z0-9\-]*(\.[a-z][a-z0-9\-]*)*$")
 _CODE_REF_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$")
 _KNOWN_EFFECTS = frozenset({"Pure", "DbRead", "DbWrite", "FileWrite", "Network", "LiveArchive", "Destructive"})
 _MUTATING_EFFECTS = frozenset({"DbWrite", "FileWrite", "Destructive"})
+_KNOWN_SAFETY_GUARDS = frozenset({"write_role_required", "confirmed_before_execute", "explicit_dry_run_evidence"})
 
 
 @pytest.mark.contract
@@ -661,6 +662,18 @@ class TestOperationSpecContract:
                     issues.append(f"unknown effects: {unknown}")
             if any(e in _MUTATING_EFFECTS for e in spec.effects) and not spec.mutates_state:
                 issues.append("mutating effects but mutates_state=False")
+            unknown_guards = [guard for guard in spec.safety_guards if guard not in _KNOWN_SAFETY_GUARDS]
+            if unknown_guards:
+                issues.append(f"unknown safety_guards: {unknown_guards}")
+            if spec.mutates_state and "mcp" in spec.surfaces and "write_role_required" not in spec.safety_guards:
+                issues.append("mutating MCP surface but no write_role_required guard")
+            if "Destructive" in spec.effects:
+                missing_guards = {
+                    "confirmed_before_execute",
+                    "explicit_dry_run_evidence",
+                } - set(spec.safety_guards)
+                if missing_guards:
+                    issues.append(f"destructive operation missing safety guards: {sorted(missing_guards)}")
             if issues:
                 offenders.append(f"{spec.name}: {'; '.join(issues)}")
 
@@ -688,6 +701,9 @@ class TestOperationSpecContract:
                 unknown = [e for e in spec.effects if e not in _KNOWN_EFFECTS]
                 if unknown:
                     issues.append(f"unknown effects: {unknown}")
+            unknown_guards = [guard for guard in spec.safety_guards if guard not in _KNOWN_SAFETY_GUARDS]
+            if unknown_guards:
+                issues.append(f"unknown safety_guards: {unknown_guards}")
             if issues:
                 offenders.append(f"{spec.name}: {'; '.join(issues)}")
 

--- a/tests/unit/mcp/test_per_tool_contracts.py
+++ b/tests/unit/mcp/test_per_tool_contracts.py
@@ -95,6 +95,11 @@ MUTATION_TOOL_NAMES: frozenset[str] = _discover_mutation_tool_names()
 _CONV_ID = "test:conv-mutation"
 _LONG_STRING = "x" * 10_000
 _DELETE_SESSION_SPEC = build_runtime_operation_catalog().by_name()["mutate-delete-session"]
+_MCP_MUTATION_OPERATION_SPECS = tuple(
+    spec
+    for spec in build_runtime_operation_catalog().specs
+    if spec.mutates_state and "mcp" in spec.surfaces and "write_role_required" in spec.safety_guards
+)
 
 TOOL_MATRIX: dict[str, dict[str, Any]] = {
     "add_tag": {
@@ -292,6 +297,18 @@ class TestMutationToolDiscovery:
         # (marks, annotations, saved views, recall packs, workspaces,
         # tags, metadata, delete_session, learning corrections).
         assert len(MUTATION_TOOL_NAMES) >= 20, sorted(MUTATION_TOOL_NAMES)
+
+    @pytest.mark.parametrize("spec", _MCP_MUTATION_OPERATION_SPECS, ids=lambda spec: spec.name)
+    def test_mcp_mutation_operation_spec_names_registered_tool(self, spec: Any) -> None:
+        tool_refs = tuple(ref for ref in spec.code_refs if ref.startswith("polylogue.mcp.server_mutation_tools."))
+        assert tool_refs, f"{spec.name} declares mcp surface but no server_mutation_tools code_ref"
+        referenced_tools = {ref.rsplit(".", 1)[-1] for ref in tool_refs}
+        missing = referenced_tools - MUTATION_TOOL_NAMES
+        assert not missing, (
+            f"{spec.name} references MCP mutation tools not registered by register_mutation_tools: {sorted(missing)}"
+        )
+        uncovered = referenced_tools - set(TOOL_MATRIX)
+        assert not uncovered, f"{spec.name} references MCP mutation tools missing TOOL_MATRIX rows: {sorted(uncovered)}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_per_tool_contracts.py
+++ b/tests/unit/mcp/test_per_tool_contracts.py
@@ -31,6 +31,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from polylogue.operations import build_runtime_operation_catalog
 from polylogue.surfaces.payloads import (
     BulkTagMutationResult,
     DeleteSessionResult,
@@ -93,6 +94,7 @@ MUTATION_TOOL_NAMES: frozenset[str] = _discover_mutation_tool_names()
 
 _CONV_ID = "test:conv-mutation"
 _LONG_STRING = "x" * 10_000
+_DELETE_SESSION_SPEC = build_runtime_operation_catalog().by_name()["mutate-delete-session"]
 
 TOOL_MATRIX: dict[str, dict[str, Any]] = {
     "add_tag": {
@@ -584,10 +586,12 @@ class TestMutationToolIdempotency:
         admin_server: MCPServerUnderTest,
         patched_mutation_seam: Any,
     ) -> None:
-        """``delete_session`` without ``confirm=true`` must return a
-        structured error envelope (safety guard). Confirmed delete must
-        succeed and surface the documented outcome.
-        """
+        """Destructive operation metadata generates the MCP confirmation contract."""
+        assert "Destructive" in _DELETE_SESSION_SPEC.effects
+        assert "confirmed_before_execute" in _DELETE_SESSION_SPEC.safety_guards
+        assert "write_role_required" in _DELETE_SESSION_SPEC.safety_guards
+        assert "mcp" in _DELETE_SESSION_SPEC.surfaces
+
         poly = patched_mutation_seam
         poly.delete_session_safe = AsyncMock(return_value=DeleteSessionResult(outcome="deleted", session_id=_CONV_ID))
         fn = admin_server._tool_manager._tools["delete_session"].fn


### PR DESCRIPTION
## Summary

Adds safety-guard metadata to runtime `OperationSpec` entries and uses that metadata to drive mutation guard contract tests for the destructive delete action and mutating MCP operation specs. This moves existing CLI/MCP delete confirmation expectations from hand-written assumptions into the operation registry, so future mutating MCP/destructive operations have to declare and prove their guard shape.

## Problem

#1849 asks for evidence-first tests generated from the surviving public action contracts. The write/mutation surfaces already had behavior tests, but the runtime operation catalog did not declare the safety guards those tests were proving, and MCP mutation operation specs were not mechanically tied to the registered mutation-tool surface.

## Solution

`OperationSpec` now carries typed `safety_guards` (`write_role_required`, `confirmed_before_execute`, `explicit_dry_run_evidence`). Mutating MCP operation specs declare role gating, and the destructive session-delete spec declares confirmation plus dry-run evidence and names its CLI delete call sites. The operation-spec contract test rejects unknown guard tokens, mutating MCP specs without write-role guards, and destructive specs without confirmation/dry-run guards. MCP discovery tests now derive mutating operation-tool coverage from runtime specs, and CLI/MCP delete tests assert behavior from the `mutate-delete-session` spec. A stale `_summary_line` helper test was corrected to use the current `id` field expected by the helper.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_archive_query.py tests/unit/mcp/test_per_tool_contracts.py tests/unit/daemon/test_daemon_http_contracts.py::TestOperationSpecContract` -> `276 passed`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push quick gate after final push -> `exit_code: 0`

## #1849 handoff checklist

Issue slice: generated action/mutation guard contracts from runtime operation specs.
Files inspected: `polylogue/operations/specs.py`, `polylogue/api/contracts/*write_surface.py`, `tests/unit/api/test_write_surface_contracts.py`, `tests/unit/mcp/test_per_tool_contracts.py`, `tests/unit/cli/test_archive_query.py`, `tests/unit/daemon/test_daemon_http_contracts.py`.
Files changed: `polylogue/operations/specs.py`, `polylogue/operations/__init__.py`, `tests/unit/daemon/test_daemon_http_contracts.py`, `tests/unit/mcp/test_per_tool_contracts.py`, `tests/unit/cli/test_archive_query.py`.
Old surface removed or retained: retained; this PR makes the operation registry the source of truth for mutation safety guards.
Contracts/tests added: `safety_guards` metadata, runtime operation safety-guard validation, operation-spec-to-MCP-tool registration coverage, MCP delete confirmation generated from `mutate-delete-session`, CLI delete confirmation/dry-run evidence generated from `mutate-delete-session`.
Generated artifacts updated: none; quick gate confirmed render surfaces are clean.
Known caveats / SPEC_MISMATCH: none.
Follow-up intentionally not included: broader public proof/QA vocabulary pruning remains under #1848/#1849; this PR only covers mutation guard contract generation.

Ref #1849