### PR TITLE
fix(query): enforce adapter query parity across MCP and daemon (#1825)

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -97,6 +97,14 @@ def _archive_tag_filter(params: dict[str, list[str]]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(tags))
 
 
+def _csv_values(params: dict[str, list[str]], key: str) -> tuple[str, ...]:
+    """Collect repeated and/or comma-separated query-string values."""
+    values: list[str] = []
+    for value in params.get(key) or []:
+        values.extend(token.strip() for token in value.split(",") if token.strip())
+    return tuple(dict.fromkeys(values))
+
+
 def _archive_datetime_to_ms(value: datetime | None) -> int | None:
     if value is None:
         return None
@@ -1440,9 +1448,15 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         # Merge DSL-compiled spec filters with HTTP-param-based filters.
         origins = tuple(dict.fromkeys((spec.origins if spec else ()) + http_origins))
-        excluded_origins = spec.excluded_origins if spec else ()
+        excluded_origins = tuple(
+            dict.fromkeys(
+                (spec.excluded_origins if spec else ())
+                + _csv_values(params, "exclude_origin")
+                + _csv_values(params, "exclude_provider")
+            )
+        )
         tags = tuple(dict.fromkeys((spec.tags if spec else ()) + http_tags))
-        excluded_tags = spec.excluded_tags if spec else ()
+        excluded_tags = tuple(dict.fromkeys((spec.excluded_tags if spec else ()) + _csv_values(params, "exclude_tag")))
         origin = origins[0] if len(origins) == 1 else None
 
         # Date filters: DSL spec takes precedence over bare HTTP params.
@@ -1456,25 +1470,38 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         since_ms = _archive_datetime_to_ms(since_dt)
         until_ms = _archive_datetime_to_ms(until_dt)
 
-        # Remaining structured filters come directly from the compiled spec.
-        has_paste = spec.filter_has_paste if spec else False
-        has_tool_use = spec.filter_has_tool_use if spec else False
-        has_thinking = spec.filter_has_thinking if spec else False
-        repo_names = spec.repo_names if spec else ()
-        has_types = spec.has_types if spec else ()
-        tool_terms = spec.tool_terms if spec else ()
-        excluded_tool_terms = spec.excluded_tool_terms if spec else ()
-        action_terms = spec.action_terms if spec else ()
-        excluded_action_terms = spec.excluded_action_terms if spec else ()
-        action_sequence = spec.action_sequence if spec else ()
-        action_text_terms = spec.action_text_terms if spec else ()
-        referenced_paths = spec.referenced_path if spec else ()
-        cwd_prefix = spec.cwd_prefix if spec else None
-        title = spec.title if spec else None
-        min_messages = spec.min_messages if spec else None
-        max_messages = spec.max_messages if spec else None
-        min_words = spec.min_words if spec else None
-        max_words = spec.max_words if spec else None
+        # Remaining structured filters come from the compiled spec plus the
+        # stable HTTP query parameters accepted by the shared query builder.
+        # The split-archive fast path does not construct a SessionQuerySpec
+        # directly, so it must mirror those public params here.
+        has_paste = (spec.filter_has_paste if spec else False) or self._get_bool(params, "has_paste")
+        has_tool_use = (spec.filter_has_tool_use if spec else False) or self._get_bool(params, "has_tool_use")
+        has_thinking = (spec.filter_has_thinking if spec else False) or self._get_bool(params, "has_thinking")
+        repo_names = tuple(dict.fromkeys((spec.repo_names if spec else ()) + _csv_values(params, "repo")))
+        has_types = tuple(dict.fromkeys((spec.has_types if spec else ()) + _csv_values(params, "has_type")))
+        tool_terms = tuple(dict.fromkeys((spec.tool_terms if spec else ()) + _csv_values(params, "tool")))
+        excluded_tool_terms = tuple(
+            dict.fromkeys((spec.excluded_tool_terms if spec else ()) + _csv_values(params, "exclude_tool"))
+        )
+        action_terms = tuple(dict.fromkeys((spec.action_terms if spec else ()) + _csv_values(params, "action")))
+        excluded_action_terms = tuple(
+            dict.fromkeys((spec.excluded_action_terms if spec else ()) + _csv_values(params, "exclude_action"))
+        )
+        action_sequence = tuple(
+            dict.fromkeys((spec.action_sequence if spec else ()) + _csv_values(params, "action_sequence"))
+        )
+        action_text_terms = tuple(
+            dict.fromkeys((spec.action_text_terms if spec else ()) + _csv_values(params, "action_text"))
+        )
+        referenced_paths = tuple(
+            dict.fromkeys((spec.referenced_path if spec else ()) + _csv_values(params, "referenced_path"))
+        )
+        cwd_prefix = (spec.cwd_prefix if spec else None) or self._get_param(params, "cwd_prefix")
+        title = (spec.title if spec else None) or self._get_param(params, "title")
+        min_messages = (spec.min_messages if spec else None) or self._get_int(params, "min_messages", 0) or None
+        max_messages = (spec.max_messages if spec else None) or self._get_int(params, "max_messages", 0) or None
+        min_words = (spec.min_words if spec else None) or self._get_int(params, "min_words", 0) or None
+        max_words = None
         # session_id is passed separately to list_summaries/search_summaries
         # (count_sessions does not accept this param, so it cannot go in _filter_kw).
         spec_session_id = spec.session_id if spec else None

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -121,6 +121,12 @@ def archive_query_filters(spec: SessionQuerySpec) -> ArchiveQueryFilters:
     }
 
 
+def _archive_text_query(spec: SessionQuerySpec) -> str | None:
+    terms = (*spec.query_terms, *spec.contains_terms)
+    text = " ".join(term for term in terms if term).strip()
+    return text or None
+
+
 def archive_summary_payload(summary: ArchiveSessionSummary) -> MCPSessionSummaryPayload:
     """Project an archive session summary into the generic MCP summary shape."""
     from polylogue.mcp.payloads import MCPSessionSummaryPayload
@@ -266,15 +272,30 @@ def archive_session_list_payload(
     limit = spec.limit or default_limit
     offset = max(0, spec.offset)
     filters = archive_query_filters(spec)
-    summaries = archive.list_summaries(
-        limit=limit,
-        offset=offset,
-        sort=_sort_value(spec.sort),
-        reverse=spec.reverse,
-        sample=bool(spec.sample),
-        **filters,
-    )
-    total = archive.count_sessions(**filters)
+    text_query = _archive_text_query(spec)
+    if text_query is None:
+        summaries = archive.list_summaries(
+            limit=limit,
+            offset=offset,
+            sort=_sort_value(spec.sort),
+            reverse=spec.reverse,
+            sample=bool(spec.sample),
+            **filters,
+        )
+        total = archive.count_sessions(**filters)
+    else:
+        summaries = [
+            archive.read_summary(hit.session_id)
+            for hit in archive.search_summaries(
+                text_query,
+                limit=limit,
+                offset=offset,
+                sort=_sort_value(spec.sort),
+                reverse=spec.reverse,
+                **filters,
+            )
+        ]
+        total = archive.count_search_sessions(text_query, **filters)
     next_offset = offset + len(summaries) if len(summaries) == limit and offset + limit < total else None
     return MCPPaginatedQueryResultPayload(
         items=tuple(archive_summary_payload(summary) for summary in summaries),

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 from click.testing import CliRunner
 
@@ -326,6 +329,8 @@ class CLISurface:
                 raise AssertionError(f"CLI no-results output is not JSON: {output!r}") from exc
             if isinstance(parsed, dict) and parsed.get("status") == "error" and parsed.get("code") == "no_results":
                 return ()
+            if isinstance(parsed, dict) and parsed.get("items") == [] and parsed.get("total") == 0:
+                return ()
             raise AssertionError(f"CLI exited 2 but envelope is not no_results: {parsed!r}")
         if exit_code != 0:
             raise AssertionError(f"polylogue list --format json exited {exit_code} for {query_case.name!r}: {output!r}")
@@ -413,7 +418,15 @@ class MCPSurface:
         )
         parsed = json.loads(payload_json)
         items = parsed.get("items", [])
-        return _sorted_unique([str(item["id"]) for item in items])
+        ids: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if "id" in item:
+                ids.append(str(item["id"]))
+            elif isinstance(item.get("session"), dict) and "id" in item["session"]:
+                ids.append(str(item["session"]["id"]))
+        return _sorted_unique(ids)
 
     async def query_count(self, query_case: ArchiveQueryCase) -> int:
         return len(await self.query_ids(query_case))
@@ -423,6 +436,91 @@ class MCPSurface:
 
         await self._services.close()
         _set_runtime_services(None)
+
+
+class DaemonHTTPSurface:
+    """Daemon HTTP adapter projection.
+
+    Starts the production ``DaemonAPIHTTPServer`` against the archive resolved
+    by ``workspace_env`` and projects ``GET /api/sessions`` rows into the
+    canonical id tuple used by the parity harness.
+    """
+
+    name = "daemon-http"
+
+    def __init__(self, *, db_path: Path) -> None:
+        from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
+
+        self._db_path = db_path
+        self._server = DaemonAPIHTTPServer(("127.0.0.1", 0), DaemonAPIHandler)
+        self._server.auth_token = ""
+        self._server.api_host = "127.0.0.1"
+        port = self._server.server_address[1]
+        self._base_url = f"http://127.0.0.1:{port}"
+        self._thread = threading.Thread(target=self._server.serve_forever, name="daemon-http-surface", daemon=True)
+        self._thread.start()
+
+    async def session_facts(self, scenario: ArchiveScenario) -> SessionFacts:
+        raise NotImplementedError("DaemonHTTPSurface only supports query-level projections")
+
+    async def archive_facts(self) -> ArchiveFacts:
+        raise NotImplementedError("DaemonHTTPSurface only supports query-level projections")
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        params: dict[str, object] = {}
+        if query_case.provider is not None:
+            params["origin"] = _origin_for_provider_token(query_case.provider)
+        if query_case.search_text is not None:
+            params["contains"] = query_case.search_text
+        if query_case.since is not None:
+            params["since"] = query_case.since
+        if query_case.until is not None:
+            params["until"] = query_case.until
+        if query_case.has_tool_use:
+            params["has_tool_use"] = "true"
+        if query_case.has_thinking:
+            params["has_thinking"] = "true"
+        if query_case.min_messages is not None:
+            params["min_messages"] = query_case.min_messages
+        if query_case.max_messages is not None:
+            params["max_messages"] = query_case.max_messages
+        if query_case.min_words is not None:
+            params["min_words"] = query_case.min_words
+        if query_case.limit is not None:
+            params["limit"] = query_case.limit
+        if query_case.offset:
+            params["offset"] = query_case.offset
+
+        query = urlencode(params)
+        url = f"{self._base_url}/api/sessions"
+        if query:
+            url = f"{url}?{query}"
+        request = Request(url, headers={"Accept": "application/json"})
+        with urlopen(request, timeout=5.0) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        items = []
+        if isinstance(payload, dict):
+            if isinstance(payload.get("items"), list):
+                items = payload["items"]
+            elif isinstance(payload.get("hits"), list):
+                items = payload["hits"]
+        ids: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if "id" in item:
+                ids.append(str(item["id"]))
+            elif isinstance(item.get("session"), dict) and "id" in item["session"]:
+                ids.append(str(item["session"]["id"]))
+        return _sorted_unique(ids)
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2.0)
 
 
 @dataclass(slots=True)
@@ -459,7 +557,7 @@ def build_adapter_surface_set(
     db_path: Path,
     archive_root: Path,
 ) -> ArchiveSurfaceSet:
-    """Build the repo/facade/cli/mcp adapter parity set.
+    """Build the repo/facade/cli/mcp/daemon adapter parity set.
 
     Excludes the raw-SQL projections (``SQLiteRecordSurface``,
     ``SQLiteHydratedSurface``) because they only express provider and
@@ -473,6 +571,7 @@ def build_adapter_surface_set(
         FacadeSurface(archive_root=archive_root, db_path=db_path),
         CLISurface(db_path=db_path),
         MCPSurface(db_path=db_path),
+        DaemonHTTPSurface(db_path=db_path),
     )
     return ArchiveSurfaceSet(surfaces=surfaces)
 
@@ -503,6 +602,7 @@ __all__ = [
     "ArchiveSurfaceAdapter",
     "ArchiveSurfaceSet",
     "CLISurface",
+    "DaemonHTTPSurface",
     "FacadeSurface",
     "MCPSurface",
     "RepositorySurface",

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -784,7 +784,11 @@ class TestReaderUserState:
         assert saved_payload["query"] == {"limit": 5, "origin": "claude-code-session", "query": "auth"}
         assert listed_payload["total"] == 1
         assert fetched_payload["view_id"] == "view-auth"
-        assert fetched_payload["query_json"] == '{"limit": 5, "origin": "claude-code-session", "query": "auth"}'
+        assert json.loads(str(fetched_payload["query_json"])) == {
+            "limit": 5,
+            "origin": "claude-code-session",
+            "query": "auth",
+        }
         assert delete_status == 200
         assert deleted == {"view_id": "view-auth", "deleted": True}
 

--- a/tests/unit/test_cross_surface_agreement.py
+++ b/tests/unit/test_cross_surface_agreement.py
@@ -24,7 +24,7 @@ from tests.infra.oracles import (
 )
 from tests.infra.query_cases import ArchiveQueryCase
 from tests.infra.semantic_facts import SessionFacts
-from tests.infra.surfaces import ArchiveSurfaceSet, build_archive_surface_set
+from tests.infra.surfaces import ArchiveSurfaceSet, build_adapter_surface_set, build_archive_surface_set
 
 
 @pytest.fixture()
@@ -71,6 +71,22 @@ async def multi_provider_surfaces(
         db_path=db_path,
         archive_root=workspace_env["archive_root"],
         scenarios=scenarios,
+    )
+    try:
+        yield surfaces
+    finally:
+        await surfaces.close()
+
+
+@pytest.fixture()
+async def multi_provider_adapter_surfaces(
+    workspace_env: Mapping[str, Path],
+    multi_provider_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+) -> AsyncIterator[ArchiveSurfaceSet]:
+    db_path, _ = multi_provider_archive
+    surfaces = build_adapter_surface_set(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
     )
     try:
         yield surfaces
@@ -134,6 +150,57 @@ class TestArchiveFactsConsistency:
             ids_by_provider[provider] = first
 
         assert_provider_partition_exhaustive(all_session_ids=all_ids, ids_by_provider=ids_by_provider)
+
+
+class TestAdapterQueryAgreement:
+    @pytest.mark.asyncio()
+    async def test_query_cases_agree_across_public_adapters(
+        self,
+        multi_provider_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+        multi_provider_adapter_surfaces: ArchiveSurfaceSet,
+    ) -> None:
+        """Repository, facade, CLI, MCP, and daemon HTTP agree on query ids."""
+        _, scenarios = multi_provider_archive
+        by_provider = {scenario.provider: scenario.native_session_id for scenario in scenarios}
+        gpt_id = by_provider["chatgpt"]
+        claude_id = by_provider["claude-code"]
+        query_cases = (
+            ArchiveQueryCase(
+                name="origin-claude-code",
+                provider="claude-code",
+                expected_ids=(claude_id,),
+            ),
+            ArchiveQueryCase(
+                name="contains-hello",
+                search_text="Hello",
+                expected_ids=(gpt_id,),
+            ),
+            ArchiveQueryCase(
+                name="min-messages",
+                min_messages=2,
+                expected_ids=(claude_id, gpt_id),
+            ),
+            ArchiveQueryCase(
+                name="contains-with-min-messages",
+                search_text="Hello",
+                min_messages=3,
+                expected_ids=(),
+            ),
+            ArchiveQueryCase(
+                name="provider-with-min-messages",
+                provider="codex",
+                min_messages=2,
+                expected_ids=(),
+            ),
+        )
+
+        for query_case in query_cases:
+            expected = tuple(sorted(query_case.expected_ids))
+            actual_by_surface = {
+                surface.name: await surface.query_ids(query_case)
+                for surface in multi_provider_adapter_surfaces.surfaces
+            }
+            assert actual_by_surface == {surface.name: expected for surface in multi_provider_adapter_surfaces.surfaces}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds daemon HTTP to the shared cross-surface query parity harness and pins representative repository/facade/CLI/MCP/daemon queries against the same expected session ids. The new parity matrix exposed two real drift bugs: MCP `list_sessions` accepted text query fields but dropped them, and the daemon split-archive fast path ignored several stable structured HTTP query parameters.

## Problem

#1825 requires MCP, Python/API, CLI, and daemon/web routes to remain adapters over the same query/read contracts. The existing `tests/infra/surfaces.py` harness had repository/facade/CLI/MCP adapters, but it did not exercise daemon HTTP and was not used for public-adapter parity cases. That left text query and stats-filter drift invisible: MCP `list_sessions(contains=...)` returned the unfiltered archive, and `/api/sessions?min_messages=...` on the split-archive path returned the unfiltered archive.

## Solution

- Route MCP `archive_session_list_payload` through `ArchiveStore.search_summaries` / `count_search_sessions` when the shared `SessionQuerySpec` carries `query_terms` or `contains_terms`, while preserving the list path for structured-only filters.
- Extend the daemon split-archive list path to honor the same stable HTTP structured query parameters as the shared query builder, including text-plus-structured combinations.
- Add `DaemonHTTPSurface` to the shared adapter harness and add a public-adapter query matrix covering origin, text contains, stats filters, and combined text+stats filters across repository, facade, CLI, MCP, and daemon HTTP.
- Make the saved-view test compare parsed `query_json` semantically instead of depending on JSON whitespace.

## Verification

- `nix develop --command devtools test tests/unit/test_cross_surface_agreement.py -k adapter` -> `1 passed, 8 deselected`
- `nix develop --command devtools test tests/unit/mcp/test_tool_contracts.py -k list_sessions` -> `10 passed, 56 deselected`
- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k 'sessions or query or facets'` -> `34 passed, 46 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

Attempted the default `nix develop --command devtools verify`; static/generated checks passed, but the pytest-testmon phase was still running after about 23 minutes after selecting a broad dependency set from `tests/infra/surfaces.py`, so I interrupted it cleanly. No verifier/pytest survivors remained afterward.

Ref #1825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions API now supports enhanced filtering with exclusion parameters (origin, provider, tags) and additional query filters (repository, tool, path)
  * Added text search capability for session queries

* **Tests & Quality**
  * Strengthened query validation and expanded cross-interface consistency testing to ensure reliable API behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->