### PR TITLE
feat(cli): complete query actions after then (#1844)

### DIFF
--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -8,9 +8,11 @@ The CLI uses a hybrid structure:
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import click
+from click.shell_completion import CompletionItem
 
 from polylogue.cli.click_command_registration import _LazyCommand, register_root_commands
 from polylogue.cli.click_option_groups import apply_query_mode_options
@@ -33,6 +35,42 @@ class QueryFirstGroup(QueryFirstGroupBase):
 
     def handle_default_mode(self, ctx: click.Context) -> None:
         _handle_query_mode(ctx)
+
+    def shell_complete(self, ctx: click.Context, incomplete: str) -> list[CompletionItem]:
+        """Keep query-action completion tied to action contracts after ``then``."""
+
+        if _is_after_then_completion():
+            from polylogue.cli.shell_completion_values import complete_query_actions
+
+            return complete_query_actions(ctx, None, incomplete)
+        if _should_complete_then_connector(incomplete):
+            return [CompletionItem("then", help="Connect query results to a verb/action.")]
+        return super().shell_complete(ctx, incomplete)
+
+
+def _completion_words() -> tuple[str, ...]:
+    raw_words = os.environ.get("COMP_WORDS", "")
+    words = tuple(part for part in raw_words.split() if part)
+    if words and words[0] == "polylogue":
+        return words[1:]
+    return words
+
+
+def _is_after_then_completion() -> bool:
+    words = _completion_words()
+    return len(words) >= 2 and words[-2] == "then"
+
+
+def _should_complete_then_connector(incomplete: str) -> bool:
+    if not "then".startswith(incomplete.lower()):
+        return False
+    words = _completion_words()
+    prior = words[:-1]
+    if not prior or "then" in prior:
+        return False
+    if prior[0] in QUERY_VERB_NAMES:
+        return False
+    return prior[0] == "find" or any(":" in word for word in prior)
 
 
 def _handle_query_mode(ctx: click.Context) -> None:

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -235,6 +235,48 @@ def test_query_structural_field_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_then_connector_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Query completion suggests the ``then`` connector after query text."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["find", "id:abc"], "th")
+    item_map = dict(items)
+    assert "then" in item_map
+    assert item_map["then"] == "Connect query results to a verb/action."
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_then_action_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``then``, completion is action-contract backed, not root-command mixed."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["find", "id:abc", "then"], "r")
+    item_map = dict(items)
+
+    assert "read" in item_map
+    assert item_map["read"] is not None and "input=query_result_set" in item_map["read"]
+    assert "read-views" not in item_map
+    assert "repo:" not in item_map
+    assert "reset" not in item_map
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_action_completion_marks_destructive_actions_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],


### PR DESCRIPTION
## Summary
Make query-mode shell completion understand the `then` connector. After `find <query> then`, completion now returns query action candidates from `ACTION_CONTRACTS` instead of mixing in root commands and query fields.

## Problem
Before this change, `polylogue find id:abc then r<TAB>` returned a mixed root vocabulary: `read`, `read-views`, `recent`, `reset`, `resume`, and `repo:`. Only `read` is valid in that position as a query action. This contradicted #1844's source-of-truth rule: completion in action position should project action contracts, not the whole root command/query surface.

## Solution
`QueryFirstGroup.shell_complete()` now detects two query-mode contexts from the active shell completion words:

- completing `th` after explicit/query-looking roots suggests the `then` connector;
- completing after `then` delegates to `complete_query_actions()`, which is backed by `ACTION_CONTRACTS` and carries the existing destructive/action metadata.

The shell completion matrix now covers bash, zsh, and fish for both connector completion and action-only post-`then` completion. The tests also assert that unrelated root commands and query fields (`read-views`, `reset`, `repo:`) do not appear after `then`.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_completion_matrix.py -k 'query_then or query_action_completion or query_field_completion or query_structural'` -> `18 passed, 49 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Refs #1844