### PR TITLE
feat(recovery): resolve subagent child links in digests (#1880)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1083,11 +1083,26 @@ class PolylogueArchiveMixin:
     async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:
         """Compile one session into the deterministic recovery digest transform."""
         from polylogue.insights.transforms import compile_recovery_digest
+        from polylogue.storage.query_models import SessionRecordQuery
 
         session = await self.get_session(session_id)
         if session is None:
             return None
-        return compile_recovery_digest(session)
+        session_links: list[dict[str, object]] = await self.repository.queries.list_session_links_for_session(
+            session_id
+        )
+        children = await self.repository.queries.list_sessions(SessionRecordQuery(parent_id=session_id))
+        session_links.extend(
+            {
+                "dst_origin": child.origin.value,
+                "dst_native_id": child.native_id,
+                "resolved_dst_session_id": str(child.session_id),
+                "status": "resolved",
+                "link_type": child.branch_type.value if child.branch_type is not None else "child",
+            }
+            for child in children
+        )
+        return compile_recovery_digest(session, session_links=session_links)
 
     async def recovery_report(self, session_id: str, preset: RecoveryReportPreset) -> str | None:
         """Render one deterministic recovery report preset for a session."""

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1081,7 +1081,7 @@ class PolylogueArchiveMixin:
             return session.with_content_projection(content_projection)
 
     async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:
-        """Compile one session into the deterministic recovery digest transform."""
+        """Compile one resolved session and its child links into a recovery digest."""
         from polylogue.insights.transforms import compile_recovery_digest
         from polylogue.storage.query_models import SessionRecordQuery
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1088,10 +1088,11 @@ class PolylogueArchiveMixin:
         session = await self.get_session(session_id)
         if session is None:
             return None
+        resolved_session_id = str(session.id)
         session_links: list[dict[str, object]] = await self.repository.queries.list_session_links_for_session(
-            session_id
+            resolved_session_id
         )
-        children = await self.repository.queries.list_sessions(SessionRecordQuery(parent_id=session_id))
+        children = await self.repository.queries.list_sessions(SessionRecordQuery(parent_id=resolved_session_id))
         session_links.extend(
             {
                 "dst_origin": child.origin.value,

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -37,6 +37,7 @@ ForensicClaimKind = Literal[
 ]
 RecoveryReportPreset = Literal["continue", "blame"]
 WorkPacketSection = Literal["events", "subagents", "run_state", "tools", "decisions"]
+SubagentChildLinkStatus = Literal["resolved", "unresolved", "repaired", "quarantined"]
 
 _ISSUE_RE = re.compile(r"(?:issues/|issue\s+|closed\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
 _PR_RE = re.compile(r"(?:pull/|PR\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
@@ -165,6 +166,9 @@ class SubagentReport(ArchiveInsightModel):
     tool_id: str | None = None
     task_id: str | None = None
     child_session_id: str | None = None
+    child_link_status: SubagentChildLinkStatus | None = None
+    child_link_type: str | None = None
+    resolved_child_session_id: str | None = None
     prompt: str = ""
     final_report_preview: str = ""
     pr_refs: tuple[str, ...] = ()
@@ -327,7 +331,11 @@ TRANSFORM_REGISTRY: dict[str, TransformDescriptor] = {
 }
 
 
-def compile_recovery_digest(session: Session) -> RecoveryDigest:
+def compile_recovery_digest(
+    session: Session,
+    *,
+    session_links: Sequence[Mapping[str, object]] = (),
+) -> RecoveryDigest:
     """Compile a session into a small deterministic recovery/digest bundle."""
 
     messages = list(session.messages)
@@ -339,7 +347,10 @@ def compile_recovery_digest(session: Session) -> RecoveryDigest:
         preview=session.display_title,
     )
     tool_summaries = tuple(_extract_tool_summaries(session, messages))
-    subagent_reports = tuple(_extract_subagent_reports(session, messages))
+    subagent_reports = _enrich_subagent_reports_with_links(
+        tuple(_extract_subagent_reports(session, messages)),
+        session_links,
+    )
     run_state = _extract_run_state(session, messages)
     events = tuple(_extract_events(session, messages))
     decisions = tuple(_extract_decision_candidates(session, messages))
@@ -927,6 +938,53 @@ def _extract_subagent_reports(session: Session, messages: Sequence[Message]) -> 
             )
 
 
+def _enrich_subagent_reports_with_links(
+    reports: Sequence[SubagentReport],
+    session_links: Sequence[Mapping[str, object]],
+) -> tuple[SubagentReport, ...]:
+    if not session_links:
+        return tuple(reports)
+
+    links_by_child_ref: dict[str, Mapping[str, object]] = {}
+    for session_link in session_links:
+        for key in _session_link_child_keys(session_link):
+            links_by_child_ref.setdefault(key, session_link)
+
+    enriched: list[SubagentReport] = []
+    for report in reports:
+        link: Mapping[str, object] | None = links_by_child_ref.get(report.child_session_id or "")
+        if link is None:
+            enriched.append(report)
+            continue
+        status = _optional_text(link.get("status"))
+        enriched.append(
+            report.model_copy(
+                update={
+                    "child_link_status": status
+                    if status in {"resolved", "unresolved", "repaired", "quarantined"}
+                    else None,
+                    "child_link_type": _optional_text(link.get("link_type")),
+                    "resolved_child_session_id": _optional_text(link.get("resolved_dst_session_id")),
+                }
+            )
+        )
+    return tuple(enriched)
+
+
+def _session_link_child_keys(link: Mapping[str, object]) -> tuple[str, ...]:
+    keys: list[str] = []
+    resolved = _optional_text(link.get("resolved_dst_session_id"))
+    if resolved:
+        keys.append(resolved)
+    native = _optional_text(link.get("dst_native_id"))
+    if native:
+        keys.append(native)
+    origin = _optional_text(link.get("dst_origin"))
+    if origin and native:
+        keys.append(f"{origin}:{native}")
+    return tuple(keys)
+
+
 def _extract_events(session: Session, messages: Sequence[Message]) -> Iterable[RecoveryEvent]:
     seen: set[tuple[str, str]] = set()
     for message in messages:
@@ -1279,11 +1337,28 @@ def _subagent_report_metadata(report: SubagentReport) -> dict[str, str]:
         metadata["task_id"] = report.task_id
     if report.child_session_id:
         metadata["child_session_id"] = report.child_session_id
+    if report.child_link_status:
+        metadata["child_link_status"] = report.child_link_status
+    if report.child_link_type:
+        metadata["child_link_type"] = report.child_link_type
+    if report.resolved_child_session_id:
+        metadata["resolved_child_session_id"] = report.resolved_child_session_id
     return metadata
 
 
 def _subagent_metadata_line(metadata: Mapping[str, str]) -> str:
-    parts = [f"{key}={metadata[key]}" for key in ("tool_id", "task_id", "child_session_id") if metadata.get(key)]
+    parts = [
+        f"{key}={metadata[key]}"
+        for key in (
+            "tool_id",
+            "task_id",
+            "child_session_id",
+            "child_link_status",
+            "child_link_type",
+            "resolved_child_session_id",
+        )
+        if metadata.get(key)
+    ]
     return ", ".join(parts)
 
 

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -942,6 +942,8 @@ def _enrich_subagent_reports_with_links(
     reports: Sequence[SubagentReport],
     session_links: Sequence[Mapping[str, object]],
 ) -> tuple[SubagentReport, ...]:
+    """Attach topology/session-link status to extracted subagent reports."""
+
     if not session_links:
         return tuple(reports)
 
@@ -972,6 +974,8 @@ def _enrich_subagent_reports_with_links(
 
 
 def _session_link_child_keys(link: Mapping[str, object]) -> tuple[str, ...]:
+    """Return all child-reference spellings that can identify one link row."""
+
     keys: list[str] = []
     resolved = _optional_text(link.get("resolved_dst_session_id"))
     if resolved:

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -650,6 +650,71 @@ async def test_recovery_digest_compiles_seeded_session(tmp_path: Path) -> None:
         await archive.close()
 
 
+async def test_recovery_digest_resolves_subagent_child_links(tmp_path: Path) -> None:
+    """Archive-backed recovery enriches raw Task child ids with topology refs."""
+    from polylogue.core.enums import BranchType
+
+    archive = _archive(tmp_path)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="recovery-parent",
+        title="Recovery Parent",
+        messages=[
+            ParsedMessage(
+                provider_message_id="parent-message",
+                role=Role.ASSISTANT,
+                text="Delegating to subagent",
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Task",
+                        tool_id="task-tool",
+                        tool_input={
+                            "taskId": "task-123",
+                            "child_session_id": "codex-session:recovery-child",
+                            "prompt": "Inspect recovery topology.",
+                        },
+                    )
+                ],
+            )
+        ],
+    )
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="recovery-child",
+        parent_session_provider_id="recovery-parent",
+        branch_type=BranchType.SUBAGENT,
+        title="Recovery Child",
+        messages=[
+            ParsedMessage(
+                provider_message_id="child-message",
+                role=Role.ASSISTANT,
+                text="Child report",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="Child report")],
+            )
+        ],
+    )
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            parent_id = archive_db.write_parsed(parent)
+            child_id = archive_db.write_parsed(child)
+
+        digest = await archive.recovery_digest(parent_id)
+
+        assert digest is not None
+        [subagent] = digest.subagent_reports
+        assert subagent.child_session_id == child_id
+        assert subagent.child_link_status == "resolved"
+        assert subagent.child_link_type == "subagent"
+        assert subagent.resolved_child_session_id == child_id
+        assert "child_link_status=resolved" in digest.resume_markdown
+        report = await archive.recovery_report(parent_id, "continue")
+        assert report is not None
+        assert "resolved_child_session_id=codex-session:recovery-child" in report
+    finally:
+        await archive.close()
+
+
 async def test_list_read_view_profiles_exposes_shared_profile_payloads(tmp_path: Path) -> None:
     """``list_read_view_profiles`` exposes the executable read-view registry."""
     archive = _archive(tmp_path)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -711,6 +711,11 @@ async def test_recovery_digest_resolves_subagent_child_links(tmp_path: Path) -> 
         report = await archive.recovery_report(parent_id, "continue")
         assert report is not None
         assert "resolved_child_session_id=codex-session:recovery-child" in report
+
+        alias_digest = await archive.recovery_digest("codex:recovery-parent")
+        assert alias_digest is not None
+        [alias_subagent] = alias_digest.subagent_reports
+        assert alias_subagent.resolved_child_session_id == child_id
     finally:
         await archive.close()
 

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -215,6 +215,29 @@ def test_every_extracted_claim_carries_raw_refs() -> None:
         assert all(ref.session_id == digest.session_id for ref in candidate.raw_refs)
 
 
+def test_recovery_digest_enriches_subagent_reports_from_session_links() -> None:
+    digest = compile_recovery_digest(
+        _session(),
+        session_links=(
+            {
+                "dst_origin": "codex-session",
+                "dst_native_id": "child-42",
+                "resolved_dst_session_id": "codex-session:child-42",
+                "status": "resolved",
+                "link_type": "subagent",
+            },
+        ),
+    )
+
+    [subagent] = digest.subagent_reports
+    assert subagent.child_session_id == "codex-session:child-42"
+    assert subagent.child_link_status == "resolved"
+    assert subagent.child_link_type == "subagent"
+    assert subagent.resolved_child_session_id == "codex-session:child-42"
+    assert "child_link_status=resolved" in digest.resume_markdown
+    assert "resolved_child_session_id=codex-session:child-42" in digest.resume_markdown
+
+
 def test_forensic_index_groups_claims_by_raw_ref() -> None:
     digest = compile_recovery_digest(_session())
     entries = {entry.evidence_id: entry for entry in digest.forensic_index.entries}


### PR DESCRIPTION
## Summary

Recovery digests now enrich subagent reports with archive-backed child-link metadata when the child session is present in the topology. The deterministic transform remains storage-free: callers can supply session-link rows, and the Python API supplies those rows from the repository before rendering digest/report output.

## Problem

#1880 already extracted raw `child_session_id` values from Task/subagent evidence, but recovery output could not distinguish a raw, unverified child id from a child session that Polylogue had actually ingested and connected through topology/session-link data. That made successor handoffs less useful: the report could point at a child id, but not say whether it was resolvable archive evidence.

## Solution

- Added additive `SubagentReport` fields for `child_link_status`, `child_link_type`, and `resolved_child_session_id`.
- Added a pure enrichment helper that matches supplied `session_links` rows against full child ids, origin/native ids, and native ids.
- Updated `compile_recovery_digest(..., session_links=...)` so enrichment happens before resume/report rendering while preserving the storage-free transform boundary.
- Updated `Polylogue.recovery_digest()` to supply both outbound session-link rows and direct child session records from the repository, so parent recovery reports resolve child sessions whose stored topology edge is child -> parent.
- Extended subagent metadata rendering so continue/blame/resume packets expose the resolved link metadata.

## Verification

- `nix develop --command devtools test tests/unit/insights/test_transforms.py tests/unit/api/test_facade_contracts.py -k 'subagent_reports_from_session_links or recovery_digest_resolves_subagent_child_links or recovery_digest_compiles_seeded_session or recovery_report_renders_seeded_session_presets'` -> `4 passed, 197 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push `devtools verify --quick` at `a8d902d1` -> `exit_code: 0`

Ref #1880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recovery digests now capture and display metadata for referenced child sessions, including link status, type, and resolved session identifiers in recovery reports and markdown output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->