### PR TITLE
feat(cli): complete query count operators (#1844)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -501,6 +501,16 @@ class StructuralQueryUnitInfo:
     example: str
 
 
+@dataclass(frozen=True)
+class CountQueryFieldInfo:
+    """Completion/query-builder metadata for readable count predicates."""
+
+    description: str
+    operators: tuple[str, ...]
+    range_keyword: str
+    example: str
+
+
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
@@ -519,6 +529,21 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     ),
 }
 
+COUNT_QUERY_FIELD_REGISTRY: dict[str, CountQueryFieldInfo] = {
+    "messages": CountQueryFieldInfo(
+        description="Message-count predicate over normalized session messages.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="messages between 5 and 20",
+    ),
+    "words": CountQueryFieldInfo(
+        description="Word-count predicate over normalized session text.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="words between 100 and 500",
+    ),
+}
+
 
 def structural_query_units() -> tuple[str, ...]:
     """Return the structural units accepted by the query grammar."""
@@ -533,6 +558,21 @@ def structural_query_fields(unit: str) -> tuple[str, ...]:
     if info is None:
         return ()
     return info.fields
+
+
+def count_query_fields() -> tuple[str, ...]:
+    """Return count fields with readable comparison/range syntax."""
+
+    return tuple(sorted(COUNT_QUERY_FIELD_REGISTRY))
+
+
+def count_query_operators(field: str) -> tuple[str, ...]:
+    """Return readable comparison/range operators accepted for a count field."""
+
+    info = COUNT_QUERY_FIELD_REGISTRY.get(field.lower())
+    if info is None:
+        return ()
+    return (*info.operators, info.range_keyword)
 
 
 def _unknown_query_field_message(field_name: str, *, include_structural: bool = False) -> str:
@@ -1621,6 +1661,10 @@ def _compile_json_spec(raw: str) -> SessionQuerySpec:
 __all__ = [
     "compile_expression",
     "compile_expression_into",
+    "CountQueryFieldInfo",
+    "COUNT_QUERY_FIELD_REGISTRY",
+    "count_query_fields",
+    "count_query_operators",
     "explain_expression",
     "ExpressionCompileError",
     "EXPRESSION_FIELD_REGISTRY",

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -39,6 +39,11 @@ class QueryFirstGroup(QueryFirstGroupBase):
     def shell_complete(self, ctx: click.Context, incomplete: str) -> list[CompletionItem]:
         """Keep query-action completion tied to action contracts after ``then``."""
 
+        count_field = _count_operator_completion_field()
+        if count_field is not None:
+            from polylogue.cli.shell_completion_values import query_count_operator_candidates
+
+            return [candidate.to_click_item() for candidate in query_count_operator_candidates(count_field, incomplete)]
         if _is_after_then_completion():
             from polylogue.cli.shell_completion_values import complete_query_actions
 
@@ -59,6 +64,22 @@ def _completion_words() -> tuple[str, ...]:
 def _is_after_then_completion() -> bool:
     words = _completion_words()
     return len(words) >= 2 and words[-2] == "then"
+
+
+def _count_operator_completion_field() -> str | None:
+    words = _completion_words()
+    raw_words = os.environ.get("COMP_WORDS", "")
+    if raw_words.endswith(" ") and words:
+        previous = words[-1].lower()
+        return previous if previous in {"messages", "words"} else None
+    if len(words) < 2:
+        return None
+    previous = words[-2].lower()
+    if previous not in {"messages", "words"}:
+        return None
+    if len(words) >= 3 and words[-3].lower() == "between":
+        return None
+    return previous
 
 
 def _should_complete_then_connector(incomplete: str) -> bool:

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -19,8 +19,11 @@ from click.shell_completion import CompletionItem
 
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.expression import (
+    COUNT_QUERY_FIELD_REGISTRY,
     EXPRESSION_FIELD_REGISTRY,
     STRUCTURAL_QUERY_UNIT_REGISTRY,
+    count_query_fields,
+    count_query_operators,
     structural_query_fields,
     structural_query_units,
 )
@@ -228,6 +231,33 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
                 group=f"{unit} structural fields",
                 description=f"Field accepted inside exists {unit}(...).",
                 source="STRUCTURAL_QUERY_UNIT_REGISTRY",
+            )
+        )
+    return candidates
+
+
+def query_count_operator_candidates(field: str, incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return readable count operators accepted by the query grammar."""
+
+    field_name = field.lower()
+    if field_name not in count_query_fields():
+        return []
+    current = incomplete.strip().lower()
+    info = COUNT_QUERY_FIELD_REGISTRY[field_name]
+    candidates: list[QueryCompletionCandidate] = []
+    for operator in count_query_operators(field_name):
+        if current and not operator.startswith(current):
+            continue
+        insert = f"{operator} " if operator == info.range_keyword else operator
+        candidates.append(
+            QueryCompletionCandidate(
+                value=operator,
+                insert=insert,
+                display=insert,
+                kind="query-count-operator",
+                group=f"{field_name} count operators",
+                description=f"{info.description} Example: {info.example}",
+                source="COUNT_QUERY_FIELD_REGISTRY",
             )
         )
     return candidates
@@ -583,6 +613,7 @@ __all__ = [
     "complete_tag_values",
     "complete_tool_values",
     "query_action_candidates",
+    "query_count_operator_candidates",
     "query_field_candidates",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -152,6 +152,17 @@ def test_query_structural_field_candidates_come_from_expression_registry() -> No
     assert type_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
 
 
+def test_query_count_operator_candidates_come_from_expression_registry() -> None:
+    candidates = shell_completion_values.query_count_operator_candidates("messages", "b")
+
+    assert [candidate.value for candidate in candidates] == ["between"]
+    between_candidate = candidates[0]
+    assert between_candidate.insert == "between "
+    assert between_candidate.kind == "query-count-operator"
+    assert between_candidate.source == "COUNT_QUERY_FIELD_REGISTRY"
+    assert "messages between 5 and 20" in between_candidate.description
+
+
 def test_query_expression_value_completion_uses_field_completion_source() -> None:
     ctx, param = _ctx_param()
 

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -235,6 +235,45 @@ def test_query_structural_field_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_count_operator_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readable count syntax completion suggests grammar-backed operators."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["messages"], "b")
+    item_map = dict(items)
+    assert item_map == {"between ": item_map["between "]}
+    assert "messages between 5 and 20" in (item_map["between "] or "")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_count_operator_empty_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a count field, completion is operator-only, not root-command mixed."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion(shell, comp_cls, ["messages"])
+    values = {value for value, _ in items}
+    assert {">=", "<=", "=", ">", "<", "between "}.issubset(values)
+    assert "backup" not in values
+    assert "blackboard" not in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_then_connector_completion_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],


### PR DESCRIPTION
## Summary
Expose readable count operators through shell completion. After `messages ` / `words `, completion now suggests grammar-backed count operators (`>=`, `<=`, `=`, `>`, `<`, `between`) instead of falling through to unrelated root commands.

## Problem
#2028 added executable readable count syntax, but completion still did not know that `messages` and `words` can be followed by comparison or range operators. In practice, `polylogue messages b<TAB>` suggested root commands like `backup` / `blackboard`, which made the new grammar less discoverable and preserved the parallel root vocabulary that #1844 is trying to eliminate.

## Solution
Added count-field/operator metadata to `polylogue.archive.query.expression` and routed shell completion through that metadata:

- `COUNT_QUERY_FIELD_REGISTRY` describes readable count predicates;
- `query_count_operator_candidates()` projects that registry into completion candidates;
- `QueryFirstGroup.shell_complete()` detects `messages` / `words` operator positions and returns only count operator completions.

The bash/zsh/fish matrix now covers both partial operator completion (`messages b`) and empty operator-position completion (`messages `), including negative assertions that root commands no longer leak into that position.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py -k 'count_operator or query_field_completion or query_structural or query_then'` -> `24 passed, 60 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Refs #1844
Refs #2006