### PR TITLE
feat(query): expose query explain execution legs (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -331,6 +331,8 @@ class QueryExpressionExplanation:
     lowerer: str
     lowered_spec: SessionQuerySpec
     plan_description: tuple[str, ...]
+    selected_units: tuple[str, ...] = ("session",)
+    execution_legs: tuple[str, ...] = ()
     unsupported_nodes: tuple[str, ...] = ()
     predicate: QueryPredicate | None = None
 
@@ -340,6 +342,8 @@ class QueryExpressionExplanation:
             "clauses": [clause.to_payload() for clause in self.clauses],
             "predicate": self.predicate.to_payload() if self.predicate is not None else None,
             "lowerer": self.lowerer,
+            "selected_units": list(self.selected_units),
+            "execution_legs": list(self.execution_legs),
             "plan_description": list(self.plan_description),
             "unsupported_nodes": list(self.unsupported_nodes),
         }
@@ -948,6 +952,70 @@ def _explain_clause(token: _LexToken) -> QueryExpressionExplainClause:
     return QueryExpressionExplainClause(kind="json", value=token.raw)
 
 
+def _predicate_units(predicate: QueryPredicate) -> set[str]:
+    units = {"session"}
+    if isinstance(predicate, QueryExistsPredicate):
+        units.add(predicate.unit)
+        units.update(_predicate_units(predicate.child))
+    elif isinstance(predicate, QueryBoolPredicate):
+        for child in predicate.children:
+            units.update(_predicate_units(child))
+    elif isinstance(predicate, QueryNotPredicate):
+        units.update(_predicate_units(predicate.child))
+    elif isinstance(predicate, QuerySequencePredicate):
+        units.add("action")
+    elif isinstance(predicate, QueryLineagePredicate):
+        units.add("lineage")
+    return units
+
+
+def _predicate_execution_legs(predicate: QueryPredicate) -> set[str]:
+    if isinstance(predicate, QueryFieldPredicate):
+        return {"sql"}
+    if isinstance(predicate, QueryTextPredicate):
+        return {"fts"}
+    if isinstance(predicate, QuerySemanticPredicate):
+        return {"vector"}
+    if isinstance(predicate, QueryLineagePredicate):
+        return {"lineage-recursive-cte"}
+    if isinstance(predicate, QuerySequencePredicate):
+        return {"sequence-action"}
+    if isinstance(predicate, QueryExistsPredicate):
+        return {f"exists-{predicate.unit}", *_predicate_execution_legs(predicate.child)}
+    if isinstance(predicate, QueryNotPredicate):
+        return _predicate_execution_legs(predicate.child)
+    if isinstance(predicate, QueryBoolPredicate):
+        legs: set[str] = set()
+        for child in predicate.children:
+            legs.update(_predicate_execution_legs(child))
+        return legs
+    return set()
+
+
+def _spec_execution_legs(spec: SessionQuerySpec) -> set[str]:
+    legs: set[str] = set()
+    if spec.query_terms:
+        legs.add("fts")
+    if spec.similar_text or spec.similar_session_id:
+        legs.add("vector")
+    if spec.boolean_predicate is not None:
+        legs.update(_predicate_execution_legs(spec.boolean_predicate))
+    if spec.to_plan().describe():
+        legs.add("sql")
+    return legs
+
+
+def _explain_selected_units(ast: QueryExpressionAST) -> tuple[str, ...]:
+    if ast.boolean_predicate is None:
+        return ("session",)
+    return tuple(sorted(_predicate_units(ast.boolean_predicate)))
+
+
+def _explain_execution_legs(spec: SessionQuerySpec) -> tuple[str, ...]:
+    legs = _spec_execution_legs(spec)
+    return tuple(sorted(legs))
+
+
 def explain_expression(expression: str) -> QueryExpressionExplanation:
     """Explain parser output, lowering path, and execution-plan descriptions."""
     source_text = expression
@@ -959,6 +1027,8 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
             clauses=(_explain_clause(_JsonToken(raw=stripped)),),
             lowerer="json-spec",
             lowered_spec=lowered,
+            selected_units=("session",),
+            execution_legs=_explain_execution_legs(lowered),
             plan_description=tuple(lowered.to_plan().describe()),
         )
     ast = parse_expression_ast(stripped)
@@ -969,6 +1039,8 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
         predicate=ast.boolean_predicate,
         lowerer="lark-query-expression-to-session-query-spec",
         lowered_spec=lowered,
+        selected_units=_explain_selected_units(ast),
+        execution_legs=_explain_execution_legs(lowered),
         plan_description=tuple(lowered.to_plan().describe()),
     )
 

--- a/polylogue/cli/commands/query_explain.py
+++ b/polylogue/cli/commands/query_explain.py
@@ -74,8 +74,14 @@ def query_explain_command(expression: tuple[str, ...], output_format: str) -> No
     click.echo(f"lowerer: {payload['lowerer']}")
     predicate = payload["predicate"]
     clauses = cast(list[object], payload["clauses"])
+    selected_units = cast(list[str], payload["selected_units"])
+    execution_legs = cast(list[str], payload["execution_legs"])
     plan_description = cast(list[str], payload["plan_description"])
     unsupported_nodes = cast(list[str], payload["unsupported_nodes"])
+    if selected_units:
+        click.echo("units: " + ", ".join(selected_units))
+    if execution_legs:
+        click.echo("execution legs: " + ", ".join(execution_legs))
     if predicate is not None:
         click.echo("predicate:")
         click.echo(json.dumps(predicate, indent=2, sort_keys=True))

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -229,6 +229,8 @@ def test_query_explain_json_outputs_ast_payload(cli_runner: CliRunner) -> None:
     assert payload["source_text"] == "sessions where repo:polylogue OR origin:chatgpt-export"
     assert payload["lowerer"] == "lark-query-expression-to-session-query-spec"
     assert payload["predicate"]["kind"] == "or"
+    assert payload["selected_units"] == ["session"]
+    assert payload["execution_legs"] == ["sql"]
     assert payload["unsupported_nodes"] == []
 
 
@@ -238,6 +240,8 @@ def test_query_explain_plain_outputs_plan(cli_runner: CliRunner) -> None:
     assert result.exit_code == 0, result.output
     assert 'query: repo:polylogue "json envelope"' in result.output
     assert "lowerer: lark-query-expression-to-session-query-spec" in result.output
+    assert "units: session" in result.output
+    assert "execution legs: fts, sql" in result.output
     assert "clauses:" in result.output
     assert "plan:" in result.output
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -157,6 +157,8 @@ class TestExplainExpression:
         assert explanation.source_text == 'repo:polylogue has:paste "json envelope"'
         assert explanation.lowerer == "lark-query-expression-to-session-query-spec"
         assert explanation.unsupported_nodes == ()
+        assert explanation.selected_units == ("session",)
+        assert explanation.execution_legs == ("fts", "sql")
         assert explanation.lowered_spec.repo_names == ("polylogue",)
         assert explanation.lowered_spec.filter_has_paste is True
         assert explanation.clauses[0].to_payload() == {
@@ -178,7 +180,26 @@ class TestExplainExpression:
         assert explanation.lowered_spec.repo_names == ("polylogue",)
         assert explanation.lowered_spec.limit == 5
         assert explanation.clauses[0].kind == "json"
+        assert explanation.selected_units == ("session",)
+        assert explanation.execution_legs == ("sql",)
         assert explanation.to_payload()["unsupported_nodes"] == []
+
+    def test_explain_expression_reports_boolean_units_and_legs(self) -> None:
+        explanation = explain_expression("sessions where exists block(type:code) AND lineage:id:root")
+
+        assert explanation.selected_units == ("block", "lineage", "session")
+        assert explanation.execution_legs == ("exists-block", "lineage-recursive-cte", "sql")
+        payload = explanation.to_payload()
+        assert payload["selected_units"] == ["block", "lineage", "session"]
+        assert payload["execution_legs"] == ["exists-block", "lineage-recursive-cte", "sql"]
+
+    def test_explain_expression_reports_semantic_and_sequence_legs(self) -> None:
+        semantic = explain_expression('sessions where semantic:"query compiler" AND title:hit')
+        sequence = explain_expression("sessions where seq(action:file_edit -> action:shell)")
+
+        assert semantic.execution_legs == ("sql", "vector")
+        assert sequence.selected_units == ("action", "session")
+        assert sequence.execution_legs == ("sequence-action",)
 
 
 class TestBooleanQueryExpression:


### PR DESCRIPTION
## Summary
Extend `query-explain` with machine-readable selected units and execution legs. JSON and plain output now state whether a query uses session/message/block/action/lineage units and whether execution involves SQL, FTS, vector, structural EXISTS, sequence, or lineage traversal legs.

## Problem
#2006 asks for explainability beyond examples and prose. The existing explain payload exposed compact clauses and `predicate.to_payload()`, but callers still had to infer execution behavior from `plan_description` strings. That is not enough for completion/query builders, MCP/web diagnostics, or agent-safe query planning.

## Solution
`QueryExpressionExplanation` now carries:

- `selected_units`: unit names derived from the typed predicate AST (`session`, `block`, `action`, `lineage`, etc.);
- `execution_legs`: concrete execution mechanisms derived from the predicate AST and lowered `SessionQuerySpec` (`sql`, `fts`, `vector`, `exists-block`, `sequence-action`, `lineage-recursive-cte`, etc.).

`polylogue query-explain` renders those fields in plain output and includes them in JSON. The tests cover compact FTS+SQL queries, JSON specs, Boolean SQL predicates, `exists block(...)`, lineage, semantic/vector, and action-sequence explain paths.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py -k 'ExplainExpression or query_explain'` -> `7 passed, 267 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Refs #2006