### PR TITLE
feat(recovery): enrich work-packet evidence details (#1838)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -466,7 +466,11 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         lines.append(f"- workdirs: {', '.join(packet.working_directories)}")
     lines.extend(["", "## Events"])
     event_entries = _packet_section(packet, "events")
-    lines.extend(_work_packet_line(entry) for entry in event_entries[:8])
+    for entry in event_entries[:8]:
+        lines.append(_work_packet_line(entry))
+        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "issue_refs", "test_evidence"))
+        if detail:
+            lines.append(f"  - details: {detail}")
     if not event_entries:
         lines.append("- none extracted")
     lines.extend(["", "## Subagents"])
@@ -495,6 +499,9 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         handler = entry.metadata.get("handler_kind", "generic")
         status = entry.metadata.get("status", "unknown")
         lines.append(f"- {_support_marker(entry)} {entry.label} [{handler}] ({status}){command}")
+        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "issue_refs", "file_refs", "test_evidence"))
+        if detail:
+            lines.append(f"  - details: {detail}")
     if not tool_entries:
         lines.append("- none extracted")
     lines.extend(["", "## Candidate Decisions / Run State"])
@@ -549,6 +556,11 @@ def _work_packet_line(entry: RecoveryWorkPacketEntry) -> str:
     return f"- {_support_marker(entry)} {entry.label}: {entry.text}"
 
 
+def _packet_metadata_line(metadata: Mapping[str, str], *, keys: Sequence[str]) -> str:
+    parts = [f"{key}={metadata[key]}" for key in keys if metadata.get(key)]
+    return "; ".join(parts)
+
+
 def _work_packet_entries(
     *,
     events: Sequence[RecoveryEvent],
@@ -564,6 +576,7 @@ def _work_packet_entries(
             section="events",
             label=event.kind,
             text=event.summary,
+            metadata=_event_packet_metadata(event),
             evidence_refs=_to_evidence_refs(event.raw_refs),
         )
     for report in subagent_reports:
@@ -613,7 +626,7 @@ def _work_packet_entries(
             section="tools",
             label=tool.tool_name,
             text=tool.command or "",
-            metadata={"handler_kind": tool.handler_kind, "status": tool.status},
+            metadata=_tool_packet_metadata(tool),
             evidence_refs=_to_evidence_refs(tool.raw_refs),
         )
     for decision in decisions:
@@ -660,6 +673,39 @@ def _work_packet_entries(
 
 def _to_evidence_refs(refs: Sequence[TransformRawRef]) -> tuple[EvidenceRef, ...]:
     return tuple(ref.to_evidence_ref() for ref in refs)
+
+
+def _event_packet_metadata(event: RecoveryEvent) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    pr_refs = tuple(_number_refs(_PR_RE, event.summary)) if event.kind.startswith("pr_") else ()
+    issue_refs = tuple(_number_refs(_ISSUE_RE, event.summary)) if event.kind == "issue_closed" else ()
+    test_evidence = (event.summary,) if event.kind.startswith(("check_", "test_")) else ()
+    if pr_refs:
+        metadata["pr_refs"] = ", ".join(pr_refs)
+    if issue_refs:
+        metadata["issue_refs"] = ", ".join(issue_refs)
+    if test_evidence:
+        metadata["test_evidence"] = " | ".join(test_evidence)
+    return metadata
+
+
+def _tool_packet_metadata(tool: ToolSummary) -> dict[str, str]:
+    metadata: dict[str, str] = {"handler_kind": tool.handler_kind, "status": tool.status}
+    issue_refs = _refs_without_pr_refs(tool.issue_refs, tool.pr_refs)
+    if tool.pr_refs:
+        metadata["pr_refs"] = ", ".join(tool.pr_refs)
+    if issue_refs:
+        metadata["issue_refs"] = ", ".join(issue_refs)
+    if tool.file_refs:
+        metadata["file_refs"] = ", ".join(tool.file_refs)
+    if tool.test_evidence:
+        metadata["test_evidence"] = " | ".join(tool.test_evidence)
+    return metadata
+
+
+def _refs_without_pr_refs(issue_refs: Sequence[str], pr_refs: Sequence[str]) -> tuple[str, ...]:
+    pr_ref_set = set(pr_refs)
+    return tuple(ref for ref in issue_refs if ref not in pr_ref_set)
 
 
 def render_recovery_report(digest: RecoveryDigest, *, preset: RecoveryReportPreset) -> str:

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -314,11 +314,35 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
     assert all(entry.evidence_refs for entry in packet.entries)
     assert {entry.support for entry in packet.entries} >= {"raw_evidence", "assertion", "caveat", "inference"}
     assert any(ref.format() == "codex-session:demo::m2::0" for entry in packet.entries for ref in entry.evidence_refs)
+    pr_event = next(entry for entry in packet.entries if entry.section == "events" and entry.label == "pr_opened")
+    assert pr_event.metadata == {"pr_refs": "#1911"}
+    issue_event = next(entry for entry in packet.entries if entry.section == "events" and entry.label == "issue_closed")
+    assert issue_event.metadata == {"issue_refs": "#1818"}
+    check_event = next(entry for entry in packet.entries if entry.section == "events" and entry.label == "check_passed")
+    assert check_event.metadata == {"test_evidence": "ruff check passed"}
+    bash_entry = next(entry for entry in packet.entries if entry.section == "tools" and entry.label == "Bash")
+    assert bash_entry.metadata == {
+        "handler_kind": "test",
+        "status": "ok",
+        "pr_refs": "#1911",
+        "test_evidence": "ruff check ... ok | 20 passed in 50.28s",
+    }
+    read_entry = next(entry for entry in packet.entries if entry.section == "tools" and entry.label == "Read")
+    assert read_entry.metadata == {
+        "handler_kind": "file_read",
+        "status": "unknown",
+        "file_refs": "polylogue/insights/transforms.py",
+    }
     assert "# Resume: Ship the backlog" in rendered
     assert "- [raw-evidence] pr_opened: PR #1911 opened" in rendered
+    assert "details: pr_refs=#1911" in rendered
+    assert "details: issue_refs=#1818" in rendered
+    assert "details: test_evidence=ruff check passed" in rendered
     assert "- [caveat] blocker: none" in rendered
     assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in rendered
     assert "- [raw-evidence] Bash [test] (ok) — devtools verify --quick" in rendered
+    assert "details: pr_refs=#1911; test_evidence=ruff check ... ok | 20 passed in 50.28s" in rendered
+    assert "details: file_refs=polylogue/insights/transforms.py" in rendered
 
 
 def test_work_packet_marks_missing_evidence_explicitly() -> None:


### PR DESCRIPTION
## Summary

Carry already-extracted PR, issue, file, check, and test evidence into recovery work-packet entries and Markdown. This makes the existing `RecoveryWorkPacket` bundle more useful as a successor-agent handoff without adding a new model, table, or proof artifact.

## Problem

#1838 asks for work packets to answer what happened, what remains, and what evidence supports the handoff. The recovery transform already extracted structured evidence such as PR refs, issue refs, file refs, and test/check lines, but the work-packet entries and renderer dropped much of that detail into plain event/tool prose.

## Solution

Added packet metadata helpers for events and tools. Event rows now carry typed PR/issue/check/test details based on the extracted event kind, and tool rows preserve PR refs, issue refs, file refs, and test evidence. The Markdown renderer emits those details as subordinate lines below event/tool rows.

The transform test fixture now asserts the packet carries and renders PR refs, issue refs, check evidence, test evidence, file refs, subagent refs, and missing-evidence markers. This stays within the existing on-demand `RecoveryWorkPacket` DTO and does not create a separate packet store.

## Verification

- `nix develop --command devtools test tests/unit/insights/test_transforms.py -k 'work_packet or compile_recovery_digest'` -> 3 passed, 11 deselected
- `nix develop --command devtools test tests/unit/insights/test_transforms.py` -> 14 passed
- `nix develop --command devtools verify --quick` -> exit_code 0

Ref #1838
Ref #1883
