### PR TITLE
chore(release): structure release gate status

### DIFF
--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -66,6 +67,38 @@ REQUIRED_RELEASE_BODY_FIELDS: tuple[str, ...] = (
     "- Known caveats scoped out:",
 )
 
+STATUS_SATISFIED_HEADING = "Satisfied:"
+STATUS_BLOCKING_HEADING = "Still blocking external release claims:"
+RETIRED_ISSUE_REFS = ("#1839",)
+_STATUS_CAVEAT_RE = re.compile(
+    r"\b(do not advertise|scoped out|unless|if the release claims|if claimed|caveat)\b", re.I
+)
+_ISSUE_REF_RE = re.compile(r"#\d+")
+
+
+def _status_list(text: str, *, heading: str) -> list[str]:
+    """Extract top-level bullet lines under a release-status heading."""
+
+    if heading not in text:
+        return []
+    after_heading = text.split(heading, 1)[1]
+    bullets: list[str] = []
+    for line in after_heading.splitlines():
+        if line.startswith("## ") or (line in {STATUS_SATISFIED_HEADING, STATUS_BLOCKING_HEADING} and line != heading):
+            break
+        if line.startswith("- "):
+            bullets.append(line[2:].strip())
+        elif bullets and line.startswith("  "):
+            bullets[-1] = f"{bullets[-1]} {line.strip()}"
+    return bullets
+
+
+def _issue_refs(lines: list[str]) -> set[str]:
+    refs: set[str] = set()
+    for line in lines:
+        refs.update(_ISSUE_REF_RE.findall(line))
+    return refs
+
 
 def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
     """Return a JSON-serializable release-gate definition report."""
@@ -73,6 +106,8 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
 
     errors: list[str] = []
     text = gate_doc.read_text(encoding="utf-8") if gate_doc.exists() else ""
+    satisfied = _status_list(text, heading=STATUS_SATISFIED_HEADING)
+    blocking = _status_list(text, heading=STATUS_BLOCKING_HEADING)
     if not text:
         errors.append(f"missing gate document: {gate_doc}")
 
@@ -90,10 +125,22 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
         if command.argv[0] == "devtools" and command.argv[1] not in COMMANDS:
             errors.append(f"unknown devtools command in release gate: {command_text}")
 
-    if "Satisfied:" not in text:
+    if STATUS_SATISFIED_HEADING not in text:
         errors.append("gate document missing satisfied release-status list")
-    if "Still blocking external release claims:" not in text:
+    if STATUS_BLOCKING_HEADING not in text:
         errors.append("gate document missing blocking release-status list")
+    for retired_ref in RETIRED_ISSUE_REFS:
+        if retired_ref in text:
+            errors.append(f"release gate references retired issue: {retired_ref}")
+
+    satisfied_refs = _issue_refs(satisfied)
+    for line in blocking:
+        overlapping_refs = sorted(satisfied_refs.intersection(_ISSUE_REF_RE.findall(line)))
+        if overlapping_refs and _STATUS_CAVEAT_RE.search(line) is None:
+            errors.append(
+                "blocking release-status line also cites satisfied issue(s) "
+                f"{', '.join(overlapping_refs)} without scoped-out/caveat wording"
+            )
 
     return {
         "ok": not errors,
@@ -101,6 +148,10 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
         "required_commands": [command.to_dict() for command in REQUIRED_COMMANDS],
         "focused_commands": [command.to_dict() for command in FOCUSED_COMMANDS],
         "required_release_body_fields": list(REQUIRED_RELEASE_BODY_FIELDS),
+        "release_status": {
+            "satisfied": satisfied,
+            "blocking_external_claims": blocking,
+        },
         "errors": errors,
     }
 
@@ -115,6 +166,9 @@ def _print_human(report: dict[str, Any]) -> None:
     print("focused commands:")
     for command in report["focused_commands"]:
         print(f"  {' '.join(command['argv'])}  # {command['reason']}")
+    print("release status:")
+    print(f"  satisfied: {len(report['release_status']['satisfied'])}")
+    print(f"  blocking external claims: {len(report['release_status']['blocking_external_claims'])}")
     if report["errors"]:
         print("errors:")
         for error in report["errors"]:

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -54,8 +54,8 @@ nix flake check
 | Machine output | JSON is finite, NDJSON is streaming, mutation/error envelopes are typed, and machine-output prompts do not block. | #1818, #1816 |
 | README commands | README examples resolve against live commands and do not cite stale APIs. | #1841 |
 | Import/demo | Public import vocabulary is stable and demo mode has deterministic private-data-free fixtures. | #1815, #1843 |
-| Recovery/digest | Agent-session recovery views are available only to the extent claimed by README/release notes. | #1880 |
-| Assertion/user state | User-tier note/assertion data is preserved and reset/delete flows are guarded. | #1883, #1839 |
+| Recovery/digest | Agent-session recovery views are available only to the extent claimed by README/release notes. | #1880, #1838 |
+| Assertion/user state | User-tier assertion data is preserved and reset/delete flows are guarded. | #1883 |
 | Public vocabulary | Public surfaces use session/origin vocabulary; provider/conversation terms are raw-source or historical only. | #1810 |
 | Web/API | Any advertised web/API surface has stable DTOs, auth posture, and route vocabulary. | #1847, #1846 |
 | Static/docs surface | Generated docs, pages, media, and topology status are current. | #1848, #1849 |
@@ -88,22 +88,27 @@ Satisfied:
   `verify-doc-commands`.
 - #1878 benchmark convergence flake is closed.
 - #1880 has recovery digest registry, extraction, CLI read view, Python API
-  facade, and GitHub/check event extraction slices.
+  facade, GitHub/check event extraction slices, and source-aligned query DSL
+  documentation for currently shipped recovery/query behavior.
 - #1883 has the assertions table, write-through adapters, delete/status
   transitions, reset user.db guard, and blackboard assertion metadata slices.
 - #1843 has deterministic demo corpus specs and the `polylogue import --demo`
-  scheduling surface.
+  scheduling surface plus fixture-world convergence coverage.
+- #1848 static/rendering redundancy pruning is closed.
 
 Still blocking external release claims:
 
-- #1843 still needs end-to-end demo archive convergence evidence and
-  README-ready commands against the generated demo archive.
 - #1847/#1846 web/API release scope is not settled.
-- #1848/#1849 static/docs/proof pruning is not fully settled; do not advertise
-  any confidence layer that is not generated from live code, fixtures, or
-  schemas.
-- #1880 persisted transform outputs and `continue`/`blame` report presets are
-  not landed; do not advertise them as shipped.
+- #1849 public docs/proof vocabulary is not fully settled; do not advertise any
+  confidence layer that is not generated from live code, fixtures, schemas, or
+  benchmark artifacts.
+- #2006 advanced query language claims are scoped to shipped Lark grammar,
+  lowerers, typed errors, docs, and fixture coverage; do not advertise future
+  pipeline/run/event/assertion query units until they land.
+- #1825 MCP/Python parity must be proven for any command/read/query/mutation
+  behavior advertised as cross-surface.
+- #1838 work-packet/bundle release claims are scoped out unless on-demand
+  evidence-bundle rendering lands with raw-ref/lossiness semantics.
 
 ## Release PR Body Requirements
 

--- a/tests/unit/devtools/test_release_readiness.py
+++ b/tests/unit/devtools/test_release_readiness.py
@@ -27,7 +27,11 @@ def _valid_gate_text() -> str:
 
 Satisfied:
 
+- #1 landed.
+
 Still blocking external release claims:
+
+- #2 blocks a release claim.
 
 ```text
 {fields}
@@ -43,6 +47,8 @@ def test_release_readiness_report_validates_committed_gate() -> None:
     assert ["devtools", "verify", "--quick"] in [command["argv"] for command in report["required_commands"]]
     assert ["devtools", "build-package"] in [command["argv"] for command in report["required_commands"]]
     assert "- Known caveats scoped out:" in report["required_release_body_fields"]
+    assert report["release_status"]["satisfied"]
+    assert report["release_status"]["blocking_external_claims"]
     assert report["errors"] == []
 
 
@@ -52,6 +58,7 @@ def test_release_readiness_json_cli(capsys: pytest.CaptureFixture[str]) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["required_commands"][0]["argv"] == ["devtools", "release-readiness"]
+    assert "release_status" in payload
 
 
 def test_release_readiness_rejects_missing_required_command(tmp_path: Path) -> None:
@@ -72,3 +79,41 @@ def test_release_readiness_rejects_missing_status_lists(tmp_path: Path) -> None:
 
     assert report["ok"] is False
     assert any("blocking release-status list" in error for error in report["errors"])
+
+
+def test_release_readiness_rejects_retired_issue_refs(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(gate_doc, _valid_gate_text().replace("#1 landed.", "#1839 was folded elsewhere."))
+
+    report = release_readiness.build_report(gate_doc=gate_doc)
+
+    assert report["ok"] is False
+    assert "release gate references retired issue: #1839" in report["errors"]
+
+
+def test_release_readiness_rejects_satisfied_issue_as_blocker_without_caveat(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(
+        gate_doc,
+        _valid_gate_text().replace("#2 blocks a release claim.", "#1 still blocks the release."),
+    )
+
+    report = release_readiness.build_report(gate_doc=gate_doc)
+
+    assert report["ok"] is False
+    assert any("also cites satisfied issue(s) #1" in error for error in report["errors"])
+
+
+def test_release_readiness_allows_satisfied_issue_in_scoped_caveat(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(
+        gate_doc,
+        _valid_gate_text().replace(
+            "#2 blocks a release claim.",
+            "#1 is scoped out: do not advertise the unshipped extension.",
+        ),
+    )
+
+    report = release_readiness.build_report(gate_doc=gate_doc)
+
+    assert report["ok"] is True


### PR DESCRIPTION
## Summary

Structures the release-readiness gate around explicit satisfied/blocking issue lists and refreshes the gate document so it reflects current tracker reality.

## Problem

The release gate had drifted into prose: retired #1839 was still referenced, already-landed #1843/#1848 work was still mixed into blocker language, and `devtools release-readiness` could not distinguish satisfied work from live external-release blockers.

## Solution

`devtools release-readiness` now parses the committed gate's `Satisfied:` and `Still blocking external release claims:` lists into a structured `release_status` report. The gate rejects retired issue refs and contradictory blocker references to already-satisfied issues unless the line is an explicit release-claim caveat. The release-readiness document was refreshed to keep closed work in the satisfied list and leave only real release-claim blockers in the blocking list.

## Verification

- `devtools test tests/unit/devtools/test_release_readiness.py` -> 7 passed.
- `devtools release-readiness --json` -> `ok: true`.
- `devtools verify --quick` -> exit_code 0.

Closes #1827.
