### PR TITLE
feat(cli): complete actions from command contracts (#1844)

### DIFF
--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -190,12 +190,16 @@ class QueryFirstGroupBase(click.Group):
 
     def shell_complete(self, ctx: click.Context, incomplete: str) -> list[click.shell_completion.CompletionItem]:
         items = list(super().shell_complete(ctx, incomplete))
-        from polylogue.cli.shell_completion_values import complete_query_expression_fields
+        from polylogue.cli.shell_completion_values import complete_query_actions, complete_query_expression_fields
 
-        query_items = complete_query_expression_fields(ctx, None, incomplete)
-        existing = {item.value for item in items}
-        items.extend(item for item in query_items if item.value not in existing)
-        return items
+        replacement_items = [
+            *complete_query_actions(ctx, None, incomplete),
+            *complete_query_expression_fields(ctx, None, incomplete),
+        ]
+        replacements = {item.value: item for item in replacement_items}
+        merged = [replacements.pop(item.value, item) for item in items]
+        merged.extend(replacements.values())
+        return merged
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """Parse args, preserving raw query terms."""

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -20,6 +20,7 @@ from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
 from polylogue.archive.query.fields import QUERY_FIELD_DESCRIPTORS, CompletionSource
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
+from polylogue.cli.action_contracts import ACTION_CONTRACTS, CliActionContract
 from polylogue.paths import active_index_db_path
 
 if TYPE_CHECKING:
@@ -59,10 +60,13 @@ class QueryCompletionCandidate:
     score: float = 1.0
 
     def to_click_item(self) -> CompletionItem:
+        help_text = self.description
+        if self.danger:
+            help_text = f"DANGER: {help_text}" if help_text else "DANGER"
         return CompletionItem(
             self.insert,
             type="plain",
-            help=self.description,
+            help=help_text,
         )
 
 
@@ -173,6 +177,38 @@ def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
     return candidates
 
 
+def _action_description(contract: CliActionContract) -> str:
+    guards = ", ".join(contract.guards)
+    detail = f"{contract.effect}; input={contract.input_unit}; cardinality={contract.cardinality}"
+    return f"{detail}; guards={guards}" if guards else detail
+
+
+def query_action_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return root query/action candidates from public action contracts."""
+
+    current = incomplete.strip().lower()
+    candidates: list[QueryCompletionCandidate] = []
+    for contract in ACTION_CONTRACTS:
+        if len(contract.path) != 1:
+            continue
+        name = contract.path[0]
+        if current and not name.startswith(current):
+            continue
+        candidates.append(
+            QueryCompletionCandidate(
+                value=name,
+                insert=name,
+                display=name,
+                kind="query-action",
+                group="query actions",
+                description=_action_description(contract),
+                source="ACTION_CONTRACTS",
+                danger=contract.effect == "destructive",
+            )
+        )
+    return candidates
+
+
 def _completion_source_for_expression_field(field_name: str) -> CompletionSource | None:
     info = EXPRESSION_FIELD_REGISTRY.get(field_name)
     if info is None:
@@ -233,6 +269,17 @@ def complete_query_expression_fields(
         return _complete_query_expression_values(ctx, param, incomplete)
     del ctx, param
     return [candidate.to_click_item() for candidate in query_field_candidates(incomplete)]
+
+
+def complete_query_actions(
+    ctx: click.Context,
+    param: click.Parameter | None,
+    incomplete: str,
+) -> list[CompletionItem]:
+    """Complete root query actions from public action contracts."""
+
+    del ctx, param
+    return [candidate.to_click_item() for candidate in query_action_candidates(incomplete)]
 
 
 def complete_origin_values(
@@ -415,6 +462,7 @@ __all__ = [
     "COMPLETION_SOURCE_HANDLERS",
     "complete_action_sequence_values",
     "complete_action_values",
+    "complete_query_actions",
     "complete_query_expression_fields",
     "complete_session_ids",
     "complete_cwd_prefix_values",
@@ -425,6 +473,7 @@ __all__ = [
     "complete_retrieval_lane_values",
     "complete_tag_values",
     "complete_tool_values",
+    "query_action_candidates",
     "query_field_candidates",
     "QueryCompletionCandidate",
 ]

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -149,6 +149,18 @@ def test_query_expression_value_completion_uses_field_completion_source() -> Non
     assert repo_items[0].help == "4 sessions"
 
 
+def test_query_action_candidates_come_from_action_contracts_with_danger_metadata() -> None:
+    candidates = shell_completion_values.query_action_candidates("de")
+
+    delete_candidate = next(candidate for candidate in candidates if candidate.value == "delete")
+    assert delete_candidate.source == "ACTION_CONTRACTS"
+    assert delete_candidate.kind == "query-action"
+    assert delete_candidate.danger is True
+    help_text = delete_candidate.to_click_item().help
+    assert help_text is not None
+    assert help_text.startswith("DANGER:")
+
+
 @pytest.fixture
 def cli_runner() -> CliRunner:
     return CliRunner()

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -198,6 +198,25 @@ def test_query_field_value_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_action_completion_marks_destructive_actions_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root action completion is backed by contracts and marks destructive actions."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, [], "de")
+    item_map = dict(items)
+    assert "delete" in item_map
+    assert item_map["delete"] is not None and item_map["delete"].startswith("DANGER:")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 @pytest.mark.parametrize("label,cwords", DYNAMIC_COMPLETERS, ids=[label for label, _ in DYNAMIC_COMPLETERS])
 def test_dynamic_completers_empty_archive_per_shell(
     shell: str,


### PR DESCRIPTION
## Summary

Makes root action completion contract-backed. Query-first shell completion now projects action candidates from `ACTION_CONTRACTS`, and destructive actions such as `delete` carry `DANGER:` help text through the real bash/zsh/fish completion adapters.

## Problem

#1844 requires action completion and danger metadata to come from shared action contracts. Field completion was registry-backed, but action completion still relied on ordinary Click command completion, which has no destructive-action context.

## Solution

Added action completion candidates from `ACTION_CONTRACTS`, mapping `effect=destructive` to `danger=True` on the structured candidate and `DANGER:` in shell-visible help. Query-first group completion now replaces overlapping Click command items with contract-backed candidates while still preserving command completion behavior.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py` -> `62 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`

Ref #1844