### PR TITLE
refactor(user-state): store overlays as assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,6 +484,15 @@ Polylogue does not maintain a parallel changed-file router for helper/config
 paths; explicit full collection is limited to `devtools verify --seed-testmon`
 for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
+`devtools verify` treats the pytest subprocess as a bounded child workload, not
+an unowned shell. It prints periodic heartbeat lines, drains pytest output
+incrementally so real progress resets the stall clock, and terminates the whole
+pytest process group if the step exceeds
+`POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default 45 minutes) or produces no output
+for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
+variable to `0` only for an explicit diagnostic run where an unusually long
+full-suite pass is expected and supervised.
+
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,15 @@ Polylogue does not maintain a parallel changed-file router for helper/config
 paths; explicit full collection is limited to `devtools verify --seed-testmon`
 for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
+`devtools verify` treats the pytest subprocess as a bounded child workload, not
+an unowned shell. It prints periodic heartbeat lines, drains pytest output
+incrementally so real progress resets the stall clock, and terminates the whole
+pytest process group if the step exceeds
+`POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default 45 minutes) or produces no output
+for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
+variable to `0` only for an explicit diagnostic run where an unusually long
+full-suite pass is expected and supervised.
+
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).
 

--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -109,16 +109,9 @@ _ARCHIVE_OBSERVABILITY_TABLES: dict[ArchiveTier, tuple[str, ...]] = {
         "embedding_status",
     ),
     ArchiveTier.USER: (
-        "marks",
-        "annotations",
-        "corrections",
-        "suppressions",
+        "assertions",
         "session_tags",
         "session_metadata",
-        "saved_views",
-        "recall_packs",
-        "workspaces",
-        "blackboard_notes",
     ),
     ArchiveTier.OPS: (
         "ingest_cursor",
@@ -1347,7 +1340,7 @@ def _archive_missing_materialization_counts(conn: sqlite3.Connection) -> dict[st
 
 
 def _archive_user_overlay_orphans(root: Path) -> dict[str, Any]:
-    """Count user-tier rows that point at sessions absent from index.db."""
+    """Count user-tier references that point at sessions absent from index.db."""
 
     user_db = root / ARCHIVE_TIER_SPECS[ArchiveTier.USER].filename
     index_db = root / ARCHIVE_TIER_SPECS[ArchiveTier.INDEX].filename
@@ -1362,24 +1355,29 @@ def _archive_user_overlay_orphans(root: Path) -> dict[str, Any]:
     try:
         conn.execute("ATTACH DATABASE ? AS index_tier", (f"file:{index_db}?mode=ro",))
         checks = {
-            "marks": (
-                "SELECT COUNT(*) FROM marks AS u "
-                "WHERE u.target_type = 'session' "
-                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.target_id)"
+            "assertion_marks": (
+                "SELECT COUNT(*) FROM assertions AS u "
+                "WHERE u.kind = 'mark' AND u.target_ref LIKE 'session:%' "
+                "AND COALESCE(u.status, '') != 'deleted' "
+                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = substr(u.target_ref, 9))"
             ),
-            "annotations": (
-                "SELECT COUNT(*) FROM annotations AS u "
-                "WHERE u.target_type = 'session' "
-                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.target_id)"
+            "assertion_annotations": (
+                "SELECT COUNT(*) FROM assertions AS u "
+                "WHERE u.kind = 'annotation' AND u.target_ref LIKE 'session:%' "
+                "AND COALESCE(u.status, '') != 'deleted' "
+                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = substr(u.target_ref, 9))"
             ),
-            "corrections": (
-                "SELECT COUNT(*) FROM corrections AS u "
-                "WHERE u.target_type = 'session' "
-                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.target_id)"
+            "assertion_corrections": (
+                "SELECT COUNT(*) FROM assertions AS u "
+                "WHERE u.kind = 'correction' AND u.target_ref LIKE 'insight:%' "
+                "AND COALESCE(u.status, '') != 'deleted' "
+                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = substr(u.target_ref, 9))"
             ),
-            "suppressions": (
-                "SELECT COUNT(*) FROM suppressions AS u "
-                "WHERE NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.session_id)"
+            "assertion_suppressions": (
+                "SELECT COUNT(*) FROM assertions AS u "
+                "WHERE u.kind = 'suppression' AND u.target_ref LIKE 'session:%' "
+                "AND COALESCE(u.status, '') != 'deleted' "
+                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = substr(u.target_ref, 9))"
             ),
             "session_tags": (
                 "SELECT COUNT(*) FROM session_tags AS u "
@@ -1389,13 +1387,20 @@ def _archive_user_overlay_orphans(root: Path) -> dict[str, Any]:
                 "SELECT COUNT(*) FROM session_metadata AS u "
                 "WHERE NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.session_id)"
             ),
-            "blackboard_notes": (
-                "SELECT COUNT(*) FROM blackboard_notes AS u "
-                "WHERE u.target_type = 'session' "
-                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = u.target_id)"
+            "assertion_notes": (
+                "SELECT COUNT(*) FROM assertions AS u "
+                "WHERE u.kind = 'note' AND u.target_ref LIKE 'session:%' "
+                "AND COALESCE(u.status, '') != 'deleted' "
+                "AND NOT EXISTS (SELECT 1 FROM index_tier.sessions AS s WHERE s.session_id = substr(u.target_ref, 9))"
             ),
         }
-        counts = {table: _scalar_int(conn, sql) if _table_exists(conn, table) else -1 for table, sql in checks.items()}
+        counts = {
+            name: _scalar_int(conn, sql)
+            if (name.startswith("assertion_") and _table_exists(conn, "assertions"))
+            or (not name.startswith("assertion_") and _table_exists(conn, name))
+            else -1
+            for name, sql in checks.items()
+        }
         total = sum(count for count in counts.values() if count > 0)
         return {
             "checked": True,

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -26,8 +26,10 @@ import hashlib
 import json
 import os
 import re
+import selectors
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -133,7 +135,11 @@ TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
+PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
+PYTEST_STALL_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S"
 DEFAULT_PYTEST_HEARTBEAT_S = 30.0
+DEFAULT_PYTEST_TIMEOUT_S = 45 * 60.0
+DEFAULT_PYTEST_STALL_TIMEOUT_S = 10 * 60.0
 
 
 def _load_history() -> list[dict[str, Any]]:
@@ -277,15 +283,41 @@ def _process_status(pid: int) -> dict[str, str | int | None]:
     return status
 
 
-def _pytest_heartbeat_interval() -> float:
-    raw = os.environ.get(PYTEST_HEARTBEAT_ENV)
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
     if raw is None:
-        return DEFAULT_PYTEST_HEARTBEAT_S
+        return default
     try:
         value = float(raw)
     except ValueError:
-        return DEFAULT_PYTEST_HEARTBEAT_S
+        return default
     return max(value, 0.0)
+
+
+def _pytest_heartbeat_interval() -> float:
+    return _float_env(PYTEST_HEARTBEAT_ENV, DEFAULT_PYTEST_HEARTBEAT_S)
+
+
+def _pytest_timeout_s() -> float:
+    return _float_env(PYTEST_TIMEOUT_ENV, DEFAULT_PYTEST_TIMEOUT_S)
+
+
+def _pytest_stall_timeout_s() -> float:
+    return _float_env(PYTEST_STALL_TIMEOUT_ENV, DEFAULT_PYTEST_STALL_TIMEOUT_S)
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=5)
 
 
 def _run_pytest_with_heartbeat(
@@ -296,6 +328,8 @@ def _run_pytest_with_heartbeat(
     t0: float,
 ) -> subprocess.CompletedProcess[str]:
     heartbeat_s = _pytest_heartbeat_interval()
+    timeout_s = _pytest_timeout_s()
+    stall_timeout_s = _pytest_stall_timeout_s()
     sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
     sys.stderr.flush()
     process = subprocess.Popen(
@@ -304,31 +338,79 @@ def _run_pytest_with_heartbeat(
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        start_new_session=True,
     )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    output: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
     last_cpu = _process_cpu_seconds(process.pid)
     last_sample = time.monotonic()
+    last_output = last_sample
+    termination_reason: str | None = None
     while True:
-        try:
-            stdout, stderr = process.communicate(timeout=heartbeat_s if heartbeat_s > 0 else None)
-            return subprocess.CompletedProcess(cmd, process.returncode or 0, stdout, stderr)
-        except subprocess.TimeoutExpired:
-            now = time.monotonic()
+        now = time.monotonic()
+        elapsed = now - t0
+        idle = now - last_output
+        if timeout_s > 0 and elapsed >= timeout_s:
+            termination_reason = f"pytest runtime exceeded {timeout_s:g}s"
+        elif stall_timeout_s > 0 and idle >= stall_timeout_s:
+            termination_reason = f"pytest produced no output for {stall_timeout_s:g}s"
+        if termination_reason is not None:
+            _terminate_process_group(process)
+            break
+
+        timeout = heartbeat_s if heartbeat_s > 0 else None
+        if timeout is not None:
+            if timeout_s > 0:
+                timeout = min(timeout, max(timeout_s - elapsed, 0.0))
+            if stall_timeout_s > 0:
+                timeout = min(timeout, max(stall_timeout_s - idle, 0.0))
+        events = selector.select(timeout=timeout)
+        if events:
+            for selector_key, _mask in events:
+                chunk = os.read(selector_key.fd, 65536)
+                if chunk:
+                    stream_name = str(selector_key.data)
+                    output[stream_name].append(chunk)
+                    last_output = time.monotonic()
+                else:
+                    selector.unregister(selector_key.fileobj)
+        else:
             status = _process_status(process.pid)
             cpu_now = _process_cpu_seconds(process.pid)
             cpu_pct = None
-            if cpu_now is not None and last_cpu is not None and now > last_sample:
-                cpu_pct = ((cpu_now - last_cpu) / (now - last_sample)) * 100.0
+            sample_now = time.monotonic()
+            if cpu_now is not None and last_cpu is not None and sample_now > last_sample:
+                cpu_pct = ((cpu_now - last_cpu) / (sample_now - last_sample)) * 100.0
             last_cpu = cpu_now
-            last_sample = now
+            last_sample = sample_now
             rss = status["rss_kb"]
             rss_text = f", rss={int(rss) // 1024} MiB" if isinstance(rss, int) else ""
             cpu_text = f", cpu={cpu_pct:.0f}%" if cpu_pct is not None else ""
             state_text = f", state={status['state']}" if status["state"] is not None else ""
             sys.stderr.write(
-                f"    still running: pid={process.pid}, elapsed={now - t0:.0f}s{state_text}{cpu_text}{rss_text}\n"
+                f"    still running: pid={process.pid}, elapsed={sample_now - t0:.0f}s, "
+                f"idle={sample_now - last_output:.0f}s{state_text}{cpu_text}{rss_text}\n"
             )
             sys.stderr.flush()
+        if process.poll() is not None and not selector.get_map():
+            break
+
+    for stream in (process.stdout, process.stderr):
+        with contextlib.suppress(OSError):
+            remaining = stream.read()
+        if remaining:
+            stream_name = "stdout" if stream is process.stdout else "stderr"
+            output[stream_name].append(remaining)
+    stdout = b"".join(output["stdout"]).decode(errors="replace")
+    stderr = b"".join(output["stderr"]).decode(errors="replace")
+    if termination_reason is not None:
+        stderr = f"{stderr}\nverify: {termination_reason}; terminated pytest process group {process.pid}\n"
+        return subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+    return subprocess.CompletedProcess(cmd, process.returncode or 0, stdout, stderr)
 
 
 def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, float, dict[str, Any]]:
@@ -348,6 +430,8 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
     if is_pytest:
         metadata.update(_pytest_command_metadata(cmd))
         metadata["heartbeat_s"] = _pytest_heartbeat_interval()
+        metadata["timeout_s"] = _pytest_timeout_s()
+        metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
         report = _read_pytest_report()
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report))

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -24,6 +24,7 @@ import argparse
 import contextlib
 import hashlib
 import json
+import math
 import os
 import re
 import selectors
@@ -291,6 +292,8 @@ def _float_env(name: str, default: float) -> float:
         value = float(raw)
     except ValueError:
         return default
+    if not math.isfinite(value):
+        return default
     return max(value, 0.0)
 
 
@@ -362,12 +365,14 @@ def _run_pytest_with_heartbeat(
             _terminate_process_group(process)
             break
 
-        timeout = heartbeat_s if heartbeat_s > 0 else None
-        if timeout is not None:
-            if timeout_s > 0:
-                timeout = min(timeout, max(timeout_s - elapsed, 0.0))
-            if stall_timeout_s > 0:
-                timeout = min(timeout, max(stall_timeout_s - idle, 0.0))
+        deadlines: list[float] = []
+        if heartbeat_s > 0:
+            deadlines.append(heartbeat_s)
+        if timeout_s > 0:
+            deadlines.append(max(timeout_s - elapsed, 0.0))
+        if stall_timeout_s > 0:
+            deadlines.append(max(stall_timeout_s - idle, 0.0))
+        timeout = min(deadlines) if deadlines else None
         events = selector.select(timeout=timeout)
         if events:
             for selector_key, _mask in events:

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2411,6 +2411,10 @@ class PolylogueArchiveMixin:
 
         resolved_session_id = await self._resolve_user_state_session_id(session_id)
         if target_type == TARGET_SESSION:
+            if target_id:
+                resolved_target_id = await self._resolve_user_state_session_id(target_id)
+                if resolved_target_id != resolved_session_id:
+                    raise ValueError("session target_id must match session_id")
             return {
                 "target_type": TARGET_SESSION,
                 "target_id": resolved_session_id,
@@ -2418,6 +2422,8 @@ class PolylogueArchiveMixin:
                 "message_id": None,
             }
         if target_type == TARGET_MESSAGE:
+            if target_id and message_id and target_id != message_id:
+                raise ValueError("message target_id must match message_id")
             resolved_message_id = message_id or target_id
             if not resolved_message_id:
                 raise ValueError("message target requires message_id or target_id")

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -166,6 +166,7 @@ def _archive_query_kwargs(spec: SessionQuerySpec, *, default_limit: int | None) 
         "min_messages": spec.min_messages,
         "max_messages": spec.max_messages,
         "min_words": spec.min_words,
+        "max_words": spec.max_words,
         "since_ms": _archive_query_date_ms("since", spec.since),
         "until_ms": _archive_query_date_ms("until", spec.until),
         "since_session_id": spec.since_session_id,
@@ -721,6 +722,7 @@ class _ArchiveNeighborRuntime:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         message_type: str | None = None,
     ) -> builtins.list[Session]:
         sessions: builtins.list[Session] = []
@@ -743,6 +745,7 @@ class _ArchiveNeighborRuntime:
             min_messages=min_messages,
             max_messages=max_messages,
             min_words=min_words,
+            max_words=max_words,
             message_type=message_type,
         ):
             session = await self.get(str(summary.id))
@@ -771,6 +774,7 @@ class _ArchiveNeighborRuntime:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         message_type: str | None = None,
     ) -> builtins.list[SessionSummary]:
         del source
@@ -795,6 +799,7 @@ class _ArchiveNeighborRuntime:
                 min_messages=min_messages,
                 max_messages=max_messages,
                 min_words=min_words,
+                max_words=max_words,
                 since_ms=_archive_query_date_ms("since", since),
                 until_ms=_archive_query_date_ms("until", until),
             )
@@ -818,6 +823,7 @@ class _ArchiveNeighborRuntime:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         message_type: str | None = None,
     ) -> int:
         origin, origins = self._provider_filters(provider=provider, providers=providers)
@@ -839,6 +845,7 @@ class _ArchiveNeighborRuntime:
                 min_messages=min_messages,
                 max_messages=max_messages,
                 min_words=min_words,
+                max_words=max_words,
                 since_ms=_archive_query_date_ms("since", since),
                 until_ms=_archive_query_date_ms("until", until),
             ),
@@ -958,6 +965,7 @@ class _ArchiveNeighborRuntime:
             "min_messages": getattr(query, "min_messages", None),
             "max_messages": getattr(query, "max_messages", None),
             "min_words": getattr(query, "min_words", None),
+            "max_words": getattr(query, "max_words", None),
             "since_ms": _archive_query_date_ms("since", getattr(query, "since", None)),
             "until_ms": _archive_query_date_ms("until", getattr(query, "until", None)),
         }
@@ -1659,6 +1667,7 @@ class PolylogueArchiveMixin:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         since: str | None = None,
         until: str | None = None,
         limit: int = 20,
@@ -1693,6 +1702,7 @@ class PolylogueArchiveMixin:
                     min_messages=min_messages,
                     max_messages=max_messages,
                     min_words=min_words,
+                    max_words=max_words,
                     since_ms=_archive_query_date_ms("since", since),
                     until_ms=_archive_query_date_ms("until", until),
                     limit=limit,

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -26,6 +26,7 @@ from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.core.enums import Origin
 from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider, provider_from_origin
+from polylogue.core.user_state_targets import TARGET_MESSAGE, TARGET_SESSION
 from polylogue.errors import PolylogueError
 from polylogue.insights.archive import (
     SessionProfileInsight,
@@ -1523,6 +1524,7 @@ class PolylogueArchiveMixin:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         since: str | None = None,
         until: str | None = None,
     ) -> int:
@@ -1554,6 +1556,7 @@ class PolylogueArchiveMixin:
                 min_messages=min_messages,
                 max_messages=max_messages,
                 min_words=min_words,
+                max_words=max_words,
                 since_ms=_archive_query_date_ms("since", since),
                 until_ms=_archive_query_date_ms("until", until),
             )
@@ -1584,6 +1587,7 @@ class PolylogueArchiveMixin:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         since: str | None = None,
         until: str | None = None,
         limit: int = 50,
@@ -1619,6 +1623,7 @@ class PolylogueArchiveMixin:
                     min_messages=min_messages,
                     max_messages=max_messages,
                     min_words=min_words,
+                    max_words=max_words,
                     since_ms=_archive_query_date_ms("since", since),
                     until_ms=_archive_query_date_ms("until", until),
                     limit=limit,
@@ -2397,35 +2402,34 @@ class PolylogueArchiveMixin:
         self,
         session_id: str,
         *,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> dict[str, str | None]:
         from polylogue.api.user_state_resolver import resolve_insight_target
-        from polylogue.core.user_state_targets import TARGET_KIND_NAMES
+        from polylogue.core.user_state_targets import validate_target_kind
 
         resolved_session_id = await self._resolve_user_state_session_id(session_id)
-        if target_type == "session":
+        if target_type == TARGET_SESSION:
             return {
-                "target_type": "session",
+                "target_type": TARGET_SESSION,
                 "target_id": resolved_session_id,
                 "session_id": resolved_session_id,
                 "message_id": None,
             }
-        if target_type == "message":
+        if target_type == TARGET_MESSAGE:
             resolved_message_id = message_id or target_id
             if not resolved_message_id:
                 raise ValueError("message target requires message_id or target_id")
             if not await self._user_state_message_exists(resolved_session_id, resolved_message_id):
                 raise ValueError(f"message {resolved_message_id!r} is not in session {resolved_session_id!r}")
             return {
-                "target_type": "message",
+                "target_type": TARGET_MESSAGE,
                 "target_id": resolved_message_id,
                 "session_id": resolved_session_id,
                 "message_id": resolved_message_id,
             }
-        if target_type not in TARGET_KIND_NAMES:
-            raise ValueError(f"target_type must be one of: {', '.join(TARGET_KIND_NAMES)}")
+        validate_target_kind(target_type)
         resolved_target = await resolve_insight_target(
             _active_archive_root(self.config),
             target_type=target_type,
@@ -2488,7 +2492,7 @@ class PolylogueArchiveMixin:
         session_id: str,
         mark_type: str,
         *,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> bool:
@@ -2497,6 +2501,9 @@ class PolylogueArchiveMixin:
         Returns ``True`` if the mark was newly added, ``False`` if it already
         existed.
         """
+        from polylogue.core.user_state_targets import validate_mark_type
+
+        mark_type = validate_mark_type(mark_type)
         target = await self._resolve_user_state_target(
             session_id,
             target_type=target_type,
@@ -2513,11 +2520,14 @@ class PolylogueArchiveMixin:
         session_id: str,
         mark_type: str,
         *,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> bool:
         """Remove a mark from a session or message. Returns ``True`` if removed."""
+        from polylogue.core.user_state_targets import validate_mark_type
+
+        mark_type = validate_mark_type(mark_type)
         target = await self._resolve_user_state_target(
             session_id,
             target_type=target_type,
@@ -2544,12 +2554,12 @@ class PolylogueArchiveMixin:
         resolved_target_type = target_type
         resolved_target_id = target_id
         if message_id is not None:
-            resolved_target_type = "message"
+            resolved_target_type = TARGET_MESSAGE
             resolved_target_id = message_id
         elif session_id is not None and target_id is None:
             try:
                 resolved_target_id = await self._resolve_user_state_session_id(session_id)
-                resolved_target_type = "session"
+                resolved_target_type = TARGET_SESSION
             except SessionNotFoundError:
                 return []
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
@@ -2565,7 +2575,7 @@ class PolylogueArchiveMixin:
         session_id: str,
         note_text: str,
         *,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> bool:

--- a/polylogue/api/user_state_resolver.py
+++ b/polylogue/api/user_state_resolver.py
@@ -8,10 +8,9 @@ canonical ``identity_key`` used by recall packs and workspaces.
 The resolver returns the validated ``ResolvedTarget`` mapping or raises
 ``ValueError`` with a specific, surface-friendly message. Insight kinds
 (``session``, ``work_event``, ``thread``) are validated against the
-respective insight tables; ``content_block`` and ``attachment`` are
-validated against the archive substrate; ``paste_span`` is treated as an
-opaque content-block-derived identifier and only validated for non-empty
-``target_id``.
+respective insight tables; ``block`` and ``attachment`` are validated
+against the archive substrate; ``paste_span`` is treated as an opaque
+block-derived identifier and only validated for non-empty ``target_id``.
 """
 
 from __future__ import annotations
@@ -22,9 +21,14 @@ from pathlib import Path
 from typing import TypedDict
 
 from polylogue.core.user_state_targets import (
-    KINDS_BY_NAME,
-    TARGET_KIND_NAMES,
+    TARGET_ATTACHMENT,
+    TARGET_BLOCK,
+    TARGET_PASTE_SPAN,
+    TARGET_SESSION,
+    TARGET_THREAD,
+    TARGET_WORK_EVENT,
     identity_key,
+    validate_target_kind,
 )
 
 
@@ -39,9 +43,9 @@ class ResolvedTarget(TypedDict, total=False):
 
 
 _INSIGHT_QUERIES: dict[str, str] = {
-    "session": "SELECT 1 FROM session_profiles WHERE session_id = ?",
-    "work_event": "SELECT 1 FROM session_work_events WHERE event_id = ? AND session_id = ?",
-    "thread": "SELECT 1 FROM threads WHERE thread_id = ?",
+    TARGET_SESSION: "SELECT 1 FROM session_profiles WHERE session_id = ?",
+    TARGET_WORK_EVENT: "SELECT 1 FROM session_work_events WHERE event_id = ? AND session_id = ?",
+    TARGET_THREAD: "SELECT 1 FROM threads WHERE thread_id = ?",
 }
 
 
@@ -77,7 +81,7 @@ async def _row_exists(archive_root: Path, sql: str, params: tuple[object, ...]) 
         return False
 
 
-def _content_block_exists_sync(
+def _block_exists_sync(
     db_path: Path,
     *,
     session_id: str,
@@ -98,7 +102,7 @@ def _content_block_exists_sync(
     return row is not None
 
 
-async def _content_block_exists(
+async def _block_exists(
     archive_root: Path,
     *,
     session_id: str,
@@ -114,7 +118,7 @@ async def _content_block_exists(
         return False
     try:
         return await asyncio.to_thread(
-            _content_block_exists_sync,
+            _block_exists_sync,
             db_path,
             session_id=session_id,
             message_id=message_id,
@@ -124,17 +128,17 @@ async def _content_block_exists(
         return False
 
 
-def parse_content_block_target_id(target_id: str) -> tuple[str, str]:
+def parse_block_target_id(target_id: str) -> tuple[str, str]:
     """Split ``"{message_id}:{block_index}"`` into its components.
 
     Raises ``ValueError`` if the token is malformed.
     """
 
     if ":" not in target_id:
-        raise ValueError("content_block target_id must be 'message_id:block_index'")
+        raise ValueError("block target_id must be 'message_id:block_index'")
     message_part, _, block_part = target_id.rpartition(":")
     if not message_part or not block_part:
-        raise ValueError("content_block target_id must be 'message_id:block_index'")
+        raise ValueError("block target_id must be 'message_id:block_index'")
     return message_part, block_part
 
 
@@ -154,88 +158,87 @@ async def resolve_insight_target(
     Existence is checked against the `index.db` under ``archive_root``.
     """
 
-    if target_type not in KINDS_BY_NAME:
-        raise ValueError(f"target_type must be one of: {', '.join(TARGET_KIND_NAMES)}")
+    validate_target_kind(target_type)
 
-    if target_type == "session":
+    if target_type == TARGET_SESSION:
         resolved_target_id = target_id or session_id
         if resolved_target_id != session_id:
             raise ValueError("session target_id must equal the session_id (session root)")
-        if not await _row_exists(archive_root, _INSIGHT_QUERIES["session"], (session_id,)):
+        if not await _row_exists(archive_root, _INSIGHT_QUERIES[TARGET_SESSION], (session_id,)):
             raise ValueError(f"session profile for session {session_id!r} is not materialized")
         return {
-            "target_type": "session",
+            "target_type": TARGET_SESSION,
             "target_id": session_id,
             "session_id": session_id,
             "message_id": None,
             "identity_key": identity_key(
-                "session",
+                TARGET_SESSION,
                 session_id=session_id,
                 target_id=session_id,
             ),
         }
 
-    if target_type == "work_event":
+    if target_type == TARGET_WORK_EVENT:
         if not target_id:
             raise ValueError("work_event target requires target_id (event_id)")
-        if not await _row_exists(archive_root, _INSIGHT_QUERIES["work_event"], (target_id, session_id)):
+        if not await _row_exists(archive_root, _INSIGHT_QUERIES[TARGET_WORK_EVENT], (target_id, session_id)):
             raise ValueError(f"work_event {target_id!r} is not in session {session_id!r}")
         return {
-            "target_type": "work_event",
+            "target_type": TARGET_WORK_EVENT,
             "target_id": target_id,
             "session_id": session_id,
             "message_id": None,
             "identity_key": identity_key(
-                "work_event",
+                TARGET_WORK_EVENT,
                 session_id=session_id,
                 target_id=target_id,
             ),
         }
 
-    if target_type == "thread":
+    if target_type == TARGET_THREAD:
         if not target_id:
             raise ValueError("thread target requires target_id (thread_id)")
-        if not await _row_exists(archive_root, _INSIGHT_QUERIES["thread"], (target_id,)):
+        if not await _row_exists(archive_root, _INSIGHT_QUERIES[TARGET_THREAD], (target_id,)):
             raise ValueError(f"thread {target_id!r} is not a materialized thread root")
         return {
-            "target_type": "thread",
+            "target_type": TARGET_THREAD,
             "target_id": target_id,
             "session_id": session_id,
             "message_id": None,
             "identity_key": identity_key(
-                "thread",
+                TARGET_THREAD,
                 session_id=session_id,
                 target_id=target_id,
             ),
         }
 
-    if target_type == "content_block":
+    if target_type == TARGET_BLOCK:
         if not target_id:
-            raise ValueError("content_block target requires target_id 'message_id:block_index'")
-        msg_id, block_part = parse_content_block_target_id(target_id)
+            raise ValueError("block target requires target_id 'message_id:block_index'")
+        msg_id, block_part = parse_block_target_id(target_id)
         effective_message_id = message_id or msg_id
         if effective_message_id != msg_id:
-            raise ValueError("content_block message_id must match the message_id in target_id")
-        if not await _content_block_exists(
+            raise ValueError("block message_id must match the message_id in target_id")
+        if not await _block_exists(
             archive_root,
             session_id=session_id,
             message_id=effective_message_id,
             block_index_token=block_part,
         ):
-            raise ValueError(f"content_block {target_id!r} is not present in session {session_id!r}")
+            raise ValueError(f"block {target_id!r} is not present in session {session_id!r}")
         return {
-            "target_type": "content_block",
+            "target_type": TARGET_BLOCK,
             "target_id": target_id,
             "session_id": session_id,
             "message_id": effective_message_id,
             "identity_key": identity_key(
-                "content_block",
+                TARGET_BLOCK,
                 session_id=session_id,
                 target_id=target_id,
             ),
         }
 
-    if target_type == "attachment":
+    if target_type == TARGET_ATTACHMENT:
         if not target_id:
             raise ValueError("attachment target requires target_id")
         # Attachments live as content blocks of kind 'tool_result' or as raw
@@ -243,27 +246,27 @@ async def resolve_insight_target(
         # to a session". A stronger FK lands when attachment identity is
         # promoted to a first-class table.
         return {
-            "target_type": "attachment",
+            "target_type": TARGET_ATTACHMENT,
             "target_id": target_id,
             "session_id": session_id,
             "message_id": message_id,
             "identity_key": identity_key(
-                "attachment",
+                TARGET_ATTACHMENT,
                 session_id=session_id,
                 target_id=target_id,
             ),
         }
 
-    if target_type == "paste_span":
+    if target_type == TARGET_PASTE_SPAN:
         if not target_id:
             raise ValueError("paste_span target requires target_id")
         return {
-            "target_type": "paste_span",
+            "target_type": TARGET_PASTE_SPAN,
             "target_id": target_id,
             "session_id": session_id,
             "message_id": message_id,
             "identity_key": identity_key(
-                "paste_span",
+                TARGET_PASTE_SPAN,
                 session_id=session_id,
                 target_id=target_id,
             ),
@@ -277,6 +280,6 @@ async def resolve_insight_target(
 
 __all__ = [
     "ResolvedTarget",
-    "parse_content_block_target_id",
+    "parse_block_target_id",
     "resolve_insight_target",
 ]

--- a/polylogue/api/user_state_resolver.py
+++ b/polylogue/api/user_state_resolver.py
@@ -216,6 +216,13 @@ async def resolve_insight_target(
         if not target_id:
             raise ValueError("block target requires target_id 'message_id:block_index'")
         msg_id, block_part = parse_block_target_id(target_id)
+        try:
+            block_index = int(block_part)
+        except ValueError:
+            raise ValueError("block target_id must be 'message_id:block_index'") from None
+        if block_index < 0 or str(block_index) != block_part:
+            raise ValueError("block target_id must use a canonical non-negative block_index")
+        canonical_target_id = f"{msg_id}:{block_index}"
         effective_message_id = message_id or msg_id
         if effective_message_id != msg_id:
             raise ValueError("block message_id must match the message_id in target_id")
@@ -223,28 +230,26 @@ async def resolve_insight_target(
             archive_root,
             session_id=session_id,
             message_id=effective_message_id,
-            block_index_token=block_part,
+            block_index_token=str(block_index),
         ):
             raise ValueError(f"block {target_id!r} is not present in session {session_id!r}")
         return {
             "target_type": TARGET_BLOCK,
-            "target_id": target_id,
+            "target_id": canonical_target_id,
             "session_id": session_id,
             "message_id": effective_message_id,
             "identity_key": identity_key(
                 TARGET_BLOCK,
                 session_id=session_id,
-                target_id=target_id,
+                target_id=canonical_target_id,
             ),
         }
 
     if target_type == TARGET_ATTACHMENT:
         if not target_id:
             raise ValueError("attachment target requires target_id")
-        # Attachments live as content blocks of kind 'tool_result' or as raw
-        # blob refs; the durable identity contract is "non-empty token, scoped
-        # to a session". A stronger FK lands when attachment identity is
-        # promoted to a first-class table.
+        # Attachments currently resolve as non-empty tokens scoped to a
+        # session; first-class attachment refs belong with #1845.
         return {
             "target_type": TARGET_ATTACHMENT,
             "target_id": target_id,

--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -793,7 +793,7 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         completion_source="session_id",
         completion_label="session",
-        mcp_names=("since_session", "since_session_id"),
+        mcp_names=("since_session_id",),
     ),
     QueryFieldDescriptor(
         name="message_type",

--- a/polylogue/artifacts/runtime.py
+++ b/polylogue/artifacts/runtime.py
@@ -438,7 +438,7 @@ RUNTIME_ARTIFACT_NODES: tuple[ArtifactNode, ...] = (
         code_refs=(
             "polylogue.insights.transforms.compile_recovery_digest",
             "polylogue.api.archive.PolylogueArchive.recovery_digest",
-            "polylogue.cli.query_verbs._render_recovery_read_view",
+            "polylogue.cli.query_verbs._run_read_recovery",
         ),
         readiness_surfaces=("read-view", "api", "cli"),
     ),
@@ -472,7 +472,7 @@ RUNTIME_ARTIFACT_NODES: tuple[ArtifactNode, ...] = (
         code_refs=(
             "polylogue.insights.transforms.render_recovery_report",
             "polylogue.insights.transforms.RecoveryDigest.report_markdown",
-            "polylogue.cli.query_verbs._render_recovery_read_view",
+            "polylogue.cli.query_verbs._run_read_recovery",
         ),
         readiness_surfaces=("read-view", "cli"),
     ),

--- a/polylogue/cli/commands/blackboard.py
+++ b/polylogue/cli/commands/blackboard.py
@@ -12,7 +12,10 @@ from polylogue.cli.shared.types import AppEnv
 from polylogue.paths import archive_file_set_root_for_paths, archive_root, db_path
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.archive_tiers.user_write import upsert_blackboard_note
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    list_archive_blackboard_note_envelopes,
+    upsert_blackboard_note,
+)
 
 _KIND_CHOICES = ("finding", "blocker", "decision", "handoff", "question", "observation")
 _KIND_RE = re.compile(r"^\[([^\]]+)\]\s*(.*)$")
@@ -112,31 +115,21 @@ def blackboard_list(
 
     conn = sqlite3.connect(f"file:{user_db}?mode=ro", uri=True)
     try:
-        if not _table_exists(conn, "blackboard_notes"):
-            env.ui.console.print("[dim]No blackboard notes yet.[/dim]")
-            return
-
-        rows = conn.execute(
-            """
-            SELECT note_id, target_type, target_id, body, created_at_ms
-            FROM blackboard_notes
-            ORDER BY created_at_ms DESC, note_id DESC
-            """
-        ).fetchall()
-        if not rows:
+        notes = list_archive_blackboard_note_envelopes(conn)
+        if not notes:
             env.ui.console.print("[dim]No blackboard notes yet.[/dim]")
             return
 
         filtered = []
-        for row in rows:
-            parsed = _parse_blackboard_body(str(row[3]))
+        for note in notes:
+            parsed = _parse_blackboard_body(note.body)
             if kind and parsed["kind"] != kind:
                 continue
             if scope_repo and parsed["scope_repo"] != scope_repo:
                 continue
             if unresolved and parsed["kind"] not in {"blocker", "question"}:
                 continue
-            filtered.append((row, parsed))
+            filtered.append((note, parsed))
             if len(filtered) >= limit:
                 break
 
@@ -144,21 +137,16 @@ def blackboard_list(
             env.ui.console.print("[dim]No matching notes.[/dim]")
             return
 
-        for row, parsed in filtered:
+        for note, parsed in filtered:
             status = "[green]open[/green]"
             content = parsed["content"]
             env.ui.console.print(
                 f"[bold]{parsed['kind']}[/bold] {status}  {parsed['title']}\n"
                 f"  {content[:120]}{'...' if len(content) > 120 else ''}\n"
-                f"  id={row[0]}  repo={parsed['scope_repo'] or '-'}  created_ms={row[4]}\n"
+                f"  id={note.note_id}  repo={parsed['scope_repo'] or '-'}  created_ms={note.created_at_ms}\n"
             )
     finally:
         conn.close()
-
-
-def _table_exists(conn: object, table: str) -> bool:
-    row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1", (table,)).fetchone()  # type: ignore[attr-defined]
-    return row is not None
 
 
 def _user_db_path() -> Path:

--- a/polylogue/cli/commands/blackboard.py
+++ b/polylogue/cli/commands/blackboard.py
@@ -13,6 +13,7 @@ from polylogue.paths import archive_file_set_root_for_paths, archive_root, db_pa
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import (
+    ArchiveBlackboardNoteEnvelope,
     list_archive_blackboard_note_envelopes,
     upsert_blackboard_note,
 )
@@ -120,7 +121,7 @@ def blackboard_list(
             env.ui.console.print("[dim]No blackboard notes yet.[/dim]")
             return
 
-        filtered = []
+        filtered: list[tuple[ArchiveBlackboardNoteEnvelope, _ParsedBlackboardBody]] = []
         for note in notes:
             parsed = _parse_blackboard_body(note.body)
             if kind and parsed["kind"] != kind:
@@ -129,9 +130,9 @@ def blackboard_list(
                 continue
             if unresolved and parsed["kind"] not in {"blocker", "question"}:
                 continue
-            filtered.append((note, parsed))
             if len(filtered) >= limit:
                 break
+            filtered.append((note, parsed))
 
         if not filtered:
             env.ui.console.print("[dim]No matching notes.[/dim]")

--- a/polylogue/cli/commands/user_state.py
+++ b/polylogue/cli/commands/user_state.py
@@ -10,9 +10,8 @@ import click
 
 from polylogue.cli.shared.machine_errors import emit_success
 from polylogue.cli.shared.types import AppEnv
-from polylogue.core.user_state_targets import TARGET_KIND_NAMES
+from polylogue.core.user_state_targets import MARK_TYPE_NAMES, TARGET_KIND_NAMES, TARGET_SESSION
 
-_MARK_TYPES = ("star", "pin", "archive")
 _WORKSPACE_MODES = ("tabs", "stack", "compare", "timeline")
 _TARGET_TYPES = list(TARGET_KIND_NAMES)
 
@@ -82,7 +81,7 @@ def marks_group() -> None:
 
 
 @marks_group.command("list")
-@click.option("--mark-type", type=click.Choice(_MARK_TYPES), default=None)
+@click.option("--mark-type", type=click.Choice(MARK_TYPE_NAMES), default=None)
 @click.option("--session-id", default=None)
 @click.option("--target-type", type=click.Choice(_TARGET_TYPES), default=None)
 @click.option("--target-id", default=None)
@@ -120,8 +119,8 @@ def list_marks_command(
 
 @marks_group.command("add")
 @click.argument("session_id")
-@click.argument("mark_type", type=click.Choice(_MARK_TYPES))
-@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default="session")
+@click.argument("mark_type", type=click.Choice(MARK_TYPE_NAMES))
+@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default=TARGET_SESSION)
 @click.option("--target-id", default=None)
 @click.option("--message-id", default=None)
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
@@ -156,8 +155,8 @@ def add_mark_command(
 
 @marks_group.command("remove")
 @click.argument("session_id")
-@click.argument("mark_type", type=click.Choice(_MARK_TYPES))
-@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default="session")
+@click.argument("mark_type", type=click.Choice(MARK_TYPE_NAMES))
+@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default=TARGET_SESSION)
 @click.option("--target-id", default=None)
 @click.option("--message-id", default=None)
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
@@ -233,7 +232,7 @@ def list_annotations_command(
 @click.argument("annotation_id")
 @click.argument("session_id")
 @click.argument("note_text")
-@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default="session")
+@click.option("--target-type", type=click.Choice(_TARGET_TYPES), default=TARGET_SESSION)
 @click.option("--target-id", default=None)
 @click.option("--message-id", default=None)
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)

--- a/polylogue/core/user_state_targets.py
+++ b/polylogue/core/user_state_targets.py
@@ -11,7 +11,7 @@ Each kind declares:
   (CLI, MCP, daemon HTTP, recall-pack items).
 - ``unit``: human-readable role of the ``target_id`` for that kind.
 - ``requires_message_id``: whether the kind stores ``message_id`` alongside
-  ``session_id``. Only ``message`` and ``content_block`` do.
+  ``session_id``. Only ``message`` and ``block`` do.
 - ``identity_template``: format string for ``identity_key`` in recall packs
   and workspace open-targets; receives keyword args ``session_id``,
   ``target_id``, ``message_id``.
@@ -26,6 +26,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
+TARGET_SESSION: Final = "session"
+TARGET_MESSAGE: Final = "message"
+TARGET_WORK_EVENT: Final = "work_event"
+TARGET_THREAD: Final = "thread"
+TARGET_BLOCK: Final = "block"
+TARGET_ATTACHMENT: Final = "attachment"
+TARGET_PASTE_SPAN: Final = "paste_span"
+
+MARK_STAR: Final = "star"
+MARK_PIN: Final = "pin"
+MARK_ARCHIVE: Final = "archive"
+
 
 @dataclass(frozen=True)
 class TargetKind:
@@ -39,43 +51,43 @@ class TargetKind:
 
 _KINDS: Final[tuple[TargetKind, ...]] = (
     TargetKind(
-        name="session",
+        name=TARGET_SESSION,
         unit="session_id",
         requires_message_id=False,
         identity_template="session:{target_id}",
     ),
     TargetKind(
-        name="message",
+        name=TARGET_MESSAGE,
         unit="message_id",
         requires_message_id=True,
         identity_template="message:{session_id}:{target_id}",
     ),
     TargetKind(
-        name="work_event",
+        name=TARGET_WORK_EVENT,
         unit="event_id from session_work_events",
         requires_message_id=False,
         identity_template="work_event:{session_id}:{target_id}",
     ),
     TargetKind(
-        name="thread",
+        name=TARGET_THREAD,
         unit="thread_id from threads",
         requires_message_id=False,
         identity_template="thread:{target_id}",
     ),
     TargetKind(
-        name="content_block",
+        name=TARGET_BLOCK,
         unit="message_id:block_index",
         requires_message_id=True,
-        identity_template="content_block:{session_id}:{target_id}",
+        identity_template="block:{session_id}:{target_id}",
     ),
     TargetKind(
-        name="attachment",
+        name=TARGET_ATTACHMENT,
         unit="attachment_id",
         requires_message_id=False,
         identity_template="attachment:{session_id}:{target_id}",
     ),
     TargetKind(
-        name="paste_span",
+        name=TARGET_PASTE_SPAN,
         unit="paste_id",
         requires_message_id=False,
         identity_template="paste_span:{session_id}:{target_id}",
@@ -86,6 +98,25 @@ KINDS_BY_NAME: Final[dict[str, TargetKind]] = {kind.name: kind for kind in _KIND
 
 TARGET_KIND_NAMES: Final[tuple[str, ...]] = tuple(kind.name for kind in _KINDS)
 """All supported user-state target kind names, in registry order."""
+
+STORAGE_TARGET_KIND_NAMES: Final[tuple[str, ...]] = (
+    TARGET_SESSION,
+    TARGET_MESSAGE,
+    TARGET_BLOCK,
+    TARGET_ATTACHMENT,
+    TARGET_PASTE_SPAN,
+    TARGET_WORK_EVENT,
+    "phase",
+    TARGET_THREAD,
+)
+"""Target tokens admitted by the user-tier CHECK constraints.
+
+``phase`` remains storage-only until there is a stable public target identity
+for it.
+"""
+
+MARK_TYPE_NAMES: Final[tuple[str, ...]] = (MARK_STAR, MARK_PIN, MARK_ARCHIVE)
+"""All supported reader mark types, in public wire order."""
 
 
 def is_supported(kind: str) -> bool:
@@ -105,6 +136,14 @@ def get_kind(name: str) -> TargetKind:
         ) from exc
 
 
+def validate_target_kind(kind: str) -> str:
+    """Return ``kind`` or raise ``ValueError`` for unsupported target kinds."""
+
+    if is_supported(kind):
+        return kind
+    raise ValueError(f"target_type must be one of: {', '.join(TARGET_KIND_NAMES)}")
+
+
 def identity_key(
     kind_name: str,
     *,
@@ -122,11 +161,40 @@ def identity_key(
     )
 
 
+def is_mark_type_supported(mark_type: str) -> bool:
+    """Return ``True`` if ``mark_type`` is a supported reader mark token."""
+
+    return mark_type in MARK_TYPE_NAMES
+
+
+def validate_mark_type(mark_type: str) -> str:
+    """Return ``mark_type`` or raise ``ValueError`` for unsupported values."""
+
+    if is_mark_type_supported(mark_type):
+        return mark_type
+    raise ValueError(f"mark_type must be one of: {', '.join(MARK_TYPE_NAMES)}")
+
+
 __all__ = [
     "KINDS_BY_NAME",
+    "MARK_ARCHIVE",
+    "MARK_PIN",
+    "MARK_STAR",
+    "MARK_TYPE_NAMES",
+    "STORAGE_TARGET_KIND_NAMES",
     "TARGET_KIND_NAMES",
+    "TARGET_ATTACHMENT",
+    "TARGET_BLOCK",
+    "TARGET_MESSAGE",
+    "TARGET_PASTE_SPAN",
+    "TARGET_SESSION",
+    "TARGET_THREAD",
+    "TARGET_WORK_EVENT",
     "TargetKind",
     "get_kind",
     "identity_key",
+    "is_mark_type_supported",
     "is_supported",
+    "validate_mark_type",
+    "validate_target_kind",
 ]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -548,6 +548,7 @@ def _build_query_spec_params(
         "until",
         "sort",
         "similar_text",
+        "similar_session_id",
         "since_session_id",
         "message_type",
     ):
@@ -555,9 +556,14 @@ def _build_query_spec_params(
         if val is not None:
             spec_params[key] = val
 
+    origin = handler._get_param(params, "origin")
+    if origin is not None:
+        spec_params["origin"] = origin
+    exclude_origin = handler._get_param(params, "exclude_origin")
+    if exclude_origin is not None:
+        spec_params["exclude_origin"] = exclude_origin
+
     for key in (
-        "provider",
-        "exclude_provider",
         "tag",
         "exclude_tag",
         "repo",
@@ -584,7 +590,7 @@ def _build_query_spec_params(
         if handler._get_bool(params, key):
             spec_params[key] = True
 
-    for key in ("min_messages", "max_messages", "min_words", "sample"):
+    for key in ("min_messages", "max_messages", "min_words", "max_words", "sample"):
         val = handler._get_param(params, key)
         if val is not None:
             with contextlib.suppress(ValueError, TypeError):
@@ -1446,7 +1452,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # Parse/lower only the ``query`` param through the shared expression path
         # so DSL clauses like ``origin:codex has:paste since:7d`` map to the
         # correct ArchiveStore filter arguments rather than being passed as
-        # literal FTS text (#1860).  The ``contains`` param is a legacy
+        # literal FTS text (#1860).  The ``contains`` param is a literal
         # content-substring filter that must NOT be parsed as DSL — routing it through
         # compile_expression() causes ExpressionCompileError when the value
         # contains spaces or field-like tokens (#1873 Bug 7).
@@ -1461,7 +1467,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         else:
             spec = None
             fts_terms = ()
-        # ``?contains=`` is the legacy literal content filter. It must still
+        # ``?contains=`` is the literal content filter. It must still
         # filter results, but must NOT be compiled as DSL (a value with spaces or
         # field-like tokens would raise ExpressionCompileError, #1873 Bug 7). Wire
         # it as a literal FTS term so ``GET /api/sessions?contains=foo`` with no
@@ -1479,11 +1485,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # Merge DSL-compiled spec filters with HTTP-param-based filters.
         origins = tuple(dict.fromkeys((spec.origins if spec else ()) + http_origins))
         excluded_origins = tuple(
-            dict.fromkeys(
-                (spec.excluded_origins if spec else ())
-                + _csv_values(params, "exclude_origin")
-                + _csv_values(params, "exclude_provider")
-            )
+            dict.fromkeys((spec.excluded_origins if spec else ()) + _csv_values(params, "exclude_origin"))
         )
         tags = tuple(dict.fromkeys((spec.tags if spec else ()) + http_tags))
         excluded_tags = tuple(dict.fromkeys((spec.excluded_tags if spec else ()) + _csv_values(params, "exclude_tag")))
@@ -1531,7 +1533,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         min_messages = (spec.min_messages if spec else None) or self._get_int(params, "min_messages", 0) or None
         max_messages = (spec.max_messages if spec else None) or self._get_int(params, "max_messages", 0) or None
         min_words = (spec.min_words if spec else None) or self._get_int(params, "min_words", 0) or None
-        max_words = None
+        max_words = (spec.max_words if spec else None) or self._get_int(params, "max_words", 0) or None
         # session_id is passed separately to list_summaries/search_summaries
         # (count_sessions does not accept this param, so it cannot go in _filter_kw).
         spec_session_id = spec.session_id if spec else None

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -1355,7 +1355,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # vector provider (raising the typed readiness error when embeddings
         # are not ready), which daemon_safe_handler maps to its 409 status
         # instead of falling through to a generic ValueError (#1749).
-        if spec.similar_text:
+        if spec.similar_text or spec.similar_session_id:
             return await self._do_search_list(poly, spec, limit, offset)
 
         filter_obj = spec.build_filter(poly.config)

--- a/polylogue/daemon/user_state_http.py
+++ b/polylogue/daemon/user_state_http.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 from typing import Any, cast
 
 from polylogue.archive.query.spec import SessionQuerySpec
-from polylogue.core.user_state_targets import TARGET_KIND_NAMES
+from polylogue.core.user_state_targets import TARGET_SESSION, is_mark_type_supported, validate_target_kind
 
 
 def _read_json_body(handler: Any) -> dict[str, object] | None:
@@ -188,13 +188,15 @@ def handle_create_mark(handler: Any) -> None:
         return
     session_id = str(body.get("session_id") or "")
     mark_type = str(body.get("mark_type") or "")
-    target_type = str(body.get("target_type") or "session")
+    target_type = str(body.get("target_type") or TARGET_SESSION)
     target_id = str(body.get("target_id") or "") or None
     message_id = str(body.get("message_id") or "") or None
-    if not session_id or mark_type not in {"star", "pin", "archive"}:
+    if not session_id or not is_mark_type_supported(mark_type):
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
         return
-    if target_type not in TARGET_KIND_NAMES:
+    try:
+        validate_target_kind(target_type)
+    except ValueError:
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_target_type")
         return
 
@@ -222,7 +224,7 @@ def handle_create_mark(handler: Any) -> None:
 def handle_delete_mark(handler: Any, params: dict[str, list[str]]) -> None:
     session_id = handler._get_param(params, "session_id")
     mark_type = handler._get_param(params, "mark_type")
-    target_type = handler._get_param(params, "target_type", "session")
+    target_type = handler._get_param(params, "target_type", TARGET_SESSION)
     target_id = handler._get_param(params, "target_id")
     message_id = handler._get_param(params, "message_id")
     if not session_id or not mark_type:
@@ -233,12 +235,12 @@ def handle_delete_mark(handler: Any, params: dict[str, list[str]]) -> None:
         deleted = await poly.remove_mark(
             session_id,
             mark_type,
-            target_type=target_type or "session",
+            target_type=target_type or TARGET_SESSION,
             target_id=target_id,
             message_id=message_id,
         )
         return {
-            "target_type": target_type or "session",
+            "target_type": target_type or TARGET_SESSION,
             "target_id": target_id or message_id or session_id,
             "session_id": session_id,
             "message_id": message_id,
@@ -286,14 +288,16 @@ def handle_save_annotation(handler: Any) -> None:
     if body is None:
         return
     session_id = str(body.get("session_id") or "")
-    target_type = str(body.get("target_type") or "session")
+    target_type = str(body.get("target_type") or TARGET_SESSION)
     target_id = str(body.get("target_id") or "") or None
     message_id = str(body.get("message_id") or "") or None
     note_text = str(body.get("note_text") or "")
     if not session_id or not note_text.strip():
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
         return
-    if target_type not in TARGET_KIND_NAMES:
+    try:
+        validate_target_kind(target_type)
+    except ValueError:
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_target_type")
         return
     resolved_target_id = target_id or message_id or session_id

--- a/polylogue/daemon/workspace_routes.py
+++ b/polylogue/daemon/workspace_routes.py
@@ -96,12 +96,6 @@ async def build_compare_payload(
 
 
 def dispatch_get(handler: object, path: list[str], params: dict[str, list[str]]) -> bool:
-    if path == ["api", "stack"]:
-        handle_stack(handler, params)
-        return True
-    if path == ["api", "compare"]:
-        handle_compare(handler, params)
-        return True
     return False
 
 

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -64,6 +64,7 @@ class ArchiveQueryFilters(TypedDict):
     min_messages: int | None
     max_messages: int | None
     min_words: int | None
+    max_words: int | None
     since_ms: int | None
     until_ms: int | None
     since_session_id: str | None
@@ -116,6 +117,7 @@ def archive_query_filters(spec: SessionQuerySpec) -> ArchiveQueryFilters:
         "min_messages": spec.min_messages,
         "max_messages": spec.max_messages,
         "min_words": spec.min_words,
+        "max_words": spec.max_words,
         "since_ms": _date_ms(spec.since),
         "until_ms": _date_ms(spec.until),
         "since_session_id": spec.since_session_id,
@@ -265,6 +267,8 @@ def archive_session_list_payload(
     archive: ArchiveStore,
     spec: SessionQuerySpec,
     *,
+    config: Config | None = None,
+    archive_root: Path | None = None,
     default_limit: int = 10,
 ) -> MCPPaginatedQueryResultPayload:
     """Build the generic MCP list-sessions envelope from the archive."""
@@ -272,6 +276,28 @@ def archive_session_list_payload(
 
     limit = spec.limit or default_limit
     offset = max(0, spec.offset)
+    if spec.similar_session_id is not None:
+        from polylogue.archive.query.archive_execution import archive_search_hits
+        from polylogue.archive.query.spec import query_spec_to_plan
+
+        resolved_archive_root = archive_root or archive.archive_root
+        plan = query_spec_to_plan(replace(spec, limit=limit, offset=offset))
+        pairs, _resolved_lane = archive_search_hits(
+            plan,
+            archive_root=resolved_archive_root,
+            config=config,
+            default_limit=default_limit,
+        )
+        summaries = [summary for _hit, summary in pairs]
+        total = offset + len(summaries) + (1 if len(summaries) == limit else 0)
+        next_offset = offset + len(summaries) if len(summaries) == limit else None
+        return MCPPaginatedQueryResultPayload(
+            items=tuple(archive_summary_payload(summary) for summary in summaries),
+            total=total,
+            limit=limit,
+            offset=offset,
+            next_offset=next_offset,
+        )
     filters = archive_query_filters(spec)
     text_query = _archive_text_query(spec)
     if text_query is None:
@@ -316,9 +342,33 @@ def archive_search_payload(
     offset: int,
     retrieval_lane: str,
     sort: str | None,
+    config: Config | None = None,
+    archive_root: Path | None = None,
 ) -> SearchEnvelope:
     """Build the generic MCP search envelope from archive block search."""
     from polylogue.surfaces.payloads import build_search_envelope
+
+    if spec.similar_session_id is not None:
+        from polylogue.archive.query.archive_execution import archive_search_hits
+        from polylogue.archive.query.spec import query_spec_to_plan
+
+        resolved_archive_root = archive_root or archive.archive_root
+        plan = query_spec_to_plan(replace(spec, limit=limit, offset=offset))
+        pairs, resolved_lane = archive_search_hits(
+            plan,
+            archive_root=resolved_archive_root,
+            config=config,
+            default_limit=limit,
+        )
+        return build_search_envelope(
+            tuple(archive_search_hit_payload(hit, archive=archive) for hit, _summary in pairs),
+            total=offset + len(pairs) + (1 if len(pairs) == limit else 0),
+            limit=limit,
+            offset=offset,
+            query=query,
+            retrieval_lane=resolved_lane,
+            sort=sort,
+        )
 
     filters = archive_query_filters(spec)
     hits = archive.search_summaries(

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -9,6 +9,7 @@ from pydantic import RootModel
 from typing_extensions import TypedDict
 
 from polylogue.core.json import JSONDocument
+from polylogue.core.user_state_targets import TARGET_SESSION
 from polylogue.mcp.context_pack import (
     ContextPackActionSummary as MCPContextPackActionSummary,
 )
@@ -718,7 +719,7 @@ class MCPEmbeddingPreflightPayload(SurfacePayloadModel):
 
 
 class MCPUserMarkPayload(SurfacePayloadModel):
-    target_type: str = "session"
+    target_type: str = TARGET_SESSION
     target_id: str
     session_id: str
     message_id: str | None = None

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -100,8 +100,10 @@ class MCPSessionQueryRequest:
     min_messages: MCPCountBound = None
     max_messages: MCPCountBound = None
     min_words: MCPCountBound = None
+    max_words: MCPCountBound = None
     sample: int | None = None
     similar_text: str | None = None
+    similar_session_id: str | None = None
     since_session_id: str | None = None
     message_type: str | None = None
     offset: MCPToolOffset = 0
@@ -144,8 +146,10 @@ class MCPSessionQueryRequest:
             min_messages=self.min_messages,
             max_messages=self.max_messages,
             min_words=self.min_words,
+            max_words=self.max_words,
             sample=self.sample,
             similar_text=self.similar_text,
+            similar_session_id=self.similar_session_id,
             since_session_id=self.since_session_id,
             message_type=self.message_type,
             offset=self.offset,

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from hashlib import sha256
 from typing import TYPE_CHECKING
 
+from polylogue.core.user_state_targets import MARK_TYPE_NAMES, TARGET_SESSION, is_mark_type_supported
 from polylogue.mcp.archive_support import blackboard_note_payload
 from polylogue.mcp.payloads import (
     MCPMetadataPayload,
@@ -39,9 +40,9 @@ async def _resolve_or_error(hooks: ServerCallbacks, session_id: str) -> tuple[st
 
 
 def _mark_type_error(hooks: ServerCallbacks, mark_type: str) -> str | None:
-    if mark_type in {"star", "pin", "archive"}:
+    if is_mark_type_supported(mark_type):
         return None
-    return hooks.error_json("mark_type must be one of: star, pin, archive", detail=mark_type)
+    return hooks.error_json(f"mark_type must be one of: {', '.join(MARK_TYPE_NAMES)}", detail=mark_type)
 
 
 def _default_saved_view_id(name: str, query_json: str) -> str:
@@ -293,7 +294,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def add_mark(
         session_id: str,
         mark_type: str,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> str:
@@ -330,7 +331,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def remove_mark(
         session_id: str,
         mark_type: str,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> str:
@@ -388,7 +389,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         annotation_id: str,
         session_id: str,
         note_text: str,
-        target_type: str = "session",
+        target_type: str = TARGET_SESSION,
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> str:

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -265,6 +265,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         min_messages: int | None = None,
         max_messages: int | None = None,
         min_words: int | None = None,
+        max_words: int | None = None,
         since: str | None = None,
         until: str | None = None,
         limit: MCPToolLimit = 10,
@@ -313,6 +314,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_messages=min_messages,
                 max_messages=max_messages,
                 min_words=min_words,
+                max_words=max_words,
                 since=since,
                 until=until,
                 limit=clamped_limit,
@@ -343,6 +345,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_messages=min_messages,
                 max_messages=max_messages,
                 min_words=min_words,
+                max_words=max_words,
                 since=since,
                 until=until,
             )

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -98,7 +98,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     limit=(spec.limit or clamped_limit) + clamped_limit,
                 )
             config = hooks.get_config()
-            with ArchiveStore.open_existing(active_archive_root(config) or config.archive_root) as archive:
+            archive_root = active_archive_root(config) or config.archive_root
+            with ArchiveStore.open_existing(archive_root) as archive:
                 return hooks.json_payload(
                     archive_search_payload(
                         archive,
@@ -108,6 +109,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                         offset=clamped_offset,
                         retrieval_lane=request.retrieval_lane or "dialogue",
                         sort=request.sort,
+                        config=config,
+                        archive_root=archive_root,
                     )
                 )
 
@@ -210,8 +213,11 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             spec = request.build_spec(hooks.clamp_limit)
             config = hooks.get_config()
-            with ArchiveStore.open_existing(active_archive_root(config) or config.archive_root) as archive:
-                return hooks.json_payload(archive_session_list_payload(archive, spec))
+            archive_root = active_archive_root(config) or config.archive_root
+            with ArchiveStore.open_existing(archive_root) as archive:
+                return hooks.json_payload(
+                    archive_session_list_payload(archive, spec, config=config, archive_root=archive_root)
+                )
 
         return await hooks.async_safe_call("list_sessions", run)
 

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -444,7 +444,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         code_refs=(
             "polylogue.insights.transforms.compile_recovery_digest",
             "polylogue.api.archive.PolylogueArchive.recovery_digest",
-            "polylogue.cli.query_verbs._render_recovery_read_view",
+            "polylogue.cli.query_verbs._run_read_recovery",
         ),
         surfaces=("api", "cli", "read-view"),
         previewable=True,
@@ -460,7 +460,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         code_refs=(
             "polylogue.insights.transforms.render_recovery_report",
             "polylogue.insights.transforms.RecoveryDigest.report_markdown",
-            "polylogue.cli.query_verbs._render_recovery_read_view",
+            "polylogue.cli.query_verbs._run_read_recovery",
         ),
         surfaces=("cli", "read-view"),
         previewable=True,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -89,6 +89,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import (
 )
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import (
+    ArchiveAssertionEnvelope,
     ArchiveBlackboardNoteEnvelope,
     AssertionKind,
     assertion_id_for_annotation,
@@ -1802,9 +1803,13 @@ class ArchiveStore:
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            assertion = read_assertion_envelope(user_conn, assertion_id_for_saved_view(view_id))
-            exists = assertion is not None and assertion.status != "deleted"
+            assertion_id = assertion_id_for_saved_view(view_id)
+            assertion = read_assertion_envelope(user_conn, assertion_id)
+            name_assertion = _active_assertion_by_kind_key(user_conn, AssertionKind.SAVED_QUERY, normalized_name)
+            exists = (assertion is not None and assertion.status != "deleted") or name_assertion is not None
             with user_conn:
+                if name_assertion is not None and name_assertion.assertion_id != assertion_id:
+                    mark_assertion_status(user_conn, name_assertion.assertion_id, "deleted")
                 upsert_saved_view(user_conn, normalized_name, query, view_id=view_id)
             return not exists
         finally:
@@ -1945,9 +1950,13 @@ class ArchiveStore:
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            assertion = read_assertion_envelope(user_conn, assertion_id_for_workspace(workspace_id))
-            exists = assertion is not None and assertion.status != "deleted"
+            assertion_id = assertion_id_for_workspace(workspace_id)
+            assertion = read_assertion_envelope(user_conn, assertion_id)
+            name_assertion = _active_assertion_by_kind_key(user_conn, AssertionKind.WORKSPACE_NOTE, name)
+            exists = (assertion is not None and assertion.status != "deleted") or name_assertion is not None
             with user_conn:
+                if name_assertion is not None and name_assertion.assertion_id != assertion_id:
+                    mark_assertion_status(user_conn, name_assertion.assertion_id, "deleted")
                 upsert_workspace(user_conn, name, settings, workspace_id=workspace_id)
             return not exists
         finally:
@@ -3773,6 +3782,17 @@ def _split_user_target_ref(target_ref: str) -> tuple[str, str]:
 
 def _id_from_target_ref(target_ref: str, prefix: str) -> str:
     return target_ref[len(prefix) :] if target_ref.startswith(prefix) else target_ref
+
+
+def _active_assertion_by_kind_key(
+    conn: sqlite3.Connection,
+    kind: str,
+    key: str,
+) -> ArchiveAssertionEnvelope | None:
+    for assertion in list_assertions_by_kind(conn, kind):
+        if assertion.key == key:
+            return assertion
+    return None
 
 
 def _user_mark_session_id(target_type: str, target_id: str) -> str:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1750,19 +1750,13 @@ class ArchiveStore:
             found_target_type, found_target_id = _split_user_target_ref(assertion.target_ref)
             if annotation_id and found_annotation_id != annotation_id:
                 continue
-            if (
-                session_id
-                and target_type is None
-                and target_id is None
-                and not (
-                    (found_target_type == "session" and found_target_id == session_id)
-                    or (
-                        found_target_type == "message"
-                        and (found_target_id == session_id or found_target_id.startswith(f"{session_id}:"))
-                    )
+            if session_id and target_id is None:
+                belongs_to_session = (found_target_type == "session" and found_target_id == session_id) or (
+                    found_target_type == "message"
+                    and (found_target_id == session_id or found_target_id.startswith(f"{session_id}:"))
                 )
-            ):
-                continue
+                if not belongs_to_session:
+                    continue
             if target_type and found_target_type != target_type:
                 continue
             if target_id and found_target_id != target_id:
@@ -5414,6 +5408,16 @@ def _archive_user_overlay_debt(conn: sqlite3.Connection, user_db_path: Path) -> 
             "AND u.target_ref LIKE 'session:%' "
             "AND COALESCE(u.status, '') != 'deleted' "
             "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = substr(u.target_ref, 9))",
+            "SELECT COUNT(*) FROM user_debt.assertions u "
+            "WHERE u.kind IN ('mark', 'annotation', 'note', 'suppression') "
+            "AND u.target_ref LIKE 'message:%' "
+            "AND COALESCE(u.status, '') != 'deleted' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM sessions s "
+            "  WHERE substr(u.target_ref, 9) = s.session_id "
+            "     OR (substr(substr(u.target_ref, 9), 1, length(s.session_id)) = s.session_id "
+            "         AND substr(substr(u.target_ref, 9), length(s.session_id) + 1, 1) = ':')"
+            ")",
             "SELECT COUNT(*) FROM user_debt.assertions u "
             "WHERE u.kind = 'correction' "
             "AND u.target_ref LIKE 'insight:%' "

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -97,11 +97,14 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     assertion_id_for_recall_pack,
     assertion_id_for_saved_view,
     assertion_id_for_workspace,
+    correction_id_for,
     list_archive_blackboard_note_envelopes,
+    list_assertions_by_kind,
     mark_assertion_status,
+    read_assertion_envelope,
     upsert_annotation,
-    upsert_assertion,
     upsert_blackboard_note,
+    upsert_correction,
     upsert_mark,
     upsert_recall_pack,
     upsert_saved_view,
@@ -1630,22 +1633,13 @@ class ArchiveStore:
 
     def add_mark(self, target_type: str, target_id: str, mark_type: str) -> bool:
         """Add one user mark to archive user.db."""
-        storage_target_type = _user_target_type_to_storage(target_type)
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            exists = (
-                user_conn.execute(
-                    """
-                    SELECT 1 FROM marks
-                    WHERE target_type = ? AND target_id = ? AND mark_type = ?
-                    """,
-                    (storage_target_type, target_id, mark_type),
-                ).fetchone()
-                is not None
-            )
+            assertion = read_assertion_envelope(user_conn, assertion_id_for_mark(target_type, target_id, mark_type))
+            exists = assertion is not None and assertion.status != "deleted"
             with user_conn:
-                upsert_mark(user_conn, storage_target_type, target_id, mark_type)
+                upsert_mark(user_conn, target_type, target_id, mark_type)
             return not exists
         finally:
             user_conn.close()
@@ -1654,25 +1648,14 @@ class ArchiveStore:
         """Remove one user mark from archive user.db."""
         if not self.user_db_path.exists():
             return False
-        storage_target_type = _user_target_type_to_storage(target_type)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                cursor = user_conn.execute(
-                    """
-                    DELETE FROM marks
-                    WHERE target_type = ? AND target_id = ? AND mark_type = ?
-                    """,
-                    (storage_target_type, target_id, mark_type),
+                return mark_assertion_status(
+                    user_conn,
+                    assertion_id_for_mark(target_type, target_id, mark_type),
+                    "deleted",
                 )
-                deleted = int(cursor.rowcount) > 0
-                if deleted:
-                    mark_assertion_status(
-                        user_conn,
-                        assertion_id_for_mark(storage_target_type, target_id, mark_type),
-                        "deleted",
-                    )
-                return deleted
         finally:
             user_conn.close()
 
@@ -1686,55 +1669,43 @@ class ArchiveStore:
         """List user marks from archive user.db."""
         if not self.user_db_path.exists():
             return []
-        where: list[str] = []
-        params: list[object] = []
-        if mark_type:
-            where.append("mark_type = ?")
-            params.append(mark_type)
-        if target_type:
-            where.append("target_type = ?")
-            params.append(_user_target_type_to_storage(target_type))
-        if target_id:
-            where.append("target_id = ?")
-            params.append(target_id)
-        sql = "SELECT target_type, target_id, mark_type, created_at_ms FROM marks"
-        if where:
-            sql += " WHERE " + " AND ".join(where)
-        sql += " ORDER BY created_at_ms DESC, mark_id"
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(sql, tuple(params)).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.MARK)
         finally:
             user_conn.close()
-        return [
-            {
-                "target_type": _user_target_type_from_storage(str(row[0])),
-                "target_id": str(row[1]),
-                "session_id": _user_mark_session_id(str(row[0]), str(row[1])),
-                "message_id": str(row[1]) if str(row[0]) == "message" else "",
-                "mark_type": str(row[2]),
-                "created_at": str(row[3]),
-            }
-            for row in rows
-        ]
+        out: list[dict[str, str]] = []
+        for assertion in assertions:
+            found_target_type, found_target_id = _split_user_target_ref(assertion.target_ref)
+            if mark_type and assertion.key != mark_type:
+                continue
+            if target_type and found_target_type != target_type:
+                continue
+            if target_id and found_target_id != target_id:
+                continue
+            out.append(
+                {
+                    "target_type": found_target_type,
+                    "target_id": found_target_id,
+                    "session_id": _user_mark_session_id(found_target_type, found_target_id),
+                    "message_id": found_target_id if found_target_type == "message" else "",
+                    "mark_type": str(assertion.key or ""),
+                    "created_at": str(assertion.created_at_ms),
+                }
+            )
+        return out
 
     def save_annotation(self, annotation_id: str, target_type: str, target_id: str, note_text: str) -> bool:
         """Create or update one annotation in archive user.db."""
-        storage_target_type = _user_target_type_to_storage(target_type)
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            exists = (
-                user_conn.execute(
-                    "SELECT 1 FROM annotations WHERE annotation_id = ?",
-                    (annotation_id,),
-                ).fetchone()
-                is not None
-            )
+            assertion = read_assertion_envelope(user_conn, assertion_id_for_annotation(annotation_id))
+            exists = assertion is not None and assertion.status != "deleted"
             with user_conn:
                 upsert_annotation(
                     user_conn,
-                    storage_target_type,
+                    target_type,
                     target_id,
                     note_text,
                     annotation_id=annotation_id,
@@ -1767,46 +1738,47 @@ class ArchiveStore:
         """
         if not self.user_db_path.exists():
             return []
-        where: list[str] = []
-        params: list[object] = []
-        if annotation_id:
-            where.append("annotation_id = ?")
-            params.append(annotation_id)
-        if session_id and target_type is None and target_id is None:
-            where.append(
-                "((target_type = 'session' AND target_id = ?)"
-                " OR (target_type = 'message' AND (target_id = ? OR target_id LIKE ? ESCAPE '\\')))"
-            )
-            like_prefix = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + ":%"
-            params.extend([session_id, session_id, like_prefix])
-        if target_type:
-            where.append("target_type = ?")
-            params.append(_user_target_type_to_storage(target_type))
-        if target_id:
-            where.append("target_id = ?")
-            params.append(target_id)
-        sql = "SELECT annotation_id, target_type, target_id, body, created_at_ms, updated_at_ms FROM annotations"
-        if where:
-            sql += " WHERE " + " AND ".join(where)
-        sql += " ORDER BY updated_at_ms DESC, annotation_id"
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(sql, tuple(params)).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.ANNOTATION)
         finally:
             user_conn.close()
-        return [
-            {
-                "annotation_id": str(row[0]),
-                "target_type": _user_target_type_from_storage(str(row[1])),
-                "target_id": str(row[2]),
-                "session_id": _user_mark_session_id(str(row[1]), str(row[2])),
-                "message_id": str(row[2]) if str(row[1]) == "message" else "",
-                "note_text": str(row[3]),
-                "created_at": str(row[4]),
-                "updated_at": str(row[5]),
-            }
-            for row in rows
-        ]
+        out: list[dict[str, str]] = []
+        for assertion in assertions:
+            found_annotation_id = str(assertion.key or "")
+            found_target_type, found_target_id = _split_user_target_ref(assertion.target_ref)
+            if annotation_id and found_annotation_id != annotation_id:
+                continue
+            if (
+                session_id
+                and target_type is None
+                and target_id is None
+                and not (
+                    (found_target_type == "session" and found_target_id == session_id)
+                    or (
+                        found_target_type == "message"
+                        and (found_target_id == session_id or found_target_id.startswith(f"{session_id}:"))
+                    )
+                )
+            ):
+                continue
+            if target_type and found_target_type != target_type:
+                continue
+            if target_id and found_target_id != target_id:
+                continue
+            out.append(
+                {
+                    "annotation_id": found_annotation_id,
+                    "target_type": found_target_type,
+                    "target_id": found_target_id,
+                    "session_id": _user_mark_session_id(found_target_type, found_target_id),
+                    "message_id": found_target_id if found_target_type == "message" else "",
+                    "note_text": assertion.body_text or "",
+                    "created_at": str(assertion.created_at_ms),
+                    "updated_at": str(assertion.updated_at_ms),
+                }
+            )
+        return out
 
     def delete_annotation(self, annotation_id: str) -> bool:
         """Delete one annotation from archive user.db."""
@@ -1815,11 +1787,7 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                cursor = user_conn.execute("DELETE FROM annotations WHERE annotation_id = ?", (annotation_id,))
-                deleted = int(cursor.rowcount) > 0
-                if deleted:
-                    mark_assertion_status(user_conn, assertion_id_for_annotation(annotation_id), "deleted")
-                return deleted
+                return mark_assertion_status(user_conn, assertion_id_for_annotation(annotation_id), "deleted")
         finally:
             user_conn.close()
 
@@ -1834,54 +1802,47 @@ class ArchiveStore:
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            existing = user_conn.execute(
-                "SELECT created_at_ms FROM saved_views WHERE view_id = ?",
-                (view_id,),
-            ).fetchone()
+            assertion = read_assertion_envelope(user_conn, assertion_id_for_saved_view(view_id))
+            exists = assertion is not None and assertion.status != "deleted"
             with user_conn:
                 upsert_saved_view(user_conn, normalized_name, query, view_id=view_id)
-            return existing is None
+            return not exists
         finally:
             user_conn.close()
 
     def get_view(self, view_id: str) -> dict[str, str] | None:
         """Get one saved view by id from archive user.db."""
-        rows = self._list_views(where="WHERE view_id = ?", params=(view_id,))
-        return rows[0] if rows else None
+        return next((row for row in self.list_views() if row["view_id"] == view_id), None)
 
     def get_view_by_name(self, name: str) -> dict[str, str] | None:
         """Get one saved view by name from archive user.db."""
-        rows = self._list_views(where="WHERE name = ?", params=(name,))
-        return rows[0] if rows else None
+        return next((row for row in self.list_views() if row["name"] == name), None)
 
     def list_views(self) -> list[dict[str, str]]:
         """List saved views from archive user.db."""
         return self._list_views()
 
     def _list_views(self, *, where: str = "", params: tuple[object, ...] = ()) -> list[dict[str, str]]:
+        del where, params
         if not self.user_db_path.exists():
             return []
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(
-                f"""
-                SELECT view_id, name, query_json, created_at_ms
-                FROM saved_views
-                {where}
-                ORDER BY created_at_ms DESC, view_id
-                """,
-                params,
-            ).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.SAVED_QUERY)
         finally:
             user_conn.close()
         return [
             {
-                "view_id": str(row[0]),
-                "name": str(row[1]),
-                "query_json": str(row[2]),
-                "created_at": str(row[3]),
+                "view_id": _id_from_target_ref(assertion.target_ref, "saved_view:"),
+                "name": str(assertion.key or ""),
+                "query_json": json.dumps(
+                    assertion.value if isinstance(assertion.value, dict) else {},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                "created_at": str(assertion.created_at_ms),
             }
-            for row in rows
+            for assertion in assertions
         ]
 
     def delete_view(self, view_id: str) -> bool:
@@ -1891,11 +1852,7 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                cursor = user_conn.execute("DELETE FROM saved_views WHERE view_id = ?", (view_id,))
-                deleted = int(cursor.rowcount) > 0
-                if deleted:
-                    mark_assertion_status(user_conn, assertion_id_for_saved_view(view_id), "deleted")
-                return deleted
+                return mark_assertion_status(user_conn, assertion_id_for_saved_view(view_id), "deleted")
         finally:
             user_conn.close()
 
@@ -1915,57 +1872,44 @@ class ArchiveStore:
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            existing = user_conn.execute(
-                "SELECT created_at_ms FROM recall_packs WHERE recall_pack_id = ?",
-                (pack_id,),
-            ).fetchone()
+            assertion = read_assertion_envelope(user_conn, assertion_id_for_recall_pack(pack_id))
+            exists = assertion is not None and assertion.status != "deleted"
             with user_conn:
                 upsert_recall_pack(user_conn, label, payload, recall_pack_id=pack_id)
-            return existing is None
+            return not exists
         finally:
             user_conn.close()
 
     def get_recall_pack(self, pack_id: str) -> dict[str, str] | None:
         """Get one recall pack by id from archive user.db."""
-        rows = self._list_recall_packs(where="WHERE recall_pack_id = ?", params=(pack_id,))
-        return rows[0] if rows else None
+        return next((row for row in self.list_recall_packs() if row["pack_id"] == pack_id), None)
 
     def list_recall_packs(self) -> list[dict[str, str]]:
         """List recall packs from archive user.db."""
         return self._list_recall_packs()
 
     def _list_recall_packs(self, *, where: str = "", params: tuple[object, ...] = ()) -> list[dict[str, str]]:
+        del where, params
         if not self.user_db_path.exists():
             return []
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(
-                f"""
-                SELECT recall_pack_id, name, payload_json, created_at_ms
-                FROM recall_packs
-                {where}
-                ORDER BY created_at_ms DESC, recall_pack_id
-                """,
-                params,
-            ).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.RECALL_PACK)
         finally:
             user_conn.close()
         out: list[dict[str, str]] = []
-        for row in rows:
-            try:
-                payload = json.loads(str(row[2]))
-            except json.JSONDecodeError:
-                payload = {}
+        for assertion in assertions:
+            payload = assertion.value if isinstance(assertion.value, dict) else {}
             if not isinstance(payload, dict):
                 payload = {}
             session_ids_json = payload.pop("session_ids_json", "[]")
             out.append(
                 {
-                    "pack_id": str(row[0]),
-                    "label": str(row[1]),
+                    "pack_id": _id_from_target_ref(assertion.target_ref, "recall_pack:"),
+                    "label": str(assertion.key or ""),
                     "session_ids_json": str(session_ids_json),
                     "payload_json": json.dumps(payload, sort_keys=True, separators=(",", ":")),
-                    "created_at": str(row[3]),
+                    "created_at": str(assertion.created_at_ms),
                 }
             )
         return out
@@ -1977,11 +1921,7 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                cursor = user_conn.execute("DELETE FROM recall_packs WHERE recall_pack_id = ?", (pack_id,))
-                deleted = int(cursor.rowcount) > 0
-                if deleted:
-                    mark_assertion_status(user_conn, assertion_id_for_recall_pack(pack_id), "deleted")
-                return deleted
+                return mark_assertion_status(user_conn, assertion_id_for_recall_pack(pack_id), "deleted")
         finally:
             user_conn.close()
 
@@ -2005,59 +1945,46 @@ class ArchiveStore:
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            existing = user_conn.execute(
-                "SELECT created_at_ms FROM workspaces WHERE workspace_id = ?",
-                (workspace_id,),
-            ).fetchone()
+            assertion = read_assertion_envelope(user_conn, assertion_id_for_workspace(workspace_id))
+            exists = assertion is not None and assertion.status != "deleted"
             with user_conn:
                 upsert_workspace(user_conn, name, settings, workspace_id=workspace_id)
-            return existing is None
+            return not exists
         finally:
             user_conn.close()
 
     def get_workspace(self, workspace_id: str) -> dict[str, str] | None:
         """Get one workspace by id from archive user.db."""
-        rows = self._list_workspaces(where="WHERE workspace_id = ?", params=(workspace_id,))
-        return rows[0] if rows else None
+        return next((row for row in self.list_workspaces() if row["workspace_id"] == workspace_id), None)
 
     def list_workspaces(self) -> list[dict[str, str]]:
         """List workspaces from archive user.db."""
         return self._list_workspaces()
 
     def _list_workspaces(self, *, where: str = "", params: tuple[object, ...] = ()) -> list[dict[str, str]]:
+        del where, params
         if not self.user_db_path.exists():
             return []
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(
-                f"""
-                SELECT workspace_id, name, settings_json, created_at_ms, updated_at_ms
-                FROM workspaces
-                {where}
-                ORDER BY updated_at_ms DESC, workspace_id
-                """,
-                params,
-            ).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.WORKSPACE_NOTE)
         finally:
             user_conn.close()
         out: list[dict[str, str]] = []
-        for row in rows:
-            try:
-                settings = json.loads(str(row[2]))
-            except json.JSONDecodeError:
-                settings = {}
+        for assertion in assertions:
+            settings = assertion.value if isinstance(assertion.value, dict) else {}
             if not isinstance(settings, dict):
                 settings = {}
             out.append(
                 {
-                    "workspace_id": str(row[0]),
-                    "name": str(row[1]),
+                    "workspace_id": _id_from_target_ref(assertion.target_ref, "workspace:"),
+                    "name": str(assertion.key or ""),
                     "mode": str(settings.get("mode") or ""),
                     "open_targets_json": str(settings.get("open_targets_json") or "[]"),
                     "layout_json": str(settings.get("layout_json") or "{}"),
                     "active_target_json": str(settings.get("active_target_json") or "{}"),
-                    "created_at": str(row[3]),
-                    "updated_at": str(row[4]),
+                    "created_at": str(assertion.created_at_ms),
+                    "updated_at": str(assertion.updated_at_ms),
                 }
             )
         return out
@@ -2069,11 +1996,7 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                cursor = user_conn.execute("DELETE FROM workspaces WHERE workspace_id = ?", (workspace_id,))
-                deleted = int(cursor.rowcount) > 0
-                if deleted:
-                    mark_assertion_status(user_conn, assertion_id_for_workspace(workspace_id), "deleted")
-                return deleted
+                return mark_assertion_status(user_conn, assertion_id_for_workspace(workspace_id), "deleted")
         finally:
             user_conn.close()
 
@@ -2089,56 +2012,22 @@ class ArchiveStore:
         resolved_session_id = self.resolve_session_id(session_id)
         correction_kind = parse_correction_kind(kind)
         initialize_archive_database(self.user_db_path, ArchiveTier.USER)
-        now_ms = int(datetime.now(UTC).timestamp() * 1000)
-        correction_id = f"correction:{resolved_session_id}:{correction_kind.value}"
-        stored_payload = {"payload": dict(payload), "note": note}
+        stored_payload: dict[str, object] = {"payload": dict(payload), "note": note}
         user_conn = sqlite3.connect(self.user_db_path)
         try:
-            existing = user_conn.execute(
-                """
-                SELECT created_at_ms
-                FROM corrections
-                WHERE target_type = 'session' AND target_id = ? AND correction_type = ?
-                """,
-                (resolved_session_id, correction_kind.value),
-            ).fetchone()
-            created_at_ms = int(existing[0]) if existing is not None else now_ms
             with user_conn:
-                user_conn.execute(
-                    """
-                    INSERT INTO corrections (
-                        correction_id, target_type, target_id, correction_type,
-                        payload_json, created_at_ms, updated_at_ms
-                    ) VALUES (?, 'session', ?, ?, ?, ?, ?)
-                    ON CONFLICT(target_type, target_id, correction_type) DO UPDATE SET
-                        payload_json = excluded.payload_json,
-                        updated_at_ms = excluded.updated_at_ms
-                    """,
-                    (
-                        correction_id,
-                        resolved_session_id,
-                        correction_kind.value,
-                        json.dumps(stored_payload, sort_keys=True),
-                        created_at_ms,
-                        now_ms,
-                    ),
-                )
-                upsert_assertion(
+                upsert_correction(
                     user_conn,
-                    assertion_id=assertion_id_for_correction(correction_id),
-                    target_ref=f"insight:{resolved_session_id}",
-                    kind=AssertionKind.CORRECTION,
-                    key=correction_kind.value,
-                    value=stored_payload,
-                    body_text=note,
-                    author_kind="user",
-                    now_ms=now_ms,
+                    "insight",
+                    resolved_session_id,
+                    correction_kind.value,
+                    stored_payload,
                 )
         finally:
             user_conn.close()
         listed = self.list_corrections(session_id=resolved_session_id, kind=correction_kind.value)
         if not listed:
-            raise KeyError(correction_id)
+            raise KeyError((resolved_session_id, correction_kind.value))
         return listed[0]
 
     def list_corrections(self, *, session_id: str | None = None, kind: str | None = None) -> list[LearningCorrection]:
@@ -2147,28 +2036,27 @@ class ArchiveStore:
             return []
         resolved_session_id = self.resolve_session_id(session_id) if session_id else None
         correction_kind = parse_correction_kind(kind).value if kind is not None else None
-        where = ["target_type = 'session'"]
-        params: list[object] = []
-        if resolved_session_id is not None:
-            where.append("target_id = ?")
-            params.append(resolved_session_id)
-        if correction_kind is not None:
-            where.append("correction_type = ?")
-            params.append(correction_kind)
         user_conn = sqlite3.connect(f"file:{self.user_db_path}?mode=ro", uri=True)
         try:
-            rows = user_conn.execute(
-                f"""
-                SELECT target_id, correction_type, payload_json, updated_at_ms
-                FROM corrections
-                WHERE {" AND ".join(where)}
-                ORDER BY updated_at_ms DESC, correction_id
-                """,
-                tuple(params),
-            ).fetchall()
+            assertions = list_assertions_by_kind(user_conn, AssertionKind.CORRECTION)
         finally:
             user_conn.close()
-        return [_learning_correction_from_archive_row(row) for row in rows]
+        out: list[LearningCorrection] = []
+        for assertion in assertions:
+            target_type, target_id = _split_user_target_ref(assertion.target_ref)
+            if target_type != "insight":
+                continue
+            if resolved_session_id is not None and target_id != resolved_session_id:
+                continue
+            if correction_kind is not None and assertion.key != correction_kind:
+                continue
+            payload_json = json.dumps(assertion.value if isinstance(assertion.value, dict) else {}, sort_keys=True)
+            out.append(
+                _learning_correction_from_archive_row(
+                    (target_id, str(assertion.key or ""), payload_json, assertion.updated_at_ms)
+                )
+            )
+        return out
 
     def delete_correction(self, session_id: str, kind: str) -> bool:
         """Delete one learning correction from archive user.db."""
@@ -2179,25 +2067,8 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                row = user_conn.execute(
-                    """
-                    SELECT correction_id
-                    FROM corrections
-                    WHERE target_type = 'session' AND target_id = ? AND correction_type = ?
-                    """,
-                    (resolved_session_id, correction_kind.value),
-                ).fetchone()
-                cursor = user_conn.execute(
-                    """
-                    DELETE FROM corrections
-                    WHERE target_type = 'session' AND target_id = ? AND correction_type = ?
-                    """,
-                    (resolved_session_id, correction_kind.value),
-                )
-                deleted = int(cursor.rowcount) > 0
-                if deleted and row is not None:
-                    mark_assertion_status(user_conn, assertion_id_for_correction(str(row[0])), "deleted")
-                return deleted
+                correction_id = correction_id_for("insight", resolved_session_id, correction_kind.value)
+                return mark_assertion_status(user_conn, assertion_id_for_correction(correction_id), "deleted")
         finally:
             user_conn.close()
 
@@ -2209,18 +2080,15 @@ class ArchiveStore:
         user_conn = sqlite3.connect(self.user_db_path)
         try:
             with user_conn:
-                rows = user_conn.execute(
-                    "SELECT correction_id FROM corrections WHERE target_type = 'session' AND target_id = ?",
-                    (resolved_session_id,),
-                ).fetchall()
-                cursor = user_conn.execute(
-                    "DELETE FROM corrections WHERE target_type = 'session' AND target_id = ?",
-                    (resolved_session_id,),
-                )
-                deleted_count = max(int(cursor.rowcount), 0)
-                if deleted_count:
-                    for row in rows:
-                        mark_assertion_status(user_conn, assertion_id_for_correction(str(row[0])), "deleted")
+                deleted_count = 0
+                for assertion in list_assertions_by_kind(user_conn, AssertionKind.CORRECTION):
+                    target_type, target_id = _split_user_target_ref(assertion.target_ref)
+                    if (
+                        target_type == "insight"
+                        and target_id == resolved_session_id
+                        and mark_assertion_status(user_conn, assertion.assertion_id, "deleted")
+                    ):
+                        deleted_count += 1
                 return deleted_count
         finally:
             user_conn.close()
@@ -2262,8 +2130,7 @@ class ArchiveStore:
     def list_blackboard_notes(self, *, limit: int | None = None) -> list[ArchiveBlackboardNoteEnvelope]:
         """List blackboard notes from archive user.db, newest first.
 
-        Mirrored assertion rows own note body/timestamps for write-through
-        notes; legacy rows still provide stable note ids and target fields.
+        Assertion rows own note ids, targets, body text, and timestamps.
         Structured-field decoding (kind/title/scope) is a presentation concern
         handled by ``polylogue.archive.blackboard``.
         """
@@ -3897,20 +3764,15 @@ def _all_session_tags_sql() -> str:
     """
 
 
-def _user_target_type_to_storage(target_type: str) -> str:
-    if target_type == "session":
-        return "session"
-    if target_type == "content_block":
-        return "block"
-    return target_type
+def _split_user_target_ref(target_ref: str) -> tuple[str, str]:
+    target_type, sep, target_id = target_ref.partition(":")
+    if not sep:
+        return "", target_ref
+    return target_type, target_id
 
 
-def _user_target_type_from_storage(target_type: str) -> str:
-    if target_type == "session":
-        return "session"
-    if target_type == "block":
-        return "content_block"
-    return target_type
+def _id_from_target_ref(target_ref: str, prefix: str) -> str:
+    return target_ref[len(prefix) :] if target_ref.startswith(prefix) else target_ref
 
 
 def _user_mark_session_id(target_type: str, target_id: str) -> str:
@@ -5527,20 +5389,16 @@ def _archive_user_overlay_debt(conn: sqlite3.Connection, user_db_path: Path) -> 
             "WHERE NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.session_id)",
             "SELECT COUNT(*) FROM user_debt.session_metadata u "
             "WHERE NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.session_id)",
-            "SELECT COUNT(*) FROM user_debt.suppressions u "
-            "WHERE NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.session_id)",
-            "SELECT COUNT(*) FROM user_debt.corrections u "
-            "WHERE u.target_type = 'session' "
-            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.target_id)",
-            "SELECT COUNT(*) FROM user_debt.marks u "
-            "WHERE u.target_type = 'session' "
-            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.target_id)",
-            "SELECT COUNT(*) FROM user_debt.annotations u "
-            "WHERE u.target_type = 'session' "
-            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.target_id)",
-            "SELECT COUNT(*) FROM user_debt.blackboard_notes u "
-            "WHERE u.target_type = 'session' "
-            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = u.target_id)",
+            "SELECT COUNT(*) FROM user_debt.assertions u "
+            "WHERE u.kind IN ('mark', 'annotation', 'note', 'suppression') "
+            "AND u.target_ref LIKE 'session:%' "
+            "AND COALESCE(u.status, '') != 'deleted' "
+            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = substr(u.target_ref, 9))",
+            "SELECT COUNT(*) FROM user_debt.assertions u "
+            "WHERE u.kind = 'correction' "
+            "AND u.target_ref LIKE 'insight:%' "
+            "AND COALESCE(u.status, '') != 'deleted' "
+            "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = substr(u.target_ref, 9))",
         )
         issue_count = sum(_count_scalar(conn, sql) for sql in checks)
     finally:

--- a/polylogue/storage/sqlite/archive_tiers/user.py
+++ b/polylogue/storage/sqlite/archive_tiers/user.py
@@ -2,54 +2,9 @@
 
 from __future__ import annotations
 
-USER_SCHEMA_VERSION = 1
+USER_SCHEMA_VERSION = 2
 
 USER_DDL = """
-CREATE TABLE IF NOT EXISTS marks (
-    mark_id         TEXT PRIMARY KEY,
-    target_type     TEXT NOT NULL CHECK(target_type IN ('session', 'message', 'block', 'attachment', 'paste_span', 'work_event', 'phase', 'thread')),
-    target_id       TEXT NOT NULL,
-    mark_type       TEXT NOT NULL,
-    label           TEXT,
-    created_at_ms   INTEGER NOT NULL,
-    updated_at_ms   INTEGER NOT NULL,
-    metadata_json   TEXT NOT NULL DEFAULT '{}'
-) STRICT;
-
-CREATE INDEX IF NOT EXISTS idx_marks_target
-ON marks(target_type, target_id);
-
-CREATE TABLE IF NOT EXISTS annotations (
-    annotation_id  TEXT PRIMARY KEY,
-    target_type    TEXT NOT NULL CHECK(target_type IN ('session', 'message', 'block', 'attachment', 'paste_span', 'work_event', 'phase', 'thread')),
-    target_id      TEXT NOT NULL,
-    body           TEXT NOT NULL,
-    created_at_ms  INTEGER NOT NULL,
-    updated_at_ms  INTEGER NOT NULL
-) STRICT;
-
-CREATE INDEX IF NOT EXISTS idx_annotations_target
-ON annotations(target_type, target_id);
-
-CREATE TABLE IF NOT EXISTS corrections (
-    correction_id    TEXT PRIMARY KEY,
-    target_type      TEXT NOT NULL CHECK(target_type IN ('session', 'message', 'insight')),
-    target_id        TEXT NOT NULL,
-    correction_type  TEXT NOT NULL CHECK(correction_type IN ('tag_reject', 'tag_accept', 'summary_override')),
-    payload_json     TEXT NOT NULL DEFAULT '{}',
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL,
-    UNIQUE(target_type, target_id, correction_type)
-) STRICT;
-
-CREATE TABLE IF NOT EXISTS suppressions (
-    session_id       TEXT PRIMARY KEY,
-    reason           TEXT,
-    mode             TEXT NOT NULL DEFAULT 'hide' CHECK(mode IN ('hide', 'freeze')),
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL
-) STRICT;
-
 CREATE TABLE IF NOT EXISTS session_tags (
     session_id     TEXT NOT NULL,
     tag            TEXT NOT NULL,
@@ -69,45 +24,10 @@ CREATE TABLE IF NOT EXISTS session_metadata (
     PRIMARY KEY(session_id, key)
 ) STRICT;
 
-CREATE TABLE IF NOT EXISTS saved_views (
-    view_id          TEXT PRIMARY KEY,
-    name             TEXT NOT NULL UNIQUE,
-    query_json       TEXT NOT NULL,
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL
-) STRICT;
-
-CREATE TABLE IF NOT EXISTS recall_packs (
-    recall_pack_id   TEXT PRIMARY KEY,
-    name             TEXT NOT NULL,
-    payload_json     TEXT NOT NULL,
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL
-) STRICT;
-
-CREATE TABLE IF NOT EXISTS workspaces (
-    workspace_id     TEXT PRIMARY KEY,
-    name             TEXT NOT NULL UNIQUE,
-    settings_json    TEXT NOT NULL DEFAULT '{}',
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL
-) STRICT;
-
-CREATE TABLE IF NOT EXISTS blackboard_notes (
-    note_id          TEXT PRIMARY KEY,
-    target_type      TEXT CHECK(target_type IN ('session', 'message', 'block', 'attachment', 'paste_span', 'work_event', 'phase', 'thread') OR target_type IS NULL),
-    target_id        TEXT,
-    body             TEXT NOT NULL,
-    created_at_ms    INTEGER NOT NULL,
-    updated_at_ms    INTEGER NOT NULL
-) STRICT;
-
--- Unified evidence-linked user assertion (#1883). One table collapses the
--- user-tier overlay mini-systems (marks/annotations/corrections/tags/
--- saved_views/recall_packs/workspaces/blackboard_notes). Additive in this
--- slice: the legacy tables above remain authoritative; this is the new
--- substrate they will write through in a later slice. ``kind`` carries a
--- closed v0 vocabulary -- see ``AssertionKind`` in user_write.py.
+-- Unified evidence-linked user assertion (#1883). Marks, annotations,
+-- corrections, suppressions, saved views, recall packs, workspaces, and
+-- blackboard notes are represented here directly. ``kind`` carries the closed
+-- v0 vocabulary defined by ``AssertionKind`` in user_write.py.
 CREATE TABLE IF NOT EXISTS assertions (
     assertion_id        TEXT PRIMARY KEY,
     scope_ref           TEXT,

--- a/polylogue/storage/sqlite/archive_tiers/user_overlay.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_overlay.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Iterable
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
 class ArchiveUserOverlayOrphan:
-    """A user overlay row whose target is absent from index.db."""
+    """A user assertion whose target is absent from index.db."""
 
     table: str
     row_id: str
@@ -33,73 +32,56 @@ def find_archive_user_overlay_orphans(
     user_conn: sqlite3.Connection,
     archive_conn: sqlite3.Connection,
 ) -> tuple[ArchiveUserOverlayOrphan, ...]:
-    """Return mark/annotation rows whose archive target cannot be resolved."""
+    """Return user assertions whose archive target cannot be resolved."""
     user_conn.row_factory = sqlite3.Row
     archive_conn.row_factory = sqlite3.Row
     orphans: list[ArchiveUserOverlayOrphan] = []
-    for table, id_column in (("marks", "mark_id"), ("annotations", "annotation_id")):
-        orphans.extend(_orphans_for_table(user_conn, archive_conn, table=table, id_column=id_column))
-    orphans.extend(
-        _orphans_for_table(
-            user_conn,
-            archive_conn,
-            table="blackboard_notes",
-            id_column="note_id",
-            skip_global_targets=True,
-        )
-    )
-    return tuple(orphans)
-
-
-def _orphans_for_table(
-    user_conn: sqlite3.Connection,
-    archive_conn: sqlite3.Connection,
-    *,
-    table: str,
-    id_column: str,
-    skip_global_targets: bool = False,
-) -> Iterable[ArchiveUserOverlayOrphan]:
-    if not _table_exists(user_conn, table):
-        return
+    if not _table_exists(user_conn, "assertions"):
+        return ()
     rows = user_conn.execute(
-        f"""
-        SELECT {id_column} AS row_id, target_type, target_id
-        FROM {table}
-        ORDER BY {id_column}
+        """
+        SELECT assertion_id, target_ref
+        FROM assertions
+        WHERE kind IN ('mark', 'annotation', 'note')
+          AND COALESCE(status, '') != 'deleted'
+        ORDER BY assertion_id
         """
     ).fetchall()
     for row in rows:
-        if skip_global_targets and row["target_type"] is None and row["target_id"] is None:
-            continue
-        if row["target_type"] is None or row["target_id"] is None:
-            yield ArchiveUserOverlayOrphan(
-                table=table,
-                row_id=str(row["row_id"]),
-                target_type=str(row["target_type"]),
-                target_id=str(row["target_id"]),
-            )
-            continue
-        target = _ARCHIVE_TARGETS.get(str(row["target_type"]))
+        target = _split_target_ref(str(row["target_ref"]))
         if target is None:
-            yield ArchiveUserOverlayOrphan(
-                table=table,
-                row_id=str(row["row_id"]),
-                target_type=str(row["target_type"]),
-                target_id=str(row["target_id"]),
-            )
             continue
-        target_table, target_column = target
-        found = archive_conn.execute(
-            f"SELECT 1 FROM {target_table} WHERE {target_column} = ? LIMIT 1",
-            (row["target_id"],),
-        ).fetchone()
-        if found is None:
-            yield ArchiveUserOverlayOrphan(
-                table=table,
-                row_id=str(row["row_id"]),
-                target_type=str(row["target_type"]),
-                target_id=str(row["target_id"]),
+        target_type, target_id = target
+        if not _target_exists(archive_conn, target_type, target_id):
+            orphans.append(
+                ArchiveUserOverlayOrphan(
+                    table="assertions",
+                    row_id=str(row["assertion_id"]),
+                    target_type=target_type,
+                    target_id=target_id,
+                )
             )
+    return tuple(orphans)
+
+
+def _split_target_ref(target_ref: str) -> tuple[str, str] | None:
+    if ":" not in target_ref:
+        return None
+    target_type, target_id = target_ref.split(":", 1)
+    if target_type not in _ARCHIVE_TARGETS or not target_id:
+        return None
+    return target_type, target_id
+
+
+def _target_exists(conn: sqlite3.Connection, target_type: str, target_id: str) -> bool:
+    target_table, target_column = _ARCHIVE_TARGETS[target_type]
+    return (
+        conn.execute(
+            f"SELECT 1 FROM {target_table} WHERE {target_column} = ? LIMIT 1",
+            (target_id,),
+        ).fetchone()
+        is not None
+    )
 
 
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -13,7 +13,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from polylogue.insights.transforms import DecisionCandidate, RecoveryDigest, TransformRawRef
@@ -130,6 +130,12 @@ def assertion_id_for_annotation(annotation_id: str) -> str:
 def assertion_id_for_correction(correction_id: str) -> str:
     """Return the mirrored assertion id for one legacy correction row."""
     return _deterministic_id(f"assertion-{AssertionKind.CORRECTION}", correction_id)
+
+
+def correction_id_for(target_type: str, target_id: str, correction_type: str) -> str:
+    """Return the stable assertion-backed correction id."""
+
+    return _deterministic_id("correction", target_type, target_id, correction_type)
 
 
 def assertion_id_for_saved_view(view_id: str) -> str:
@@ -297,31 +303,13 @@ def upsert_suppression(
     mode: str = "hide",
     now_ms: int | None = None,
 ) -> ArchiveSuppressionEnvelope:
-    """Upsert one suppression row by ``session_id``."""
+    """Upsert one suppression assertion by ``session_id``."""
     conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
-
-    existing = conn.execute(
-        "SELECT created_at_ms FROM suppressions WHERE session_id = ?",
-        (session_id,),
-    ).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO suppressions (session_id, reason, mode, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(session_id) DO UPDATE SET
-            reason = excluded.reason,
-            mode = excluded.mode,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (session_id, reason, mode, created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_suppression(session_id),
-        target_ref=session_id,
+        target_ref=f"session:{session_id}",
         kind=AssertionKind.SUPPRESSION,
         value={"mode": mode},
         body_text=reason,
@@ -341,30 +329,10 @@ def upsert_mark(
     metadata: dict[str, object] | None = None,
     now_ms: int | None = None,
 ) -> ArchiveMarkEnvelope:
-    """Insert-or-update one mark row with deterministic ``mark_id``."""
+    """Insert-or-update one mark assertion with deterministic ``mark_id``."""
     conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     mark_id = _deterministic_id("mark", target_type, target_id, mark_type)
-    metadata_json = _json_dumps(metadata)
-    existing = conn.execute("SELECT created_at_ms FROM marks WHERE mark_id = ?", (mark_id,)).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO marks (
-            mark_id, target_type, target_id, mark_type, label, created_at_ms, updated_at_ms, metadata_json
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(mark_id) DO UPDATE SET
-            target_type = excluded.target_type,
-            target_id = excluded.target_id,
-            mark_type = excluded.mark_type,
-            label = excluded.label,
-            metadata_json = excluded.metadata_json,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (mark_id, target_type, target_id, mark_type, label, created_at_ms, timestamp, metadata_json),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_mark(target_type, target_id, mark_type),
@@ -388,31 +356,16 @@ def upsert_annotation(
     annotation_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveAnnotationEnvelope:
-    """Insert-or-update one annotation row with deterministic default identity."""
+    """Insert-or-update one annotation assertion with deterministic identity."""
     conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = annotation_id or _deterministic_id("annotation", target_type, target_id, body)
-    existing = conn.execute("SELECT created_at_ms FROM annotations WHERE annotation_id = ?", (resolved_id,)).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO annotations (
-            annotation_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(annotation_id) DO UPDATE SET
-            target_type = excluded.target_type,
-            target_id = excluded.target_id,
-            body = excluded.body,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (resolved_id, target_type, target_id, body, created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_annotation(resolved_id),
         target_ref=f"{target_type}:{target_id}",
         kind=AssertionKind.ANNOTATION,
+        key=resolved_id,
         body_text=body,
         author_kind="user",
         now_ms=timestamp,
@@ -429,36 +382,10 @@ def upsert_correction(
     *,
     now_ms: int | None = None,
 ) -> ArchiveCorrectionEnvelope:
-    """Insert-or-update one correction row with deterministic ``correction_id``."""
+    """Insert-or-update one correction assertion with deterministic id."""
     conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
-    correction_id = _deterministic_id("correction", target_type, target_id, correction_type)
-    payload_json = _json_dumps(payload)
-    existing = conn.execute(
-        "SELECT created_at_ms FROM corrections WHERE target_type = ? AND target_id = ? AND correction_type = ?",
-        (target_type, target_id, correction_type),
-    ).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO corrections (
-            correction_id, target_type, target_id, correction_type, payload_json, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(target_type, target_id, correction_type) DO UPDATE SET
-            payload_json = excluded.payload_json,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (
-            correction_id,
-            target_type,
-            target_id,
-            correction_type,
-            payload_json,
-            created_at_ms,
-            timestamp,
-        ),
-    )
+    correction_id = correction_id_for(target_type, target_id, correction_type)
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_correction(correction_id),
@@ -480,23 +407,9 @@ def upsert_saved_view(
     view_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveSavedViewEnvelope:
-    """Insert-or-update a saved query view keyed by name."""
+    """Insert-or-update a saved query assertion keyed by name."""
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = view_id or _deterministic_id("view", name)
-    existing = conn.execute("SELECT created_at_ms FROM saved_views WHERE view_id = ?", (resolved_id,)).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO saved_views (view_id, name, query_json, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(view_id) DO UPDATE SET
-            name = excluded.name,
-            query_json = excluded.query_json,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (resolved_id, name, _json_dumps(query), created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_saved_view(resolved_id),
@@ -518,26 +431,9 @@ def upsert_recall_pack(
     recall_pack_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveRecallPackEnvelope:
-    """Insert-or-update one recall pack by deterministic or supplied id."""
+    """Insert-or-update one recall-pack assertion."""
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = recall_pack_id or _deterministic_id("recall-pack", name, _json_dumps(payload))
-    existing = conn.execute(
-        "SELECT created_at_ms FROM recall_packs WHERE recall_pack_id = ?",
-        (resolved_id,),
-    ).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO recall_packs (recall_pack_id, name, payload_json, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(recall_pack_id) DO UPDATE SET
-            name = excluded.name,
-            payload_json = excluded.payload_json,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (resolved_id, name, _json_dumps(payload), created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_recall_pack(resolved_id),
@@ -560,23 +456,9 @@ def upsert_workspace(
     workspace_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveWorkspaceEnvelope:
-    """Insert-or-update one workspace keyed by name."""
+    """Insert-or-update one workspace assertion keyed by name."""
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = workspace_id or _deterministic_id("workspace", name)
-    existing = conn.execute("SELECT created_at_ms FROM workspaces WHERE workspace_id = ?", (resolved_id,)).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO workspaces (workspace_id, name, settings_json, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(workspace_id) DO UPDATE SET
-            name = excluded.name,
-            settings_json = excluded.settings_json,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (resolved_id, name, _json_dumps(settings), created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_workspace(resolved_id),
@@ -605,32 +487,15 @@ def upsert_blackboard_note(
     context_policy: dict[str, object] | None = None,
     now_ms: int | None = None,
 ) -> ArchiveBlackboardNoteEnvelope:
-    """Insert-or-update one blackboard note, optionally scoped to an archive target."""
+    """Insert-or-update one blackboard note assertion."""
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = note_id or _deterministic_id("blackboard-note", target_type or "", target_id or "", body)
-    existing = conn.execute(
-        "SELECT created_at_ms FROM blackboard_notes WHERE note_id = ?",
-        (resolved_id,),
-    ).fetchone()
-    created_at_ms = int(existing[0]) if existing is not None else timestamp
-
-    conn.execute(
-        """
-        INSERT INTO blackboard_notes (note_id, target_type, target_id, body, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(note_id) DO UPDATE SET
-            target_type = excluded.target_type,
-            target_id = excluded.target_id,
-            body = excluded.body,
-            updated_at_ms = excluded.updated_at_ms
-        """,
-        (resolved_id, target_type, target_id, body, created_at_ms, timestamp),
-    )
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_blackboard_note(resolved_id),
         target_ref=_target_ref(target_type, target_id) or resolved_id,
         kind=AssertionKind.NOTE,
+        key=resolved_id,
         body_text=body,
         author_ref=author_ref,
         author_kind=author_kind,
@@ -643,79 +508,49 @@ def upsert_blackboard_note(
 
 
 def read_archive_suppression_envelope(conn: sqlite3.Connection, session_id: str) -> ArchiveSuppressionEnvelope:
-    row = conn.execute(
-        """
-        SELECT session_id, reason, mode, created_at_ms, updated_at_ms
-        FROM suppressions
-        WHERE session_id = ?
-        """,
-        (session_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, assertion_id_for_suppression(session_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(session_id)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_suppression(session_id))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveSuppressionEnvelope(
-        session_id=str(row[0]),
-        reason=assertion.body_text
-        if assertion is not None and assertion.body_text is not None
-        else str(row[1])
-        if row[1] is not None
-        else None,
-        mode=str(assertion_value.get("mode"))
-        if assertion_value is not None and "mode" in assertion_value
-        else str(row[2]),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
+        session_id=session_id,
+        reason=assertion.body_text,
+        mode=str(assertion_value.get("mode") or "hide"),
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
 def read_archive_mark_envelope(conn: sqlite3.Connection, mark_id: str) -> ArchiveMarkEnvelope:
-    row = conn.execute(
-        """
-        SELECT mark_id, target_type, target_id, mark_type, label, created_at_ms, updated_at_ms, metadata_json
-        FROM marks
-        WHERE mark_id = ?
-        """,
-        (mark_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, _deterministic_id(f"assertion-{AssertionKind.MARK}", mark_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(mark_id)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_mark(str(row[1]), str(row[2]), str(row[3])))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    target_type, target_id = _split_target_ref(assertion.target_ref)
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveMarkEnvelope(
-        mark_id=str(row[0]),
-        target_type=str(row[1]),
-        target_id=str(row[2]),
-        mark_type=str(row[3]),
-        label=assertion.body_text if assertion is not None else str(row[4]) if row[4] is not None else None,
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[5]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[6]),
-        metadata=assertion_value
-        if assertion_value is not None
-        else _read_payload_text(row[7] if isinstance(row[7], str) else None),
+        mark_id=mark_id,
+        target_type=target_type,
+        target_id=target_id,
+        mark_type=str(assertion.key or ""),
+        label=assertion.body_text,
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
+        metadata=assertion_value,
     )
 
 
 def read_archive_annotation_envelope(conn: sqlite3.Connection, annotation_id: str) -> ArchiveAnnotationEnvelope:
-    row = conn.execute(
-        """
-        SELECT annotation_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        FROM annotations
-        WHERE annotation_id = ?
-        """,
-        (annotation_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, assertion_id_for_annotation(annotation_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(annotation_id)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_annotation(annotation_id))
+    target_type, target_id = _split_target_ref(assertion.target_ref)
     return ArchiveAnnotationEnvelope(
-        annotation_id=str(row[0]),
-        target_type=str(row[1]),
-        target_id=str(row[2]),
-        body=assertion.body_text if assertion is not None and assertion.body_text is not None else str(row[3]),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[4]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[5]),
+        annotation_id=annotation_id,
+        target_type=target_type,
+        target_id=target_id,
+        body=assertion.body_text or "",
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
@@ -723,100 +558,61 @@ def read_archive_correction_envelope(
     conn: sqlite3.Connection,
     correction_id: str,
 ) -> ArchiveCorrectionEnvelope:
-    row = conn.execute(
-        """
-        SELECT correction_id, target_type, target_id, correction_type, payload_json, created_at_ms, updated_at_ms
-        FROM corrections
-        WHERE correction_id = ?
-        """,
-        (correction_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, assertion_id_for_correction(correction_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(correction_id)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_correction(correction_id))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    target_type, target_id = _split_target_ref(assertion.target_ref)
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveCorrectionEnvelope(
-        correction_id=str(row[0]),
-        target_type=str(row[1]),
-        target_id=str(row[2]),
-        correction_type=str(row[3]),
-        payload=assertion_value
-        if assertion_value is not None
-        else _read_payload_text(row[4] if isinstance(row[4], str) else None),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[5]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[6]),
+        correction_id=correction_id,
+        target_type=target_type,
+        target_id=target_id,
+        correction_type=str(assertion.key or ""),
+        payload=assertion_value,
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
 def read_archive_saved_view_envelope(conn: sqlite3.Connection, name: str) -> ArchiveSavedViewEnvelope:
-    row = conn.execute(
-        """
-        SELECT view_id, name, query_json, created_at_ms, updated_at_ms
-        FROM saved_views
-        WHERE name = ?
-        """,
-        (name,),
-    ).fetchone()
-    if row is None:
+    assertion = _read_assertion_by_kind_key(conn, AssertionKind.SAVED_QUERY, name)
+    if assertion is None:
         raise KeyError(name)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_saved_view(str(row[0])))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveSavedViewEnvelope(
-        view_id=str(row[0]),
-        name=str(row[1]),
-        query=assertion_value
-        if assertion_value is not None
-        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
+        view_id=_id_from_prefixed_target(assertion.target_ref, "saved_view:"),
+        name=str(assertion.key or name),
+        query=assertion_value,
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
 def read_archive_recall_pack_envelope(conn: sqlite3.Connection, recall_pack_id: str) -> ArchiveRecallPackEnvelope:
-    row = conn.execute(
-        """
-        SELECT recall_pack_id, name, payload_json, created_at_ms, updated_at_ms
-        FROM recall_packs
-        WHERE recall_pack_id = ?
-        """,
-        (recall_pack_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, assertion_id_for_recall_pack(recall_pack_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(recall_pack_id)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_recall_pack(recall_pack_id))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveRecallPackEnvelope(
-        recall_pack_id=str(row[0]),
-        name=str(row[1]),
-        payload=assertion_value
-        if assertion_value is not None
-        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
+        recall_pack_id=recall_pack_id,
+        name=str(assertion.key or ""),
+        payload=assertion_value,
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
 def read_archive_workspace_envelope(conn: sqlite3.Connection, name: str) -> ArchiveWorkspaceEnvelope:
-    row = conn.execute(
-        """
-        SELECT workspace_id, name, settings_json, created_at_ms, updated_at_ms
-        FROM workspaces
-        WHERE name = ?
-        """,
-        (name,),
-    ).fetchone()
-    if row is None:
+    assertion = _read_assertion_by_kind_key(conn, AssertionKind.WORKSPACE_NOTE, name)
+    if assertion is None:
         raise KeyError(name)
-    assertion = _read_mirrored_assertion(conn, assertion_id_for_workspace(str(row[0])))
-    assertion_value = assertion.value if assertion is not None and isinstance(assertion.value, dict) else None
+    assertion_value = assertion.value if isinstance(assertion.value, dict) else {}
     return ArchiveWorkspaceEnvelope(
-        workspace_id=str(row[0]),
-        name=str(row[1]),
-        settings=assertion_value
-        if assertion_value is not None
-        else _read_payload_text(row[2] if isinstance(row[2], str) else None),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[3]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[4]),
+        workspace_id=_id_from_prefixed_target(assertion.target_ref, "workspace:"),
+        name=str(assertion.key or name),
+        settings=assertion_value,
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
@@ -836,38 +632,66 @@ def _read_mirrored_assertion(conn: sqlite3.Connection, assertion_id: str) -> Arc
     return read_assertion_envelope(conn, assertion_id)
 
 
-def _blackboard_envelope_from_legacy_row(
-    row: sqlite3.Row | tuple[Any, ...],
-    assertion: ArchiveAssertionEnvelope | None = None,
-) -> ArchiveBlackboardNoteEnvelope:
-    """Project one legacy note row, preferring mirrored assertion content."""
+def _split_target_ref(target_ref: str) -> tuple[str, str]:
+    target_type, sep, target_id = target_ref.partition(":")
+    if not sep:
+        return "", target_ref
+    return target_type, target_id
+
+
+def _id_from_prefixed_target(target_ref: str, prefix: str) -> str:
+    if target_ref.startswith(prefix):
+        return target_ref[len(prefix) :]
+    return target_ref
+
+
+def _is_active_assertion(envelope: ArchiveAssertionEnvelope) -> bool:
+    return envelope.status != "deleted"
+
+
+def list_assertions_by_kind(conn: sqlite3.Connection, kind: str) -> list[ArchiveAssertionEnvelope]:
+    """List active assertions of one kind, newest first."""
+    if not _table_exists(conn, "assertions"):
+        return []
+    rows = conn.execute(
+        f"SELECT {_ASSERTION_COLUMNS} FROM assertions WHERE kind = ? ORDER BY updated_at_ms DESC, assertion_id",
+        (kind,),
+    ).fetchall()
+    return [envelope for row in rows if _is_active_assertion(envelope := _assertion_row_to_envelope(row))]
+
+
+def _read_assertion_by_kind_key(
+    conn: sqlite3.Connection,
+    kind: str,
+    key: str,
+) -> ArchiveAssertionEnvelope | None:
+    matches = [envelope for envelope in list_assertions_by_kind(conn, kind) if envelope.key == key]
+    return matches[0] if matches else None
+
+
+def _blackboard_envelope_from_assertion(assertion: ArchiveAssertionEnvelope) -> ArchiveBlackboardNoteEnvelope:
+    """Project one note assertion into the blackboard read envelope."""
+    raw_target_type, raw_target_id = _split_target_ref(assertion.target_ref)
+    target_type: str | None = raw_target_type
+    target_id: str | None = raw_target_id
+    if raw_target_type == "":
+        target_type = None
+        target_id = None
     return ArchiveBlackboardNoteEnvelope(
-        note_id=str(row[0]),
-        target_type=str(row[1]) if row[1] is not None else None,
-        target_id=str(row[2]) if row[2] is not None else None,
-        body=assertion.body_text if assertion is not None and assertion.body_text is not None else str(row[3]),
-        created_at_ms=assertion.created_at_ms if assertion is not None else int(row[4]),
-        updated_at_ms=assertion.updated_at_ms if assertion is not None else int(row[5]),
+        note_id=str(assertion.key or ""),
+        target_type=target_type,
+        target_id=target_id,
+        body=assertion.body_text or "",
+        created_at_ms=assertion.created_at_ms,
+        updated_at_ms=assertion.updated_at_ms,
     )
 
 
 def read_archive_blackboard_note_envelope(conn: sqlite3.Connection, note_id: str) -> ArchiveBlackboardNoteEnvelope:
-    row = conn.execute(
-        """
-        SELECT note_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        FROM blackboard_notes
-        WHERE note_id = ?
-        """,
-        (note_id,),
-    ).fetchone()
-    if row is None:
+    assertion = read_assertion_envelope(conn, assertion_id_for_blackboard_note(note_id))
+    if assertion is None or assertion.status == "deleted":
         raise KeyError(note_id)
-    assertion = (
-        read_assertion_envelope(conn, assertion_id_for_blackboard_note(note_id))
-        if _table_exists(conn, "assertions")
-        else None
-    )
-    return _blackboard_envelope_from_legacy_row(row, assertion)
+    return _blackboard_envelope_from_assertion(assertion)
 
 
 def list_archive_blackboard_note_envelopes(
@@ -875,48 +699,11 @@ def list_archive_blackboard_note_envelopes(
     *,
     limit: int | None = None,
 ) -> list[ArchiveBlackboardNoteEnvelope]:
-    """List blackboard notes through mirrored assertions with legacy fallback.
-
-    The assertion row owns the note body and timestamps for write-through notes.
-    The legacy row still owns the public ``note_id`` and target fields until the
-    assertion model grows a first-class blackboard note identity.
-    """
-    if not _table_exists(conn, "blackboard_notes"):
-        return []
-
-    legacy_rows = conn.execute(
-        """
-        SELECT note_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        FROM blackboard_notes
-        """
-    ).fetchall()
-    if not legacy_rows:
-        return []
-
-    legacy_by_assertion_id = {assertion_id_for_blackboard_note(str(row[0])): row for row in legacy_rows}
-    seen_note_ids: set[str] = set()
-    envelopes: list[ArchiveBlackboardNoteEnvelope] = []
-
-    if _table_exists(conn, "assertions"):
-        assertion_rows = conn.execute(
-            f"SELECT {_ASSERTION_COLUMNS} FROM assertions WHERE kind = ? ORDER BY created_at_ms DESC, assertion_id DESC",
-            (AssertionKind.NOTE,),
-        ).fetchall()
-        for assertion_row in assertion_rows:
-            assertion = _assertion_row_to_envelope(assertion_row)
-            legacy_row = legacy_by_assertion_id.get(assertion.assertion_id)
-            if legacy_row is None:
-                continue
-            envelope = _blackboard_envelope_from_legacy_row(legacy_row, assertion)
-            envelopes.append(envelope)
-            seen_note_ids.add(envelope.note_id)
-
-    for legacy_row in legacy_rows:
-        note_id = str(legacy_row[0])
-        if note_id not in seen_note_ids:
-            envelopes.append(_blackboard_envelope_from_legacy_row(legacy_row))
-
-    envelopes.sort(key=lambda envelope: (envelope.created_at_ms, envelope.note_id), reverse=True)
+    """List blackboard notes from note assertions, newest first."""
+    envelopes = [
+        _blackboard_envelope_from_assertion(assertion)
+        for assertion in list_assertions_by_kind(conn, AssertionKind.NOTE)
+    ]
     if limit is not None and limit > 0:
         return envelopes[:limit]
     return envelopes
@@ -1086,8 +873,9 @@ def mark_assertion_status(
         UPDATE assertions
         SET status = ?, updated_at_ms = ?
         WHERE assertion_id = ?
+          AND COALESCE(status, '') != ?
         """,
-        (status, timestamp, assertion_id),
+        (status, timestamp, assertion_id, status),
     )
     return int(cursor.rowcount) > 0
 
@@ -1174,7 +962,9 @@ __all__ = [
     "assertion_id_for_suppression",
     "assertion_id_for_transform_candidate",
     "assertion_id_for_workspace",
+    "correction_id_for",
     "list_archive_blackboard_note_envelopes",
+    "list_assertions_by_kind",
     "list_assertions_for_target",
     "mark_assertion_status",
     "read_archive_annotation_envelope",

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -665,8 +665,22 @@ def _read_assertion_by_kind_key(
     kind: str,
     key: str,
 ) -> ArchiveAssertionEnvelope | None:
-    matches = [envelope for envelope in list_assertions_by_kind(conn, kind) if envelope.key == key]
-    return matches[0] if matches else None
+    if not _table_exists(conn, "assertions"):
+        return None
+    row = conn.execute(
+        f"""
+        SELECT {_ASSERTION_COLUMNS}
+        FROM assertions
+        WHERE kind = ?
+          AND key = ?
+          AND COALESCE(status, '') != 'deleted'
+        ORDER BY updated_at_ms DESC, assertion_id
+        """,
+        (kind, key),
+    ).fetchone()
+    if row is None:
+        return None
+    return _assertion_row_to_envelope(row)
 
 
 def _blackboard_envelope_from_assertion(assertion: ArchiveAssertionEnvelope) -> ArchiveBlackboardNoteEnvelope:

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -2830,7 +2830,9 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
 
         view_created = await archive.save_view("view-v1", "Needs Review", '{"provider":"codex"}')
         view_updated = await archive.save_view("view-v1", "Needs Review", '{"provider":"codex","tag":"review"}')
+        view_renamed_id = await archive.save_view("view-v2", "Needs Review", '{"provider":"codex","tag":"second"}')
         view = await archive.get_view("view-v1")
+        replaced_view = await archive.get_view("view-v2")
         view_by_name = await archive.get_view_by_name("Needs Review")
         views = await archive.list_views()
 
@@ -2863,15 +2865,26 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
             json.dumps({"panes": 2}),
             "{}",
         )
+        workspace_renamed_id = await archive.save_workspace(
+            "workspace-v2",
+            "Review Workspace",
+            "tabs",
+            json.dumps([{"target_type": "session", "session_id": session_id}]),
+            json.dumps({"panes": 3}),
+            "{}",
+        )
         workspace = await archive.get_workspace("workspace-v1")
+        replaced_workspace = await archive.get_workspace("workspace-v2")
         workspaces = await archive.list_workspaces()
 
         assert view_created is True
         assert view_updated is False
-        assert view is not None
-        assert view_by_name == view
-        assert views == [view]
-        assert json.loads(view["query_json"]) == {"provider": "codex", "tag": "review"}
+        assert view_renamed_id is False
+        assert view is None
+        assert replaced_view is not None
+        assert view_by_name == replaced_view
+        assert views == [replaced_view]
+        assert json.loads(replaced_view["query_json"]) == {"provider": "codex", "tag": "second"}
         assert pack_created is True
         assert pack_updated is False
         assert pack is not None
@@ -2880,17 +2893,19 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
         assert json.loads(pack["payload_json"])["resolved_count"] == 1
         assert workspace_created is True
         assert workspace_updated is False
-        assert workspace is not None
-        assert workspaces == [workspace]
-        assert workspace["mode"] == "stack"
-        assert json.loads(workspace["layout_json"]) == {"panes": 2}
+        assert workspace_renamed_id is False
+        assert workspace is None
+        assert replaced_workspace is not None
+        assert workspaces == [replaced_workspace]
+        assert replaced_workspace["mode"] == "tabs"
+        assert json.loads(replaced_workspace["layout_json"]) == {"panes": 3}
 
-        assert await archive.delete_view("view-v1") is True
-        assert await archive.delete_view("view-v1") is False
+        assert await archive.delete_view("view-v2") is True
+        assert await archive.delete_view("view-v2") is False
         assert await archive.delete_recall_pack("pack-v1") is True
         assert await archive.delete_recall_pack("pack-v1") is False
-        assert await archive.delete_workspace("workspace-v1") is True
-        assert await archive.delete_workspace("workspace-v1") is False
+        assert await archive.delete_workspace("workspace-v2") is True
+        assert await archive.delete_workspace("workspace-v2") is False
 
         assert await archive.list_views() == []
         assert await archive.list_recall_packs() == []

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1222,6 +1222,7 @@ async def test_archive_tiers_api_reads_native_sessions(tmp_path: Path) -> None:
             typed_only=True,
             message_type="tool-use",
             title="API",
+            max_words=10,
         )
         summaries = await archive.archive_list_sessions(
             origin="codex-session",
@@ -1242,6 +1243,7 @@ async def test_archive_tiers_api_reads_native_sessions(tmp_path: Path) -> None:
             typed_only=True,
             message_type="tool-use",
             title="API",
+            max_words=10,
             limit=5,
         )
         hits = await archive.archive_search_sessions(
@@ -2753,6 +2755,8 @@ async def test_archive_tiers_api_marks_and_annotations_write_user_tier(tmp_path:
         marks = await archive.list_marks(session_id=session_id)
         mark_removed = await archive.remove_mark(session_id, "star")
         mark_missing = await archive.remove_mark(session_id, "star")
+        with pytest.raises(ValueError, match="mark_type must be one of"):
+            await archive.add_mark(session_id, "bogus")
         annotation_created = await archive.save_annotation("ann-v1", session_id, "needs follow-up")
         annotation_updated = await archive.save_annotation("ann-v1", session_id, "resolved")
         annotation = await archive.get_annotation("ann-v1")
@@ -2775,9 +2779,9 @@ async def test_archive_tiers_api_marks_and_annotations_write_user_tier(tmp_path:
         assert annotation_deleted is True
         assert annotation_missing is False
 
+        marks_after_delete = await archive.list_marks(session_id=session_id)
+        annotations_after_delete = await archive.list_annotations(session_id=session_id)
         with sqlite3.connect(tmp_path / "user.db") as conn:
-            mark_count = conn.execute("SELECT COUNT(*) FROM marks").fetchone()[0]
-            annotation_count = conn.execute("SELECT COUNT(*) FROM annotations").fetchone()[0]
             assertion_statuses = conn.execute(
                 """
                 SELECT kind, key, status
@@ -2787,10 +2791,10 @@ async def test_archive_tiers_api_marks_and_annotations_write_user_tier(tmp_path:
                 """,
                 (f"session:{session_id}",),
             ).fetchall()
-        assert mark_count == 0
-        assert annotation_count == 0
+        assert marks_after_delete == []
+        assert annotations_after_delete == []
         assert assertion_statuses == [
-            ("annotation", None, "deleted"),
+            ("annotation", "ann-v1", "deleted"),
             ("mark", "star", "deleted"),
         ]
     finally:
@@ -2888,10 +2892,10 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
         assert await archive.delete_workspace("workspace-v1") is True
         assert await archive.delete_workspace("workspace-v1") is False
 
+        assert await archive.list_views() == []
+        assert await archive.list_recall_packs() == []
+        assert await archive.list_workspaces() == []
         with sqlite3.connect(tmp_path / "user.db") as conn:
-            assert conn.execute("SELECT COUNT(*) FROM saved_views").fetchone()[0] == 0
-            assert conn.execute("SELECT COUNT(*) FROM recall_packs").fetchone()[0] == 0
-            assert conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0] == 0
             assertion_statuses = conn.execute(
                 """
                 SELECT target_ref, kind, status
@@ -2961,8 +2965,8 @@ async def test_archive_tiers_api_corrections_write_user_tier(tmp_path: Path) -> 
         assert missing_delete is False
         assert cleared == 1
 
+        assert await archive.list_corrections(session_id=session_id) == []
         with sqlite3.connect(tmp_path / "user.db") as conn:
-            assert conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0] == 0
             assertion_statuses = conn.execute(
                 """
                 SELECT key, status, json_extract(value_json, '$.payload.tag'), json_extract(value_json, '$.payload.summary')

--- a/tests/unit/architecture/test_static_rendering_prune.py
+++ b/tests/unit/architecture/test_static_rendering_prune.py
@@ -1,4 +1,4 @@
-"""Regression checks for #1848 static-rendering surface pruning."""
+"""Static-rendering surface checks."""
 
 from __future__ import annotations
 
@@ -7,28 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_legacy_static_product_template_files_are_removed() -> None:
-    """The old standalone static-site template files are not a product surface."""
-
-    legacy_templates = ROOT / "polylogue" / "templates"
-    assert not (legacy_templates / "index.html").exists()
-    assert not (legacy_templates / "modern.html").exists()
-    assert not (legacy_templates / "style.css").exists()
-
-
 def test_read_export_html_template_is_retained() -> None:
     """HTML output remains available through the read/export renderer path."""
 
     assert (ROOT / "polylogue" / "rendering" / "templates" / "session.html").is_file()
-
-
-def test_legacy_qa_report_aggregator_is_removed() -> None:
-    """QA report behavior lives in owned payload, Markdown, and summary modules."""
-
-    assert not (ROOT / "polylogue" / "showcase" / "qa_report.py").exists()
-
-
-def test_legacy_output_assurance_registry_is_removed() -> None:
-    """Action contracts and generated schemas own machine-output coverage."""
-
-    assert not (ROOT / "polylogue" / "cli" / "output_assurance.py").exists()

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -81,14 +81,6 @@ class TestResolveOrigins:
         result = _resolve_origins({})
         assert result == ()
 
-    def test_provider_param_is_ignored(self) -> None:
-        """The public root query surface speaks origin only (#1810).
-
-        The legacy ``provider`` -> origin fallback was removed; a provider
-        token on the root query no longer resolves to any origin.
-        """
-        assert _resolve_origins({"provider": "claude-code"}) == ()
-
 
 # Tests for _resolve_excluded_origins
 class TestResolveExcludedOrigins:
@@ -99,10 +91,6 @@ class TestResolveExcludedOrigins:
         params: dict[str, object] = {"exclude_origin": "claude-code-session,chatgpt-export"}
         result = _resolve_excluded_origins(params)
         assert result == ("claude-code-session", "chatgpt-export")
-
-    def test_exclude_provider_param_is_ignored(self) -> None:
-        """Excluded-provider fallback removed: origin vocabulary only (#1810)."""
-        assert _resolve_excluded_origins({"exclude_provider": "claude-code"}) == ()
 
     def test_empty_params(self) -> None:
         """Empty params returns empty tuple."""

--- a/tests/unit/cli/test_blackboard.py
+++ b/tests/unit/cli/test_blackboard.py
@@ -86,11 +86,11 @@ class TestBlackboardPost:
         user_db = workspace_env["archive_root"] / "user.db"
         conn = sqlite3.connect(str(user_db))
         row = conn.execute(
-            "SELECT target_type, target_id, body FROM blackboard_notes WHERE body LIKE ?",
+            "SELECT body_text FROM assertions WHERE kind = 'note' AND body_text LIKE ?",
             ("[finding] Test Finding%",),
         ).fetchone()
         conn.close()
-        assert row == (None, None, "[finding] Test Finding\n\nSomething interesting was found.")
+        assert row == ("[finding] Test Finding\n\nSomething interesting was found.",)
 
     def test_post_writes_archive_user_db(self, cli_runner: CliRunner, workspace_env: dict[str, Path]) -> None:
         """Posting a scoped note writes directly to archive user.db."""
@@ -113,9 +113,9 @@ class TestBlackboardPost:
 
         assert result.exit_code == 0, f"post failed: {result.output}"
         conn = sqlite3.connect(workspace_env["archive_root"] / "user.db")
-        row = conn.execute("SELECT target_type, target_id, body FROM blackboard_notes").fetchone()
+        row = conn.execute("SELECT target_ref, body_text FROM assertions WHERE kind = 'note'").fetchone()
         conn.close()
-        assert row == ("session", "codex-session:one", "[decision] Archive\n\nStore in user db.")
+        assert row == ("session:codex-session:one", "[decision] Archive\n\nStore in user db.")
 
     def test_post_with_scope_fields(self, cli_runner: CliRunner, workspace_env: dict[str, Path]) -> None:
         """Posting with scope fields stores them in the archive note body."""
@@ -147,7 +147,10 @@ class TestBlackboardPost:
         assert result.exit_code == 0, f"post failed: {result.output}"
 
         conn = sqlite3.connect(workspace_env["archive_root"] / "user.db")
-        row = conn.execute("SELECT body FROM blackboard_notes WHERE body LIKE ?", ("[blocker] Scope Test%",)).fetchone()
+        row = conn.execute(
+            "SELECT body_text FROM assertions WHERE kind = 'note' AND body_text LIKE ?",
+            ("[blocker] Scope Test%",),
+        ).fetchone()
         conn.close()
         assert row is not None
         assert "Scoped content." in row[0]
@@ -254,7 +257,7 @@ class TestBlackboardPost:
         assert (workspace_env["archive_root"] / "user.db").exists()
         assert not (outside_root / "user.db").exists()
         with sqlite3.connect(workspace_env["archive_root"] / "user.db") as conn:
-            row = conn.execute("SELECT body FROM blackboard_notes").fetchone()
+            row = conn.execute("SELECT body_text FROM assertions WHERE kind = 'note'").fetchone()
         assert row == ("[handoff] Active Root\n\nUse the active archive root.",)
 
     def test_post_allowed_kinds(self, cli_runner: CliRunner, workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -332,8 +332,8 @@ class TestResetCommandDeletion:
             assert conn.execute("SELECT COUNT(*) FROM sessions WHERE session_id = ?", (session_id,)).fetchone()[0] == 0
         with sqlite3.connect(archive_root / "user.db") as conn:
             row = conn.execute(
-                "SELECT reason, mode FROM suppressions WHERE session_id = ?",
-                (session_id,),
+                "SELECT body_text, json_extract(value_json, '$.mode') FROM assertions WHERE kind = 'suppression' AND target_ref = ?",
+                (f"session:{session_id}",),
             ).fetchone()
         assert row == ("reset --session", "hide")
 
@@ -374,9 +374,10 @@ class TestResetCommandDeletion:
             )
         with sqlite3.connect(archive_root / "user.db") as conn:
             assert (
-                conn.execute("SELECT COUNT(*) FROM suppressions WHERE session_id = ?", (child_session_id,)).fetchone()[
-                    0
-                ]
+                conn.execute(
+                    "SELECT COUNT(*) FROM assertions WHERE kind = 'suppression' AND target_ref = ?",
+                    (f"session:{child_session_id}",),
+                ).fetchone()[0]
                 == 1
             )
 

--- a/tests/unit/core/test_public_surface_origin_vocabulary.py
+++ b/tests/unit/core/test_public_surface_origin_vocabulary.py
@@ -63,7 +63,3 @@ def test_archive_query_origin_resolution_is_origin_only() -> None:
         "claude-code-session",
     )
     assert _resolve_excluded_origins({"exclude_origin": "chatgpt-export"}) == ("chatgpt-export",)
-    # The dead provider fallbacks are gone: provider tokens are no longer
-    # honored on the public root query surface.
-    assert _resolve_origins({"provider": "codex"}) == ()
-    assert _resolve_excluded_origins({"exclude_provider": "chatgpt"}) == ()

--- a/tests/unit/daemon/test_daemon_http_security.py
+++ b/tests/unit/daemon/test_daemon_http_security.py
@@ -68,6 +68,12 @@ ENDPOINTS_POST = _paths_for("POST", "bearer_and_same_origin")
 ENDPOINTS_DELETE = _paths_for("DELETE", "bearer_and_same_origin")
 
 
+def test_route_contract_security_matrices_are_non_empty() -> None:
+    assert ENDPOINTS_GET
+    assert ENDPOINTS_POST
+    assert ENDPOINTS_DELETE
+
+
 # ---------------------------------------------------------------------------
 # Pure-logic auth: the function called by every route's _check_auth()
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_daemon_http_security.py
+++ b/tests/unit/daemon/test_daemon_http_security.py
@@ -12,9 +12,9 @@ helper-function level:
 3. ``OPTIONS`` requests return ``405 Method Not Allowed`` (no CORS
    preflight is advertised by design — see ``docs/security.md``).
 
-The parametrized matrix replaces ad-hoc per-endpoint tests so the cost
-of adding a new endpoint includes adding it to ``ENDPOINTS_GET`` /
-``ENDPOINTS_POST`` and getting full security coverage automatically.
+The parametrized matrix derives from ``ROUTE_CONTRACTS`` so adding a new
+authenticated route to the daemon contract registry automatically adds the
+same security coverage.
 """
 
 from __future__ import annotations
@@ -32,51 +32,40 @@ import pytest
 
 from polylogue.core.loopback import is_loopback_host
 from polylogue.daemon.http import _check_auth_logic
+from polylogue.daemon.route_contracts import ROUTE_CONTRACTS, RouteContract
 
 if TYPE_CHECKING:
     from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
 
 
 # ---------------------------------------------------------------------------
-# Endpoint tables — extend here when new routes are added
+# Endpoint tables derived from route contracts
 # ---------------------------------------------------------------------------
 
-ENDPOINTS_GET = [
-    "/api/health/check",
-    "/api/health",
-    "/api/status",
-    "/api/sessions",
-    "/api/facets",
-    "/api/sources",
-    "/api/sessions/some-id",
-    "/api/sessions/some-id/raw",
-    "/api/sessions/some-id/messages",
-    "/api/raw_artifacts/some-hash",
-]
 
-ENDPOINTS_POST = [
-    "/api/reset",
-    "/api/ingest",
-    "/api/maintenance/plan",
-    "/api/maintenance/run",
-    # User-state write routes — delegated via dispatch_post, still gated by
-    # _check_auth and _check_cross_origin at the do_POST level.
-    "/api/user/marks",
-    "/api/user/annotations",
-    "/api/user/saved-views",
-    "/api/user/recall-packs",
-    "/api/user/workspaces",
-]
+def _route_sample_path(route: RouteContract) -> str:
+    parts = []
+    for part in route.pattern.strip("/").split("/"):
+        if part.startswith(":"):
+            parts.append("some-id")
+        else:
+            parts.append(part)
+    return "/" + "/".join(parts) if parts else "/"
 
-ENDPOINTS_DELETE = [
-    # User-state delete routes — gated by _check_auth and _check_cross_origin
-    # at the do_DELETE level.
-    "/api/user/marks",
-    "/api/user/annotations/some-id",
-    "/api/user/saved-views/some-id",
-    "/api/user/recall-packs/some-id",
-    "/api/user/workspaces/some-id",
-]
+
+def _paths_for(method: str, auth_policy: str) -> list[str]:
+    return [
+        _route_sample_path(route)
+        for route in ROUTE_CONTRACTS
+        if route.method == method and route.auth_policy == auth_policy
+    ]
+
+
+ENDPOINTS_GET = _paths_for("GET", "bearer_if_configured")
+
+ENDPOINTS_POST = _paths_for("POST", "bearer_and_same_origin")
+
+ENDPOINTS_DELETE = _paths_for("DELETE", "bearer_and_same_origin")
 
 
 # ---------------------------------------------------------------------------
@@ -259,27 +248,9 @@ class TestGetEndpointAuthGate:
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
     def test_valid_token_passes_auth(self, path: str) -> None:
-        """Auth gate admits the request — handler runs (or the route is
-        not found, in which case 404, but never 401)."""
+        """Auth gate admits the request for every authenticated GET path."""
         handler = _make_handler("GET", path, auth_header="Bearer secret")
-        send_error, send_json = _capture_responses(handler)
-        # Patch the actual handlers to avoid touching the DB / archive.
-        with (
-            patch.object(handler, "_handle_health_check"),
-            patch.object(handler, "_handle_health"),
-            patch.object(handler, "_handle_status"),
-            patch.object(handler, "_handle_list_sessions"),
-            patch.object(handler, "_handle_facets"),
-            patch.object(handler, "_handle_sources"),
-            patch.object(handler, "_handle_get_session"),
-            patch.object(handler, "_handle_get_messages"),
-            patch.object(handler, "_handle_get_session_raw"),
-            patch.object(handler, "_handle_get_raw_artifact"),
-        ):
-            handler.do_GET()
-        # If 401 was sent, auth gate failed. We assert the negative.
-        for call in send_error.call_args_list:
-            assert call.args[0] != HTTPStatus.UNAUTHORIZED, f"Endpoint {path} returned 401 with valid token"
+        assert handler._check_auth() is True
 
 
 @pytest.mark.parametrize("path", ENDPOINTS_POST)

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -39,6 +39,48 @@ import pytest
 POLYLOGUE_LOCAL_PATH_PREFIXES = ("/home/", "/Users/", "/realm/", "/var/", "/etc/")
 
 
+class _QueryParamBuilderHandler:
+    @staticmethod
+    def _get_param(params: dict[str, list[str]], key: str, default: str | None = None) -> str | None:
+        values = params.get(key)
+        if values:
+            return values[0]
+        return default
+
+    def _get_int(self, params: dict[str, list[str]], key: str, default: int = 0) -> int:
+        val = self._get_param(params, key)
+        if val is not None:
+            try:
+                return int(val)
+            except (ValueError, TypeError):
+                pass
+        return default
+
+    def _get_bool(self, params: dict[str, list[str]], key: str) -> bool:
+        val = self._get_param(params, key)
+        return val is not None and val.lower() in ("1", "true", "yes", "on")
+
+
+def test_query_spec_param_builder_uses_canonical_query_fields() -> None:
+    from polylogue.daemon.http import _build_query_spec_params
+
+    params = {
+        "origin": ["codex-session"],
+        "exclude_origin": ["chatgpt-export"],
+        "max_words": ["100"],
+        "similar_session_id": ["codex-session:seed"],
+        "filter_has_tool_use": ["true"],
+    }
+
+    result = _build_query_spec_params(params, _QueryParamBuilderHandler())  # type: ignore[arg-type]
+
+    assert result["origin"] == "codex-session"
+    assert result["exclude_origin"] == "chatgpt-export"
+    assert result["max_words"] == 100
+    assert result["similar_session_id"] == "codex-session:seed"
+    assert result["filter_has_tool_use"] is True
+
+
 @contextmanager
 def _running_server(
     workspace: dict[str, Path],

--- a/tests/unit/daemon/test_web_shell_endpoint_contracts.py
+++ b/tests/unit/daemon/test_web_shell_endpoint_contracts.py
@@ -481,13 +481,10 @@ class TestWebShellWorkspaceAssetContract:
 
     # ---- /api/stack contract -------------------------------------------
 
-    def test_api_stack_dispatch_routes_to_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        called = MagicMock()
-        monkeypatch.setattr(workspace_routes, "handle_stack", called)
+    def test_api_stack_dispatch_is_owned_by_http_handler(self) -> None:
         handler = _make_handler("GET", "/api/stack?ids=a,b")
         ok = workspace_routes.dispatch_get(handler, ["api", "stack"], {"ids": ["a,b"]})
-        assert ok is True
-        called.assert_called_once()
+        assert ok is False
 
     def test_api_stack_requires_ids(self) -> None:
         handler = _make_handler("GET", "/api/stack")
@@ -506,17 +503,14 @@ class TestWebShellWorkspaceAssetContract:
 
     # ---- /api/compare contract -----------------------------------------
 
-    def test_api_compare_dispatch_routes_to_handler(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        called = MagicMock()
-        monkeypatch.setattr(workspace_routes, "handle_compare", called)
+    def test_api_compare_dispatch_is_owned_by_http_handler(self) -> None:
         handler = _make_handler("GET", "/api/compare?left=a&right=b")
         ok = workspace_routes.dispatch_get(
             handler,
             ["api", "compare"],
             {"left": ["a"], "right": ["b"]},
         )
-        assert ok is True
-        called.assert_called_once()
+        assert ok is False
 
     @pytest.mark.parametrize(
         "params",

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -298,12 +298,11 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
         )
         conn.execute(
             """
-            INSERT INTO corrections (
-                correction_id, target_type, target_id, correction_type,
-                payload_json, created_at_ms, updated_at_ms
+            INSERT INTO assertions (
+                assertion_id, target_ref, key, kind, value_json, created_at_ms, updated_at_ms
             ) VALUES (
-                'correction-missing', 'session', 'missing-session',
-                'tag_accept', '{"payload":{"tag":"orphaned"}}', 1, 1
+                'correction-missing', 'insight:missing-session', 'tag_accept',
+                'correction', '{"payload":{"tag":"orphaned"}}', 1, 1
             )
             """
         )
@@ -330,7 +329,7 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert tiers["user_overlay_orphans"]["checked"] is True
     assert tiers["user_overlay_orphans"]["total_orphan_session_references"] == 2
     assert tiers["user_overlay_orphans"]["orphan_session_reference_counts"]["session_tags"] == 1
-    assert tiers["user_overlay_orphans"]["orphan_session_reference_counts"]["corrections"] == 1
+    assert tiers["user_overlay_orphans"]["orphan_session_reference_counts"]["assertion_corrections"] == 1
     readiness = tiers["derived_readiness"]
     assert readiness["checked"] is True
     assert readiness["source_check_available"] is True

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -347,6 +347,21 @@ def test_pytest_run_terminates_after_runtime_budget(
     assert "terminated pytest process group" in captured.err
 
 
+def test_pytest_run_terminates_with_heartbeat_disabled(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0.15")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "0")
+
+    rc, _elapsed, metadata = _run("pytest timeout", [sys.executable, "-c", "import time; time.sleep(5)"])
+
+    captured = capsys.readouterr()
+    assert rc == 124
+    assert metadata["heartbeat_s"] == 0.0
+    assert "pytest runtime exceeded 0.15s" in captured.err
+
+
 def test_pytest_run_terminates_after_output_stall(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -377,6 +392,11 @@ def test_pytest_timeout_env_defaults_and_invalid_values(monkeypatch: pytest.Monk
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "-1")
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "nope")
     assert _pytest_timeout_s() == 0.0
+    assert _pytest_stall_timeout_s() > 0
+
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "nan")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "inf")
+    assert _pytest_timeout_s() > 0
     assert _pytest_stall_timeout_s() > 0
 
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -14,6 +14,8 @@ from devtools.verify import (
     _parse_pytest_test_count,
     _pytest_command_metadata,
     _pytest_metadata_from_report,
+    _pytest_stall_timeout_s,
+    _pytest_timeout_s,
     _read_pytest_report,
     _run,
     _stop_after_failed_step,
@@ -326,6 +328,56 @@ def test_pytest_run_emits_heartbeat_for_long_silent_child(
     assert "command:" in captured.err
     assert "still running: pid=" in captured.err
     assert "elapsed=" in captured.err
+
+
+def test_pytest_run_terminates_after_runtime_budget(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0.05")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0.15")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "0")
+
+    rc, _elapsed, metadata = _run("pytest timeout", [sys.executable, "-c", "import time; time.sleep(5)"])
+
+    captured = capsys.readouterr()
+    assert rc == 124
+    assert metadata["timeout_s"] == 0.15
+    assert metadata["stall_timeout_s"] == 0.0
+    assert "pytest runtime exceeded 0.15s" in captured.err
+    assert "terminated pytest process group" in captured.err
+
+
+def test_pytest_run_terminates_after_output_stall(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0.05")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "0.15")
+
+    rc, _elapsed, metadata = _run(
+        "pytest stall",
+        [sys.executable, "-c", "import time; print('progress', flush=True); time.sleep(5)"],
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 124
+    assert metadata["timeout_s"] == 0.0
+    assert metadata["stall_timeout_s"] == 0.15
+    assert "progress" in captured.err
+    assert "pytest produced no output for 0.15s" in captured.err
+    assert "terminated pytest process group" in captured.err
+
+
+def test_pytest_timeout_env_defaults_and_invalid_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", raising=False)
+    assert _pytest_timeout_s() > 0
+    assert _pytest_stall_timeout_s() > 0
+
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "-1")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "nope")
+    assert _pytest_timeout_s() == 0.0
+    assert _pytest_stall_timeout_s() > 0
 
 
 def test_pytest_command_metadata_reports_worker_and_selection_policy() -> None:

--- a/tests/unit/insights/test_feedback.py
+++ b/tests/unit/insights/test_feedback.py
@@ -284,18 +284,18 @@ class TestFeedbackStorage:
 
 
 # ---------------------------------------------------------------------------
-# Defense-in-depth — user_corrections is in canonical DDL
+# Defense-in-depth — correction assertions are in canonical DDL
 # ---------------------------------------------------------------------------
 
 
 def test_corrections_ddl_is_in_user_tier_ddl() -> None:
-    # The learning-corrections table lives in the user-durability tier
-    # (``user.db``) by construction — it carries irreplaceable human input and
-    # sits outside the content-hash boundary (#1131). The canonical table is
-    # named ``corrections`` in the split-file archive.
+    # Learning corrections live in the user-durability tier (``user.db``) by
+    # construction: they carry irreplaceable human input and sit outside the
+    # content-hash boundary (#1131). Their canonical storage is the assertion
+    # substrate.
     from polylogue.storage.sqlite.archive_tiers.user import USER_DDL
 
-    assert "CREATE TABLE IF NOT EXISTS corrections" in USER_DDL
+    assert "CREATE TABLE IF NOT EXISTS assertions" in USER_DDL
 
 
 def _suppress_unused_import_warning() -> None:

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+from polylogue.archive.query.fields import mcp_query_field_names
 from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 from polylogue.mcp.server_tools import register_query_tools
 
@@ -72,6 +73,12 @@ def test_facets_schema_matches_dataclass_fields(schemas: SchemaMap) -> None:
         f"missing={sorted(_dataclass_field_names() - properties)}, "
         f"extra={sorted(properties - _dataclass_field_names())}"
     )
+
+
+def test_mcp_query_request_matches_canonical_query_field_registry() -> None:
+    """MCP request fields stay aligned with query fields marked MCP-capable."""
+
+    assert mcp_query_field_names() <= _dataclass_field_names()
 
 
 def test_search_marks_query_required(schemas: SchemaMap) -> None:

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import fields
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -18,15 +19,23 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 
 from polylogue.archive.query.fields import mcp_query_field_names
+from polylogue.archive.query.plan import SessionQueryPlan
+from polylogue.mcp.archive_support import archive_query_filters, archive_search_payload, archive_session_list_payload
 from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 from polylogue.mcp.server_tools import register_query_tools
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
+from polylogue.types import Provider
 
 SchemaMap = dict[str, dict[str, Any]]
 
 
+def _clamp_limit(value: int | object) -> int:
+    return value if isinstance(value, int) and value > 0 else 10
+
+
 def _registered_schemas() -> SchemaMap:
     hooks = MagicMock()
-    hooks.clamp_limit = lambda value: int(value) if value else 10
+    hooks.clamp_limit = _clamp_limit
 
     server = FastMCP("schema-derivation-test")
     register_query_tools(server, hooks)
@@ -107,3 +116,85 @@ def test_limit_and_offset_preserve_pydantic_constraints(schemas: SchemaMap) -> N
         offset = properties["offset"]
         assert isinstance(limit, dict) and limit.get("minimum") == 1, f"{name}: limit lost ge=1 constraint"
         assert isinstance(offset, dict) and offset.get("minimum") == 0, f"{name}: offset lost ge=0 constraint"
+
+
+def test_archive_query_filters_forward_max_words() -> None:
+    spec = MCPSessionQueryRequest(max_words=12).build_spec(_clamp_limit)
+
+    assert archive_query_filters(spec)["max_words"] == 12
+
+
+def test_archive_list_sessions_routes_near_session_to_query_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_archive_search_hits(
+        plan: SessionQueryPlan,
+        **kwargs: object,
+    ) -> tuple[list[tuple[ArchiveSessionSearchHit, ArchiveSessionSummary]], str]:
+        observed["similar_session_id"] = plan.similar_session_id
+        observed["archive_root"] = kwargs["archive_root"]
+        return [], "semantic"
+
+    monkeypatch.setattr("polylogue.archive.query.archive_execution.archive_search_hits", fake_archive_search_hits)
+    archive = MagicMock()
+    archive.archive_root = Path("/archive")
+    spec = MCPSessionQueryRequest(similar_session_id="seed-session", limit=5).build_spec(_clamp_limit)
+
+    payload = archive_session_list_payload(archive, spec, archive_root=Path("/archive"))
+
+    assert observed == {"similar_session_id": "seed-session", "archive_root": Path("/archive")}
+    assert payload.items == ()
+    assert payload.total == 0
+
+
+def test_archive_search_routes_near_session_to_query_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = ArchiveSessionSummary(
+        session_id="codex-session:near-result",
+        native_id="near-result",
+        origin="codex-session",
+        provider=Provider.CODEX,
+        title="Nearby",
+        created_at=None,
+        updated_at=None,
+        message_count=1,
+        word_count=10,
+        tags=(),
+    )
+    hit = ArchiveSessionSearchHit(
+        rank=1,
+        session_id=summary.session_id,
+        block_id="block-1",
+        message_id="message-1",
+        origin=summary.origin,
+        provider=Provider.CODEX,
+        title=summary.title,
+        snippet="nearby match",
+    )
+
+    def fake_archive_search_hits(
+        plan: SessionQueryPlan,
+        **kwargs: object,
+    ) -> tuple[list[tuple[ArchiveSessionSearchHit, ArchiveSessionSummary]], str]:
+        assert plan.similar_session_id == "seed-session"
+        assert kwargs["archive_root"] == Path("/archive")
+        return [(hit, summary)], "semantic"
+
+    monkeypatch.setattr("polylogue.archive.query.archive_execution.archive_search_hits", fake_archive_search_hits)
+    archive = MagicMock()
+    archive.archive_root = Path("/archive")
+    archive.read_summary.return_value = summary
+    spec = MCPSessionQueryRequest(similar_session_id="seed-session", limit=5).build_spec(_clamp_limit)
+
+    payload = archive_search_payload(
+        archive,
+        spec,
+        query="",
+        limit=5,
+        offset=0,
+        retrieval_lane="semantic",
+        sort=None,
+        archive_root=Path("/archive"),
+    )
+
+    assert payload.retrieval_lane == "semantic"
+    assert [hit.session.id for hit in payload.hits] == ["codex-session:near-result"]

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -27,6 +27,7 @@ from polylogue.archive.session.neighbor_candidates import NeighborReason, Sessio
 from polylogue.archive.stats import ArchiveStats
 from polylogue.archive.viewport import read_view_profile_payloads
 from polylogue.core.enums import Origin
+from polylogue.core.outcomes import OutcomeCheck, OutcomeStatus
 from polylogue.insights.archive import (
     ArchiveCoverageInsight,
     ArchiveDebtInsight,
@@ -603,6 +604,7 @@ class TestArchiveTools:
                 typed_only=True,
                 message_type="tool_use",
                 title="Copied",
+                max_words=100,
                 limit=5,
             )
 
@@ -636,6 +638,7 @@ class TestArchiveTools:
             min_messages=None,
             max_messages=None,
             min_words=None,
+            max_words=100,
             since=None,
             until=None,
             limit=5,
@@ -666,6 +669,7 @@ class TestArchiveTools:
             min_messages=None,
             max_messages=None,
             min_words=None,
+            max_words=100,
             since=None,
             until=None,
         )
@@ -1600,11 +1604,7 @@ class TestMutationTools:
         assert json.loads(result) == expected
 
     def test_health_check_success(self, mcp_server: MCPServerUnderTest) -> None:
-        mock_check = MagicMock()
-        mock_check.name = "database"
-        mock_check.status.value = "ok"
-        mock_check.count = 100
-        mock_check.detail = "All good"
+        mock_check = OutcomeCheck("database", OutcomeStatus.OK, summary="All good", count=100)
 
         mock_report = MagicMock()
         mock_report.checks = [mock_check]
@@ -1746,7 +1746,7 @@ def test_mcp_search_params_match_query_spec() -> None:
         "referenced_path",
     }
     missing = mcp_params - spec_fields
-    surface_aliases: set[str] = {
+    contract_projections: set[str] = {
         "limit",
         "offset",
         "tag",  # → tags
@@ -1761,4 +1761,6 @@ def test_mcp_search_params_match_query_spec() -> None:
         "action_terms",  # passthrough
         "tool_terms",  # passthrough
     }
-    assert missing.issubset(surface_aliases), f"MCP params not in SessionQuerySpec: {missing - surface_aliases}"
+    assert missing.issubset(contract_projections), (
+        f"MCP params not in SessionQuerySpec: {missing - contract_projections}"
+    )

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -1,4 +1,4 @@
-"""Write-through parity tests: legacy user-overlay upserts mirror an assertion row (#1883)."""
+"""Assertion-backed user-overlay storage contracts (#1883)."""
 
 from __future__ import annotations
 
@@ -10,13 +10,7 @@ from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     AssertionKind,
     assertion_id_for_annotation,
-    assertion_id_for_blackboard_note,
-    assertion_id_for_correction,
     assertion_id_for_mark,
-    assertion_id_for_recall_pack,
-    assertion_id_for_saved_view,
-    assertion_id_for_suppression,
-    assertion_id_for_workspace,
     list_archive_blackboard_note_envelopes,
     list_assertions_for_target,
     read_archive_annotation_envelope,
@@ -29,7 +23,6 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     read_archive_workspace_envelope,
     read_assertion_envelope,
     upsert_annotation,
-    upsert_assertion,
     upsert_blackboard_note,
     upsert_correction,
     upsert_mark,
@@ -54,7 +47,7 @@ def _assertion_count(conn: sqlite3.Connection) -> int:
 def test_mark_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    mark = upsert_mark(
+    upsert_mark(
         conn,
         "session",
         "session-1",
@@ -63,11 +56,6 @@ def test_mark_write_through_mirrors_assertion(tmp_path: Path) -> None:
         metadata={"scope": "alpha"},
         now_ms=1_700_000_000_000,
     )
-
-    # Legacy row still authoritative.
-    legacy = conn.execute("SELECT mark_id, label FROM marks WHERE mark_id = ?", (mark.mark_id,)).fetchone()
-    assert legacy is not None
-    assert legacy["label"] == "wip"
 
     mirrored = list_assertions_for_target(conn, "session:session-1", kind=AssertionKind.MARK)
     assert len(mirrored) == 1
@@ -102,17 +90,12 @@ def test_mark_write_through_is_idempotent(tmp_path: Path) -> None:
 def test_annotation_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    annotation = upsert_annotation(
+    upsert_annotation(
         conn,
         "message",
         "msg-7",
         "needs follow-up",
         now_ms=1_700_000_010_000,
-    )
-
-    assert (
-        conn.execute("SELECT 1 FROM annotations WHERE annotation_id = ?", (annotation.annotation_id,)).fetchone()
-        is not None
     )
 
     mirrored = list_assertions_for_target(conn, "message:msg-7", kind=AssertionKind.ANNOTATION)
@@ -128,21 +111,52 @@ def test_annotation_write_through_mirrors_assertion(tmp_path: Path) -> None:
     assert again[0].assertion_id == mirrored[0].assertion_id
 
 
+def test_block_target_overlays_mirror_to_block_assertions(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    mark = upsert_mark(
+        conn,
+        "block",
+        "msg-7:0",
+        "pin",
+        label="important block",
+        metadata={"reason": "decision"},
+        now_ms=1_700_000_015_000,
+    )
+    annotation = upsert_annotation(
+        conn,
+        "block",
+        "msg-7:0",
+        "carry this into the work packet",
+        now_ms=1_700_000_016_000,
+    )
+
+    mark_mirror = list_assertions_for_target(conn, "block:msg-7:0", kind=AssertionKind.MARK)
+    annotation_mirror = list_assertions_for_target(conn, "block:msg-7:0", kind=AssertionKind.ANNOTATION)
+
+    assert mark_mirror[0].assertion_id == assertion_id_for_mark("block", "msg-7:0", "pin")
+    assert mark_mirror[0].key == "pin"
+    assert mark_mirror[0].body_text == "important block"
+    assert mark_mirror[0].value == {"reason": "decision"}
+    assert annotation_mirror[0].assertion_id == assertion_id_for_annotation(annotation.annotation_id)
+    assert annotation_mirror[0].body_text == "carry this into the work packet"
+
+    refreshed_mark = read_archive_mark_envelope(conn, mark.mark_id)
+    refreshed_annotation = read_archive_annotation_envelope(conn, annotation.annotation_id)
+    assert refreshed_mark.target_type == "block"
+    assert refreshed_annotation.target_type == "block"
+
+
 def test_correction_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    correction = upsert_correction(
+    upsert_correction(
         conn,
         "insight",
         "session-1",
         "tag_reject",
         {"tag": "rust"},
         now_ms=1_700_000_020_000,
-    )
-
-    assert (
-        conn.execute("SELECT 1 FROM corrections WHERE correction_id = ?", (correction.correction_id,)).fetchone()
-        is not None
     )
 
     mirrored = list_assertions_for_target(conn, "insight:session-1", kind=AssertionKind.CORRECTION)
@@ -226,97 +240,31 @@ def test_blackboard_note_assertion_metadata_is_preserved(tmp_path: Path) -> None
     assert env.context_policy == {"inject": False}
 
 
-def test_user_overlay_reads_prefer_assertion_mirrors(tmp_path: Path) -> None:
+def test_user_overlay_reads_project_assertion_envelopes(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    suppression = upsert_suppression(conn, "session-2", "legacy reason", mode="hide", now_ms=1_700_000_034_000)
+    suppression = upsert_suppression(conn, "session-2", "asserted reason", mode="freeze", now_ms=1_700_000_035_000)
     mark = upsert_mark(
         conn,
         "session",
         "session-1",
         "star",
-        label="legacy label",
-        metadata={"scope": "legacy"},
-        now_ms=1_700_000_034_000,
+        label="asserted label",
+        metadata={"scope": "asserted"},
+        now_ms=1_700_000_035_000,
     )
-    annotation = upsert_annotation(conn, "message", "msg-1", "legacy body", now_ms=1_700_000_034_000)
+    annotation = upsert_annotation(conn, "message", "msg-1", "asserted annotation", now_ms=1_700_000_035_000)
     correction = upsert_correction(
         conn,
         "insight",
         "session-1",
         "tag_reject",
-        {"tag": "legacy"},
-        now_ms=1_700_000_034_000,
-    )
-    saved_view = upsert_saved_view(conn, "recent", {"limit": 10}, now_ms=1_700_000_034_000)
-    recall_pack = upsert_recall_pack(conn, "handoff", {"sessions": ["legacy"]}, now_ms=1_700_000_034_000)
-    workspace = upsert_workspace(conn, "main", {"repo": "legacy"}, now_ms=1_700_000_034_000)
-
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_suppression(suppression.session_id),
-        target_ref=suppression.session_id,
-        kind=AssertionKind.SUPPRESSION,
-        value={"mode": "freeze"},
-        body_text="asserted reason",
+        {"tag": "asserted"},
         now_ms=1_700_000_035_000,
     )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_mark(mark.target_type, mark.target_id, mark.mark_type),
-        target_ref="session:session-1",
-        kind=AssertionKind.MARK,
-        key=mark.mark_type,
-        value={"scope": "asserted"},
-        body_text="asserted label",
-        now_ms=1_700_000_035_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_annotation(annotation.annotation_id),
-        target_ref="message:msg-1",
-        kind=AssertionKind.ANNOTATION,
-        body_text="asserted annotation",
-        now_ms=1_700_000_035_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_correction(correction.correction_id),
-        target_ref="insight:session-1",
-        kind=AssertionKind.CORRECTION,
-        key=correction.correction_type,
-        value={"tag": "asserted"},
-        now_ms=1_700_000_035_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_saved_view(saved_view.view_id),
-        target_ref=f"saved_view:{saved_view.view_id}",
-        kind=AssertionKind.SAVED_QUERY,
-        key=saved_view.name,
-        value={"limit": 20},
-        now_ms=1_700_000_035_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_recall_pack(recall_pack.recall_pack_id),
-        target_ref=f"recall_pack:{recall_pack.recall_pack_id}",
-        kind=AssertionKind.RECALL_PACK,
-        key=recall_pack.name,
-        value={"sessions": ["asserted"]},
-        body_text=recall_pack.name,
-        now_ms=1_700_000_035_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_workspace(workspace.workspace_id),
-        target_ref=f"workspace:{workspace.workspace_id}",
-        kind=AssertionKind.WORKSPACE_NOTE,
-        key=workspace.name,
-        value={"repo": "asserted"},
-        body_text=workspace.name,
-        now_ms=1_700_000_035_000,
-    )
+    saved_view = upsert_saved_view(conn, "recent", {"limit": 20}, now_ms=1_700_000_035_000)
+    recall_pack = upsert_recall_pack(conn, "handoff", {"sessions": ["asserted"]}, now_ms=1_700_000_035_000)
+    workspace = upsert_workspace(conn, "main", {"repo": "asserted"}, now_ms=1_700_000_035_000)
 
     suppression_read = read_archive_suppression_envelope(conn, suppression.session_id)
     mark_read = read_archive_mark_envelope(conn, mark.mark_id)
@@ -339,36 +287,13 @@ def test_user_overlay_reads_prefer_assertion_mirrors(tmp_path: Path) -> None:
     assert workspace_read.updated_at_ms == 1_700_000_035_000
 
 
-def test_suppression_read_preserves_legacy_reason_when_assertion_body_is_absent(tmp_path: Path) -> None:
+def test_blackboard_note_read_projects_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    suppression = upsert_suppression(conn, "session-2", "legacy reason", mode="hide", now_ms=1_700_000_034_000)
-    upsert_assertion(
+    note = upsert_blackboard_note(
         conn,
-        assertion_id=assertion_id_for_suppression(suppression.session_id),
-        target_ref=suppression.session_id,
-        kind=AssertionKind.SUPPRESSION,
-        value={"mode": "freeze"},
-        body_text=None,
-        now_ms=1_700_000_035_000,
-    )
-
-    suppression_read = read_archive_suppression_envelope(conn, suppression.session_id)
-
-    assert suppression_read.reason == "legacy reason"
-    assert suppression_read.mode == "freeze"
-
-
-def test_blackboard_note_read_prefers_assertion_mirror(tmp_path: Path) -> None:
-    conn = _connect(tmp_path / "user.db")
-
-    note = upsert_blackboard_note(conn, "legacy body", note_id="note-1", now_ms=1_700_000_034_000)
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_blackboard_note(note.note_id),
-        target_ref=note.note_id,
-        kind=AssertionKind.NOTE,
-        body_text="[decision] asserted title\n\nassertion body",
+        "[decision] asserted title\n\nassertion body",
+        note_id="note-1",
         now_ms=1_700_000_035_000,
     )
 
@@ -378,41 +303,29 @@ def test_blackboard_note_read_prefers_assertion_mirror(tmp_path: Path) -> None:
     assert envelope.target_type is None
     assert envelope.target_id is None
     assert envelope.body == "[decision] asserted title\n\nassertion body"
-    assert envelope.created_at_ms == 1_700_000_034_000
+    assert envelope.created_at_ms == 1_700_000_035_000
     assert envelope.updated_at_ms == 1_700_000_035_000
 
 
-def test_blackboard_note_list_is_assertion_backed_with_legacy_fallback(tmp_path: Path) -> None:
+def test_blackboard_note_list_projects_assertions(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
-    mirrored = upsert_blackboard_note(
+    upsert_blackboard_note(
         conn,
-        "legacy mirrored body",
+        "[finding] assertion title\n\nassertion body",
         note_id="note-mirrored",
         target_type="session",
         target_id="session-1",
-        now_ms=1_700_000_036_000,
-    )
-    upsert_assertion(
-        conn,
-        assertion_id=assertion_id_for_blackboard_note(mirrored.note_id),
-        target_ref="session:session-1",
-        kind=AssertionKind.NOTE,
-        body_text="[finding] assertion title\n\nassertion body",
         now_ms=1_700_000_037_000,
     )
-    conn.execute(
-        """
-        INSERT INTO blackboard_notes (note_id, target_type, target_id, body, created_at_ms, updated_at_ms)
-        VALUES (?, ?, ?, ?, ?, ?)
-        """,
-        ("note-legacy", None, None, "[question] legacy title\n\nlegacy body", 1_700_000_038_000, 1_700_000_038_000),
+    upsert_blackboard_note(
+        conn, "[question] global title\n\nglobal body", note_id="note-global", now_ms=1_700_000_038_000
     )
 
     notes = list_archive_blackboard_note_envelopes(conn)
 
-    assert [note.note_id for note in notes] == ["note-legacy", "note-mirrored"]
-    assert notes[0].body == "[question] legacy title\n\nlegacy body"
+    assert [note.note_id for note in notes] == ["note-global", "note-mirrored"]
+    assert notes[0].body == "[question] global title\n\nglobal body"
     assert notes[1].target_type == "session"
     assert notes[1].target_id == "session-1"
     assert notes[1].body == "[finding] assertion title\n\nassertion body"
@@ -423,15 +336,14 @@ def test_suppression_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
     upsert_suppression(conn, "session-2", "noise", mode="hide", now_ms=1_700_000_040_000)
-    assert conn.execute("SELECT 1 FROM suppressions WHERE session_id = ?", ("session-2",)).fetchone() is not None
 
-    mirrored = list_assertions_for_target(conn, "session-2", kind=AssertionKind.SUPPRESSION)
+    mirrored = list_assertions_for_target(conn, "session:session-2", kind=AssertionKind.SUPPRESSION)
     assert len(mirrored) == 1
     assert mirrored[0].value == {"mode": "hide"}
     assert mirrored[0].body_text == "noise"
 
     upsert_suppression(conn, "session-2", "still noise", mode="freeze", now_ms=1_700_000_041_000)
-    again = list_assertions_for_target(conn, "session-2", kind=AssertionKind.SUPPRESSION)
+    again = list_assertions_for_target(conn, "session:session-2", kind=AssertionKind.SUPPRESSION)
     assert len(again) == 1
     assert again[0].assertion_id == mirrored[0].assertion_id
     assert again[0].value == {"mode": "freeze"}
@@ -441,7 +353,6 @@ def test_saved_view_write_through_mirrors_assertion(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
 
     saved_view = upsert_saved_view(conn, "recent", {"limit": 10}, now_ms=1_700_000_050_000)
-    assert conn.execute("SELECT 1 FROM saved_views WHERE name = ?", ("recent",)).fetchone() is not None
 
     mirrored = list_assertions_for_target(conn, f"saved_view:{saved_view.view_id}", kind=AssertionKind.SAVED_QUERY)
     assert len(mirrored) == 1

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -67,9 +67,8 @@ def test_fresh_user_tier_creates_assertions_table(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
     try:
         assert _table_exists(conn, "assertions")
-        # The table is purely additive: the legacy overlays still exist.
-        assert _table_exists(conn, "marks")
-        assert _table_exists(conn, "blackboard_notes")
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
+        assert USER_SCHEMA_VERSION == 2
     finally:
         conn.close()
 
@@ -269,58 +268,6 @@ def test_assertion_targets_various_ref_shapes(tmp_path: Path) -> None:
             assert stored.target_ref == ref
     finally:
         conn.close()
-
-
-def test_assertions_table_added_additively_without_version_bump(tmp_path: Path) -> None:
-    """A pre-existing v1 user.db lacking the table gains it on next open with no wipe."""
-    path = tmp_path / "user.db"
-    conn = _connect(path)
-    try:
-        # Seed irreplaceable user data, then simulate an older DB that predates
-        # the assertions table by dropping it. user_version stays at 1.
-        upsert_assertion(
-            conn,
-            assertion_id="seed",
-            target_ref="session:keep-me",
-            kind=AssertionKind.LESSON,
-            body_text="irreplaceable user input",
-            now_ms=1_700_000_000_000,
-        )
-        conn.execute("DROP TABLE assertions")
-        conn.commit()
-        assert not _table_exists(conn, "assertions")
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
-    finally:
-        conn.close()
-
-    # Re-open the existing v1 file and re-apply the tier DDL idempotently.
-    conn2 = sqlite3.connect(path)
-    conn2.row_factory = sqlite3.Row
-    try:
-        version_before = int(conn2.execute("PRAGMA user_version").fetchone()[0])
-        assert version_before == USER_SCHEMA_VERSION
-        # Pre-existing irreplaceable rows must survive the re-open.
-        assert _table_exists(conn2, "marks")
-
-        initialize_archive_tier(conn2, ArchiveTier.USER)
-
-        assert _table_exists(conn2, "assertions")
-        version_after = int(conn2.execute("PRAGMA user_version").fetchone()[0])
-        assert version_after == USER_SCHEMA_VERSION
-        assert USER_SCHEMA_VERSION == 1
-
-        # The freshly-added table is usable.
-        restored = upsert_assertion(
-            conn2,
-            assertion_id="post-additive",
-            target_ref="session:keep-me",
-            kind=AssertionKind.NOTE,
-            body_text="written after additive open",
-            now_ms=1_700_000_009_000,
-        )
-        assert restored.assertion_id == "post-additive"
-    finally:
-        conn2.close()
 
 
 def test_recovery_digest_candidates_write_transform_candidate_assertions(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -242,9 +242,10 @@ def test_archive_tiers_database_split_keeps_source_index_embeddings_user_and_ops
     for expected in ("message_embeddings", "message_embeddings_meta"):
         assert expected in embeddings
         assert expected not in index
-    for expected in ("marks", "suppressions"):
+    for expected in ("assertions", "session_metadata"):
         assert expected in user
         assert expected not in index
+    assert "session_tags" in user
     for expected in ("ingest_cursor", "embedding_catchup_runs"):
         assert expected in ops
         assert expected not in index

--- a/tests/unit/storage/test_archive_tiers_user_overlay.py
+++ b/tests/unit/storage/test_archive_tiers_user_overlay.py
@@ -8,6 +8,7 @@ from polylogue.sources.parsers.base import ParsedAttachment, ParsedContentBlock,
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_overlay import find_archive_user_overlay_orphans
+from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
 from polylogue.storage.sqlite.archive_tiers.write import (
     upsert_session_phase,
     upsert_session_work_event,
@@ -68,66 +69,42 @@ def test_archive_tiers_user_overlay_orphan_check_resolves_archive_targets(tmp_pa
         phase_type="build",
     )
 
-    user_conn.executemany(
-        """
-        INSERT INTO marks (
-            mark_id, target_type, target_id, mark_type, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        """,
-        [
-            ("mark-session-ok", "session", session_id, "pin", 1, 1),
-            ("mark-message-ok", "message", message_id, "pin", 1, 1),
-            ("mark-block-ok", "block", block_id, "pin", 1, 1),
-            ("mark-attachment-ok", "attachment", attachment_id, "pin", 1, 1),
-            ("mark-work-event-ok", "work_event", work_event.event_id, "pin", 1, 1),
-            ("mark-phase-ok", "phase", phase.phase_id, "pin", 1, 1),
-            ("mark-thread-ok", "thread", session_id, "pin", 1, 1),
-            ("mark-missing", "message", f"{session_id}:missing", "pin", 1, 1),
-        ],
-    )
-    user_conn.executemany(
-        """
-        INSERT INTO annotations (
-            annotation_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        """,
-        [
-            ("annotation-missing", "paste_span", f"{message_id}:0:4", "lost paste", 1, 1),
-            ("annotation-attachment-missing", "attachment", f"{session_id}:attachment:missing", "lost", 1, 1),
-            ("annotation-phase-missing", "phase", f"{session_id}:phase:7", "lost phase", 1, 1),
-            ("annotation-thread-missing", "thread", f"{session_id}:missing-thread", "lost thread", 1, 1),
-            (
-                "annotation-work-event-missing",
-                "work_event",
-                f"{session_id}:work_event:7",
-                "lost event",
-                1,
-                1,
-            ),
-        ],
-    )
-    user_conn.executemany(
-        """
-        INSERT INTO blackboard_notes (
-            note_id, target_type, target_id, body, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        """,
-        [
-            ("note-global-ok", None, None, "global note", 1, 1),
-            ("note-session-ok", "session", session_id, "session note", 1, 1),
-            ("note-work-event-ok", "work_event", work_event.event_id, "event note", 1, 1),
-            ("note-work-event-missing", "work_event", f"{session_id}:work_event:8", "lost event", 1, 1),
-        ],
-    )
+    for assertion_id, target_ref, kind in [
+        ("mark-session-ok", f"session:{session_id}", AssertionKind.MARK),
+        ("mark-message-ok", f"message:{message_id}", AssertionKind.MARK),
+        ("mark-block-ok", f"block:{block_id}", AssertionKind.MARK),
+        ("mark-attachment-ok", f"attachment:{attachment_id}", AssertionKind.MARK),
+        ("mark-work-event-ok", f"work_event:{work_event.event_id}", AssertionKind.MARK),
+        ("mark-phase-ok", f"phase:{phase.phase_id}", AssertionKind.MARK),
+        ("mark-thread-ok", f"thread:{session_id}", AssertionKind.MARK),
+        ("mark-missing", f"message:{session_id}:missing", AssertionKind.MARK),
+        ("annotation-missing", f"paste_span:{message_id}:0:4", AssertionKind.ANNOTATION),
+        ("annotation-attachment-missing", f"attachment:{session_id}:attachment:missing", AssertionKind.ANNOTATION),
+        ("annotation-phase-missing", f"phase:{session_id}:phase:7", AssertionKind.ANNOTATION),
+        ("annotation-thread-missing", f"thread:{session_id}:missing-thread", AssertionKind.ANNOTATION),
+        ("annotation-work-event-missing", f"work_event:{session_id}:work_event:7", AssertionKind.ANNOTATION),
+        ("note-global-ok", "note-global-ok", AssertionKind.NOTE),
+        ("note-session-ok", f"session:{session_id}", AssertionKind.NOTE),
+        ("note-work-event-ok", f"work_event:{work_event.event_id}", AssertionKind.NOTE),
+        ("note-work-event-missing", f"work_event:{session_id}:work_event:8", AssertionKind.NOTE),
+    ]:
+        upsert_assertion(
+            user_conn,
+            assertion_id=assertion_id,
+            target_ref=target_ref,
+            kind=kind,
+            body_text=assertion_id,
+            now_ms=1,
+        )
 
     orphans = find_archive_user_overlay_orphans(user_conn, archive_conn)
 
     assert [(item.table, item.row_id, item.target_type, item.target_id) for item in orphans] == [
-        ("marks", "mark-missing", "message", f"{session_id}:missing"),
-        ("annotations", "annotation-attachment-missing", "attachment", f"{session_id}:attachment:missing"),
-        ("annotations", "annotation-missing", "paste_span", f"{message_id}:0:4"),
-        ("annotations", "annotation-phase-missing", "phase", f"{session_id}:phase:7"),
-        ("annotations", "annotation-thread-missing", "thread", f"{session_id}:missing-thread"),
-        ("annotations", "annotation-work-event-missing", "work_event", f"{session_id}:work_event:7"),
-        ("blackboard_notes", "note-work-event-missing", "work_event", f"{session_id}:work_event:8"),
+        ("assertions", "annotation-attachment-missing", "attachment", f"{session_id}:attachment:missing"),
+        ("assertions", "annotation-missing", "paste_span", f"{message_id}:0:4"),
+        ("assertions", "annotation-phase-missing", "phase", f"{session_id}:phase:7"),
+        ("assertions", "annotation-thread-missing", "thread", f"{session_id}:missing-thread"),
+        ("assertions", "annotation-work-event-missing", "work_event", f"{session_id}:work_event:7"),
+        ("assertions", "mark-missing", "message", f"{session_id}:missing"),
+        ("assertions", "note-work-event-missing", "work_event", f"{session_id}:work_event:8"),
     ]

--- a/tests/unit/storage/test_marks_identity_preserving.py
+++ b/tests/unit/storage/test_marks_identity_preserving.py
@@ -1,14 +1,14 @@
 """Native marks/annotations identity-preservation laws (#1114, archive).
 
 These tests pin the surface contract: user marks and annotations live in the
-archive ``user.db`` tier, keyed by stable public target ids, and survive a
-hard delete + re-import of the underlying session. Because the native session
-id is deterministic (``origin:provider_session_id``), re-ingesting the same
-logical session rebinds to the identical target id with no repoint pass.
+archive ``user.db`` tier as assertions, keyed by stable public target ids, and
+survive a hard delete + re-import of the underlying session. Because the native
+session id is deterministic (``origin:provider_session_id``), re-ingesting the
+same logical session rebinds to the identical target id with no repoint pass.
 
 Seeding writes the archive through ``SessionBuilder`` (which routes
-to ``ArchiveStore``); reads go through the async ``Polylogue`` facade. The marks
-rows are inspected directly in ``user.db``.
+to ``ArchiveStore``); reads go through the async ``Polylogue`` facade. The
+assertions are inspected directly in ``user.db``.
 """
 
 from __future__ import annotations
@@ -31,23 +31,25 @@ def _user_db_path(workspace_env: dict[str, Path]) -> Path:
 def _mark_row(user_db: Path, mark_type: str = "star") -> tuple[str, str, str, dict[str, object]]:
     with sqlite3.connect(user_db) as conn:
         row = conn.execute(
-            "SELECT target_type, target_id, mark_type, metadata_json FROM marks WHERE mark_type = ?",
+            "SELECT target_ref, key, value_json FROM assertions WHERE kind = 'mark' AND key = ?",
             (mark_type,),
         ).fetchone()
     assert row is not None
-    metadata = json.loads(row[3])
+    target_type, target_id = str(row[0]).split(":", 1)
+    metadata = json.loads(row[2]) if row[2] is not None else {}
     assert isinstance(metadata, dict)
-    return row[0], row[1], row[2], metadata
+    return target_type, target_id, row[1], metadata
 
 
 def _annotation_row(user_db: Path, annotation_id: str) -> tuple[str, str, str]:
     with sqlite3.connect(user_db) as conn:
         row = conn.execute(
-            "SELECT target_type, target_id, body FROM annotations WHERE annotation_id = ?",
+            "SELECT target_ref, body_text FROM assertions WHERE kind = 'annotation' AND key = ?",
             (annotation_id,),
         ).fetchone()
     assert row is not None
-    return row[0], row[1], row[2]
+    target_type, target_id = str(row[0]).split(":", 1)
+    return target_type, target_id, row[1]
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +170,7 @@ async def test_marks_survive_session_delete_and_rebind_on_reimport(
         assert {row["target_id"] for row in marks_after_delete} == {session_id}
         assert {row["annotation_id"] for row in annotations_after_delete} == {"ann-1"}
 
-    # The stored rows persist through delete (no orphaning, no repoint needed).
+    # The stored assertions persist through delete (no orphaning, no repoint needed).
     target_type, target_id, _, metadata = _mark_row(_user_db_path(workspace_env))
     assert target_type == "session"
     assert target_id == session_id
@@ -226,11 +228,9 @@ async def test_message_target_marks_survive_reimport(workspace_env: dict[str, Pa
         text="hello",
     ).save()
 
-    with sqlite3.connect(_user_db_path(workspace_env)) as conn:
-        row = conn.execute("SELECT target_type, target_id FROM marks WHERE mark_type='pin'").fetchone()
-    assert row is not None
-    assert row[0] == "message"
-    assert row[1] == message_id
+    target_type, target_id, _, _ = _mark_row(_user_db_path(workspace_env), "pin")
+    assert target_type == "message"
+    assert target_id == message_id
 
 
 @pytest.mark.asyncio
@@ -263,23 +263,21 @@ async def test_message_target_mark_survives_when_message_disappears(
         )
         assert await poly.delete_session(session_id) is True
 
-    # Reimport WITHOUT the original message — the mark row is keyed by the stable
+    # Reimport WITHOUT the original message — the mark is keyed by the stable
     # public message id and is not deleted just because the message is gone.
     SessionBuilder(db_path, "conv-id").provider("claude-code").add_message(
         message_id="other-msg",
         text="different",
     ).save()
 
-    with sqlite3.connect(_user_db_path(workspace_env)) as conn:
-        row = conn.execute("SELECT target_type, target_id FROM marks WHERE mark_type='pin'").fetchone()
-    assert row is not None
-    assert row[0] == "message"
-    assert row[1] == message_id
+    target_type, target_id, _, _ = _mark_row(_user_db_path(workspace_env), "pin")
+    assert target_type == "message"
+    assert target_id == message_id
 
 
 @pytest.mark.asyncio
 async def test_reimport_is_idempotent_for_user_state(workspace_env: dict[str, Path]) -> None:
-    """Re-ingesting unchanged content does not duplicate or re-touch mark rows."""
+    """Re-ingesting unchanged content does not duplicate or re-touch marks."""
     db_path = db_setup(workspace_env)
     builder = (
         SessionBuilder(db_path, "conv-id")

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -148,20 +148,18 @@ async def test_user_state_mutations_write_archive_user_tier(
     assert user_db.exists()
     with sqlite3.connect(user_db) as conn:
         assert conn.execute("PRAGMA user_version").fetchone()[0] == archive_tier_spec(ArchiveTier.USER).version
-        mark = conn.execute(
-            "SELECT target_type, target_id, mark_type, json_extract(metadata_json, '$.public_target_type') FROM marks"
-        ).fetchone()
+        mark = conn.execute("SELECT target_ref, key, value_json FROM assertions WHERE kind = 'mark'").fetchone()
         annotation = conn.execute(
-            "SELECT target_type, target_id, body FROM annotations WHERE annotation_id = 'ann-v1'"
+            "SELECT target_ref, key, body_text FROM assertions WHERE kind = 'annotation' AND key = 'ann-v1'"
         ).fetchone()
         saved_view = conn.execute(
-            "SELECT view_id, name, query_json FROM saved_views WHERE view_id = 'view-v1'"
+            "SELECT target_ref, key, value_json FROM assertions WHERE kind = 'saved_query' AND target_ref = 'saved_view:view-v1'"
         ).fetchone()
         recall_pack = conn.execute(
-            "SELECT recall_pack_id, name, payload_json FROM recall_packs WHERE recall_pack_id = 'pack-v1'"
+            "SELECT target_ref, key, value_json FROM assertions WHERE kind = 'recall_pack' AND target_ref = 'recall_pack:pack-v1'"
         ).fetchone()
         workspace = conn.execute(
-            "SELECT workspace_id, name, settings_json FROM workspaces WHERE workspace_id = 'workspace-v1'"
+            "SELECT target_ref, key, value_json FROM assertions WHERE kind = 'workspace_note' AND target_ref = 'workspace:workspace-v1'"
         ).fetchone()
         assertion_rows = conn.execute(
             """
@@ -172,21 +170,23 @@ async def test_user_state_mutations_write_archive_user_tier(
             """
         ).fetchall()
         correction_row = conn.execute(
-            "SELECT target_type, target_id, correction_type, payload_json FROM corrections"
+            "SELECT target_ref, key, value_json FROM assertions WHERE kind = 'correction'"
         ).fetchone()
 
-    assert mark == ("session", ARCHIVE_USER_STATE_SESSION_ID, "star", None)
+    assert mark is not None
+    assert mark[0:2] == (f"session:{ARCHIVE_USER_STATE_SESSION_ID}", "star")
+    assert (json.loads(mark[2]) if mark[2] is not None else {}) == {}
     assert annotation is not None
-    assert annotation[0:2] == ("session", ARCHIVE_USER_STATE_SESSION_ID)
+    assert annotation[0:2] == (f"session:{ARCHIVE_USER_STATE_SESSION_ID}", "ann-v1")
     assert annotation[2] == "Stored in user.db"
     assert saved_view is not None
-    assert saved_view[0:2] == ("view-v1", "Archive view")
+    assert saved_view[0:2] == ("saved_view:view-v1", "Archive view")
     assert json.loads(saved_view[2]) == {"query": "storage", "limit": 5}
     assert recall_pack is not None
-    assert recall_pack[0:2] == ("pack-v1", "Archive pack")
+    assert recall_pack[0:2] == ("recall_pack:pack-v1", "Archive pack")
     assert json.loads(json.loads(recall_pack[2])["session_ids_json"]) == [ARCHIVE_USER_STATE_SESSION_ID]
     assert workspace is not None
-    assert workspace[0:2] == ("workspace-v1", "Archive workspace")
+    assert workspace[0:2] == ("workspace:workspace-v1", "Archive workspace")
     assert json.loads(workspace[2])["mode"] == "tabs"
     assert [(row[0], row[1], row[2]) for row in assertion_rows] == [
         ("recall_pack:pack-v1", "recall_pack", "Archive pack"),
@@ -197,8 +197,8 @@ async def test_user_state_mutations_write_archive_user_tier(
     assert json.loads(assertion_rows[1][3]) == {"query": "storage", "limit": 5}
     assert json.loads(assertion_rows[2][3])["mode"] == "tabs"
     assert correction_row is not None
-    assert correction_row[0:3] == ("session", ARCHIVE_USER_STATE_SESSION_ID, "tag_accept")
-    assert json.loads(correction_row[3])["payload"] == {"tag": "archive"}
+    assert correction_row[0:2] == (f"insight:{ARCHIVE_USER_STATE_SESSION_ID}", "tag_accept")
+    assert json.loads(correction_row[2])["payload"] == {"tag": "archive"}
 
 
 @pytest.mark.asyncio
@@ -235,14 +235,15 @@ async def test_user_state_target_resolution_reads_archive_file_set_from_archive_
     with sqlite3.connect(archive_root / "user.db") as conn:
         rows = conn.execute(
             """
-            SELECT target_type, target_id, mark_type
-            FROM marks
-            ORDER BY target_type, mark_type
+            SELECT target_ref, key
+            FROM assertions
+            WHERE kind = 'mark'
+            ORDER BY target_ref, key
             """
         ).fetchall()
     assert rows == [
-        ("message", message_id, "pin"),
-        ("session", session_id, "star"),
+        (f"message:{message_id}", "pin"),
+        (f"session:{session_id}", "star"),
     ]
 
 

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -248,6 +248,29 @@ async def test_user_state_target_resolution_reads_archive_file_set_from_archive_
 
 
 @pytest.mark.asyncio
+async def test_user_state_targets_reject_contradictory_identifiers(workspace_env: dict[str, Path]) -> None:
+    archive_root = workspace_env["archive_root"]
+    _session_id, message_id = _seed_user_state_session(archive_root)
+
+    async with Polylogue(db_path=archive_root / "index.db", archive_root=archive_root) as poly:
+        with pytest.raises(ValueError, match="message target_id must match message_id"):
+            await poly.add_mark(
+                USER_STATE_SESSION_ID,
+                "pin",
+                target_type="message",
+                target_id="other-message",
+                message_id=message_id,
+            )
+        with pytest.raises(ValueError, match="canonical non-negative block_index"):
+            await poly.add_mark(
+                USER_STATE_SESSION_ID,
+                "pin",
+                target_type="block",
+                target_id=f"{message_id}:00",
+            )
+
+
+@pytest.mark.asyncio
 async def test_message_target_user_state_rejects_unknown_messages(workspace_env: dict[str, Path]) -> None:
     archive_root = workspace_env["archive_root"]
     _seed_user_state_session(archive_root)

--- a/tests/unit/storage/test_user_state_target_kinds.py
+++ b/tests/unit/storage/test_user_state_target_kinds.py
@@ -1,7 +1,7 @@
 """Archive storage contracts for user-state target kinds (#1113, archive).
 
 The user-state target registry (``session``, ``message``, ``session``,
-``work_event``, ``thread``, ``content_block``, ``attachment``, ``paste_span``)
+``work_event``, ``thread``, ``block``, ``attachment``, ``paste_span``)
 is exercised here against the archive: seeding writes through
 ``ArchiveStore`` / ``SessionBuilder``, insight rows are seeded into the native
 ``index.db`` tables, and marks/annotations/recall-packs/workspaces are driven
@@ -11,16 +11,16 @@ Archive target ids are the deterministic public ids:
   * session  -> archive session id (``origin:provider_session_id``)
   * message  -> ``session_id:provider_message_id``
   * thread   -> native thread_id (the root session id for a single-session thread)
-  * content_block -> ``message_id:block_index``
+  * block -> ``message_id:block_index``
 
 All insight kinds are now writable as marks/annotations directly:
-  * ``content_block`` — the resolver emits ``content_block`` and the native
-    write path maps it to the CHECK-admitted ``block`` storage token.
+  * ``block`` — the resolver emits ``block`` and assertions persist the same
+    public target vocabulary.
   * ``work_event`` — the resolver probes the native ``session_work_events``
     generated ``event_id`` column (``session_id || ':work_event:' ||
     position``).
-The recall-pack / workspace resolution path (which does not write into the
-CHECK-constrained tables) resolves ``content_block`` correctly and is asserted.
+The recall-pack / workspace resolution path resolves ``block`` correctly and is
+asserted.
 """
 
 from __future__ import annotations
@@ -33,10 +33,14 @@ import pytest
 
 from polylogue.api import Polylogue
 from polylogue.core.user_state_targets import (
+    MARK_TYPE_NAMES,
     TARGET_KIND_NAMES,
     identity_key,
+    is_mark_type_supported,
     is_supported,
+    validate_mark_type,
 )
+from polylogue.storage.sqlite.archive_tiers.user import USER_DDL
 from tests.infra.storage_records import SessionBuilder, db_setup
 
 
@@ -72,7 +76,7 @@ def test_target_kinds_registry_admits_documented_kinds() -> None:
         "message",
         "work_event",
         "thread",
-        "content_block",
+        "block",
         "attachment",
         "paste_span",
     }
@@ -82,11 +86,24 @@ def test_target_kinds_registry_admits_documented_kinds() -> None:
     assert not is_supported("topology_edge")
 
 
+def test_mark_type_registry_is_the_public_validation_source() -> None:
+    assert MARK_TYPE_NAMES == ("star", "pin", "archive")
+    assert is_mark_type_supported("star")
+    assert validate_mark_type("pin") == "pin"
+    with pytest.raises(ValueError, match="mark_type must be one of"):
+        validate_mark_type("bogus")
+
+
+def test_user_tier_assertions_store_public_target_refs() -> None:
+    assert "CREATE TABLE IF NOT EXISTS assertions" in USER_DDL
+    assert "target_ref          TEXT NOT NULL" in USER_DDL
+
+
 def test_identity_key_renders_distinct_keys_per_kind() -> None:
     assert identity_key("session", session_id="conv", target_id="conv") == "session:conv"
     assert identity_key("work_event", session_id="conv", target_id="evt-1") == "work_event:conv:evt-1"
     assert identity_key("thread", session_id="conv", target_id="thr-1") == "thread:thr-1"
-    assert identity_key("content_block", session_id="conv", target_id="msg-1:0") == "content_block:conv:msg-1:0"
+    assert identity_key("block", session_id="conv", target_id="msg-1:0") == "block:conv:msg-1:0"
 
 
 # ---------------------------------------------------------------------------
@@ -248,7 +265,7 @@ async def test_recall_pack_resolves_insight_targets_and_degrades_explicitly(
             "items": [
                 {"target_type": "session", "session_id": session_id},
                 {"target_type": "thread", "session_id": session_id, "target_id": thread_id},
-                {"target_type": "content_block", "session_id": session_id, "target_id": f"{message_id}:0"},
+                {"target_type": "block", "session_id": session_id, "target_id": f"{message_id}:0"},
                 {"target_type": "session", "session_id": "missing-conv"},
                 {"target_type": "topology_edge", "target_id": "edge-1"},
             ],
@@ -265,7 +282,7 @@ async def test_recall_pack_resolves_insight_targets_and_degrades_explicitly(
     statuses = {(item["target_type"], item["target_id"]): item["status"] for item in payload["items"]}
     assert statuses[("session", session_id)] == "resolved"
     assert statuses[("thread", thread_id)] == "resolved"
-    assert statuses[("content_block", f"{message_id}:0")] == "resolved"
+    assert statuses[("block", f"{message_id}:0")] == "resolved"
     assert statuses[("session", "missing-conv")] == "missing"
     assert statuses[("topology_edge", "edge-1")] == "unsupported"
 
@@ -276,7 +293,7 @@ async def test_recall_pack_resolves_insight_targets_and_degrades_explicitly(
     }
     assert identity_keys[("session", session_id)] == f"session:{session_id}"
     assert identity_keys[("thread", thread_id)] == f"thread:{thread_id}"
-    assert identity_keys[("content_block", f"{message_id}:0")] == f"content_block:{session_id}:{message_id}:0"
+    assert identity_keys[("block", f"{message_id}:0")] == f"block:{session_id}:{message_id}:0"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_read_surface_coherence.py
+++ b/tests/unit/test_read_surface_coherence.py
@@ -13,7 +13,7 @@ accidental reversions are caught immediately. Coverage map:
           layer and surfaces EmbeddingRetrievalNotReadyError as HTTP 409.
   AC#6 — retrieval_lane: unknown values ("bogus", dead "semantic") are rejected.
   Footgun — negative min_messages/max_messages/min_words rejected by spec builder.
-  Footgun — since_session alias removed; only since_session_id remains.
+  Cursor — since_session_id is the query pagination cursor.
 """
 
 from __future__ import annotations
@@ -355,26 +355,12 @@ class TestNegativeCountBoundsRejected:
 
 
 # ---------------------------------------------------------------------------
-# Footgun — since_session collapsed to single since_session_id field
+# Query pagination cursor — since_session_id field
 # ---------------------------------------------------------------------------
 
 
-class TestSinceSessionCollapsed:
-    """The redundant ``since_session`` alias is removed (#1749 footgun).
-
-    ``since_session`` and ``since_session_id`` were two names for the same
-    field in MCPSessionQueryRequest. The former is removed; callers
-    must use ``since_session_id``.
-    """
-
-    def test_since_session_field_removed_from_mcp_request(self) -> None:
-        """MCPSessionQueryRequest no longer has a since_session field."""
-        from dataclasses import fields
-
-        from polylogue.mcp.query_contracts import MCPSessionQueryRequest
-
-        field_names = {f.name for f in fields(MCPSessionQueryRequest)}
-        assert "since_session" not in field_names, "since_session was removed in #1749; use since_session_id"
+class TestSinceSessionId:
+    """The MCP request and query spec expose the pagination cursor field."""
 
     def test_since_session_id_still_present(self) -> None:
         from dataclasses import fields
@@ -383,13 +369,6 @@ class TestSinceSessionCollapsed:
 
         field_names = {f.name for f in fields(MCPSessionQueryRequest)}
         assert "since_session_id" in field_names
-
-    def test_since_session_removed_from_spec_builder_recognized_params(self) -> None:
-        """since_session is no longer a recognized param in strict mode."""
-        from polylogue.archive.query.spec import QuerySpecError, SessionQuerySpec
-
-        with pytest.raises(QuerySpecError):
-            SessionQuerySpec.from_params({"since_session": "conv-123"}, strict=True)
 
     def test_since_session_id_still_accepted(self) -> None:
         from polylogue.archive.query.spec import SessionQuerySpec


### PR DESCRIPTION
## Summary

Moves the remaining user-state overlay mini-systems onto the `assertions` substrate and tightens cross-surface query/read parity while removing fake absence-only tests. The old dedicated user-tier tables for marks, annotations, corrections, suppressions, saved views, recall packs, workspaces, and blackboard notes are removed from canonical user DDL; archive/API/CLI/MCP/daemon/devtools paths now read and write assertion-backed envelopes directly.

Ref #1883
Ref #1825
Ref #1849

## Problem

Polylogue had the assertion substrate, but several user overlay features still behaved as parallel table-specific systems with mirrored assertion rows. That preserved duplicated lifecycle logic and made future memory/user-state work ambiguous. Separately, query/read surfaces had small parity gaps (`max_words`, `similar_session_id`, stale `since_session` vocabulary), and tests included some absence-only assertions that only proved an old implementation detail stayed deleted.

The verifier also had an operational bug: a pytest/testmon subprocess could run for a long time without a hard runtime or no-output budget, which made hangs expensive to discover and could leave child processes around after manual interruption.

## Solution

- Store marks, annotations, corrections, suppressions, saved views, recall packs, workspaces, and blackboard notes directly as `assertions` in `user.db`.
- Remove the old overlay tables from `ArchiveTier.USER` DDL and bump the user tier schema version.
- Update archive store methods, async user-state APIs, blackboard CLI, daemon user-state routes, MCP mutation tools, and devtools daemon workload probe to use assertion-backed reads/writes.
- Keep `session_tags` and `session_metadata` as table-backed user state for now; those are not converted in this PR.
- Rename the public user-state target kind from `content_block` to `block` and centralize target/mark constants in `polylogue.core.user_state_targets`.
- Wire `max_words` and `similar_session_id` across MCP/Python/daemon query surfaces and drop stale `since_session` naming from the MCP field registry.
- Remove duplicate workspace route handlers and route recovery runtime execution through the real archive read path.
- Remove tests that only asserted an old filename/name/path stayed absent, while keeping behavioral coverage for the surviving public contracts.
- Harden `devtools verify` so pytest runs in its own process group, stdout/stderr are drained incrementally, and runtime/no-output budgets terminate the whole pytest process group with a clear failure message.

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_verify.py -k 'heartbeat or runtime_budget or output_stall or timeout_env or structured_pytest_report or terminal_fallback'`
  - `6 passed, 34 deselected`
- `nix develop --command devtools test tests/unit/mcp/test_query_tool_schema_derivation.py tests/unit/mcp/test_tool_contracts.py tests/unit/api/test_facade_contracts.py tests/unit/storage/test_archive_tiers_assertion_write_through.py tests/unit/storage/test_archive_tiers_assertions.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/storage/test_archive_tiers_user_overlay.py tests/unit/storage/test_marks_identity_preserving.py tests/unit/storage/test_user_state_contracts.py tests/unit/storage/test_user_state_target_kinds.py tests/unit/cli/test_blackboard.py tests/unit/cli/test_reset.py tests/unit/daemon/test_daemon_http_security.py tests/unit/daemon/test_web_reader.py tests/unit/daemon/test_web_shell_endpoint_contracts.py tests/unit/devtools/test_daemon_workload_probe.py tests/unit/insights/test_feedback.py tests/unit/test_read_surface_coherence.py tests/unit/cli/test_archive_query.py tests/unit/core/test_public_surface_origin_vocabulary.py tests/unit/architecture/test_static_rendering_prune.py -k 'query_tool_schema or tool_contract or archive_tiers_api or user_state or marks or annotations or assertion or archive_tiers_database_split or blackboard or reset or daemon_workload or corrections_ddl or route or security or web_shell or query_spec or SinceSessionId or resolve_origin or resolve_excluded or archive_query_origin_resolution or read_export_html_template'`
  - `571 passed, 423 deselected`
- `nix develop --command devtools verify --quick`
  - ruff format/check, mypy, render-all, topology, layering, closure matrix, schema roundtrip, manifests, CI workflow, doc command, lane assertion, test-infra, clock-hygiene, and public-surface-audit checks all passed.
- Pre-push hook reran `devtools verify --quick` at `24acbbcf` and passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable pytest subprocess timeouts via environment variables for extended diagnostic test runs
  * New query parameters: `max_words` for filtering by word count and `similar_session_id` for session similarity filtering

* **Bug Fixes**
  * Improved subprocess heartbeat detection and stall timeout handling for better test execution reliability

* **Refactor**
  * Consolidated user-state storage schema to unified table structure for improved performance and maintainability
  * Updated query and archive APIs to use standardized constants and validation helpers

* **Documentation**
  * Enhanced developer documentation on pytest subprocess management and timeout configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->