### PR TITLE
feat(query): explain terminal unit sources (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1419,6 +1419,11 @@ def _explain_execution_legs(spec: SessionQuerySpec) -> tuple[str, ...]:
     return tuple(sorted(legs))
 
 
+def _explain_unit_source_execution_legs(source: QueryUnitSource) -> tuple[str, ...]:
+    legs = {"sql", f"terminal-{source.unit}-rows", *_predicate_execution_legs(source.predicate)}
+    return tuple(sorted(legs))
+
+
 def explain_expression(expression: str) -> QueryExpressionExplanation:
     """Explain parser output, lowering path, and execution-plan descriptions."""
     source_text = expression
@@ -1433,6 +1438,24 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
             selected_units=("session",),
             execution_legs=_explain_execution_legs(lowered),
             plan_description=tuple(lowered.to_plan().describe()),
+        )
+    unit_source = parse_unit_source_expression(stripped)
+    if unit_source is not None:
+        lowered = SessionQuerySpec(
+            boolean_predicate=QueryExistsPredicate(unit=unit_source.unit, child=unit_source.predicate)
+        )
+        return QueryExpressionExplanation(
+            source_text=source_text,
+            clauses=(),
+            predicate=unit_source.predicate,
+            lowerer="lark-query-unit-source-to-terminal-unit",
+            lowered_spec=lowered,
+            selected_units=(unit_source.unit,),
+            execution_legs=_explain_unit_source_execution_legs(unit_source),
+            plan_description=(
+                f"terminal unit source: {unit_source.unit}",
+                f"compatibility session selector: exists {unit_source.unit}(...)",
+            ),
         )
     ast = parse_expression_ast(stripped)
     lowered = compile_expression(stripped)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -760,6 +760,24 @@ async def test_explain_query_expression_exposes_shared_query_payload(tmp_path: P
         await archive.close()
 
 
+async def test_explain_query_expression_exposes_terminal_unit_payload(tmp_path: Path) -> None:
+    """Unit-source explain output reports the terminal row unit."""
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_query_expression("actions where action:file_edit AND path:polylogue")
+
+        assert payload["lowerer"] == "lark-query-unit-source-to-terminal-unit"
+        assert payload["selected_units"] == ["action"]
+        assert payload["execution_legs"] == ["sql", "terminal-action-rows"]
+        assert payload["plan_description"] == [
+            "terminal unit source: action",
+            "compatibility session selector: exists action(...)",
+        ]
+        assert payload["predicate"]
+    finally:
+        await archive.close()
+
+
 async def test_query_completions_exposes_shared_completion_payload(tmp_path: Path) -> None:
     """``query_completions`` exposes registry-backed query metadata."""
     archive = _archive(tmp_path)

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -234,6 +234,24 @@ def test_query_explain_json_outputs_ast_payload(cli_runner: CliRunner) -> None:
     assert payload["unsupported_nodes"] == []
 
 
+def test_query_explain_json_outputs_terminal_unit_payload(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        ["--plain", "query-explain", "--format", "json", "messages where role:assistant AND text:timeout"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["lowerer"] == "lark-query-unit-source-to-terminal-unit"
+    assert payload["selected_units"] == ["message"]
+    assert payload["execution_legs"] == ["sql", "terminal-message-rows"]
+    assert payload["plan_description"] == [
+        "terminal unit source: message",
+        "compatibility session selector: exists message(...)",
+    ]
+    assert payload["predicate"]["kind"] == "and"
+
+
 def test_query_explain_plain_outputs_plan(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(click_cli, ["--plain", "query-explain", 'repo:polylogue "json envelope"'])
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -225,6 +225,24 @@ class TestExplainExpression:
         assert sequence.selected_units == ("action", "session")
         assert sequence.execution_legs == ("sequence-action",)
 
+    def test_explain_expression_reports_terminal_unit_source(self) -> None:
+        explanation = explain_expression("messages where role:assistant AND text:timeout")
+
+        assert explanation.lowerer == "lark-query-unit-source-to-terminal-unit"
+        assert explanation.selected_units == ("message",)
+        assert explanation.execution_legs == ("sql", "terminal-message-rows")
+        assert explanation.plan_description == (
+            "terminal unit source: message",
+            "compatibility session selector: exists message(...)",
+        )
+        assert explanation.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="role", values=("assistant",)),
+                QueryFieldPredicate(field="text", values=("timeout",)),
+            ),
+        )
+
 
 class TestBooleanQueryExpression:
     def test_boolean_ast_exposes_predicate_tree(self) -> None:


### PR DESCRIPTION
## Summary

`query-explain` now distinguishes terminal unit-source expressions such as `messages where ...` and `actions where ...` from compatibility session selectors. The explain payload names the terminal row unit, records the terminal execution leg, and still shows the current compatibility lowering into `exists <unit>(...)` so callers can see both the target semantics and the implementation bridge.

## Problem

The new query DSL issue calls for terminal units and explainable execution planning, but the existing explain path lowered every non-JSON expression through the compatibility session-query compiler. That made `messages where role:assistant` look like an ordinary session-level selector, which is misleading for agents trying to reason about the future query pipeline.

## Solution

`polylogue/archive/query/expression.py` now parses `QueryUnitSource` expressions before the compatibility AST path and emits a `lark-query-unit-source-to-terminal-unit` explanation with `selected_units`, `terminal-<unit>-rows` execution legs, and a compatibility-lowering note. CLI and Python API contract tests cover message and action terminal-unit explanations.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py tests/unit/api/test_facade_contracts.py -k 'explain_expression_reports_terminal_unit_source or query_explain_json_outputs_terminal_unit_payload or explain_query_expression_exposes_terminal_unit_payload or explain_expression_reports_boolean_units_and_legs or query_explain_json_outputs_ast_payload or explain_query_expression_exposes_shared_query_payload'` -> `6 passed, 490 deselected`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`

Ref #2006