### PR TITLE
refactor(cli): remove embed activate alias (#1849)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -896,7 +896,7 @@ The `polylogue embed` group is the operator-facing onboarding surface:
 | Command | Purpose |
 |---------|---------|
 | `polylogue embed preflight` | Count pending messages + Voyage cost estimate without contacting the provider. |
-| `polylogue embed enable` (alias `activate`) | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
+| `polylogue embed enable` | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
 | `polylogue embed backfill` | Run a bounded, resumable embedding batch with per-session cost feedback; honours `embedding_max_cost_usd` as a soft cap and persists run progress. |
 | `polylogue embed disable` | Flip `embedding.enabled = false` without dropping existing embeddings — previously-embedded messages remain queryable via `--similar`. |
 | `polylogue embed status` | Coverage / freshness / configured model+cap / latest catch-up / next-action snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,7 +261,7 @@ The `polylogue embed` group is the operator-facing onboarding surface:
 | Command | Purpose |
 |---------|---------|
 | `polylogue embed preflight` | Count pending messages + Voyage cost estimate without contacting the provider. |
-| `polylogue embed enable` (alias `activate`) | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
+| `polylogue embed enable` | Verify `sqlite-vec`, capture the Voyage key, print the cost preflight, and on confirmation persist `[embedding] enabled = true` (and the API key unless `--no-store-key`) into the user `polylogue.toml`. |
 | `polylogue embed backfill` | Run a bounded, resumable embedding batch with per-session cost feedback; honours `embedding_max_cost_usd` as a soft cap and persists run progress. |
 | `polylogue embed disable` | Flip `embedding.enabled = false` without dropping existing embeddings — previously-embedded messages remain queryable via `--similar`. |
 | `polylogue embed status` | Coverage / freshness / configured model+cap / latest catch-up / next-action snapshot via `embedding_status_payload`. Use `--detail` for exact pending-message and retrieval-band accounting. |

--- a/docs/cli-audit.md
+++ b/docs/cli-audit.md
@@ -56,7 +56,7 @@ Registered in `polylogue/cli/click_command_registration.py`.
 | `cost` | Analytics | **Keep** | Subscription usage and cost telemetry. Subcommand: `outlook`. |
 | `insights` | Insights | **Keep (restructure)** | 14 subcommands. Needs grouping — see Subcommand Grouping below. |
 | `diagnostics` | Diagnostics | **Keep** | Temporal session diagnostics. Subcommands: `pace`, `tools`, `turns`. |
-| `embed` | Embeddings | **Keep** | Embedding pipeline management. Subcommands: `activate`, `backfill`, `disable`, `enable`, `preflight`, `status`. |
+| `embed` | Embeddings | **Keep** | Embedding pipeline management. Subcommands: `backfill`, `disable`, `enable`, `preflight`, `status`. |
 | `feedback` | User-State | **Keep** | Learning corrections for derived insights. Subcommands: `clear`, `list`, `record`. |
 | `schema` | Schema | **Keep** | Schema package inspection. Subcommands: `compare`, `explain`, `list`. |
 | `tags` | User-State | **Keep** | Tag management. Flat command with list/add/remove. Works as-is in the query-first model. |
@@ -110,11 +110,10 @@ Rename `insights tags` to `insights tag-rollups` to resolve collision with `poly
 | `tools` | **Keep** | Top tools by invocation count. |
 | `turns` | **Keep** | Per-turn cost and duration. |
 
-#### `embed` (6 subcommands)
+#### `embed` (5 subcommands)
 
 | Subcommand | Recommendation | Notes |
 |-----------|---------------|-------|
-| `activate` | **Keep (alias)** | Alias for `enable`. Keep both — `activate` is the user-facing verb, `enable` is the config verb. |
 | `backfill` | **Keep** | Run embedding batch. |
 | `disable` | **Keep** | Disable pipeline without dropping embeddings. |
 | `enable` | **Keep** | Turn on pipeline. |

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `271`
+- scenario projections: `270`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
-  - exercise: `164`
+  - exercise: `163`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -365,7 +365,6 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-diagnostics-turns` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | diagnostics turns help |
 | `exercise` | `help-doctor` | `message-fts-readiness-loop`<br>`retrieval-band-readiness-loop` | `message_fts`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`archive_readiness` | `cli.help`<br>`project-archive-readiness` | — | `generated`<br>`help`<br>`structural` | doctor help |
 | `exercise` | `help-embed` | `embedding-materialization-loop` | `archive_session_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | embed help |
-| `exercise` | `help-embed-activate` | `embedding-materialization-loop` | `archive_session_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | embed activate help |
 | `exercise` | `help-embed-backfill` | `embedding-materialization-loop` | `archive_session_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | embed backfill help |
 | `exercise` | `help-embed-disable` | `embedding-materialization-loop` | `archive_session_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | embed disable help |
 | `exercise` | `help-embed-enable` | `embedding-materialization-loop` | `archive_session_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | embed enable help |

--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -2,11 +2,11 @@
 
 This is the operator-facing onboarding surface for the embedding pipeline
 described in [`docs/architecture.md`](../../../docs/architecture.md) —
-``polylogue embed enable`` (alias: ``activate``) writes the config flip and
-records the Voyage API key in ``polylogue.toml``; ``polylogue embed preflight``
-counts the sessions that would be embedded plus the Voyage cost estimate
-without contacting the provider; ``polylogue embed backfill`` runs the first
-batch with per-session cost feedback against the cost cap; and
+``polylogue embed enable`` writes the config flip and records the Voyage API
+key in ``polylogue.toml``; ``polylogue embed preflight`` counts the sessions
+that would be embedded plus the Voyage cost estimate without contacting the
+provider; ``polylogue embed backfill`` runs the first batch with per-session
+cost feedback against the cost cap; and
 ``polylogue embed disable`` flips the gate back off without dropping any
 existing embeddings.
 
@@ -37,11 +37,11 @@ from polylogue.storage.embeddings.preflight import (
 )
 
 # Resolution order for the API key:
-#   1. explicit --voyage-api-key flag on the activate command
+#   1. explicit --voyage-api-key flag on the enable command
 #   2. existing voyage_api_key in user TOML (set by a prior activation)
 #   3. VOYAGE_API_KEY environment variable
-# Only #1 and #3 are accepted by ``activate``; #2 is reused on the second
-# activation so existing keys are not lost.
+# Only #1 and #3 are accepted by ``enable``; #2 is reused on the second
+# enable run so existing keys are not lost.
 
 
 def _effective_cost_cap(config_cap_usd: float, run_cap_usd: float | None) -> float:
@@ -191,7 +191,7 @@ def _splice_embedding_section(
 
 
 def _resolve_user_config_path() -> Path:
-    """Return the user TOML path the activate flow should write to.
+    """Return the user TOML path the enable flow should write to.
 
     Honors ``POLYLOGUE_CONFIG`` so tests and per-project setups can redirect
     the write; otherwise falls back to the XDG starter path.
@@ -303,13 +303,6 @@ def enable_subcommand(
     if no_store_key:
         click.echo("API key not stored in config; ensure VOYAGE_API_KEY remains set for daemon and CLI.")
     click.echo("Run [bold]polylogue embed backfill[/bold] to start the first embedding batch, or restart polylogued.")
-
-
-@embed_command.command("activate")
-@click.pass_context
-def activate_subcommand(ctx: click.Context) -> None:
-    """Alias for ``embed enable`` retained as a discoverable verb."""
-    ctx.forward(enable_subcommand)
 
 
 @embed_command.command("disable")
@@ -615,7 +608,6 @@ def status_subcommand(env: AppEnv, output_format: str, detail: bool) -> None:
 
 __all__ = [
     "PreflightReport",
-    "activate_subcommand",
     "backfill_subcommand",
     "disable_subcommand",
     "embed_command",

--- a/tests/baselines/showcase/help-embed-activate.txt
+++ b/tests/baselines/showcase/help-embed-activate.txt
@@ -1,6 +1,0 @@
-Usage: polylogue embed activate [OPTIONS]
-
-  Alias for ``embed enable`` retained as a discoverable verb.
-
-Options:
-  -h, --help  Show this message and exit.

--- a/tests/baselines/showcase/help-embed.txt
+++ b/tests/baselines/showcase/help-embed.txt
@@ -6,7 +6,6 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  activate   Alias for ``embed enable`` retained as a discoverable verb.
   backfill   Run the first embedding batch with per-session cost feedback.
   disable    Disable the embedding pipeline without dropping existing...
   enable     Turn on the embedding pipeline.


### PR DESCRIPTION
## Summary
Remove `polylogue embed activate` as a duplicate public command. `polylogue embed enable` is now the single embedding activation surface.

## Problem
`embed activate` was only a forwarding alias to `embed enable`, but it still appeared in help output, showcase baselines, docs, and generated agent memory. That kept an explicit compatibility alias in the command tree contrary to the current cleanup direction.

## Solution
Delete the `activate` Click subcommand and export, remove its help baseline, and update architecture/audit/generated quality references so onboarding points only at `embed enable`.

## Verification
- exact stale-reference scan for `embed activate|activate_subcommand|Alias for ``embed enable``|alias: ``activate``|help-embed-activate` -> no matches.
- `nix develop --command devtools test tests/unit/cli/test_embed_activation.py tests/unit/cli/test_embed.py -k 'EnableCommand or SpliceEmbeddingSection or DisableCommand or PreflightCommand or embed'` -> 55 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- pre-push `devtools verify --quick` -> exit_code 0.

Closes none; continues #1849.