### PR TITLE
refactor(query): collapse DSL parsing into one Lark grammar (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -348,31 +348,16 @@ class QueryExpressionExplanation:
 # ---------------------------------------------------------------------------
 
 _QUERY_GRAMMAR = r"""
-    start: clause*
+    flat_query: flat_clause*
 
-    ?clause: COUNT_CLAUSE       -> count_clause
+    ?flat_clause: COUNT_CLAUSE       -> count_clause
         | FIELD_CLAUSE          -> field_clause
         | NEG_QUOTED_TEXT       -> neg_quoted_text
         | QUOTED_TEXT           -> quoted_text
         | NEG_BARE_TEXT         -> neg_bare_text
         | BARE_TEXT             -> bare_text
 
-    COUNT_CLAUSE.5: /(messages|words):(>=|<=|=)\d+(?!\S)/
-    FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
-    NEG_QUOTED_TEXT.3: /-"(\\.|[^"\\])*"/
-    QUOTED_TEXT.2: /"(\\.|[^"\\])*"/
-    NEG_BARE_TEXT.1: /-[^\s"]+/
-    BARE_TEXT: /[^\s"]+/
-
-    %import common.WS
-    %ignore WS
-"""
-
-
-_QUERY_PARSER = Lark(_QUERY_GRAMMAR, parser="lalr", maybe_placeholders=False)
-
-_BOOLEAN_QUERY_GRAMMAR = r"""
-    start: session_prefix? expr
+    boolean_query: session_prefix? expr
 
     session_prefix: SESSIONS WHERE
 
@@ -407,13 +392,22 @@ _BOOLEAN_QUERY_GRAMMAR = r"""
     FTS_BARE_TEXT.5: /~[^\s"()]+/
     COUNT_CLAUSE.5: /(messages|words):(>=|<=|=)\d+(?!\S)/
     FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
+    NEG_QUOTED_TEXT.3: /-"(\\.|[^"\\])*"/
+    QUOTED_TEXT.2: /"(\\.|[^"\\])*"/
+    NEG_BARE_TEXT.1: /-[^\s"]+/
+    BARE_TEXT: /[^\s"]+/
 
     %import common.WS
     %ignore WS
 """
 
 
-_BOOLEAN_QUERY_PARSER = Lark(_BOOLEAN_QUERY_GRAMMAR, parser="lalr", maybe_placeholders=False)
+_QUERY_PARSER = Lark(
+    _QUERY_GRAMMAR,
+    parser="lalr",
+    start=["flat_query", "boolean_query"],
+    maybe_placeholders=False,
+)
 
 _COUNT_CLAUSE_RE = re.compile(r"^(messages|words):(>=|<=|=)(\d+)$")
 _FIELD_CLAUSE_RE = re.compile(
@@ -497,7 +491,7 @@ def _parse_error_message(expression: str, exc: UnexpectedInput) -> str:
 
 @v_args(inline=True)
 class _QueryTransformer(Transformer[Token, _LexToken | str | QueryExpressionAST]):
-    def start(self, *clauses: _LexToken) -> QueryExpressionAST:
+    def flat_query(self, *clauses: _LexToken) -> QueryExpressionAST:
         return QueryExpressionAST(tuple(clauses))
 
     def count_clause(self, token: Token) -> _CountToken:
@@ -687,7 +681,7 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
 
 @v_args(inline=True)
 class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
-    def start(self, *items: object) -> QueryPredicate:
+    def boolean_query(self, *items: object) -> QueryPredicate:
         predicates = _predicate_children(items)
         if len(predicates) != 1:
             raise ExpressionCompileError("Boolean query did not produce exactly one predicate", field=None)
@@ -776,7 +770,7 @@ def _is_boolean_expression(expression: str) -> bool:
 
 def _parse_boolean_predicate(expression: str) -> QueryPredicate:
     try:
-        tree = _BOOLEAN_QUERY_PARSER.parse(expression)
+        tree = _QUERY_PARSER.parse(expression, start="boolean_query")
     except UnexpectedInput as exc:
         raise ExpressionCompileError(_parse_error_message(expression, exc), field=None) from exc
     try:
@@ -870,7 +864,7 @@ def parse_expression_ast(expression: str) -> QueryExpressionAST:
     if _is_boolean_expression(expression):
         return QueryExpressionAST((), boolean_predicate=_parse_boolean_predicate(expression))
     try:
-        tree = _QUERY_PARSER.parse(expression)
+        tree = _QUERY_PARSER.parse(expression, start="flat_query")
     except UnexpectedInput as exc:
         raise ExpressionCompileError(_parse_error_message(expression, exc), field=None) from exc
     transformed = _QUERY_TRANSFORMER.transform(tree)

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -873,14 +873,6 @@ def parse_expression_ast(expression: str) -> QueryExpressionAST:
     return transformed
 
 
-def _lex(expression: str) -> list[_LexToken]:
-    """Project the canonical Lark AST into the current clause lowerer input."""
-    ast = parse_expression_ast(expression)
-    if ast.boolean_predicate is not None:
-        raise ExpressionCompileError("Boolean query cannot be projected to flat clauses", field=None)
-    return list(ast.clauses)
-
-
 def _explain_clause(token: _LexToken) -> QueryExpressionExplainClause:
     if isinstance(token, _FieldToken):
         return QueryExpressionExplainClause(

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -29,7 +29,6 @@ from polylogue.archive.query.expression import (
     ExpressionCompileError,
     _CountToken,
     _FieldToken,
-    _lex,
     _TextToken,
     compile_expression,
     compile_expression_into,
@@ -59,6 +58,11 @@ def _spec(**kwargs: Any) -> SessionQuerySpec:
     return SessionQuerySpec(**kwargs)
 
 
+def _clauses(expression: str) -> list[object]:
+    """Return parsed flat-query clauses through the canonical AST entry point."""
+    return list(parse_expression_ast(expression).clauses)
+
+
 # ---------------------------------------------------------------------------
 # Lexer tests
 # ---------------------------------------------------------------------------
@@ -75,14 +79,14 @@ class TestLexer:
         )
 
     def test_bare_words(self) -> None:
-        tokens = _lex("json envelope")
+        tokens = _clauses("json envelope")
         assert tokens == [
             _TextToken(text="json", quoted=False, negated=False),
             _TextToken(text="envelope", quoted=False, negated=False),
         ]
 
     def test_bare_boolean_words_remain_fts_terms(self) -> None:
-        tokens = _lex("error or timeout not retry")
+        tokens = _clauses("error or timeout not retry")
         assert tokens == [
             _TextToken(text="error", quoted=False, negated=False),
             _TextToken(text="or", quoted=False, negated=False),
@@ -92,7 +96,7 @@ class TestLexer:
         ]
 
     def test_code_like_bare_words(self) -> None:
-        tokens = _lex("foo(bar) array[0] dict{key}")
+        tokens = _clauses("foo(bar) array[0] dict{key}")
         assert tokens == [
             _TextToken(text="foo(bar)", quoted=False, negated=False),
             _TextToken(text="array[0]", quoted=False, negated=False),
@@ -100,32 +104,32 @@ class TestLexer:
         ]
 
     def test_quoted_phrase(self) -> None:
-        tokens = _lex('"json envelope"')
+        tokens = _clauses('"json envelope"')
         assert tokens == [_TextToken(text="json envelope", quoted=True, negated=False)]
 
     def test_negated_quoted_phrase(self) -> None:
-        tokens = _lex('-"bad phrase"')
+        tokens = _clauses('-"bad phrase"')
         assert tokens == [_TextToken(text="bad phrase", quoted=True, negated=True)]
 
     def test_field_bare(self) -> None:
-        tokens = _lex("repo:polylogue")
+        tokens = _clauses("repo:polylogue")
         assert tokens == [_FieldToken(field="repo", raw_value="polylogue", negated=False)]
 
     def test_field_negated(self) -> None:
-        tokens = _lex("-origin:chatgpt-export")
+        tokens = _clauses("-origin:chatgpt-export")
         assert tokens == [_FieldToken(field="origin", raw_value="chatgpt-export", negated=True)]
 
     def test_field_quoted_value(self) -> None:
-        tokens = _lex('near:"semantic search"')
+        tokens = _clauses('near:"semantic search"')
         assert tokens == [_FieldToken(field="near", raw_value="semantic search", negated=False)]
 
     def test_field_paren_alternation(self) -> None:
-        tokens = _lex("origin:(claude-code-session|codex-session)")
+        tokens = _clauses("origin:(claude-code-session|codex-session)")
         assert tokens == [_FieldToken(field="origin", raw_value="claude-code-session|codex-session", negated=False)]
 
     def test_unclosed_quote_raises(self) -> None:
         with pytest.raises(ExpressionCompileError, match="unclosed quoted"):
-            _lex('"not closed')
+            parse_expression_ast('"not closed')
 
     def test_cross_field_or_paren_builds_boolean_ast(self) -> None:
         ast = parse_expression_ast("(origin:claude-code-session OR origin:chatgpt-export)")
@@ -140,10 +144,10 @@ class TestLexer:
         )
 
     def test_empty_expression(self) -> None:
-        assert _lex("") == []
+        assert _clauses("") == []
 
     def test_whitespace_only(self) -> None:
-        assert _lex("   ") == []
+        assert _clauses("   ") == []
 
 
 class TestExplainExpression:


### PR DESCRIPTION
## Summary
Collapse the query DSL parser implementation from two grammar strings into one Lark grammar with explicit `flat_query` and `boolean_query` entry points, and remove the private `_lex()` compatibility projection. Current behavior remains covered, but tests now inspect flat clauses through the canonical AST entry point.

## Problem
#2006 defines one canonical query grammar and AST/lowering path. The code already used Lark, but `expression.py` still carried `_QUERY_GRAMMAR` for flat clauses and `_BOOLEAN_QUERY_GRAMMAR` for Boolean predicates. Tests also imported `_lex()`, preserving a flat-parser artifact as if it were a real floor grammar. That split made the old flat path look like retained architecture instead of compatibility behavior absorbed by the Lark DSL.

## Solution
`polylogue/archive/query/expression.py` now has a single `_QUERY_GRAMMAR` and a single `_QUERY_PARSER` configured with two starts. The flat and Boolean transformers still own their respective AST projections, but both parse from the same grammar definition. `_lex()` is deleted; tests use `parse_expression_ast(...).clauses` directly.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py -k 'query_expression or query_explain or BooleanQueryExpression or Lexer or ExplainExpression'` -> `205 passed, 60 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` -> `exit_code 0`

Ref #2006