### PR TITLE
test(cli): match delete verb callback contract

### DIFF
--- a/tests/unit/cli/test_verb_cardinality.py
+++ b/tests/unit/cli/test_verb_cardinality.py
@@ -259,10 +259,9 @@ class TestDeleteVerbCardinality:
         dry_run: bool = False,
         yes_flag: bool = False,
         all_flag: bool = False,
-        force: bool = False,
     ) -> None:
         cb = self._delete_callback()
-        cb(child, dry_run, yes_flag, all_flag, force)  # type: ignore[operator]
+        cb(child, dry_run, yes_flag, all_flag)  # type: ignore[operator]
 
     def test_dry_run_skips_cardinality_check(self) -> None:
         _, child = _context_pair()
@@ -585,7 +584,7 @@ class TestDeleteUsesPreResolvedIds:
             ),
         ):
             cb = self._delete_callback()
-            cb(child, False, True, True, False)  # type: ignore[operator]  # dry_run=F, yes=T, all=T, force=F
+            cb(child, False, True, True)  # type: ignore[operator]  # dry_run=F, yes=T, all=T
 
         assert captured, "execute_delete_by_session_ids must be called"
         assert len(captured[0]) == 50, (
@@ -607,7 +606,7 @@ class TestDeleteUsesPreResolvedIds:
             patch("polylogue.cli.query_verbs._execute_query_verb") as mock_exec,
         ):
             cb = self._delete_callback()
-            cb(child, False, True, False, False)  # type: ignore[operator]  # yes=T
+            cb(child, False, True, False)  # type: ignore[operator]  # yes=T
 
         mock_exec.assert_not_called()
 
@@ -680,7 +679,7 @@ class TestDeleteCardinalityLargeNonMocked:
 
         _, child = _context_pair(query_terms=(self.TOKEN,))
         child.obj = env
-        self._delete_callback()(child, dry_run, yes_flag, all_flag, False)  # type: ignore[operator]
+        self._delete_callback()(child, dry_run, yes_flag, all_flag)  # type: ignore[operator]
         # _emit_delete prints exactly one JSON document to stdout.
         captured = self._capsys.readouterr().out.strip()
         return cast(dict[str, object], json.loads(captured))


### PR DESCRIPTION
## Summary

Updates the delete-cardinality regression tests to call the live `delete_verb` Click callback signature.

## Problem

Clean `origin/master` fails the delete-cardinality selection before exercising behavior because the tests still pass a removed fifth `force` argument to `delete_verb.callback`. The command no longer has a separate force parameter; `--yes` is the confirmation/force bit passed to `execute_delete_by_session_ids`.

## Solution

Removed the stale callback argument from the direct test invocations. The tests still verify the important behavior: dry-run previews the full resolved set, non-dry-run delete uses pre-resolved IDs instead of re-querying, `--all` governs multi-match cardinality, and `--yes` propagates force to the archive delete path.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_verb_cardinality.py -k 'DeleteVerbCardinality or DeleteUsesPreResolvedIds or DeleteCardinalityLargeNonMocked'` -> 10 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.

Ref #1873