### PR TITLE
feat(query): execute semantic DSL predicates (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -74,6 +74,7 @@ from polylogue.archive.query.predicate import (
     QueryFieldPredicate,
     QueryNotPredicate,
     QueryPredicate,
+    QuerySemanticPredicate,
     QuerySequencePredicate,
     QueryTextPredicate,
 )
@@ -374,6 +375,8 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
         | atom
     ?atom: EXISTS STRUCT_UNIT "(" expr ")" -> exists_leaf
         | SEQ "(" sequence_step (ARROW sequence_step)+ ")" -> sequence_leaf
+        | SEMANTIC_QUOTED_TEXT             -> semantic_quoted_leaf
+        | SEMANTIC_BARE_TEXT               -> semantic_bare_leaf
         | FTS_QUOTED_TEXT                  -> fts_quoted_leaf
         | FTS_BARE_TEXT                    -> fts_bare_leaf
         | COUNT_CLAUSE                     -> count_leaf
@@ -390,6 +393,8 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
     OR: /or/i
     AND: /and/i
     NOT: /not/i
+    SEMANTIC_QUOTED_TEXT.7: /(?:semantic|near:text):"(\\.|[^"\\])*"/i
+    SEMANTIC_BARE_TEXT.6: /(?:semantic|near:text):[^\s"()]+/i
     FTS_QUOTED_TEXT.6: /~"(\\.|[^"\\])*"/
     FTS_BARE_TEXT.5: /~[^\s"()]+/
     COUNT_CLAUSE.5: /(messages|words):(>=|<=|=)\d+(?!\S)/
@@ -586,7 +591,8 @@ def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]
             | QueryNotPredicate
             | QueryExistsPredicate
             | QuerySequencePredicate
-            | QueryTextPredicate,
+            | QueryTextPredicate
+            | QuerySemanticPredicate,
         )
     )
 
@@ -639,6 +645,12 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         if not predicate.text.strip():
             raise ExpressionCompileError("FTS predicate requires text", field=None)
         return
+    if isinstance(predicate, QuerySemanticPredicate):
+        if unit != "session":
+            raise ExpressionCompileError("semantic predicates are only supported from sessions", field=None)
+        if not predicate.text.strip():
+            raise ExpressionCompileError("semantic predicate requires text", field=None)
+        return
 
 
 @v_args(inline=True)
@@ -679,6 +691,19 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
             raise ExpressionCompileError("FTS predicate requires text", field=None)
         return QueryTextPredicate(text=value)
 
+    def semantic_quoted_leaf(self, token: Token) -> QueryPredicate:
+        raw = str(token)
+        quoted = raw[len("near:text:") :] if raw.lower().startswith("near:text:") else raw[len("semantic:") :]
+        return QuerySemanticPredicate(text=_decode_escaped_string(Token("ESCAPED_STRING", quoted)))
+
+    def semantic_bare_leaf(self, token: Token) -> QueryPredicate:
+        raw = str(token)
+        value = raw[len("near:text:") :] if raw.lower().startswith("near:text:") else raw[len("semantic:") :]
+        value = value.strip()
+        if not value:
+            raise ExpressionCompileError("semantic predicate requires text", field=None)
+        return QuerySemanticPredicate(text=value)
+
     def exists_leaf(self, _exists: Token, unit: Token, child: QueryPredicate) -> QueryPredicate:
         unit_value = str(unit).lower()
         if unit_value not in {"message", "action"}:
@@ -712,6 +737,8 @@ def _is_boolean_expression(expression: str) -> bool:
         return True
     if "~" in expression:
         return True
+    if re.search(r"\b(?:semantic|near:text):", expression, re.IGNORECASE):
+        return True
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
 
@@ -733,11 +760,73 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
         | QueryNotPredicate
         | QueryExistsPredicate
         | QuerySequencePredicate
-        | QueryTextPredicate,
+        | QueryTextPredicate
+        | QuerySemanticPredicate,
     ):
         raise ExpressionCompileError("Boolean query did not produce a predicate", field=None)
     _validate_predicate_context(transformed, unit="session")
     return transformed
+
+
+def _contains_semantic_predicate(predicate: QueryPredicate) -> bool:
+    if isinstance(predicate, QuerySemanticPredicate):
+        return True
+    if isinstance(predicate, QueryNotPredicate):
+        return _contains_semantic_predicate(predicate.child)
+    if isinstance(predicate, QueryBoolPredicate):
+        return any(_contains_semantic_predicate(child) for child in predicate.children)
+    if isinstance(predicate, QueryExistsPredicate):
+        return _contains_semantic_predicate(predicate.child)
+    return False
+
+
+def _merge_semantic_seed(existing: str | None, new_value: str) -> str:
+    if existing is not None:
+        raise ExpressionCompileError(
+            "only one semantic predicate is supported per query until the ranked planner supports multiple vector legs",
+            field=None,
+        )
+    return new_value
+
+
+def _extract_semantic_seed(predicate: QueryPredicate) -> tuple[str | None, QueryPredicate | None]:
+    """Lift a positive top-level semantic predicate into ``SessionQuerySpec.similar_text``.
+
+    Semantic vector search is rank-producing, not a simple SQL truth predicate.
+    The currently executable shape is therefore ``semantic:"text" AND <filters>``:
+    the vector leg produces ranked message candidates and the residual predicate
+    filters those candidates through existing archive lowerers.
+    """
+
+    if isinstance(predicate, QuerySemanticPredicate):
+        return predicate.text, None
+    if isinstance(predicate, QueryNotPredicate):
+        if _contains_semantic_predicate(predicate.child):
+            raise ExpressionCompileError("semantic predicates are not supported under NOT", field=None)
+        return None, predicate
+    if isinstance(predicate, QueryExistsPredicate):
+        if _contains_semantic_predicate(predicate.child):
+            raise ExpressionCompileError("semantic predicates are only supported at session scope", field=None)
+        return None, predicate
+    if isinstance(predicate, QueryBoolPredicate):
+        if predicate.op != "and":
+            if _contains_semantic_predicate(predicate):
+                raise ExpressionCompileError("semantic predicates are not supported under OR yet", field=None)
+            return None, predicate
+        semantic_text: str | None = None
+        residual_children: list[QueryPredicate] = []
+        for child in predicate.children:
+            child_semantic, residual = _extract_semantic_seed(child)
+            if child_semantic is not None:
+                semantic_text = _merge_semantic_seed(semantic_text, child_semantic)
+            if residual is not None:
+                residual_children.append(residual)
+        if not residual_children:
+            return semantic_text, None
+        if len(residual_children) == 1:
+            return semantic_text, residual_children[0]
+        return semantic_text, QueryBoolPredicate("and", tuple(residual_children))
+    return None, predicate
 
 
 def parse_expression_ast(expression: str) -> QueryExpressionAST:
@@ -1174,7 +1263,8 @@ def compile_expression(expression: str) -> SessionQuerySpec:
 
     ast = parse_expression_ast(expression)
     if ast.boolean_predicate is not None:
-        return SessionQuerySpec(boolean_predicate=ast.boolean_predicate)
+        similar_text, residual_predicate = _extract_semantic_seed(ast.boolean_predicate)
+        return SessionQuerySpec(similar_text=similar_text, boolean_predicate=residual_predicate)
     tokens = list(ast.clauses)
 
     # Check for JSON tokens (should only appear alone; mixed is an error)

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -73,6 +73,16 @@ class QueryTextPredicate:
         return {"kind": "fts", "unit": "session", "text": self.text}
 
 
+@dataclass(frozen=True)
+class QuerySemanticPredicate:
+    """Semantic vector predicate over session message/block text."""
+
+    text: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "semantic", "unit": "session", "text": self.text}
+
+
 QueryPredicate: TypeAlias = (
     QueryFieldPredicate
     | QueryNotPredicate
@@ -80,6 +90,7 @@ QueryPredicate: TypeAlias = (
     | QueryExistsPredicate
     | QuerySequencePredicate
     | QueryTextPredicate
+    | QuerySemanticPredicate
 )
 
 
@@ -91,6 +102,7 @@ __all__ = [
     "QueryFieldPredicate",
     "QueryNotPredicate",
     "QueryPredicate",
+    "QuerySemanticPredicate",
     "QuerySequencePredicate",
     "QueryTextPredicate",
 ]

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -41,10 +41,12 @@ from polylogue.archive.query.predicate import (
     QueryExistsPredicate,
     QueryFieldPredicate,
     QueryNotPredicate,
+    QuerySemanticPredicate,
     QuerySequencePredicate,
     QueryTextPredicate,
 )
 from polylogue.archive.query.spec import SessionQuerySpec
+from polylogue.storage.runtime import MessageRecord
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -576,6 +578,90 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["chatgpt-export:ext-hit"]
+
+    def test_semantic_predicate_lowers_to_vector_seed_and_residual_filter(self) -> None:
+        spec = compile_expression('sessions where semantic:"query compiler" AND title:hit')
+
+        assert spec.similar_text == "query compiler"
+        assert spec.boolean_predicate == QueryFieldPredicate(field="title", values=("hit",))
+
+    def test_near_text_predicate_is_semantic_alias(self) -> None:
+        ast = parse_expression_ast('sessions where near:text:"query compiler"')
+
+        assert ast.boolean_predicate == QuerySemanticPredicate(text="query compiler")
+        assert compile_expression('sessions where near:text:"query compiler"').similar_text == "query compiler"
+
+    @pytest.mark.parametrize(
+        "expression, message",
+        [
+            ('sessions where semantic:"query compiler" OR title:hit', "under OR"),
+            ('sessions where NOT semantic:"query compiler"', "under NOT"),
+            ('sessions where semantic:"query compiler" AND semantic:"review loop"', "only one semantic"),
+        ],
+    )
+    def test_semantic_predicate_rejects_ranked_boolean_forms(self, expression: str, message: str) -> None:
+        with pytest.raises(ExpressionCompileError, match=message):
+            compile_expression(expression)
+
+    async def test_semantic_predicate_executes_via_vector_plan(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.archive_execution import list_summaries_archive
+        from tests.infra.storage_records import SessionBuilder
+
+        class StubVectorProvider:
+            model = "stub"
+
+            def upsert(self, session_id: str, messages: list[MessageRecord]) -> None:
+                raise NotImplementedError
+
+            def query(self, text: str, limit: int = 10) -> list[tuple[str, float]]:
+                assert text == "query compiler"
+                assert limit >= 6
+                return [
+                    ("chatgpt-export:ext-hit:m-hit", 0.01),
+                    ("chatgpt-export:ext-miss:m-miss", 0.02),
+                ]
+
+            def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+                raise NotImplementedError
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("semantic hit")
+            .add_message(
+                "m-hit",
+                role="assistant",
+                text="query compiler plan",
+                blocks=[{"type": "text", "text": "query compiler plan"}],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("semantic miss")
+            .add_message(
+                "m-miss",
+                role="assistant",
+                text="query compiler plan",
+                blocks=[{"type": "text", "text": "query compiler plan"}],
+            )
+            .save()
+        )
+
+        spec = compile_expression('sessions where semantic:"query compiler" AND title:hit')
+        rows = await list_summaries_archive(
+            spec.to_plan(vector_provider=StubVectorProvider()),
+            archive_root=archive_root,
+            config=None,
+        )
+
+        assert [row.id for row in rows] == ["chatgpt-export:ext-hit"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds semantic/vector predicates to the canonical Lark query DSL. `semantic:"..."` and the explicit alias `near:text:"..."` now parse into a typed `QuerySemanticPredicate`, compile into the existing `SessionQuerySpec.similar_text` vector seed, and execute through the existing semantic archive path with any remaining Boolean predicate applied as a structured filter.

## Problem

The #2006 DSL had executable SQL, structural, sequence, and FTS predicates, but semantic search still lived only on the older `near:` / `similar_text` path. A semantic predicate cannot honestly lower to a storage `WHERE` clause: vector search produces ranked message candidates first, then archive filters resolve those candidates to sessions.

## Solution

The grammar now accepts `semantic:<text>` and `near:text:<text>` at session scope. The AST bridge lifts a single positive semantic predicate out of a top-level conjunction into `similar_text`, leaving the residual predicate tree as normal Boolean filtering. Unsupported ranked Boolean forms (`OR`, `NOT`, nested structural semantic predicates, or multiple semantic seeds) fail with typed `ExpressionCompileError` messages instead of broadening to lexical search or pretending vector ranking is ordinary set logic.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` → `196 passed in 27.05s`
- `nix develop --command devtools verify --quick` → `exit_code: 0`

Ref #2006