### PR TITLE
docs: refresh current issue execution map (#1807)

### DIFF
--- a/docs/plans/current-issue-execution-control-plane.md
+++ b/docs/plans/current-issue-execution-control-plane.md
@@ -10,43 +10,62 @@ Do not preserve stale public aliases. Do not add ceremonial proof, witness, QA, 
 
 ## Current critical path
 
-1. #1873: stop-line correctness for query/action behavior.
-2. #1818: machine-output/action-contract hub, gating #1842, #1849, #1825, and #1847.
-3. #1842: public command-floor prune. Ship the familiar `find QUERY then ACTION` floor and remove the old command zoo. Do not absorb the full #2006 ceiling.
-4. #2006: full query DSL substrate.
-5. #1880: transform-first recovery/digest views for agent sessions.
-6. #1883, #1882, #1881: KV/assertions, agent identity/context/delivery, and Beads/GitHub/Polylogue boundary.
-7. Demo, README, release, web workbench, and work packets follow the import/query/action/output spine.
+The old command/output floor is largely landed. The active path is no longer
+"make the archive usable at all"; it is making the surviving query, recovery,
+assertion, API, and web surfaces coherent enough that a new agent or user can
+inspect real AI work without reading chat logs.
+
+1. #2006: full query DSL substrate. Keep extending the one Lark-backed grammar,
+   typed AST, lowerers, explain output, and completion/query-builder metadata.
+2. #1880: on-demand recovery views for coding-agent sessions. Recovery is a
+   deterministic transform/read surface, not a stored compile step.
+3. #1883 + #1845: assertion and ref substrate. User overlays, transform
+   candidates, caveats, decisions, and lessons must point at evidence refs.
+4. #1882 + #1840 + #1838: run/context/event projection into recovery/work
+   packets. Build fixture-backed projections that improve handoff views.
+5. #1847 + #1846 + #1824: stable local web/API/capture route contracts, then a
+   demonstrable workbench flow over the same query/read/recovery/assertion
+   contracts.
+6. #1825 + #1827 + #1849: cross-surface parity, release gate truthfulness, and
+   deletion/folding of any proof or documentation surface that is not coupled
+   to executable behavior.
 
 ## Issue notes
 
-#1818 needs an executable action contract beside command/action registration. The contract should describe path, effect, input kind, supported formats, default format, machine schema, cardinality, daemon requirement, guards, and completion context. JSON means one finite document on stdout. NDJSON means one object per line. Human diagnostics go to stderr.
-
-#1842 owns the public command floor: `find`, `import`, `config`, `ops`, and terminal actions `read`, `mark`, `analyze`, `remove`, and `continue` if it truly resumes work. `read` absorbs show/open/messages/raw/export. `mark` absorbs tags/user-state/blackboard/feedback. `analyze` absorbs stats/facets/cost/neighbors/insights/diagnostics/correlate.
+#1816 remains the action-contract source for mutation/read command behavior.
+Do not recreate parallel machine-output registries. JSON means one finite
+document on stdout. NDJSON means one object per line. Human diagnostics go to
+stderr.
 
 #2006 owns the full query DSL: a typed AST and lowering pipeline over SQLite, FTS5, vector search, recursive CTEs, EXISTS subqueries, and existing read/action contracts. It is not a custom database engine. The Lark grammar is the query grammar today; compact field/text clauses and explicit Boolean predicates are entry shapes in that grammar, not a legacy/future split. Current execution covers Boolean session predicates, message/action/block `exists`, action sequences, FTS, lineage, and semantic seed plus residual filters. Remaining work is broader unit coverage (runs/events/assertions/context/bundles), traversal, aggregation, terminal report/action stages, explain metadata, and shared completion/query-builder metadata.
 
-#1815 owns public import/demo/source vocabulary. Public command is `import`; internal ingestion terminology may remain only for daemon or pipeline mechanics. Remaining work is demo fixture worlds, parser regression coverage, and operation/status truthfulness.
-
-#1810 owns terminology cleanup: public vocabulary is session/origin, not conversation/provider. Raw third-party export terms stay only inside parser/raw-fixture boundaries.
-
-#1844 completion must consume the same grammar/AST as CLI, daemon, MCP, and web. It suggests fields, values, and actions from the archive and contracts. Completion performs no writes.
-
-#1880 makes compiled recovery/digest views the default read surface for coding-agent sessions. Initial outputs: resume packet, digest, typed timeline, subagent reports, tool summaries, decisions/KV candidates, forensic index. Every extracted claim links back to raw evidence.
+#1880 makes on-demand recovery/digest views the default handoff surface for
+coding-agent sessions. Initial outputs include resume packet, digest, typed
+timeline, subagent reports, tool summaries, decision/assertion candidates,
+forensic index, and work packet views. Every extracted claim links back to raw
+evidence.
 
 #1883 unifies user and agent overlays as typed KV/assertions: marks, annotations, highlights, corrections, lessons, decisions, blockers, handoffs, RunState, prompt evaluations, and transform candidates. Raw evidence and deterministic indexes are not KV.
 
-#1882 separates RoleSpec, AgentPath, AgentInstance, AgentRun, ContextEnvelope, CommunicationEvent, and DeliveryEvent so work packets can say which session ran, what context it had, and what outside review material was actually seen.
+#1882 owns the bounded Run, ContextSnapshot, and ObservedEvent projection. Use
+these to say which concrete execution acted, what context it had, what it
+spawned, and which review/check/comment evidence was actually seen or injected.
+Do not add a broader agent ontology unless fixtures prove the primitive set
+cannot represent the behavior.
 
-#1881 keeps the boundary clear: Beads owns internal work graph state; GitHub owns public collaboration state; Polylogue owns evidence, traces, context, KV assertions, work packets, and reports.
+The Beads/GitHub/Polylogue boundary is now expressed by #1807 and child issue
+bodies rather than a separate issue: Beads owns internal work graph state;
+GitHub owns public collaboration state; Polylogue owns evidence, traces,
+context, assertions, work packets, and reports.
 
 #1838/#1840/#1845 work packets are forensic bundles around attempts and outcomes, not a task tracker. They link sessions/runs, identity, context, branch/worktree, PR/issues/Beads, checks, touched files, KV assertions, caveats, and outcome.
 
 #1846/#1847 web workbench should inspect the same objects as CLI/MCP and must not create a second query/action/DTO model.
 
-#1848/#1849 replace stale public mental models only when their useful behavior is absorbed by read/analyze/web/tests. Replace proof/QA/showcase confidence layers with code-coupled contracts, fixture worlds, and generated tests.
-
-#1830/#1832/#1851 status/readiness/performance must expose real archive health and import/backpressure state. Performance fixes are profile-first and produce artifacts.
+#1849 replaces stale public mental models only when their useful behavior is
+absorbed by read/analyze/web/tests. Replace proof/QA/showcase confidence layers
+with code-coupled contracts, fixture worlds, generated tests, and benchmark
+artifacts that fail on real drift.
 
 ## Review discipline
 

--- a/docs/plans/query-pipeline-substrate.md
+++ b/docs/plans/query-pipeline-substrate.md
@@ -4,7 +4,12 @@ Owning issue: #2006.
 
 ## Purpose
 
-Polylogue needs a richer query language without becoming its own query engine. The surface language should compile onto the archive storage and search layers already present in the project. The Lark grammar in `polylogue/archive/query/expression.py` is the query grammar; compact field/text clauses and explicit Boolean predicates are entry shapes in that grammar, not separate floor/ceiling languages.
+Polylogue needs a richer query language without becoming its own query engine.
+The surface language should lower onto the archive storage and search layers
+already present in the project. The Lark grammar in
+`polylogue/archive/query/expression.py` is the query grammar; compact field/text
+clauses and explicit Boolean predicates are entry shapes in that grammar, not
+separate floor/ceiling languages.
 
 ## Current limitation
 
@@ -16,7 +21,8 @@ Build a typed AST and lowering layer.
 
 Predicate nodes: And, Or, Not, Leaf, Fts, Semantic, Structural, Sequence, Lineage, Relational.
 
-Pipeline stages: source or filter, traverse, transform, aggregate, terminal action.
+Pipeline stages: source or filter, traverse, transform, aggregate, sort/limit,
+and terminal action or view.
 
 Implemented units: session, message, action, block, lineage.
 
@@ -28,15 +34,22 @@ Compact examples: repo filters, origin filters, tags, date filters, phrases, and
 
 Power examples: grouped conditions, numeric operators, semantic clauses, message predicates, sequence predicates, lineage predicates, and pipelines that change unit from sessions to messages or lineage and back.
 
-## Implementation slices
+## Implementation phases
 
-1. Keep compact and explicit Boolean syntax on the same Lark grammar and AST path.
-2. Extend explain output to show unsupported unit/pipeline stages, not just the lowered `SessionQuerySpec`.
+These are coherent PR-sized implementation phases, not conceptual
+micro-slices. Each phase should land useful executable queries and tests.
+
+1. Keep compact and explicit Boolean syntax on the same Lark grammar and AST
+   path.
+2. Extend explain output to show terminal unit sources, unsupported
+   unit/pipeline stages, and the concrete lowerer/execution legs selected.
 3. Add run/event/assertion/context units only with real lowerers and fixtures.
-4. Add traversal stages that change the active unit and lower to SQL/recursive CTEs or existing read models.
+4. Add traversal stages that change the active unit and lower to SQL/recursive
+   CTEs or existing read models.
 5. Add aggregation/sort/limit stages over supported units.
 6. Lower terminal stages through existing read/analyze/bundle/action contracts.
-7. Add completion/query-builder metadata from the same grammar, unit, field, operator, and action registries.
+7. Add completion/query-builder metadata from the same grammar, unit, field,
+   operator, and action registries.
 
 ## Acceptance criteria
 
@@ -44,4 +57,6 @@ Power examples: grouped conditions, numeric operators, semantic clauses, message
 - Unsupported forms fail with typed errors and do not broaden results.
 - CLI, daemon, MCP, web, and completion can share the same parser and AST.
 - Natural-language query tools target the AST.
-- #1842 can ship its command-floor work without waiting for this full ceiling.
+- Query surfaces can keep using compatibility function names such as
+  `compile_expression`, but their bodies delegate to this grammar/AST/lowering
+  path rather than forming a separate legacy compiler.


### PR DESCRIPTION
## Summary

Refresh the top-down issue execution docs so they match the current open Polylogue issue set after the recent command-floor, output-contract, README, recovery, assertions, and query work. The docs now point agents at the surviving coherent phases: query DSL, recovery views, assertions/refs, run/context/event projection, web/API/capture, cross-surface parity, release truthfulness, and proof cleanup.

## Problem

`docs/plans/current-issue-execution-control-plane.md` still treated closed/deleted issues as current dispatch truth and used older vocabulary such as compiled recovery views. That makes the repo-local planning layer conflict with the GitHub issue bodies and can steer future agents toward obsolete work.

## Solution

Remove stale closed/deleted issue dispatch references, restate the current critical path around live issues, clarify recovery as an on-demand transform/read surface, and clarify the query substrate as one Lark grammar/AST/lowering path rather than a legacy compiler plus future ceiling. `docs/plans/query-pipeline-substrate.md` now says implementation phases rather than conceptual slices and records terminal unit explain output as part of the plan.

## Verification

- `nix develop --command devtools render-pages` -> site cache rebuilt
- `nix develop --command devtools render-all --check` -> `OK: /realm/project/polylogue/.cache/site matches sources.`
- `nix develop --command devtools verify-doc-commands` -> `100 doc files scanned, no stale commands`

Ref #1807