### PR TITLE
feat(cli): complete query date operators (#1844)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -546,6 +546,16 @@ class CountQueryFieldInfo:
     example: str
 
 
+@dataclass(frozen=True)
+class DateQueryFieldInfo:
+    """Completion/query-builder metadata for readable date predicates."""
+
+    description: str
+    operators: tuple[str, ...]
+    range_keyword: str
+    example: str
+
+
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
@@ -579,6 +589,15 @@ COUNT_QUERY_FIELD_REGISTRY: dict[str, CountQueryFieldInfo] = {
     ),
 }
 
+DATE_QUERY_FIELD_REGISTRY: dict[str, DateQueryFieldInfo] = {
+    "date": DateQueryFieldInfo(
+        description="Session timestamp predicate over COALESCE(updated_at, created_at).",
+        operators=(">=", "<=", ">", "<"),
+        range_keyword="between",
+        example="date between 2026-01-01 and 2026-02-01",
+    ),
+}
+
 
 def structural_query_units() -> tuple[str, ...]:
     """Return the structural units accepted by the query grammar."""
@@ -605,6 +624,21 @@ def count_query_operators(field: str) -> tuple[str, ...]:
     """Return readable comparison/range operators accepted for a count field."""
 
     info = COUNT_QUERY_FIELD_REGISTRY.get(field.lower())
+    if info is None:
+        return ()
+    return (*info.operators, info.range_keyword)
+
+
+def date_query_fields() -> tuple[str, ...]:
+    """Return date fields with readable comparison/range syntax."""
+
+    return tuple(sorted(DATE_QUERY_FIELD_REGISTRY))
+
+
+def date_query_operators(field: str) -> tuple[str, ...]:
+    """Return readable comparison/range operators accepted for a date field."""
+
+    info = DATE_QUERY_FIELD_REGISTRY.get(field.lower())
     if info is None:
         return ()
     return (*info.operators, info.range_keyword)
@@ -1807,6 +1841,10 @@ __all__ = [
     "COUNT_QUERY_FIELD_REGISTRY",
     "count_query_fields",
     "count_query_operators",
+    "DateQueryFieldInfo",
+    "DATE_QUERY_FIELD_REGISTRY",
+    "date_query_fields",
+    "date_query_operators",
     "explain_expression",
     "ExpressionCompileError",
     "EXPRESSION_FIELD_REGISTRY",

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -44,6 +44,11 @@ class QueryFirstGroup(QueryFirstGroupBase):
             from polylogue.cli.shell_completion_values import query_count_operator_candidates
 
             return [candidate.to_click_item() for candidate in query_count_operator_candidates(count_field, incomplete)]
+        date_field = _date_operator_completion_field()
+        if date_field is not None:
+            from polylogue.cli.shell_completion_values import query_date_operator_candidates
+
+            return [candidate.to_click_item() for candidate in query_date_operator_candidates(date_field, incomplete)]
         if _is_after_then_completion():
             from polylogue.cli.shell_completion_values import complete_query_actions
 
@@ -76,6 +81,21 @@ def _count_operator_completion_field() -> str | None:
         return None
     previous = words[-2].lower()
     if previous not in {"messages", "words"}:
+        return None
+    if len(words) >= 3 and words[-3].lower() == "between":
+        return None
+    return previous
+
+
+def _date_operator_completion_field() -> str | None:
+    words = _completion_words()
+    raw_words = os.environ.get("COMP_WORDS", "")
+    if raw_words.endswith(" ") and words:
+        return "date" if words[-1].lower() == "date" else None
+    if len(words) < 2:
+        return None
+    previous = words[-2].lower()
+    if previous != "date":
         return None
     if len(words) >= 3 and words[-3].lower() == "between":
         return None

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -20,10 +20,13 @@ from click.shell_completion import CompletionItem
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.expression import (
     COUNT_QUERY_FIELD_REGISTRY,
+    DATE_QUERY_FIELD_REGISTRY,
     EXPRESSION_FIELD_REGISTRY,
     STRUCTURAL_QUERY_UNIT_REGISTRY,
     count_query_fields,
     count_query_operators,
+    date_query_fields,
+    date_query_operators,
     structural_query_fields,
     structural_query_units,
 )
@@ -258,6 +261,33 @@ def query_count_operator_candidates(field: str, incomplete: str) -> list[QueryCo
                 group=f"{field_name} count operators",
                 description=f"{info.description} Example: {info.example}",
                 source="COUNT_QUERY_FIELD_REGISTRY",
+            )
+        )
+    return candidates
+
+
+def query_date_operator_candidates(field: str, incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return readable date operators accepted by the query grammar."""
+
+    field_name = field.lower()
+    if field_name not in date_query_fields():
+        return []
+    current = incomplete.strip().lower()
+    info = DATE_QUERY_FIELD_REGISTRY[field_name]
+    candidates: list[QueryCompletionCandidate] = []
+    for operator in date_query_operators(field_name):
+        if current and not operator.startswith(current):
+            continue
+        insert = f"{operator} " if operator == info.range_keyword else operator
+        candidates.append(
+            QueryCompletionCandidate(
+                value=operator,
+                insert=insert,
+                display=insert,
+                kind="query-date-operator",
+                group=f"{field_name} date operators",
+                description=f"{info.description} Example: {info.example}",
+                source="DATE_QUERY_FIELD_REGISTRY",
             )
         )
     return candidates
@@ -614,6 +644,7 @@ __all__ = [
     "complete_tool_values",
     "query_action_candidates",
     "query_count_operator_candidates",
+    "query_date_operator_candidates",
     "query_field_candidates",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -274,6 +274,46 @@ def test_query_count_operator_empty_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_date_operator_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readable date syntax completion suggests grammar-backed operators."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["date"], "b")
+    item_map = dict(items)
+    assert item_map == {"between ": item_map["between "]}
+    assert "date between 2026-01-01 and 2026-02-01" in (item_map["between "] or "")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_date_operator_empty_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``date``, completion is operator-only, not root-command mixed."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion(shell, comp_cls, ["date"])
+    values = {value for value, _ in items}
+    assert {">=", "<=", ">", "<", "between "}.issubset(values)
+    assert "=" not in values
+    assert "backup" not in values
+    assert "blackboard" not in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_then_connector_completion_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],


### PR DESCRIPTION
## Summary
Make the new readable `date` comparison syntax discoverable in shell completion.

## Problem
#2031 made `date >= ...`, `date <= ...`, and `date between ... and ...` executable through the shared query grammar. Completion still recognized only readable count fields (`messages`, `words`), so the new grammar-backed date syntax was hidden from the shell/query-builder metadata path tracked by #1844.

## Solution
- Add date comparison metadata to `polylogue.archive.query.expression`.
- Expose `date_query_fields()` / `date_query_operators()` beside the count metadata helpers.
- Wire Click completion after `date` to suggest only date operators.
- Add bash/zsh/fish completion matrix coverage for filtered `between` completion and operator-only completion.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_completion_matrix.py -k "date_operator or count_operator"` — 12 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.

Ref #1844.
Ref #2006.