### PR TITLE
test(qa): pin removal of output assurance registry (#1849)

### DIFF
--- a/tests/unit/architecture/test_static_rendering_prune.py
+++ b/tests/unit/architecture/test_static_rendering_prune.py
@@ -26,3 +26,9 @@ def test_legacy_qa_report_aggregator_is_removed() -> None:
     """QA report behavior lives in owned payload, Markdown, and summary modules."""
 
     assert not (ROOT / "polylogue" / "showcase" / "qa_report.py").exists()
+
+
+def test_legacy_output_assurance_registry_is_removed() -> None:
+    """Action contracts and generated schemas own machine-output coverage."""
+
+    assert not (ROOT / "polylogue" / "cli" / "output_assurance.py").exists()


### PR DESCRIPTION
## Summary

Adds an architecture regression check that keeps the legacy `polylogue/cli/output_assurance.py` registry removed.

## Problem

#1849 says the old hand-authored assurance registry must not survive beside `ACTION_CONTRACTS` and generated CLI output schemas. Current master has already deleted `polylogue/cli/output_assurance.py`, but the absence was not pinned in the same prune-test layer that already guards other removed proof/static surfaces.

## Solution

`tests/unit/architecture/test_static_rendering_prune.py` now asserts `polylogue/cli/output_assurance.py` does not exist, alongside the existing guards for removed static templates and the old QA report aggregator.

## Verification

- `devtools test tests/unit/architecture/test_static_rendering_prune.py` -> 4 passed.
- `devtools verify --quick` -> exit_code 0.
- pre-push `devtools verify --quick` -> exit_code 0.

Ref #1849