### PR TITLE
refactor: remove rename-sentinel residue (#1849)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -359,11 +359,11 @@ components:
 
         so the UI can render "disabled because X" / "loading" / "dangerous"
 
-        without conflating them under a single boolean (#1488). ``enabled``
+        without conflating them under a single boolean (#1488). ``enabled`` is the
 
-        is kept as a back-compat alias derived from ``state`` so existing
+        compact actionability bit consumed by current reader clients; ``state`` is
 
-        call sites that only know about enabled/disabled continue to work.'
+        the richer reason category.'
       properties:
         enabled:
           default: true

--- a/docs/plans/query-pipeline-substrate.md
+++ b/docs/plans/query-pipeline-substrate.md
@@ -57,6 +57,5 @@ micro-slices. Each phase should land useful executable queries and tests.
 - Unsupported forms fail with typed errors and do not broaden results.
 - CLI, daemon, MCP, web, and completion can share the same parser and AST.
 - Natural-language query tools target the AST.
-- Query surfaces can keep using compatibility function names such as
-  `compile_expression`, but their bodies delegate to this grammar/AST/lowering
-  path rather than forming a separate legacy compiler.
+- Query surfaces should name and call the grammar/AST/lowering path directly.
+  There is no separate compatibility compiler or floor grammar.

--- a/docs/plans/static-rendering-surface-classification.md
+++ b/docs/plans/static-rendering-surface-classification.md
@@ -8,13 +8,13 @@ breaking required gates.
 | --- | --- | --- | --- |
 | `polylogue/rendering/` | read/export format | Retain | Imported by CLI/API rendering paths; owns Markdown and HTML session output. |
 | `polylogue/rendering/templates/session.html` | read/export format | Retain | HTML session renderer template, not a separate product UI. |
-| `polylogue/templates/` | dead static-site product residue | Deleted | No live imports or package/runtime references were found; `tests/unit/architecture/test_static_rendering_prune.py` pins absence while retaining `polylogue/rendering/templates/session.html`. |
+| `polylogue/templates/` | dead static-site product residue | Deleted | No live imports or package/runtime references were found; the retained HTML session renderer lives under `polylogue/rendering/templates/session.html`. |
 | `polylogue/publication/` | report manifest helper | Retain for lab reports | Used by report writers as an output manifest type. |
 | `devtools/pages_builder.py` | documentation site build | Retain | `devtools render-pages` and site renderer tests exercise it. |
 | `devtools/pages_templates.py` | documentation site build | Retain | Template source for `pages_builder.py`. |
 | `devtools/render_pages.py` | documentation site build | Retain | Registered generated-surface command and covered by renderer tests. |
-| `devtools/generate_readme_media.py` | public docs media generator | Retain and police | Generates README diagrams; stale product labels are blocked by the public-surface audit. |
-| `docs/media/*.mmd` | public docs media source | Retain and police | Mermaid sources are public README assets and must avoid stale product wording. |
+| `devtools/generate_readme_media.py` | public docs media generator | Retain | Generates README diagrams; normal render/docs review owns accuracy. |
+| `docs/media/*.mmd` | public docs media source | Retain | Mermaid sources are public README assets reviewed with the README and generated media. |
 | `docs/media/*.svg` | public docs media output | Retain | Committed render output for environments without `mmdc`. |
 | `polylogue/scenarios/` | fixture/demo and contract substrate | Retain | Used by demo import, validation lanes, benchmarks, and pipeline probes. |
 | `polylogue/showcase/` | verification-lab runner substrate | Retain until #1849 replacement | Required by `devtools lab-scenario`, validation lanes, and command help baselines. |
@@ -27,7 +27,6 @@ Deletion candidates after #1849 or a focused import graph proves disuse:
 - any `polylogue/showcase/*` report/output adapters that are no longer used by
   `devtools lab-scenario`, validation lanes, or command help baselines.
 
-Current rule: public docs and README media describe the web reader,
-read/export output, demos, and verification-lab evidence. Internal devtools,
-baseline, and historical docs may keep older terms only where they name
-existing verification machinery.
+Current rule: public docs and README media describe the current web reader,
+read/export output, demos, and verification-lab evidence directly. Internal
+devtools and historical docs should name the current machinery plainly.

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -106,7 +106,7 @@
     },
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-list-row.schema.json
+++ b/docs/schemas/cli-output/session-list-row.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-message-row.schema.json
+++ b/docs/schemas/cli-output/session-message-row.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-messages-response.schema.json
+++ b/docs/schemas/cli-output/session-messages-response.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-neighbor-candidate.schema.json
+++ b/docs/schemas/cli-output/session-neighbor-candidate.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-search-hit.schema.json
+++ b/docs/schemas/cli-output/session-search-hit.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/docs/schemas/cli-output/session-summary.schema.json
+++ b/docs/schemas/cli-output/session-summary.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "ReaderActionAvailabilityPayload": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled``\nis kept as a back-compat alias derived from ``state`` so existing\ncall sites that only know about enabled/disabled continue to work.",
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
       "properties": {
         "disabled_reason": {
           "anyOf": [

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -507,15 +507,6 @@ def _user_config_path() -> Path | None:
     return None
 
 
-def _config_file_path() -> Path | None:
-    """Back-compat alias for :func:`_user_config_path`.
-
-    Retained because earlier tests reference it indirectly via the loader's
-    behavior; new callers should pick the explicit user/site helper.
-    """
-    return _user_config_path()
-
-
 def _default_config_values() -> dict[str, object]:
     """Built-in defaults (layer 1).
 

--- a/polylogue/daemon/notifications.py
+++ b/polylogue/daemon/notifications.py
@@ -165,9 +165,8 @@ def _parse_backend_spec(spec: object) -> list[str]:
 def _resolve_backend(backend_name: str, config: dict[str, object] | None = None) -> NotificationBackend:
     """Resolve a single backend name to an instance.
 
-    Accepts a comma-separated string or a single name; if more than one
-    name resolves, returns a :class:`FanOutNotificationBackend`. Kept as a
-    private name for back-compat with existing test imports.
+    Accepts a comma-separated string or a single name; if more than one name
+    resolves, returns a :class:`FanOutNotificationBackend`.
     """
     names = _parse_backend_spec(backend_name)
     if not names:

--- a/polylogue/daemon/web_shell_reader.py
+++ b/polylogue/daemon/web_shell_reader.py
@@ -424,9 +424,8 @@ function renderMessageBlocks(messages) {
     }
     else body = _polyBodyHtml(m);
     // MK3 attachment strip (#1199). Prepended above the body so the
-    // cards stay visible regardless of fold variant. The hook is
-    // optional so legacy harnesses without the attachment slice still
-    // render cleanly.
+    // cards stay visible regardless of fold variant. The hook stays
+    // optional because not every message renderer includes attachments.
     var attachmentStrip = (typeof _polyAttachmentStripHtml === 'function')
       ? _polyAttachmentStripHtml(m) : '';
     if (attachmentStrip) body = attachmentStrip + body;

--- a/polylogue/insights/archive_models.py
+++ b/polylogue/insights/archive_models.py
@@ -17,8 +17,8 @@ ARCHIVE_INSIGHT_CONTRACT_VERSION = 9
 class ArchiveInsightModel(BaseModel):
     """Shared base for public archive insight payloads."""
 
-    # extra="ignore" tolerates legacy fields from older materialized records
-    # (e.g. primary_work_kind, decisions removed in the March 2026 cleanup)
+    # Materialized insight records are sparse across materializer versions;
+    # readers ignore unknown payload keys and consume the typed fields below.
     model_config = ConfigDict(extra="ignore", frozen=True, protected_namespaces=())
 
     def to_json(self, *, exclude_none: bool = False) -> str:

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -218,9 +218,9 @@ class ReaderActionAvailabilityPayload(SurfacePayloadModel):
 
     Reader actions surface seven distinct states (see :data:`ReaderActionState`)
     so the UI can render "disabled because X" / "loading" / "dangerous"
-    without conflating them under a single boolean (#1488). ``enabled``
-    is kept as a back-compat alias derived from ``state`` so existing
-    call sites that only know about enabled/disabled continue to work.
+    without conflating them under a single boolean (#1488). ``enabled`` is the
+    compact actionability bit consumed by current reader clients; ``state`` is
+    the richer reason category.
     """
 
     enabled: bool = True

--- a/tests/infra/frozen_clock.py
+++ b/tests/infra/frozen_clock.py
@@ -196,12 +196,6 @@ def frozen_clock_fixture(request: pytest.FixtureRequest) -> Iterator[FrozenClock
         yield clock
 
 
-@pytest.fixture(name="clock")
-def clock_fixture(frozen_clock: FrozenClock) -> FrozenClock:
-    """Back-compat alias for the original ``clock`` fixture (#1300)."""
-    return frozen_clock
-
-
 def pytest_configure(config: pytest.Config) -> None:
     """Register the ``frozen_clock_modules`` marker.
 
@@ -217,7 +211,6 @@ def pytest_configure(config: pytest.Config) -> None:
 __all__ = [
     "DEFAULT_FROZEN_EPOCH",
     "FrozenClock",
-    "clock_fixture",
     "fixed_now",
     "freeze_clock",
     "frozen_clock_fixture",

--- a/tests/unit/infra/test_frozen_clock.py
+++ b/tests/unit/infra/test_frozen_clock.py
@@ -78,11 +78,6 @@ def test_fixed_now_returns_canonical_anchor() -> None:
     assert fixed_now() == datetime.fromtimestamp(DEFAULT_FROZEN_EPOCH, tz=timezone.utc)
 
 
-def test_clock_alias_returns_same_instance(frozen_clock: FrozenClock, clock: FrozenClock) -> None:
-    """The ``clock`` back-compat fixture aliases ``frozen_clock``."""
-    assert clock is frozen_clock
-
-
 def test_default_step_is_zero_relative_timing_is_stable(frozen_clock: FrozenClock) -> None:
     """Two ``now()`` reads bracket the same instant, so deltas are predictable."""
     anchor = frozen_clock.now()

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -427,8 +427,8 @@ class TestQueryTools:
         parsed = json.loads(result)
         assert parsed["hits"] == []
         assert parsed["total"] == 0
-        # Archive search has no legacy miss-diagnostics path; the envelope still
-        # carries the field, defaulted to null.
+        # Archive search has no miss-diagnostics payload for an empty result;
+        # the envelope carries the field, defaulted to null.
         assert parsed["diagnostics"] is None
 
     @pytest.mark.asyncio

--- a/tests/unit/surfaces/test_message_render_envelope.py
+++ b/tests/unit/surfaces/test_message_render_envelope.py
@@ -192,13 +192,11 @@ def test_from_message_omits_target_ref_when_no_session_id() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Back-compat with the existing test_web_reader contract test
+# Minimal construction contract
 # ---------------------------------------------------------------------------
 
 
-def test_construction_with_only_legacy_fields_still_works() -> None:
-    """The roundtrip pattern from ``test_reader_target_ref_and_action_payloads_roundtrip``
-    in tests/unit/daemon/test_web_reader.py must still construct cleanly."""
+def test_minimal_message_payload_constructs() -> None:
     payload = SessionMessagePayload(
         id="m-c1",
         role="user",

--- a/tests/unit/surfaces/test_reader_action_vocabulary.py
+++ b/tests/unit/surfaces/test_reader_action_vocabulary.py
@@ -1,18 +1,4 @@
-"""Reader action vocabulary contract (#1488).
-
-Pins:
-
-1. ``READER_ACTION_IDS`` is a closed registry the UI can rely on.
-2. ``ReaderActionState`` covers the seven canonical states required
-   by the issue (enabled, disabled, partial, dangerous, loading,
-   target, unavailable).
-3. ``ReaderActionAvailabilityPayload`` accepts every state value and
-   surfaces ``disabled_reason``, ``repair_path``, ``inspect_path``
-   when supplied.
-4. Back-compat: existing callers that construct the payload with
-   only ``enabled=True`` or ``enabled=False`` still work and the
-   default ``state`` is ``"enabled"``.
-"""
+"""Reader action vocabulary contract (#1488)."""
 
 from __future__ import annotations
 
@@ -109,7 +95,7 @@ def test_payload_rejects_unknown_state() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Back-compat contract: existing call sites continue to work
+# Default payload contract
 # ---------------------------------------------------------------------------
 
 
@@ -120,8 +106,7 @@ def test_default_payload_is_enabled_state() -> None:
     assert payload.state == "enabled"
 
 
-def test_enabled_false_back_compat_still_constructs() -> None:
-    """Existing callers that pass only ``enabled=False`` are unbroken."""
+def test_enabled_false_can_carry_disabled_reason() -> None:
     payload = ReaderActionAvailabilityPayload(enabled=False, disabled_reason="paste unknown")
     assert payload.enabled is False
     assert payload.disabled_reason == "paste unknown"


### PR DESCRIPTION
## Summary

Removes leftover rename-sentinel/back-compat framing after the #1849 public-surface audit cleanup. The branch deletes two unused compatibility aliases and rewrites docs/tests/schema descriptions so they describe current contracts directly rather than asserting old names stayed gone.

## Problem

The previous #1849 cleanup removed the public-surface audit machinery, but adjacent docs and tests still carried the same pattern in prose: “pins absence”, “public-surface audit”, “back-compat alias”, and compatibility compiler wording. That invites future agents to preserve stale names or add absence-policing tests instead of treating the codebase shape itself as the authority.

## Solution

- Deleted unused private/test aliases: `polylogue.config._config_file_path()` and the `clock` pytest fixture alias.
- Reframed reader-action payload docs/tests around current `enabled` + `state` behavior instead of back-compat preservation.
- Removed stale public-surface-audit and pinned-absence wording from static-rendering docs.
- Tightened the query-pipeline plan to say surfaces should call the grammar/AST/lowering path directly, with no compatibility compiler.
- Regenerated CLI output schemas and OpenAPI descriptions from the updated payload docstring.

## Verification

- `devtools test tests/unit/surfaces/test_reader_action_vocabulary.py tests/unit/surfaces/test_message_render_envelope.py tests/unit/infra/test_frozen_clock.py tests/unit/daemon/test_notification_backends.py tests/unit/daemon/test_notification_webhook.py`
  - `79 passed`
- `devtools test tests/unit/mcp/test_tool_contracts.py -k search_no_match`
  - `1 passed`
- `devtools verify --quick`
  - `exit_code 0`