### PR TITLE
test(storage): cover assertion overlay parity (#1883)

### DIFF
--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -1,0 +1,39 @@
+"""Incremental pytest event ledger for ``devtools verify``.
+
+The pytest-json-report and JUnit artifacts are written at session end. When a
+long verify run is killed for timeout or output stall, those reports may never
+flush. This plugin writes one JSON object per completed test call so the
+operator still has node-level failure evidence after an interrupted run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
+
+
+def pytest_runtest_logreport(report: Any) -> None:
+    """Append one test-call event when configured by ``devtools verify``."""
+    if getattr(report, "when", None) != "call":
+        return
+    raw_path = os.environ.get(_EVENTS_ENV)
+    if not raw_path:
+        return
+    payload = {
+        "event": "test_report",
+        "updated_at": datetime.now(UTC).isoformat(),
+        "nodeid": str(getattr(report, "nodeid", "")),
+        "outcome": str(getattr(report, "outcome", "")),
+        "duration_s": round(float(getattr(report, "duration", 0.0) or 0.0), 4),
+    }
+    if payload["outcome"] == "failed":
+        payload["longrepr"] = str(getattr(report, "longrepr", ""))
+    path = Path(raw_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -8,6 +8,7 @@ operator still has node-level failure evidence after an interrupted run.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from datetime import UTC, datetime
@@ -19,7 +20,9 @@ _EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
 
 def pytest_runtest_logreport(report: Any) -> None:
     """Append one test-call event when configured by ``devtools verify``."""
-    if getattr(report, "when", None) != "call":
+    when = str(getattr(report, "when", ""))
+    outcome = str(getattr(report, "outcome", ""))
+    if when != "call" and outcome not in {"failed", "error"}:
         return
     raw_path = os.environ.get(_EVENTS_ENV)
     if not raw_path:
@@ -28,12 +31,14 @@ def pytest_runtest_logreport(report: Any) -> None:
         "event": "test_report",
         "updated_at": datetime.now(UTC).isoformat(),
         "nodeid": str(getattr(report, "nodeid", "")),
-        "outcome": str(getattr(report, "outcome", "")),
+        "when": when,
+        "outcome": outcome,
         "duration_s": round(float(getattr(report, "duration", 0.0) or 0.0), 4),
     }
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
     path = Path(raw_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    with contextlib.suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -137,6 +137,8 @@ TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
 PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
+PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
+PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
 PYTEST_STALL_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S"
@@ -254,10 +256,15 @@ def _pytest_command_metadata(cmd: list[str]) -> dict[str, Any]:
 
 def _clear_pytest_report() -> None:
     """Remove a stale report before a pytest step runs."""
-    with contextlib.suppress(FileNotFoundError):
-        PYTEST_REPORT_PATH.unlink()
-    with contextlib.suppress(FileNotFoundError):
-        PYTEST_PROGRESS_PATH.unlink()
+    for path in (PYTEST_REPORT_PATH, PYTEST_PROGRESS_PATH, PYTEST_EVENTS_PATH, PYTEST_OUTPUT_PATH):
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+
+
+def _write_pytest_output(stdout: str, stderr: str) -> None:
+    """Persist captured pytest output for killed runs and post-mortem review."""
+    PYTEST_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PYTEST_OUTPUT_PATH.write_text(stdout + ("\n" if stdout and stderr else "") + stderr, encoding="utf-8")
 
 
 def _write_pytest_progress(
@@ -492,6 +499,7 @@ def _run_pytest_with_heartbeat(
             output_bytes[stream_name] += len(remaining)
     stdout = b"".join(output["stdout"]).decode(errors="replace")
     stderr = b"".join(output["stderr"]).decode(errors="replace")
+    _write_pytest_output(stdout, stderr)
     if termination_reason is not None:
         _write_pytest_progress(
             event="terminated",
@@ -535,6 +543,8 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         metadata["timeout_s"] = _pytest_timeout_s()
         metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
+        metadata["events_path"] = str(PYTEST_EVENTS_PATH)
+        metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
         report = _read_pytest_report()
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report))
@@ -562,6 +572,7 @@ def _subprocess_env() -> dict[str, str]:
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
+    env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
     return env
 
 
@@ -624,6 +635,8 @@ def build_verify_steps(
             "--json-report",
             "--json-report-omit=collectors,log,streams,warnings",
             f"--json-report-file={PYTEST_REPORT_PATH}",
+            "-p",
+            "devtools.pytest_progress_plugin",
         ]
         base_marker = f"not slow and {scale_marker_expr}" if skip_slow else scale_marker_expr
         if seed_testmon:

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from devtools import pytest_progress_plugin
+
+
+@dataclass(frozen=True)
+class _Report:
+    nodeid: str
+    when: str
+    outcome: str
+    duration: float = 0.0
+    longrepr: str = ""
+
+
+def test_progress_plugin_records_call_and_setup_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", str(events_path))
+
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test_ok", "setup", "passed"))
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test_body", "call", "passed", duration=0.25))
+    pytest_progress_plugin.pytest_runtest_logreport(
+        _Report("test_setup", "setup", "failed", duration=0.1, longrepr="fixture exploded")
+    )
+
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    assert [(event["nodeid"], event["when"], event["outcome"]) for event in events] == [
+        ("test_body", "call", "passed"),
+        ("test_setup", "setup", "failed"),
+    ]
+    assert events[0]["duration_s"] == 0.25
+    assert events[1]["longrepr"] == "fixture exploded"
+
+
+def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
+
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test_body", "call", "failed", longrepr="boom"))

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 import pytest
 
 from devtools.verify import (
+    PYTEST_EVENTS_PATH,
+    PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
     PYTEST_REPORT_PATH,
     ROOT,
@@ -75,6 +77,7 @@ def test_pytest_step_requests_structured_json_report() -> None:
         for label, command in pytest_steps:
             assert "--json-report" in command, f"{label}: {command}"
             assert any(arg.startswith("--json-report-file=") for arg in command), label
+            assert command[command.index("-p") + 1] == "devtools.pytest_progress_plugin"
         # The canonical report path consumed by verify/dashboards is emitted by
         # the primary lane; the #1775 isolated lane writes its own file.
         expected_target = f"--json-report-file={PYTEST_REPORT_PATH}"
@@ -265,6 +268,8 @@ def test_run_records_pytest_count_metadata_from_terminal_fallback() -> None:
     assert rc == 0
     assert metadata["count"] == 4
     assert metadata["report_path"] is None
+    assert metadata["events_path"] == str(PYTEST_EVENTS_PATH)
+    assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
     assert metadata["pytest_workers"] == "unset"
     assert metadata["pytest_selection"] == "full"
 
@@ -283,6 +288,7 @@ def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyP
     assert env["POLYLOGUE_ROOT"] == str(ROOT)
     assert env["POLYLOGUE_REPO_ROOT"] == str(ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(ROOT / ".cache" / "pycache")
+    assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(ROOT / PYTEST_EVENTS_PATH)
 
 
 def test_run_reads_structured_pytest_report() -> None:
@@ -312,6 +318,8 @@ def test_run_reads_structured_pytest_report() -> None:
     assert metadata["total"] == 13
     assert metadata["pytest_duration_s"] == 4.56
     assert metadata["report_path"] == str(PYTEST_REPORT_PATH)
+    assert metadata["events_path"] == str(PYTEST_EVENTS_PATH)
+    assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
     assert metadata["pytest_workers"] == "8"
     assert metadata["pytest_selection"] == "testmon"
 
@@ -346,11 +354,13 @@ def test_pytest_run_writes_live_progress_artifact(tmp_path: Path, monkeypatch: p
     assert rc == 0
     progress_path = tmp_path / PYTEST_PROGRESS_PATH
     assert metadata["progress_path"] == str(PYTEST_PROGRESS_PATH)
+    assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
     progress = json.loads(progress_path.read_text())
     assert progress["event"] == "finished"
     assert progress["returncode"] == 0
     assert progress["output_bytes"]["stdout"] > 0
     assert "updated_at" in progress
+    assert "pytest-progress" in (tmp_path / PYTEST_OUTPUT_PATH).read_text()
 
 
 def test_pytest_run_terminates_after_runtime_budget(
@@ -366,6 +376,8 @@ def test_pytest_run_terminates_after_runtime_budget(
     assert rc == 124
     assert metadata["timeout_s"] == 0.15
     assert metadata["stall_timeout_s"] == 0.0
+    assert metadata["events_path"] == str(PYTEST_EVENTS_PATH)
+    assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
     assert "pytest runtime exceeded 0.15s" in captured.err
     assert "terminated pytest process group" in captured.err
 

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -15,6 +15,7 @@ from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, Pa
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import archive_tier_spec
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, list_assertions_for_target
 
 USER_STATE_SESSION_ID = "claude-code-session:conv-user-state"
 ARCHIVE_USER_STATE_SESSION_ID = "claude-code-session:conv-v1-user-state"
@@ -199,6 +200,89 @@ async def test_user_state_mutations_write_archive_user_tier(
     assert correction_row is not None
     assert correction_row[0:2] == (f"insight:{ARCHIVE_USER_STATE_SESSION_ID}", "tag_accept")
     assert json.loads(correction_row[2])["payload"] == {"tag": "archive"}
+
+
+@pytest.mark.asyncio
+async def test_blackboard_public_surface_writes_assertion_metadata(
+    workspace_env: dict[str, Path],
+) -> None:
+    archive_root = workspace_env["archive_root"]
+    session_id, message_id = _seed_user_state_session(
+        archive_root,
+        native_id="conv-blackboard-assertion",
+        message_native_id="msg-blackboard-assertion",
+    )
+
+    async with Polylogue(db_path=archive_root / "index.db", archive_root=archive_root) as poly:
+        note = await poly.post_blackboard_note(
+            kind="finding",
+            title="Assertion-backed blackboard",
+            content="The public blackboard surface should persist assertion metadata.",
+            scope_session=session_id,
+            author_ref="agent:codex-session:unit",
+            author_kind="agent",
+            evidence_refs=(f"message:{message_id}",),
+            staleness={"expires_after_days": 7},
+            context_policy={"inject": False, "promotion_required": True},
+        )
+        notes = await poly.list_blackboard_notes(kind="finding", limit=5)
+
+    assert [listed.note_id for listed in notes] == [note.note_id]
+    with sqlite3.connect(archive_root / "user.db") as conn:
+        conn.row_factory = sqlite3.Row
+        mirrored = list_assertions_for_target(conn, f"session:{session_id}", kind=AssertionKind.NOTE)
+
+    assert len(mirrored) == 1
+    assertion = mirrored[0]
+    assert assertion.key == note.note_id
+    assert assertion.author_ref == "agent:codex-session:unit"
+    assert assertion.author_kind == "agent"
+    assert assertion.evidence_refs == [f"message:{message_id}"]
+    assert assertion.staleness == {"expires_after_days": 7}
+    assert assertion.context_policy == {"inject": False, "promotion_required": True}
+
+
+@pytest.mark.asyncio
+async def test_tags_and_metadata_remain_table_backed_user_metadata(
+    workspace_env: dict[str, Path],
+) -> None:
+    archive_root = workspace_env["archive_root"]
+    session_id, _message_id = _seed_user_state_session(
+        archive_root,
+        native_id="conv-tag-metadata",
+        message_native_id="msg-tag-metadata",
+    )
+
+    async with Polylogue(db_path=archive_root / "index.db", archive_root=archive_root) as poly:
+        tag_result = await poly.add_tag(session_id, "Planning")
+        metadata_result = await poly.set_metadata(session_id, "owner", {"name": "sinity"})
+
+    assert tag_result.outcome == "added"
+    assert metadata_result.outcome == "set"
+    with sqlite3.connect(archive_root / "user.db") as conn:
+        tag_row = conn.execute(
+            """
+            SELECT tag, tag_source, method
+            FROM session_tags
+            WHERE session_id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+        metadata_row = conn.execute(
+            """
+            SELECT key, value_json
+            FROM session_metadata
+            WHERE session_id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+        assertion_rows = conn.execute("SELECT kind FROM assertions WHERE kind IN ('tag', 'metadata')").fetchall()
+
+    assert tag_row == ("planning", "user", "cli")
+    assert metadata_row is not None
+    assert metadata_row[0] == "owner"
+    assert json.loads(metadata_row[1]) == {"name": "sinity"}
+    assert assertion_rows == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds public-surface assertion parity coverage for #1883 and fixes the verification harness gap that surfaced while running the default baseline. The storage tests now prove blackboard writes through `Polylogue.post_blackboard_note()` preserve assertion metadata, and they prove ordinary session tags/session metadata remain the intentional table-backed user metadata exception rather than lifecycle assertions.

## Problem

#1883 had helper-level assertion write-through coverage and readiness audit coverage, but the durable public-facade proof was incomplete for two important cases: blackboard assertion metadata and the explicit tags/metadata exception. While validating the branch, `devtools verify` selected a very large pytest-testmon set, ran for 45 minutes, then timed out at 82%. Because pytest-json-report never flushed, verify reported `report_path: null` and lost node-level failure evidence despite many visible failures. That made the broad gate hard to act on.

## Solution

- Extend `tests/unit/storage/test_user_state_contracts.py` with public-facade assertions for blackboard author/evidence/staleness/context-policy metadata.
- Add explicit table-backed coverage for `Polylogue.add_tag()` and `Polylogue.set_metadata()`, matching #1883's current design: simple tag/metadata rows are user metadata, not assertion lifecycle claims.
- Add `devtools.pytest_progress_plugin`, loaded by every `devtools verify` pytest lane, which writes per-test call outcomes incrementally to `.cache/verify/current-pytest-events.jsonl`.
- Persist captured pytest stdout/stderr to `.cache/verify/current-pytest-output.log` and expose both paths in verify metadata so timeout/stall terminations leave usable evidence.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_user_state_contracts.py` -> `9 passed`.
- `nix develop --command devtools test tests/unit/devtools/test_verify.py tests/unit/storage/test_user_state_contracts.py` -> `52 passed`.
- `nix develop --command devtools verify --quick` -> `exit_code: 0` at `8c0a2e94`.
- Attempted default `nix develop --command devtools verify` before the harness fix: static gates passed, pytest-testmon timed out after 2700s at 82% with `report_path: null`. This PR fixes that evidence-loss path; I did not rerun another 45-minute default baseline after the harness patch.

Ref #1883
Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for assertion metadata persistence and user state validation.
  * Added verification for test execution artifact tracking and metadata propagation.

* **Chores**
  * Enhanced test execution monitoring with improved artifact generation for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->