### PR TITLE
feat(daemon): expose query completion metadata endpoint (#1844)

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -825,6 +825,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_list_sessions(params)
         elif path == ["api", "facets"]:
             self._handle_facets(params)
+        elif path == ["api", "query-completions"]:
+            self._handle_query_completions(params)
         elif path == ["api", "paste-browser"]:
             self._handle_paste_browser(params)
         elif path == ["api", "attachments"]:
@@ -2131,6 +2133,23 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         from polylogue.daemon.thread_continue import build_templates_envelope
 
         self._send_json(HTTPStatus.OK, build_templates_envelope())
+
+    @daemon_safe_handler
+    def _handle_query_completions(self, params: dict[str, list[str]]) -> None:
+        """``GET /api/query-completions`` exposes shared query metadata."""
+
+        from polylogue.archive.query.completions import QueryCompletionError, query_completion_payload
+
+        kind = self._get_param(params, "kind") or "field"
+        incomplete = self._get_param(params, "incomplete") or ""
+        unit = self._get_param(params, "unit")
+        field = self._get_param(params, "field")
+        try:
+            payload = query_completion_payload(kind, incomplete=incomplete, unit=unit, field=field)
+        except QueryCompletionError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_query_completion", "message": str(exc)})
+            return
+        self._send_json(HTTPStatus.OK, {"query_completions": payload})
 
     # ------------------------------------------------------------------
     # Handlers: per-session embedding similarity (#1123)

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -955,6 +955,31 @@ class TestReaderDegradedStates:
         assert payload["total"] == 0
 
 
+class TestReaderQueryCompletions:
+    def test_query_completions_endpoint_exposes_shared_payload(self) -> None:
+        with _running_server_without_seed() as (_server, base_url):
+            payload = _get_json(base_url, "/api/query-completions?kind=field&incomplete=d")
+
+        assert isinstance(payload, dict)
+        envelope = payload["query_completions"]
+        assert isinstance(envelope, dict)
+        assert envelope["kind"] == "field"
+        candidates = envelope["candidates"]
+        assert isinstance(candidates, list)
+        candidate_payloads = [cast(dict[str, object], candidate) for candidate in candidates]
+        date_candidate = next(candidate for candidate in candidate_payloads if candidate["value"] == "date")
+        assert date_candidate["insert"] == "date "
+        assert date_candidate["source"] == "DATE_QUERY_FIELD_REGISTRY"
+
+    def test_query_completions_endpoint_reports_invalid_context(self) -> None:
+        with _running_server_without_seed() as (_server, base_url):
+            status, payload = _get_json_ex(base_url, "/api/query-completions?kind=structural-field")
+
+        assert status == 400
+        assert payload["error"] == "invalid_query_completion"
+        assert "--unit is required" in str(payload["message"])
+
+
 class TestReaderPrivacy:
     """The reader must never expose absolute local paths or auth tokens.
 


### PR DESCRIPTION
## Summary

Adds a read-only daemon/web API endpoint for shared query-completion metadata. `GET /api/query-completions` now returns the same `query_completions` payload already used by CLI JSON, Python API, and MCP.

## Problem

After #2038, the completion metadata contract was shared across CLI/API/MCP, but the local web/workbench surface still had no route to consume it. That left future query-builder work one step away from either reusing the contract or reimplementing completion metadata in the browser layer.

## Solution

- Route `GET /api/query-completions` through `polylogue.archive.query.completions.query_completion_payload`.
- Default omitted `kind` to `field`, matching the most useful discovery case.
- Return a typed 400 JSON error for invalid completion context, such as `kind=structural-field` without `unit`.
- Add live HTTP tests for success and invalid-context behavior.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k query_completions` — 2 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.
- Push hook reran `devtools verify --quick` at `b884da43` — exit_code 0.

Ref #1844
Ref #1846