### PR TITLE
fix: retarget query DSL planning and restore quick gate

### DIFF
--- a/devtools/verify_schema_roundtrip.py
+++ b/devtools/verify_schema_roundtrip.py
@@ -94,7 +94,7 @@ def _verify_corpus_roundtrip_for_provider(
 
     Returns a list of failure messages (empty if all records validate).
     """
-    if SyntheticCorpus is None or jsonschema is None:  # type: ignore[redundant-expr]  # defensive: imports may fail
+    if SyntheticCorpus is None or jsonschema is None:  # defensive: imports may fail
         return ["synthetic corpus or jsonschema not available (import failed)"]
     if provider not in PROVIDER_WIRE_FORMATS:
         return [f"no wire format configured for provider {provider!r}"]

--- a/docs/plans/current-issue-execution-control-plane.md
+++ b/docs/plans/current-issue-execution-control-plane.md
@@ -12,8 +12,8 @@ Do not preserve stale public aliases. Do not add ceremonial proof, witness, QA, 
 
 1. #1873: stop-line correctness for query/action behavior.
 2. #1818: machine-output/action-contract hub, gating #1842, #1849, #1825, and #1847.
-3. #1842: public command-floor prune. Ship the familiar `find QUERY then ACTION` floor and remove the old command zoo. Do not absorb the full #1879 ceiling.
-4. #1879: future predicate/pipeline query substrate.
+3. #1842: public command-floor prune. Ship the familiar `find QUERY then ACTION` floor and remove the old command zoo. Do not absorb the full #2006 ceiling.
+4. #2006: full query DSL substrate.
 5. #1880: transform-first recovery/digest views for agent sessions.
 6. #1883, #1882, #1881: KV/assertions, agent identity/context/delivery, and Beads/GitHub/Polylogue boundary.
 7. Demo, README, release, web workbench, and work packets follow the import/query/action/output spine.
@@ -24,7 +24,7 @@ Do not preserve stale public aliases. Do not add ceremonial proof, witness, QA, 
 
 #1842 owns the public command floor: `find`, `import`, `config`, `ops`, and terminal actions `read`, `mark`, `analyze`, `remove`, and `continue` if it truly resumes work. `read` absorbs show/open/messages/raw/export. `mark` absorbs tags/user-state/blackboard/feedback. `analyze` absorbs stats/facets/cost/neighbors/insights/diagnostics/correlate.
 
-#1879 owns the future query ceiling: a typed AST compiled onto SQLite, FTS5, vector search, and recursive CTEs. It is not a custom database engine and must not block #1842.
+#2006 owns the full query DSL: a typed AST and lowering pipeline over SQLite, FTS5, vector search, recursive CTEs, EXISTS subqueries, and existing read/action contracts. It is not a custom database engine. It includes Boolean predicates, structural message/action predicates, lineage/run/event/assertion traversal, aggregation, terminal report/action stages, and explain output. The old flat compiler remains the floor; #2006 owns the ceiling.
 
 #1815 owns public import/demo/source vocabulary. Public command is `import`; internal ingestion terminology may remain only for daemon or pipeline mechanics. Remaining work is demo fixture worlds, parser regression coverage, and operation/status truthfulness.
 

--- a/docs/plans/final-cli-command-floor.md
+++ b/docs/plans/final-cli-command-floor.md
@@ -42,4 +42,4 @@ A quoted query may omit `find` only when the parser can treat it unambiguously a
 - Old roots are absent from command registration, docs, completion, and tests.
 - Read/mark/analyze/remove share one selection path.
 - Ambiguity errors are typed and machine-readable.
-- #1879 future query ceiling is not required for this issue.
+- #2006 full query DSL ceiling is not required for this command-floor issue.

--- a/docs/plans/query-pipeline-substrate.md
+++ b/docs/plans/query-pipeline-substrate.md
@@ -1,8 +1,10 @@
 # Query pipeline substrate
 
+Owning issue: #2006.
+
 ## Purpose
 
-Polylogue needs a richer query ceiling without becoming its own query engine. The surface language should compile onto the archive storage and search layers already present in the project.
+Polylogue needs a richer query ceiling without becoming its own query engine. The surface language should compile onto the archive storage and search layers already present in the project. The old `SessionQuerySpec` / query-expression compiler is the floor; #2006 owns the full DSL ceiling.
 
 ## Current limitation
 

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -353,7 +353,7 @@ def _lower_grouped_payload(
         return []
 
     messages = _record_messages(record)
-    grouped_payload = messages if messages is not None else [record]
+    grouped_payload: PayloadSequence = messages if messages is not None else [record]
     return [_grouped_records_spec(provider, grouped_payload, fallback_id)]
 
 
@@ -559,7 +559,7 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedSession]:
 
     if spec.mode == "chunked_prompt":
         record = _payload_record(spec.payload)
-        payload = record if record is not None else {"chunks": _payload_sequence(spec.payload) or []}
+        payload: JSONDocument = record if record is not None else {"chunks": _payload_sequence(spec.payload) or []}
         return [drive.parse_chunked_prompt(spec.provider, payload, spec.fallback_id)]
 
     if spec.mode == "generic_messages":

--- a/tests/benchmarks/test_daemon_convergence_multi_provider.py
+++ b/tests/benchmarks/test_daemon_convergence_multi_provider.py
@@ -14,15 +14,22 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, TypeAlias, cast
 
 import pytest
 
 from tests.benchmarks.helpers import BenchmarkFixture
 
 # ── Synthetic data generation per provider ────────────────────────────
+
+JsonRecordList: TypeAlias = list[dict[str, object]]
+JsonRecord: TypeAlias = dict[str, object]
+JsonlGenerator: TypeAlias = Callable[[str, int], JsonRecordList]
+JsonGenerator: TypeAlias = Callable[[str, int], JsonRecord]
+ProviderGenerator: TypeAlias = tuple[Literal["jsonl"], JsonlGenerator] | tuple[Literal["json"], JsonGenerator]
 
 
 def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
@@ -114,7 +121,7 @@ def _make_chatgpt_session(conv_id: str, n_messages: int) -> dict[str, object]:
 
 
 # mypy note: generator functions have different signatures but all return list[dict].
-_PROVIDER_GENERATORS = {
+_PROVIDER_GENERATORS: dict[str, ProviderGenerator] = {
     "claude-code": ("jsonl", _make_claude_code_session),
     "codex": ("jsonl", _make_codex_session),
     "chatgpt": ("json", _make_chatgpt_session),
@@ -127,16 +134,28 @@ _SCALE_TIERS = {
 }
 
 
+def _jsonl_generator(provider: str) -> JsonlGenerator:
+    fmt, generator = _PROVIDER_GENERATORS[provider]
+    if fmt != "jsonl":
+        raise AssertionError(f"provider {provider} is not JSONL-backed")
+    return cast(JsonlGenerator, generator)
+
+
+def _json_generator(provider: str) -> JsonGenerator:
+    fmt, generator = _PROVIDER_GENERATORS[provider]
+    if fmt != "json":
+        raise AssertionError(f"provider {provider} is not JSON-backed")
+    return cast(JsonGenerator, generator)
+
+
 def _generate_corpus(tmp_path: Path, tier: str, provider: str) -> Path:
     spec = _SCALE_TIERS[tier]
     root = tmp_path / "corpus" / f"{provider}-project"
-    fmt, generator = _PROVIDER_GENERATORS[provider]
-    write = _write_jsonl if fmt == "jsonl" else _write_json
 
     for i in range(spec["files"]):
         if provider == "chatgpt":
             conv_id = f"chatgpt-conv-{i:04d}"
-            conv_data = generator(conv_id, spec["msgs_per_file"])  # type: ignore[operator]
+            conv_data = _json_generator(provider)(conv_id, spec["msgs_per_file"])
             # chats/ subdir with individual JSON files
             chat_dir = root / "chats"
             chat_dir.mkdir(parents=True, exist_ok=True)
@@ -144,8 +163,8 @@ def _generate_corpus(tmp_path: Path, tier: str, provider: str) -> Path:
                 json.dump(conv_data, f)
         else:
             uuid = f"deadbeef-0000-0000-0000-{i:012x}"
-            records = generator(uuid, spec["msgs_per_file"])  # type: ignore[operator]
-            write(root / f"{uuid}.jsonl", records)
+            records = _jsonl_generator(provider)(uuid, spec["msgs_per_file"])
+            _write_jsonl(root / f"{uuid}.jsonl", records)
     return root.parent
 
 
@@ -269,16 +288,9 @@ def test_convergence_single_file_per_provider(
 ) -> None:
     """Per-provider throughput on a single 500-message file."""
     root = tmp_path / "corpus" / "test"
-    fmt, generator = _PROVIDER_GENERATORS[provider]
     uuid = f"single-{provider}-test"
-    if fmt == "jsonl":
-        records = generator(uuid, 500)  # type: ignore[operator]
-        _write_jsonl(root / f"{uuid}.jsonl", records)
-    else:
-        conv_data = generator(uuid, 500)  # type: ignore[operator]
-        root.mkdir(parents=True, exist_ok=True)
-        with open(root / f"{uuid}.json", "w") as f:
-            json.dump(conv_data, f)
+    records = _jsonl_generator(provider)(uuid, 500)
+    _write_jsonl(root / f"{uuid}.jsonl", records)
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     monkeypatch.setenv("POLYLOGUE_CONFIG", str(tmp_path / "polylogue.toml"))


### PR DESCRIPTION
## Summary

Retargets stale query-DSL planning references from the deleted/stale #1879 owner to #2006, and fixes the narrow mypy type regressions that blocked the required quick gate during push.

## Problem

The issue set now has a detailed owner for the full query DSL substrate, but repo planning docs still pointed agents at #1879. That made the query ceiling look orphaned and encouraged agents to treat the old flat compiler as the whole DSL.

The enforced pre-push quick gate also exposed current mypy failures in parser dispatch typing, benchmark generator unions, and a stale ignore.

## Solution

- Update the current issue execution control plane to name #2006 as the full query DSL owner.
- Update the final CLI command-floor note so #1842 remains scoped to the command floor while #2006 owns the query ceiling.
- Add explicit #2006 ownership to the query-pipeline substrate plan.
- Add precise type annotations/casts for grouped payloads, chunked prompt payloads, benchmark provider generators, and remove a stale ignore.

## Verification

- `nix develop --command devtools verify-doc-commands` -> `verify-doc-commands: 100 doc files scanned, no stale commands`
- `nix develop --command mypy polylogue tests devtools` -> `Success: no issues found in 1639 source files`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code cleanup and type annotation improvements for schema verification and payload handling
  * Benchmark test refactoring with enhanced type safety for multi-provider corpus generation
  * Documentation updates to planning and design documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->