### PR TITLE
refactor(query): clarify DSL lowerer naming (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -398,9 +398,9 @@ class QueryExpressionExplanation:
 # ---------------------------------------------------------------------------
 
 _QUERY_GRAMMAR = r"""
-    flat_query: flat_clause*
+    compact_query: compact_clause*
 
-    ?flat_clause: COUNT_CLAUSE       -> count_clause
+    ?compact_clause: COUNT_CLAUSE       -> count_clause
         | COUNT_FIELD BETWEEN INT AND INT -> count_between_clause
         | COUNT_FIELD COMP_OP INT    -> count_compare_clause
         | DATE_FIELD BETWEEN DATE_VALUE AND DATE_VALUE -> date_between_clause
@@ -470,7 +470,7 @@ _QUERY_GRAMMAR = r"""
 _QUERY_PARSER = Lark(
     _QUERY_GRAMMAR,
     parser="lalr",
-    start=["flat_query", "boolean_query"],
+    start=["compact_query", "boolean_query"],
     maybe_placeholders=False,
 )
 
@@ -733,7 +733,7 @@ def _normalize_date_range(min_text: str, max_text: str) -> _DateRangeToken:
 
 @v_args(inline=True)
 class _QueryTransformer(Transformer[Token, _LexToken | str | QueryExpressionAST]):
-    def flat_query(self, *clauses: _LexToken) -> QueryExpressionAST:
+    def compact_query(self, *clauses: _LexToken) -> QueryExpressionAST:
         return QueryExpressionAST(tuple(clauses))
 
     def count_clause(self, token: Token) -> _CountToken:
@@ -1199,7 +1199,7 @@ def parse_expression_ast(expression: str) -> QueryExpressionAST:
     if _is_boolean_expression(expression):
         return QueryExpressionAST((), boolean_predicate=_parse_boolean_predicate(expression))
     try:
-        tree = _QUERY_PARSER.parse(expression, start="flat_query")
+        tree = _QUERY_PARSER.parse(expression, start="compact_query")
     except UnexpectedInput as exc:
         raise ExpressionCompileError(
             _parse_error_message(expression, exc), field=_parse_error_field(expression)
@@ -1355,7 +1355,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
 
 
 # ---------------------------------------------------------------------------
-# Compiler
+# Lowering
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -1,8 +1,8 @@
-"""Unit tests for the query expression compiler (#1812).
+"""Unit tests for the shared Lark query DSL and lowerer (#2006).
 
 Covers:
 - Lexer AST output for key token forms
-- Compiler field mapping (field → spec attribute)
+- Lowerer field mapping (field → spec attribute)
 - Flag ↔ expression equivalence (same spec from --origin x and origin:x)
 - Rejected unknown fields (loud error)
 - Relative + absolute date pass-through
@@ -953,11 +953,11 @@ class TestBooleanQueryExpression:
 
 
 # ---------------------------------------------------------------------------
-# Compiler field-mapping tests
+# Lowerer field-mapping tests
 # ---------------------------------------------------------------------------
 
 
-class TestCompilerFieldMapping:
+class TestLowererFieldMapping:
     def test_repo(self) -> None:
         spec = compile_expression("repo:polylogue")
         assert spec.repo_names == ("polylogue",)
@@ -1515,7 +1515,7 @@ class TestFieldRegistry:
 
 
 class TestMCPWiring:
-    """build_query_spec routes free-text query through the shared compiler."""
+    """build_query_spec routes free-text query through the shared DSL lowerer."""
 
     def test_bare_words_preserved_as_fts(self) -> None:
         from polylogue.mcp.query_contracts import build_query_spec
@@ -1572,7 +1572,7 @@ class TestMCPWiring:
 
 
 # ---------------------------------------------------------------------------
-# Cross-surface parity (#1860 / #1812)
+# Cross-surface parity (#1860 / #2006)
 # ---------------------------------------------------------------------------
 
 
@@ -1584,8 +1584,8 @@ class TestCrossSurfaceParity:
     Daemon path: compile_expression_into(query_str, base_spec)  (same function)
 
     Because all three surfaces ultimately call compile_expression_into, these
-    tests verify that the compiler is wired symmetrically and that no surface
-    silently re-parses the expression through its own ad-hoc logic.
+    tests verify that the Lark-backed lowerer is wired symmetrically and that
+    no surface silently re-parses the expression through its own ad-hoc logic.
     """
 
     _EXPRESSION = "origin:claude-code-session has:paste repo:polylogue"


### PR DESCRIPTION
## Summary
Clarifies the query DSL implementation language so #2006 is represented as one Lark-backed grammar and lowerer, not a legacy flat compiler plus a future grammar.

## Problem
The code still named the compact-query start rule `flat_query` and the test suite described the surface as the old #1812 compiler. That wording made it easy to infer a preserved floor grammar or separate old compiler, which is explicitly not the #2006 direction.

## Solution
Renamed the Lark start rule and transformer method from `flat_query` to `compact_query`, retitled the implementation section from compiler to lowering, and updated the query-expression tests to describe the shared Lark DSL/lowerer. The public `compile_expression` function remains only as the existing callsite entrypoint; it still routes through the same Lark AST path.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k 'parse_expression_ast or LowererFieldMapping or CrossSurfaceParity'` → 58 passed, 167 deselected
- `nix develop --command devtools verify --quick` → exit_code 0

Ref #2006