### PR TITLE
feat(query): execute structural and sequence predicates (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -6,7 +6,8 @@ future surfaces that wire in).
 
 Current executable grammar
 --------------------------
-An expression is a whitespace-separated sequence of *clauses*, all AND'd:
+The executable language is the Lark-backed query grammar in this module. It
+currently accepts the historical flat session query form:
 
     repo:polylogue since:7d "json envelope"
     origin:(codex-session|claude-code-session) has:paste
@@ -27,10 +28,15 @@ Clause forms:
 - ``words:>=N``            — count comparison (min_words)
 - ``{...}``                — direct JSON spec (validated into SessionQuerySpec)
 
-Cross-field OR and nested Boolean groups are **rejected loudly** until #2006
-adds executable Boolean AST lowerers. Unknown fields also fail loudly. The
-Lark grammar in this module is the query grammar; there is no separate
-long-lived "floor grammar."
+and explicit Boolean session predicates:
+
+    sessions where (repo:polylogue OR origin:chatgpt-export) AND NOT tag:stale
+    repo:polylogue OR repo:sinex
+
+Unknown fields and unsupported structured forms fail loudly. The Lark grammar
+in this module is the query grammar; historical flat lowering is compatibility
+plumbing to be absorbed and deleted as #2006 grows the AST lowerers, not a
+separate long-lived "floor grammar."
 
 Field registry
 --------------
@@ -57,16 +63,18 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field, replace
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from lark import Lark, Token, Transformer, v_args
 from lark.exceptions import UnexpectedInput, VisitError
 
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
+    QueryExistsPredicate,
     QueryFieldPredicate,
     QueryNotPredicate,
     QueryPredicate,
+    QuerySequencePredicate,
 )
 from polylogue.archive.query.spec import (
     QUERY_ACTION_TYPES,
@@ -363,12 +371,19 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
     ?and_expr: not_expr (AND not_expr)*    -> and_expr
     ?not_expr: NOT not_expr                -> not_expr
         | atom
-    ?atom: COUNT_CLAUSE                    -> count_leaf
+    ?atom: EXISTS STRUCT_UNIT "(" expr ")" -> exists_leaf
+        | SEQ "(" sequence_step (ARROW sequence_step)+ ")" -> sequence_leaf
+        | COUNT_CLAUSE                     -> count_leaf
         | FIELD_CLAUSE                     -> field_leaf
         | "(" expr ")"
+    sequence_step: FIELD_CLAUSE
 
     SESSIONS: /sessions/i
     WHERE: /where/i
+    EXISTS: /exists/i
+    SEQ: /seq/i
+    ARROW: "->"
+    STRUCT_UNIT: /(message|action)/i
     OR: /or/i
     AND: /and/i
     NOT: /not/i
@@ -417,6 +432,19 @@ _BOOLEAN_SUPPORTED_FIELDS = {
     "messages",
     "words",
 }
+_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
+    "role",
+    "type",
+    "text",
+    "tool",
+    "action",
+    "command",
+    "path",
+    "output",
+    "words",
+}
+_MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command", "path", "output", "words"}
+_ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text"}
 
 
 def _decode_escaped_string(token: Token) -> str:
@@ -431,11 +459,7 @@ def _decode_escaped_string(token: Token) -> str:
 
 def _parse_error_message(expression: str, exc: UnexpectedInput) -> str:
     if expression.lstrip().startswith("("):
-        return (
-            "cross-field OR parentheses are not supported; express as separate queries "
-            "or use field:(a|b|c) for in-field OR. "
-            "Boolean-tree queries are tracked in issue #2006."
-        )
+        return f"invalid Boolean query expression near column {exc.column}"
     if '"' in expression:
         return "unclosed quoted string"
     return f"invalid query expression near column {exc.column}"
@@ -488,13 +512,16 @@ _QUERY_TRANSFORMER = _QueryTransformer()
 
 def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
     field_name = token.field
-    if field_name not in EXPRESSION_FIELD_REGISTRY:
+    if field_name not in EXPRESSION_FIELD_REGISTRY and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
         recognized = sorted(EXPRESSION_FIELD_REGISTRY)
         raise ExpressionCompileError(
-            f"unknown query field {field_name!r}; recognized fields: " + ", ".join(recognized),
+            f"unknown query field {field_name!r}; recognized fields: "
+            + ", ".join(recognized)
+            + "; structural fields: "
+            + ", ".join(sorted(_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS)),
             field=field_name,
         )
-    if field_name not in _BOOLEAN_SUPPORTED_FIELDS:
+    if field_name not in _BOOLEAN_SUPPORTED_FIELDS and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
         raise ExpressionCompileError(
             f"field {field_name!r} is not supported inside Boolean SQL predicates yet",
             field=field_name,
@@ -518,7 +545,7 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
                     field="action",
                 )
         values = tuple(value.strip().lower() for value in values if value.strip())
-    elif field_name == "tool" or field_name == "has":
+    elif field_name in {"tool", "has", "role", "type", "command", "path", "output"}:
         values = tuple(value.strip().lower() for value in values if value.strip())
     elif field_name in {"since", "until"} and values:
         values = (_parse_relative_date(values[-1]),)
@@ -545,8 +572,61 @@ def _merge_bool_children(op: Literal["and", "or"], children: tuple[QueryPredicat
 
 def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]:
     return tuple(
-        item for item in items if isinstance(item, QueryFieldPredicate | QueryBoolPredicate | QueryNotPredicate)
+        item
+        for item in items
+        if isinstance(
+            item,
+            QueryFieldPredicate
+            | QueryBoolPredicate
+            | QueryNotPredicate
+            | QueryExistsPredicate
+            | QuerySequencePredicate,
+        )
     )
+
+
+def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["session", "message", "action"]) -> None:
+    if isinstance(predicate, QueryFieldPredicate):
+        if unit == "session":
+            supported = _BOOLEAN_SUPPORTED_FIELDS
+        elif unit == "message":
+            supported = _MESSAGE_STRUCTURAL_FIELDS
+        else:
+            supported = _ACTION_STRUCTURAL_FIELDS
+        if predicate.field not in supported:
+            raise ExpressionCompileError(
+                f"field {predicate.field!r} is not supported for {unit} predicates",
+                field=predicate.field,
+            )
+        if (
+            predicate.field in {"role", "type", "text", "tool", "action", "command", "path", "output"}
+            and not predicate.values
+        ):
+            raise ExpressionCompileError(f"field {predicate.field!r} requires a value", field=predicate.field)
+        if predicate.field == "words":
+            if not predicate.values:
+                raise ExpressionCompileError("field 'words' requires a numeric value", field="words")
+            try:
+                int(predicate.values[-1])
+            except ValueError as exc:
+                raise ExpressionCompileError("field 'words' requires a numeric value", field="words") from exc
+        return
+    if isinstance(predicate, QueryNotPredicate):
+        _validate_predicate_context(predicate.child, unit=unit)
+        return
+    if isinstance(predicate, QueryBoolPredicate):
+        for child in predicate.children:
+            _validate_predicate_context(child, unit=unit)
+        return
+    if isinstance(predicate, QueryExistsPredicate):
+        if unit != "session":
+            raise ExpressionCompileError("exists predicates are only supported from sessions", field=None)
+        _validate_predicate_context(predicate.child, unit=predicate.unit)
+        return
+    if isinstance(predicate, QuerySequencePredicate):
+        if unit != "session":
+            raise ExpressionCompileError("seq predicates are only supported from sessions", field=None)
+        return
 
 
 @v_args(inline=True)
@@ -578,12 +658,36 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
     def field_leaf(self, token: Token) -> QueryPredicate:
         return _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
 
+    def exists_leaf(self, _exists: Token, unit: Token, child: QueryPredicate) -> QueryPredicate:
+        unit_value = str(unit).lower()
+        if unit_value not in {"message", "action"}:
+            raise ExpressionCompileError(f"unsupported structural query unit {unit_value!r}", field=None)
+        return QueryExistsPredicate(unit=cast(Literal["message", "action"], unit_value), child=child)
+
+    def sequence_step(self, token: Token) -> QueryPredicate:
+        predicate = _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
+        if not isinstance(predicate, QueryFieldPredicate) or predicate.field != "action" or predicate.op != "=":
+            raise ExpressionCompileError("seq() currently supports action:<kind> steps", field=None)
+        if len(predicate.values) != 1:
+            raise ExpressionCompileError("seq() action steps must name exactly one action", field="action")
+        return predicate
+
+    def sequence_leaf(self, _seq: Token, *items: object) -> QueryPredicate:
+        steps = [item for item in items if isinstance(item, QueryFieldPredicate)]
+        if len(steps) < 2:
+            raise ExpressionCompileError("seq() requires at least two action steps", field=None)
+        return QuerySequencePredicate(action_terms=tuple(step.values[0] for step in steps))
+
 
 _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()
 
 
 def _is_boolean_expression(expression: str) -> bool:
-    if re.search(r"^\s*\(|^\s*sessions\s+where\b", expression, re.IGNORECASE):
+    if re.search(
+        r"^\s*\(|^\s*sessions\s+where\b|^\s*exists\s+(?:message|action)\s*\(|^\s*seq\s*\(",
+        expression,
+        re.IGNORECASE,
+    ):
         return True
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
@@ -599,8 +703,12 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
         if isinstance(exc.orig_exc, ExpressionCompileError):
             raise exc.orig_exc from exc
         raise
-    if not isinstance(transformed, QueryFieldPredicate | QueryBoolPredicate | QueryNotPredicate):
+    if not isinstance(
+        transformed,
+        QueryFieldPredicate | QueryBoolPredicate | QueryNotPredicate | QueryExistsPredicate | QuerySequencePredicate,
+    ):
         raise ExpressionCompileError("Boolean query did not produce a predicate", field=None)
+    _validate_predicate_context(transformed, unit="session")
     return transformed
 
 

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -42,14 +42,39 @@ class QueryBoolPredicate:
         return {"kind": self.op, "children": [child.to_payload() for child in self.children]}
 
 
-QueryPredicate: TypeAlias = QueryFieldPredicate | QueryNotPredicate | QueryBoolPredicate
+@dataclass(frozen=True)
+class QueryExistsPredicate:
+    """Correlated structural predicate over a child archive unit."""
+
+    unit: Literal["message", "action"]
+    child: QueryPredicate
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "exists", "unit": self.unit, "child": self.child.to_payload()}
+
+
+@dataclass(frozen=True)
+class QuerySequencePredicate:
+    """Ordered action-sequence predicate over a session."""
+
+    action_terms: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "sequence", "unit": "action", "actions": list(self.action_terms)}
+
+
+QueryPredicate: TypeAlias = (
+    QueryFieldPredicate | QueryNotPredicate | QueryBoolPredicate | QueryExistsPredicate | QuerySequencePredicate
+)
 
 
 __all__ = [
     "QueryBoolOp",
     "QueryBoolPredicate",
     "QueryCompareOp",
+    "QueryExistsPredicate",
     "QueryFieldPredicate",
     "QueryNotPredicate",
     "QueryPredicate",
+    "QuerySequencePredicate",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -8,14 +8,16 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from types import TracebackType
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
+    QueryExistsPredicate,
     QueryFieldPredicate,
     QueryNotPredicate,
     QueryPredicate,
+    QuerySequencePredicate,
 )
 from polylogue.archive.semantic.pricing import (
     CostBasisPayload,
@@ -4300,6 +4302,189 @@ def _field_predicate_clause(
     return _clause_without_prefix(where, prefix="WHERE"), params
 
 
+def _in_or_equals_clause(column: str, values: tuple[str, ...], *, lower: bool = False) -> tuple[str, list[object]]:
+    normalized = tuple(value.strip().lower() if lower else value.strip() for value in values if value.strip())
+    if not normalized:
+        return "", []
+    expression = f"lower({column})" if lower else column
+    if len(normalized) == 1:
+        return f"{expression} = ?", [normalized[0]]
+    placeholders = ", ".join("?" for _ in normalized)
+    return f"{expression} IN ({placeholders})", list(normalized)
+
+
+def _count_predicate_clause(column: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
+    if not predicate.values:
+        return "", []
+    value = int(predicate.values[-1])
+    if predicate.op == ">=":
+        return f"{column} >= ?", [value]
+    if predicate.op == "<=":
+        return f"{column} <= ?", [value]
+    return f"{column} = ?", [value]
+
+
+def _like_clause(
+    expression: str,
+    values: tuple[str, ...],
+    *,
+    joiner: Literal["AND", "OR"] = "OR",
+) -> tuple[str, list[object]]:
+    normalized = tuple(value.strip().lower() for value in values if value.strip())
+    if not normalized:
+        return "", []
+    clauses = [f"lower({expression}) LIKE ?" for _ in normalized]
+    joined = f" {joiner} ".join(clauses)
+    return (f"({joined})" if len(clauses) > 1 else joined), [f"%{value}%" for value in normalized]
+
+
+def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
+    field = predicate.field
+    if field == "role":
+        return _in_or_equals_clause(f"{message_alias}.role", predicate.values, lower=True)
+    if field == "type":
+        return _in_or_equals_clause(f"{message_alias}.message_type", predicate.values, lower=True)
+    if field == "words":
+        return _count_predicate_clause(f"{message_alias}.word_count", predicate)
+    if field in {"text", "command", "path", "output", "tool", "action"}:
+        action_clause = ""
+        params: list[object] = []
+        if field == "text":
+            block_clause, params = _like_clause("COALESCE(filter_blocks.search_text, '')", predicate.values)
+            action_clause = f"""
+                EXISTS (
+                    SELECT 1
+                    FROM blocks filter_blocks
+                    WHERE filter_blocks.message_id = {message_alias}.message_id
+                      AND {block_clause}
+                )
+            """.strip()
+        elif field == "tool":
+            inner_clause, params = _in_or_equals_clause("filter_actions.tool_name", predicate.values, lower=True)
+            action_clause = f"""
+                EXISTS (
+                    SELECT 1
+                    FROM actions filter_actions
+                    WHERE filter_actions.message_id = {message_alias}.message_id
+                      AND {inner_clause}
+                )
+            """.strip()
+        elif field == "action":
+            inner_clause, params = _in_or_equals_clause("filter_actions.semantic_type", predicate.values, lower=True)
+            action_clause = f"""
+                EXISTS (
+                    SELECT 1
+                    FROM actions filter_actions
+                    WHERE filter_actions.message_id = {message_alias}.message_id
+                      AND {inner_clause}
+                )
+            """.strip()
+        else:
+            action_column = {
+                "command": "COALESCE(filter_actions.tool_command, '')",
+                "path": "REPLACE(COALESCE(filter_actions.tool_path, ''), char(92), '/')",
+                "output": "COALESCE(filter_actions.output_text, '')",
+            }[field]
+            inner_clause, params = _like_clause(action_column, predicate.values)
+            action_clause = f"""
+                EXISTS (
+                    SELECT 1
+                    FROM actions filter_actions
+                    WHERE filter_actions.message_id = {message_alias}.message_id
+                      AND {inner_clause}
+                )
+            """.strip()
+        return action_clause, params
+    raise ValueError(f"unsupported message predicate field: {field}")
+
+
+def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
+    field = predicate.field
+    if field == "tool":
+        return _in_or_equals_clause(f"{action_alias}.tool_name", predicate.values, lower=True)
+    if field in {"action", "type"}:
+        return _in_or_equals_clause(f"{action_alias}.semantic_type", predicate.values, lower=True)
+    if field == "command":
+        return _like_clause(f"COALESCE({action_alias}.tool_command, '')", predicate.values)
+    if field == "path":
+        return _like_clause(f"REPLACE(COALESCE({action_alias}.tool_path, ''), char(92), '/')", predicate.values)
+    if field == "output":
+        return _like_clause(f"COALESCE({action_alias}.output_text, '')", predicate.values)
+    if field == "text":
+        return _like_clause(
+            f"""
+            COALESCE({action_alias}.tool_name, '') || ' ' ||
+            COALESCE({action_alias}.semantic_type, '') || ' ' ||
+            COALESCE({action_alias}.tool_command, '') || ' ' ||
+            COALESCE({action_alias}.tool_path, '') || ' ' ||
+            COALESCE({action_alias}.tool_input, '') || ' ' ||
+            COALESCE({action_alias}.output_text, '')
+            """.strip(),
+            predicate.values,
+        )
+    raise ValueError(f"unsupported action predicate field: {field}")
+
+
+def _structural_predicate_clause(
+    unit: str,
+    row_alias: str,
+    predicate: QueryPredicate,
+) -> tuple[str, list[object]]:
+    if isinstance(predicate, QueryFieldPredicate):
+        if unit == "message":
+            return _message_field_predicate_clause(row_alias, predicate)
+        if unit == "action":
+            return _action_field_predicate_clause(row_alias, predicate)
+    if isinstance(predicate, QueryNotPredicate):
+        clause, params = _structural_predicate_clause(unit, row_alias, predicate.child)
+        return (f"NOT ({clause})" if clause else "", params)
+    if isinstance(predicate, QueryBoolPredicate):
+        child_clauses: list[str] = []
+        merged_params: list[object] = []
+        for child in predicate.children:
+            clause, child_params = _structural_predicate_clause(unit, row_alias, child)
+            if clause:
+                child_clauses.append(f"({clause})")
+                merged_params.extend(child_params)
+        if not child_clauses:
+            return "", merged_params
+        joiner = " OR " if predicate.op == "or" else " AND "
+        return joiner.join(child_clauses), merged_params
+    raise ValueError(f"unsupported nested structural predicate for {unit}: {predicate!r}")
+
+
+def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) -> tuple[str, list[object]]:
+    if predicate.unit == "message":
+        row_alias = "exists_messages"
+        child_clause, params = _structural_predicate_clause(predicate.unit, row_alias, predicate.child)
+        return (
+            f"""
+            EXISTS (
+                SELECT 1
+                FROM messages {row_alias}
+                WHERE {row_alias}.session_id = {table_alias}.session_id
+                  AND {child_clause}
+            )
+            """.strip(),
+            params,
+        )
+    if predicate.unit == "action":
+        row_alias = "exists_actions"
+        child_clause, params = _structural_predicate_clause(predicate.unit, row_alias, predicate.child)
+        return (
+            f"""
+            EXISTS (
+                SELECT 1
+                FROM actions {row_alias}
+                WHERE {row_alias}.session_id = {table_alias}.session_id
+                  AND {child_clause}
+            )
+            """.strip(),
+            params,
+        )
+    raise ValueError(f"unsupported structural query unit: {predicate.unit}")
+
+
 def _boolean_predicate_clause(
     table_alias: str,
     predicate: QueryPredicate,
@@ -4308,6 +4493,10 @@ def _boolean_predicate_clause(
 ) -> tuple[str, list[object]]:
     if isinstance(predicate, QueryFieldPredicate):
         return _field_predicate_clause(table_alias, predicate, tags_relation=tags_relation)
+    if isinstance(predicate, QueryExistsPredicate):
+        return _exists_predicate_clause(table_alias, predicate)
+    if isinstance(predicate, QuerySequencePredicate):
+        return _action_sequence_clause(table_alias, predicate.action_terms)
     if isinstance(predicate, QueryNotPredicate):
         clause, params = _boolean_predicate_clause(table_alias, predicate.child, tags_relation=tags_relation)
         return (f"NOT ({clause})" if clause else "", params)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -36,7 +36,13 @@ from polylogue.archive.query.expression import (
     explain_expression,
     parse_expression_ast,
 )
-from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate, QueryNotPredicate
+from polylogue.archive.query.predicate import (
+    QueryBoolPredicate,
+    QueryExistsPredicate,
+    QueryFieldPredicate,
+    QueryNotPredicate,
+    QuerySequencePredicate,
+)
 from polylogue.archive.query.spec import SessionQuerySpec
 
 # ---------------------------------------------------------------------------
@@ -197,6 +203,37 @@ class TestBooleanQueryExpression:
         assert isinstance(spec.boolean_predicate, QueryBoolPredicate)
         assert spec.query_terms == ()
 
+    def test_structural_exists_ast_exposes_child_unit_predicate(self) -> None:
+        ast = parse_expression_ast("exists message(role:assistant AND text:timeout)")
+
+        assert ast.boolean_predicate == QueryExistsPredicate(
+            unit="message",
+            child=QueryBoolPredicate(
+                op="and",
+                children=(
+                    QueryFieldPredicate(field="role", values=("assistant",)),
+                    QueryFieldPredicate(field="text", values=("timeout",)),
+                ),
+            ),
+        )
+
+    def test_sequence_ast_exposes_ordered_action_terms(self) -> None:
+        ast = parse_expression_ast("seq(action:file_edit -> action:shell -> action:file_edit)")
+
+        assert ast.boolean_predicate == QuerySequencePredicate(action_terms=("file_edit", "shell", "file_edit"))
+
+    def test_structural_field_at_session_scope_raises(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="not supported for session predicates"):
+            compile_expression("role:assistant OR title:needle")
+
+    def test_session_field_inside_structural_predicate_raises(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="not supported for message predicates"):
+            compile_expression("exists message(origin:chatgpt-export)")
+
+    def test_structural_words_requires_numeric_value(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="requires a numeric value"):
+            compile_expression("exists message(words:many)")
+
     def test_boolean_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from tests.infra.storage_records import SessionBuilder
@@ -256,6 +293,235 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["chatgpt-export:ext-keep"]
+
+    def test_exists_message_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("structural hit")
+            .add_message("m-hit", role="assistant", text="the timeout happened")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-role")
+            .provider("chatgpt")
+            .title("wrong role")
+            .add_message("m-wrong-role", role="user", text="the timeout happened")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-text")
+            .provider("chatgpt")
+            .title("wrong text")
+            .add_message("m-wrong-text", role="assistant", text="ordinary response")
+            .save()
+        )
+
+        spec = compile_expression("exists message(role:assistant AND text:timeout)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["chatgpt-export:ext-hit"]
+
+    def test_structural_text_alternation_uses_or_semantics(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        for session_id, text in [
+            ("timeout", "request timeout"),
+            ("panic", "panic in parser"),
+            ("miss", "ordinary response"),
+        ]:
+            (
+                SessionBuilder(index_db, session_id)
+                .provider("chatgpt")
+                .title(session_id)
+                .add_message(f"m-{session_id}", role="assistant", text=text)
+                .save()
+            )
+
+        spec = compile_expression("exists message(text:(timeout|panic))")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert {row.session_id for row in rows} == {
+            "chatgpt-export:ext-timeout",
+            "chatgpt-export:ext-panic",
+        }
+
+    def test_exists_action_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("action hit")
+            .add_message(
+                "m-hit",
+                role="assistant",
+                text="edited file",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-1",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("claude-code")
+            .title("action miss")
+            .add_message(
+                "m-miss",
+                role="assistant",
+                text="read file",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Read",
+                        "tool_id": "tool-2",
+                        "input": {"file_path": "polylogue/README.md"},
+                        "semantic_type": "file_read",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        spec = compile_expression("exists action(action:file_edit AND path:archive/query)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
+
+    def test_exists_action_path_normalizes_backslashes(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "windows-path")
+            .provider("claude-code")
+            .title("windows path")
+            .add_message(
+                "m-path",
+                role="assistant",
+                text="edited windows path",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-path",
+                        "input": {"file_path": r"polylogue\archive\query\expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        spec = compile_expression("exists action(path:archive/query)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-windows-path"]
+
+    def test_sequence_predicate_executes_in_order_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("sequence hit")
+            .add_message(
+                "m-hit-1",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-hit-1",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
+                "m-hit-2",
+                role="assistant",
+                text="test",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "tool-hit-2",
+                        "input": {"command": "pytest tests/unit/cli/test_query_expression.py"},
+                        "semantic_type": "shell",
+                    }
+                ],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "reversed")
+            .provider("claude-code")
+            .title("sequence reversed")
+            .add_message(
+                "m-reversed-1",
+                role="assistant",
+                text="test",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "tool-reversed-1",
+                        "input": {"command": "pytest"},
+                        "semantic_type": "shell",
+                    }
+                ],
+            )
+            .add_message(
+                "m-reversed-2",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-reversed-2",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        spec = compile_expression("seq(action:file_edit -> action:shell)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds executable structural and sequence query predicates to the #2006 DSL path. `exists message(...)`, `exists action(...)`, and `seq(action:a -> action:b)` now parse into the typed predicate AST and lower into SQLite predicates against `messages`, `blocks`, the `actions` view, and the existing ordered action-sequence lowerer.

## Problem
After #2010, Boolean predicates could combine session-level fields, but the DSL still could not ask archive-evidence questions such as “sessions with an assistant message mentioning timeout,” “sessions with a file edit under this path,” or “sessions where file edit happened before a shell run.” That left #2006's structural and sequence lowerers as parser-only target language instead of executable query behavior.

## Solution
Introduced `QueryExistsPredicate` and `QuerySequencePredicate`, extended the Lark Boolean grammar with `exists message(...)`, `exists action(...)`, and `seq(...)`, and wired storage lowering to correlated `EXISTS` clauses plus the archive's existing action-sequence SQL. Structural fields now cover message role/type/text/words and action tool/action/command/path/output/text, with typed unit-ownership and value validation so malformed structural fields cannot fall through to SQLite. Review feedback also tightened structural alternation and path handling: `field:(a|b)` preserves OR semantics inside correlated SQL, multi-term LIKE clauses are parenthesized, and structural path matching normalizes backslashes like the session-level path filter.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` -> `187 passed in 24.22s`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` on `32ea3acf` -> `exit_code: 0`

Ref #2006