### PR TITLE
test(query): prove completion fields follow registry deletion (#1844)

### DIFF
--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -150,6 +150,16 @@ def test_query_field_candidates_include_readable_operator_fields() -> None:
     assert "messages between 5 and 20" in message_candidate.description
 
 
+def test_query_field_candidates_disappear_with_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY
+
+    monkeypatch.delitem(EXPRESSION_FIELD_REGISTRY, "repo")
+
+    candidates = shell_completion_values.query_field_candidates("re")
+
+    assert "repo" not in {candidate.value for candidate in candidates}
+
+
 def test_query_structural_unit_candidates_come_from_expression_registry() -> None:
     candidates = shell_completion_values.query_structural_unit_candidates("b")
     assert [candidate.value for candidate in candidates] == ["block"]


### PR DESCRIPTION
## Summary

Adds the missing #1844 contract test that proves query-field completion candidates are mechanically sourced from `EXPRESSION_FIELD_REGISTRY`: if a registry entry is removed, its completion candidate disappears.

## Problem

The issue acceptance criteria explicitly require proof that deleted/renamed query metadata disappears from completion automatically through the shared registry. Existing tests proved candidates were present and sourced from the registry, but not the disappearance behavior.

## Solution

Adds a focused test that removes `repo` from `EXPRESSION_FIELD_REGISTRY` with `monkeypatch.delitem(...)` and verifies `query_field_candidates("re")` no longer emits it.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py -k 'query_field_candidates'` — 3 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.
- Push hook reran `devtools verify --quick` at `d5ac86e6` — exit_code 0.

Closes #1844