### PR TITLE
refactor(cli): remove backup include-blobs flag (#1849)

### DIFF
--- a/polylogue/cli/commands/backup.py
+++ b/polylogue/cli/commands/backup.py
@@ -26,13 +26,6 @@ from polylogue.logging import configure_logging
     help="Verify backup prerequisites without creating a backup.",
 )
 @click.option(
-    "--include-blobs",
-    "include_blobs",
-    is_flag=True,
-    default=False,
-    help="Accepted for compatibility; backups copy referenced blobs automatically.",
-)
-@click.option(
     "--verify",
     "verify",
     is_flag=True,
@@ -49,7 +42,6 @@ from polylogue.logging import configure_logging
 def backup_command(
     output_dir: Path,
     check_only: bool,
-    include_blobs: bool,
     verify: bool,
     profile: BackupProfile,
 ) -> None:
@@ -66,7 +58,6 @@ def backup_command(
     result = backup_archive(
         output_dir=output_dir,
         check_only=check_only,
-        include_blobs=include_blobs,
         verify=verify,
         profile=profile,
     )

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -268,7 +268,6 @@ def backup_archive(
     *,
     output_dir: Path,
     check_only: bool = False,
-    include_blobs: bool = False,
     verify: bool = False,
     profile: BackupProfile = "rebuildable_cache_exclude",
 ) -> BackupResult:
@@ -282,8 +281,6 @@ def backup_archive(
     Args:
         output_dir: Target directory for the backup.
         check_only: If True, only verify prerequisites without creating a backup.
-        include_blobs: Retained for CLI compatibility; backups copy
-            only blobs referenced by source.db.
         verify: Restore the finished backup into a scratch directory and run
             integrity/smoke checks before returning.
         profile: Named backup profile controlling which archive tiers are copied.
@@ -306,7 +303,6 @@ def backup_archive(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    del include_blobs
     result = _backup_archive(output_dir=output_dir, started=started, profile=profile)
     if verify and result.ok and result.output_path is not None:
         _verify_backup_result(result)

--- a/tests/baselines/showcase/help-backup.txt
+++ b/tests/baselines/showcase/help-backup.txt
@@ -7,8 +7,6 @@ Options:
                                   [required]
   --check                         Verify backup prerequisites without creating
                                   a backup.
-  --include-blobs                 Accepted for compatibility; backups copy
-                                  referenced blobs automatically.
   --verify                        Restore the finished backup into a scratch
                                   directory and run smoke checks.
   --profile [full_evidence|user_overlays|rebuildable_cache_exclude|diagnostics_bundle]

--- a/tests/unit/cli/test_backup_command.py
+++ b/tests/unit/cli/test_backup_command.py
@@ -32,7 +32,6 @@ def test_backup_command_passes_profile_to_archive_backup(
         {
             "output_dir": tmp_path,
             "check_only": False,
-            "include_blobs": False,
             "verify": False,
             "profile": "full_evidence",
         }


### PR DESCRIPTION
## Summary
Remove the no-op `polylogue backup --include-blobs` compatibility flag and the matching daemon keyword. Backups already copy blobs referenced by `source.db`; the flag did not alter behavior.

## Problem
`--include-blobs` was still exposed as a public option even though `backup_archive()` immediately discarded the value. The focused CLI test then asserted pass-through of a dead parameter, which is exactly the kind of compatibility residue #1849 is removing.

## Solution
Deleted the Click option, removed `include_blobs` from `backup_archive()`, updated the CLI test, and refreshed the `help-backup` showcase baseline so the public help surface matches the command.

## Verification
- `rg -n 'include_blobs|include-blobs|Accepted for compatibility|Retained for CLI compatibility' polylogue tests docs AGENTS.md` -> no matches
- `nix develop --command devtools test tests/unit/cli/test_backup_command.py tests/unit/daemon/test_backup.py tests/unit/showcase/test_verification_lane.py -k 'backup or baseline'` -> 22 passed, 5 deselected
- `nix develop --command devtools lab-scenario verify-baselines --update` -> 79 exercises updated
- `nix develop --command devtools verify --quick` -> exit_code 0
- pre-push `devtools verify --quick` -> exit_code 0

Ref #1849