### PR TITLE
refactor: remove compatibility alias residue (#1849)

### DIFF
--- a/docs/audits/2026-05-20-cross-surface-coherence-audit.md
+++ b/docs/audits/2026-05-20-cross-surface-coherence-audit.md
@@ -35,8 +35,8 @@ The contract substrate already exists:
   shadow adapters used by mypy contract checks. They are **not** in the
   request path of production CLI / MCP / HTTP code.
 - `polylogue/mcp/payloads.py` — MCP-local envelope variants
-  (`MCPPaginatedQueryResultPayload`, `MCPPaginatedSearchResultPayload`,
-  `MCPErrorPayload`).
+  (`MCPPaginatedQueryResultPayload`, `MCPErrorPayload`) plus direct use of
+  the shared `SearchEnvelope`.
 - `polylogue/mcp/query_contracts.py` — `MCPConversationQueryRequest`,
   the typed input spec that already encodes every filter parameter
   declared one at a time in `mcp/server_tools.py`.
@@ -96,7 +96,7 @@ HTTP paths never call into it. #859 closed without wiring this through.
 
 - Daemon HTTP returns `hits` with nested `match` (reader anchors,
   actions).
-- MCP returns `MCPPaginatedSearchResultPayload`.
+- MCP returns the shared `SearchEnvelope`.
 - CLI rolls its own payload via `_search_hit_to_payload`.
 
 #1266 standardized the ranked envelope but the production CLI/MCP/HTTP

--- a/docs/cli-audit.md
+++ b/docs/cli-audit.md
@@ -255,33 +255,28 @@ confusing. The `polylogue commands` listing already provides discoverability.
 The following clusters are filed as separate GitHub issues so each can land as
 an independent PR.
 
-1. **[#1723](https://github.com/Sinity/polylogue/issues/1723)** — Deprecate `show` and `select` query verbs
+1. **[#1723](https://github.com/Sinity/polylogue/issues/1723)** — Remove `show` and `select` query verbs after their replacements are wired
 2. **[#1724](https://github.com/Sinity/polylogue/issues/1724)** — Align `doctor`/`check` naming; rename `insights tags` to `insights tag-rollups`
 3. **[#1725](https://github.com/Sinity/polylogue/issues/1725)** — Merge `context-pack` into `context`, `resume-candidates` into `resume`, `bulk-export` into `export`
 4. **[#1726](https://github.com/Sinity/polylogue/issues/1726)** — Add section headers to `insights --help` output
-5. **[#1727](https://github.com/Sinity/polylogue/issues/1727)** — Add deprecation-warning alias infrastructure with one-release grace period
+5. Alias infrastructure is intentionally not a CLI-audit deliverable.
 
 ---
 
-## Backward Compatibility Window
+## Replacement Policy
 
-Per acceptance criterion 5 of #1681:
+Renames and command consolidations are clean breaks in this codebase. Wire the
+replacement fully, update docs/examples/completion/snapshots, and remove the
+old spelling in the same change. Do not add deprecation wrappers, warning
+aliases, or one-release grace-period commands.
 
-1. **Deprecation release**: Renamed commands emit a deprecation warning to
-   stderr listing the replacement, then delegate to the new implementation.
-   The old name continues to work.
-2. **Removal release** (next minor): The old alias raises "unknown command"
-   with a rebuild hint.
-3. **Implementation pattern**: A `DeprecatingCommand` wrapper (similar to
-   `_LazyCommand`) that prints the warning on first invocation.
-
-Commands requiring deprecation aliases:
-- `show` → `list`
-- `select` → `list --json | jq`
+Replacement map:
+- `show` → the current read/list surface selected by the owning issue
+- `select` → the current query/list JSON surface selected by the owning issue
 - `context-pack` → `context pack`
 - `resume-candidates` → `resume --candidates`
 - `bulk-export` → `export bulk`
-- `check` (internal) / `doctor` (CLI): pick one, alias the other
+- `check` / `doctor`: choose one public spelling and remove the other
 
 ---
 

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -884,9 +884,8 @@ def _deliver_content(env: AppEnv, content: str, *, destination: str, out_path: s
 @click.option("--dry-run", is_flag=True, help="Preview what would be deleted without deleting")
 @click.option("--yes", "yes_flag", is_flag=True, help="Confirm the deletion (required for actual deletion)")
 @click.option("--all", "all_flag", is_flag=True, help="Delete all matched sessions (required when multiple match)")
-@click.option("--force", is_flag=True, hidden=True, help="(legacy alias for --yes) Skip confirmation prompt")
 @click.pass_context
-def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: bool, force: bool) -> None:
+def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: bool) -> None:
     """Delete matched sessions.
 
     \b
@@ -927,7 +926,7 @@ def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: boo
         raise click.UsageError(str(exc)) from exc
 
     # Delete using the pre-resolved IDs so all matched sessions are removed.
-    execute_delete_by_session_ids(env, session_ids, force=yes_flag or force)
+    execute_delete_by_session_ids(env, session_ids, force=yes_flag)
 
 
 @click.command("mark")

--- a/polylogue/insights/confidence.py
+++ b/polylogue/insights/confidence.py
@@ -111,12 +111,11 @@ def from_score(score: float) -> ConfidenceBand:
     return ConfidenceBand.WEAK
 
 
-def from_legacy(value: str | ConfidenceBand | None) -> ConfidenceBand:
-    """Coerce a legacy string literal into a typed band.
+def confidence_band_from_stored(value: str | ConfidenceBand | None) -> ConfidenceBand:
+    """Coerce a stored string literal into a typed band.
 
-    Accepts the existing wire values verbatim. Unknown strings collapse
-    to ``WEAK`` rather than raising — older stored records and downstream
-    consumers that stored ad-hoc spellings stay readable.
+    Accepts the persisted wire values verbatim. Unknown strings collapse
+    to ``WEAK`` rather than raising so stored records remain readable.
     """
 
     if isinstance(value, ConfidenceBand):
@@ -132,7 +131,7 @@ def from_legacy(value: str | ConfidenceBand | None) -> ConfidenceBand:
 
 __all__ = [
     "ConfidenceBand",
-    "from_legacy",
+    "confidence_band_from_stored",
     "from_score",
     "from_signals",
 ]

--- a/polylogue/maintenance/planner.py
+++ b/polylogue/maintenance/planner.py
@@ -109,6 +109,22 @@ class BackfillKind(str, Enum):
     CONFIG_DRIVEN = "config-driven"
 
 
+_RETIRED_STORED_KIND_MAP: dict[str, BackfillKind] = {
+    "backfill": BackfillKind.DERIVED_REBUILD,
+    "rebuild": BackfillKind.DERIVED_REBUILD,
+    "reindex": BackfillKind.INDEX_REPAIR,
+    "reset": BackfillKind.CONFIG_DRIVEN,
+}
+
+
+def _coerce_backfill_kind(value: object) -> BackfillKind:
+    text = str(value)
+    try:
+        return BackfillKind(text)
+    except ValueError:
+        return _RETIRED_STORED_KIND_MAP.get(text, BackfillKind.DERIVED_REBUILD)
+
+
 class BackfillStatus(str, Enum):
     """Lifecycle status of a backfill operation."""
 
@@ -285,11 +301,7 @@ class BackfillOperation:
         """
 
         op_id = str(payload.get("operation_id", ""))
-        kind_raw = str(payload.get("kind", BackfillKind.DERIVED_REBUILD.value))
-        try:
-            kind = BackfillKind(kind_raw)
-        except ValueError:
-            kind = BackfillKind.DERIVED_REBUILD
+        kind = _coerce_backfill_kind(payload.get("kind", BackfillKind.DERIVED_REBUILD.value))
         status_raw = str(payload.get("status", BackfillStatus.PENDING.value))
         try:
             status = BackfillStatus(status_raw)

--- a/polylogue/maintenance/planner.py
+++ b/polylogue/maintenance/planner.py
@@ -98,9 +98,7 @@ class BackfillKind(str, Enum):
     """What kind of maintenance operation this is.
 
     The values map to the typed-operation taxonomy the rest of the
-    maintenance cluster expects (see #1144). The compatibility aliases
-    (``REBUILD``, ``REINDEX``, ``RESET``, ``BACKFILL``) are retained as
-    compatibility shims for callers that have not moved yet.
+    maintenance cluster expects (see #1144).
     """
 
     # Typed taxonomy (issue #1144).
@@ -109,12 +107,6 @@ class BackfillKind(str, Enum):
     INDEX_REPAIR = "index-repair"
     SEMANTIC_REMATERIALIZE = "semantic-rematerialize"
     CONFIG_DRIVEN = "config-driven"
-
-    # Legacy aliases — kept so existing surfaces keep round-tripping.
-    REBUILD = "rebuild"
-    REINDEX = "reindex"
-    RESET = "reset"
-    BACKFILL = "backfill"
 
 
 class BackfillStatus(str, Enum):

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -216,13 +216,6 @@ class MCPPaginatedQueryResultPayload(SurfacePayloadModel):
     diagnostics: MCPQueryMissDiagnosticsPayload | None = None
 
 
-#: MCP search uses the canonical :class:`~polylogue.surfaces.payloads.SearchEnvelope`
-#: shape (#1266). The compatibility alias is retained so existing call sites keep
-#: working; new code should import :class:`SearchEnvelope` directly from
-#: ``polylogue.surfaces.payloads``.
-MCPPaginatedSearchResultPayload = SearchEnvelope
-
-
 class MCPSessionTreePayload(SurfacePayloadModel):
     """Bounded envelope for ``get_session_tree``.
 
@@ -939,7 +932,6 @@ __all__ = [
     "MutationResultPayload",
     "MCPNeighborCandidatesPayload",
     "MCPPaginatedQueryResultPayload",
-    "MCPPaginatedSearchResultPayload",
     "MCPQueryMissDiagnosticsPayload",
     "MCPQueryMissReasonPayload",
     "MCPRawArtifactPayload",

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -491,17 +491,16 @@ def test_resolve_target_session_id_resolves_latest(monkeypatch: pytest.MonkeyPat
     assert captured_limits == [1]
 
 
-def test_delete_verb_updates_force_and_dry_run_flags() -> None:
+def test_delete_verb_updates_confirmation_and_dry_run_flags() -> None:
     _, child = _context_pair(query_terms=("alpha",))
     wrapped = getattr(query_verbs.delete_verb.callback, "__wrapped__", None)
     assert callable(wrapped)
 
-    # Signature is delete_verb(ctx, dry_run, yes_flag, all_flag, force).
     # Dry-run previews the SAME full pre-resolved id set the real delete acts on
     # via execute_delete_by_session_ids(dry_run=True). It must NOT route through
     # _execute_query_verb, which re-runs the query at the default limit of 20 and
-    # would preview fewer sessions than --yes --all deletes (#1873). force is True
-    # so the preview never triggers the interactive confirmation prompt.
+    # would preview fewer sessions than --yes --all deletes (#1873). The preview
+    # uses force=True internally so it never triggers an interactive prompt.
     with (
         patch(
             "polylogue.cli.verb_cardinality.resolve_session_ids_for_verb",
@@ -510,7 +509,7 @@ def test_delete_verb_updates_force_and_dry_run_flags() -> None:
         patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as execute,
         patch("polylogue.cli.query_verbs._execute_query_verb") as legacy,
     ):
-        wrapped(child, True, False, False, False)
+        wrapped(child, True, False, False)
 
     legacy.assert_not_called()
     resolve.assert_called_once()
@@ -518,3 +517,17 @@ def test_delete_verb_updates_force_and_dry_run_flags() -> None:
     assert list(args[1]) == ["alpha-id"]
     assert kwargs.get("dry_run") is True
     assert kwargs.get("force") is True
+
+    with (
+        patch(
+            "polylogue.cli.verb_cardinality.resolve_session_ids_for_verb",
+            return_value=["alpha-id"],
+        ),
+        patch("polylogue.cli.verb_cardinality.check_cardinality"),
+        patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as execute_confirmed,
+    ):
+        wrapped(child, False, True, False)
+
+    _, confirmed_kwargs = execute_confirmed.call_args
+    assert confirmed_kwargs.get("force") is True
+    assert confirmed_kwargs.get("dry_run") is None

--- a/tests/unit/daemon/test_maintenance_endpoints.py
+++ b/tests/unit/daemon/test_maintenance_endpoints.py
@@ -92,7 +92,7 @@ class TestMaintenanceAPIRoutes:
 
                 fake_op = BackfillOperation(
                     operation_id="test-001",
-                    kind=BackfillKind.BACKFILL,
+                    kind=BackfillKind.DERIVED_REBUILD,
                     targets=("session_insights",),
                     status=BackfillStatus.PENDING,
                     affected_rows=10,
@@ -115,7 +115,7 @@ class TestMaintenanceAPIRoutes:
 
                 fake_op = BackfillOperation(
                     operation_id="test-002",
-                    kind=BackfillKind.BACKFILL,
+                    kind=BackfillKind.INDEX_REPAIR,
                     targets=("fts_repair",),
                     status=BackfillStatus.COMPLETED,
                     affected_rows=42,

--- a/tests/unit/insights/test_confidence_vocab.py
+++ b/tests/unit/insights/test_confidence_vocab.py
@@ -6,7 +6,7 @@ import pytest
 
 from polylogue.insights.confidence import (
     ConfidenceBand,
-    from_legacy,
+    confidence_band_from_stored,
     from_score,
     from_signals,
 )
@@ -34,7 +34,7 @@ def test_band_is_str_subclass_for_json_compat() -> None:
 
 
 # ---------------------------------------------------------------------------
-# from_signals — preserves the legacy support_level() decision rule
+# from_signals — support-level decision rule
 # ---------------------------------------------------------------------------
 
 
@@ -88,7 +88,7 @@ def test_from_score_thirds(score: float, expected: ConfidenceBand) -> None:
 
 
 # ---------------------------------------------------------------------------
-# from_legacy — coerce stored string into typed band
+# confidence_band_from_stored — coerce stored string into typed band
 # ---------------------------------------------------------------------------
 
 
@@ -101,17 +101,17 @@ def test_from_score_thirds(score: float, expected: ConfidenceBand) -> None:
         ("none", ConfidenceBand.NONE),
     ],
 )
-def test_from_legacy_accepts_known_spellings(value: str, expected: ConfidenceBand) -> None:
-    assert from_legacy(value) is expected
+def test_confidence_band_from_stored_accepts_known_spellings(value: str, expected: ConfidenceBand) -> None:
+    assert confidence_band_from_stored(value) is expected
 
 
-def test_from_legacy_passes_through_enum_instances() -> None:
-    assert from_legacy(ConfidenceBand.STRONG) is ConfidenceBand.STRONG
+def test_confidence_band_from_stored_passes_through_enum_instances() -> None:
+    assert confidence_band_from_stored(ConfidenceBand.STRONG) is ConfidenceBand.STRONG
 
 
 @pytest.mark.parametrize("value", [None, "", "unknown", "medium", "high"])
-def test_from_legacy_unknown_spellings_collapse_to_weak(value: str | None) -> None:
-    assert from_legacy(value) is ConfidenceBand.WEAK
+def test_confidence_band_from_stored_unknown_spellings_collapse_to_weak(value: str | None) -> None:
+    assert confidence_band_from_stored(value) is ConfidenceBand.WEAK
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/maintenance/test_planner_contract.py
+++ b/tests/unit/maintenance/test_planner_contract.py
@@ -69,6 +69,25 @@ class TestBackfillKindCoverage:
         payload = op.to_dict()
         assert payload["kind"] == kind.value
 
+    @pytest.mark.parametrize(
+        ("stored_kind", "expected"),
+        [
+            ("backfill", BackfillKind.DERIVED_REBUILD),
+            ("rebuild", BackfillKind.DERIVED_REBUILD),
+            ("reindex", BackfillKind.INDEX_REPAIR),
+            ("reset", BackfillKind.CONFIG_DRIVEN),
+        ],
+    )
+    def test_retired_stored_kind_values_rehydrate_to_typed_kind(self, stored_kind: str, expected: BackfillKind) -> None:
+        op = BackfillOperation.from_dict(
+            {
+                "operation_id": "op-1",
+                "kind": stored_kind,
+                "targets": ["session_insights"],
+            }
+        )
+        assert op.kind is expected
+
 
 class TestInvalidationReasonCoverage:
     """Every InvalidationReason value from #1144 must be representable

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -208,15 +208,14 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         MCPMessagesListPayload,
         MCPNeighborCandidatesPayload,
         MCPPaginatedQueryResultPayload,
-        MCPPaginatedSearchResultPayload,
         MCPRawArtifactsListPayload,
         MCPSessionTopologyPayload,
         MCPSessionTreePayload,
     )
-    from polylogue.surfaces.payloads import QueryUnitEnvelope
+    from polylogue.surfaces.payloads import QueryUnitEnvelope, SearchEnvelope
 
     return {
-        "search": MCPPaginatedSearchResultPayload,
+        "search": SearchEnvelope,
         "query_units": QueryUnitEnvelope,
         "list_sessions": MCPPaginatedQueryResultPayload,
         "neighbor_candidates": MCPNeighborCandidatesPayload,


### PR DESCRIPTION
## Summary

Removes remaining compatibility-alias residue found while auditing the rename/deletion sentinel cleanup. Maintenance operations now expose only the typed `BackfillKind` taxonomy, MCP search envelope checks use the shared `SearchEnvelope` directly, confidence-band string coercion is named around persisted data instead of legacy support, and the query `delete` verb no longer accepts hidden `--force` as a `--yes` alias.

## Problem

The repo still contained code and docs that taught agents to keep aliases around: `BackfillKind.REBUILD/REINDEX/RESET/BACKFILL`, `MCPPaginatedSearchResultPayload = SearchEnvelope`, hidden `delete --force`, and CLI-audit guidance for deprecation-wrapper aliases. That conflicts with the current policy: cleanly replace obsolete spellings instead of preserving compatibility shims.

## Solution

- Removed maintenance enum alias values and updated endpoint tests to use typed maintenance kinds.
- Kept existing `.maintenance-state` files readable through a private persisted-kind coercion map, without restoring public enum aliases.
- Removed the dead MCP paginated search payload alias and pointed envelope contract tests at `SearchEnvelope`.
- Removed the hidden query `delete --force` alias so `--yes` is the only destructive confirmation flag.
- Renamed confidence-band persisted-string coercion from `from_legacy` to `confidence_band_from_stored`.
- Rewrote CLI audit guidance to prohibit deprecation aliases and updated the cross-surface audit to name the shared search envelope.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_maintenance_endpoints.py tests/unit/mcp/test_envelope_contracts.py tests/unit/insights/test_confidence_vocab.py` → 70 passed
- `nix develop --command devtools test tests/unit/cli/test_query_verbs_runtime.py tests/unit/daemon/test_maintenance_endpoints.py tests/unit/mcp/test_envelope_contracts.py tests/unit/insights/test_confidence_vocab.py -k 'delete or maintenance or envelope or confidence'` → 73 passed, 23 deselected
- `nix develop --command devtools test tests/unit/maintenance/test_planner_contract.py tests/unit/cli/test_query_verbs_runtime.py tests/unit/daemon/test_maintenance_endpoints.py tests/unit/mcp/test_envelope_contracts.py tests/unit/insights/test_confidence_vocab.py -k 'retired_stored_kind or delete or maintenance or envelope or confidence'` → 115 passed, 23 deselected
- `nix develop --command devtools verify --quick` → exit_code 0
- pre-push `devtools verify --quick` → exit_code 0