### PR TITLE
feat(mcp): expose recovery work packets (#1825)

### DIFF
--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -782,6 +782,29 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("list_read_view_profiles", run)
 
     @mcp.tool()
+    async def get_recovery_work_packet(session_id: str) -> str:
+        """Return the shared recovery work-packet DTO for one session."""
+
+        async def run() -> str:
+            packet = await hooks.get_polylogue().recovery_work_packet(session_id)
+            if packet is None:
+                return hooks.error_json(
+                    f"Session not found: {session_id}",
+                    code="not_found",
+                    tool="get_recovery_work_packet",
+                )
+            return hooks.json_payload(
+                MCPRootPayload(
+                    root=cast(
+                        dict[str, object],
+                        {"recovery_work_packet": packet.model_dump(mode="json", exclude_none=True)},
+                    )
+                )
+            )
+
+        return await hooks.async_safe_call("get_recovery_work_packet", run)
+
+    @mcp.tool()
     async def explain_query_expression(expression: str) -> str:
         """Explain query DSL parsing and lowering through the shared grammar."""
 

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -48,6 +48,7 @@ EXPECTED_TOOL_NAMES = {
     "get_logical_session",
     "get_stats_by",
     "list_read_view_profiles",
+    "get_recovery_work_packet",
     "explain_query_expression",
     "query_completions",
     "readiness_check",
@@ -197,6 +198,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.get_session_topology = AsyncMock(return_value=None)
     poly.get_logical_session = AsyncMock(return_value=None)
     poly.list_read_view_profiles = AsyncMock(return_value=[])
+    poly.recovery_work_packet = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -83,6 +83,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     # ------- single record -------
     "get_session": "single_object",
     "get_session_summary": "single_object",
+    "get_recovery_work_packet": "single_object",
     "archive_get_session": "single_object",
     "get_metadata": "single_object",
     "session_profile": "single_object",

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -15,6 +15,8 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Session, SessionSummary
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.enums import BlockType, Provider
+from polylogue.core.refs import EvidenceRef
+from polylogue.insights.transforms import RecoveryWorkPacket, RecoveryWorkPacketEntry
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.types import SessionId
@@ -750,6 +752,62 @@ class TestArchiveGenericToolSurfaces:
         payload = json.loads(result)
         assert payload["session_id"] == session_id
         assert payload["messages"][0]["text"] == "tool message from archive index"
+
+    @pytest.mark.asyncio
+    async def test_get_recovery_work_packet_reads_shared_facade_dto(
+        self: object, mcp_server: MCPServerUnderTest
+    ) -> None:
+        packet = RecoveryWorkPacket(
+            session_id="session-1",
+            title="Recovery target",
+            source_origin="codex-session",
+            message_count=3,
+            entries=(
+                RecoveryWorkPacketEntry(
+                    section="assertions",
+                    label="Assertion",
+                    text="The retry path is evidence-backed.",
+                    evidence_refs=(EvidenceRef(session_id="session-1"),),
+                    support="assertion",
+                    metadata={"kind": "fact"},
+                ),
+            ),
+            evidence_refs=(EvidenceRef(session_id="session-1"),),
+        )
+        mock_poly = make_polylogue_mock()
+        mock_poly.recovery_work_packet.return_value = packet
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_recovery_work_packet"].fn,
+                session_id="session-1",
+            )
+
+        payload = json.loads(result)
+        assert payload["recovery_work_packet"]["session_id"] == "session-1"
+        assert payload["recovery_work_packet"]["entries"][0]["section"] == "assertions"
+        assert payload["recovery_work_packet"]["entries"][0]["support"] == "assertion"
+        assert payload["recovery_work_packet"]["entries"][0]["evidence_refs"][0]["session_id"] == "session-1"
+        mock_poly.recovery_work_packet.assert_awaited_once_with("session-1")
+
+    @pytest.mark.asyncio
+    async def test_get_recovery_work_packet_reports_missing_session(
+        self: object, mcp_server: MCPServerUnderTest
+    ) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.recovery_work_packet.return_value = None
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_recovery_work_packet"].fn,
+                session_id="missing",
+            )
+
+        payload = json.loads(result)
+        assert payload["is_error"] is True
+        assert payload["code"] == "not_found"
+        assert payload["tool"] == "get_recovery_work_packet"
+        mock_poly.recovery_work_packet.assert_awaited_once_with("missing")
 
 
 class TestPromptSurfaces:


### PR DESCRIPTION
## Summary

Expose the recovery work-packet read contract through MCP. Agents can now request the same evidence-bearing `RecoveryWorkPacket` DTO that the Python API exposes, instead of only discovering that the recovery read-view profile exists.

## Problem

#1825 tracks keeping MCP on shared query/read/action contracts. After #1838 made recovery work packets concrete and evidence-backed, MCP still had only `list_read_view_profiles`; there was no MCP read path for the actual work-packet payload, so profile discovery and execution were split across surfaces.

## Solution

Added `get_recovery_work_packet(session_id)` to the MCP read tools. The tool calls `Polylogue.recovery_work_packet`, serializes the shared DTO with `model_dump(mode="json", exclude_none=True)`, and uses the existing MCP `not_found` error envelope when the facade returns no packet. The MCP expected-tool registry and live surface tests cover registration, success serialization, and missing-session behavior.

This does not add a query shortcut or a surface-local recovery shape; MCP remains an adapter over the shared API DTO.

## Verification

- `nix develop --command devtools test tests/unit/mcp/test_server_surfaces.py -k 'server_surface_contract or recovery_work_packet'` -> 6 passed, 59 deselected
- `nix develop --command devtools verify --quick` -> exit_code 0

Ref #1825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve recovery work packet data by session identifier, with appropriate error handling for missing sessions.

* **Tests**
  * Added unit tests covering recovery work packet retrieval scenarios, including success cases and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->