### PR TITLE
feat(query): expose query explain through API and MCP (#2006)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1101,6 +1101,12 @@ class PolylogueArchiveMixin:
 
         return list(read_view_profile_payloads())
 
+    async def explain_query_expression(self, expression: str) -> JSONDocument:
+        """Explain query DSL parsing, AST metadata, and lowering details."""
+        from polylogue.archive.query.expression import explain_expression
+
+        return cast(JSONDocument, explain_expression(expression).to_payload())
+
     async def get_sessions(
         self,
         session_ids: list[str],

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -687,6 +687,16 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("list_read_view_profiles", run)
 
+    @mcp.tool()
+    async def explain_query_expression(expression: str) -> str:
+        """Explain query DSL parsing and lowering through the shared grammar."""
+
+        async def run() -> str:
+            explanation = await hooks.get_polylogue().explain_query_expression(expression)
+            return hooks.json_payload(MCPRootPayload(root=cast(dict[str, object], {"query_explanation": explanation})))
+
+        return await hooks.async_safe_call("explain_query_expression", run)
+
 
 def register_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     register_query_tools(mcp, hooks)

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -47,6 +47,7 @@ EXPECTED_TOOL_NAMES = {
     "get_logical_session",
     "get_stats_by",
     "list_read_view_profiles",
+    "explain_query_expression",
     "readiness_check",
     "rebuild_index",
     "update_index",
@@ -194,6 +195,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.get_session_topology = AsyncMock(return_value=None)
     poly.get_logical_session = AsyncMock(return_value=None)
     poly.list_read_view_profiles = AsyncMock(return_value=[])
+    poly.explain_query_expression = AsyncMock(return_value={})
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))
     poly.get_session = AsyncMock(return_value=None)
     poly.get_session_profile_insight = AsyncMock(return_value=None)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -174,6 +174,7 @@ METADATA_MUTATION_METHODS: frozenset[str] = frozenset(
 # parametrized contract families because they take complex args).
 BESPOKE_METHODS: frozenset[str] = frozenset(
     {
+        "explain_query_expression",
         "get_sessions",
         "get_actions_batch",
         "query_sessions",
@@ -664,6 +665,25 @@ async def test_list_read_view_profiles_exposes_shared_profile_payloads(tmp_path:
         formats = views["recovery"]["formats"]
         assert isinstance(formats, list)
         assert "markdown" in formats
+    finally:
+        await archive.close()
+
+
+async def test_explain_query_expression_exposes_shared_query_payload(tmp_path: Path) -> None:
+    """``explain_query_expression`` exposes the canonical query compiler payload."""
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_query_expression("sessions where exists block(type:code) AND messages > 10")
+
+        assert payload["source_text"] == "sessions where exists block(type:code) AND messages > 10"
+        selected_units = payload["selected_units"]
+        execution_legs = payload["execution_legs"]
+        assert isinstance(selected_units, list)
+        assert isinstance(execution_legs, list)
+        assert selected_units == ["block", "session"]
+        assert "exists-block" in execution_legs
+        assert "sql" in execution_legs
+        assert payload["predicate"]
     finally:
         await archive.close()
 

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -61,6 +61,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     ),
     "get_messages": ("envelope", frozenset({"messages", "total"})),
     "list_read_view_profiles": ("envelope", frozenset({"read_views", "total"})),
+    "explain_query_expression": "single_object",
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     "archive_list_sessions": ("envelope", frozenset({"items", "total", "limit", "offset"})),
     "archive_search_sessions": ("envelope", frozenset({"items", "total", "limit", "query"})),

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -809,6 +809,28 @@ class TestReadViewProfilesTool:
         assert {profile["view_id"] for profile in body["read_views"]} >= {"raw", "summary", "recovery"}
 
 
+class TestQueryExplanationTool:
+    def test_explain_query_expression_uses_facade_contract(self, mcp_server: MCPServerUnderTest) -> None:
+        explanation = {
+            "source_text": "sessions where repo:polylogue",
+            "selected_units": ["sessions"],
+            "execution_legs": ["sql"],
+        }
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.explain_query_expression = AsyncMock(return_value=explanation)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["explain_query_expression"].fn,
+                expression="sessions where repo:polylogue",
+            )
+
+        body = json.loads(result)
+        assert body["query_explanation"] == explanation
+        mock_poly.explain_query_expression.assert_awaited_once_with("sessions where repo:polylogue")
+
+
 class TestInsightTools:
     @pytest.mark.asyncio
     async def test_session_profile_tool_uses_archive_insight_contract(self, mcp_server: MCPServerUnderTest) -> None:


### PR DESCRIPTION
## Summary
Expose the canonical query explanation payload outside the CLI by adding `Polylogue.explain_query_expression()` and an MCP `explain_query_expression` read tool.

## Problem
`query-explain` already reports parser, AST, selected-unit, and execution-leg metadata for the Lark-backed query compiler, but that contract was CLI-only. MCP and Python API callers could not inspect the shared query compiler without duplicating parser logic, which worked against #2006 and the #1825 cross-surface contract.

## Solution
- Add `PolylogueArchiveMixin.explain_query_expression(expression)` as the Python API facade over `explain_expression(...).to_payload()`.
- Add an MCP `explain_query_expression` tool that delegates to the facade and returns `{ "query_explanation": ... }`.
- Register the MCP tool/envelope contract and update test mocks.
- Add API and MCP tests proving the payload shape and MCP facade delegation.

## Verification
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k "explain_query_expression or list_read_view_profiles or no_undiscovered_async_methods"` — 5 passed.
- `nix develop --command devtools test tests/unit/mcp/test_tool_contracts.py -k "QueryExplanationTool or ReadViewProfilesTool"` — 2 passed.
- `nix develop --command devtools test tests/unit/mcp/test_envelope_contracts.py` — 31 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.

Ref #2006.
Ref #1825.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new query expression explanation feature that provides detailed compilation information including selected units, execution legs, and predicate analysis.

* **Tests**
  * Added comprehensive test coverage for the query expression explanation capability across API and MCP interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->