### PR TITLE
feat(query): scope unit predicates by owning session (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -74,7 +74,7 @@ Unit queries select terminal rows instead of sessions:
 
 ```bash
 polylogue messages where 'role:assistant AND text:timeout'
-polylogue actions where 'action:file_edit AND path:polylogue/archive'
+polylogue actions where 'session.repo:polylogue AND action:file_edit AND path:polylogue/archive'
 polylogue blocks where 'type:code AND text:sqlite'
 ```
 
@@ -140,10 +140,16 @@ one child row matching the nested predicate.
 | `action` | `action`, `command`, `output`, `path`, `text`, `tool`, `type` |
 | `block` | `action`, `command`, `path`, `text`, `tool`, `type` |
 
+All three structural units also accept `session.<field>` predicates for the
+owning session fields, such as `session.repo`, `session.origin`,
+`session.tag`, `session.title`, `session.date`, `session.since`, and
+`session.until`. This lets a unit query carry its session scope inline instead
+of splitting selection between the query string and parallel parameters.
+
 Examples:
 
 ```bash
-polylogue sessions where 'exists action(tool:bash AND text:pytest)'
+polylogue sessions where 'exists action(session.repo:polylogue AND tool:bash AND text:pytest)'
 polylogue sessions where 'exists block(type:code AND text:timeout)'
 ```
 
@@ -169,7 +175,7 @@ rows instead:
 
 ```bash
 polylogue --format json messages where role:assistant AND text:timeout
-polylogue --format ndjson actions where action:file_edit AND path:polylogue/archive
+polylogue --format ndjson actions where session.repo:polylogue AND action:file_edit AND path:polylogue/archive
 polylogue --format yaml blocks where type:code AND text:sqlite
 ```
 
@@ -180,6 +186,15 @@ transport-specific renderings of the same message/action/block row payloads.
 Those surfaces share the same session-scoping filters for the row source
 where applicable, such as origin, tag, repo, title, date bounds, message-type
 and tool/paste/thinking feature filters.
+
+Use `session.<field>` inside the expression when the unit rows should be scoped
+by their owning session:
+
+```bash
+polylogue messages where session.origin:claude-code-session AND role:assistant
+polylogue actions where session.repo:polylogue AND action:file_edit
+polylogue blocks where session.since:7d AND type:code
+```
 
 Session filters such as `--origin`, `--tag`, `--repo`, `--since`, and `--until`
 still narrow the owning sessions before rows are returned. Session-only actions

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -477,7 +477,7 @@ _QUERY_GRAMMAR = r"""
     FTS_QUOTED_TEXT.6: /~"(\\.|[^"\\])*"/
     FTS_BARE_TEXT.5: /~[^\s"()]+/
     COUNT_CLAUSE.8: /(messages|words):(>=|<=|=)\d+(?!\S)/
-    FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
+    FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_.]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
     NEG_QUOTED_TEXT.3: /-"(\\.|[^"\\])*"/
     QUOTED_TEXT.2: /"(\\.|[^"\\])*"/
     NEG_BARE_TEXT.1: /-[^\s"]+/
@@ -500,7 +500,7 @@ _COUNT_CLAUSE_RE = re.compile(r"^(messages|words):(>=|<=|=)(\d+)$")
 _FIELD_CLAUSE_RE = re.compile(
     r"""
     ^(-?)
-    ([a-zA-Z_][a-zA-Z0-9_]*)
+    ([a-zA-Z_][a-zA-Z0-9_.]*)
     :
     (
         "(?:\\.|[^"\\])*"
@@ -554,6 +554,7 @@ _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
 _MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command", "path", "output", "words"}
 _ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text"}
 _BLOCK_STRUCTURAL_FIELDS = {"type", "text", "tool", "action", "command", "path"}
+_SCOPED_SESSION_STRUCTURAL_FIELDS = tuple(f"session.{field}" for field in sorted(_BOOLEAN_SUPPORTED_FIELDS))
 
 
 @dataclass(frozen=True)
@@ -588,18 +589,18 @@ class DateQueryFieldInfo:
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
-        fields=tuple(sorted(_ACTION_STRUCTURAL_FIELDS)),
-        example="exists action(tool:bash AND text:pytest)",
+        fields=tuple(sorted((*_ACTION_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        example="exists action(session.repo:polylogue AND tool:bash AND text:pytest)",
     ),
     "block": StructuralQueryUnitInfo(
         description="Match sessions with at least one parsed message block satisfying the child predicate.",
-        fields=tuple(sorted(_BLOCK_STRUCTURAL_FIELDS)),
-        example="exists block(type:code AND text:timeout)",
+        fields=tuple(sorted((*_BLOCK_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        example="exists block(session.origin:codex-session AND type:code AND text:timeout)",
     ),
     "message": StructuralQueryUnitInfo(
         description="Match sessions with at least one message satisfying the child predicate.",
-        fields=tuple(sorted(_MESSAGE_STRUCTURAL_FIELDS)),
-        example="exists message(role:assistant AND text:timeout)",
+        fields=tuple(sorted((*_MESSAGE_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        example="exists message(session.repo:polylogue AND role:assistant AND text:timeout)",
     ),
 }
 
@@ -831,19 +832,28 @@ _QUERY_TRANSFORMER = _QueryTransformer()
 
 def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
     field_name = token.field
-    if field_name not in EXPRESSION_FIELD_REGISTRY and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
+    session_field = _scoped_session_field(field_name)
+    validation_field = session_field or field_name
+    if (
+        session_field is None
+        and field_name not in EXPRESSION_FIELD_REGISTRY
+        and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS
+    ):
         raise ExpressionCompileError(
             _unknown_query_field_message(field_name, include_structural=True),
             field=field_name,
         )
-    if field_name not in _BOOLEAN_SUPPORTED_FIELDS and field_name not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS:
+    if (
+        validation_field not in _BOOLEAN_SUPPORTED_FIELDS
+        and validation_field not in _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS
+    ):
         raise ExpressionCompileError(
             f"field {field_name!r} is not supported inside Boolean SQL predicates yet",
             field=field_name,
         )
 
     values = _split_alternation(token.raw_value) if token.raw_value else ()
-    if field_name == "origin":
+    if validation_field == "origin":
         known_origins = {o.value for o in Origin}
         for value in values:
             if value not in known_origins:
@@ -851,7 +861,7 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
                     f"unknown origin {value!r}; recognized: " + ", ".join(sorted(known_origins)),
                     field="origin",
                 )
-    elif field_name == "action":
+    elif validation_field == "action":
         for value in values:
             candidate = value.strip().lower()
             if candidate not in QUERY_ACTION_TYPES:
@@ -860,11 +870,11 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
                     field="action",
                 )
         values = tuple(value.strip().lower() for value in values if value.strip())
-    elif field_name in {"tool", "has", "role", "type", "command", "path", "output"}:
+    elif validation_field in {"tool", "has", "role", "type", "command", "path", "output"}:
         values = tuple(value.strip().lower() for value in values if value.strip())
-    elif field_name in {"since", "until"} and values:
+    elif validation_field in {"since", "until"} and values:
         values = (_parse_relative_date(values[-1]),)
-    elif field_name == "lineage":
+    elif validation_field == "lineage":
         if token.negated:
             raise ExpressionCompileError("negation is not supported for 'lineage'", field=field_name)
         seed = values[-1].strip() if values else ""
@@ -876,6 +886,16 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
 
     predicate: QueryPredicate = QueryFieldPredicate(field=field_name, values=values)
     return QueryNotPredicate(predicate) if token.negated else predicate
+
+
+def _scoped_session_field(field_name: str) -> str | None:
+    prefix = "session."
+    if not field_name.startswith(prefix):
+        return None
+    scoped = field_name[len(prefix) :]
+    if not scoped:
+        raise ExpressionCompileError("session. predicates require a field name", field=field_name)
+    return scoped
 
 
 def _count_token_to_predicate(token: _CountToken) -> QueryFieldPredicate:
@@ -940,30 +960,37 @@ def _validate_predicate_context(
     predicate: QueryPredicate, *, unit: Literal["session", "message", "action", "block"]
 ) -> None:
     if isinstance(predicate, QueryFieldPredicate):
+        session_field = _scoped_session_field(predicate.field)
         if unit == "session":
             supported = _BOOLEAN_SUPPORTED_FIELDS
+            effective_field = predicate.field
         elif unit == "message":
             supported = _MESSAGE_STRUCTURAL_FIELDS
+            effective_field = session_field or predicate.field
         elif unit == "action":
             supported = _ACTION_STRUCTURAL_FIELDS
+            effective_field = session_field or predicate.field
         else:
             supported = _BLOCK_STRUCTURAL_FIELDS
-        if predicate.field not in supported:
+            effective_field = session_field or predicate.field
+        if session_field is not None and unit != "session":
+            supported = _BOOLEAN_SUPPORTED_FIELDS
+        if effective_field not in supported:
             raise ExpressionCompileError(
                 f"field {predicate.field!r} is not supported for {unit} predicates",
                 field=predicate.field,
             )
         if (
-            predicate.field in {"role", "type", "text", "tool", "action", "command", "path", "output"}
+            effective_field in {"role", "type", "text", "tool", "action", "command", "path", "output"}
             and not predicate.values
         ):
             raise ExpressionCompileError(f"field {predicate.field!r} requires a value", field=predicate.field)
-        if predicate.field == "date":
+        if effective_field == "date":
             if not predicate.values:
                 raise ExpressionCompileError("field 'date' requires a value", field="date")
             if predicate.op not in {">=", "<="}:
                 raise ExpressionCompileError("field 'date' supports only >=, <=, >, <, and between", field="date")
-        if predicate.field == "words":
+        if effective_field == "words":
             if not predicate.values:
                 raise ExpressionCompileError("field 'words' requires a numeric value", field="words")
             try:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3221,7 +3221,7 @@ class ArchiveStore:
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
-        clause, params = _structural_predicate_clause("message", "m", predicate)
+        clause, params = _structural_predicate_clause("message", "m", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
         if session_filters:
@@ -3283,7 +3283,7 @@ class ArchiveStore:
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
-        clause, params = _structural_predicate_clause("action", "a", predicate)
+        clause, params = _structural_predicate_clause("action", "a", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
         if session_filters:
@@ -3343,7 +3343,7 @@ class ArchiveStore:
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
-        clause, params = _structural_predicate_clause("block", "b", predicate)
+        clause, params = _structural_predicate_clause("block", "b", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
         if session_filters:
@@ -4421,6 +4421,14 @@ def _field_predicate_clause(
     return _clause_without_prefix(where, prefix="WHERE"), params
 
 
+def _scoped_session_field(field: str) -> str | None:
+    prefix = "session."
+    if not field.startswith(prefix):
+        return None
+    scoped = field[len(prefix) :]
+    return scoped or None
+
+
 def _in_or_equals_clause(column: str, values: tuple[str, ...], *, lower: bool = False) -> tuple[str, list[object]]:
     normalized = tuple(value.strip().lower() if lower else value.strip() for value in values if value.strip())
     if not normalized:
@@ -4568,8 +4576,19 @@ def _structural_predicate_clause(
     unit: str,
     row_alias: str,
     predicate: QueryPredicate,
+    *,
+    session_alias: str | None = None,
 ) -> tuple[str, list[object]]:
     if isinstance(predicate, QueryFieldPredicate):
+        session_field = _scoped_session_field(predicate.field)
+        if session_field is not None:
+            if session_alias is None:
+                raise ValueError(f"session-scoped {unit} predicate requires a session alias")
+            return _field_predicate_clause(
+                session_alias,
+                QueryFieldPredicate(field=session_field, values=predicate.values, op=predicate.op),
+                tags_relation="session_tags",
+            )
         if unit == "message":
             return _message_field_predicate_clause(row_alias, predicate)
         if unit == "action":
@@ -4577,13 +4596,13 @@ def _structural_predicate_clause(
         if unit == "block":
             return _block_field_predicate_clause(row_alias, predicate)
     if isinstance(predicate, QueryNotPredicate):
-        clause, params = _structural_predicate_clause(unit, row_alias, predicate.child)
+        clause, params = _structural_predicate_clause(unit, row_alias, predicate.child, session_alias=session_alias)
         return (f"NOT ({clause})" if clause else "", params)
     if isinstance(predicate, QueryBoolPredicate):
         child_clauses: list[str] = []
         merged_params: list[object] = []
         for child in predicate.children:
-            clause, child_params = _structural_predicate_clause(unit, row_alias, child)
+            clause, child_params = _structural_predicate_clause(unit, row_alias, child, session_alias=session_alias)
             if clause:
                 child_clauses.append(f"({clause})")
                 merged_params.extend(child_params)
@@ -4597,7 +4616,12 @@ def _structural_predicate_clause(
 def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) -> tuple[str, list[object]]:
     if predicate.unit == "message":
         row_alias = "exists_messages"
-        child_clause, params = _structural_predicate_clause(predicate.unit, row_alias, predicate.child)
+        child_clause, params = _structural_predicate_clause(
+            predicate.unit,
+            row_alias,
+            predicate.child,
+            session_alias=table_alias,
+        )
         return (
             f"""
             EXISTS (
@@ -4611,7 +4635,12 @@ def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) 
         )
     if predicate.unit == "action":
         row_alias = "exists_actions"
-        child_clause, params = _structural_predicate_clause(predicate.unit, row_alias, predicate.child)
+        child_clause, params = _structural_predicate_clause(
+            predicate.unit,
+            row_alias,
+            predicate.child,
+            session_alias=table_alias,
+        )
         return (
             f"""
             EXISTS (
@@ -4625,7 +4654,12 @@ def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) 
         )
     if predicate.unit == "block":
         row_alias = "exists_blocks"
-        child_clause, params = _structural_predicate_clause(predicate.unit, row_alias, predicate.child)
+        child_clause, params = _structural_predicate_clause(
+            predicate.unit,
+            row_alias,
+            predicate.child,
+            session_alias=table_alias,
+        )
         return (
             f"""
             EXISTS (

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -710,6 +710,73 @@ class TestBooleanQueryExpression:
             )
         ]
 
+    def test_session_scoped_message_predicate_executes_against_archive(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .git_repository_url("polylogue")
+            .title("session scoped hit")
+            .add_message("m-hit", role="assistant", text="the timeout happened")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .git_repository_url("sinex")
+            .title("session scoped miss")
+            .add_message("m-miss", role="assistant", text="the timeout happened")
+            .save()
+        )
+
+        spec = compile_expression("exists message(session.repo:polylogue AND role:assistant AND text:timeout)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["chatgpt-export:ext-hit"]
+
+    def test_terminal_message_source_accepts_session_scoped_predicate(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("message source hit")
+            .add_message("m-hit", role="assistant", text="the timeout happened")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("message source miss")
+            .add_message("m-miss", role="assistant", text="the timeout happened")
+            .save()
+        )
+
+        source = parse_unit_source_expression("messages where session.origin:claude-code-session AND role:assistant")
+        assert source is not None
+        field_predicate = source.predicate.children[0] if isinstance(source.predicate, QueryBoolPredicate) else None
+        assert isinstance(field_predicate, QueryFieldPredicate)
+        assert field_predicate.field == "session.origin"
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.session_id, row.message_id) for row in rows] == [
+            ("claude-code-session:ext-hit", "claude-code-session:ext-hit:m-hit")
+        ]
+
     def test_exists_action_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from tests.infra.storage_records import SessionBuilder
@@ -803,6 +870,44 @@ class TestBooleanQueryExpression:
                 "polylogue/archive/query/expression.py",
             )
         ]
+
+    def test_terminal_action_source_accepts_session_scoped_predicate(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        for session_id, repo_name in [("hit", "polylogue"), ("miss", "sinex")]:
+            (
+                SessionBuilder(index_db, session_id)
+                .provider("claude-code")
+                .git_repository_url(repo_name)
+                .title(f"action {session_id}")
+                .add_message(
+                    f"m-{session_id}",
+                    role="assistant",
+                    text="edited file",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Edit",
+                            "tool_id": f"tool-{session_id}",
+                            "input": {"file_path": "polylogue/archive/query/expression.py"},
+                            "semantic_type": "file_edit",
+                        }
+                    ],
+                )
+                .save()
+            )
+
+        source = parse_unit_source_expression("actions where session.repo:polylogue AND action:file_edit")
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_actions(source.predicate, limit=100)
+
+        assert [(row.session_id, row.semantic_type) for row in rows] == [("claude-code-session:ext-hit", "file_edit")]
 
     def test_exists_action_path_normalizes_backslashes(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -906,6 +1011,46 @@ class TestBooleanQueryExpression:
                 "def query_timeout_guard(): pass",
             )
         ]
+
+    def test_terminal_block_source_accepts_session_scoped_predicate(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("block hit")
+            .add_message(
+                "m-hit",
+                role="assistant",
+                text="assistant response",
+                blocks=[{"type": "code", "text": "def query_timeout_guard(): pass"}],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("claude-code")
+            .title("block miss")
+            .add_message(
+                "m-miss",
+                role="assistant",
+                text="assistant response",
+                blocks=[{"type": "code", "text": "def query_timeout_guard(): pass"}],
+            )
+            .save()
+        )
+
+        source = parse_unit_source_expression("blocks where session.origin:chatgpt-export AND type:code")
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_blocks(source.predicate, limit=100)
+
+        assert [(row.session_id, row.block_type) for row in rows] == [("chatgpt-export:ext-hit", "code")]
 
     def test_exists_block_tool_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary
Adds `session.<field>` predicates inside message/action/block unit queries so row-level DSL forms can scope by their owning session inline. This works for both terminal unit rows (`messages/actions/blocks where ...`) and session selectors lowered through `exists <unit>(...)`.

## Problem
#2006 had executable terminal unit rows, but owning-session constraints still had to travel as parallel surface parameters. That fragmented the DSL: `actions where action:file_edit` could select action rows, while repo/origin/date/tag scope lived outside the expression unless the query was first collapsed back to sessions.

## Solution
The Lark field token now accepts dotted field names and preserves `session.<field>` in the typed predicate AST. Predicate validation permits these scoped fields only inside message/action/block predicates, then the SQLite structural lowerer routes them through the existing session filter clause against the current session alias. The public search docs and query-expression tests now cover both `exists message(session.repo:...)` and terminal message/action/block row queries scoped by `session.origin` or `session.repo`.

## Verification
- `devtools test tests/unit/cli/test_query_expression.py -k 'session_scoped or terminal_message_source_accepts_session_scoped or terminal_action_source_accepts_session_scoped or terminal_block_source_accepts_session_scoped'` -> `4 passed, 235 deselected`
- `devtools test tests/unit/cli/test_query_expression.py` -> `239 passed`
- `devtools verify --quick` -> `exit_code: 0`

Ref #2006