### PR TITLE
test(surfaces): cover inline unit session scope (#1825)

### DIFF
--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1142,6 +1142,49 @@ async def test_query_units_applies_session_scope_filters(tmp_path: Path) -> None
         await archive.close()
 
 
+async def test_query_units_accepts_inline_session_scope(tmp_path: Path) -> None:
+    """``query_units()`` accepts owning-session scope inside the shared DSL."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="unit-inline-codex",
+                    title="Unit inline Codex",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            text="shared inline needle",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="shared inline needle")],
+                        )
+                    ],
+                )
+            )
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CHATGPT,
+                    provider_session_id="unit-inline-chatgpt",
+                    title="Unit inline ChatGPT",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            text="shared inline needle",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="shared inline needle")],
+                        )
+                    ],
+                )
+            )
+
+        envelope = await archive.query_units("messages where session.origin:codex-session AND text:needle")
+
+        assert [item.session_id for item in envelope.items] == ["codex-session:unit-inline-codex"]
+    finally:
+        await archive.close()
+
+
 async def test_query_units_rejects_session_expression(tmp_path: Path) -> None:
     """``query_units()`` is only for terminal source expressions."""
     from polylogue.archive.query.expression import ExpressionCompileError

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1104,6 +1104,14 @@ class TestReaderQueryUnits:
         items = cast(list[dict[str, object]], payload["items"])
         assert [item["session_id"] for item in items] == [C2]
 
+    def test_query_units_endpoint_accepts_inline_session_scope(self, workspace_env: dict[str, Path]) -> None:
+        expression = quote("messages where session.origin:chatgpt-export AND text:Hello")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(dict[str, object], _get_json(base_url, f"/api/query-units?expression={expression}"))
+
+        items = cast(list[dict[str, object]], payload["items"])
+        assert [item["session_id"] for item in items] == [C2]
+
     def test_query_units_endpoint_rejects_session_expression(self, workspace_env: dict[str, Path]) -> None:
         expression = quote("repo:polylogue")
         with _running_server(workspace_env) as (_, base_url):

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -643,6 +643,42 @@ class TestArchiveGenericToolSurfaces:
         assert [item["session_id"] for item in payload["items"]] == [kept_id]
 
     @pytest.mark.asyncio
+    async def test_query_units_tool_accepts_inline_session_scope(
+        self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        with ArchiveStore(archive_root) as archive:
+            kept_id = _write_archive_session(
+                archive,
+                provider=Provider.CODEX,
+                native_id="tool-query-units-inline-kept",
+                text="shared inline terminal row",
+            )
+            _write_archive_session(
+                archive,
+                provider=Provider.CHATGPT,
+                native_id="tool-query-units-inline-dropped",
+                text="shared inline terminal row",
+            )
+
+        with (
+            patch("polylogue.mcp.server._get_config") as mock_get_config,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        ):
+            mock_get_config.return_value = SimpleNamespace(
+                archive_root=archive_root,
+                db_path=archive_root / "index.db",
+            )
+            mock_get_polylogue.side_effect = AssertionError("query_units tool must not open archive operations")
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["query_units"].fn,
+                expression="messages where session.origin:codex-session AND text:terminal",
+            )
+
+        payload = json.loads(result)
+        assert [item["session_id"] for item in payload["items"]] == [kept_id]
+
+    @pytest.mark.asyncio
     async def test_query_units_tool_rejects_session_expression(self: object, mcp_server: MCPServerUnderTest) -> None:
         result = await invoke_surface_async(
             mcp_server._tool_manager._tools["query_units"].fn,


### PR DESCRIPTION
## Summary
Adds cross-surface parity coverage for `session.<field>` predicates inside terminal `messages/actions/blocks where ...` query-unit expressions.

## Problem
#2076 made inline owning-session scope executable in the shared query DSL, but #1825 requires advertised API/MCP/daemon surfaces to keep consuming the same semantics. Without consumer coverage, a surface could keep only the older parallel `origin=`/`repo=` parameters working and drift from the DSL.

## Solution
Added representative inline-scope query-unit cases for:
- Python `Polylogue.query_units()`;
- MCP `query_units`;
- daemon `GET /api/query-units`.

Each case selects rows by message text and narrows the owning session inline with `session.origin:...`, proving the shared parser/lowerer reaches the consumer surface.

## Verification
- `devtools test tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/daemon/test_web_reader.py -k 'query_units'` -> `13 passed, 331 deselected`
- `devtools verify --quick` -> `exit_code: 0`

Ref #1825