### PR TITLE
refactor(types): stop re-exporting core enums (#1849)

### DIFF
--- a/devtools/pipeline_probe/engine.py
+++ b/devtools/pipeline_probe/engine.py
@@ -42,6 +42,7 @@ from devtools.pipeline_probe.staging import (
     _write_probe_sources,
 )
 from polylogue.config import Config, Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, is_json_document, loads, require_json_document
 from polylogue.core.metrics import PipelineMetrics
 from polylogue.paths import active_index_db_path, blob_store_root
@@ -59,7 +60,6 @@ from polylogue.storage.sqlite import SQLiteBackend, create_backend
 from polylogue.storage.sqlite.archive_tiers.archive import _provider_for_origin
 from polylogue.storage.sqlite.connection import open_connection
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
-from polylogue.types import Provider
 
 
 def _safe_git_commit() -> str | None:

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -23,7 +23,7 @@ from polylogue.archive.query.spec import normalize_action_sequence, normalize_ac
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session, SessionSummary
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.core.user_state_targets import TARGET_MESSAGE, TARGET_SESSION
@@ -48,7 +48,7 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     ArchiveSessionEnvelope,
 )
 from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 if TYPE_CHECKING:
     from polylogue.archive.filter.filters import SessionFilter

--- a/polylogue/archive/actions/actions.py
+++ b/polylogue/archive/actions/actions.py
@@ -25,7 +25,7 @@ from polylogue.archive.actions.fields import (
 )
 from polylogue.archive.actions.parsing import build_tool_calls_from_content_blocks
 from polylogue.archive.viewport.viewports import ToolCall, ToolCategory
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 _CANONICAL_TOOL_NAMES = {
     "bash": "bash",

--- a/polylogue/archive/actions/parsing.py
+++ b/polylogue/archive/actions/parsing.py
@@ -6,8 +6,8 @@ import json
 from collections.abc import Mapping, Sequence
 
 from polylogue.archive.viewport.viewports import ToolCall, ToolCategory, classify_tool
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document
-from polylogue.types import Provider
 
 
 def _clean_str(value: object) -> str | None:

--- a/polylogue/archive/artifact_taxonomy/models.py
+++ b/polylogue/archive/artifact_taxonomy/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 
 class ArtifactKind(StrEnum):

--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -17,8 +17,8 @@ from polylogue.archive.artifact_taxonomy.support import (
     normalize_source_path,
     path_only_sidecar_reason,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, json_document
-from polylogue.types import Provider
 
 
 def classify_artifact_path(

--- a/polylogue/archive/message/model_runtime.py
+++ b/polylogue/archive/message/model_runtime.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 
 def _block_texts(blocks: Iterable[Mapping[str, object]], *, block_type: str) -> list[str]:

--- a/polylogue/archive/message/models.py
+++ b/polylogue/archive/message/models.py
@@ -10,7 +10,7 @@ from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.model_runtime import MessageRuntimeMixin
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 
 class Message(MessageRuntimeMixin, BaseModel):

--- a/polylogue/archive/provider/semantics.py
+++ b/polylogue/archive/provider/semantics.py
@@ -11,8 +11,8 @@ from polylogue.archive.viewport.viewports import (
     ToolCall,
     classify_tool,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document
-from polylogue.types import Provider
 
 
 def content_text(value: object) -> str | None:

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -19,8 +19,9 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.domain_models import Session, SessionSummary
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -13,9 +13,9 @@ from polylogue.archive.artifact_taxonomy import (
     classify_artifact,
 )
 from polylogue.archive.raw_payload.streams import raw_line_stream
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, is_json_value, loads
 from polylogue.sources.dispatch import detect_provider
-from polylogue.types import Provider
 
 WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument

--- a/polylogue/archive/semantic/support.py
+++ b/polylogue/archive/semantic/support.py
@@ -7,7 +7,7 @@ from typing import Protocol, TypeAlias
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.viewport.viewports import ReasoningTrace, TokenUsage, ToolCall
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 ContentBlockSequence: TypeAlias = Sequence[Mapping[str, object]]
 

--- a/polylogue/archive/session/domain_models.py
+++ b/polylogue/archive/session/domain_models.py
@@ -12,9 +12,9 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_runtime import SessionRuntimeMixin
 from polylogue.archive.session.events import SessionEvent
 from polylogue.archive.session.summary_runtime import SessionSummaryRuntimeMixin
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 
 def _coerce_origin(v: object) -> Origin:

--- a/polylogue/archive/session/events.py
+++ b/polylogue/archive/session/events.py
@@ -6,11 +6,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import json_document
 from polylogue.core.sources import origin_from_provider
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import MessageId, Provider, SessionEventId, SessionId
+from polylogue.types import MessageId, SessionEventId, SessionId
 
 
 class SessionEvent(BaseModel):

--- a/polylogue/archive/session/neighbor_candidates.py
+++ b/polylogue/archive/session/neighbor_candidates.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+from polylogue.core.enums import Provider
 from polylogue.errors import PolylogueError
 from polylogue.storage.query_models import SessionRecordQuery
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.archive.query.search_hits import SessionSearchHit

--- a/polylogue/archive/viewport/models.py
+++ b/polylogue/archive/viewport/models.py
@@ -14,7 +14,7 @@ from polylogue.archive.viewport.tools import (
     clean_metadata_path_candidate,
     clean_shell_path_candidate,
 )
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 
 class ReasoningTrace(BaseModel):

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -7,8 +7,8 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.core.json import is_json_document, json_document
-from polylogue.types import Provider
 
 BROWSER_CAPTURE_KIND: Literal["browser_llm_session"] = "browser_llm_session"
 BROWSER_CAPTURE_SCHEMA_VERSION: Literal[1] = 1

--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -32,9 +32,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.provider_identity import CORE_SCHEMA_PROVIDERS
-from polylogue.types import Provider
 
 __all__ = [
     "ALL_SOURCES",

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -22,7 +22,7 @@ from typing import Any, TypeAlias, cast
 
 import click
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.errors import PolylogueError
 from polylogue.insights.archive import (
@@ -38,7 +38,6 @@ from polylogue.insights.archive import (
     ThreadInsightQuery,
 )
 from polylogue.insights.tool_usage import ToolUsageInsightQuery
-from polylogue.types import Provider
 
 InsightAccessor: TypeAlias = Callable[[ArchiveInsightModel], str]
 

--- a/polylogue/insights/tag_rollups.py
+++ b/polylogue/insights/tag_rollups.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.insights.archive import SessionTagRollupInsight
 from polylogue.insights.archive_models import ArchiveInsightProvenance
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore

--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import unicodedata
 from typing import TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.hashing import hash_payload
 from polylogue.core.json import JSONValue
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources import ParsedMessage, ParsedSession
 from polylogue.sources.parsers.base import ParsedContentBlock
-from polylogue.types import ContentHash, MessageId, Provider, SessionEventId, SessionId
+from polylogue.types import ContentHash, MessageId, SessionEventId, SessionId
 
 # Sentinel values to distinguish None from empty in hash computations
 _NULL_SENTINEL = "__POLYLOGUE_NULL__"

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -22,6 +22,7 @@ from polylogue.archive.artifact_taxonomy import ArtifactClassification, Artifact
 from polylogue.archive.artifact_taxonomy.support import is_subagent_path
 from polylogue.archive.raw_payload.decode import RawPayloadEnvelope
 from polylogue.core.common import format_malformed_jsonl_error as _format_malformed_jsonl_error
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.logging import get_logger
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.pipeline.ids import session_id as make_session_id
@@ -30,11 +31,6 @@ from polylogue.sources.dispatch import STREAM_RECORD_PROVIDERS
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import (
     RawSessionRecord,
-)
-from polylogue.types import (
-    Provider,
-    ValidationMode,
-    ValidationStatus,
 )
 
 if TYPE_CHECKING:

--- a/polylogue/pipeline/services/planning_runtime.py
+++ b/polylogue/pipeline/services/planning_runtime.py
@@ -8,13 +8,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from polylogue.config import Source
+from polylogue.core.enums import PlanStage
 from polylogue.pipeline.ingest_support import expand_requested_stage, normalize_stage_sequence
 from polylogue.pipeline.stage_models import ValidateResult
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.raw.artifacts import RawIngestArtifactState
 from polylogue.storage.run_state import PlanCounts, PlanDetails, PlanResult
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import PlanStage
 
 from .acquisition import AcquisitionService
 from .planning_backlog import collect_parse_backlog, collect_validation_backlog, dedupe_ids

--- a/polylogue/pipeline/services/validation.py
+++ b/polylogue/pipeline/services/validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polylogue.core.enums import ValidationMode
 from polylogue.pipeline.services.validation_flow import (
     evaluate_raw_artifacts as _evaluate_raw_artifacts,
 )
@@ -17,7 +18,6 @@ from polylogue.pipeline.services.validation_flow import (
 from polylogue.pipeline.stage_models import ValidateResult
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import ValidationMode
 
 if TYPE_CHECKING:
     from polylogue.storage.repository import SessionRepository

--- a/polylogue/pipeline/services/validation_flow.py
+++ b/polylogue/pipeline/services/validation_flow.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 
 from polylogue.config import load_polylogue_config
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.logging import get_logger
 from polylogue.paths import blob_store_root
 from polylogue.pipeline.services.process_pool import process_pool_executor
@@ -13,7 +14,6 @@ from polylogue.pipeline.services.validation_runtime import _validate_record_sync
 from polylogue.pipeline.stage_models import ValidatedRawRecord, ValidateResult
 from polylogue.protocols import ProgressCallback, RawValidationStore
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 logger = get_logger(__name__)
 

--- a/polylogue/pipeline/services/validation_runtime.py
+++ b/polylogue/pipeline/services/validation_runtime.py
@@ -7,11 +7,11 @@ from pathlib import Path
 
 from polylogue.archive.raw_payload import RawPayloadEnvelope, build_raw_payload_envelope
 from polylogue.core.common import format_malformed_jsonl_error as _format_malformed_jsonl_error
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.logging import get_logger
 from polylogue.schemas.validator import SchemaValidator
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 logger = get_logger(__name__)
 

--- a/polylogue/pipeline/stage_models.py
+++ b/polylogue/pipeline/stage_models.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from polylogue.core.enums import Provider, ValidationStatus
 from polylogue.pipeline.payload_types import AcquireDiagnostics
-from polylogue.types import Provider, ValidationStatus
 
 if TYPE_CHECKING:
     from polylogue.sources.parsers.base import ParsedSession

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -11,8 +11,8 @@ import builtins
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.core.json import JSONDocument, JSONValue
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 if TYPE_CHECKING:
     import aiosqlite

--- a/polylogue/rendering/blocks.py
+++ b/polylogue/rendering/blocks.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from html import escape
 
+from polylogue.core.enums import BlockType
 from polylogue.rendering.block_models import RenderableBlock
-from polylogue.types import BlockType
 
 # -------------------------------------------------------------------
 # Markdown rendering

--- a/polylogue/schemas/generation/provider_bundle.py
+++ b/polylogue/schemas/generation/provider_bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.paths import db_path as index_db_path
 from polylogue.schemas.generation.cluster_collection import (
     _collect_cluster_accumulators,
@@ -25,7 +26,6 @@ from polylogue.schemas.generation.support import GENSON_AVAILABLE
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig, resolve_provider_config
 from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
-from polylogue.types import Provider
 
 
 def build_provider_error_bundle(

--- a/polylogue/schemas/generation/provider_bundle_packages.py
+++ b/polylogue/schemas/generation/provider_bundle_packages.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue
 from polylogue.schemas.generation.cluster_support import (
     _artifact_priority,
@@ -37,7 +38,6 @@ from polylogue.schemas.packages import (
 from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
-from polylogue.types import Provider
 
 
 @dataclass(frozen=True)

--- a/polylogue/schemas/observation_identity.py
+++ b/polylogue/schemas/observation_identity.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.schemas.observation_models import PROVIDERS, ProviderConfig, SchemaClusterPayload
-from polylogue.types import Provider
 
 
 def resolve_provider_config(source_name: str | Provider) -> ProviderConfig:

--- a/polylogue/schemas/observation_models.py
+++ b/polylogue/schemas/observation_models.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocumentList, JSONValue
-from polylogue.types import Provider
 
 SchemaSampleGranularity: TypeAlias = Literal["document", "record"]
 SchemaClusterPayload: TypeAlias = JSONValue

--- a/polylogue/schemas/observation_runtime.py
+++ b/polylogue/schemas/observation_runtime.py
@@ -9,10 +9,10 @@ from typing import TypeAlias
 
 from polylogue.archive.artifact_taxonomy import classify_artifact
 from polylogue.archive.raw_payload import extract_payload_samples, record_bucket_key
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, is_json_value, json_document
 from polylogue.schemas.observation_identity import derive_bundle_scope, schema_cluster_id
 from polylogue.schemas.observation_models import ProviderConfig, SchemaClusterPayload, SchemaUnit
-from polylogue.types import Provider
 
 SchemaSample: TypeAlias = JSONDocument
 

--- a/polylogue/schemas/operator/inference.py
+++ b/polylogue/schemas/operator/inference.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.scenarios import CorpusScenario, CorpusSpec, build_corpus_scenarios, build_inferred_corpus_specs
 from polylogue.schemas.audit.models import AuditReport
@@ -24,7 +25,6 @@ from polylogue.schemas.operator.registry import SchemaRegistryLike, schema_regis
 from polylogue.schemas.packages import SchemaPackageCatalog
 from polylogue.schemas.privacy_config import PrivacyConfig, PrivacyLevel
 from polylogue.schemas.tooling_models import ClusterManifest
-from polylogue.types import Provider
 
 
 def _typed_registry() -> SchemaRegistryLike:

--- a/polylogue/schemas/packages.py
+++ b/polylogue/schemas/packages.py
@@ -6,8 +6,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Literal, TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document, json_document_list
-from polylogue.types import Provider
 
 
 def _provider_value(provider: str | Provider) -> str:

--- a/polylogue/schemas/pinning.py
+++ b/polylogue/schemas/pinning.py
@@ -23,8 +23,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Literal, TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document, json_document_list
-from polylogue.types import Provider
 
 logger = logging.getLogger(__name__)
 

--- a/polylogue/schemas/runtime_registry.py
+++ b/polylogue/schemas/runtime_registry.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from polylogue.archive.raw_payload.decode import JSONRecord
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document
 from polylogue.core.provider_identity import canonical_schema_provider as _canonical_schema_provider
 from polylogue.core.provider_identity import normalize_provider_token
@@ -28,7 +29,6 @@ from polylogue.schemas.packages import (
     SchemaResolutionReason,
     SchemaVersionPackage,
 )
-from polylogue.types import Provider
 
 SCHEMA_DIR = Path(__file__).parent / "providers"
 SchemaProvider = Provider | str

--- a/polylogue/schemas/sampling.py
+++ b/polylogue/schemas/sampling.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 from polylogue.archive.raw_payload import build_raw_payload_envelope, collect_limited_samples
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.paths import db_path as index_db_path
 from polylogue.schemas.observation import resolve_provider_config
@@ -20,7 +21,6 @@ from polylogue.schemas.sampling_sessions import (
     _iter_samples_from_sessions,
     _iter_schema_units_from_sessions,
 )
-from polylogue.types import Provider
 
 
 def iter_schema_units(

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -11,7 +11,7 @@ from typing import Literal, TypeAlias, overload
 
 from polylogue.archive.raw_payload import extract_record_samples_from_raw_content
 from polylogue.archive.raw_payload.decode import RawPayloadEnvelope
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.provider_identity import (
     canonical_runtime_provider,
@@ -28,7 +28,6 @@ from polylogue.schemas.observation import (
 )
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.sqlite.connection_profile import connection_context
-from polylogue.types import Provider
 
 logger = get_logger(__name__)
 

--- a/polylogue/schemas/sampling_sessions.py
+++ b/polylogue/schemas/sampling_sessions.py
@@ -7,10 +7,10 @@ from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document, loads
 from polylogue.schemas.observation import ProviderConfig, extract_schema_units_from_payload
 from polylogue.schemas.observation_models import SchemaUnit
-from polylogue.types import Provider
 
 _SESSION_SAMPLE_SUFFIXES = (".jsonl", ".json")
 

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document, json_document_list, require_json_value
 from polylogue.schemas.observation import schema_cluster_id
 from polylogue.schemas.observation_models import SchemaClusterPayload
@@ -20,7 +21,6 @@ from polylogue.schemas.runtime_registry import (
 )
 from polylogue.schemas.tooling_diff import diff_schemas
 from polylogue.schemas.tooling_models import ClusterManifest, PropertyChange, SchemaCluster, SchemaDiff
-from polylogue.types import Provider
 
 SchemaPayload: TypeAlias = SchemaInputDocument
 ObservedSchemaSample: TypeAlias = object

--- a/polylogue/schemas/validation/artifacts.py
+++ b/polylogue/schemas/validation/artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from polylogue.archive.artifact_taxonomy import ArtifactKind
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.storage.artifacts.persistence import materialize_artifact_observations
 from polylogue.storage.artifacts.queries import (
     filter_artifact_observations,
@@ -14,7 +15,6 @@ from polylogue.storage.artifacts.views import ArtifactCohortSummary
 from polylogue.storage.query_models import ArtifactObservationListQuery
 from polylogue.storage.runtime import ArtifactObservationRecord
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import ArtifactSupportStatus, Provider
 
 from .models import ArtifactCoverageReport, ProviderArtifactCoverage
 from .requests import ArtifactCoverageRequest, ArtifactObservationQuery, bounded_window

--- a/polylogue/schemas/validator.py
+++ b/polylogue/schemas/validator.py
@@ -15,9 +15,9 @@ except ImportError:
     Draft202012Validator = None
 
 from polylogue.archive.raw_payload import extract_payload_samples
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, is_json_value, json_document
 from polylogue.schemas.runtime_registry import SchemaRegistry
-from polylogue.types import Provider
 
 from .validator_resolution import (
     available_providers as _available_providers,

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -6,10 +6,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.paths import data_home
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution, SchemaVersionPackage

--- a/polylogue/showcase/dimensions.py
+++ b/polylogue/showcase/dimensions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from polylogue.types import ExerciseIOMode
+from polylogue.core.enums import ExerciseIOMode
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/showcase/generators.py
+++ b/polylogue/showcase/generators.py
@@ -15,6 +15,7 @@ import click
 
 from polylogue.cli.click_app import cli as root_cli
 from polylogue.cli.command_inventory import CommandPath, iter_command_paths
+from polylogue.core.enums import ExerciseIOMode
 from polylogue.scenarios import (
     build_insight_contract_surfaces,
     build_operational_contract_surfaces,
@@ -22,7 +23,6 @@ from polylogue.scenarios import (
 )
 from polylogue.showcase.dimensions import query_read, schema_exercise
 from polylogue.showcase.exercise_models import AssertionSpec, Exercise
-from polylogue.types import ExerciseIOMode
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from typing_extensions import TypedDict
 
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 
 from .parsers.base import ParsedSession
 

--- a/polylogue/sources/cursor.py
+++ b/polylogue/sources/cursor.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
 from polylogue.sources.assembly import SidecarData
 from polylogue.storage.cursor_state import CursorFailurePayload, CursorStatePayload
-from polylogue.types import Provider
 
 logger = get_logger(__name__)
 

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from typing import IO
 
 from polylogue.archive.artifact_taxonomy import classify_artifact_path
+from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from .cursor import _record_cursor_failure
 from .parsers.base import ParsedSession, RawSessionData

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -10,10 +10,10 @@ from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, is_json_document, is_json_value, normalize_json_decimal
 from polylogue.core.payload_coercion import optional_string
 from polylogue.logging import get_logger
-from polylogue.types import Provider
 
 from .decoders import _decode_json_bytes, _iter_json_stream
 from .parsers import antigravity, browser_capture, chatgpt, claude, codex, drive, local_agent

--- a/polylogue/sources/drive/__init__.py
+++ b/polylogue/sources/drive/__init__.py
@@ -4,9 +4,9 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from ...assets import asset_path
 from ...config import Source

--- a/polylogue/sources/emitter.py
+++ b/polylogue/sources/emitter.py
@@ -9,9 +9,9 @@ from itertools import chain
 from typing import IO, TYPE_CHECKING
 
 from polylogue.archive.artifact_taxonomy import ArtifactClassification, classify_artifact
+from polylogue.core.enums import Provider
 from polylogue.core.json import dumps_bytes as json_dumps_bytes
 from polylogue.logging import get_logger
-from polylogue.types import Provider
 
 from .assembly import get_assembly_spec
 from .cursor import _ParseContext

--- a/polylogue/sources/import_preflight.py
+++ b/polylogue/sources/import_preflight.py
@@ -17,9 +17,9 @@ from itertools import islice
 from pathlib import Path
 from typing import Any
 
+from polylogue.core.enums import Provider
 from polylogue.sources.decoders import _decode_json_bytes, _iter_json_stream
 from polylogue.sources.dispatch import detect_provider
-from polylogue.types import Provider
 
 _JSON_SUFFIXES = frozenset({".json", ".jsonl", ".ndjson"})
 _ZIP_JSON_SUFFIXES = (".json", ".jsonl", ".ndjson", ".jsonl.txt")

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -7,13 +7,13 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Protocol
 
+from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
 from polylogue.paths import blob_store_root
 from polylogue.sources.live.batch_support import _AppendPlan, _AppendResult
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from polylogue.types import Provider
 
 logger = get_logger(__name__)
 

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from polylogue.config import Source
 from polylogue.core.degraded import is_degraded
+from polylogue.core.enums import Provider
 from polylogue.core.memory import release_process_memory
 from polylogue.core.metrics import (
     read_cgroup_memory_current_mb,
@@ -99,7 +100,6 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import (
 from polylogue.storage.sqlite.archive_tiers.bootstrap import (
     initialize_active_archive_root as initialize_archive_root,
 )
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.api import Polylogue

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -14,11 +14,11 @@ from typing import Protocol, cast
 import orjson
 
 from polylogue.archive.artifact_taxonomy import classify_artifact, classify_artifact_path
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
 from polylogue.pipeline.services.ingest_batch._core import _select_ingest_worker_count
 from polylogue.sources.dispatch import _detect_provider_from_raw_bytes, detect_provider
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider
 
 _LARGE_FULL_PARSE_PROGRESS_BYTES = 64 * 1024 * 1024
 _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES = 64 * 1024 * 1024

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -17,8 +17,8 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument, dumps_bytes, loads
-from polylogue.types import BlockType, Provider
 
 from .base import ParsedContentBlock, ParsedMessage, ParsedSession
 

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -9,10 +9,9 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator, model_vali
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import BlockType, Provider, TitleSource
 from polylogue.core.security import sanitize_path as _sanitize_path_helper
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import BlockType, Provider
 
 
 class ParsedContentBlock(BaseModel):

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType
 from polylogue.core.hashing import hash_text
-from polylogue.types import BlockType
 
 from .base_models import (
     ParsedAttachment,

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from polylogue.browser_capture.models import BrowserCaptureEnvelope, looks_like_browser_capture
+from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base_models import ParsedAttachment, ParsedMessage, ParsedSession
-from polylogue.types import Provider
 
 
 def looks_like(payload: object) -> bool:

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import BlockType, Provider
 
 from .base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession
 

--- a/polylogue/sources/parsers/claude/ai_parser.py
+++ b/polylogue/sources/parsers/claude/ai_parser.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping
 
 from pydantic import ValidationError
 
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.providers.claude_ai import ClaudeAISession
-from polylogue.types import BlockType, Provider
 
 from ..base import (
     ParsedContentBlock,

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -10,10 +10,9 @@ from polylogue.archive.message.artifacts import classify_text_message_type
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import PasteBoundary
+from polylogue.core.enums import BlockType, PasteBoundary, Provider
 from polylogue.logging import get_logger
 from polylogue.pipeline.semantic_capture import detect_context_compaction
-from polylogue.types import BlockType, Provider
 
 from ..base import (
     ParsedContentBlock,

--- a/polylogue/sources/parsers/claude/common.py
+++ b/polylogue/sources/parsers/claude/common.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Mapping
 
 from polylogue.archive.message.roles import Role
-from polylogue.types import BlockType
+from polylogue.core.enums import BlockType
 
 from ..base import (
     ParsedAttachment,

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -13,10 +13,10 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.provider.semantics import extract_codex_text
 from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.timestamps import parse_timestamp_pair
 from polylogue.logging import get_logger
 from polylogue.sources.providers.codex import CodexRecord
-from polylogue.types import BlockType, Provider
 
 from .base import (
     ParsedContentBlock,

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -6,11 +6,10 @@ from typing import cast
 from pydantic import ValidationError
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import Provider, TitleSource
 from polylogue.core.json import JSONDocument, json_document
 from polylogue.logging import get_logger
 from polylogue.sources.providers.gemini import GeminiMessage
-from polylogue.types import Provider
 
 from .base import ParsedAttachment, ParsedMessage, ParsedSession
 from .drive_support import (

--- a/polylogue/sources/parsers/drive_support_blocks.py
+++ b/polylogue/sources/parsers/drive_support_blocks.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from polylogue.archive.viewport.viewports import ContentBlock
+from polylogue.core.enums import BlockType
 from polylogue.core.json import JSONDocument, json_document, json_document_list
-from polylogue.types import BlockType
 
 from .base import ParsedContentBlock
 

--- a/polylogue/sources/parsers/local_agent.py
+++ b/polylogue/sources/parsers/local_agent.py
@@ -6,8 +6,8 @@ import json
 from collections.abc import Mapping
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument, json_document
-from polylogue.types import BlockType, Provider
 
 from .base import ParsedContentBlock, ParsedMessage, ParsedSession
 

--- a/polylogue/sources/providers/chatgpt_message_models.py
+++ b/polylogue/sources/providers/chatgpt_message_models.py
@@ -16,8 +16,8 @@ from polylogue.archive.viewport.viewports import (
     ReasoningTrace,
     ToolCall,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import Provider
 
 ChatGPTMetadata: TypeAlias = dict[str, object]
 ChatGPTPartValue: TypeAlias = object

--- a/polylogue/sources/providers/claude_ai.py
+++ b/polylogue/sources/providers/claude_ai.py
@@ -13,8 +13,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.viewport.viewports import ContentBlock, ContentType, MessageMeta, ReasoningTrace, ToolCall
+from polylogue.core.enums import Provider
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import Provider
 
 ClaudeAIObject: TypeAlias = dict[str, object]
 

--- a/polylogue/sources/providers/claude_code_models.py
+++ b/polylogue/sources/providers/claude_code_models.py
@@ -7,8 +7,8 @@ from typing import Literal, TypeAlias
 from pydantic import BaseModel, ConfigDict, Field
 
 from polylogue.archive.viewport.viewports import ReasoningTrace, TokenUsage, ToolCall, classify_tool
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document
-from polylogue.types import Provider
 
 ClaudeCodeBlockRecord: TypeAlias = dict[str, object]
 ClaudeCodeContentBlocks: TypeAlias = list[ClaudeCodeBlockRecord]

--- a/polylogue/sources/providers/claude_code_record.py
+++ b/polylogue/sources/providers/claude_code_record.py
@@ -22,9 +22,9 @@ from polylogue.archive.viewport.viewports import (
     TokenUsage,
     ToolCall,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONDocumentList, json_document, json_document_list
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import Provider
 
 from .claude_code_models import ClaudeCodeMessageContent, ClaudeCodeUsage, ClaudeCodeUserMessage
 

--- a/polylogue/sources/providers/codex.py
+++ b/polylogue/sources/providers/codex.py
@@ -25,9 +25,9 @@ from polylogue.archive.viewport.viewports import (
     ReasoningTrace,
     ToolCall,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONDocumentList, json_document, json_document_list
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import Provider
 
 
 class CodexContentBlock(BaseModel):

--- a/polylogue/sources/providers/gemini_message.py
+++ b/polylogue/sources/providers/gemini_message.py
@@ -16,9 +16,9 @@ from polylogue.archive.viewport.viewports import (
     TokenUsage,
     ToolCall,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.types import Provider
 
 from .gemini_models import GeminiBranchParent, GeminiGrounding, GeminiPart, GeminiThoughtSignature
 

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -7,11 +7,11 @@ from collections.abc import Iterable
 from typing import IO, TypeAlias
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from . import cursor as _cursor
 from . import decoders as _decoders

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -11,12 +11,12 @@ from typing import IO, TypeAlias
 
 from polylogue.archive.artifact_taxonomy import classify_artifact
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, is_json_value, normalize_json_decimal
 from polylogue.core.json import dumps_bytes as json_dumps_bytes
 from polylogue.core.metrics import read_current_rss_mb, read_peak_rss_self_mb
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from . import decoders as _decoders
 from .decoders import _zip_entry_provider_hint

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -8,10 +8,10 @@ from collections.abc import Iterable
 
 from polylogue.archive.artifact_taxonomy import classify_artifact_path
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from . import cursor as _cursor
 from . import decoders as _decoders

--- a/polylogue/sources/source_walk.py
+++ b/polylogue/sources/source_walk.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 from . import cursor as _cursor
 from .assembly import SidecarData, get_assembly_spec

--- a/polylogue/storage/artifacts/inspection.py
+++ b/polylogue/storage/artifacts/inspection.py
@@ -7,12 +7,12 @@ from datetime import datetime, timezone
 
 from polylogue.archive.artifact_taxonomy import ArtifactKind, classify_artifact_path
 from polylogue.archive.raw_payload import JSONValue, RawPayloadEnvelope, build_raw_payload_envelope
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.schemas.observation import derive_bundle_scope, schema_cluster_id
 from polylogue.schemas.packages import SchemaResolution
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.runtime import ArtifactObservationRecord, RawSessionRecord
-from polylogue.types import ArtifactSupportStatus, Provider
 
 _SCHEMA_REGISTRY = SchemaRegistry()
 

--- a/polylogue/storage/artifacts/queries.py
+++ b/polylogue/storage/artifacts/queries.py
@@ -12,10 +12,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from polylogue.archive.artifact_taxonomy import ArtifactKind
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.storage.artifacts.views import ArtifactCohortSummary
 from polylogue.storage.query_models import ArtifactObservationListQuery
 from polylogue.storage.runtime import ArtifactObservationRecord
-from polylogue.types import ArtifactSupportStatus, Provider
 
 _MAX_SAMPLE_PATHS = 5
 

--- a/polylogue/storage/artifacts/views.py
+++ b/polylogue/storage/artifacts/views.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
-from polylogue.types import ArtifactSupportStatus, Provider
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 
 
 class ArtifactCohortSummary(BaseModel):

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -20,7 +20,7 @@ from polylogue.archive.message.models import Message
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.archive.session.events import SessionEvent
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import loads
 from polylogue.core.sources import provider_from_origin
 from polylogue.core.timestamps import parse_timestamp
@@ -30,7 +30,7 @@ from polylogue.storage.runtime import (
     SessionEventRecord,
     SessionRecord,
 )
-from polylogue.types import MessageId, Provider
+from polylogue.types import MessageId
 
 
 def _parse_json_blob(raw: object) -> object | None:

--- a/polylogue/storage/raw/artifacts.py
+++ b/polylogue/storage/raw/artifacts.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from polylogue.core.enums import ValidationStatus
 from polylogue.storage.raw.models import RawSessionState
-from polylogue.types import ValidationStatus
 
 _PARSEABLE_VALIDATION_STATUSES = (
     ValidationStatus.PASSED,

--- a/polylogue/storage/raw/models.py
+++ b/polylogue/storage/raw/models.py
@@ -7,7 +7,7 @@ from typing import Final
 
 from pydantic import BaseModel, field_validator
 
-from polylogue.types import Provider, ValidationMode, ValidationStatus
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 
 
 class RawSessionState(BaseModel):

--- a/polylogue/storage/repository/raw/repository_raw.py
+++ b/polylogue/storage/repository/raw/repository_raw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.storage.raw.models import RawSessionState, RawSessionStateUpdate
 from polylogue.storage.repository.repository_contracts import RepositoryBackendProtocol
 from polylogue.storage.runtime import (
@@ -13,7 +14,6 @@ from polylogue.storage.runtime import (
 )
 from polylogue.storage.sqlite.queries import artifacts as artifacts_q
 from polylogue.storage.sqlite.queries import raw as raw_queries
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 
 class RepositoryRawMixin:

--- a/polylogue/storage/run_state.py
+++ b/polylogue/storage/run_state.py
@@ -8,8 +8,8 @@ from typing import ClassVar, TypeVar
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import TypedDict
 
+from polylogue.core.enums import PlanStage
 from polylogue.storage.cursor_state import CursorFailurePayload, CursorStatePayload
-from polylogue.types import PlanStage
 
 _PayloadModelT = TypeVar("_PayloadModelT", bound=BaseModel)
 

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -9,20 +9,12 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, SemanticBlockType
 from polylogue.core.hashing import hash_text
 from polylogue.core.json import json_document
 from polylogue.core.security import sanitize_path as _sanitize_path_helper
 from polylogue.core.timestamps import canonical_timestamp_text
-from polylogue.types import (
-    AttachmentId,
-    BlockType,
-    ContentHash,
-    MessageId,
-    SemanticBlockType,
-    SessionEventId,
-    SessionId,
-)
+from polylogue.types import AttachmentId, ContentHash, MessageId, SessionEventId, SessionId
 
 JSONObject = dict[str, object]
 

--- a/polylogue/storage/runtime/raw/records.py
+++ b/polylogue/storage/runtime/raw/records.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, field_validator
 
-from polylogue.types import ArtifactSupportStatus, Provider, ValidationMode, ValidationStatus
+from polylogue.core.enums import ArtifactSupportStatus, Provider, ValidationMode, ValidationStatus
 
 
 class RawSessionRecord(BaseModel):

--- a/polylogue/storage/sqlite/async_sqlite_raw.py
+++ b/polylogue/storage/sqlite/async_sqlite_raw.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.raw.models import RawSessionState, RawSessionStateUpdate
 from polylogue.storage.runtime import ArtifactObservationRecord, RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.write import _timestamp_ms
 from polylogue.storage.sqlite.queries import artifacts as artifacts_q
 from polylogue.storage.sqlite.queries import raw as raw_queries
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/polylogue/storage/sqlite/queries/artifacts.py
+++ b/polylogue/storage/sqlite/queries/artifacts.py
@@ -13,9 +13,9 @@ from datetime import datetime
 
 import aiosqlite
 
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.runtime import ArtifactObservationRecord
-from polylogue.types import Provider
 
 __all__ = [
     "RAW_ARTIFACT_UPSERT_SQL",

--- a/polylogue/storage/sqlite/queries/attachment_records.py
+++ b/polylogue/storage/sqlite/queries/attachment_records.py
@@ -6,10 +6,11 @@ from datetime import datetime
 
 import aiosqlite
 
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.runtime import AttachmentRecord
 from polylogue.storage.search.models import SessionSearchEvidenceRow
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 
 def _row_value(row: aiosqlite.Row, key: str) -> object | None:

--- a/polylogue/storage/sqlite/queries/filter_builder.py
+++ b/polylogue/storage/sqlite/queries/filter_builder.py
@@ -6,8 +6,8 @@ from polylogue.archive.message.types import validate_message_type_filter
 from polylogue.archive.query.fields import storage_filters_require_stats_join
 from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
 from polylogue.archive.viewport.viewports import ToolCategory
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider
 
 _SEMANTIC_ACTION_TYPES = tuple(category.value for category in ToolCategory)
 

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -8,7 +8,14 @@ from datetime import datetime, timezone
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import Origin
+from polylogue.core.enums import (
+    ArtifactSupportStatus,
+    BlockType,
+    Origin,
+    SemanticBlockType,
+    ValidationMode,
+    ValidationStatus,
+)
 from polylogue.core.sources import provider_from_origin
 from polylogue.storage.runtime import (
     ArtifactObservationRecord,
@@ -25,15 +32,7 @@ from polylogue.storage.sqlite.queries.mappers_support import (
     _row_int,
     _row_text,
 )
-from polylogue.types import (
-    ArtifactSupportStatus,
-    BlockType,
-    MessageId,
-    SemanticBlockType,
-    SessionId,
-    ValidationMode,
-    ValidationStatus,
-)
+from polylogue.types import MessageId, SessionId
 
 
 def _row_to_session(row: sqlite3.Row) -> SessionRecord:

--- a/polylogue/storage/sqlite/queries/raw_state.py
+++ b/polylogue/storage/sqlite/queries/raw_state.py
@@ -6,11 +6,11 @@ from datetime import datetime, timezone
 
 import aiosqlite
 
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.raw.models import UNSET, RawSessionStateUpdate, _RawStateUnset
 from polylogue.storage.sqlite.archive_tiers.write import _timestamp_ms
 from polylogue.storage.sqlite.connection import _build_source_scope_filter
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 # raw_sessions carries a single ``origin`` column (#1743). Provider-token
 # filters translate the token to its canonical origin value before matching.

--- a/polylogue/storage/sqlite/queries/raw_writes.py
+++ b/polylogue/storage/sqlite/queries/raw_writes.py
@@ -6,10 +6,10 @@ import hashlib
 
 import aiosqlite
 
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.write import _timestamp_ms
-from polylogue.types import Provider
 
 
 async def save_raw_session(

--- a/polylogue/storage/sqlite/queries/sessions_reads.py
+++ b/polylogue/storage/sqlite/queries/sessions_reads.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import aiosqlite
 
+from polylogue.core.enums import Provider
 from polylogue.storage.runtime import SessionRecord
 from polylogue.storage.sqlite.queries.filter_builder import _build_session_filters, _needs_stats_join
 from polylogue.storage.sqlite.queries.mappers import _row_to_session
-from polylogue.types import Provider
 
 _SESSION_RECORD_SELECT = """
     session_id,

--- a/polylogue/types.py
+++ b/polylogue/types.py
@@ -1,21 +1,9 @@
-"""Type aliases and legacy enum import paths for polylogue."""
+"""Semantic ID types for polylogue."""
 
 from __future__ import annotations
 
 from typing import NewType
 
-from polylogue.core.enums import (
-    ArtifactSupportStatus,
-    BlockType,
-    ExerciseIOMode,
-    PlanStage,
-    Provider,
-    SemanticBlockType,
-    ValidationMode,
-    ValidationStatus,
-)
-
-# Semantic ID types - provides compile-time distinction
 SessionId = NewType("SessionId", str)
 MessageId = NewType("MessageId", str)
 AttachmentId = NewType("AttachmentId", str)
@@ -25,16 +13,8 @@ SessionEventId = NewType("SessionEventId", str)
 
 __all__ = [
     "AttachmentId",
-    "ArtifactSupportStatus",
-    "BlockType",
     "ContentHash",
-    "SessionId",
-    "ExerciseIOMode",
     "MessageId",
-    "PlanStage",
-    "Provider",
+    "SessionId",
     "SessionEventId",
-    "SemanticBlockType",
-    "ValidationMode",
-    "ValidationStatus",
 ]

--- a/tests/infra/archive_scenarios.py
+++ b/tests/infra/archive_scenarios.py
@@ -44,9 +44,9 @@ def native_session_id_for(provider: str, session_id: str) -> str:
     session with ``provider_session_id = "ext-<session_id>"``
     and the origin derived from ``provider``.
     """
+    from polylogue.core.enums import Provider
     from polylogue.core.identity_law import session_id as archive_session_id
     from polylogue.core.sources import origin_from_provider
-    from polylogue.types import Provider
 
     origin = origin_from_provider(Provider.from_string(provider))
     return archive_session_id(origin.value, f"ext-{session_id}")

--- a/tests/infra/builders.py
+++ b/tests/infra/builders.py
@@ -22,8 +22,9 @@ from collections.abc import Sequence
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Message, Session
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 
 def make_msg(

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -9,7 +9,7 @@ from typing import Protocol, TypeAlias, TypeVar, runtime_checkable
 from unittest.mock import AsyncMock, MagicMock
 
 from polylogue.archive.models import Session
-from polylogue.types import Provider
+from polylogue.core.enums import Provider
 from tests.infra.builders import make_conv, make_msg
 
 EXPECTED_TOOL_NAMES = {

--- a/tests/infra/semantic_facts.py
+++ b/tests/infra/semantic_facts.py
@@ -13,11 +13,10 @@ from dataclasses import dataclass
 
 from polylogue.archive.models import Session
 from polylogue.archive.semantic.facts import build_session_semantic_facts
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument, json_document_list
 from polylogue.core.sources import provider_from_origin
 from polylogue.storage.runtime import AttachmentRecord, MessageRecord, SessionRecord
-from polylogue.types import Provider
 
 
 def _string_value(value: object) -> str:

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, Provider, SemanticBlockType, ValidationMode, ValidationStatus
 from polylogue.core.json import dumps, loads, require_json_document, require_json_value
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.core.timestamps import _timestamp_sort_key
@@ -33,17 +33,7 @@ from polylogue.storage.runtime import (
 )
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import connection_context, open_connection
-from polylogue.types import (
-    AttachmentId,
-    BlockType,
-    ContentHash,
-    MessageId,
-    Provider,
-    SemanticBlockType,
-    SessionId,
-    ValidationMode,
-    ValidationStatus,
-)
+from polylogue.types import AttachmentId, ContentHash, MessageId, SessionId
 
 if TYPE_CHECKING:
     from polylogue.archive.session.domain_models import Session

--- a/tests/infra/strategies/messages.py
+++ b/tests/infra/strategies/messages.py
@@ -12,8 +12,9 @@ from typing import TYPE_CHECKING, TypeAlias
 from hypothesis import strategies as st
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 if TYPE_CHECKING:
     from polylogue.archive.models import Message, Session

--- a/tests/infra/strategies/summaries.py
+++ b/tests/infra/strategies/summaries.py
@@ -8,8 +8,9 @@ from datetime import datetime, timedelta, timezone
 from hypothesis import strategies as st
 
 from polylogue.archive.models import SessionSummary
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 _PROVIDERS = ("claude-ai", "chatgpt", "gemini", "codex", "claude-code")
 _SLUG_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789-"

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -33,8 +33,8 @@ def _sorted_unique(values: list[str] | tuple[str, ...] | set[str]) -> tuple[str,
 
 
 def _origin_for_provider_token(provider: str) -> str:
+    from polylogue.core.enums import Provider
     from polylogue.core.sources import origin_from_provider
-    from polylogue.types import Provider
 
     return origin_from_provider(Provider.from_string(provider)).value
 

--- a/tests/integration/test_live_write_amplification.py
+++ b/tests/integration/test_live_write_amplification.py
@@ -90,8 +90,8 @@ def _bootstrap_archive(root: Path) -> Path:
 def _make_parsed_session(session_id: str, n_messages: int = 5) -> Any:
     """Build a minimal ParsedSession with ``n_messages`` user messages."""
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import Provider
     from polylogue.sources.parsers.base_models import ParsedMessage, ParsedSession
-    from polylogue.types import Provider
 
     messages = [
         ParsedMessage(

--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -23,12 +23,12 @@ import pytest
 
 from polylogue.api import Polylogue
 from polylogue.config import Config, Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider
 from polylogue.pipeline.services.parsing import ParsingService
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
-from polylogue.types import Provider
 
 pytestmark = pytest.mark.slow
 

--- a/tests/property/test_encoding_boundary_matrix.py
+++ b/tests/property/test_encoding_boundary_matrix.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.core.hashing import hash_text
 from polylogue.pipeline.ids import (
     _normalize_for_hash,
@@ -40,7 +41,6 @@ from polylogue.storage.index import rebuild_index
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.search import search_messages
 from polylogue.storage.search.query_support import escape_fts5_query
-from polylogue.types import Provider
 from tests.infra.storage_records import make_message, make_session, save_current_archive_records
 
 # ---------------------------------------------------------------------------

--- a/tests/property/test_rendering_preservation.py
+++ b/tests/property/test_rendering_preservation.py
@@ -17,10 +17,11 @@ from hypothesis import HealthCheck, given, settings
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Message, Session
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.rendering.core_markdown import format_session_markdown
 from polylogue.rendering.formatting import format_session
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.strategies.messages import session_strategy
 
 

--- a/tests/property/test_semantic_properties.py
+++ b/tests/property/test_semantic_properties.py
@@ -14,10 +14,10 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType
 from polylogue.sources.dispatch import detect_provider, parse_payload
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.parsers.base_models import ParsedSessionEvent
-from polylogue.types import BlockType
 from tests.infra.strategies.schema_driven import schema_conformant_payload
 
 PARSEABLE_PROVIDERS = ("chatgpt", "claude-code", "codex")

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -35,11 +35,10 @@ import pytest
 from polylogue import Polylogue
 from polylogue.api.archive import SessionNotFoundError
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, Provider
 from polylogue.errors import DatabaseError, PolylogueError
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.types import BlockType, Provider
 from tests.infra.storage_records import db_setup
 
 # ---------------------------------------------------------------------------
@@ -265,9 +264,9 @@ def _archive(tmp_path: Path) -> Polylogue:
 async def test_archive_tiers_facade_reads_active_db_override_root(tmp_path: Path) -> None:
     """Archive facade reads open the active index root, not just config.archive_root."""
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     configured_root = tmp_path / "configured"
     active_root = tmp_path / "active"
@@ -1160,6 +1159,7 @@ async def test_archive_tiers_api_reads_native_sessions(tmp_path: Path) -> None:
     from polylogue.archive.message.roles import Role
     from polylogue.archive.message.types import MessageType
     from polylogue.archive.query.spec import SessionQuerySpec
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import (
         ArchiveSessionSearchHit,
@@ -1167,7 +1167,6 @@ async def test_archive_tiers_api_reads_native_sessions(tmp_path: Path) -> None:
         ArchiveStore,
     )
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveSessionEnvelope
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -1390,9 +1389,9 @@ async def test_archive_tiers_api_reads_session_topology(tmp_path: Path) -> None:
     """Topology facade helpers project parent/session rows."""
     from polylogue.archive.message.roles import Role
     from polylogue.archive.session.branch_type import BranchType
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     root = ParsedSession(
@@ -1509,9 +1508,9 @@ async def test_archive_tiers_api_user_mutations_write_user_tier(tmp_path: Path) 
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -1577,11 +1576,11 @@ async def test_archive_tiers_api_tag_rollups_read_index_and_user_tiers(tmp_path:
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import SessionTagRollupQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_session_tag
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     first = ParsedSession(
@@ -1645,11 +1644,11 @@ async def test_archive_tiers_api_archive_coverage_reads_index_tier(tmp_path: Pat
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import ArchiveCoverageInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_session_profile_costs, upsert_session_work_event
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     codex = ParsedSession(
@@ -1769,10 +1768,10 @@ async def test_archive_tiers_api_archive_coverage_reads_index_tier(tmp_path: Pat
 async def test_archive_tiers_api_tool_usage_reads_index_actions(tmp_path: Path) -> None:
     """Tool-usage API reads archive ``actions`` instead of retired action tables."""
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.tool_usage import ToolUsageInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     codex = ParsedSession(
@@ -1851,9 +1850,9 @@ async def test_archive_tiers_api_delete_uses_index_tier_and_keeps_user_overlay(t
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -1895,9 +1894,9 @@ async def test_archive_tiers_api_delete_uses_index_tier_and_keeps_user_overlay(t
 async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) -> None:
     """Raw artifact facade reads ``source.db`` rows."""
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     payload = b'{"session":"raw-artifact-v1"}'
@@ -1947,6 +1946,7 @@ async def test_archive_tiers_api_timeline_insights_read_index_tier(tmp_path: Pat
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import SessionPhaseInsightQuery, SessionWorkEventInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1955,7 +1955,6 @@ async def test_archive_tiers_api_timeline_insights_read_index_tier(tmp_path: Pat
         upsert_session_phase,
         upsert_session_work_event,
     )
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2061,6 +2060,7 @@ async def test_archive_tiers_api_threads_read_index_tier(tmp_path: Path) -> None
 
     from polylogue.archive.message.roles import Role
     from polylogue.archive.session.branch_type import BranchType
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import ThreadInsightQuery
     from polylogue.insights.audit import InsightRigorAuditQuery
     from polylogue.insights.export_bundles import InsightExportBundleRequest
@@ -2068,7 +2068,6 @@ async def test_archive_tiers_api_threads_read_index_tier(tmp_path: Path) -> None
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_insight_materialization
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     parent = ParsedSession(
@@ -2256,6 +2255,7 @@ async def test_archive_tiers_api_session_costs_read_index_tier(tmp_path: Path) -
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import CostRollupInsightQuery, SessionCostInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2263,7 +2263,6 @@ async def test_archive_tiers_api_session_costs_read_index_tier(tmp_path: Path) -
         upsert_insight_materialization,
         upsert_session_profile_costs,
     )
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     priced_session = ParsedSession(
@@ -2370,11 +2369,11 @@ async def test_archive_tiers_api_latency_profiles_read_index_tier(tmp_path: Path
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import SessionLatencyProfileInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_insight_materialization
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2464,10 +2463,10 @@ async def test_archive_tiers_api_archive_debt_reads_archive_consistency(tmp_path
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import ArchiveDebtInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2519,11 +2518,11 @@ async def test_archive_tiers_api_session_profiles_read_index_tier(tmp_path: Path
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.archive import SessionProfileInsightQuery
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_insight_materialization
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2634,10 +2633,10 @@ async def test_archive_tiers_api_session_insight_status_reads_index_tier(tmp_pat
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.write import upsert_insight_materialization
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     first = ParsedSession(
@@ -2730,9 +2729,9 @@ async def test_archive_tiers_api_marks_and_annotations_write_user_tier(tmp_path:
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2807,9 +2806,9 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -2933,10 +2932,10 @@ async def test_archive_tiers_api_corrections_write_user_tier(tmp_path: Path) -> 
     import sqlite3
 
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType
     from polylogue.insights.feedback import CorrectionKind
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType
 
     archive = _archive(tmp_path)
     session = ParsedSession(

--- a/tests/unit/api/test_read_surface_contracts.py
+++ b/tests/unit/api/test_read_surface_contracts.py
@@ -24,8 +24,8 @@ from polylogue.api.contracts import (
 )
 from polylogue.api.contracts.tui_surface import TUIReadSurface
 from polylogue.archive.query.spec import SessionQuerySpec
+from polylogue.core.enums import Provider
 from polylogue.surfaces.payloads import SessionListResponse
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import native_session_id_for
 from tests.infra.storage_records import SessionBuilder, db_setup
 

--- a/tests/unit/api/test_write_surface_contracts.py
+++ b/tests/unit/api/test_write_surface_contracts.py
@@ -39,11 +39,11 @@ from polylogue.api.contracts import (
 from polylogue.api.contracts.api_write_surface import APIWriteSurface
 from polylogue.api.contracts.cli_write_surface import CLIWriteSurface
 from polylogue.api.contracts.mcp_write_surface import MCPWriteSurface
+from polylogue.core.enums import Provider
 from polylogue.maintenance.planner import BackfillOperation
 from polylogue.operations.import_contracts import ImportOperation
 from polylogue.services import build_runtime_services
 from polylogue.surfaces.payloads import TagMutationResult
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import native_session_id_for
 from tests.infra.storage_records import SessionBuilder, db_setup
 

--- a/tests/unit/archive/test_coverage_diagnostics.py
+++ b/tests/unit/archive/test_coverage_diagnostics.py
@@ -4,8 +4,9 @@ from datetime import datetime, timezone
 
 from polylogue.archive.coverage import analyze_coverage
 from polylogue.archive.session.domain_models import SessionSummary
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 
 def _summary(

--- a/tests/unit/archive/test_facets.py
+++ b/tests/unit/archive/test_facets.py
@@ -14,9 +14,10 @@ from polylogue.archive.query.facets import (
     compute_idf,
 )
 from polylogue.archive.session.domain_models import SessionSummary
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.surfaces.payloads import FacetBucketsPayload, FacetsResponse
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 
 def _summary(

--- a/tests/unit/archive/test_near_session_seed_execution.py
+++ b/tests/unit/archive/test_near_session_seed_execution.py
@@ -21,13 +21,12 @@ from polylogue.archive.query.expression import ExpressionCompileError, compile_e
 from polylogue.archive.query.plan import SessionQueryPlan
 from polylogue.archive.query.search_hits import plan_has_search_hit_evidence, search_hits_for_plan
 from polylogue.config import Config, Source
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.embedding_write import upsert_message_embedding
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.types import Provider
 from tests.infra.storage_records import SessionBuilder
 
 

--- a/tests/unit/archive/test_phase_extraction.py
+++ b/tests/unit/archive/test_phase_extraction.py
@@ -8,8 +8,9 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
 from polylogue.archive.phase.extraction import extract_phases
 from polylogue.archive.session.events import SessionEvent
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionEventId, SessionId
+from polylogue.types import SessionEventId, SessionId
 from tests.infra.builders import make_conv, make_msg
 
 

--- a/tests/unit/archive/test_query_runtime_filters.py
+++ b/tests/unit/archive/test_query_runtime_filters.py
@@ -10,8 +10,9 @@ from polylogue.archive.query.plan import SessionQueryPlan
 from polylogue.archive.query.runtime_filters import apply_common_filters, apply_full_filters
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import SessionSummary
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.builders import make_conv, make_msg
 
 

--- a/tests/unit/archive/test_query_runtime_matching.py
+++ b/tests/unit/archive/test_query_runtime_matching.py
@@ -16,8 +16,8 @@ from polylogue.archive.query.runtime_matching import (
 )
 from polylogue.archive.session.domain_models import Session
 from polylogue.archive.viewport.enums import ToolCategory
-from polylogue.core.enums import Origin
-from polylogue.types import Provider, SessionId
+from polylogue.core.enums import Origin, Provider
+from polylogue.types import SessionId
 
 
 def _session() -> Session:

--- a/tests/unit/archive/test_query_search_runtime.py
+++ b/tests/unit/archive/test_query_search_runtime.py
@@ -26,8 +26,8 @@ from polylogue.archive.query.search_hits import (
     search_hits_for_plan,
 )
 from polylogue.config import Config, Source
+from polylogue.core.enums import Provider
 from polylogue.protocols import VectorProvider
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import native_session_id_for
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.storage_records import SessionBuilder

--- a/tests/unit/archive/test_repo_identity.py
+++ b/tests/unit/archive/test_repo_identity.py
@@ -21,11 +21,11 @@ from polylogue.archive.session.repo_identity import (
 from polylogue.archive.session.session_profile import SessionProfile, build_session_profile
 from polylogue.archive.session.session_summaries import summarize_day
 from polylogue.archive.viewport.viewports import ToolCategory
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.insights.archive_models import DaySessionSummaryPayload
 from polylogue.insights.archive_summaries import aggregate_day_session_summary_insights
 from polylogue.storage.runtime import DaySessionSummaryRecord
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 README_PATH = REPO_ROOT / "README.md"

--- a/tests/unit/archive/test_search_hits.py
+++ b/tests/unit/archive/test_search_hits.py
@@ -14,8 +14,8 @@ from polylogue.archive.query.search_hits import (
     session_search_hit_from_summary,
 )
 from polylogue.archive.session.domain_models import Session, SessionSummary
-from polylogue.core.enums import Origin
-from polylogue.types import Provider, SessionId
+from polylogue.core.enums import Origin, Provider
+from polylogue.types import SessionId
 
 
 def _session() -> Session:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands import maintenance
+from polylogue.core.enums import Provider
 from polylogue.storage.blob_gc import read_gc_history
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
@@ -16,7 +17,6 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveTierInitResult,
 )
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitAction, ArchiveInitPlan
-from polylogue.types import Provider
 
 _ARCHIVE_TIERS = ("source.db", "index.db", "embeddings.db", "ops.db", "user.db")
 

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from polylogue.cli import cli
 from polylogue.cli.shared.check_workflow import CheckCommandOptions, run_check_workflow
 from polylogue.cli.shared.types import AppEnv
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.readiness import ReadinessCheck, ReadinessReport, VerifyStatus
 from polylogue.schemas.operator.models import (
@@ -27,7 +28,6 @@ from polylogue.schemas.validation.models import (
 )
 from polylogue.storage.artifacts.views import ArtifactCohortSummary
 from polylogue.storage.runtime import ArtifactObservationRecord
-from polylogue.types import ArtifactSupportStatus, Provider
 from polylogue.ui import create_ui
 from tests.infra.archive_scenarios import open_index_db
 from tests.infra.json_contracts import (

--- a/tests/unit/cli/test_context_pack_view.py
+++ b/tests/unit/cli/test_context_pack_view.py
@@ -19,9 +19,9 @@ import pytest
 from polylogue.archive.message.roles import Role
 from polylogue.cli.commands.context_pack import run_context_pack_view
 from polylogue.cli.shared.types import AppEnv
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.types import BlockType, Provider
 
 
 def _archive_env(archive_root: Path) -> AppEnv:

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -202,9 +202,9 @@ class TestPreflightCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from polylogue.archive.message.roles import Role
+        from polylogue.core.enums import BlockType, Provider
         from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-        from polylogue.types import BlockType, Provider
 
         archive_root = tmp_path / "archive"
         monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
@@ -244,9 +244,9 @@ class TestPreflightCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from polylogue.archive.message.roles import Role
+        from polylogue.core.enums import BlockType, Provider
         from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-        from polylogue.types import BlockType, Provider
 
         archive_root = tmp_path / "archive"
         monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -33,10 +33,10 @@ from polylogue.cli.query_contracts import (
     QueryOutputSpec,
 )
 from polylogue.cli.shared.types import AppEnv
+from polylogue.core.enums import Provider
 from polylogue.services import build_runtime_services
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
 from polylogue.surfaces.payloads import decode_search_cursor
-from polylogue.types import Provider
 from tests.infra.builders import make_conv, make_msg
 
 pytestmark = pytest.mark.query_routing

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -41,9 +41,9 @@ from polylogue.cli.query_output import (
     render_stream_transcript,
 )
 from polylogue.cli.query_output_contracts import StructuredRowsDocument
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.rendering.formatting import _conv_to_dict, _yaml_safe, format_session
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.builders import make_conv as build_conv
 from tests.infra.builders import make_msg as build_msg
 

--- a/tests/unit/cli/test_query_support_runtime.py
+++ b/tests/unit/cli/test_query_support_runtime.py
@@ -19,8 +19,9 @@ from polylogue.cli import query_output, query_semantic, query_stats
 from polylogue.cli.query_actions import apply_modifiers, apply_transform, delete_sessions, resolve_stream_target
 from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryMutationSpec, QueryOutputSpec
 from polylogue.cli.shared.types import AppEnv
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.builders import make_conv, make_msg
 
 

--- a/tests/unit/core/test_enums.py
+++ b/tests/unit/core/test_enums.py
@@ -13,8 +13,8 @@ from polylogue.core.enums import (
     sql_check_in,
     sql_value_list,
 )
-from polylogue.types import BlockType as TypesBlockType
-from polylogue.types import Provider as LegacyProvider
+from polylogue.core.enums import BlockType as TypesBlockType
+from polylogue.core.enums import Provider as LegacyProvider
 
 
 def test_core_enums_preserve_legacy_import_identity() -> None:

--- a/tests/unit/core/test_facade_api.py
+++ b/tests/unit/core/test_facade_api.py
@@ -354,9 +354,9 @@ class TestPolylogueReadSurfaces:
 
     @pytest.mark.asyncio
     async def test_get_raw_artifacts_resolves_id_and_handles_missing(self: object, tmp_path: Path) -> None:
+        from polylogue.core.enums import Provider
         from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-        from polylogue.types import Provider
 
         archive = _archive(tmp_path)
 

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -20,8 +20,9 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from polylogue.core import json as core_json
+from polylogue.core.enums import Provider
 from polylogue.core.provider_identity import normalize_provider_token
-from polylogue.types import AttachmentId, ContentHash, MessageId, Provider, SessionId
+from polylogue.types import AttachmentId, ContentHash, MessageId, SessionId
 
 SURROGATE_CATEGORY: tuple[Literal["Cs"], ...] = ("Cs",)
 

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -17,7 +17,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Message
 from polylogue.archive.raw_payload import build_raw_payload_envelope
 from polylogue.archive.viewport.viewports import ToolCall, classify_tool
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider, SemanticBlockType
 from polylogue.core.json import JSONDocument, JSONValue, json_document
 from polylogue.core.provider_identity import (
     canonical_acquisition_provider,
@@ -34,7 +34,7 @@ from polylogue.storage.hydrators import (
 from polylogue.storage.runtime import (
     MessageRecord,
 )
-from polylogue.types import ContentHash, MessageId, Provider, SemanticBlockType, SessionId
+from polylogue.types import ContentHash, MessageId, SessionId
 from tests.infra.builders import make_msg
 from tests.infra.storage_records import make_attachment, make_content_block, make_message, make_session
 

--- a/tests/unit/core/test_runtime_registry_helpers.py
+++ b/tests/unit/core/test_runtime_registry_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
 from polylogue.schemas.runtime_registry import (
     SchemaRegistry,
@@ -15,7 +16,6 @@ from polylogue.schemas.runtime_registry import (
     _resolved_package_version,
     canonical_schema_provider,
 )
-from polylogue.types import Provider
 
 
 def _package(

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig
 from polylogue.schemas.sampling import load_samples_from_db, load_samples_from_sessions
-from polylogue.types import Provider
 from tests.infra.schema_access import schema_node
 
 

--- a/tests/unit/core/test_schema_corpus_alignment.py
+++ b/tests/unit/core/test_schema_corpus_alignment.py
@@ -17,6 +17,7 @@ from polylogue.archive.raw_payload.sampling_extract import (
     extract_payload_samples,
     extract_record_samples_from_raw_content,
 )
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue, json_document
 from polylogue.schemas.field_stats.stats import FieldStats
 from polylogue.schemas.generation.schema_builder import (
@@ -34,7 +35,6 @@ from polylogue.schemas.inference.semantic.runtime import (
 )
 from polylogue.schemas.observation_models import ProviderConfig
 from polylogue.schemas.operator.annotations import build_review_evidence
-from polylogue.types import Provider
 
 
 def _payload_documents(records: list[dict[str, str]]) -> list[JSONValue]:

--- a/tests/unit/core/test_schema_laws.py
+++ b/tests/unit/core/test_schema_laws.py
@@ -12,6 +12,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document
 from polylogue.schemas.operator.schema_inference import (
     _remove_nested_required,
@@ -22,7 +23,6 @@ from polylogue.schemas.operator.schema_inference import (
     load_samples_from_sessions,
 )
 from polylogue.schemas.validator import SchemaValidator
-from polylogue.types import Provider
 from tests.infra.schema_access import schema_node, schema_properties
 from tests.infra.strategies import (
     SessionJsonlFileSpec,

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import json_document
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas import ValidationResult
@@ -19,7 +20,6 @@ from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.validation.corpus import verify_raw_corpus
 from polylogue.schemas.validation.requests import SchemaVerificationRequest
 from polylogue.schemas.validator import SchemaValidator, _normalize_empty_arrays, validate_provider_export
-from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from polylogue.config import Source

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -25,10 +25,10 @@ from polylogue.archive.session import extraction as work_event_extraction
 from polylogue.archive.session import runtime as session_profile_runtime
 from polylogue.archive.session.events import SessionEvent
 from polylogue.archive.session.session_profile import build_session_profile
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.archive_views import SessionRenderProjection
-from polylogue.types import Provider, SessionEventId, SessionId
+from polylogue.types import SessionEventId, SessionId
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.storage_records import make_attachment, make_message, make_session
 

--- a/tests/unit/core/test_sources.py
+++ b/tests/unit/core/test_sources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import (
     ALL_SOURCES,
     Source,
@@ -14,7 +14,6 @@ from polylogue.core.sources import (
     source_for_family,
     source_to_provider,
 )
-from polylogue.types import Provider
 
 
 def test_every_provider_has_source() -> None:

--- a/tests/unit/core/test_verification.py
+++ b/tests/unit/core/test_verification.py
@@ -40,10 +40,10 @@ def _insert_raw_record(
     raw_content: bytes,
 ) -> str:
     """Insert a raw record, writing content to blob store. Returns actual raw_id (hash)."""
+    from polylogue.core.enums import Provider
     from polylogue.core.sources import origin_from_provider
     from polylogue.storage.blob_store import get_blob_store
     from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session_blob_ref
-    from polylogue.types import Provider
 
     blob_store = get_blob_store()
     raw_id, blob_size = blob_store.write_from_bytes(raw_content)

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -14,6 +14,7 @@ import pytest
 
 import polylogue.daemon.convergence_stages as stages
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.daemon.convergence_stages import (
     make_default_convergence_stages,
     make_embed_stage,
@@ -28,7 +29,6 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import BlockType, Provider
 from tests.infra.frozen_clock import FrozenClock
 
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -992,10 +992,10 @@ def test_daemon_cli_active_archive_uses_index_when_db_anchor_exists(
 
 def test_daemon_cli_heartbeat_counts_archive(tmp_path: Path) -> None:
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.daemon import cli as daemon_cli
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     archive_root = tmp_path
     with ArchiveStore(archive_root) as archive:
@@ -1022,10 +1022,10 @@ def test_ensure_fts_startup_readiness_handles_archive(
     tmp_path: Path,
 ) -> None:
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.daemon import cli as daemon_cli
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     with ArchiveStore(tmp_path) as archive:
@@ -1064,10 +1064,10 @@ def test_ensure_fts_startup_readiness_uses_extended_write_timeout(
 ) -> None:
     import polylogue.daemon.fts_startup as fts_startup
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.daemon import cli as daemon_cli
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     with ArchiveStore(tmp_path) as archive:

--- a/tests/unit/daemon/test_fts_readiness_fallback.py
+++ b/tests/unit/daemon/test_fts_readiness_fallback.py
@@ -15,13 +15,13 @@ from pathlib import Path
 from typing import cast
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.daemon.fts_status import fts_readiness_info
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.fts.freshness import record_fts_surface_state_sync
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
-from polylogue.types import BlockType, Provider
 
 
 def _populated_index(db: Path) -> None:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -153,8 +153,8 @@ _SEED_SPECS = [
 
 
 def _origin_for(provider: str) -> str:
+    from polylogue.core.enums import Provider
     from polylogue.core.sources import origin_from_provider
-    from polylogue.types import Provider
 
     return origin_from_provider(Provider.from_string(provider)).value
 
@@ -186,9 +186,9 @@ def _seed_empty_schema(workspace: dict[str, Path]) -> None:
 def _seed_test_db(workspace: dict[str, Path]) -> None:
     """Seed a archive with three single-message sessions."""
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     workspace["archive_root"].mkdir(parents=True, exist_ok=True)
     with ArchiveStore(workspace["archive_root"]) as archive:
@@ -215,9 +215,9 @@ def _seed_test_db(workspace: dict[str, Path]) -> None:
 
 def _seed_archive_test_archive(workspace: dict[str, Path]) -> str:
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     workspace["archive_root"].mkdir(parents=True, exist_ok=True)
     with ArchiveStore(workspace["archive_root"]) as archive:
@@ -477,9 +477,9 @@ class TestReaderSessionState:
 
     def test_session_messages_apply_content_projection_flags(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.archive.message.roles import Role
+        from polylogue.core.enums import BlockType, Provider
         from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-        from polylogue.types import BlockType, Provider
 
         _seed_test_db(workspace_env)
         with ArchiveStore(workspace_env["archive_root"]) as archive:

--- a/tests/unit/daemon/test_web_shell_reader.py
+++ b/tests/unit/daemon/test_web_shell_reader.py
@@ -75,10 +75,10 @@ def _index_db_path(workspace: dict[str, Path]) -> Path:
 def _seed_test_db(workspace: dict[str, Path]) -> None:
     import sqlite3
 
+    from polylogue.core.enums import Provider
     from polylogue.core.sources import origin_from_provider
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
     from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-    from polylogue.types import Provider
 
     db = _index_db_path(workspace)
     db.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/devtools/test_benchmark_campaigns.py
+++ b/tests/unit/devtools/test_benchmark_campaigns.py
@@ -26,10 +26,10 @@ from devtools.synthetic_benchmark_runtime import (
     run_daemon_live_convergence_campaign,
     run_session_insight_materialization_campaign,
 )
+from polylogue.core.enums import Provider
 from polylogue.scenarios import ExecutionKind
 from polylogue.sources.dispatch import detect_provider
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
-from polylogue.types import Provider
 
 
 def test_synthetic_benchmark_registry_is_compiled_from_authored_scenarios() -> None:

--- a/tests/unit/mcp/test_context_pack.py
+++ b/tests/unit/mcp/test_context_pack.py
@@ -12,10 +12,10 @@ import pytest
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Session
 from polylogue.archive.query.spec import SessionQuerySpec
+from polylogue.core.enums import BlockType, Provider
 from polylogue.mcp.context_pack import select_context_pack_sessions
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.types import BlockType, Provider
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
     EXPECTED_TOOL_NAMES,

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -529,9 +529,9 @@ class TestNativeReadSurfaceHonorsContract:
     @staticmethod
     def _seed(archive_root: Path) -> str:
         from polylogue.archive.message.roles import Role
+        from polylogue.core.enums import BlockType, Provider
         from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-        from polylogue.types import BlockType, Provider
 
         with ArchiveStore(archive_root) as archive:
             return archive.write_parsed(

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -20,11 +20,11 @@ from mcp.server.fastmcp import FastMCP
 
 from polylogue.archive.query.fields import mcp_query_field_names
 from polylogue.archive.query.plan import SessionQueryPlan
+from polylogue.core.enums import Provider
 from polylogue.mcp.archive_support import archive_query_filters, archive_search_payload, archive_session_list_payload
 from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 from polylogue.mcp.server_tools import register_query_tools
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
-from polylogue.types import Provider
 
 SchemaMap = dict[str, dict[str, Any]]
 

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -14,9 +14,10 @@ import pytest
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Session, SessionSummary
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.types import BlockType, Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
     EXPECTED_PROMPT_NAMES,

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -26,7 +26,7 @@ from polylogue.archive.semantic.pricing import CostEstimatePayload, CostUsagePay
 from polylogue.archive.session.neighbor_candidates import NeighborReason, SessionNeighborCandidate
 from polylogue.archive.stats import ArchiveStats
 from polylogue.archive.viewport import read_view_profile_payloads
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, Provider
 from polylogue.core.outcomes import OutcomeCheck, OutcomeStatus
 from polylogue.insights.archive import (
     ArchiveCoverageInsight,
@@ -61,7 +61,7 @@ from polylogue.mcp.archive_support import (
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.surfaces.payloads import TagMutationResult
-from polylogue.types import BlockType, Provider, SessionId
+from polylogue.types import SessionId
 from tests.infra.mcp import (
     MCPServerUnderTest,
     invoke_surface,

--- a/tests/unit/pipeline/test_acquisition_streams.py
+++ b/tests/unit/pipeline/test_acquisition_streams.py
@@ -7,10 +7,10 @@ from pathlib import Path
 import pytest
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.pipeline.services import acquisition_streams
 from polylogue.sources.parsers.base import RawSessionData
-from polylogue.types import Provider
 
 
 async def test_iter_raw_record_stream_logs_make_raw_record_value_errors(

--- a/tests/unit/pipeline/test_archive_write.py
+++ b/tests/unit/pipeline/test_archive_write.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.pipeline.services.validation import ValidationService
 from polylogue.schemas import ValidationResult
 from polylogue.sources.parsers.base import (
@@ -25,7 +26,6 @@ from polylogue.sources.parsers.base import (
     ParsedSessionEvent,
 )
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
-from polylogue.types import BlockType, Provider
 from tests.infra.live_ingest import ingest_session
 
 

--- a/tests/unit/pipeline/test_branching.py
+++ b/tests/unit/pipeline/test_branching.py
@@ -12,6 +12,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Session
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.identity_law import session_id as archive_session_id
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources import iter_source_sessions
@@ -19,7 +20,6 @@ from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import archive_for_scenario_db
 from tests.infra.live_ingest import ingest_session
 from tests.infra.storage_records import SessionBuilder, db_setup

--- a/tests/unit/pipeline/test_content_hash_determinism.py
+++ b/tests/unit/pipeline/test_content_hash_determinism.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.hashing import hash_payload, hash_text
 from polylogue.pipeline.ids import (
     _normalize_for_hash,
@@ -17,7 +18,6 @@ from polylogue.pipeline.ids import (
 )
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.sources.parsers.base_models import ParsedSessionEvent
-from polylogue.types import BlockType, Provider
 
 
 def _msg(provider_id: str, role: str, text: str, timestamp: str | None = "2024-01-01T00:00:00Z") -> ParsedMessage:

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -16,6 +16,7 @@ import pytest
 
 import polylogue.pipeline.services.ingest_batch._core as ingest_batch_core
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.pipeline.services.ingest_batch import (
     _build_batch_memory_observation,
     _drain_ready_session_entries,
@@ -51,7 +52,7 @@ from polylogue.storage.search.cache import get_cache_stats
 from polylogue.storage.search.runtime import search_messages
 from polylogue.storage.sqlite.archive_tiers.write import _attachment_id
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import BlockType, Provider, SessionId
+from polylogue.types import SessionId
 
 BlockSpec: TypeAlias = tuple[str, ParsedContentBlock]
 AttachmentRefSpec: TypeAlias = tuple[str, str]

--- a/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
+++ b/tests/unit/pipeline/test_ingest_batch_resource_bounds.py
@@ -9,11 +9,11 @@ import pytest
 
 import polylogue.pipeline.services.ingest_batch._core as ingest_batch_core
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.pipeline.services.ingest_batch import _IngestWorkerRequest, _iter_ingest_results_sync
 from polylogue.pipeline.services.ingest_worker import IngestRecordResult, SessionWritePayload
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider
 
 
 def _large_raw_record() -> RawSessionRecord:

--- a/tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py
+++ b/tests/unit/pipeline/test_ingest_batch_wal_checkpoint.py
@@ -7,13 +7,13 @@ from pathlib import Path
 import pytest
 
 import polylogue.pipeline.services.ingest_batch._core as ingest_batch_core
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.pipeline.services.ingest_batch import _process_ingest_batch_sync
 from polylogue.pipeline.services.ingest_worker import IngestRecordResult
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.connection import open_connection
 from polylogue.storage.sqlite.wal_checkpoint import WalCheckpointObservation, maybe_checkpoint_wal
-from polylogue.types import Provider
 
 
 def test_process_ingest_batch_sync_records_wal_checkpoint_observation(

--- a/tests/unit/pipeline/test_malformed_jsonl_accounting.py
+++ b/tests/unit/pipeline/test_malformed_jsonl_accounting.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.archive.artifact_taxonomy import ArtifactClassification, ArtifactKind
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.pipeline.services.ingest_worker import (
     _IngestContext,
     _ParsePlan,
@@ -29,7 +30,6 @@ from polylogue.pipeline.services.ingest_worker import (
 from polylogue.storage.artifacts.inspection import inspect_raw_artifact
 from polylogue.storage.blob_store import BlobStore, reset_blob_store
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 
 @pytest.fixture

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -14,6 +14,7 @@ import pytest
 
 from polylogue.archive.raw_payload.decode import JSONValue
 from polylogue.config import Config, Source
+from polylogue.core.enums import Provider
 from polylogue.errors import DatabaseError
 from polylogue.pipeline.payload_types import ParseBatchObservation
 from polylogue.pipeline.services.acquisition import AcquireResult, AcquisitionService
@@ -25,7 +26,6 @@ from polylogue.sources.parsers.base import RawSessionData
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
-from polylogue.types import Provider
 
 WorkspacePaths = dict[str, Path]
 SessionPayload = dict[str, JSONValue]

--- a/tests/unit/pipeline/test_pipeline_ids.py
+++ b/tests/unit/pipeline/test_pipeline_ids.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import (
     session_content_hash,
     session_id,
 )
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
-from polylogue.types import Provider
 
 
 def _parsed_message(provider_message_id: str, role: str, text: str, timestamp: str | None) -> ParsedMessage:

--- a/tests/unit/pipeline/test_prepare.py
+++ b/tests/unit/pipeline/test_prepare.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.api import Polylogue
+from polylogue.core.enums import Provider
 from polylogue.core.identity_law import session_id as archive_session_id
 from polylogue.core.json import dumps
 from polylogue.core.sources import origin_from_provider
@@ -15,7 +16,6 @@ from polylogue.rendering.renderers.html import render_session_html
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.runtime import SessionRecord
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import native_session_id_for
 from tests.infra.storage_records import (
     SessionBuilder,

--- a/tests/unit/pipeline/test_prepare_semantic.py
+++ b/tests/unit/pipeline/test_prepare_semantic.py
@@ -10,12 +10,12 @@ Covers:
 from __future__ import annotations
 
 from polylogue.archive.viewport.viewports import ToolCategory, classify_tool
+from polylogue.core.enums import BlockType
 from polylogue.core.json import JSONDocument, json_document
 from polylogue.pipeline.semantic_capture import extract_subagent_spawns, parse_git_operation
 from polylogue.pipeline.semantic_metadata import extract_tool_metadata
 from polylogue.sources.parsers.base_models import ParsedContentBlock
 from polylogue.storage.sqlite.archive_tiers.write import _semantic_type
-from polylogue.types import BlockType
 
 
 def _payload(data: object) -> JSONDocument:

--- a/tests/unit/pipeline/test_quarantine_fixtures.py
+++ b/tests/unit/pipeline/test_quarantine_fixtures.py
@@ -34,13 +34,13 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import ValidationMode, ValidationStatus
 from polylogue.pipeline.services.ingest_worker import ingest_record
 from polylogue.pipeline.services.validation_flow import validate_raw_ids
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.raw.artifacts import RawIngestArtifactState
 from polylogue.storage.raw.models import RawSessionState
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import ValidationMode, ValidationStatus
 
 EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -24,6 +24,7 @@ from typing_extensions import TypedDict
 from polylogue.archive.message.roles import Role
 from polylogue.archive.raw_payload.decode import JSONValue
 from polylogue.config import Source
+from polylogue.core.enums import BlockType, Provider, ValidationStatus
 from polylogue.pipeline.services.acquisition import AcquisitionService
 from polylogue.pipeline.services.parsing import ParseResult, ParsingService
 from polylogue.pipeline.services.validation import ValidationService
@@ -38,7 +39,6 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
-from polylogue.types import BlockType, Provider, ValidationStatus
 from tests.infra.strategies import (
     AcquisitionInputSpec,
     ParseMergeEvent,

--- a/tests/unit/pipeline/test_roundtrip_hydration_laws.py
+++ b/tests/unit/pipeline/test_roundtrip_hydration_laws.py
@@ -15,9 +15,9 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.schemas.synthetic.core import SyntheticCorpus
-from polylogue.types import Provider
 from tests.infra.pipeline_roundtrip import parse_payload_roundtrip, write_and_hydrate
 from tests.infra.storage_records import db_setup
 

--- a/tests/unit/pipeline/test_validation_parallelism_contracts.py
+++ b/tests/unit/pipeline/test_validation_parallelism_contracts.py
@@ -31,6 +31,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.pipeline.services.validation_flow import evaluate_raw_artifacts
 from polylogue.pipeline.services.validation_runtime import (
     _validate_record_sync,
@@ -38,7 +39,6 @@ from polylogue.pipeline.services.validation_runtime import (
 )
 from polylogue.pipeline.stage_models import ValidateResult
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/rendering/test_output_snapshots.py
+++ b/tests/unit/rendering/test_output_snapshots.py
@@ -26,9 +26,9 @@ syrupy = pytest.importorskip("syrupy")
 
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.models import Message, Session
+from polylogue.core.enums import BlockType
 from polylogue.rendering.core_markdown import format_session_markdown
 from polylogue.rendering.renderers.html import render_session_html
-from polylogue.types import BlockType
 from tests.infra.builders import make_conv as build_conv
 from tests.infra.builders import make_msg as build_msg
 

--- a/tests/unit/rendering/test_rendering.py
+++ b/tests/unit/rendering/test_rendering.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 import pytest
 
 from polylogue.archive.models import Message, Session, SessionSummary
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, Provider
 from polylogue.rendering.block_models import RenderableBlock
 from polylogue.rendering.blocks import (
     render_blocks_html,
@@ -23,7 +23,7 @@ from polylogue.rendering.renderers.html import (
     _attach_branches,
     render_session_html,
 )
-from polylogue.types import BlockType, Provider, SessionId
+from polylogue.types import SessionId
 from polylogue.ui.facade_console import PlainConsole
 from tests.infra.builders import make_conv, make_msg
 

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -203,9 +203,9 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
 
 def test_build_demo_corpus_specs_materializes_with_synthetic_generator(tmp_path: Path) -> None:
     from polylogue.config import Source
+    from polylogue.core.enums import BlockType
     from polylogue.schemas.synthetic import SyntheticCorpus
     from polylogue.sources import iter_source_sessions
-    from polylogue.types import BlockType
 
     written = SyntheticCorpus.write_specs_artifacts(
         build_demo_corpus_specs(),

--- a/tests/unit/schemas/test_observation_runtime.py
+++ b/tests/unit/schemas/test_observation_runtime.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from polylogue.core.enums import Provider
 from polylogue.schemas.observation import ProviderConfig, extract_schema_units_from_payload
-from polylogue.types import Provider
 
 
 class TestExtractSchemaUnitsFromPayload:

--- a/tests/unit/sources/parsers/test_antigravity.py
+++ b/tests/unit/sources/parsers/test_antigravity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.sources.parsers.antigravity import (
     BRAIN_METADATA_FRAGMENT_FLAG,
@@ -11,7 +12,6 @@ from polylogue.sources.parsers.antigravity import (
     parse_brain_metadata,
     parse_markdown_export,
 )
-from polylogue.types import BlockType, Provider
 
 
 def test_parse_markdown_export_splits_known_sections() -> None:

--- a/tests/unit/sources/parsers/test_origin_regression_pack.py
+++ b/tests/unit/sources/parsers/test_origin_regression_pack.py
@@ -54,7 +54,7 @@ from typing import Any
 import pytest
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import Origin, Provider
+from polylogue.core.enums import BlockType, Origin, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources.dispatch import detect_provider, parse_payload
@@ -81,7 +81,6 @@ from polylogue.sources.parsers.local_agent import (
     parse_gemini_cli,
     parse_hermes,
 )
-from polylogue.types import BlockType
 
 # ---------------------------------------------------------------------------
 # Sentinel for "not applicable for this origin"

--- a/tests/unit/sources/test_antigravity_language_server.py
+++ b/tests/unit/sources/test_antigravity_language_server.py
@@ -16,6 +16,7 @@ from urllib.error import URLError
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.sources.parsers import antigravity
 from polylogue.sources.parsers.antigravity import (
     AntigravityExportError,
@@ -24,7 +25,6 @@ from polylogue.sources.parsers.antigravity import (
     discover_language_server,
     iter_language_server_exports,
 )
-from polylogue.types import Provider
 
 
 class _FakeHTTPResponse:

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -9,7 +9,7 @@ import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import Provider, TitleSource
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_session_index
@@ -20,7 +20,6 @@ from polylogue.sources.parsers.claude.index import (
     _looks_like_git_branch,
     enrich_session_from_index,
 )
-from polylogue.types import Provider
 
 
 def _parsed_message(provider_message_id: str, role: str, text: str) -> ParsedMessage:

--- a/tests/unit/sources/test_assembly_claude_code_history.py
+++ b/tests/unit/sources/test_assembly_claude_code_history.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.sources.assembly import SidecarData
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.parsers.base import (
@@ -23,7 +24,6 @@ from polylogue.sources.parsers.base import (
     ParsedSession,
 )
 from polylogue.sources.parsers.claude.history import HistoryEntry, HistoryPaste
-from polylogue.types import Provider
 
 
 def _iso(ts_ms: int) -> str:

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -8,8 +8,8 @@ from polylogue.api import Polylogue
 from polylogue.browser_capture.models import BrowserCaptureEnvelope
 from polylogue.browser_capture.receiver import write_capture_envelope
 from polylogue.config import Source, get_config
+from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import detect_provider, parse_payload
-from polylogue.types import Provider
 from tests.infra.archive_scenarios import open_index_db
 
 

--- a/tests/unit/sources/test_codex_event_stream_contract.py
+++ b/tests/unit/sources/test_codex_event_stream_contract.py
@@ -28,11 +28,11 @@ import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.enums import BlockType
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.parsers.codex import looks_like as _looks_like_impl
 from polylogue.sources.parsers.codex import parse as _parse_impl
 from polylogue.sources.parsers.codex import parse_stream
-from polylogue.types import BlockType
 
 CATALOG_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "codex_event_stream"
 

--- a/tests/unit/sources/test_compaction.py
+++ b/tests/unit/sources/test_compaction.py
@@ -464,8 +464,9 @@ class TestProfileCompactionCounting:
         from polylogue.archive.session.domain_models import Session
         from polylogue.archive.session.events import SessionEvent
         from polylogue.archive.session.runtime import build_session_profile
+        from polylogue.core.enums import Provider
         from polylogue.core.sources import origin_from_provider
-        from polylogue.types import Provider, SessionEventId, SessionId
+        from polylogue.types import SessionEventId, SessionId
 
         session = Session(
             id=SessionId("claude-code:session-1"),

--- a/tests/unit/sources/test_dispatch_ordering.py
+++ b/tests/unit/sources/test_dispatch_ordering.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import detect_provider
-from polylogue.types import Provider
 
 
 def _payload(obj: object) -> object:

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import _payload_record, _payload_sequence, parse_payload
-from polylogue.types import Provider
 
 
 def test_payload_sequence_normalizes_streaming_decimals() -> None:

--- a/tests/unit/sources/test_drive_ops.py
+++ b/tests/unit/sources/test_drive_ops.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, JSONValue
 from polylogue.sources import DriveFile, download_drive_files, iter_drive_sessions
 from polylogue.sources.drive import _apply_drive_attachments
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedSession
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.types import Provider
 
 
 def _attachment(

--- a/tests/unit/sources/test_gemini_chunked_prompt_contract.py
+++ b/tests/unit/sources/test_gemini_chunked_prompt_contract.py
@@ -29,11 +29,11 @@ from typing import cast
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.parsers.drive import looks_like as _looks_like_impl
 from polylogue.sources.parsers.drive import parse_chunked_prompt
-from polylogue.types import BlockType, Provider
 
 CATALOG_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "gemini_chunked_prompt"
 CATALOG_FIXTURES = (

--- a/tests/unit/sources/test_import_preflight.py
+++ b/tests/unit/sources/test_import_preflight.py
@@ -6,8 +6,8 @@ import json
 import zipfile
 from pathlib import Path
 
+from polylogue.core.enums import Provider
 from polylogue.sources.import_preflight import ImportPreflightStatus, preflight_import_source
-from polylogue.types import Provider
 
 
 def _chatgpt_payload() -> dict[str, object]:

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.append_ingest import ingest_append_plans
 from polylogue.sources.live.batch import _MAX_APPEND_PLAN_PAYLOAD_BYTES, LiveBatchProcessor
@@ -19,7 +20,6 @@ from polylogue.sources.live.batch_support import (
     _parse_path_as_session_artifact,
 )
 from polylogue.sources.live.cursor import CursorStore
-from polylogue.types import Provider
 
 
 def test_full_ingest_heartbeats_small_file_groups_with_current_path(

--- a/tests/unit/sources/test_null_guard_properties.py
+++ b/tests/unit/sources/test_null_guard_properties.py
@@ -29,11 +29,11 @@ from hypothesis.strategies import SearchStrategy
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Message, Session, SessionSummary
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.core.timestamps import parse_timestamp
 from polylogue.sources.providers.gemini import GeminiMessage, GeminiPart
-from polylogue.types import Provider, SessionId
+from polylogue.types import SessionId
 
 TimestampInput: TypeAlias = str | int | float | None
 SparseProviderMeta: TypeAlias = dict[str, object] | None

--- a/tests/unit/sources/test_parser_contract_v1.py
+++ b/tests/unit/sources/test_parser_contract_v1.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
-from polylogue.types import Provider
 
 
 def test_parsed_message_exposes_optional_archive_contract_fields() -> None:

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -845,7 +845,7 @@ def test_code_interpreter_content_is_preserved() -> None:
     assert "print(1)" in texts
     assert "1\n" in texts
     # Content-block types reflect the code-interpreter semantics.
-    from polylogue.types import BlockType
+    from polylogue.core.enums import BlockType
 
     code_msg = next(m for m in conv.messages if m.text == "print(1)")
     assert any(b.type == BlockType.CODE for b in code_msg.blocks)

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -6,12 +6,12 @@ import pytest
 
 from polylogue.archive.artifact_taxonomy import classify_artifact, classify_artifact_path
 from polylogue.config import Source
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.sources.dispatch import detect_provider, parse_payload
 from polylogue.sources.parsers import antigravity
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.source_parsing import iter_source_sessions
-from polylogue.types import BlockType, Provider
 
 
 def test_gemini_cli_session_document_parses_through_dispatch() -> None:

--- a/tests/unit/sources/test_paste_batch.py
+++ b/tests/unit/sources/test_paste_batch.py
@@ -13,12 +13,12 @@ import sqlite3
 from pathlib import Path
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import parse_payload
 from polylogue.sources.parsers.base import ParsedMessage, ParsedPasteEvidence, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
-from polylogue.types import Provider
 
 
 def _connect(path: Path) -> sqlite3.Connection:

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -21,7 +21,7 @@ from typing_extensions import TypedDict
 
 from polylogue.archive.message.roles import Role, normalize_role
 from polylogue.config import Source
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import Provider, TitleSource
 from polylogue.core.json import JSONDocument, JSONValue, is_json_value
 from polylogue.sources import decoders as decoders_module
 from polylogue.sources import dispatch as dispatch_module
@@ -84,7 +84,6 @@ from polylogue.sources.source_parsing import (
 from polylogue.sources.source_walk import _has_supported_extension
 from polylogue.storage.blob_store import BlobStore, Heartbeat
 from polylogue.storage.cursor_state import CursorFailurePayload, CursorStatePayload
-from polylogue.types import Provider
 from tests.infra.source_builders import GenericSessionBuilder, make_claude_chat_message
 from tests.infra.strategies import (
     json_array_bytes_strategy,

--- a/tests/unit/sources/test_tool_result_role_reclassification.py
+++ b/tests/unit/sources/test_tool_result_role_reclassification.py
@@ -10,12 +10,12 @@ The reclassification flips USER → TOOL when content is exclusively
 from __future__ import annotations
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType
 from polylogue.sources.parsers.base import ParsedContentBlock
 from polylogue.sources.parsers.claude.common import (
     extract_messages_from_chat_messages,
     reclassify_tool_result_envelope,
 )
-from polylogue.types import BlockType
 
 
 def _tool_result(idx: int) -> ParsedContentBlock:

--- a/tests/unit/storage/conftest.py
+++ b/tests/unit/storage/conftest.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import pytest
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
-from polylogue.types import Provider
 
 
 @pytest.fixture

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -9,6 +9,7 @@ import pytest
 
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.session.domain_models import Session
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources.parsers.drive import parse_chunked_prompt
@@ -27,7 +28,7 @@ from polylogue.storage.search_providers.hybrid_sessions import (
 )
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.query_store import SQLiteQueryStore
-from polylogue.types import ContentHash, Provider, SessionId
+from polylogue.types import ContentHash, SessionId
 from tests.infra.live_ingest import ingest_session
 
 

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedPasteEvidence, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.write import read_session_tags
-from polylogue.types import BlockType, Provider
 
 
 def test_active_archive_root_facade_writes_reads_and_searches_archive_db(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_tiers_provider_fixtures.py
+++ b/tests/unit/storage/test_archive_tiers_provider_fixtures.py
@@ -5,6 +5,7 @@ import sqlite3
 from pathlib import Path
 from typing import cast
 
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument
 from polylogue.sources.dispatch import parse_payload
 from polylogue.sources.parsers import antigravity
@@ -15,7 +16,6 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     search_archive_blocks,
     write_parsed_session_to_archive,
 )
-from polylogue.types import Provider
 
 
 def _connect(path: Path) -> sqlite3.Connection:

--- a/tests/unit/storage/test_archive_tiers_self_verify.py
+++ b/tests/unit/storage/test_archive_tiers_self_verify.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -21,7 +22,6 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     upsert_session_work_event,
     write_parsed_session_to_archive,
 )
-from polylogue.types import BlockType, Provider
 
 
 def test_archive_tiers_archive_self_verify_envelope_is_stable(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_tiers_user_overlay.py
+++ b/tests/unit/storage/test_archive_tiers_user_overlay.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -14,7 +15,6 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     upsert_session_work_event,
     write_parsed_session_to_archive,
 )
-from polylogue.types import BlockType, Provider
 
 
 def _connect(path: Path, tier: ArchiveTier) -> sqlite3.Connection:

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import BlockType, Provider, TitleSource
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -37,7 +37,6 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     upsert_session_work_event,
     write_parsed_session_to_archive,
 )
-from polylogue.types import BlockType, Provider
 
 
 def _connect(path: Path) -> sqlite3.Connection:

--- a/tests/unit/storage/test_artifact_loss_surfacing.py
+++ b/tests/unit/storage/test_artifact_loss_surfacing.py
@@ -13,13 +13,13 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.storage.artifacts.inspection import (
     _INSPECTION_PREFIX_BYTES,
     inspect_raw_artifact,
 )
 from polylogue.storage.blob_store import BlobStore, reset_blob_store
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.types import ArtifactSupportStatus, Provider
 
 
 @pytest.fixture

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -620,9 +620,9 @@ def test_provider_error_records_error_status_and_clears_retry(tmp_path: Path) ->
 
 def test_archive_pending_window_and_embedding_success(tmp_path: Path) -> None:
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     archive_root = tmp_path / "archive"
     long_text = "This archive message is long enough to embed for semantic search."
@@ -689,9 +689,9 @@ def test_archive_pending_window_and_embedding_success(tmp_path: Path) -> None:
 
 def test_archive_embedding_error_records_retryable_status(tmp_path: Path) -> None:
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-    from polylogue.types import BlockType, Provider
 
     class ErrorProvider(_FakeV1VectorProvider):
         def _get_embeddings(self, texts: list[str], input_type: str = "document") -> list[list[float]]:

--- a/tests/unit/storage/test_fts5.py
+++ b/tests/unit/storage/test_fts5.py
@@ -39,9 +39,9 @@ from tests.infra.strategies import fts5_match_text_strategy, search_query_strate
 
 
 def _archive_session_id(source_name: str, provider_session_id: str) -> str:
+    from polylogue.core.enums import Provider
     from polylogue.core.identity_law import session_id as make_archive_session_id
     from polylogue.core.sources import origin_from_provider
-    from polylogue.types import Provider
 
     return make_archive_session_id(origin_from_provider(Provider.from_string(source_name)).value, provider_session_id)
 

--- a/tests/unit/storage/test_parse_tracking.py
+++ b/tests/unit/storage/test_parse_tracking.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_DDL
@@ -25,7 +26,6 @@ from polylogue.storage.sqlite.schema import (
     SCHEMA_VERSION,
     _ensure_schema,
 )
-from polylogue.types import Provider
 
 # ─── Backend method tests ──────────────────────────────────────────────────
 

--- a/tests/unit/storage/test_pricing_chain_roundtrip.py
+++ b/tests/unit/storage/test_pricing_chain_roundtrip.py
@@ -21,11 +21,11 @@ from polylogue.archive.semantic.pricing import (
     PRICING,
     estimate_cost,
 )
+from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.pricing_seed import _catalog_id
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
-from polylogue.types import Provider
 
 
 def _make_archive(tmp_path: Path) -> sqlite3.Connection:

--- a/tests/unit/storage/test_run_state_models.py
+++ b/tests/unit/storage/test_run_state_models.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from polylogue.core.enums import PlanStage
 from polylogue.storage.run_state import DriftBucket, PlanCounts, PlanResult, RunCounts, RunDrift
-from polylogue.types import PlanStage
 
 
 def test_plan_result_coerces_stage_sequence_counts_details_and_cursors() -> None:

--- a/tests/unit/storage/test_session_insight_profiles.py
+++ b/tests/unit/storage/test_session_insight_profiles.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from polylogue.archive.models import Session
 from polylogue.archive.session.session_profile import build_session_analysis, build_session_profile
+from polylogue.core.enums import Provider
 from polylogue.storage.insights.session.profiles import (
     assistant_turn_texts,
     blocker_texts,
@@ -15,7 +16,6 @@ from polylogue.storage.insights.session.profiles import (
     session_enrichment_payload,
     user_turn_texts,
 )
-from polylogue.types import Provider
 from tests.infra.builders import make_conv, make_msg
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/unit/storage/test_session_insight_timeline_rows.py
+++ b/tests/unit/storage/test_session_insight_timeline_rows.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 from polylogue.archive.models import Session
 from polylogue.archive.session.session_profile import build_session_analysis, build_session_profile
+from polylogue.core.enums import Provider
 from polylogue.storage.insights.session.timeline_rows import (
     build_session_phase_records,
     build_session_work_event_records,
     hydrate_session_phase,
     hydrate_work_event,
 )
-from polylogue.types import Provider
 from tests.infra.builders import make_conv, make_msg
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -22,7 +22,7 @@ from typing_extensions import TypedDict, Unpack
 
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.session.domain_models import Session
-from polylogue.core.enums import Origin
+from polylogue.core.enums import BlockType, Origin, Provider, SemanticBlockType
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.query_models import SessionRecordQuery
 from polylogue.storage.repository import SessionRepository
@@ -36,15 +36,7 @@ from polylogue.storage.runtime import (
 )
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import (
-    AttachmentId,
-    BlockType,
-    ContentHash,
-    MessageId,
-    Provider,
-    SemanticBlockType,
-    SessionId,
-)
+from polylogue.types import AttachmentId, ContentHash, MessageId, SessionId
 from tests.infra.storage_records import (
     _prune_attachment_refs,
     make_attachment,

--- a/tests/unit/storage/test_surface_parity_adapters.py
+++ b/tests/unit/storage/test_surface_parity_adapters.py
@@ -25,9 +25,9 @@ from pathlib import Path
 import pytest
 
 from polylogue.api import Polylogue
+from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.types import Provider
 from tests.infra.storage_records import SessionBuilder, _record_to_parsed_session, db_setup
 
 # ---------------------------------------------------------------------------
@@ -146,8 +146,8 @@ class _SubstrateSurface:
                 return tuple(sorted({hit.session_id for hit in hits}))
             origin = None
             if case.provider is not None:
+                from polylogue.core.enums import Provider
                 from polylogue.core.sources import origin_from_provider
-                from polylogue.types import Provider
 
                 origin = origin_from_provider(Provider.from_string(case.provider)).value
             summaries = archive.list_summaries(

--- a/tests/unit/storage/test_topology_edges.py
+++ b/tests/unit/storage/test_topology_edges.py
@@ -33,6 +33,7 @@ import pytest
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.topology.edge import TopologyEdgeStatus, TopologyEdgeType
+from polylogue.core.enums import Provider
 from polylogue.core.identity_law import session_id as archive_session_id
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources import iter_source_sessions
@@ -40,7 +41,6 @@ from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.connection import open_connection
-from polylogue.types import Provider
 from tests.infra.live_ingest import ingest_session
 from tests.infra.storage_records import db_setup
 

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -10,11 +10,11 @@ import pytest
 
 from polylogue.api import Polylogue
 from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import archive_tier_spec
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.types import BlockType, Provider
 
 USER_STATE_SESSION_ID = "claude-code-session:conv-user-state"
 ARCHIVE_USER_STATE_SESSION_ID = "claude-code-session:conv-v1-user-state"

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -162,8 +162,8 @@ ATT_RAWHTML = _attachment_native_id(READER_C1_M1, "att-rawhtml")
 def _build_reader_c1(workspace: ReaderWorkspace, *, attachments: bool = False) -> None:
     """(Re)ingest the ``reader-c1`` session, optionally with the six
     MK3-state attachments linked to its first message."""
+    from polylogue.core.enums import BlockType
     from polylogue.daemon.web_shell_attachments import PREVIEW_SIZE_BUDGET
-    from polylogue.types import BlockType
     from tests.infra.storage_records import SessionBuilder
 
     builder = (


### PR DESCRIPTION
## Summary
Make `polylogue.types` the semantic ID-type module only. Core enums now come from `polylogue.core.enums` everywhere instead of being re-exported through a legacy-looking compatibility boundary.

## Problem
`polylogue.types` had two unrelated meanings: it defined real NewTypes (`SessionId`, `MessageId`, `AttachmentId`, `ContentHash`, `SessionEventId`) and also re-exported `Provider`, `BlockType`, `ValidationMode`, `ValidationStatus`, and related core enums. That kept an obsolete enum import path alive across production, devtools, and tests.

## Solution
Remove enum imports and enum names from `polylogue.types.__all__`. Mechanically migrate every enum import to `polylogue.core.enums`, splitting mixed imports so ID NewTypes stay on `polylogue.types` and enum types use their canonical module.

## Verification
- Source scan: enum imports from `polylogue.types` -> `bad [] count 0`; remaining imports are only `SessionId`, `ContentHash`, `MessageId`, `SessionEventId`, and `AttachmentId`.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- pre-push `devtools verify --quick` -> exit_code 0.

Closes none; continues #1849.