### PR TITLE
feat(query): expose structured query lowering plans

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -397,13 +397,17 @@ class QueryExpressionExplanation:
     execution_legs: tuple[str, ...] = ()
     unsupported_nodes: tuple[str, ...] = ()
     predicate: QueryPredicate | None = None
+    ast: dict[str, object] | None = None
+    lowering_plan: dict[str, object] | None = None
 
     def to_payload(self) -> dict[str, object]:
         return {
             "source_text": self.source_text,
             "clauses": [clause.to_payload() for clause in self.clauses],
             "predicate": self.predicate.to_payload() if self.predicate is not None else None,
+            "ast": self.ast,
             "lowerer": self.lowerer,
+            "lowering_plan": self.lowering_plan,
             "selected_units": list(self.selected_units),
             "execution_legs": list(self.execution_legs),
             "plan_description": list(self.plan_description),
@@ -1424,50 +1428,133 @@ def _explain_unit_source_execution_legs(source: QueryUnitSource) -> tuple[str, .
     return tuple(sorted(legs))
 
 
+def _ast_payload(
+    *,
+    entry: str,
+    clauses: tuple[QueryExpressionExplainClause, ...] = (),
+    predicate: QueryPredicate | None = None,
+    unit_source: QueryUnitSource | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {"entry": entry}
+    if clauses:
+        payload["clauses"] = [clause.to_payload() for clause in clauses]
+    if predicate is not None:
+        payload["predicate"] = predicate.to_payload()
+    if unit_source is not None:
+        payload["unit_source"] = {
+            "unit": unit_source.unit,
+            "predicate": unit_source.predicate.to_payload(),
+        }
+    return payload
+
+
+def _lowering_plan_payload(
+    *,
+    lowerer: str,
+    selected_units: tuple[str, ...],
+    execution_legs: tuple[str, ...],
+    plan_description: tuple[str, ...],
+    compatibility_selector: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "lowerer": lowerer,
+        "selected_units": list(selected_units),
+        "execution_legs": list(execution_legs),
+        "plan_description": list(plan_description),
+    }
+    if compatibility_selector is not None:
+        payload["compatibility_selector"] = compatibility_selector
+    return payload
+
+
 def explain_expression(expression: str) -> QueryExpressionExplanation:
     """Explain parser output, lowering path, and execution-plan descriptions."""
     source_text = expression
     stripped = expression.strip()
+    clauses: tuple[QueryExpressionExplainClause, ...]
+    selected_units: tuple[str, ...]
+    execution_legs: tuple[str, ...]
+    plan_description: tuple[str, ...]
     if stripped.startswith("{") or stripped.startswith("["):
         lowered = _compile_json_spec(stripped)
+        clauses = (_explain_clause(_JsonToken(raw=stripped)),)
+        selected_units = ("session",)
+        execution_legs = _explain_execution_legs(lowered)
+        plan_description = tuple(lowered.to_plan().describe())
+        lowerer = "json-spec"
         return QueryExpressionExplanation(
             source_text=source_text,
-            clauses=(_explain_clause(_JsonToken(raw=stripped)),),
-            lowerer="json-spec",
+            clauses=clauses,
+            lowerer=lowerer,
             lowered_spec=lowered,
-            selected_units=("session",),
-            execution_legs=_explain_execution_legs(lowered),
-            plan_description=tuple(lowered.to_plan().describe()),
+            selected_units=selected_units,
+            execution_legs=execution_legs,
+            plan_description=plan_description,
+            ast=_ast_payload(entry="json", clauses=clauses),
+            lowering_plan=_lowering_plan_payload(
+                lowerer=lowerer,
+                selected_units=selected_units,
+                execution_legs=execution_legs,
+                plan_description=plan_description,
+            ),
         )
     unit_source = parse_unit_source_expression(stripped)
     if unit_source is not None:
         lowered = SessionQuerySpec(
             boolean_predicate=QueryExistsPredicate(unit=unit_source.unit, child=unit_source.predicate)
         )
+        selected_units = (unit_source.unit,)
+        execution_legs = _explain_unit_source_execution_legs(unit_source)
+        plan_description = (
+            f"terminal unit source: {unit_source.unit}",
+            f"compatibility session selector: exists {unit_source.unit}(...)",
+        )
+        lowerer = "lark-query-unit-source-to-terminal-unit"
         return QueryExpressionExplanation(
             source_text=source_text,
             clauses=(),
             predicate=unit_source.predicate,
-            lowerer="lark-query-unit-source-to-terminal-unit",
+            lowerer=lowerer,
             lowered_spec=lowered,
-            selected_units=(unit_source.unit,),
-            execution_legs=_explain_unit_source_execution_legs(unit_source),
-            plan_description=(
-                f"terminal unit source: {unit_source.unit}",
-                f"compatibility session selector: exists {unit_source.unit}(...)",
+            selected_units=selected_units,
+            execution_legs=execution_legs,
+            plan_description=plan_description,
+            ast=_ast_payload(entry="unit_source", predicate=unit_source.predicate, unit_source=unit_source),
+            lowering_plan=_lowering_plan_payload(
+                lowerer=lowerer,
+                selected_units=selected_units,
+                execution_legs=execution_legs,
+                plan_description=plan_description,
+                compatibility_selector=f"exists {unit_source.unit}(...)",
             ),
         )
     ast = parse_expression_ast(stripped)
     lowered = compile_expression(stripped)
+    clauses = tuple(_explain_clause(clause) for clause in ast.clauses)
+    selected_units = _explain_selected_units(ast)
+    execution_legs = _explain_execution_legs(lowered)
+    plan_description = tuple(lowered.to_plan().describe())
+    lowerer = "lark-query-expression-to-session-query-spec"
     return QueryExpressionExplanation(
         source_text=source_text,
-        clauses=tuple(_explain_clause(clause) for clause in ast.clauses),
+        clauses=clauses,
         predicate=ast.boolean_predicate,
-        lowerer="lark-query-expression-to-session-query-spec",
+        lowerer=lowerer,
         lowered_spec=lowered,
-        selected_units=_explain_selected_units(ast),
-        execution_legs=_explain_execution_legs(lowered),
-        plan_description=tuple(lowered.to_plan().describe()),
+        selected_units=selected_units,
+        execution_legs=execution_legs,
+        plan_description=plan_description,
+        ast=_ast_payload(
+            entry="boolean" if ast.boolean_predicate is not None else "compact",
+            clauses=clauses,
+            predicate=ast.boolean_predicate,
+        ),
+        lowering_plan=_lowering_plan_payload(
+            lowerer=lowerer,
+            selected_units=selected_units,
+            execution_legs=execution_legs,
+            plan_description=plan_description,
+        ),
     )
 
 

--- a/polylogue/cli/commands/query_explain.py
+++ b/polylogue/cli/commands/query_explain.py
@@ -77,6 +77,7 @@ def query_explain_command(expression: tuple[str, ...], output_format: str) -> No
     selected_units = cast(list[str], payload["selected_units"])
     execution_legs = cast(list[str], payload["execution_legs"])
     plan_description = cast(list[str], payload["plan_description"])
+    lowering_plan = cast(dict[str, object] | None, payload["lowering_plan"])
     unsupported_nodes = cast(list[str], payload["unsupported_nodes"])
     if selected_units:
         click.echo("units: " + ", ".join(selected_units))
@@ -89,6 +90,9 @@ def query_explain_command(expression: tuple[str, ...], output_format: str) -> No
         click.echo("clauses:")
         for clause in clauses:
             click.echo(f"  - {json.dumps(clause, sort_keys=True)}")
+    if lowering_plan is not None:
+        click.echo("lowering plan:")
+        click.echo(json.dumps(lowering_plan, indent=2, sort_keys=True))
     if plan_description:
         click.echo("plan:")
         for line in plan_description:

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -229,6 +229,9 @@ def test_query_explain_json_outputs_ast_payload(cli_runner: CliRunner) -> None:
     assert payload["source_text"] == "sessions where repo:polylogue OR origin:chatgpt-export"
     assert payload["lowerer"] == "lark-query-expression-to-session-query-spec"
     assert payload["predicate"]["kind"] == "or"
+    assert payload["ast"]["entry"] == "boolean"
+    assert payload["ast"]["predicate"]["kind"] == "or"
+    assert payload["lowering_plan"]["lowerer"] == "lark-query-expression-to-session-query-spec"
     assert payload["selected_units"] == ["session"]
     assert payload["execution_legs"] == ["sql"]
     assert payload["unsupported_nodes"] == []
@@ -249,6 +252,9 @@ def test_query_explain_json_outputs_terminal_unit_payload(cli_runner: CliRunner)
         "terminal unit source: message",
         "compatibility session selector: exists message(...)",
     ]
+    assert payload["ast"]["entry"] == "unit_source"
+    assert payload["ast"]["unit_source"]["unit"] == "message"
+    assert payload["lowering_plan"]["compatibility_selector"] == "exists message(...)"
     assert payload["predicate"]["kind"] == "and"
 
 
@@ -261,6 +267,7 @@ def test_query_explain_plain_outputs_plan(cli_runner: CliRunner) -> None:
     assert "units: session" in result.output
     assert "execution legs: fts, sql" in result.output
     assert "clauses:" in result.output
+    assert "lowering plan:" in result.output
     assert "plan:" in result.output
 
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -204,6 +204,26 @@ class TestExplainExpression:
         payload = explanation.to_payload()
         assert payload["selected_units"] == ["block", "lineage", "session"]
         assert payload["execution_legs"] == ["exists-block", "lineage-recursive-cte", "sql"]
+        assert payload["ast"] == {
+            "entry": "boolean",
+            "predicate": {
+                "children": [
+                    {
+                        "child": {"field": "type", "kind": "field", "op": "=", "values": ["code"]},
+                        "kind": "exists",
+                        "unit": "block",
+                    },
+                    {"kind": "lineage", "seed_session_id": "root", "unit": "session"},
+                ],
+                "kind": "and",
+            },
+        }
+        assert payload["lowering_plan"] == {
+            "lowerer": "lark-query-expression-to-session-query-spec",
+            "selected_units": ["block", "lineage", "session"],
+            "execution_legs": ["exists-block", "lineage-recursive-cte", "sql"],
+            "plan_description": explanation.to_payload()["plan_description"],
+        }
 
     def test_explain_expression_reports_readable_count_range_clause(self) -> None:
         explanation = explain_expression("messages between 5 and 20")
@@ -235,6 +255,37 @@ class TestExplainExpression:
             "terminal unit source: message",
             "compatibility session selector: exists message(...)",
         )
+        payload = explanation.to_payload()
+        assert payload["ast"] == {
+            "entry": "unit_source",
+            "predicate": {
+                "children": [
+                    {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+                    {"field": "text", "kind": "field", "op": "=", "values": ["timeout"]},
+                ],
+                "kind": "and",
+            },
+            "unit_source": {
+                "unit": "message",
+                "predicate": {
+                    "children": [
+                        {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+                        {"field": "text", "kind": "field", "op": "=", "values": ["timeout"]},
+                    ],
+                    "kind": "and",
+                },
+            },
+        }
+        assert payload["lowering_plan"] == {
+            "lowerer": "lark-query-unit-source-to-terminal-unit",
+            "selected_units": ["message"],
+            "execution_legs": ["sql", "terminal-message-rows"],
+            "plan_description": [
+                "terminal unit source: message",
+                "compatibility session selector: exists message(...)",
+            ],
+            "compatibility_selector": "exists message(...)",
+        }
         assert explanation.predicate == QueryBoolPredicate(
             op="and",
             children=(


### PR DESCRIPTION
## Summary

Adds first-class structured `ast` and `lowering_plan` objects to the query DSL explain payload. This makes the current Lark-backed parser/lowerer explain surface more useful to CLI JSON, Python API, daemon/API consumers, MCP/web query builders, and future debugging without adding parser-only vocabulary.

Ref #2006

## Problem

#2006 requires parsed queries to be explainable in machine-readable form: original source, parsed AST, selected units, lowering plan, execution legs, and unsupported/degraded nodes. The existing explain payload exposed clauses, predicate, selected units, execution legs, and plan prose, but the AST/lowering-plan concepts were only implicit across several fields.

## Solution

- Extend `QueryExpressionExplanation` with explicit `ast` and `lowering_plan` payloads.
- Populate those payloads for JSON specs, compact/Boolean session expressions, and terminal unit-source expressions such as `messages where ...`.
- Preserve existing payload keys for compatibility while adding the structured objects.
- Include the same lowering-plan object in plain `polylogue query-explain` output so human and machine explain paths carry the same information.
- Add focused tests for expression payloads and CLI JSON/plain output.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py -k 'explain_expression or query_explain'`
  - `10 passed, 294 deselected`
- `nix develop --command devtools verify --quick`
  - ruff format/check, mypy, render-all, topology, layering, closure matrix, schema roundtrip, manifests, CI workflow, doc command, lane assertion, test-infra, clock-hygiene, and public-surface-audit checks all passed.
- Pre-push hook reran `devtools verify --quick` at `955c321e` and passed.
