### PR TITLE
feat(api): expose assertion claim reads (#1883)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from polylogue.storage.repository import SessionRepository
     from polylogue.storage.search.models import SearchResult
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
+    from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveSessionEnvelope
     from polylogue.surfaces.payloads import (
         BulkTagMutationResult,
@@ -420,25 +421,56 @@ def _archive_tier_readiness_check(tier: ArchiveTier, path: Any) -> Any:
     )
 
 
-def _archive_assertion_work_packet_entries(config: Config, session_id: str) -> tuple[Any, ...]:
-    """Return assertion-backed work-packet rows for one target session."""
+def _archive_list_assertion_claims(
+    config: Config,
+    *,
+    kinds: Sequence[str] | None = None,
+    target_ref: str | None = None,
+    scope_ref: str | None = None,
+    statuses: Sequence[str] | None = ("active", "candidate"),
+    context_inject: bool | None = None,
+    limit: int | None = None,
+) -> list[Any]:
+    """Return assertion-backed lifecycle claims from ``user.db``."""
 
-    from polylogue.core.refs import EvidenceRef
-    from polylogue.insights.transforms import RecoveryWorkPacketEntry
     from polylogue.storage.sqlite.archive_tiers.user_write import list_assertion_claims
 
     user_db = _active_archive_root(config) / "user.db"
     if not user_db.exists():
-        return ()
+        return []
     try:
         conn = sqlite3.connect(f"file:{user_db}?mode=ro", uri=True)
         conn.row_factory = sqlite3.Row
         try:
-            claims = list_assertion_claims(conn, target_ref=f"session:{session_id}", limit=20)
+            if kinds is None:
+                return list_assertion_claims(
+                    conn,
+                    target_ref=target_ref,
+                    scope_ref=scope_ref,
+                    statuses=statuses,
+                    context_inject=context_inject,
+                    limit=limit,
+                )
+            return list_assertion_claims(
+                conn,
+                kinds=kinds,
+                target_ref=target_ref,
+                scope_ref=scope_ref,
+                statuses=statuses,
+                context_inject=context_inject,
+                limit=limit,
+            )
         finally:
             conn.close()
     except sqlite3.Error:
-        return ()
+        return []
+
+
+def _archive_assertion_work_packet_entries(claims: Sequence[Any], session_id: str) -> tuple[Any, ...]:
+    """Return assertion-backed work-packet rows for one target session."""
+
+    from polylogue.core.refs import EvidenceRef
+    from polylogue.insights.transforms import RecoveryWorkPacketEntry
 
     entries: list[RecoveryWorkPacketEntry] = []
     fallback_ref = EvidenceRef(session_id=session_id)
@@ -1199,10 +1231,36 @@ class PolylogueArchiveMixin:
         if digest is None:
             return None
         packet = digest.work_packet()
-        assertion_entries = _archive_assertion_work_packet_entries(self.config, digest.session_id)
+        claims = await self.list_assertion_claims(target_ref=f"session:{digest.session_id}", limit=20)
+        assertion_entries = _archive_assertion_work_packet_entries(claims, digest.session_id)
         if not assertion_entries:
             return packet
         return packet.model_copy(update={"entries": (*packet.entries, *assertion_entries)})
+
+    async def list_assertion_claims(
+        self,
+        *,
+        kinds: Sequence[str] | None = None,
+        target_ref: str | None = None,
+        scope_ref: str | None = None,
+        statuses: Sequence[str] | None = ("active", "candidate"),
+        context_inject: bool | None = None,
+        limit: int | None = None,
+    ) -> list[ArchiveAssertionEnvelope]:
+        """List assertion-backed lifecycle claims for read-surface consumers."""
+
+        return cast(
+            list["ArchiveAssertionEnvelope"],
+            _archive_list_assertion_claims(
+                self.config,
+                kinds=kinds,
+                target_ref=target_ref,
+                scope_ref=scope_ref,
+                statuses=statuses,
+                context_inject=context_inject,
+                limit=limit,
+            ),
+        )
 
     async def list_read_view_profiles(self) -> list[JSONDocument]:
         """List executable read-view profile metadata."""

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -72,6 +72,7 @@ READ_BY_ID_NONE_METHODS: frozenset[str] = frozenset(
         "get_session_latency_profile_insight",
         "resume_brief",
         "recovery_digest",
+        "recovery_work_packet",
     }
 )
 
@@ -104,6 +105,7 @@ READ_NULLARY_METHODS: frozenset[str] = frozenset(
         "list_annotations",
         "list_views",
         "list_read_view_profiles",
+        "list_assertion_claims",
         "list_recall_packs",
         "list_workspaces",
         "list_corrections",
@@ -848,6 +850,95 @@ async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) ->
         assert "## Evidence" in work_packet_report
         assert await archive.recovery_report("nonexistent", "continue") is None
         assert await archive.recovery_work_packet("nonexistent") is None
+    finally:
+        await archive.close()
+
+
+async def test_list_assertion_claims_filters_lifecycle_claims(tmp_path: Path) -> None:
+    """``list_assertion_claims`` exposes policy-aware assertion reads."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
+    archive = _archive(tmp_path)
+    user_db = archive.config.archive_root / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    with sqlite3.connect(user_db) as conn:
+        upsert_assertion(
+            conn,
+            assertion_id="claim-decision-inject",
+            target_ref="session:codex-session:claim-target",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.DECISION,
+            body_text="Use the shared query metadata module.",
+            author_ref="agent:codex",
+            author_kind="agent",
+            evidence_refs=["codex-session:claim-target::m1"],
+            status="active",
+            visibility="private",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-caveat-private",
+            target_ref="session:codex-session:claim-target",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.CAVEAT,
+            body_text="Review evidence is still partial.",
+            author_ref="agent:codex",
+            author_kind="agent",
+            status="candidate",
+            visibility="private",
+            context_policy={"inject": False},
+            now_ms=1_700_000_000_100,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-deleted",
+            target_ref="session:codex-session:claim-target",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.DECISION,
+            body_text="Deleted claims should not appear by default.",
+            status="deleted",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_200,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-other-target",
+            target_ref="session:codex-session:other",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.LESSON,
+            body_text="Other target.",
+            status="active",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_300,
+        )
+        conn.commit()
+
+    try:
+        claims = await archive.list_assertion_claims(target_ref="session:codex-session:claim-target")
+        assert [claim.assertion_id for claim in claims] == ["claim-caveat-private", "claim-decision-inject"]
+
+        injectable = await archive.list_assertion_claims(
+            target_ref="session:codex-session:claim-target",
+            context_inject=True,
+        )
+        assert [claim.assertion_id for claim in injectable] == ["claim-decision-inject"]
+
+        decisions = await archive.list_assertion_claims(
+            kinds=(AssertionKind.DECISION,),
+            target_ref="session:codex-session:claim-target",
+            statuses=("active",),
+        )
+        assert [claim.assertion_id for claim in decisions] == ["claim-decision-inject"]
+
+        deleted = await archive.list_assertion_claims(
+            target_ref="session:codex-session:claim-target",
+            statuses=("deleted",),
+        )
+        assert [claim.assertion_id for claim in deleted] == ["claim-deleted"]
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Adds a first-class archive facade read helper for assertion-backed lifecycle claims and routes recovery work-packet assertion entries through that helper instead of opening `user.db` directly in the work-packet adapter.

## Problem

#1883's assertion substrate already had a storage-level reader for scoped, status-aware, context-injection-aware claims, but higher read surfaces still had to either bypass the facade or keep assertion reads embedded inside one recovery-specific helper. That made assertions less reusable than the user-state overlays they are replacing.

## Solution

- Add `PolylogueArchiveMixin.list_assertion_claims(...)` with kind, target, scope, status, context-injection, and limit filters.
- Factor the user-tier read into a shared private archive helper used by the facade method.
- Change `recovery_work_packet` to consume `list_assertion_claims(...)`, so recovery packets now use the same public assertion read path other consumers can use.
- Extend the facade contract matrix and add coverage for target filtering, default active/candidate status behavior, explicit deleted status reads, kind filters, and context-injection filtering.

## Verification

- `devtools test tests/unit/api/test_facade_contracts.py -k 'assertion_claims or recovery_report_renders_seeded_session_presets or no_undiscovered_async_methods or categorized_methods_cover_discovered_methods or stale_known_methods'` → `4 passed, 194 deselected`
- `devtools verify --quick` → exit code 0

Ref #1883