### PR TITLE
fix(devtools): expose live pytest verify progress (#2006)

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -34,6 +34,7 @@ import signal
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -135,6 +136,7 @@ TESTMON_DATA = Path(".testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
+PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
 PYTEST_STALL_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S"
@@ -254,6 +256,52 @@ def _clear_pytest_report() -> None:
     """Remove a stale report before a pytest step runs."""
     with contextlib.suppress(FileNotFoundError):
         PYTEST_REPORT_PATH.unlink()
+    with contextlib.suppress(FileNotFoundError):
+        PYTEST_PROGRESS_PATH.unlink()
+
+
+def _write_pytest_progress(
+    *,
+    event: str,
+    cmd: list[str],
+    started_at: float,
+    pid: int | None = None,
+    returncode: int | None = None,
+    elapsed_s: float | None = None,
+    idle_s: float | None = None,
+    output_bytes: Mapping[str, int] | None = None,
+    status: Mapping[str, str | int | None] | None = None,
+    cpu_pct: float | None = None,
+    termination_reason: str | None = None,
+) -> None:
+    """Write a live pytest progress artifact for long verify runs."""
+    if elapsed_s is None:
+        elapsed_s = time.monotonic() - started_at
+    payload: dict[str, Any] = {
+        "event": event,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "elapsed_s": round(elapsed_s, 2),
+        "command": cmd,
+    }
+    if pid is not None:
+        payload["pid"] = pid
+    if returncode is not None:
+        payload["returncode"] = returncode
+    if idle_s is not None:
+        payload["idle_s"] = round(idle_s, 2)
+    if output_bytes is not None:
+        payload["output_bytes"] = dict(output_bytes)
+    if status is not None:
+        payload["process_state"] = status.get("state")
+        payload["rss_kb"] = status.get("rss_kb")
+    if cpu_pct is not None:
+        payload["cpu_pct"] = round(cpu_pct, 2)
+    if termination_reason is not None:
+        payload["termination_reason"] = termination_reason
+    PYTEST_PROGRESS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PYTEST_PROGRESS_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    tmp.replace(PYTEST_PROGRESS_PATH)
 
 
 def _process_cpu_seconds(pid: int) -> float | None:
@@ -345,10 +393,18 @@ def _run_pytest_with_heartbeat(
     )
     assert process.stdout is not None
     assert process.stderr is not None
+    _write_pytest_progress(
+        event="started",
+        cmd=cmd,
+        started_at=t0,
+        pid=process.pid,
+        output_bytes={"stdout": 0, "stderr": 0},
+    )
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ, "stdout")
     selector.register(process.stderr, selectors.EVENT_READ, "stderr")
     output: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
+    output_bytes = {"stdout": 0, "stderr": 0}
     last_cpu = _process_cpu_seconds(process.pid)
     last_sample = time.monotonic()
     last_output = last_sample
@@ -380,9 +436,19 @@ def _run_pytest_with_heartbeat(
                 if chunk:
                     stream_name = str(selector_key.data)
                     output[stream_name].append(chunk)
+                    output_bytes[stream_name] += len(chunk)
                     sys.stderr.write(chunk.decode(errors="replace"))
                     sys.stderr.flush()
                     last_output = time.monotonic()
+                    _write_pytest_progress(
+                        event="output",
+                        cmd=cmd,
+                        started_at=t0,
+                        pid=process.pid,
+                        idle_s=0.0,
+                        output_bytes=output_bytes,
+                        status=_process_status(process.pid),
+                    )
                 else:
                     selector.unregister(selector_key.fileobj)
         else:
@@ -403,6 +469,17 @@ def _run_pytest_with_heartbeat(
                 f"idle={sample_now - last_output:.0f}s{state_text}{cpu_text}{rss_text}\n"
             )
             sys.stderr.flush()
+            _write_pytest_progress(
+                event="heartbeat",
+                cmd=cmd,
+                started_at=t0,
+                pid=process.pid,
+                elapsed_s=sample_now - t0,
+                idle_s=sample_now - last_output,
+                output_bytes=output_bytes,
+                status=status,
+                cpu_pct=cpu_pct,
+            )
         if process.poll() is not None and not selector.get_map():
             break
 
@@ -412,11 +489,29 @@ def _run_pytest_with_heartbeat(
         if remaining:
             stream_name = "stdout" if stream is process.stdout else "stderr"
             output[stream_name].append(remaining)
+            output_bytes[stream_name] += len(remaining)
     stdout = b"".join(output["stdout"]).decode(errors="replace")
     stderr = b"".join(output["stderr"]).decode(errors="replace")
     if termination_reason is not None:
+        _write_pytest_progress(
+            event="terminated",
+            cmd=cmd,
+            started_at=t0,
+            pid=process.pid,
+            returncode=124,
+            output_bytes=output_bytes,
+            termination_reason=termination_reason,
+        )
         stderr = f"{stderr}\nverify: {termination_reason}; terminated pytest process group {process.pid}\n"
         return subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+    _write_pytest_progress(
+        event="finished",
+        cmd=cmd,
+        started_at=t0,
+        pid=process.pid,
+        returncode=process.returncode or 0,
+        output_bytes=output_bytes,
+    )
     return subprocess.CompletedProcess(cmd, process.returncode or 0, stdout, stderr)
 
 
@@ -439,6 +534,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         metadata["heartbeat_s"] = _pytest_heartbeat_interval()
         metadata["timeout_s"] = _pytest_timeout_s()
         metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
+        metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
         report = _read_pytest_report()
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report))

--- a/tests/unit/core/test_query_descriptor_parity.py
+++ b/tests/unit/core/test_query_descriptor_parity.py
@@ -12,18 +12,14 @@ from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 
 
 def test_descriptor_mcp_names_match_mcp_query_request_fields() -> None:
-    """Every MCPSessionQueryRequest field with a descriptor must match."""
+    """Every query-bearing MCPSessionQueryRequest field has descriptor metadata."""
     mcp_fields = {field.name for field in fields(MCPSessionQueryRequest)}
     declared: set[str] = set()
     for d in QUERY_FIELD_DESCRIPTORS:
         declared.update(d.mcp_names)
-    # Control fields (limit, offset, sort) don't need descriptors
     control_fields = {"limit", "offset", "sort"}
     query_fields = mcp_fields - control_fields
-    missing = query_fields - declared
-    # Not all MCP fields need descriptors; this is informational
-    if missing:
-        pass  # flag for review, not blocking
+    assert query_fields - declared == set()
 
 
 def test_all_descriptors_have_mcp_or_api_name() -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -8,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from devtools.verify import (
+    PYTEST_PROGRESS_PATH,
     PYTEST_REPORT_PATH,
     ROOT,
     _format_completion_notification,
@@ -335,6 +337,18 @@ def test_pytest_run_streams_child_output_live(capsys: pytest.CaptureFixture[str]
     captured = capsys.readouterr()
     assert rc == 0
     assert "pytest-progress" in captured.err
+
+
+def test_pytest_run_writes_live_progress_artifact() -> None:
+    rc, _elapsed, metadata = _run("pytest progress", [sys.executable, "-c", "print('pytest-progress')"])
+
+    assert rc == 0
+    assert metadata["progress_path"] == str(PYTEST_PROGRESS_PATH)
+    progress = json.loads(PYTEST_PROGRESS_PATH.read_text())
+    assert progress["event"] == "finished"
+    assert progress["returncode"] == 0
+    assert progress["output_bytes"]["stdout"] > 0
+    assert "updated_at" in progress
 
 
 def test_pytest_run_terminates_after_runtime_budget(

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -339,12 +339,14 @@ def test_pytest_run_streams_child_output_live(capsys: pytest.CaptureFixture[str]
     assert "pytest-progress" in captured.err
 
 
-def test_pytest_run_writes_live_progress_artifact() -> None:
+def test_pytest_run_writes_live_progress_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
     rc, _elapsed, metadata = _run("pytest progress", [sys.executable, "-c", "print('pytest-progress')"])
 
     assert rc == 0
+    progress_path = tmp_path / PYTEST_PROGRESS_PATH
     assert metadata["progress_path"] == str(PYTEST_PROGRESS_PATH)
-    progress = json.loads(PYTEST_PROGRESS_PATH.read_text())
+    progress = json.loads(progress_path.read_text())
     assert progress["event"] == "finished"
     assert progress["returncode"] == 0
     assert progress["output_bytes"]["stdout"] > 0


### PR DESCRIPTION
## Summary

Adds a live progress artifact for pytest-backed `devtools verify` runs and turns MCP query descriptor parity into an enforced contract now that coverage is complete.

## Problem

The final pytest JSON report is written only when pytest exits. During long pytest-testmon runs, that left no machine-readable progress artifact to inspect, so an active verify could look hung even when the subprocess was alive. Separately, the MCP query descriptor parity test had become a no-op even though current MCP query fields are fully represented by descriptor metadata.

## Solution

`devtools verify` now writes `.cache/verify/current-pytest-progress.json` during pytest steps on start, output, heartbeat, timeout/stall termination, and finish. The artifact records elapsed time, pid, output byte counts, RSS/state when sampled, return code, and termination reason when applicable. Pytest step metadata now reports the progress path. The descriptor parity test now asserts that every query-bearing `MCPSessionQueryRequest` field is represented by `QUERY_FIELD_DESCRIPTORS`, excluding only control fields.

## Verification

- `nix develop --command devtools test tests/unit/core/test_query_descriptor_parity.py tests/unit/devtools/test_verify.py -k 'descriptor_mcp_names_match_mcp_query_request_fields or pytest_run_writes_live_progress_artifact or pytest_run_streams_child_output_live or pytest_run_emits_heartbeat_for_long_silent_child or pytest_run_terminates_after_runtime_budget or pytest_run_terminates_after_output_stall or run_reads_structured_pytest_report'` -> 7 passed, 41 deselected.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` reran on `d8510ef1` -> exit_code 0.

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running verification runs now emit live progress artifacts with real-time tracking of timing, output metrics, and process status.

* **Tests**
  * Strengthened query descriptor parity validation to enforce strict alignment of descriptor fields.
  * Added test coverage for progress artifact generation during verification runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->