### PR TITLE
feat(cli): complete query field values from descriptors (#1844)

### DIFF
--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -18,7 +18,7 @@ from click.shell_completion import CompletionItem
 
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
-from polylogue.archive.query.fields import CompletionSource
+from polylogue.archive.query.fields import QUERY_FIELD_DESCRIPTORS, CompletionSource
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
 from polylogue.paths import active_index_db_path
 
@@ -173,6 +173,53 @@ def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
     return candidates
 
 
+def _completion_source_for_expression_field(field_name: str) -> CompletionSource | None:
+    info = EXPRESSION_FIELD_REGISTRY.get(field_name)
+    if info is None:
+        return None
+    spec_fields = tuple(part.strip() for part in info["spec_field"].split("/") if part.strip())
+    for spec_field in spec_fields:
+        for descriptor in QUERY_FIELD_DESCRIPTORS:
+            if spec_field in {descriptor.name, descriptor.spec_attr} and descriptor.completion_source is not None:
+                return descriptor.completion_source
+    return None
+
+
+def _prefixed_query_value_items(
+    items: list[CompletionItem],
+    *,
+    prefix: str,
+) -> list[CompletionItem]:
+    return [
+        CompletionItem(
+            f"{prefix}{item.value}",
+            type=item.type,
+            help=item.help,
+        )
+        for item in items
+    ]
+
+
+def _complete_query_expression_values(
+    ctx: click.Context,
+    param: click.Parameter | None,
+    incomplete: str,
+) -> list[CompletionItem]:
+    negated = incomplete.startswith("-")
+    token = incomplete[1:] if negated else incomplete
+    field_name, value_prefix = token.split(":", 1)
+    field_name = field_name.lower()
+    if not field_name or value_prefix.startswith("("):
+        return []
+    source = _completion_source_for_expression_field(field_name)
+    if source is None:
+        return []
+    value_param = param or click.Option(["--query-value"])
+    items = complete_query_source(source)(ctx, value_param, value_prefix)
+    prefix = f"{'-' if negated else ''}{field_name}:"
+    return _prefixed_query_value_items(items, prefix=prefix)
+
+
 def complete_query_expression_fields(
     ctx: click.Context,
     param: click.Parameter | None,
@@ -180,9 +227,11 @@ def complete_query_expression_fields(
 ) -> list[CompletionItem]:
     """Complete query DSL field tokens from the canonical grammar registry."""
 
-    del ctx, param
     if incomplete.startswith("--"):
         return []
+    if ":" in incomplete:
+        return _complete_query_expression_values(ctx, param, incomplete)
+    del ctx, param
     return [candidate.to_click_item() for candidate in query_field_candidates(incomplete)]
 
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -130,6 +130,25 @@ def test_query_field_candidates_come_from_expression_registry() -> None:
     assert click_item.type == "plain"
 
 
+def test_query_expression_value_completion_uses_field_completion_source() -> None:
+    ctx, param = _ctx_param()
+
+    origin_items = shell_completion_values.complete_query_expression_fields(ctx, param, "origin:cla")
+    assert [item.value for item in origin_items] == ["origin:claude-ai-export", "origin:claude-code-session"]
+
+    with (
+        patch("polylogue.cli.shell_completion_values._db_exists", return_value=True),
+        patch("polylogue.cli.shell_completion_values._run_completion") as run_completion,
+    ):
+        mock_archive = MagicMock()
+        mock_archive.stats_by.return_value = {"polylogue": 4}
+        run_completion.side_effect = lambda action: list(action(mock_archive))
+        repo_items = shell_completion_values.complete_query_expression_fields(ctx, param, "repo:poly")
+
+    assert [item.value for item in repo_items] == ["repo:polylogue"]
+    assert repo_items[0].help == "4 sessions"
+
+
 @pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner()

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -179,6 +179,25 @@ def test_query_field_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_field_value_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root query completion suggests values through field completion sources."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, [], "origin:cla")
+    values = {value for value, _ in items}
+    assert "origin:claude-ai-export" in values
+    assert "origin:claude-code-session" in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 @pytest.mark.parametrize("label,cwords", DYNAMIC_COMPLETERS, ids=[label for label, _ in DYNAMIC_COMPLETERS])
 def test_dynamic_completers_empty_archive_per_shell(
     shell: str,


### PR DESCRIPTION
## Summary

Adds value completion for query DSL field prefixes. `origin:cla<TAB>` now completes supported origin values through the real shell adapters, and archive-backed fields such as `repo:` route through the same existing completion providers used by root options.

## Problem

The first #1844 completion layer exposed field names from `EXPRESSION_FIELD_REGISTRY`, but it stopped once a field prefix was typed. Completion still had to know, separately, that `origin:` should use origin values or `repo:` should use archive repo values.

## Solution

Mapped `EXPRESSION_FIELD_REGISTRY[field].spec_field` onto `QUERY_FIELD_DESCRIPTORS` and reused the descriptor `completion_source` to dispatch to existing completion providers. The shell adapter preserves the DSL field prefix around returned values, so the inserted candidate remains a valid query expression token.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py` -> `58 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`

Ref #1844