### PR TITLE
feat(query): execute Boolean FTS predicates (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -75,6 +75,7 @@ from polylogue.archive.query.predicate import (
     QueryNotPredicate,
     QueryPredicate,
     QuerySequencePredicate,
+    QueryTextPredicate,
 )
 from polylogue.archive.query.spec import (
     QUERY_ACTION_TYPES,
@@ -373,6 +374,8 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
         | atom
     ?atom: EXISTS STRUCT_UNIT "(" expr ")" -> exists_leaf
         | SEQ "(" sequence_step (ARROW sequence_step)+ ")" -> sequence_leaf
+        | FTS_QUOTED_TEXT                  -> fts_quoted_leaf
+        | FTS_BARE_TEXT                    -> fts_bare_leaf
         | COUNT_CLAUSE                     -> count_leaf
         | FIELD_CLAUSE                     -> field_leaf
         | "(" expr ")"
@@ -387,6 +390,8 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
     OR: /or/i
     AND: /and/i
     NOT: /not/i
+    FTS_QUOTED_TEXT.6: /~"(\\.|[^"\\])*"/
+    FTS_BARE_TEXT.5: /~[^\s"()]+/
     COUNT_CLAUSE.5: /(messages|words):(>=|<=|=)\d+(?!\S)/
     FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
 
@@ -580,7 +585,8 @@ def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]
             | QueryBoolPredicate
             | QueryNotPredicate
             | QueryExistsPredicate
-            | QuerySequencePredicate,
+            | QuerySequencePredicate
+            | QueryTextPredicate,
         )
     )
 
@@ -627,6 +633,12 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         if unit != "session":
             raise ExpressionCompileError("seq predicates are only supported from sessions", field=None)
         return
+    if isinstance(predicate, QueryTextPredicate):
+        if unit != "session":
+            raise ExpressionCompileError("FTS predicates are only supported from sessions", field=None)
+        if not predicate.text.strip():
+            raise ExpressionCompileError("FTS predicate requires text", field=None)
+        return
 
 
 @v_args(inline=True)
@@ -657,6 +669,15 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
 
     def field_leaf(self, token: Token) -> QueryPredicate:
         return _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
+
+    def fts_quoted_leaf(self, token: Token) -> QueryPredicate:
+        return QueryTextPredicate(text=_decode_escaped_string(Token("ESCAPED_STRING", str(token)[1:])))
+
+    def fts_bare_leaf(self, token: Token) -> QueryPredicate:
+        value = str(token)[1:].strip()
+        if not value:
+            raise ExpressionCompileError("FTS predicate requires text", field=None)
+        return QueryTextPredicate(text=value)
 
     def exists_leaf(self, _exists: Token, unit: Token, child: QueryPredicate) -> QueryPredicate:
         unit_value = str(unit).lower()
@@ -689,6 +710,8 @@ def _is_boolean_expression(expression: str) -> bool:
         re.IGNORECASE,
     ):
         return True
+    if "~" in expression:
+        return True
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
 
@@ -705,7 +728,12 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
         raise
     if not isinstance(
         transformed,
-        QueryFieldPredicate | QueryBoolPredicate | QueryNotPredicate | QueryExistsPredicate | QuerySequencePredicate,
+        QueryFieldPredicate
+        | QueryBoolPredicate
+        | QueryNotPredicate
+        | QueryExistsPredicate
+        | QuerySequencePredicate
+        | QueryTextPredicate,
     ):
         raise ExpressionCompileError("Boolean query did not produce a predicate", field=None)
     _validate_predicate_context(transformed, unit="session")

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -63,8 +63,23 @@ class QuerySequencePredicate:
         return {"kind": "sequence", "unit": "action", "actions": list(self.action_terms)}
 
 
+@dataclass(frozen=True)
+class QueryTextPredicate:
+    """Lexical FTS predicate over session message/block text."""
+
+    text: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "fts", "unit": "session", "text": self.text}
+
+
 QueryPredicate: TypeAlias = (
-    QueryFieldPredicate | QueryNotPredicate | QueryBoolPredicate | QueryExistsPredicate | QuerySequencePredicate
+    QueryFieldPredicate
+    | QueryNotPredicate
+    | QueryBoolPredicate
+    | QueryExistsPredicate
+    | QuerySequencePredicate
+    | QueryTextPredicate
 )
 
 
@@ -77,4 +92,5 @@ __all__ = [
     "QueryNotPredicate",
     "QueryPredicate",
     "QuerySequencePredicate",
+    "QueryTextPredicate",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -18,6 +18,7 @@ from polylogue.archive.query.predicate import (
     QueryNotPredicate,
     QueryPredicate,
     QuerySequencePredicate,
+    QueryTextPredicate,
 )
 from polylogue.archive.semantic.pricing import (
     CostBasisPayload,
@@ -4485,6 +4486,25 @@ def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) 
     raise ValueError(f"unsupported structural query unit: {predicate.unit}")
 
 
+def _fts_predicate_clause(table_alias: str, predicate: QueryTextPredicate) -> tuple[str, list[object]]:
+    match_query = normalize_fts5_query(predicate.text)
+    if match_query is None:
+        raise ValueError("FTS predicate requires non-empty text")
+    return (
+        f"""
+        EXISTS (
+            SELECT 1
+            FROM messages_fts
+            JOIN blocks filter_fts_blocks
+              ON filter_fts_blocks.rowid = messages_fts.rowid
+            WHERE filter_fts_blocks.session_id = {table_alias}.session_id
+              AND messages_fts MATCH ?
+        )
+        """.strip(),
+        [match_query],
+    )
+
+
 def _boolean_predicate_clause(
     table_alias: str,
     predicate: QueryPredicate,
@@ -4497,6 +4517,8 @@ def _boolean_predicate_clause(
         return _exists_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QuerySequencePredicate):
         return _action_sequence_clause(table_alias, predicate.action_terms)
+    if isinstance(predicate, QueryTextPredicate):
+        return _fts_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QueryNotPredicate):
         clause, params = _boolean_predicate_clause(table_alias, predicate.child, tags_relation=tags_relation)
         return (f"NOT ({clause})" if clause else "", params)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -42,6 +42,7 @@ from polylogue.archive.query.predicate import (
     QueryFieldPredicate,
     QueryNotPredicate,
     QuerySequencePredicate,
+    QueryTextPredicate,
 )
 from polylogue.archive.query.spec import SessionQuerySpec
 
@@ -221,6 +222,22 @@ class TestBooleanQueryExpression:
         ast = parse_expression_ast("seq(action:file_edit -> action:shell -> action:file_edit)")
 
         assert ast.boolean_predicate == QuerySequencePredicate(action_terms=("file_edit", "shell", "file_edit"))
+
+    def test_fts_ast_exposes_text_predicate(self) -> None:
+        ast = parse_expression_ast('repo:polylogue AND ~"timeout failure"')
+
+        assert ast.boolean_predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="repo", values=("polylogue",)),
+                QueryTextPredicate(text="timeout failure"),
+            ),
+        )
+
+    def test_bare_fts_ast_exposes_text_predicate(self) -> None:
+        ast = parse_expression_ast("~timeout")
+
+        assert ast.boolean_predicate == QueryTextPredicate(text="timeout")
 
     def test_structural_field_at_session_scope_raises(self) -> None:
         with pytest.raises(ExpressionCompileError, match="not supported for session predicates"):
@@ -522,6 +539,43 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
+
+    def test_fts_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("fts hit")
+            .add_message(
+                "m-hit",
+                role="assistant",
+                text="timeout failure",
+                blocks=[{"type": "text", "text": "timeout failure in query pipeline"}],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("fts miss")
+            .add_message(
+                "m-miss",
+                role="assistant",
+                text="ordinary response",
+                blocks=[{"type": "text", "text": "ordinary response"}],
+            )
+            .save()
+        )
+
+        spec = compile_expression('sessions where origin:chatgpt-export AND ~"timeout failure"')
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["chatgpt-export:ext-hit"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds executable lexical predicates to the #2006 Boolean DSL. `~term` and `~"quoted phrase"` now parse into a typed `QueryTextPredicate` and lower into a correlated FTS5 filter against `messages_fts` joined through `blocks`.

## Problem
After #2011, the DSL could execute session fields, structural `exists(...)`, and action `seq(...)`, but lexical text inside Boolean predicates was still not representable. That meant users could not write queries such as `sessions where origin:chatgpt-export AND ~"timeout failure"` without dropping back to the older flat ranked FTS path.

## Solution
Introduced `QueryTextPredicate`, extended the Lark Boolean grammar with `~text` / `~"phrase"`, and wired the archive Boolean lowerer to `messages_fts MATCH ?`. Because `messages_fts` is contentless and its unindexed columns read back as NULL, the lowerer joins `blocks` by rowid for session correlation, matching the existing search path's storage reality. This PR gives Boolean FTS filter semantics; the existing flat query-term path remains the ranked lexical search path.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` -> `190 passed in 24.52s`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` on pushed branch -> `exit_code: 0`

Ref #2006