### PR TITLE
feat(cli): complete read formats from view profiles (#1844)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -282,7 +282,7 @@ Options:
                                   [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
-  -f, --format [text|markdown|json|ndjson|yaml|html|obsidian|org|csv]
+  -f, --format [csv|html|json|markdown|ndjson|obsidian|org|plaintext|text|yaml]
                                   Output format (where applicable).
   --out PATH                      File path for --to file.
   --all                           Apply to all matched sessions (bulk export).

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from polylogue.cli.root_request import RootModeRequest
     from polylogue.insights.transforms import RecoveryReportPreset
 
-from polylogue.archive.viewport import READ_VIEW_PROFILES, read_view_choices
+from polylogue.archive.viewport import READ_VIEW_PROFILE_BY_ID, READ_VIEW_PROFILES, read_view_choices
 from polylogue.cli.click_option_groups import _LazyChoice
 from polylogue.cli.shared.types import AppEnv
 from polylogue.cli.verb_names import VERB_NAMES
@@ -59,7 +59,7 @@ _complete_message_type = _lazy_shell_complete("message_type")
 _READ_VIEWS = read_view_choices()
 _READ_VIEW_HELP = "What to render (" + ", ".join(_READ_VIEWS) + ")."
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
-_READ_FORMATS = ("text", "markdown", "json", "ndjson", "yaml", "html", "obsidian", "org", "csv")
+_READ_FORMATS = tuple(sorted({fmt for profile in READ_VIEW_PROFILES for fmt in profile.formats}))
 _RECOVERY_REPORT_PRESETS = ("continue", "blame")
 
 
@@ -72,6 +72,29 @@ def _complete_read_view(ctx: click.Context, param: click.Parameter, incomplete: 
         for profile in READ_VIEW_PROFILES
         if profile.view_id.startswith(needle)
     ]
+
+
+def _selected_read_view(ctx: click.Context) -> str | None:
+    value = ctx.params.get("view")
+    if isinstance(value, str) and value in READ_VIEW_PROFILE_BY_ID:
+        return value
+    return None
+
+
+def _complete_read_format(ctx: click.Context, param: click.Parameter, incomplete: str) -> list[CompletionItem]:
+    """Complete output formats from read-view profile metadata."""
+
+    del param
+    needle = incomplete.lower()
+    selected_view = _selected_read_view(ctx)
+    profiles = (READ_VIEW_PROFILE_BY_ID[selected_view],) if selected_view is not None else READ_VIEW_PROFILES
+    items: dict[str, str] = {}
+    for profile in profiles:
+        for output_format in profile.formats:
+            if needle and not output_format.startswith(needle):
+                continue
+            items.setdefault(output_format, f"Supported by read --view {profile.view_id}")
+    return [CompletionItem(output_format, help=help_text) for output_format, help_text in sorted(items.items())]
 
 
 @click.command("list")
@@ -181,6 +204,7 @@ def recent_verb(
     "output_format",
     type=click.Choice(_READ_FORMATS),
     default=None,
+    shell_complete=_complete_read_format,
     help="Output format (where applicable).",
 )
 @click.option("--out", "out_path", type=click.Path(), default=None, help="File path for --to file.")

--- a/tests/baselines/showcase/help-read.txt
+++ b/tests/baselines/showcase/help-read.txt
@@ -31,7 +31,7 @@ Options:
                                   [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
-  -f, --format [text|markdown|json|ndjson|yaml|html|obsidian|org|csv]
+  -f, --format [csv|html|json|markdown|ndjson|obsidian|org|plaintext|text|yaml]
                                   Output format (where applicable).
   --out PATH                      File path for --to file.
   --all                           Apply to all matched sessions (bulk export).

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -45,6 +45,8 @@ STATIC_COMPLETERS: tuple[tuple[str, list[str]], ...] = (
     ("action", ["--action"]),
     ("action_sequence", ["--action-sequence"]),
     ("message_type", ["messages", "--message-type"]),
+    ("read_view", ["read", "--view"]),
+    ("read_format", ["read", "--format"]),
 )
 
 CONTRACT_COMPLETION_COMMANDS: dict[CompletionContext, list[str]] = {
@@ -372,6 +374,25 @@ def test_query_action_completion_marks_destructive_actions_per_shell(
     item_map = dict(items)
     assert "delete" in item_map
     assert item_map["delete"] is not None and item_map["delete"].startswith("DANGER:")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_read_format_completion_uses_selected_view_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """read --format completion narrows to the selected read-view profile."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion(shell, comp_cls, ["read", "--view", "raw", "--format"])
+    item_map = dict(items)
+
+    assert item_map == {"json": "Supported by read --view raw"}
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import click
 import pytest
 
-from polylogue.archive.viewport import read_view_choices
+from polylogue.archive.viewport import READ_VIEW_PROFILE_BY_ID, READ_VIEW_PROFILES, read_view_choices
 from polylogue.cli import query_verbs
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
@@ -117,6 +117,25 @@ def test_read_view_completion_comes_from_view_profiles() -> None:
     assert items[0].help is not None
     assert "Recovery:" in items[0].help
     assert "successor-agent recovery digest" in items[0].help
+
+
+def test_read_format_click_choices_come_from_view_profiles() -> None:
+    option = next(param for param in query_verbs.read_verb.params if param.name == "output_format")
+    expected = tuple(sorted({fmt for profile in READ_VIEW_PROFILES for fmt in profile.formats}))
+
+    assert isinstance(option.type, click.Choice)
+    assert tuple(option.type.choices) == expected
+
+
+def test_read_format_completion_comes_from_selected_view_profile() -> None:
+    option = next(param for param in query_verbs.read_verb.params if param.name == "output_format")
+    context = click.Context(query_verbs.read_verb)
+    context.params["view"] = "raw"
+
+    items = option.shell_complete(context, "")
+
+    assert [item.value for item in items] == list(READ_VIEW_PROFILE_BY_ID["raw"].formats)
+    assert items[0].help == "Supported by read --view raw"
 
 
 def _read_verb_kwargs(**overrides: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary
Makes `read --format` choices and shell completions come from `SessionViewProfile.formats`, matching the existing profile-backed `read --view` behavior.

## Problem
#1844 says completion metadata should come from the parser/action/view registries rather than parallel lists. `read --view` already used `READ_VIEW_PROFILES`, but `read --format` still used an ad hoc static tuple, so a view-profile format rename/add/delete could drift from the CLI option and shell completions.

## Solution
Derive the read format choice set from the union of `READ_VIEW_PROFILES[*].formats`, add a read-format completer that narrows candidates to the selected `--view` when available, and test both direct Click metadata and bash/zsh/fish completion behavior. The CLI reference was regenerated for the changed option surface.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_verbs_runtime.py -k 'read_format or read_view'` → 7 passed, 16 deselected
- `nix develop --command devtools test tests/unit/cli/test_completion_matrix.py -k 'read_format or static_completers'` → 24 passed, 64 deselected
- `nix develop --command devtools verify --quick` → exit_code 0

Ref #1844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Shell completion for `read --format` now intelligently filters available formats based on the selected `--view`.

* **Documentation**
  - Updated CLI reference and help text to display all supported output formats for the `read` command, including plaintext and text options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->