### PR TITLE
feat(query): expose structural grammar completion metadata (#1844)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -38,11 +38,13 @@ in this module is the query grammar. Compact field/text clauses and explicit
 Boolean predicates are two entry shapes in that grammar, not separate languages
 or a preserved legacy compiler.
 
-Field registry
---------------
-:data:`EXPRESSION_FIELD_REGISTRY` maps every recognized DSL token to its spec
-field name.  Completion tools (#1844) should introspect this single registry
-rather than maintain a parallel list.
+Field and structure registries
+------------------------------
+:data:`EXPRESSION_FIELD_REGISTRY` maps every recognized session-scope DSL token
+to its spec field name. :data:`STRUCTURAL_QUERY_UNIT_REGISTRY` maps the
+``exists <unit>(...)`` units to the structural fields accepted for each unit.
+Completion tools (#1844) should introspect these registries rather than
+maintain parallel lists.
 
 Public API
 ----------
@@ -461,6 +463,49 @@ _ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "outpu
 _BLOCK_STRUCTURAL_FIELDS = {"type", "text", "tool", "action", "command", "path"}
 
 
+@dataclass(frozen=True)
+class StructuralQueryUnitInfo:
+    """Completion/query-builder metadata for one ``exists <unit>(...)`` unit."""
+
+    description: str
+    fields: tuple[str, ...]
+    example: str
+
+
+STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
+    "action": StructuralQueryUnitInfo(
+        description="Match sessions with at least one action row satisfying the child predicate.",
+        fields=tuple(sorted(_ACTION_STRUCTURAL_FIELDS)),
+        example="exists action(tool:bash AND text:pytest)",
+    ),
+    "block": StructuralQueryUnitInfo(
+        description="Match sessions with at least one parsed message block satisfying the child predicate.",
+        fields=tuple(sorted(_BLOCK_STRUCTURAL_FIELDS)),
+        example="exists block(type:code AND text:timeout)",
+    ),
+    "message": StructuralQueryUnitInfo(
+        description="Match sessions with at least one message satisfying the child predicate.",
+        fields=tuple(sorted(_MESSAGE_STRUCTURAL_FIELDS)),
+        example="exists message(role:assistant AND text:timeout)",
+    ),
+}
+
+
+def structural_query_units() -> tuple[str, ...]:
+    """Return the structural units accepted by the query grammar."""
+
+    return tuple(sorted(STRUCTURAL_QUERY_UNIT_REGISTRY))
+
+
+def structural_query_fields(unit: str) -> tuple[str, ...]:
+    """Return structural field names accepted inside ``exists <unit>(...)``."""
+
+    info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit.lower())
+    if info is None:
+        return ()
+    return info.fields
+
+
 def _unknown_query_field_message(field_name: str, *, include_structural: bool = False) -> str:
     recognized = sorted(EXPRESSION_FIELD_REGISTRY)
     message = f"unknown query field {field_name!r}; recognized fields: " + ", ".join(recognized)
@@ -761,7 +806,7 @@ _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()
 
 def _is_boolean_expression(expression: str) -> bool:
     if re.search(
-        r"^\s*\(|^\s*sessions\s+where\b|^\s*exists\s+(?:message|action)\s*\(|^\s*seq\s*\(|^\s*lineage:",
+        r"^\s*\(|^\s*sessions\s+where\b|^\s*exists\s+(?:message|action|block)\s*\(|^\s*seq\s*\(|^\s*lineage:",
         expression,
         re.IGNORECASE,
     ):
@@ -1393,9 +1438,13 @@ __all__ = [
     "explain_expression",
     "ExpressionCompileError",
     "EXPRESSION_FIELD_REGISTRY",
+    "StructuralQueryUnitInfo",
+    "STRUCTURAL_QUERY_UNIT_REGISTRY",
     "QueryExpressionExplainClause",
     "QueryExpressionExplanation",
     "QueryExpressionAST",
     "_HAS_BOOL_MAP",
     "parse_expression_ast",
+    "structural_query_fields",
+    "structural_query_units",
 ]

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -9,6 +9,7 @@ yet and degrades to an empty completion list.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
@@ -17,7 +18,12 @@ import click
 from click.shell_completion import CompletionItem
 
 from polylogue.archive.message.types import MessageType
-from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
+from polylogue.archive.query.expression import (
+    EXPRESSION_FIELD_REGISTRY,
+    STRUCTURAL_QUERY_UNIT_REGISTRY,
+    structural_query_fields,
+    structural_query_units,
+)
 from polylogue.archive.query.fields import QUERY_FIELD_DESCRIPTORS, CompletionSource
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
 from polylogue.cli.action_contracts import ACTION_CONTRACTS, CliActionContract
@@ -177,6 +183,56 @@ def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
     return candidates
 
 
+def query_structural_unit_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return ``exists <unit>(...)`` candidates from the grammar registry."""
+
+    current = incomplete.strip().lower()
+    candidates: list[QueryCompletionCandidate] = []
+    for unit in structural_query_units():
+        if current and not unit.startswith(current):
+            continue
+        info = STRUCTURAL_QUERY_UNIT_REGISTRY[unit]
+        description = info.description
+        if info.example:
+            description = f"{description} Example: {info.example}" if description else f"Example: {info.example}"
+        candidates.append(
+            QueryCompletionCandidate(
+                value=unit,
+                insert=f"{unit}(",
+                display=f"{unit}(",
+                kind="query-structural-unit",
+                group="query structural units",
+                description=_trim_help(description),
+                source="STRUCTURAL_QUERY_UNIT_REGISTRY",
+            )
+        )
+    return candidates
+
+
+def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return field candidates accepted inside ``exists <unit>(...)``."""
+
+    current = incomplete.strip().lstrip("-").lower()
+    if ":" in current:
+        return []
+    candidates: list[QueryCompletionCandidate] = []
+    for field_name in structural_query_fields(unit):
+        if current and not field_name.startswith(current):
+            continue
+        candidates.append(
+            QueryCompletionCandidate(
+                value=field_name,
+                insert=f"{field_name}:",
+                display=f"{field_name}:",
+                kind="query-structural-field",
+                group=f"{unit} structural fields",
+                description=f"Field accepted inside exists {unit}(...).",
+                source="STRUCTURAL_QUERY_UNIT_REGISTRY",
+            )
+        )
+    return candidates
+
+
 def _action_description(contract: CliActionContract) -> str:
     guards = ", ".join(contract.guards)
     detail = f"{contract.effect}; input={contract.input_unit}; cardinality={contract.cardinality}"
@@ -256,6 +312,56 @@ def _complete_query_expression_values(
     return _prefixed_query_value_items(items, prefix=prefix)
 
 
+def _completion_words() -> tuple[str, ...]:
+    raw_words = os.environ.get("COMP_WORDS", "")
+    words = tuple(part for part in raw_words.split() if part)
+    if words and words[0] == "polylogue":
+        return words[1:]
+    return words
+
+
+def _structural_completion_context(incomplete: str) -> tuple[str, str] | None:
+    stripped = incomplete.strip()
+    lower = stripped.lower()
+    if lower.startswith("exists "):
+        after_exists = stripped[len("exists ") :].lstrip()
+        if "(" not in after_exists:
+            return "unit", after_exists
+        unit, field_prefix = after_exists.split("(", 1)
+        unit = unit.strip().lower()
+        if unit in structural_query_units() and ")" not in field_prefix:
+            return unit, field_prefix.rsplit(" ", 1)[-1]
+        return None
+    if lower.startswith("exists"):
+        return "unit", stripped[len("exists") :].lstrip()
+    for unit in structural_query_units():
+        prefix = f"{unit}("
+        if lower.startswith(prefix):
+            return unit, stripped[len(prefix) :].rsplit(" ", 1)[-1]
+
+    words = _completion_words()
+    if words:
+        previous = words[-2].lower() if len(words) >= 2 else ""
+        if previous == "exists":
+            return "unit", stripped
+        for word in reversed(words[:-1]):
+            word_lower = word.lower()
+            for unit in structural_query_units():
+                if word_lower == f"{unit}(" or word_lower.startswith(f"{unit}("):
+                    return unit, stripped
+    return None
+
+
+def _complete_structural_query_context(incomplete: str) -> list[CompletionItem] | None:
+    context = _structural_completion_context(incomplete)
+    if context is None:
+        return None
+    unit_or_kind, prefix = context
+    if unit_or_kind == "unit":
+        return [candidate.to_click_item() for candidate in query_structural_unit_candidates(prefix)]
+    return [candidate.to_click_item() for candidate in query_structural_field_candidates(unit_or_kind, prefix)]
+
+
 def complete_query_expression_fields(
     ctx: click.Context,
     param: click.Parameter | None,
@@ -265,6 +371,9 @@ def complete_query_expression_fields(
 
     if incomplete.startswith("--"):
         return []
+    structural_items = _complete_structural_query_context(incomplete)
+    if structural_items is not None:
+        return structural_items
     if ":" in incomplete:
         return _complete_query_expression_values(ctx, param, incomplete)
     del ctx, param
@@ -475,5 +584,7 @@ __all__ = [
     "complete_tool_values",
     "query_action_candidates",
     "query_field_candidates",
+    "query_structural_field_candidates",
+    "query_structural_unit_candidates",
     "QueryCompletionCandidate",
 ]

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -130,6 +130,28 @@ def test_query_field_candidates_come_from_expression_registry() -> None:
     assert click_item.type == "plain"
 
 
+def test_query_structural_unit_candidates_come_from_expression_registry() -> None:
+    candidates = shell_completion_values.query_structural_unit_candidates("b")
+    assert [candidate.value for candidate in candidates] == ["block"]
+
+    block_candidate = candidates[0]
+    assert block_candidate.insert == "block("
+    assert block_candidate.kind == "query-structural-unit"
+    assert block_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
+    assert block_candidate.description.startswith("Match sessions with at least one parsed message block")
+
+
+def test_query_structural_field_candidates_come_from_expression_registry() -> None:
+    candidates = shell_completion_values.query_structural_field_candidates("block", "t")
+    values = {candidate.value for candidate in candidates}
+
+    assert {"text", "type"}.issubset(values)
+    type_candidate = next(candidate for candidate in candidates if candidate.value == "type")
+    assert type_candidate.insert == "type:"
+    assert type_candidate.kind == "query-structural-field"
+    assert type_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
+
+
 def test_query_expression_value_completion_uses_field_completion_source() -> None:
     ctx, param = _ctx_param()
 
@@ -147,6 +169,17 @@ def test_query_expression_value_completion_uses_field_completion_source() -> Non
 
     assert [item.value for item in repo_items] == ["repo:polylogue"]
     assert repo_items[0].help == "4 sessions"
+
+
+def test_query_expression_completion_handles_structural_contexts() -> None:
+    ctx, param = _ctx_param()
+
+    unit_items = shell_completion_values.complete_query_expression_fields(ctx, param, "exists b")
+    assert [item.value for item in unit_items] == ["block("]
+
+    field_items = shell_completion_values.complete_query_expression_fields(ctx, param, "exists block(t")
+    values = {item.value for item in field_items}
+    assert {"text:", "type:"}.issubset(values)
 
 
 def test_query_action_candidates_come_from_action_contracts_with_danger_metadata() -> None:

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -198,6 +198,43 @@ def test_query_field_value_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_structural_unit_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root query completion suggests structural units after ``exists``."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["exists"], "b")
+    values = {value for value, _ in items}
+    assert "block(" in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_structural_field_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root query completion suggests fields inside structural predicates."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["exists", "block("], "t")
+    values = {value for value, _ in items}
+    assert "text:" in values
+    assert "type:" in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_action_completion_marks_destructive_actions_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -239,6 +239,14 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_compile_expression_detects_single_block_exists_predicate(self) -> None:
+        spec = compile_expression("exists block(type:code)")
+
+        assert spec.boolean_predicate == QueryExistsPredicate(
+            unit="block",
+            child=QueryFieldPredicate(field="type", values=("code",)),
+        )
+
     def test_sequence_ast_exposes_ordered_action_terms(self) -> None:
         ast = parse_expression_ast("seq(action:file_edit -> action:shell -> action:file_edit)")
 


### PR DESCRIPTION
## Summary
Expose structural query-unit metadata from the Lark-backed query grammar and use it for shell completion. Completion now suggests `block(` after `exists` and structural fields such as `type:` / `text:` inside `exists block(...)`, all sourced from the expression module's grammar metadata rather than a parallel list.

## Problem
The query grammar now supports structural predicates over messages, actions, and blocks, but completion only projected session field metadata from `EXPRESSION_FIELD_REGISTRY`. That would make #1844 drift from #2006. There was also a concrete parser-path bug: `_is_boolean_expression()` recognized `exists message(...)` and `exists action(...)`, but not `exists block(...)`, so single-child block predicates could miss the Boolean grammar path.

## Solution
Added a typed `StructuralQueryUnitInfo` registry in `polylogue/archive/query/expression.py`, exported `structural_query_units()` / `structural_query_fields()`, and wired `polylogue/cli/shell_completion_values.py` to produce structural unit and structural field candidates from that registry. The completion callback now recognizes both full partial text (`exists block(t`) and normal shell-token contexts (`exists` + `b`, `exists block(` + `t`). The block detector now routes `exists block(...)` through the same Boolean grammar as message/action predicates.

The durable issue text for #1844 and #2006 was also updated to remove the misleading "floor grammar" framing: there is one Lark grammar/AST/lowerer path.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py tests/unit/cli/test_query_expression.py -k 'query_structural or block_exists or structural_exists or query_field_completion or query_field_value_completion'` -> `17 passed, 261 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- `nix develop --command devtools verify` reached `pytest testmon` after static/generated checks passed and was interrupted after about 12 minutes with no failure output; this PR uses the focused slice plus quick gate as the local evidence.

Refs #1844
Refs #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structural query support enabling users to filter conversation elements with field-based conditions.
  * Enhanced shell completion to intelligently suggest available query units and their supported fields during query composition.

* **Tests**
  * Added test coverage for structural query parsing and shell completion functionality across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->