### PR TITLE
feat(query): expose assertions as terminal query units (#2006)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -762,6 +762,87 @@ components:
       - tool_use_block_id
       title: ActionQueryRowPayload
       type: object
+    AssertionQueryRowPayload:
+      additionalProperties: false
+      description: Shared terminal-query row for user-tier assertions.
+      properties:
+        unit:
+          const: assertion
+          default: assertion
+          title: Unit
+          type: string
+        assertion_id:
+          title: Assertion Id
+          type: string
+        target_ref:
+          title: Target Ref
+          type: string
+        scope_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Scope Ref
+        kind:
+          title: Kind
+          type: string
+        key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Key
+        body_text:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Body Text
+        value:
+          title: Value
+        author_ref:
+          title: Author Ref
+          type: string
+        author_kind:
+          title: Author Kind
+          type: string
+        status:
+          title: Status
+          type: string
+        visibility:
+          title: Visibility
+          type: string
+        evidence_refs:
+          items:
+            type: string
+          title: Evidence Refs
+          type: array
+        staleness:
+          title: Staleness
+        context_policy:
+          title: Context Policy
+        created_at_ms:
+          title: Created At Ms
+          type: integer
+        updated_at_ms:
+          title: Updated At Ms
+          type: integer
+      required:
+      - assertion_id
+      - target_ref
+      - kind
+      - value
+      - author_ref
+      - author_kind
+      - status
+      - visibility
+      - evidence_refs
+      - staleness
+      - context_policy
+      - created_at_ms
+      - updated_at_ms
+      title: AssertionQueryRowPayload
+      type: object
     BlockQueryRowPayload:
       additionalProperties: false
       description: Shared terminal-query row for archive content blocks.
@@ -886,7 +967,7 @@ components:
       type: object
     QueryUnitEnvelope:
       additionalProperties: false
-      description: Shared envelope for ``messages/actions/blocks where ...`` query results.
+      description: Shared envelope for explicit terminal unit-source query results.
       properties:
         mode:
           const: query-unit
@@ -898,6 +979,7 @@ components:
           - message
           - action
           - block
+          - assertion
           title: Unit
           type: string
         query:
@@ -909,6 +991,7 @@ components:
             - $ref: '#/components/schemas/MessageQueryRowPayload'
             - $ref: '#/components/schemas/ActionQueryRowPayload'
             - $ref: '#/components/schemas/BlockQueryRowPayload'
+            - $ref: '#/components/schemas/AssertionQueryRowPayload'
           title: Items
           type: array
         total:

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -120,6 +120,123 @@
       "title": "ActionQueryRowPayload",
       "type": "object"
     },
+    "AssertionQueryRowPayload": {
+      "additionalProperties": false,
+      "description": "Shared terminal-query row for user-tier assertions.",
+      "properties": {
+        "assertion_id": {
+          "title": "Assertion Id",
+          "type": "string"
+        },
+        "author_kind": {
+          "title": "Author Kind",
+          "type": "string"
+        },
+        "author_ref": {
+          "title": "Author Ref",
+          "type": "string"
+        },
+        "body_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Body Text"
+        },
+        "context_policy": {
+          "title": "Context Policy"
+        },
+        "created_at_ms": {
+          "title": "Created At Ms",
+          "type": "integer"
+        },
+        "evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Key"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "scope_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Scope Ref"
+        },
+        "staleness": {
+          "title": "Staleness"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "target_ref": {
+          "title": "Target Ref",
+          "type": "string"
+        },
+        "unit": {
+          "const": "assertion",
+          "default": "assertion",
+          "title": "Unit",
+          "type": "string"
+        },
+        "updated_at_ms": {
+          "title": "Updated At Ms",
+          "type": "integer"
+        },
+        "value": {
+          "title": "Value"
+        },
+        "visibility": {
+          "title": "Visibility",
+          "type": "string"
+        }
+      },
+      "required": [
+        "assertion_id",
+        "target_ref",
+        "kind",
+        "value",
+        "author_ref",
+        "author_kind",
+        "status",
+        "visibility",
+        "evidence_refs",
+        "staleness",
+        "context_policy",
+        "created_at_ms",
+        "updated_at_ms"
+      ],
+      "title": "AssertionQueryRowPayload",
+      "type": "object"
+    },
     "BlockQueryRowPayload": {
       "additionalProperties": false,
       "description": "Shared terminal-query row for archive content blocks.",
@@ -323,6 +440,9 @@
           },
           {
             "$ref": "#/$defs/BlockQueryRowPayload"
+          },
+          {
+            "$ref": "#/$defs/AssertionQueryRowPayload"
           }
         ]
       },
@@ -367,7 +487,8 @@
       "enum": [
         "message",
         "action",
-        "block"
+        "block",
+        "assertion"
       ],
       "title": "Unit",
       "type": "string"

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1176,7 +1176,7 @@ class PolylogueArchiveMixin:
         max_words: int | None = None,
         message_type: str | None = None,
     ) -> QueryUnitEnvelope:
-        """Execute a terminal ``messages/actions/blocks where`` query."""
+        """Execute a terminal unit-source query."""
         from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
         from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1184,7 +1184,7 @@ class PolylogueArchiveMixin:
         source = parse_unit_source_expression(expression)
         if source is None:
             raise ExpressionCompileError(
-                "query_units requires an explicit messages/actions/blocks where expression",
+                "query_units requires an explicit messages/actions/blocks/assertions where expression",
                 field=None,
             )
         session_filters = query_unit_session_filters(

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -41,7 +41,7 @@ and explicit Boolean session predicates:
     actions where action:file_edit AND path:polylogue/archive
     blocks where type:code AND text:timeout
 
-Unit-scoped ``messages/actions/blocks where ...`` predicates are executable
+Unit-scoped ``messages/actions/blocks/assertions where ...`` predicates are executable
 in two shared paths: ``compile_expression`` keeps the compatibility session
 selector behavior by lowering them to correlated ``exists <unit>(...)``
 predicates, while terminal query-unit surfaces preserve the selected unit and
@@ -104,6 +104,8 @@ from polylogue.archive.query.spec import (
 )
 from polylogue.core.enums import Origin
 from polylogue.errors import PolylogueError
+
+QueryUnitName = Literal["message", "action", "block", "assertion"]
 
 # ---------------------------------------------------------------------------
 # Error
@@ -336,7 +338,7 @@ class QueryExpressionAST:
 class QueryUnitSource:
     """Explicit unit-changing source parsed from ``<unit>s where ...``."""
 
-    unit: Literal["message", "action", "block"]
+    unit: QueryUnitName
     predicate: QueryPredicate
 
 
@@ -462,7 +464,7 @@ _QUERY_GRAMMAR = r"""
     EXISTS: /exists/i
     SEQ: /seq/i
     ARROW: "->"
-    STRUCT_UNIT: /(message|action|block)/i
+    STRUCT_UNIT: /(message|action|block|assertion)/i
     OR: /or/i
     AND: /and/i
     NOT: /not/i
@@ -514,13 +516,15 @@ _FIELD_CLAUSE_RE = re.compile(
     re.VERBOSE,
 )
 
-_SOURCE_WHERE_SOURCES: tuple[tuple[str, Literal["message", "action", "block"]], ...] = (
+_SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = (
     ("message", "message"),
     ("messages", "message"),
     ("action", "action"),
     ("actions", "action"),
     ("block", "block"),
     ("blocks", "block"),
+    ("assertion", "assertion"),
+    ("assertions", "assertion"),
 )
 _BOOLEAN_SUPPORTED_FIELDS = {
     "repo",
@@ -554,6 +558,25 @@ _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
 _MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command", "path", "output", "words"}
 _ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text"}
 _BLOCK_STRUCTURAL_FIELDS = {"type", "text", "tool", "action", "command", "path"}
+_ASSERTION_STRUCTURAL_FIELDS = {
+    "kind",
+    "status",
+    "target",
+    "target_ref",
+    "scope",
+    "scope_ref",
+    "key",
+    "text",
+    "body",
+    "author",
+    "author_ref",
+    "author_kind",
+    "visibility",
+    "value",
+    "evidence",
+    "context",
+}
+_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_ASSERTION_STRUCTURAL_FIELDS)
 _SCOPED_SESSION_STRUCTURAL_FIELDS = tuple(f"session.{field}" for field in sorted(_BOOLEAN_SUPPORTED_FIELDS))
 
 
@@ -601,6 +624,11 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
         description="Match sessions with at least one message satisfying the child predicate.",
         fields=tuple(sorted((*_MESSAGE_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
         example="exists message(session.repo:polylogue AND role:assistant AND text:timeout)",
+    ),
+    "assertion": StructuralQueryUnitInfo(
+        description="Match sessions with at least one session-targeted assertion satisfying the child predicate.",
+        fields=tuple(sorted((*_ASSERTION_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        example="exists assertion(kind:decision AND status:active AND text:review)",
     ),
 }
 
@@ -956,9 +984,7 @@ def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]
     )
 
 
-def _validate_predicate_context(
-    predicate: QueryPredicate, *, unit: Literal["session", "message", "action", "block"]
-) -> None:
+def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["session"] | QueryUnitName) -> None:
     if isinstance(predicate, QueryFieldPredicate):
         session_field = _scoped_session_field(predicate.field)
         if unit == "session":
@@ -970,8 +996,11 @@ def _validate_predicate_context(
         elif unit == "action":
             supported = _ACTION_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
-        else:
+        elif unit == "block":
             supported = _BLOCK_STRUCTURAL_FIELDS
+            effective_field = session_field or predicate.field
+        else:
+            supported = _ASSERTION_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
         if session_field is not None and unit != "session":
             supported = _BOOLEAN_SUPPORTED_FIELDS
@@ -981,7 +1010,32 @@ def _validate_predicate_context(
                 field=predicate.field,
             )
         if (
-            effective_field in {"role", "type", "text", "tool", "action", "command", "path", "output"}
+            effective_field
+            in {
+                "role",
+                "type",
+                "text",
+                "body",
+                "tool",
+                "action",
+                "command",
+                "path",
+                "output",
+                "kind",
+                "status",
+                "target",
+                "target_ref",
+                "scope",
+                "scope_ref",
+                "key",
+                "author",
+                "author_ref",
+                "author_kind",
+                "visibility",
+                "value",
+                "evidence",
+                "context",
+            }
             and not predicate.values
         ):
             raise ExpressionCompileError(f"field {predicate.field!r} requires a value", field=predicate.field)
@@ -1115,9 +1169,9 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
 
     def exists_leaf(self, _exists: Token, unit: Token, child: QueryPredicate) -> QueryPredicate:
         unit_value = str(unit).lower()
-        if unit_value not in {"message", "action", "block"}:
+        if unit_value not in {"message", "action", "block", "assertion"}:
             raise ExpressionCompileError(f"unsupported structural query unit {unit_value!r}", field=None)
-        return QueryExistsPredicate(unit=cast(Literal["message", "action", "block"], unit_value), child=child)
+        return QueryExistsPredicate(unit=cast(QueryUnitName, unit_value), child=child)
 
     def sequence_step(self, token: Token) -> QueryPredicate:
         predicate = _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
@@ -1171,7 +1225,7 @@ def _is_boolean_expression(expression: str) -> bool:
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
 
-def _source_where_unit(source: str) -> Literal["message", "action", "block"]:
+def _source_where_unit(source: str) -> QueryUnitName:
     normalized = source.strip().lower()
     if normalized in {"message", "messages"}:
         return "message"
@@ -1179,6 +1233,8 @@ def _source_where_unit(source: str) -> Literal["message", "action", "block"]:
         return "action"
     if normalized in {"block", "blocks"}:
         return "block"
+    if normalized in {"assertion", "assertions"}:
+        return "assertion"
     raise ExpressionCompileError(f"unsupported query source {source!r}", field=None)
 
 
@@ -1217,7 +1273,7 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
 
 
 def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
-    """Parse ``messages/actions/blocks where ...`` as a terminal unit source.
+    """Parse ``messages/actions/blocks/assertions where ...`` as a terminal unit source.
 
     ``compile_expression`` still lowers these forms to session selectors for
     existing surfaces. Terminal query execution uses this helper to preserve
@@ -1226,7 +1282,7 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
 
     stripped = expression.strip()
     lower = stripped.lower()
-    source_match: tuple[str, Literal["message", "action", "block"], str] | None = None
+    source_match: tuple[str, QueryUnitName, str] | None = None
     for source, unit in _SOURCE_WHERE_SOURCES:
         marker = f"{source} where"
         if lower == marker:

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -46,7 +46,7 @@ class QueryBoolPredicate:
 class QueryExistsPredicate:
     """Correlated structural predicate over a child archive unit."""
 
-    unit: Literal["message", "action", "block"]
+    unit: Literal["message", "action", "block", "assertion"]
     child: QueryPredicate
 
     def to_payload(self) -> dict[str, object]:

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -18,6 +18,7 @@ from polylogue.archive.query.spec import (
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.surfaces.payloads import (
     ActionQueryRowPayload,
+    AssertionQueryRowPayload,
     BlockQueryRowPayload,
     MessageQueryRowPayload,
     QueryUnitEnvelope,
@@ -47,7 +48,7 @@ def _epoch_ms(field: str, value: object) -> int | None:
 def query_unit_session_filters(**params: object) -> dict[str, object]:
     """Normalize shared session filters for terminal query-unit rows.
 
-    Terminal ``messages/actions/blocks where ...`` execution returns row-level
+    Terminal unit-source execution returns row-level
     results, but callers still need the same surrounding session scope as the
     normal session query surfaces.  This helper is the single cross-surface
     adapter into ``ArchiveStore.query_*``'s ``session_filters`` argument.
@@ -108,7 +109,7 @@ def query_unit_rows(
     offset: int = 0,
     session_filters: Mapping[str, object] | None = None,
 ) -> QueryUnitEnvelope:
-    """Execute an explicit ``messages/actions/blocks where`` source query."""
+    """Execute an explicit unit-source query."""
 
     fetch_limit = limit + 1
     if source.unit == "message":
@@ -140,6 +141,21 @@ def query_unit_rows(
             limit=limit,
             offset=offset,
             has_next=len(action_rows) > limit,
+        )
+    if source.unit == "assertion":
+        assertion_rows = archive.query_assertions(
+            source.predicate,
+            limit=fetch_limit,
+            offset=offset,
+            session_filters=session_filters,
+        )
+        return build_query_unit_envelope(
+            tuple(AssertionQueryRowPayload.from_row(row) for row in assertion_rows[:limit]),
+            unit=source.unit,
+            query=query,
+            limit=limit,
+            offset=offset,
+            has_next=len(assertion_rows) > limit,
         )
     block_rows = archive.query_blocks(
         source.predicate,

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2284,7 +2284,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 HTTPStatus.BAD_REQUEST,
                 {
                     "error": "invalid_query",
-                    "message": "query-units requires a messages/actions/blocks where expression",
+                    "message": "query-units requires a messages/actions/blocks/assertions where expression",
                 },
             )
             return

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -405,7 +405,7 @@ def archive_query_unit_payload(
     source = parse_unit_source_expression(expression)
     if source is None:
         raise ExpressionCompileError(
-            "query_units requires an explicit messages/actions/blocks where expression",
+            "query_units requires an explicit messages/actions/blocks/assertions where expression",
             field=None,
         )
     return query_unit_rows(

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -156,7 +156,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         max_words: MCPCountBound = None,
         message_type: str | None = None,
     ) -> str:
-        """Return terminal rows for ``messages/actions/blocks where`` query expressions."""
+        """Return terminal rows for explicit unit-source query expressions."""
 
         async def run() -> str:
             from polylogue.archive.query.expression import ExpressionCompileError

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -32,6 +32,7 @@ from polylogue.archive.semantic.pricing import (
 from polylogue.archive.stats import ArchiveStats
 from polylogue.core.dates import parse_date
 from polylogue.core.enums import Provider
+from polylogue.core.json import JSONValue, require_json_value
 from polylogue.core.sources import origin_from_provider
 from polylogue.insights.archive import (
     ArchiveCoverageInsight,
@@ -221,6 +222,28 @@ class ArchiveBlockQueryRow:
     semantic_type: str | None
     tool_command: str | None
     tool_path: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveAssertionQueryRow:
+    """Terminal query projection over user-tier assertion rows."""
+
+    assertion_id: str
+    target_ref: str
+    scope_ref: str | None
+    kind: str
+    key: str | None
+    body_text: str | None
+    value: JSONValue
+    author_ref: str
+    author_kind: str
+    status: str
+    visibility: str
+    evidence_refs: tuple[str, ...]
+    staleness: JSONValue
+    context_policy: JSONValue
+    created_at_ms: int
+    updated_at_ms: int
 
 
 class ArchiveStore:
@@ -3391,6 +3414,76 @@ class ArchiveStore:
             for row in rows
         ]
 
+    def query_assertions(
+        self,
+        predicate: QueryPredicate,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        session_filters: Mapping[str, object] | None = None,
+    ) -> list[ArchiveAssertionQueryRow]:
+        """Return user-tier assertion rows matching a unit-scoped predicate."""
+
+        if not self.user_db_path.exists():
+            return []
+        self._attach_user_tier_if_present()
+        normalized_limit = max(int(limit), 0)
+        normalized_offset = max(int(offset), 0)
+        clause, params = _structural_predicate_clause("assertion", "a", predicate, session_alias="s")
+        session_clause = ""
+        session_params: list[object] = []
+        if session_filters:
+            session_clause, session_params = cast(Any, _session_filter_clause)("s", prefix="AND", **session_filters)
+        rows = self._conn.execute(
+            f"""
+            SELECT
+                a.assertion_id,
+                a.target_ref,
+                a.scope_ref,
+                a.kind,
+                a.key,
+                a.body_text,
+                a.value_json,
+                a.author_ref,
+                a.author_kind,
+                a.status,
+                a.visibility,
+                a.evidence_refs_json,
+                a.staleness_json,
+                a.context_policy_json,
+                a.created_at_ms,
+                a.updated_at_ms
+            FROM user_tier.assertions a
+            LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id
+            WHERE {clause}
+            {session_clause}
+            ORDER BY a.updated_at_ms DESC, a.assertion_id
+            LIMIT ? OFFSET ?
+            """,
+            [*params, *session_params, normalized_limit, normalized_offset],
+        ).fetchall()
+        return [
+            ArchiveAssertionQueryRow(
+                assertion_id=str(row["assertion_id"]),
+                target_ref=str(row["target_ref"]),
+                scope_ref=str(row["scope_ref"]) if row["scope_ref"] is not None else None,
+                kind=str(row["kind"]),
+                key=str(row["key"]) if row["key"] is not None else None,
+                body_text=str(row["body_text"]) if row["body_text"] is not None else None,
+                value=_json_value(row["value_json"], default={}),
+                author_ref=str(row["author_ref"]),
+                author_kind=str(row["author_kind"]),
+                status=str(row["status"]),
+                visibility=str(row["visibility"]),
+                evidence_refs=_json_str_tuple(row["evidence_refs_json"]),
+                staleness=_json_value(row["staleness_json"], default={}),
+                context_policy=_json_value(row["context_policy_json"], default={}),
+                created_at_ms=int(row["created_at_ms"]),
+                updated_at_ms=int(row["updated_at_ms"]),
+            )
+            for row in rows
+        ]
+
     def stats(
         self,
         *,
@@ -4247,6 +4340,24 @@ def _json_object_from_text(value: object) -> dict[str, object]:
     return decoded if isinstance(decoded, dict) else {}
 
 
+def _json_value(value: object, *, default: JSONValue) -> JSONValue:
+    try:
+        decoded = json.loads(str(value or json.dumps(default)))
+    except json.JSONDecodeError:
+        return default
+    try:
+        return require_json_value(decoded)
+    except TypeError:
+        return default
+
+
+def _json_str_tuple(value: object) -> tuple[str, ...]:
+    decoded = _json_value(value, default=[])
+    if not isinstance(decoded, list):
+        return ()
+    return tuple(str(item) for item in decoded)
+
+
 def _stats_by_sql(group_by: str, where: str, *, tags_relation: str = "session_tags") -> str:
     if group_by in {"provider", "origin"}:
         return f"""
@@ -4572,6 +4683,27 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
     raise ValueError(f"unsupported block predicate field: {field}")
 
 
+def _assertion_field_predicate_clause(assertion_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
+    field = predicate.field
+    if field in {"kind", "status", "key", "author_kind", "visibility"}:
+        return _in_or_equals_clause(f"{assertion_alias}.{field}", predicate.values, lower=True)
+    if field in {"target", "target_ref"}:
+        return _like_clause(f"{assertion_alias}.target_ref", predicate.values)
+    if field in {"scope", "scope_ref"}:
+        return _like_clause(f"{assertion_alias}.scope_ref", predicate.values)
+    if field in {"author", "author_ref"}:
+        return _like_clause(f"{assertion_alias}.author_ref", predicate.values)
+    if field in {"text", "body"}:
+        return _like_clause(f"{assertion_alias}.body_text", predicate.values)
+    if field == "value":
+        return _like_clause(f"{assertion_alias}.value_json", predicate.values)
+    if field == "evidence":
+        return _like_clause(f"{assertion_alias}.evidence_refs_json", predicate.values)
+    if field == "context":
+        return _like_clause(f"{assertion_alias}.context_policy_json", predicate.values)
+    raise ValueError(f"unsupported assertion predicate field: {field}")
+
+
 def _structural_predicate_clause(
     unit: str,
     row_alias: str,
@@ -4595,6 +4727,8 @@ def _structural_predicate_clause(
             return _action_field_predicate_clause(row_alias, predicate)
         if unit == "block":
             return _block_field_predicate_clause(row_alias, predicate)
+        if unit == "assertion":
+            return _assertion_field_predicate_clause(row_alias, predicate)
     if isinstance(predicate, QueryNotPredicate):
         clause, params = _structural_predicate_clause(unit, row_alias, predicate.child, session_alias=session_alias)
         return (f"NOT ({clause})" if clause else "", params)
@@ -4666,6 +4800,25 @@ def _exists_predicate_clause(table_alias: str, predicate: QueryExistsPredicate) 
                 SELECT 1
                 FROM blocks {row_alias}
                 WHERE {row_alias}.session_id = {table_alias}.session_id
+                  AND {child_clause}
+            )
+            """.strip(),
+            params,
+        )
+    if predicate.unit == "assertion":
+        row_alias = "exists_assertions"
+        child_clause, params = _structural_predicate_clause(
+            predicate.unit,
+            row_alias,
+            predicate.child,
+            session_alias=table_alias,
+        )
+        return (
+            f"""
+            EXISTS (
+                SELECT 1
+                FROM user_tier.assertions {row_alias}
+                WHERE {row_alias}.target_ref = 'session:' || {table_alias}.session_id
                   AND {child_clause}
             )
             """.strip(),

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from polylogue.archive.session.neighbor_candidates import NeighborReason, SessionNeighborCandidate
     from polylogue.storage.sqlite.archive_tiers.archive import (
         ArchiveActionQueryRow,
+        ArchiveAssertionQueryRow,
         ArchiveBlockQueryRow,
         ArchiveMessageQueryRow,
     )
@@ -828,7 +829,7 @@ class SearchEnvelope(SurfacePayloadModel):
     diagnostics: QueryMissDiagnosticsPayload | None = None
 
 
-QueryUnitKind: TypeAlias = Literal["message", "action", "block"]
+QueryUnitKind: TypeAlias = Literal["message", "action", "block", "assertion"]
 """Terminal query source unit exposed by query-unit envelopes."""
 
 
@@ -929,12 +930,57 @@ class BlockQueryRowPayload(SurfacePayloadModel):
         )
 
 
-QueryUnitRowPayload: TypeAlias = MessageQueryRowPayload | ActionQueryRowPayload | BlockQueryRowPayload
+class AssertionQueryRowPayload(SurfacePayloadModel):
+    """Shared terminal-query row for user-tier assertions."""
+
+    unit: Literal["assertion"] = "assertion"
+    assertion_id: str
+    target_ref: str
+    scope_ref: str | None = None
+    kind: str
+    key: str | None = None
+    body_text: str | None = None
+    value: object
+    author_ref: str
+    author_kind: str
+    status: str
+    visibility: str
+    evidence_refs: tuple[str, ...]
+    staleness: object
+    context_policy: object
+    created_at_ms: int
+    updated_at_ms: int
+
+    @classmethod
+    def from_row(cls, row: ArchiveAssertionQueryRow) -> AssertionQueryRowPayload:
+        return cls(
+            assertion_id=row.assertion_id,
+            target_ref=row.target_ref,
+            scope_ref=row.scope_ref,
+            kind=row.kind,
+            key=row.key,
+            body_text=row.body_text,
+            value=row.value,
+            author_ref=row.author_ref,
+            author_kind=row.author_kind,
+            status=row.status,
+            visibility=row.visibility,
+            evidence_refs=row.evidence_refs,
+            staleness=row.staleness,
+            context_policy=row.context_policy,
+            created_at_ms=row.created_at_ms,
+            updated_at_ms=row.updated_at_ms,
+        )
+
+
+QueryUnitRowPayload: TypeAlias = (
+    MessageQueryRowPayload | ActionQueryRowPayload | BlockQueryRowPayload | AssertionQueryRowPayload
+)
 """Union of terminal row payloads returned by explicit unit-source queries."""
 
 
 class QueryUnitEnvelope(SurfacePayloadModel):
-    """Shared envelope for ``messages/actions/blocks where ...`` query results."""
+    """Shared envelope for explicit terminal unit-source query results."""
 
     mode: Literal["query-unit"] = "query-unit"
     unit: QueryUnitKind
@@ -1572,6 +1618,7 @@ __all__ = [
     "SearchCursor",
     "SearchEnvelope",
     "MessageQueryRowPayload",
+    "AssertionQueryRowPayload",
     "InvalidSearchCursorError",
     "SurfacePayloadModel",
     "TagMutationOutcome",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -28,7 +28,7 @@ import inspect
 import json
 from collections.abc import Iterable
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -1137,7 +1137,7 @@ async def test_query_units_applies_session_scope_filters(tmp_path: Path) -> None
 
         envelope = await archive.query_units("messages where text:needle", origin="codex-session")
 
-        assert [item.session_id for item in envelope.items] == ["codex-session:unit-filter-codex"]
+        assert [cast(Any, item).session_id for item in envelope.items] == ["codex-session:unit-filter-codex"]
     finally:
         await archive.close()
 
@@ -1180,7 +1180,97 @@ async def test_query_units_accepts_inline_session_scope(tmp_path: Path) -> None:
 
         envelope = await archive.query_units("messages where session.origin:codex-session AND text:needle")
 
-        assert [item.session_id for item in envelope.items] == ["codex-session:unit-inline-codex"]
+        assert [cast(Any, item).session_id for item in envelope.items] == ["codex-session:unit-inline-codex"]
+    finally:
+        await archive.close()
+
+
+async def test_query_units_returns_assertion_rows(tmp_path: Path) -> None:
+    """``query_units()`` exposes assertion terminal rows through the facade."""
+    import sqlite3
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="unit-assertion-codex",
+                    title="Unit assertion Codex",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            text="assertion target",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="assertion target")],
+                        )
+                    ],
+                )
+            )
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CHATGPT,
+                    provider_session_id="unit-assertion-chatgpt",
+                    title="Unit assertion ChatGPT",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            text="assertion target",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="assertion target")],
+                        )
+                    ],
+                )
+            )
+        user_db = archive.config.archive_root / "user.db"
+        initialize_archive_database(user_db, ArchiveTier.USER)
+        with sqlite3.connect(user_db) as conn:
+            upsert_assertion(
+                conn,
+                assertion_id="facade-decision-hit",
+                target_ref="session:codex-session:unit-assertion-codex",
+                kind=AssertionKind.DECISION,
+                key="query-unit",
+                value={"rank": 1},
+                body_text="Review assertion query unit facade wiring.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                evidence_refs=["session:codex-session:unit-assertion-codex#message:m1"],
+                status="active",
+                visibility="public",
+                now_ms=1000,
+            )
+            upsert_assertion(
+                conn,
+                assertion_id="facade-decision-miss",
+                target_ref="session:chatgpt-export:unit-assertion-chatgpt",
+                kind=AssertionKind.DECISION,
+                body_text="Review another origin.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                status="active",
+                now_ms=500,
+            )
+            conn.commit()
+
+        envelope = await archive.query_units(
+            "assertions where kind:decision AND status:active AND text:facade",
+            origin="codex-session",
+        )
+
+        assert envelope.unit == "assertion"
+        [item] = envelope.items
+        payload = item.model_dump(mode="json")
+        assert payload["unit"] == "assertion"
+        assert payload["assertion_id"] == "facade-decision-hit"
+        assert payload["target_ref"] == "session:codex-session:unit-assertion-codex"
+        assert payload["kind"] == "decision"
+        assert payload["value"] == {"rank": 1}
+        assert payload["evidence_refs"] == ["session:codex-session:unit-assertion-codex#message:m1"]
     finally:
         await archive.close()
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -422,6 +422,33 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_assertion_source_where_lowers_to_structural_exists(self) -> None:
+        ast = parse_expression_ast("assertions where kind:decision AND text:review")
+
+        assert ast.boolean_predicate == QueryExistsPredicate(
+            unit="assertion",
+            child=QueryBoolPredicate(
+                op="and",
+                children=(
+                    QueryFieldPredicate(field="kind", values=("decision",)),
+                    QueryFieldPredicate(field="text", values=("review",)),
+                ),
+            ),
+        )
+
+    def test_parse_assertion_source_expression_preserves_terminal_unit(self) -> None:
+        source = parse_unit_source_expression("assertions where kind:decision AND status:active")
+
+        assert source is not None
+        assert source.unit == "assertion"
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="kind", values=("decision",)),
+                QueryFieldPredicate(field="status", values=("active",)),
+            ),
+        )
+
     def test_action_source_where_lowers_to_structural_exists(self) -> None:
         ast = parse_expression_ast("actions where action:file_edit AND path:archive/query")
 
@@ -436,7 +463,9 @@ class TestBooleanQueryExpression:
             ),
         )
 
-    @pytest.mark.parametrize("expression", ["messages where", "actions where   ", "blocks where\t"])
+    @pytest.mark.parametrize(
+        "expression", ["messages where", "actions where   ", "blocks where\t", "assertions where "]
+    )
     def test_source_where_without_predicate_is_rejected(self, expression: str) -> None:
         with pytest.raises(ExpressionCompileError, match="where requires a predicate"):
             compile_expression(expression)
@@ -1051,6 +1080,146 @@ class TestBooleanQueryExpression:
             rows = archive.query_blocks(source.predicate, limit=100)
 
         assert [(row.session_id, row.block_type) for row in rows] == [("chatgpt-export:ext-hit", "code")]
+
+    def test_exists_assertion_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        import sqlite3
+
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+        from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("codex")
+            .title("assertion hit")
+            .add_message("m-hit", role="assistant", text="target session")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("codex")
+            .title("assertion miss")
+            .add_message("m-miss", role="assistant", text="target session")
+            .save()
+        )
+        user_db = archive_root / "user.db"
+        initialize_archive_database(user_db, ArchiveTier.USER)
+        with sqlite3.connect(user_db) as conn:
+            upsert_assertion(
+                conn,
+                assertion_id="decision-hit",
+                target_ref="session:codex-session:ext-hit",
+                kind=AssertionKind.DECISION,
+                body_text="Review the query unit before merge.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                status="active",
+                now_ms=2000,
+            )
+            upsert_assertion(
+                conn,
+                assertion_id="decision-miss",
+                target_ref="session:codex-session:ext-miss",
+                kind=AssertionKind.DECISION,
+                body_text="Review unrelated branch.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                status="deleted",
+                now_ms=1000,
+            )
+            conn.commit()
+
+        spec = compile_expression("exists assertion(kind:decision AND status:active AND text:query)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(archive_root) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["codex-session:ext-hit"]
+
+    def test_terminal_assertion_source_returns_assertion_rows(self, workspace_env: dict[str, Path]) -> None:
+        import sqlite3
+
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+        from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .title("assertion hit")
+            .add_message("m-hit", role="assistant", text="target session")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-repo")
+            .provider("codex")
+            .git_repository_url("sinex")
+            .title("assertion wrong repo")
+            .add_message("m-wrong-repo", role="assistant", text="target session")
+            .save()
+        )
+        user_db = archive_root / "user.db"
+        initialize_archive_database(user_db, ArchiveTier.USER)
+        with sqlite3.connect(user_db) as conn:
+            upsert_assertion(
+                conn,
+                assertion_id="decision-hit",
+                target_ref="session:codex-session:ext-hit",
+                kind=AssertionKind.DECISION,
+                key="next-step",
+                value={"priority": 1},
+                body_text="Review the query unit before merge.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                evidence_refs=["session:codex-session:ext-hit#message:m-hit"],
+                status="active",
+                visibility="public",
+                staleness={"policy": "manual"},
+                context_policy={"inject": False},
+                now_ms=2000,
+            )
+            upsert_assertion(
+                conn,
+                assertion_id="decision-wrong-repo",
+                target_ref="session:codex-session:ext-wrong-repo",
+                kind=AssertionKind.DECISION,
+                body_text="Review the other archive.",
+                author_ref="agent:codex",
+                author_kind="agent",
+                status="active",
+                now_ms=1000,
+            )
+            conn.commit()
+
+        source = parse_unit_source_expression(
+            "assertions where session.repo:polylogue AND kind:decision AND status:active AND text:query"
+        )
+        assert source is not None
+        assert source.unit == "assertion"
+        with ArchiveStore.open_existing(archive_root) as archive:
+            rows = archive.query_assertions(source.predicate, limit=100)
+
+        assert [(row.assertion_id, row.target_ref, row.kind, row.body_text) for row in rows] == [
+            (
+                "decision-hit",
+                "session:codex-session:ext-hit",
+                "decision",
+                "Review the query unit before merge.",
+            )
+        ]
+        assert rows[0].value == {"priority": 1}
+        assert rows[0].evidence_refs == ("session:codex-session:ext-hit#message:m-hit",)
+        assert rows[0].staleness == {"policy": "manual"}
+        assert rows[0].context_policy == {"inject": False}
 
     def test_exists_block_tool_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary

Adds assertion rows to the executable terminal query-unit surface: `assertions where ...` now parses through the shared Lark DSL, lowers to `exists assertion(...)` for session selection, and returns typed assertion rows through `query_units`.

## Problem

The full query DSL already exposed terminal rows for messages, actions, and blocks, but the assertion substrate from #1883 was not part of the same selection language. That forced future assertion workflows toward bespoke readers instead of the shared query/API/MCP/daemon path.

## Solution

- Added `assertion` / `assertions where ...` to the query-unit grammar and structural field registry.
- Added `exists assertion(...)` support to the session selector lowering path.
- Implemented `ArchiveStore.query_assertions()` over attached `user.db` assertions joined to session scope where applicable.
- Added `AssertionQueryRowPayload` to `QueryUnitEnvelope` and regenerated CLI/OpenAPI schemas.
- Updated API/MCP/daemon query-unit error/help text so assertions are part of the documented accepted unit-source forms.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k 'assertion_source or exists_assertion or terminal_assertion or source_where_without_predicate'` -> 8 passed.
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k query_units` -> 6 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- `nix develop --command devtools verify` was started; static/generated checks passed, but pytest-testmon showed broad pre-existing failures by 5% progress and was aborted to avoid burning the run. I checked `origin/master` in a temporary worktree and reproduced the delete-verb callback failures there (`tests/unit/cli/test_verb_cardinality.py -k 'DeleteVerbCardinality or DeleteUsesPreResolvedIds or DeleteCardinalityLargeNonMocked'` -> 10 failed with `delete_verb() takes 4 positional arguments but 5 were given`). Those inherited failures are not from this branch and should be handled separately.

Ref #2006
Ref #1883