### PR TITLE
feat(api): expose read view profiles (#1997)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -24,6 +24,7 @@ from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.core.enums import Origin
+from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.errors import PolylogueError
 from polylogue.insights.archive import (
@@ -1093,6 +1094,12 @@ class PolylogueArchiveMixin:
         if digest is None:
             return None
         return digest.report_markdown(preset)
+
+    async def list_read_view_profiles(self) -> list[JSONDocument]:
+        """List executable read-view profile metadata."""
+        from polylogue.archive.viewport import read_view_profile_payloads
+
+        return list(read_view_profile_payloads())
 
     async def get_sessions(
         self,

--- a/polylogue/archive/viewport/__init__.py
+++ b/polylogue/archive/viewport/__init__.py
@@ -6,6 +6,7 @@ from polylogue.archive.viewport.profiles import (
     SessionViewProfile,
     get_read_view_profile,
     read_view_choices,
+    read_view_profile_payloads,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "SessionViewProfile",
     "get_read_view_profile",
     "read_view_choices",
+    "read_view_profile_payloads",
 ]

--- a/polylogue/archive/viewport/profiles.py
+++ b/polylogue/archive/viewport/profiles.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from polylogue.core.json import JSONDocument
+
 ViewEvidencePolicy = Literal["required", "optional", "unavailable", "omitted"]
 ViewLossiness = Literal["raw", "normalized", "filtered", "summarized", "derived", "browse-only"]
 
@@ -31,6 +33,25 @@ class SessionViewProfile:
     machine_payload: str | None
     degraded_states: tuple[str, ...]
     successor_handoff: bool = False
+
+    def to_payload(self) -> JSONDocument:
+        """Return a JSON-native representation for CLI/API/MCP surfaces."""
+
+        return {
+            "view_id": self.view_id,
+            "label": self.label,
+            "owner": self.owner,
+            "purpose": self.purpose,
+            "input_scope": self.input_scope,
+            "included_kinds": list(self.included_kinds),
+            "lossiness": self.lossiness,
+            "evidence_policy": self.evidence_policy,
+            "privacy_policy": self.privacy_policy,
+            "formats": list(self.formats),
+            "machine_payload": self.machine_payload,
+            "degraded_states": list(self.degraded_states),
+            "successor_handoff": self.successor_handoff,
+        }
 
 
 READ_VIEW_PROFILES: tuple[SessionViewProfile, ...] = (
@@ -180,6 +201,12 @@ def get_read_view_profile(view_id: str) -> SessionViewProfile:
     return READ_VIEW_PROFILE_BY_ID[view_id]
 
 
+def read_view_profile_payloads() -> list[JSONDocument]:
+    """Return JSON-native payloads for all executable read-view profiles."""
+
+    return [profile.to_payload() for profile in READ_VIEW_PROFILES]
+
+
 __all__ = [
     "READ_VIEW_PROFILE_BY_ID",
     "READ_VIEW_PROFILES",
@@ -187,5 +214,6 @@ __all__ = [
     "ViewEvidencePolicy",
     "ViewLossiness",
     "get_read_view_profile",
+    "read_view_profile_payloads",
     "read_view_choices",
 ]

--- a/polylogue/cli/commands/read_views.py
+++ b/polylogue/cli/commands/read_views.py
@@ -4,31 +4,8 @@ from __future__ import annotations
 
 import click
 
-from polylogue.archive.viewport import READ_VIEW_PROFILES, SessionViewProfile
+from polylogue.archive.viewport import READ_VIEW_PROFILES, read_view_profile_payloads
 from polylogue.cli.shared.machine_errors import emit_success
-from polylogue.core.json import JSONDocument
-
-
-def _profile_payload(profile: SessionViewProfile) -> JSONDocument:
-    return {
-        "view_id": profile.view_id,
-        "label": profile.label,
-        "owner": profile.owner,
-        "purpose": profile.purpose,
-        "input_scope": profile.input_scope,
-        "included_kinds": list(profile.included_kinds),
-        "lossiness": profile.lossiness,
-        "evidence_policy": profile.evidence_policy,
-        "privacy_policy": profile.privacy_policy,
-        "formats": list(profile.formats),
-        "machine_payload": profile.machine_payload,
-        "degraded_states": list(profile.degraded_states),
-        "successor_handoff": profile.successor_handoff,
-    }
-
-
-def _profile_payloads() -> list[JSONDocument]:
-    return [_profile_payload(profile) for profile in READ_VIEW_PROFILES]
 
 
 def _render_plain() -> str:
@@ -49,7 +26,7 @@ def read_views_command(output_format: str) -> None:
     """List executable read-view profile metadata."""
 
     if output_format == "json":
-        emit_success({"read_views": _profile_payloads()})
+        emit_success({"read_views": read_view_profile_payloads()})
         return
     click.echo(_render_plain())
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -29,6 +29,7 @@ from polylogue.mcp.payloads import (
     MCPRawArtifactPayload,
     MCPRawArtifactsListPayload,
     MCPReadinessReportPayload,
+    MCPRootPayload,
     MCPStatsByPayload,
     logical_session_payload,
     neighbor_candidates_payload,
@@ -673,6 +674,18 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
 
         return hooks.safe_call("readiness_check", run)
+
+    @mcp.tool()
+    async def list_read_view_profiles() -> str:
+        """List executable read-view profile metadata for agents."""
+
+        async def run() -> str:
+            profiles = await hooks.get_polylogue().list_read_view_profiles()
+            return hooks.json_payload(
+                MCPRootPayload(root=cast(dict[str, object], {"read_views": profiles, "total": len(profiles)}))
+            )
+
+        return await hooks.async_safe_call("list_read_view_profiles", run)
 
 
 def register_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -46,6 +46,7 @@ EXPECTED_TOOL_NAMES = {
     "get_session_topology",
     "get_logical_session",
     "get_stats_by",
+    "list_read_view_profiles",
     "readiness_check",
     "rebuild_index",
     "update_index",
@@ -192,6 +193,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.get_raw_artifacts_for_session = AsyncMock(return_value=([], 0))
     poly.get_session_topology = AsyncMock(return_value=None)
     poly.get_logical_session = AsyncMock(return_value=None)
+    poly.list_read_view_profiles = AsyncMock(return_value=[])
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))
     poly.get_session = AsyncMock(return_value=None)
     poly.get_session_profile_insight = AsyncMock(return_value=None)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -102,6 +102,7 @@ READ_NULLARY_METHODS: frozenset[str] = frozenset(
         "list_marks",
         "list_annotations",
         "list_views",
+        "list_read_view_profiles",
         "list_recall_packs",
         "list_workspaces",
         "list_corrections",
@@ -642,6 +643,27 @@ async def test_recovery_digest_compiles_seeded_session(tmp_path: Path) -> None:
         assert digest.resume_markdown.startswith("# Resume: Alpha")
         assert digest.raw_refs
         assert await archive.recovery_digest("nonexistent") is None
+    finally:
+        await archive.close()
+
+
+async def test_list_read_view_profiles_exposes_shared_profile_payloads(tmp_path: Path) -> None:
+    """``list_read_view_profiles`` exposes the executable read-view registry."""
+    archive = _archive(tmp_path)
+    try:
+        profiles = await archive.list_read_view_profiles()
+
+        views = {}
+        for profile in profiles:
+            view_id = profile["view_id"]
+            assert isinstance(view_id, str)
+            views[view_id] = profile
+        assert views["raw"]["lossiness"] == "raw"
+        assert views["raw"]["evidence_policy"] == "required"
+        assert views["recovery"]["successor_handoff"] is True
+        formats = views["recovery"]["formats"]
+        assert isinstance(formats, list)
+        assert "markdown" in formats
     finally:
         await archive.close()
 

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -60,6 +60,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
         frozenset({"session_id", "root_id", "thread", "siblings", "descendants", "cycle_detected"}),
     ),
     "get_messages": ("envelope", frozenset({"messages", "total"})),
+    "list_read_view_profiles": ("envelope", frozenset({"read_views", "total"})),
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     "archive_list_sessions": ("envelope", frozenset({"items", "total", "limit", "offset"})),
     "archive_search_sessions": ("envelope", frozenset({"items", "total", "limit", "query"})),

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -25,6 +25,7 @@ from polylogue.archive.query.spec import SessionQuerySpec
 from polylogue.archive.semantic.pricing import CostEstimatePayload, CostUsagePayload
 from polylogue.archive.session.neighbor_candidates import NeighborReason, SessionNeighborCandidate
 from polylogue.archive.stats import ArchiveStats
+from polylogue.archive.viewport import read_view_profile_payloads
 from polylogue.core.enums import Origin
 from polylogue.insights.archive import (
     ArchiveCoverageInsight,
@@ -790,6 +791,22 @@ class TestGetSessionTool:
             )
 
         assert isinstance(json.loads(result), dict)
+
+
+class TestReadViewProfilesTool:
+    def test_list_read_view_profiles_uses_facade_contract(self, mcp_server: MCPServerUnderTest) -> None:
+        profiles = read_view_profile_payloads()
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_read_view_profiles = AsyncMock(return_value=profiles)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(mcp_server._tool_manager._tools["list_read_view_profiles"].fn)
+
+        body = json.loads(result)
+        assert body["read_views"] == profiles
+        assert body["total"] == len(profiles)
+        assert {profile["view_id"] for profile in body["read_views"]} >= {"raw", "summary", "recovery"}
 
 
 class TestInsightTools:


### PR DESCRIPTION
## Summary
Expose the executable read-view profile registry through Python and MCP, and route the CLI JSON command through the same shared payload helper.

## Problem
#1997 made session read-view profiles executable for CLI consumers, but the metadata contract was still effectively CLI-local. Python and MCP callers had no shared way to discover the same view IDs, evidence/lossiness policy, supported formats, or handoff semantics, which left #1825-style surface parity incomplete.

## Solution
`SessionViewProfile` now owns JSON-native serialization, and `read_view_profile_payloads()` is the shared helper for adapters. The `polylogue read-views --format json` command uses that helper instead of duplicating `asdict()` logic, `PolylogueArchiveMixin.list_read_view_profiles()` exposes it to Python consumers, and MCP registers `list_read_view_profiles` as a read-role tool returning `{read_views, total}` with the same item payloads. MCP discovery/envelope tests and facade-contract tests pin the new surface.

## Verification
- `devtools test tests/unit/archive/test_view_profiles.py tests/unit/cli/test_click_app.py tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_envelope_contracts.py -k 'read_view_profiles or read_views or nullary_methods or every_registered_tool_is_classified or expected_tool_names_subset'` -> `7 passed, 339 deselected`
- `devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` -> `exit_code 0`

Refs #1997
Refs #1825