### PR TITLE
fix(daemon): restore Drive source catch-up

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -50,6 +50,7 @@ from polylogue.sources.live.watcher import INBOX_SOURCE_SUFFIXES, default_source
 
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
+_DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS = 3600
 
 # Track the pidfile path for atexit cleanup.
 _pidfile_path: Path | None = None
@@ -243,6 +244,73 @@ async def _periodic_status_snapshot_refresh() -> None:
         except Exception:
             logger.warning("daemon: status snapshot refresh failed", exc_info=True)
         await asyncio.sleep(10)
+
+
+async def _run_drive_source_catchup_once() -> int:
+    """Acquire and parse configured Drive sources once.
+
+    The live watcher only observes filesystem roots. Google Drive sources are
+    remote acquisition roots, so the daemon has to run their catch-up through
+    the staged acquisition pipeline explicitly.
+    """
+    from polylogue.config import get_config
+    from polylogue.pipeline.services.ingest_batch import refresh_session_insights_bulk
+    from polylogue.pipeline.services.parsing import ParsingService
+    from polylogue.services import build_runtime_services
+
+    config = get_config()
+    sources = [source for source in config.sources if source.is_drive]
+    if not sources:
+        return 0
+
+    services = build_runtime_services(config=config, db_path=config.db_path)
+    try:
+        repository = services.get_repository()
+        backend = services.get_backend()
+        parser = ParsingService(
+            repository=repository,
+            archive_root=config.archive_root,
+            config=config,
+        )
+        result = await parser.ingest_sources(
+            sources=sources,
+            stage="all",
+            parse_records=True,
+        )
+        session_ids = sorted(result.parse_result.processed_ids)
+        if session_ids:
+            await refresh_session_insights_bulk(backend, session_ids)
+        logger.info(
+            "daemon: Drive source catch-up complete — sources=%d raw=%d sessions=%d changed=%d errors=%d",
+            len(sources),
+            len(result.acquire_result.raw_ids),
+            result.parse_result.counts["sessions"],
+            len(session_ids),
+            result.acquire_result.errors,
+        )
+        return len(session_ids)
+    finally:
+        await services.close()
+
+
+async def _run_drive_source_catchup_safely() -> int:
+    """Run Drive catch-up without letting remote-source failures kill daemon."""
+    try:
+        return await _run_drive_source_catchup_once()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("daemon: Drive source catch-up failed", exc_info=True)
+        return 0
+
+
+async def _periodic_drive_source_catchup() -> None:
+    """Periodically converge remote Drive sources such as AiStudio exports."""
+    while True:
+        await asyncio.sleep(_DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS)
+        changed = await _run_drive_source_catchup_safely()
+        if changed:
+            logger.info("daemon: Drive catch-up refreshed %d session(s)", changed)
 
 
 async def _periodic_heartbeat() -> None:
@@ -681,6 +749,9 @@ async def run_daemon_services(
             # not trigger a merge of the full (hundreds-of-MB) existing
             # segments (#1851).  A periodic merge pass amortises the cost.
             await _configure_fts_automerge()
+            changed_drive_sessions = await _run_drive_source_catchup_safely()
+            if changed_drive_sessions:
+                logger.info("daemon: startup Drive catch-up refreshed %d session(s)", changed_drive_sessions)
             maintenance_tasks.extend(
                 asyncio.create_task(loop)
                 for loop in (
@@ -688,6 +759,7 @@ async def run_daemon_services(
                     _periodic_fts_merge(),
                     _periodic_heartbeat(),
                     periodic_embedding_backlog_check(),
+                    _periodic_drive_source_catchup(),
                     _periodic_health_check(),
                     _periodic_db_optimize(),
                     _periodic_status_snapshot_refresh(),

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -384,6 +384,100 @@ def test_polylogued_watch_builds_sources_from_roots(tmp_path: Path) -> None:
     assert "Watching 2 source(s); debounce=2.0s" in result.stderr
 
 
+def test_drive_source_catchup_skips_when_no_drive_sources(tmp_path: Path) -> None:
+    from polylogue.config import Config
+    from polylogue.daemon import cli as daemon_cli
+
+    config = Config(
+        archive_root=tmp_path,
+        render_root=tmp_path / "render",
+        sources=[],
+        db_path=tmp_path / "index.db",
+    )
+
+    with (
+        patch("polylogue.config.get_config", return_value=config),
+        patch("polylogue.services.build_runtime_services") as build_services,
+    ):
+        changed = asyncio.run(daemon_cli._run_drive_source_catchup_once())
+
+    assert changed == 0
+    build_services.assert_not_called()
+
+
+def test_drive_source_catchup_ingests_configured_drive_source(tmp_path: Path) -> None:
+    from polylogue.config import Config, Source
+    from polylogue.daemon import cli as daemon_cli
+
+    drive_source = Source(name="aistudio", folder="Google AI Studio", path=tmp_path / "drive-cache" / "gemini")
+    config = Config(
+        archive_root=tmp_path,
+        render_root=tmp_path / "render",
+        sources=[drive_source],
+        db_path=tmp_path / "index.db",
+    )
+    events: list[object] = []
+
+    class FakeServices:
+        def get_repository(self) -> object:
+            events.append("repository")
+            return object()
+
+        def get_backend(self) -> object:
+            events.append("backend")
+            return object()
+
+        async def close(self) -> None:
+            events.append("close")
+
+    class FakeParser:
+        def __init__(self, *, repository: object, archive_root: Path, config: Config) -> None:
+            events.append(("parser", repository, archive_root, config))
+
+        async def ingest_sources(self, *, sources: list[Source], stage: str, parse_records: bool) -> SimpleNamespace:
+            events.append(("ingest", sources, stage, parse_records))
+            return SimpleNamespace(
+                acquire_result=SimpleNamespace(raw_ids=["raw-1"], errors=0),
+                parse_result=SimpleNamespace(
+                    processed_ids={"session-b", "session-a"},
+                    counts={"sessions": 2},
+                ),
+            )
+
+    async def fake_refresh(_backend: object, session_ids: list[str]) -> None:
+        events.append(("refresh", session_ids))
+
+    with (
+        patch("polylogue.config.get_config", return_value=config),
+        patch("polylogue.services.build_runtime_services", return_value=FakeServices()) as build_services,
+        patch("polylogue.pipeline.services.parsing.ParsingService", FakeParser),
+        patch("polylogue.pipeline.services.ingest_batch.refresh_session_insights_bulk", fake_refresh),
+    ):
+        changed = asyncio.run(daemon_cli._run_drive_source_catchup_once())
+
+    assert changed == 2
+    build_services.assert_called_once_with(config=config, db_path=config.db_path)
+    assert ("ingest", [drive_source], "all", True) in events
+    assert ("refresh", ["session-a", "session-b"]) in events
+    assert events[-1] == "close"
+
+
+def test_drive_source_catchup_safe_wrapper_logs_failure() -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    async def fail_catchup() -> int:
+        raise RuntimeError("drive unavailable")
+
+    with (
+        patch.object(daemon_cli, "_run_drive_source_catchup_once", fail_catchup),
+        patch.object(daemon_cli.logger, "warning") as warning,
+    ):
+        changed = asyncio.run(daemon_cli._run_drive_source_catchup_safely())
+
+    assert changed == 0
+    warning.assert_called_once_with("daemon: Drive source catch-up failed", exc_info=True)
+
+
 def test_explicit_archive_inbox_root_keeps_import_suffixes(workspace_env: dict[str, Path]) -> None:
     from polylogue.daemon import cli as daemon_cli
     from polylogue.sources.live.watcher import INBOX_SOURCE_SUFFIXES
@@ -1078,6 +1172,10 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     async def fake_sweep_orphaned_blob_leases() -> None:
         events.append("sweep")
 
+    async def fake_drive_catchup() -> int:
+        events.append("drive-once")
+        return 0
+
     async def fake_loop(name: str) -> None:
         events.append(name)
         await asyncio.Event().wait()
@@ -1096,6 +1194,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         patch.object(daemon_cli, "Polylogue", FakePolylogue),
         patch.object(daemon_cli, "LiveWatcher", FakeWatcher),
         patch.object(daemon_cli, "_ensure_fts_startup_readiness", fake_fts_startup),
+        patch.object(daemon_cli, "_run_drive_source_catchup_safely", fake_drive_catchup),
         patch.object(daemon_cli, "_sweep_orphaned_blob_leases", fake_sweep_orphaned_blob_leases),
         patch.object(daemon_cli, "_periodic_wal_checkpoint", lambda: fake_loop("wal")),
         patch.object(daemon_cli, "_periodic_heartbeat", lambda: fake_loop("heartbeat")),
@@ -1103,6 +1202,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         patch.object(daemon_cli, "_periodic_health_check", lambda: fake_loop("health")),
         patch.object(daemon_cli, "_periodic_db_optimize", lambda: fake_loop("optimize")),
         patch.object(daemon_cli, "_periodic_status_snapshot_refresh", lambda: fake_loop("status")),
+        patch.object(daemon_cli, "_periodic_drive_source_catchup", lambda: fake_loop("drive")),
         patch("polylogue.daemon.embedding_backlog.periodic_embedding_backlog_check", lambda: fake_loop("embedding")),
         patch("polylogue.daemon.convergence.DaemonConverger", FakeConverger),
         patch("polylogue.daemon.convergence_stages.make_default_convergence_stages", return_value=()),
@@ -1122,7 +1222,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
 
     assert "watcher" in events
     assert events.index("fts") < events.index("watcher")
+    assert events.index("drive-once") < events.index("watcher")
     assert events.index("fts") < events.index("convergence")
+    assert events.index("fts") < events.index("drive")
     assert events.index("fts") < events.index("converger")
 
 
@@ -1262,6 +1364,7 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
         patch.object(daemon_cli, "_periodic_health_check", side_effect=fail_background_work),
         patch.object(daemon_cli, "_periodic_db_optimize", side_effect=fail_background_work),
         patch.object(daemon_cli, "_periodic_status_snapshot_refresh", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_drive_source_catchup", side_effect=fail_background_work),
         patch("polylogue.daemon.convergence.DaemonConverger", side_effect=fail_background_work),
         patch.object(daemon_cli, "make_server", return_value=server),
         pytest.raises(RuntimeError, match="server stopped"),


### PR DESCRIPTION
## Summary

Restores daemon-owned Google Drive/AiStudio catch-up so `polylogued run` converges configured remote Drive sources instead of only filesystem watcher roots.

## Problem

The deployed daemon only watches local roots from `default_sources()`, while the Google Drive/AiStudio source is configured through `Config.sources` as a remote `Source.is_drive` entry. The older Sinnix `polylogue-run.service` timer that used to run durable catch-up is no longer installed, and the old `polylogue run acquire parse materialize render index` entrypoint no longer exists. As a result, credentials can be present while `aistudio-drive` stays at zero rows because no daemon task invokes Drive acquisition.

Closes #1993.

## Solution

Add a daemon Drive catch-up pass that filters configured Drive sources, runs them through the existing staged acquisition/parsing pipeline, refreshes session insights for processed sessions, and logs remote failures without killing `polylogued`. Startup runs one safe catch-up after schema/FTS readiness and before the live watcher starts, avoiding concurrent startup writers; an hourly maintenance loop handles retries afterward.

The implementation intentionally reuses `ParsingService.ingest_sources()` so Drive acquisition keeps using the existing `source.is_drive` branch rather than adding a second parser path.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py` → 36 passed.
- `devtools verify --quick` → passed.
- `git push` pre-push hook ran `devtools verify --quick` again → passed.
- `devtools verify` static stages passed, but pytest-testmon selected a broad slice and hit its 1000s timeout at 86%; pytest was killed before writing `.cache/verify/last-pytest.json`, so no finalized failure report was available from that broad run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon now automatically synchronizes configured Google Drive sources on startup and periodically during regular maintenance tasks.
  * Enhanced error handling ensures Drive synchronization failures don't disrupt other daemon operations.

* **Tests**
  * Added unit tests for Google Drive source synchronization workflow and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->