### PR TITLE
feat(cli): complete query fields from grammar registry (#1844)

### DIFF
--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -188,6 +188,15 @@ def _detect_subcommand_and_verb(group: click.Group, args: list[str]) -> tuple[st
 class QueryFirstGroupBase(click.Group):
     """Custom Click group that routes to query mode by default."""
 
+    def shell_complete(self, ctx: click.Context, incomplete: str) -> list[click.shell_completion.CompletionItem]:
+        items = list(super().shell_complete(ctx, incomplete))
+        from polylogue.cli.shell_completion_values import complete_query_expression_fields
+
+        query_items = complete_query_expression_fields(ctx, None, incomplete)
+        existing = {item.value for item in items}
+        items.extend(item for item in query_items if item.value not in existing)
+        return items
+
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """Parse args, preserving raw query terms."""
         # Capture the raw argv slice up-front so ``--diagnose`` can show it

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -10,12 +10,14 @@ yet and degrades to an empty completion list.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
 import click
 from click.shell_completion import CompletionItem
 
 from polylogue.archive.message.types import MessageType
+from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
 from polylogue.archive.query.fields import CompletionSource
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
 from polylogue.paths import active_index_db_path
@@ -39,6 +41,29 @@ _ORIGIN_DESCRIPTIONS: Final[dict[str, str]] = {
 _MAX_ID_COMPLETIONS = 24
 _MAX_VALUE_COMPLETIONS = 32
 CompletionCallback = Callable[[click.Context, click.Parameter, str], list[CompletionItem]]
+
+
+@dataclass(frozen=True)
+class QueryCompletionCandidate:
+    """Structured query-completion candidate shared by shell adapters."""
+
+    value: str
+    insert: str
+    display: str
+    kind: str
+    group: str
+    description: str
+    source: str
+    stale: bool = False
+    danger: bool = False
+    score: float = 1.0
+
+    def to_click_item(self) -> CompletionItem:
+        return CompletionItem(
+            self.insert,
+            type=self.kind,
+            help=self.description,
+        )
 
 
 def _split_csv_incomplete(incomplete: str) -> tuple[str, str]:
@@ -117,6 +142,48 @@ def _static_completion_items(
     current_lower = current.lower()
     items = [CompletionItem(value) for value in values if not current_lower or value.lower().startswith(current_lower)]
     return _with_csv_prefix(items, prefix) if csv else items
+
+
+def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return DSL field candidates from the shared expression registry."""
+
+    current = incomplete.strip().lstrip("-").lower()
+    if ":" in current:
+        return []
+    candidates: list[QueryCompletionCandidate] = []
+    for field_name, info in sorted(EXPRESSION_FIELD_REGISTRY.items()):
+        if current and not field_name.startswith(current):
+            continue
+        insert = f"{field_name}:"
+        description = info.get("description", "")
+        example = info.get("example")
+        if example:
+            description = f"{description} Example: {example}" if description else f"Example: {example}"
+        candidates.append(
+            QueryCompletionCandidate(
+                value=field_name,
+                insert=insert,
+                display=insert,
+                kind="query-field",
+                group="query fields",
+                description=_trim_help(description),
+                source="EXPRESSION_FIELD_REGISTRY",
+            )
+        )
+    return candidates
+
+
+def complete_query_expression_fields(
+    ctx: click.Context,
+    param: click.Parameter | None,
+    incomplete: str,
+) -> list[CompletionItem]:
+    """Complete query DSL field tokens from the canonical grammar registry."""
+
+    del ctx, param
+    if incomplete.startswith("--"):
+        return []
+    return [candidate.to_click_item() for candidate in query_field_candidates(incomplete)]
 
 
 def complete_origin_values(
@@ -299,6 +366,7 @@ __all__ = [
     "COMPLETION_SOURCE_HANDLERS",
     "complete_action_sequence_values",
     "complete_action_values",
+    "complete_query_expression_fields",
     "complete_session_ids",
     "complete_cwd_prefix_values",
     "complete_message_type_values",
@@ -308,4 +376,6 @@ __all__ = [
     "complete_retrieval_lane_values",
     "complete_tag_values",
     "complete_tool_values",
+    "query_field_candidates",
+    "QueryCompletionCandidate",
 ]

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -61,7 +61,7 @@ class QueryCompletionCandidate:
     def to_click_item(self) -> CompletionItem:
         return CompletionItem(
             self.insert,
-            type=self.kind,
+            type="plain",
             help=self.description,
         )
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -125,6 +125,9 @@ def test_query_field_candidates_come_from_expression_registry() -> None:
     assert repo_candidate.kind == "query-field"
     assert repo_candidate.source == "EXPRESSION_FIELD_REGISTRY"
     assert EXPRESSION_FIELD_REGISTRY["repo"]["description"] in repo_candidate.description
+    click_item = repo_candidate.to_click_item()
+    assert click_item.value == "repo:"
+    assert click_item.type == "plain"
 
 
 @pytest.fixture

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -113,6 +113,20 @@ def test_completion_source_registry_covers_descriptor_sources() -> None:
     )
 
 
+def test_query_field_candidates_come_from_expression_registry() -> None:
+    from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
+
+    candidates = shell_completion_values.query_field_candidates("re")
+    values = {candidate.value for candidate in candidates}
+
+    assert "repo" in values
+    repo_candidate = next(candidate for candidate in candidates if candidate.value == "repo")
+    assert repo_candidate.insert == "repo:"
+    assert repo_candidate.kind == "query-field"
+    assert repo_candidate.source == "EXPRESSION_FIELD_REGISTRY"
+    assert EXPRESSION_FIELD_REGISTRY["repo"]["description"] in repo_candidate.description
+
+
 @pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner()

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -110,6 +110,31 @@ def _run_completion(
     return [(it.value, it.help) for it in items]
 
 
+def _run_completion_for_partial(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    cwords: list[str],
+    incomplete: str,
+) -> list[tuple[str, str | None]]:
+    saved = {k: os.environ.get(k) for k in ("COMP_WORDS", "COMP_CWORD")}
+    os.environ["COMP_WORDS"] = " ".join(["polylogue", *cwords, incomplete])
+    os.environ["COMP_CWORD"] = incomplete if shell == "fish" else str(len(cwords) + 1)
+    try:
+        comp = comp_cls(cli, {}, "polylogue", "_POLYLOGUE_COMPLETE")
+        args, actual_incomplete = comp.get_completion_args()
+        assert actual_incomplete == incomplete
+        items = comp.get_completions(args, actual_incomplete)
+        formatted = [comp.format_completion(item) for item in items]
+        assert all(isinstance(line, str) for line in formatted), shell
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    return [(it.value, it.help) for it in items]
+
+
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 @pytest.mark.parametrize("label,cwords", STATIC_COMPLETERS, ids=[label for label, _ in STATIC_COMPLETERS])
 def test_static_completers_per_shell(
@@ -133,6 +158,24 @@ def test_static_completers_per_shell(
 
     items = _run_completion(shell, comp_cls, cwords)
     assert items, f"static completer {label} produced no items on {shell}"
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_field_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root query completion suggests DSL fields from the shared grammar registry."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, [], "re")
+    values = {value for value, _ in items}
+    assert "repo:" in values
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])


### PR DESCRIPTION
## Summary

Adds the first grammar-backed completion layer for #1844: root query shell completion now suggests DSL field names from `EXPRESSION_FIELD_REGISTRY`, and the shell adapters for bash, zsh, and fish are covered by tests.

## Problem

Completion was still centered on option value providers. The query language field names themselves were not projected from the shared grammar registry, so shell completion could drift from #2006's parser metadata or fail to make query-first field syntax discoverable.

## Solution

Added a structured `QueryCompletionCandidate` model in `shell_completion_values`, generated field candidates directly from `EXPRESSION_FIELD_REGISTRY`, and wired the query-first root group's `shell_complete` hook to append those candidates lazily. The hook preserves the lightweight query-group import boundary by importing completion metadata only during completion.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py` -> `54 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`

Ref #1844