### PR TITLE
feat(query): suggest close field names in DSL errors (#1844)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field, replace
+from difflib import get_close_matches
 from typing import Any, Literal, cast
 
 from lark import Lark, Token, Transformer, v_args
@@ -465,6 +466,17 @@ _MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command
 _ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text"}
 
 
+def _unknown_query_field_message(field_name: str, *, include_structural: bool = False) -> str:
+    recognized = sorted(EXPRESSION_FIELD_REGISTRY)
+    message = f"unknown query field {field_name!r}; recognized fields: " + ", ".join(recognized)
+    suggestions = get_close_matches(field_name, recognized, n=3, cutoff=0.6)
+    if suggestions:
+        message += "; did you mean: " + ", ".join(suggestions)
+    if include_structural:
+        message += "; structural fields: " + ", ".join(sorted(_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS))
+    return message
+
+
 def _decode_escaped_string(token: Token) -> str:
     try:
         decoded = json.loads(str(token))
@@ -531,12 +543,8 @@ _QUERY_TRANSFORMER = _QueryTransformer()
 def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
     field_name = token.field
     if field_name not in EXPRESSION_FIELD_REGISTRY and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
-        recognized = sorted(EXPRESSION_FIELD_REGISTRY)
         raise ExpressionCompileError(
-            f"unknown query field {field_name!r}; recognized fields: "
-            + ", ".join(recognized)
-            + "; structural fields: "
-            + ", ".join(sorted(_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS)),
+            _unknown_query_field_message(field_name, include_structural=True),
             field=field_name,
         )
     if field_name not in _BOOLEAN_SUPPORTED_FIELDS and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
@@ -1173,9 +1181,8 @@ class _SpecAccumulator:
             )
 
         else:
-            recognized = sorted(EXPRESSION_FIELD_REGISTRY)
             raise ExpressionCompileError(
-                f"unknown query field {fname!r}; recognized fields: " + ", ".join(recognized),
+                _unknown_query_field_message(fname),
                 field=fname,
             )
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -900,9 +900,19 @@ class TestRejection:
             compile_expression("nosuchfield:value")
         assert exc_info.value.field == "nosuchfield"
 
+    def test_unknown_field_suggests_close_registry_match(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="did you mean: origin") as exc_info:
+            compile_expression("origon:chatgpt-export")
+        assert exc_info.value.field == "origon"
+
     def test_unknown_field_message_lists_recognized(self) -> None:
         with pytest.raises(ExpressionCompileError, match="recognized fields"):
             compile_expression("xyz:value")
+
+    def test_boolean_unknown_field_suggests_close_registry_match(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="did you mean: origin") as exc_info:
+            compile_expression("sessions where origon:chatgpt-export")
+        assert exc_info.value.field == "origon"
 
     def test_cross_field_or_compiles_to_boolean_predicate(self) -> None:
         spec = compile_expression("repo:polylogue OR repo:sinex")


### PR DESCRIPTION
## Summary

Adds typo suggestions to query DSL unknown-field errors. A mistyped field such as `origon:chatgpt-export` now reports `did you mean: origin` while preserving the existing recognized-field list and typed `ExpressionCompileError.field` value.

## Problem

#1844 requires useful unknown-field suggestions. The DSL parser already failed loudly, but it forced users and agents to scan the whole recognized-field list even for obvious typos.

## Solution

Added a shared unknown-field error formatter backed by `EXPRESSION_FIELD_REGISTRY` and `difflib.get_close_matches`. Both the flat compatibility accumulator and Boolean predicate validation path use the same formatter, so suggestions are consistent across current query syntaxes.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` -> `202 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`

Ref #1844