### PR TITLE
feat(query): execute lineage DSL predicates (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -72,6 +72,7 @@ from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
     QueryExistsPredicate,
     QueryFieldPredicate,
+    QueryLineagePredicate,
     QueryNotPredicate,
     QueryPredicate,
     QuerySemanticPredicate,
@@ -219,6 +220,12 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
         "spec_field": "retrieval_lane",
         "negatable": "no",
         "example": "lane:dialogue",
+    },
+    "lineage": {
+        "description": "Filter to sessions sharing a logical lineage with a seed session id",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "lineage:id:chatgpt-export:ext-root",
     },
 }
 
@@ -441,6 +448,7 @@ _BOOLEAN_SUPPORTED_FIELDS = {
     "until",
     "messages",
     "words",
+    "lineage",
 }
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
     "role",
@@ -559,6 +567,15 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
         values = tuple(value.strip().lower() for value in values if value.strip())
     elif field_name in {"since", "until"} and values:
         values = (_parse_relative_date(values[-1]),)
+    elif field_name == "lineage":
+        if token.negated:
+            raise ExpressionCompileError("negation is not supported for 'lineage'", field=field_name)
+        seed = values[-1].strip() if values else ""
+        if seed.startswith("id:"):
+            seed = seed[len("id:") :].strip()
+        if not seed:
+            raise ExpressionCompileError("lineage:id: requires a session id", field=field_name)
+        return QueryLineagePredicate(seed_session_id=seed)
 
     predicate: QueryPredicate = QueryFieldPredicate(field=field_name, values=values)
     return QueryNotPredicate(predicate) if token.negated else predicate
@@ -590,6 +607,7 @@ def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]
             | QueryBoolPredicate
             | QueryNotPredicate
             | QueryExistsPredicate
+            | QueryLineagePredicate
             | QuerySequencePredicate
             | QueryTextPredicate
             | QuerySemanticPredicate,
@@ -634,6 +652,12 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         if unit != "session":
             raise ExpressionCompileError("exists predicates are only supported from sessions", field=None)
         _validate_predicate_context(predicate.child, unit=predicate.unit)
+        return
+    if isinstance(predicate, QueryLineagePredicate):
+        if unit != "session":
+            raise ExpressionCompileError("lineage predicates are only supported from sessions", field=None)
+        if not predicate.seed_session_id.strip():
+            raise ExpressionCompileError("lineage predicate requires a session id", field="lineage")
         return
     if isinstance(predicate, QuerySequencePredicate):
         if unit != "session":
@@ -730,7 +754,7 @@ _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()
 
 def _is_boolean_expression(expression: str) -> bool:
     if re.search(
-        r"^\s*\(|^\s*sessions\s+where\b|^\s*exists\s+(?:message|action)\s*\(|^\s*seq\s*\(",
+        r"^\s*\(|^\s*sessions\s+where\b|^\s*exists\s+(?:message|action)\s*\(|^\s*seq\s*\(|^\s*lineage:",
         expression,
         re.IGNORECASE,
     ):
@@ -759,6 +783,7 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
         | QueryBoolPredicate
         | QueryNotPredicate
         | QueryExistsPredicate
+        | QueryLineagePredicate
         | QuerySequencePredicate
         | QueryTextPredicate
         | QuerySemanticPredicate,

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -83,6 +83,16 @@ class QuerySemanticPredicate:
         return {"kind": "semantic", "unit": "session", "text": self.text}
 
 
+@dataclass(frozen=True)
+class QueryLineagePredicate:
+    """Session-topology predicate selecting the seed's logical lineage."""
+
+    seed_session_id: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "lineage", "unit": "session", "seed_session_id": self.seed_session_id}
+
+
 QueryPredicate: TypeAlias = (
     QueryFieldPredicate
     | QueryNotPredicate
@@ -91,6 +101,7 @@ QueryPredicate: TypeAlias = (
     | QuerySequencePredicate
     | QueryTextPredicate
     | QuerySemanticPredicate
+    | QueryLineagePredicate
 )
 
 
@@ -100,6 +111,7 @@ __all__ = [
     "QueryCompareOp",
     "QueryExistsPredicate",
     "QueryFieldPredicate",
+    "QueryLineagePredicate",
     "QueryNotPredicate",
     "QueryPredicate",
     "QuerySemanticPredicate",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -15,6 +15,7 @@ from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
     QueryExistsPredicate,
     QueryFieldPredicate,
+    QueryLineagePredicate,
     QueryNotPredicate,
     QueryPredicate,
     QuerySequencePredicate,
@@ -4505,6 +4506,22 @@ def _fts_predicate_clause(table_alias: str, predicate: QueryTextPredicate) -> tu
     )
 
 
+def _lineage_predicate_clause(table_alias: str, predicate: QueryLineagePredicate) -> tuple[str, list[object]]:
+    seed_session_id = predicate.seed_session_id.strip()
+    if not seed_session_id:
+        raise ValueError("lineage predicate requires a session id")
+    return (
+        f"""
+        COALESCE({table_alias}.root_session_id, {table_alias}.session_id) = (
+            SELECT COALESCE(seed.root_session_id, seed.session_id)
+            FROM sessions seed
+            WHERE seed.session_id = ?
+        )
+        """.strip(),
+        [seed_session_id],
+    )
+
+
 def _boolean_predicate_clause(
     table_alias: str,
     predicate: QueryPredicate,
@@ -4519,6 +4536,8 @@ def _boolean_predicate_clause(
         return _action_sequence_clause(table_alias, predicate.action_terms)
     if isinstance(predicate, QueryTextPredicate):
         return _fts_predicate_clause(table_alias, predicate)
+    if isinstance(predicate, QueryLineagePredicate):
+        return _lineage_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QueryNotPredicate):
         clause, params = _boolean_predicate_clause(table_alias, predicate.child, tags_relation=tags_relation)
         return (f"NOT ({clause})" if clause else "", params)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -40,6 +40,7 @@ from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
     QueryExistsPredicate,
     QueryFieldPredicate,
+    QueryLineagePredicate,
     QueryNotPredicate,
     QuerySemanticPredicate,
     QuerySequencePredicate,
@@ -663,6 +664,46 @@ class TestBooleanQueryExpression:
 
         assert [row.id for row in rows] == ["chatgpt-export:ext-hit"]
 
+    def test_lineage_predicate_ast_exposes_seed(self) -> None:
+        ast = parse_expression_ast("lineage:id:chatgpt-export:ext-root")
+
+        assert ast.boolean_predicate == QueryLineagePredicate(seed_session_id="chatgpt-export:ext-root")
+
+    def test_lineage_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (SessionBuilder(index_db, "root").provider("chatgpt").title("root").add_message("m-root", text="root").save())
+        (
+            SessionBuilder(index_db, "child")
+            .provider("chatgpt")
+            .title("child")
+            .parent_session("ext-root")
+            .add_message("m-child", text="child")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "other")
+            .provider("chatgpt")
+            .title("other")
+            .add_message("m-other", text="other")
+            .save()
+        )
+
+        spec = compile_expression("lineage:id:chatgpt-export:ext-child")
+        assert spec.boolean_predicate == QueryLineagePredicate(seed_session_id="chatgpt-export:ext-child")
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(
+                limit=100,
+                boolean_predicate=spec.boolean_predicate,
+            )
+
+        assert sorted(row.session_id for row in rows) == [
+            "chatgpt-export:ext-child",
+            "chatgpt-export:ext-root",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Compiler field-mapping tests
@@ -1096,6 +1137,11 @@ class TestFieldRegistry:
         "messages": ("messages:>=10", "min_messages", 10),
         "words": ("words:>=200", "min_words", 200),
         "lane": ("lane:dialogue", "retrieval_lane", "dialogue"),
+        "lineage": (
+            "lineage:id:chatgpt-export:ext-root",
+            "boolean_predicate",
+            QueryLineagePredicate(seed_session_id="chatgpt-export:ext-root"),
+        ),
     }
 
     def test_registry_has_required_fields(self) -> None:


### PR DESCRIPTION
## Summary

Adds a concrete lineage/topology predicate to the canonical query DSL. `lineage:id:<session-id>` now parses into `QueryLineagePredicate` and executes against the existing archive topology materialization, returning sessions that share the seed session's logical root.

## Problem

#2006 requires traversal coverage, not only scalar session filters. Polylogue already materializes logical lineage in `sessions.root_session_id`; the query DSL could not use that evidence directly.

## Solution

The parser registry now exposes `lineage` as a session-scope predicate. The storage Boolean lowerer resolves the seed root with `COALESCE(root_session_id, session_id)` and compares candidate sessions against that same root. This keeps the implementation on the existing topology/read-model contract and avoids inventing a separate traversal engine.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` → `200 passed in 27.89s`
- `nix develop --command devtools verify --quick` → `exit_code: 0`

Ref #2006