### PR TITLE
feat(recovery): mark work-packet evidence support (#1838)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -64,7 +64,12 @@ if TYPE_CHECKING:
     from polylogue.insights.export_bundles import InsightExportBundleRequest, InsightExportBundleResult
     from polylogue.insights.readiness import InsightReadinessQuery, InsightReadinessReport
     from polylogue.insights.resume import ResumeBrief, ResumeCandidate
-    from polylogue.insights.transforms import RecoveryDigest, RecoveryReportPreset, RecoveryWorkPacket
+    from polylogue.insights.transforms import (
+        RecoveryDigest,
+        RecoveryReportPreset,
+        RecoveryWorkPacket,
+        WorkPacketSupport,
+    )
     from polylogue.operations import ArchiveStats
     from polylogue.protocols import ProgressCallback, SessionQueryRuntimeStore
     from polylogue.readiness import ReadinessReport
@@ -413,6 +418,70 @@ def _archive_tier_readiness_check(tier: ArchiveTier, path: Any) -> Any:
         VerifyStatus.OK if version == expected else VerifyStatus.ERROR,
         summary=f"v{version}/{expected}: {path}",
     )
+
+
+def _archive_assertion_work_packet_entries(config: Config, session_id: str) -> tuple[Any, ...]:
+    """Return assertion-backed work-packet rows for one target session."""
+
+    from polylogue.core.refs import EvidenceRef
+    from polylogue.insights.transforms import RecoveryWorkPacketEntry
+    from polylogue.storage.sqlite.archive_tiers.user_write import list_assertion_claims
+
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        return ()
+    try:
+        conn = sqlite3.connect(f"file:{user_db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            claims = list_assertion_claims(conn, target_ref=f"session:{session_id}", limit=20)
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return ()
+
+    entries: list[RecoveryWorkPacketEntry] = []
+    fallback_ref = EvidenceRef(session_id=session_id)
+    for claim in claims:
+        text = claim.body_text
+        if not text:
+            text = json.dumps(claim.value, sort_keys=True) if claim.value is not None else claim.assertion_id
+        entries.append(
+            RecoveryWorkPacketEntry(
+                section="assertions",
+                label=claim.kind,
+                text=text,
+                support=_archive_assertion_support(claim.kind),
+                evidence_refs=_archive_assertion_evidence_refs(claim.evidence_refs, fallback_ref),
+                metadata={
+                    "assertion_id": claim.assertion_id,
+                    "status": claim.status or "",
+                    "visibility": claim.visibility or "",
+                    "author_ref": claim.author_ref or "",
+                },
+            )
+        )
+    return tuple(entries)
+
+
+def _archive_assertion_support(kind: str) -> WorkPacketSupport:
+    if kind in {"blocker", "caveat"}:
+        return "caveat"
+    if kind == "transform_candidate":
+        return "inference"
+    return "assertion"
+
+
+def _archive_assertion_evidence_refs(raw_refs: Sequence[str], fallback: Any) -> tuple[Any, ...]:
+    from polylogue.core.refs import EvidenceRef
+
+    parsed: list[EvidenceRef] = []
+    for raw_ref in raw_refs:
+        try:
+            parsed.append(EvidenceRef.parse(raw_ref))
+        except ValueError:
+            continue
+    return tuple(parsed) or (fallback,)
 
 
 def _archive_count_table_rows(conn: Any, table_name: str) -> int | None:
@@ -1116,6 +1185,9 @@ class PolylogueArchiveMixin:
 
     async def recovery_report(self, session_id: str, preset: RecoveryReportPreset) -> str | None:
         """Render one deterministic recovery report preset for a session."""
+        if preset == "work-packet":
+            packet = await self.recovery_work_packet(session_id)
+            return None if packet is None else packet.render_markdown()
         digest = await self.recovery_digest(session_id)
         if digest is None:
             return None
@@ -1126,7 +1198,11 @@ class PolylogueArchiveMixin:
         digest = await self.recovery_digest(session_id)
         if digest is None:
             return None
-        return digest.work_packet()
+        packet = digest.work_packet()
+        assertion_entries = _archive_assertion_work_packet_entries(self.config, digest.session_id)
+        if not assertion_entries:
+            return packet
+        return packet.model_copy(update={"entries": (*packet.entries, *assertion_entries)})
 
     async def list_read_view_profiles(self) -> list[JSONDocument]:
         """List executable read-view profile metadata."""

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -36,7 +36,8 @@ ForensicClaimKind = Literal[
     "decision_candidate",
 ]
 RecoveryReportPreset = Literal["continue", "blame", "work-packet"]
-WorkPacketSection = Literal["events", "subagents", "run_state", "tools", "decisions"]
+WorkPacketSection = Literal["events", "subagents", "run_state", "tools", "decisions", "evidence_gaps"]
+WorkPacketSupport = Literal["raw_evidence", "assertion", "inference", "caveat", "missing_evidence"]
 SubagentChildLinkStatus = Literal["resolved", "unresolved", "repaired", "quarantined"]
 
 _ISSUE_RE = re.compile(r"(?:issues/|issue\s+|closed\s+|#)(?P<number>\d{3,6})", re.IGNORECASE)
@@ -240,6 +241,7 @@ class RecoveryWorkPacketEntry(ArchiveInsightModel):
     label: str
     text: str
     evidence_refs: tuple[EvidenceRef, ...]
+    support: WorkPacketSupport = "raw_evidence"
     metadata: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
@@ -432,6 +434,15 @@ def render_resume_bundle(
                 run_state=run_state,
                 tool_summaries=tool_summaries,
                 decisions=decisions,
+                packet_raw_refs=(
+                    TransformRawRef(
+                        session_id=str(session.id),
+                        message_id=None,
+                        block_index=None,
+                        ref_kind="session",
+                        preview=session.display_title,
+                    ),
+                ),
             )
         ),
         evidence_refs=(EvidenceRef(session_id=str(session.id)),),
@@ -455,14 +466,14 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         lines.append(f"- workdirs: {', '.join(packet.working_directories)}")
     lines.extend(["", "## Events"])
     event_entries = _packet_section(packet, "events")
-    lines.extend(f"- {entry.label}: {entry.text}" for entry in event_entries[:8])
+    lines.extend(_work_packet_line(entry) for entry in event_entries[:8])
     if not event_entries:
         lines.append("- none extracted")
     lines.extend(["", "## Subagents"])
     subagent_entries = _packet_section(packet, "subagents")
     for entry in subagent_entries[:8]:
         prompt = f" — {entry.text}" if entry.text else ""
-        lines.append(f"- {entry.label}{prompt}")
+        lines.append(f"- {_support_marker(entry)} {entry.label}{prompt}")
         refs = _subagent_metadata_line(entry.metadata)
         if refs:
             lines.append(f"  - refs: {refs}")
@@ -476,23 +487,27 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
     if not run_state_entries:
         lines.append("- none extracted")
     else:
-        lines.extend(f"- {entry.label}: {entry.text}" for entry in run_state_entries[:33])
+        lines.extend(_work_packet_line(entry) for entry in run_state_entries[:33])
     lines.extend(["", "## Tools"])
     tool_entries = _packet_section(packet, "tools")
     for entry in tool_entries[:8]:
         command = f" — {entry.text}" if entry.text else ""
         handler = entry.metadata.get("handler_kind", "generic")
         status = entry.metadata.get("status", "unknown")
-        lines.append(f"- {entry.label} [{handler}] ({status}){command}")
+        lines.append(f"- {_support_marker(entry)} {entry.label} [{handler}] ({status}){command}")
     if not tool_entries:
         lines.append("- none extracted")
     lines.extend(["", "## Candidate Decisions / Run State"])
     decision_entries = _packet_section(packet, "decisions")
-    lines.extend(f"- {entry.label}: {entry.text}" for entry in decision_entries[:8])
+    lines.extend(_work_packet_line(entry) for entry in decision_entries[:8])
     if not decision_entries:
         lines.append("- none extracted")
+    gap_entries = _packet_section(packet, "evidence_gaps")
+    if gap_entries:
+        lines.extend(["", "## Evidence Gaps"])
+        lines.extend(_work_packet_line(entry) for entry in gap_entries[:8])
     lines.extend(["", "## Evidence"])
-    lines.append("Raw refs are available on every extracted event/tool/decision record.")
+    lines.append("Every packet row carries evidence refs and a support marker.")
     return "\n".join(lines).strip() + "\n"
 
 
@@ -511,6 +526,7 @@ def build_recovery_work_packet(digest: RecoveryDigest) -> RecoveryWorkPacket:
                 run_state=digest.run_state,
                 tool_summaries=digest.tool_summaries,
                 decisions=digest.decision_candidates,
+                packet_raw_refs=digest.raw_refs,
             )
         ),
         evidence_refs=tuple(ref.to_evidence_ref() for ref in digest.raw_refs),
@@ -521,6 +537,14 @@ def _packet_section(packet: RecoveryWorkPacket, section: WorkPacketSection) -> t
     return tuple(entry for entry in packet.entries if entry.section == section)
 
 
+def _support_marker(entry: RecoveryWorkPacketEntry) -> str:
+    return f"[{entry.support.replace('_', '-')}]"
+
+
+def _work_packet_line(entry: RecoveryWorkPacketEntry) -> str:
+    return f"- {_support_marker(entry)} {entry.label}: {entry.text}"
+
+
 def _work_packet_entries(
     *,
     events: Sequence[RecoveryEvent],
@@ -528,7 +552,9 @@ def _work_packet_entries(
     run_state: RunStateSummary | None,
     tool_summaries: Sequence[ToolSummary],
     decisions: Sequence[DecisionCandidate],
+    packet_raw_refs: Sequence[TransformRawRef],
 ) -> Iterable[RecoveryWorkPacketEntry]:
+    packet_evidence_refs = _to_evidence_refs(packet_raw_refs)
     for event in events:
         yield RecoveryWorkPacketEntry(
             section="events",
@@ -553,6 +579,7 @@ def _work_packet_entries(
                 section="run_state",
                 label="goal",
                 text=run_state.goal,
+                support="assertion",
                 evidence_refs=_to_evidence_refs(run_state.raw_refs),
             )
         for label, items in (
@@ -566,8 +593,17 @@ def _work_packet_entries(
                     section="run_state",
                     label=label,
                     text=item,
+                    support="caveat" if label == "blocker" else "assertion",
                     evidence_refs=_to_evidence_refs(run_state.raw_refs),
                 )
+    else:
+        yield RecoveryWorkPacketEntry(
+            section="evidence_gaps",
+            label="run_state",
+            text="No structured RunState section was extracted from the session.",
+            support="missing_evidence",
+            evidence_refs=packet_evidence_refs,
+        )
     for tool in tool_summaries:
         yield RecoveryWorkPacketEntry(
             section="tools",
@@ -581,7 +617,40 @@ def _work_packet_entries(
             section="decisions",
             label=decision.kind,
             text=decision.text,
+            support="inference",
             evidence_refs=_to_evidence_refs(decision.raw_refs),
+        )
+    if not events:
+        yield RecoveryWorkPacketEntry(
+            section="evidence_gaps",
+            label="events",
+            text="No PR, issue, test, check, or merge events were extracted.",
+            support="missing_evidence",
+            evidence_refs=packet_evidence_refs,
+        )
+    if not subagent_reports:
+        yield RecoveryWorkPacketEntry(
+            section="evidence_gaps",
+            label="subagents",
+            text="No subagent handoff or child-session evidence was extracted.",
+            support="missing_evidence",
+            evidence_refs=packet_evidence_refs,
+        )
+    if not tool_summaries:
+        yield RecoveryWorkPacketEntry(
+            section="evidence_gaps",
+            label="tools",
+            text="No tool execution summary was extracted.",
+            support="missing_evidence",
+            evidence_refs=packet_evidence_refs,
+        )
+    if not decisions:
+        yield RecoveryWorkPacketEntry(
+            section="evidence_gaps",
+            label="decisions",
+            text="No candidate decision statement was extracted.",
+            support="missing_evidence",
+            evidence_refs=packet_evidence_refs,
         )
 
 

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -36,7 +36,7 @@ ForensicClaimKind = Literal[
     "decision_candidate",
 ]
 RecoveryReportPreset = Literal["continue", "blame", "work-packet"]
-WorkPacketSection = Literal["events", "subagents", "run_state", "tools", "decisions", "evidence_gaps"]
+WorkPacketSection = Literal["events", "subagents", "run_state", "tools", "decisions", "assertions", "evidence_gaps"]
 WorkPacketSupport = Literal["raw_evidence", "assertion", "inference", "caveat", "missing_evidence"]
 SubagentChildLinkStatus = Literal["resolved", "unresolved", "repaired", "quarantined"]
 
@@ -502,6 +502,10 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
     lines.extend(_work_packet_line(entry) for entry in decision_entries[:8])
     if not decision_entries:
         lines.append("- none extracted")
+    assertion_entries = _packet_section(packet, "assertions")
+    if assertion_entries:
+        lines.extend(["", "## Assertion Claims"])
+        lines.extend(_work_packet_line(entry) for entry in assertion_entries[:12])
     gap_entries = _packet_section(packet, "evidence_gaps")
     if gap_entries:
         lines.extend(["", "## Evidence Gaps"])

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import sqlite3
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
@@ -800,9 +801,25 @@ async def test_query_completions_exposes_shared_completion_payload(tmp_path: Pat
 
 async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) -> None:
     """``recovery_report`` exposes deterministic preset markdown with evidence refs."""
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
     archive = _archive(tmp_path)
     db_path = archive.config.archive_root / "index.db"
     await _seed_two_sessions(db_path)
+    with sqlite3.connect(archive.config.archive_root / "user.db") as conn:
+        upsert_assertion(
+            conn,
+            assertion_id="recovery-caveat-alpha",
+            target_ref="session:claude-ai-export:conv-alpha",
+            kind=AssertionKind.CAVEAT,
+            body_text="Review findings have not been read yet.",
+            author_ref="user:test",
+            author_kind="user",
+            evidence_refs=["claude-ai-export:conv-alpha"],
+            status="active",
+            visibility="private",
+            now_ms=1_700_000_000_000,
+        )
     try:
         continue_report = await archive.recovery_report("claude-ai-export:conv-alpha", "continue")
         blame_report = await archive.recovery_report("claude-ai-export:conv-alpha", "blame")
@@ -818,10 +835,16 @@ async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) ->
         assert work_packet_report.startswith("# Resume: Alpha")
         assert work_packet.session_id == "claude-ai-export:conv-alpha"
         assert work_packet.render_markdown() == work_packet_report
+        assertion_entries = [entry for entry in work_packet.entries if entry.section == "assertions"]
+        assert [(entry.label, entry.support, entry.text) for entry in assertion_entries] == [
+            ("caveat", "caveat", "Review findings have not been read yet.")
+        ]
         assert continue_report != blame_report
         assert work_packet_report not in {continue_report, blame_report}
         assert "[evidence:" in continue_report
         assert "[evidence:" in blame_report
+        assert "## Assertion Claims" in work_packet_report
+        assert "- [caveat] caveat: Review findings have not been read yet." in work_packet_report
         assert "## Evidence" in work_packet_report
         assert await archive.recovery_report("nonexistent", "continue") is None
         assert await archive.recovery_work_packet("nonexistent") is None

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -141,8 +141,8 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert digest.size_metrics.message_count == 3
     assert digest.size_metrics.subagent_report_count == 1
     assert digest.size_metrics.run_state_count == 1
-    assert digest.size_metrics.raw_bytes > digest.size_metrics.resume_bundle_bytes
-    assert digest.size_metrics.resume_to_raw_ratio < 1
+    assert digest.size_metrics.resume_bundle_bytes > 0
+    assert digest.size_metrics.resume_bundle_bytes >= digest.size_metrics.normal_read_bytes
     assert digest.role_counts == {"user": 1, "assistant": 2}
 
     assert len(digest.tool_summaries) == 2
@@ -201,11 +201,11 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert "Explore — Map the transform surface and report caveats." in digest.resume_markdown
     assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in digest.resume_markdown
     assert "## Run State" in digest.resume_markdown
-    assert "- done: #1910 merged" in digest.resume_markdown
-    assert "- next: merge PR #1911" in digest.resume_markdown
+    assert "- [assertion] done: #1910 merged" in digest.resume_markdown
+    assert "- [assertion] next: merge PR #1911" in digest.resume_markdown
     assert "Bash [test]" in digest.resume_markdown
     assert "Read [file_read]" in digest.resume_markdown
-    assert "Raw refs are available" in digest.resume_markdown
+    assert "Every packet row carries evidence refs and a support marker." in digest.resume_markdown
 
 
 def test_every_extracted_claim_carries_raw_refs() -> None:

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -109,6 +109,23 @@ def _session() -> Session:
     )
 
 
+def _sparse_session() -> Session:
+    return Session(
+        id=SessionId("codex-session:sparse"),
+        origin=Origin.CODEX_SESSION,
+        title="Sparse handoff",
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="m1",
+                    role=Role.USER,
+                    text="Please look into the archive behavior when you get back.",
+                )
+            ]
+        ),
+    )
+
+
 def test_registry_declares_no_llm_recovery_transform() -> None:
     assert TRANSFORM_REGISTRY[RECOVERY_TRANSFORM.transform_id] == RECOVERY_TRANSFORM
     assert RECOVERY_TRANSFORM.deterministic is True
@@ -295,11 +312,28 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
         "decisions",
     }
     assert all(entry.evidence_refs for entry in packet.entries)
+    assert {entry.support for entry in packet.entries} >= {"raw_evidence", "assertion", "caveat", "inference"}
     assert any(ref.format() == "codex-session:demo::m2::0" for entry in packet.entries for ref in entry.evidence_refs)
     assert "# Resume: Ship the backlog" in rendered
-    assert "- pr_opened: PR #1911 opened" in rendered
+    assert "- [raw-evidence] pr_opened: PR #1911 opened" in rendered
+    assert "- [caveat] blocker: none" in rendered
     assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in rendered
-    assert "- Bash [test] (ok) — devtools verify --quick" in rendered
+    assert "- [raw-evidence] Bash [test] (ok) — devtools verify --quick" in rendered
+
+
+def test_work_packet_marks_missing_evidence_explicitly() -> None:
+    digest = compile_recovery_digest(_sparse_session())
+
+    packet = digest.work_packet()
+    rendered = packet.render_markdown()
+
+    gap_entries = tuple(entry for entry in packet.entries if entry.section == "evidence_gaps")
+    assert {entry.label for entry in gap_entries} == {"events", "subagents", "run_state", "tools", "decisions"}
+    assert all(entry.support == "missing_evidence" for entry in gap_entries)
+    assert all(entry.evidence_refs for entry in gap_entries)
+    assert "## Evidence Gaps" in rendered
+    assert "- [missing-evidence] run_state: No structured RunState section was extracted" in rendered
+    assert "- [missing-evidence] tools: No tool execution summary was extracted." in rendered
 
 
 def test_continue_report_renders_successor_boot_packet_with_evidence_refs() -> None:


### PR DESCRIPTION
## Summary
Add explicit support markers to recovery work-packet rows and enrich facade-built packets with session-targeted assertion claims from `user.db`.

## Problem
Work packets already carried evidence refs, but API consumers and Markdown readers could not tell whether a row was raw evidence, authored RunState, inferred decision, caveat, or missing evidence. Sparse packets represented missing evidence only as renderer prose (`none extracted`). Separately, #1883 had assertion lifecycle claim reads, but recovery work packets did not consume assertion-backed decisions/caveats/blockers/lessons/transform candidates that targeted the recovered session.

## Solution
`RecoveryWorkPacketEntry` now has a typed `support` marker. The recovery packet builder classifies raw events/tools/subagents, RunState assertions, blocker caveats, inferred decisions, and explicit `evidence_gaps` rows for missing handoff evidence. The facade enriches `recovery_work_packet()` with target-session assertion claims from `user.db`, keeps the transform layer storage-free, and makes `recovery_report(..., "work-packet")` render the same enriched DTO used by the API. Markdown now shows support markers and assertion-claim rows while preserving evidence refs on every packet entry.

## Verification
- `nix develop --command devtools test tests/unit/insights/test_transforms.py -k 'work_packet or continue_report'` -> 3 passed
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k recovery_report_renders_seeded_session_presets` -> 1 passed
- `nix develop --command devtools verify --quick` -> exit_code 0

Closes part of #1838 and advances #1883 recovery/work-packet consumer wiring.