### PR TITLE
feat(cli): expose query-backed select verb (#1844)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -194,6 +194,7 @@ Commands:
   resume             Resume from recent session context.
   resume-candidates  Rank resume candidates for the current context.
   schema             Inspect and audit provider schemas.
+  select
   stats              Show statistics for matched sessions.
   status             Show daemon and archive status.
   tags               Manage session tags.
@@ -600,6 +601,7 @@ It records the public action floor, not every utility command in the Click tree.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `polylogue find` | `read` | `none` | `any` | `human`, `json`, `ndjson` | `human` | `result_set` | `explicit_query_intent` | `query_expression` |
 | `polylogue read` | `read` | `query_result_set` | `explicit_multi` | `human`, `json`, `ndjson` | `human` | `item` | `single_match_unless_all`, `file_destination_requires_out` | `session_id` |
+| `polylogue select` | `read` | `query_result_set` | `singleton` | `human`, `json` | `human` | `item` | - | `session_id` |
 | `polylogue mark` | `write` | `query_result_set` | `explicit_multi` | `human` | `human` | `mutation` | `single_match_unless_all_or_first` | `session_id` |
 | `polylogue analyze` | `read` | `query_result_set` | `any` | `human`, `json`, `ndjson` | `human` | `result_set` | - | `query_expression` |
 | `polylogue delete` | `destructive` | `query_result_set` | `destructive_multi` | `human` | `human` | `mutation` | `dry_run_or_yes_required`, `single_match_unless_all` | `session_id` |

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `270`
+- scenario projections: `271`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
-  - exercise: `163`
+  - exercise: `164`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -419,6 +419,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-schema-compare` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema compare help |
 | `exercise` | `help-schema-explain` | `schema-explain-query-loop` | `schema_packages`<br>`schema_explanation_results` | `cli.help`<br>`query-schema-explanations` | — | `generated`<br>`help`<br>`structural` | schema explain help |
 | `exercise` | `help-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `cli.help`<br>`query-schema-catalog` | — | `generated`<br>`help`<br>`structural` | schema list help |
+| `exercise` | `help-select` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | select help |
 | `exercise` | `help-stats` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | stats help |
 | `exercise` | `help-status` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | status help |
 | `exercise` | `help-tags` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | tags help |

--- a/polylogue/cli/action_contracts.py
+++ b/polylogue/cli/action_contracts.py
@@ -53,6 +53,7 @@ VIRTUAL_ACTION_PATHS: frozenset[tuple[str, ...]] = frozenset(
 
 PUBLIC_ACTION_FLOOR: tuple[tuple[str, ...], ...] = (
     ("find",),
+    ("select",),
     ("read",),
     ("mark",),
     ("analyze",),
@@ -90,6 +91,17 @@ ACTION_CONTRACTS: tuple[CliActionContract, ...] = (
         machine_envelope="item",
         requires_daemon=False,
         guards=("single_match_unless_all", "file_destination_requires_out"),
+        completion_context="session_id",
+    ),
+    CliActionContract(
+        path=("select",),
+        effect="read",
+        input_unit="query_result_set",
+        cardinality="singleton",
+        formats=frozenset({"human", "json"}),
+        default_format="human",
+        machine_envelope="item",
+        requires_daemon=False,
         completion_context="session_id",
     ),
     CliActionContract(

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from polylogue.archive.session.domain_models import Session, SessionSummary
     from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
     from polylogue.cli.root_request import RootModeRequest
+    from polylogue.cli.select import SelectPrintField
     from polylogue.insights.transforms import RecoveryReportPreset
 
 from polylogue.archive.viewport import READ_VIEW_PROFILE_BY_ID, READ_VIEW_PROFILES, read_view_choices
@@ -125,6 +126,28 @@ def list_verb(ctx: click.Context, output_format: str | None, fields: str | None,
 def count_verb(ctx: click.Context) -> None:
     """Print count of matched sessions."""
     _execute_query_verb(ctx, _parent_request(ctx).with_param_updates(count_only=True))
+
+
+@click.command("select")
+@click.option(
+    "--limit", "-n", default=20, show_default=True, type=click.IntRange(min=1), help="Max candidate sessions."
+)
+@click.option(
+    "--print",
+    "print_field",
+    type=click.Choice(["id", "title", "origin"]),
+    default="id",
+    show_default=True,
+    help="Field to print for the selected session.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Print the selected session as one JSON object.")
+@click.pass_context
+def select_verb(ctx: click.Context, limit: int, print_field: str, json_output: bool) -> None:
+    """Select one matched session with fzf/prompt fallback."""
+    from polylogue.cli.select import run_select
+
+    field: SelectPrintField = "json" if json_output else cast("SelectPrintField", print_field)
+    run_select(ctx.obj, _parent_request(ctx), limit=limit, print_field=field)
 
 
 @click.command("stats")
@@ -1150,6 +1173,7 @@ QUERY_VERBS = (
     count_verb,
     stats_verb,
     recent_verb,
+    select_verb,
     read_verb,
     delete_verb,
     mark_verb,
@@ -1167,5 +1191,6 @@ __all__ = [
     "mark_verb",
     "read_verb",
     "recent_verb",
+    "select_verb",
     "stats_verb",
 ]

--- a/polylogue/cli/verb_names.py
+++ b/polylogue/cli/verb_names.py
@@ -11,6 +11,7 @@ VERB_NAMES: frozenset[str] = frozenset(
         "mark",
         "read",
         "recent",
+        "select",
         "stats",
     }
 )

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -183,6 +183,7 @@ Commands:
   resume             Resume from recent session context.
   resume-candidates  Rank resume candidates for the current context.
   schema             Inspect and audit provider schemas.
+  select
   stats              Show statistics for matched sessions.
   status             Show daemon and archive status.
   tags               Manage session tags.

--- a/tests/baselines/showcase/help-select.txt
+++ b/tests/baselines/showcase/help-select.txt
@@ -1,0 +1,10 @@
+Usage: polylogue select [OPTIONS]
+
+  Select one matched session with fzf/prompt fallback.
+
+Options:
+  -n, --limit INTEGER RANGE  Max candidate sessions.  [default: 20; x>=1]
+  --print [id|title|origin]  Field to print for the selected session.
+                             [default: id]
+  --json                     Print the selected session as one JSON object.
+  --help                     Show this message and exit.

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -712,6 +712,7 @@ class TestCliMetadata:
             "count",
             "stats",
             "read",
+            "select",
             "delete",
             "mark",
             "analyze",

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -347,11 +347,11 @@ def test_query_then_action_completion_per_shell(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
 
-    items = _run_completion_for_partial(shell, comp_cls, ["find", "id:abc", "then"], "r")
+    items = _run_completion_for_partial(shell, comp_cls, ["find", "id:abc", "then"], "s")
     item_map = dict(items)
 
-    assert "read" in item_map
-    assert item_map["read"] is not None and "input=query_result_set" in item_map["read"]
+    assert "select" in item_map
+    assert item_map["select"] is not None and "input=query_result_set" in item_map["select"]
     assert "read-views" not in item_map
     assert "repo:" not in item_map
     assert "reset" not in item_map

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -101,6 +101,33 @@ def test_stats_verb_toggles_stats_only_and_updates_grouping() -> None:
     assert grouped_request.query_params()["limit"] == 3
 
 
+def test_select_verb_invokes_query_backed_selector() -> None:
+    _, child = _context_pair(params={"origin": "chatgpt-export"}, query_terms=("alpha",))
+    wrapped = getattr(query_verbs.select_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.select.run_select") as run_select:
+        wrapped(child, 7, "title", False)
+
+    request = run_select.call_args.args[1]
+    assert run_select.call_args.args[0] is child.obj
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["origin"] == "chatgpt-export"
+    assert request.query_params()["query"] == ("alpha",)
+    assert run_select.call_args.kwargs == {"limit": 7, "print_field": "title"}
+
+
+def test_select_verb_json_flag_overrides_print_field() -> None:
+    _, child = _context_pair(query_terms=("alpha",))
+    wrapped = getattr(query_verbs.select_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.select.run_select") as run_select:
+        wrapped(child, 5, "id", True)
+
+    assert run_select.call_args.kwargs == {"limit": 5, "print_field": "json"}
+
+
 def test_read_view_click_choices_come_from_view_profiles() -> None:
     option = next(param for param in query_verbs.read_verb.params if param.name == "view")
 


### PR DESCRIPTION
## Summary
Adds `select` to the query-first CLI verb floor as a read-only session picker backed by the existing selector helpers.

## Problem
#1844 calls for fuzzy/session-result narrowing over the shared query/action surface. The selector implementation already existed in `polylogue/cli/select.py`, including fzf/UI fallback and plain-mode first-result behavior, but it was not reachable as a public query verb and had no action contract.

## Solution
- registers `select` as a query verb and lightweight verb name;
- routes it through `run_select(env, RootModeRequest, limit, print_field)` so it uses the same query/filter path as other query verbs;
- adds `--print id|title|origin`, `--json`, and `--limit` options;
- declares a read-only singleton `CliActionContract` with human/json formats;
- updates completion/action tests so `find ... then select` is action-contract backed;
- regenerates CLI reference, quality workflow projections, and showcase help baselines.

## Verification
- `nix develop --command devtools test tests/unit/cli/test_query_verbs_runtime.py -k select` -> 5 passed.
- `nix develop --command devtools test tests/unit/cli/test_click_app.py -k "all_subcommands or help_flag_lists_subcommands"` -> 2 passed.
- `nix develop --command devtools test tests/unit/cli/test_cli_action_contracts.py -k "public_floor or contract_paths or machine_formats"` -> 3 passed.
- `nix develop --command devtools test tests/unit/cli/test_completion_matrix.py -k "then_action_completion"` -> 3 passed.
- `nix develop --command devtools test tests/unit/cli/test_select.py` -> 9 passed.
- `nix develop --command devtools lab-scenario verify-baselines` -> all baselines match.
- `nix develop --command devtools verify --quick` -> all quick checks passed.

Ref #1844