### PR TITLE
feat(daemon): expose read view profile metadata (#1997)

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -827,6 +827,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_facets(params)
         elif path == ["api", "query-completions"]:
             self._handle_query_completions(params)
+        elif path == ["api", "read-view-profiles"]:
+            self._handle_read_view_profiles()
         elif path == ["api", "paste-browser"]:
             self._handle_paste_browser(params)
         elif path == ["api", "attachments"]:
@@ -2150,6 +2152,15 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_query_completion", "message": str(exc)})
             return
         self._send_json(HTTPStatus.OK, {"query_completions": payload})
+
+    @daemon_safe_handler
+    def _handle_read_view_profiles(self) -> None:
+        """``GET /api/read-view-profiles`` exposes shared read-view metadata."""
+
+        from polylogue.archive.viewport import read_view_profile_payloads
+
+        profiles = read_view_profile_payloads()
+        self._send_json(HTTPStatus.OK, {"read_views": profiles, "total": len(profiles)})
 
     # ------------------------------------------------------------------
     # Handlers: per-session embedding similarity (#1123)

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -980,6 +980,22 @@ class TestReaderQueryCompletions:
         assert "--unit is required" in str(payload["message"])
 
 
+class TestReaderViewProfiles:
+    def test_read_view_profiles_endpoint_exposes_shared_profile_semantics(self) -> None:
+        with _running_server_without_seed() as (_server, base_url):
+            payload = _get_json(base_url, "/api/read-view-profiles")
+
+        assert isinstance(payload, dict)
+        assert payload["total"] >= 3
+        read_views = payload["read_views"]
+        assert isinstance(read_views, list)
+        profiles = {profile["view_id"]: profile for profile in read_views}
+        assert profiles["raw"]["lossiness"] == "raw"
+        assert profiles["raw"]["evidence_policy"] == "required"
+        assert profiles["recovery"]["successor_handoff"] is True
+        assert "markdown" in profiles["recovery"]["formats"]
+
+
 class TestReaderPrivacy:
     """The reader must never expose absolute local paths or auth tokens.
 


### PR DESCRIPTION
## Summary

Adds `GET /api/read-view-profiles`, a read-only daemon/web endpoint over the existing `SessionViewProfile` registry. The web/workbench surface can now inspect the same read-view semantics already exposed through CLI, Python API, and MCP.

## Problem

#1997 asks for read-view semantics to be shared across CLI, web/API, MCP/API, and exports. The registry and CLI/API/MCP surfaces already existed, but daemon HTTP did not expose the profile inventory, leaving future web workbench code one step away from duplicating view vocabulary.

## Solution

- Route `/api/read-view-profiles` through `read_view_profile_payloads()`.
- Return `{read_views, total}` with the same profile fields as existing API/MCP surfaces.
- Add a live HTTP test proving raw/recovery semantics survive through the daemon endpoint.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k 'read_view_profiles or query_completions'` — 3 passed.
- `nix develop --command devtools verify --quick` — exit_code 0.
- Push hook reran `devtools verify --quick` at `afa34c63` — exit_code 0.

Ref #1997
Ref #1846