### PR TITLE
fix(devtools): stream pytest progress during verify

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -380,6 +380,8 @@ def _run_pytest_with_heartbeat(
                 if chunk:
                     stream_name = str(selector_key.data)
                     output[stream_name].append(chunk)
+                    sys.stderr.write(chunk.decode(errors="replace"))
+                    sys.stderr.flush()
                     last_output = time.monotonic()
                 else:
                     selector.unregister(selector_key.fileobj)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -329,6 +329,14 @@ def test_pytest_run_emits_heartbeat_for_long_silent_child(
     assert "elapsed=" in captured.err
 
 
+def test_pytest_run_streams_child_output_live(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, _elapsed, _metadata = _run("pytest output", [sys.executable, "-c", "print('pytest-progress')"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "pytest-progress" in captured.err
+
+
 def test_pytest_run_terminates_after_runtime_budget(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

Stream pytest stdout/stderr live from `devtools verify` while still retaining the output for failure metadata. Long pytest-testmon phases now show actual child progress instead of hiding all dots/failures until the process exits.

## Problem

The verify harness already had heartbeat lines, but it buffered pytest output in memory. A large pytest-testmon run could therefore look idle and opaque even while pytest was actively executing and printing progress. That made it hard to distinguish a real hang from an oversized affected set or storage contention.

## Solution

- Tee each pytest stdout/stderr chunk to the parent stderr as soon as it is read.
- Keep the existing captured-output buffers so failure reporting and metadata behavior remain unchanged.
- Add a focused unit test proving child output is visible on a passing pytest subprocess.

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_verify.py -k 'pytest_run_streams_child_output_live or pytest_run_emits_heartbeat_for_long_silent_child or pytest_run_terminates_after_output_stall or run_reads_structured_pytest_report'` selected 4 tests: 4 passed, 38 deselected.
- `nix develop --command devtools verify --quick` exited 0.