### PR TITLE
fix(mcp): expose shared error envelope core (#1825)

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -93,12 +93,16 @@ class MCPRootPayload(RootModel[TRoot], Generic[TRoot]):
 
 class MCPErrorPayload(SurfacePayloadModel):
     # Canonical machine-error envelope core (#1818): ``status``/``code``/
-    # ``message``/``detail`` match the CLI ``MachineError`` and daemon error
-    # shapes. MCP-specific fields below are additive optional keys.
+    # ``message``/``detail`` match the CLI ``MachineError`` shape. ``ok`` /
+    # ``error`` / ``field`` mirror the shared ``QueryErrorPayload`` core so
+    # agent clients can handle MCP and daemon query failures with one parser.
+    ok: Literal[False] = False
     status: Literal["error"] = "error"
+    error: str = "error"
     message: str
     code: int | str | None = None
     detail: str | None = None
+    field: str | None = None
     tool: str | None = None
     session_id: str | None = None
     # Schema-mismatch surface (#1611): when an MCP tool body raises

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -158,7 +158,10 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         except Exception as exc:
             return hooks.json_payload(
                 MCPErrorPayload(
-                    message="internal MCP resource error", code="internal_error", detail=type(exc).__name__
+                    message="internal MCP resource error",
+                    code="internal_error",
+                    error="internal_error",
+                    detail=type(exc).__name__,
                 ),
                 exclude_none=True,
             )

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -122,6 +122,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         payload = MCPErrorPayload(
             message=str(exc),
             code="schema_version_mismatch",
+            error="schema_version_mismatch",
             detail=type(exc).__name__,
             tool=fn_name,
             current_version=exc.current_version,
@@ -134,6 +135,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         payload = MCPErrorPayload(
             message=str(exc),
             code="embedding_retrieval_not_ready",
+            error="embedding_retrieval_not_ready",
             detail=type(exc).__name__,
             tool=fn_name,
             readiness_status=exc.readiness_status,
@@ -142,6 +144,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         payload = MCPErrorPayload(
             message=f"{fn_name}: {type(exc).__name__}",
             code="polylogue_error",
+            error="polylogue_error",
             detail=type(exc).__name__,
             tool=fn_name,
         )
@@ -149,6 +152,7 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
         payload = MCPErrorPayload(
             message=f"{fn_name}: internal error ({type(exc).__name__})",
             code="internal_error",
+            error="internal_error",
             detail=type(exc).__name__,
             tool=fn_name,
         )
@@ -208,7 +212,8 @@ async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -
 def _error_json(message: str, **extra: object) -> str:
     """Return a JSON-encoded error dict."""
     code = extra.pop("code", None)
-    return _json_payload(MCPErrorPayload(message=message, code=code, **extra), exclude_none=True)  # type: ignore[arg-type]
+    error = str(code) if code is not None else "error"
+    return _json_payload(MCPErrorPayload(message=message, code=code, error=error, **extra), exclude_none=True)  # type: ignore[arg-type]
 
 
 def _set_runtime_services(services: RuntimeServices | None) -> None:

--- a/tests/unit/mcp/test_contract_evidence.py
+++ b/tests/unit/mcp/test_contract_evidence.py
@@ -55,7 +55,9 @@ pytestmark = pytest.mark.contract
 def _structured_error(payload: str) -> dict[str, Any]:
     body = json.loads(payload)
     assert isinstance(body, dict), f"error payload is not a JSON object: {payload!r}"
+    assert body.get("ok") is False, f"missing or true shared 'ok': {body}"
     assert body.get("status") == "error", f"missing/wrong 'status': {body}"
+    assert isinstance(body.get("error"), str) and body["error"], f"missing/empty shared 'error': {body}"
     assert body.get("is_error") is True, f"missing or false 'is_error': {body}"
     assert isinstance(body.get("message"), str) and body["message"], f"missing/empty 'message': {body}"
     return body

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -348,11 +348,14 @@ def _assert_structured_error(payload: str, *, expected_code: str | None = None) 
     """Assert payload is a structured MCPErrorPayload with the canonical
     ``status``/``message`` core (#1818) plus the MCP ``is_error`` flag and code."""
     body = json.loads(payload)
+    assert body.get("ok") is False, f"missing or true shared 'ok': {body}"
     assert body.get("status") == "error", f"missing/wrong 'status': {body}"
+    assert isinstance(body.get("error"), str) and body["error"], f"missing/empty shared 'error': {body}"
     assert "message" in body, f"missing 'message' field: {body}"
     assert body.get("is_error") is True, f"missing or false 'is_error': {body}"
     if expected_code is not None:
         assert body.get("code") == expected_code, f"expected code={expected_code}, got {body.get('code')}"
+        assert body.get("error") == expected_code, f"expected error={expected_code}, got {body.get('error')}"
 
 
 class TestSessionTreeResourceShapeMatchesTool:


### PR DESCRIPTION
## Summary

Adds the shared query-error envelope core to MCP error payloads while preserving the existing MCP-specific `status`/`message`/`code`/`is_error` fields.

## Problem

#1825 calls for representative error-envelope parity across public surfaces. `QueryErrorPayload` already documents itself as shared with MCP, but MCP errors did not expose the `ok: false` / `error` / `field` core that daemon HTTP uses. Agent clients therefore needed MCP-specific parsing even for ordinary typed failures such as `not_found`, `internal_error`, or embedding readiness errors.

## Solution

- Extend `MCPErrorPayload` with additive `ok`, `error`, and `field` fields.
- Populate `error` from the same stable machine code as `code` in central MCP exception/error serializers.
- Align the direct readiness-resource fallback with the same core.
- Strengthen MCP error-envelope contract tests to require both the existing MCP fields and the shared query-error fields.

## Verification

- `nix develop --command devtools test tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_contract_evidence.py -k 'error or not_found or invalid'` -> `22 passed, 35 deselected`
- `nix develop --command devtools test tests/unit/mcp/test_embedding_retrieval_not_ready.py tests/unit/mcp/test_per_tool_contracts.py -k 'error or payload or invalid'` -> `18 passed, 147 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` -> `exit_code: 0`

Ref #1825