### PR TITLE
feat(mcp): expose assertion claim reads (#1883)

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
     from polylogue.readiness import ReadinessCheck, ReadinessReport
     from polylogue.storage.runtime import RawSessionRecord
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
+    from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
 
 TRoot = TypeVar("TRoot")
@@ -140,6 +141,60 @@ class MCPBlackboardNoteListPayload(SurfacePayloadModel):
 
     items: tuple[MCPBlackboardNotePayload, ...]
     total: int
+
+
+class MCPAssertionClaimPayload(SurfacePayloadModel):
+    """One assertion-backed lifecycle claim."""
+
+    assertion_id: str
+    scope_ref: str | None = None
+    target_ref: str
+    key: str | None = None
+    kind: str
+    value: object | None = None
+    body_text: str | None = None
+    author_ref: str | None = None
+    author_kind: str | None = None
+    evidence_refs: tuple[str, ...] = ()
+    status: str | None = None
+    visibility: str | None = None
+    confidence: float | None = None
+    staleness: dict[str, Any] | None = None
+    context_policy: dict[str, Any] | None = None
+    supersedes: tuple[str, ...] = ()
+    created_at_ms: int
+    updated_at_ms: int
+
+    @classmethod
+    def from_envelope(cls, envelope: ArchiveAssertionEnvelope) -> MCPAssertionClaimPayload:
+        return cls(
+            assertion_id=envelope.assertion_id,
+            scope_ref=envelope.scope_ref,
+            target_ref=envelope.target_ref,
+            key=envelope.key,
+            kind=envelope.kind,
+            value=envelope.value,
+            body_text=envelope.body_text,
+            author_ref=envelope.author_ref,
+            author_kind=envelope.author_kind,
+            evidence_refs=tuple(envelope.evidence_refs),
+            status=envelope.status,
+            visibility=envelope.visibility,
+            confidence=envelope.confidence,
+            staleness=envelope.staleness,
+            context_policy=envelope.context_policy,
+            supersedes=tuple(envelope.supersedes),
+            created_at_ms=envelope.created_at_ms,
+            updated_at_ms=envelope.updated_at_ms,
+        )
+
+
+class MCPAssertionClaimListPayload(SurfacePayloadModel):
+    """Envelope for assertion-backed lifecycle claims."""
+
+    items: tuple[MCPAssertionClaimPayload, ...]
+    total: int
+    limit: int
 
 
 class MCPFencedCodeBlock(TypedDict):

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -24,6 +24,8 @@ from polylogue.mcp.payloads import (
     MCPArchiveSessionPayload,
     MCPArchiveSessionSummaryPayload,
     MCPArchiveStatsPayload,
+    MCPAssertionClaimListPayload,
+    MCPAssertionClaimPayload,
     MCPBlackboardNoteListPayload,
     MCPEmbeddingPreflightPayload,
     MCPEmbeddingStatusPayload,
@@ -595,6 +597,33 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(MCPBlackboardNoteListPayload(items=items, total=len(items)))
 
         return await hooks.async_safe_call("blackboard_list", run)
+
+    @mcp.tool()
+    async def list_assertion_claims(
+        kinds: str | None = None,
+        target_ref: str | None = None,
+        scope_ref: str | None = None,
+        statuses: str | None = "active,candidate",
+        context_inject: bool | None = None,
+        limit: MCPToolLimit = 20,
+    ) -> str:
+        """List assertion-backed lifecycle claims."""
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            clamped_limit = hooks.clamp_limit(limit)
+            claims = await poly.list_assertion_claims(
+                kinds=_split_archive_csv(kinds) or None,
+                target_ref=target_ref,
+                scope_ref=scope_ref,
+                statuses=None if statuses is None else _split_archive_csv(statuses),
+                context_inject=context_inject,
+                limit=clamped_limit,
+            )
+            items = tuple(MCPAssertionClaimPayload.from_envelope(claim) for claim in claims)
+            return hooks.json_payload(MCPAssertionClaimListPayload(items=items, total=len(items), limit=clamped_limit))
+
+        return await hooks.async_safe_call("list_assertion_claims", run)
 
     @mcp.tool()
     async def get_session_summary(id: str) -> str:

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -19,6 +19,7 @@ EXPECTED_TOOL_NAMES = {
     "build_context_pack",
     "blackboard_list",
     "blackboard_post",
+    "list_assertion_claims",
     "get_session",
     "neighbor_candidates",
     "stats",
@@ -198,6 +199,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.get_session_topology = AsyncMock(return_value=None)
     poly.get_logical_session = AsyncMock(return_value=None)
     poly.list_read_view_profiles = AsyncMock(return_value=[])
+    poly.list_assertion_claims = AsyncMock(return_value=[])
     poly.recovery_work_packet = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -62,6 +62,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     ),
     "get_messages": ("envelope", frozenset({"messages", "total"})),
     "list_read_view_profiles": ("envelope", frozenset({"read_views", "total"})),
+    "list_assertion_claims": ("envelope", frozenset({"items", "total", "limit"})),
     "explain_query_expression": "single_object",
     "query_completions": "single_object",
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
@@ -206,6 +207,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
     from polylogue.mcp.payloads import (
         MCPArchiveSearchPayload,
         MCPArchiveSessionListPayload,
+        MCPAssertionClaimListPayload,
         MCPMessagesListPayload,
         MCPNeighborCandidatesPayload,
         MCPPaginatedQueryResultPayload,
@@ -223,6 +225,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         "get_session_tree": MCPSessionTreePayload,
         "get_session_topology": MCPSessionTopologyPayload,
         "get_messages": MCPMessagesListPayload,
+        "list_assertion_claims": MCPAssertionClaimListPayload,
         "raw_artifacts": MCPRawArtifactsListPayload,
         "archive_list_sessions": MCPArchiveSessionListPayload,
         "archive_search_sessions": MCPArchiveSearchPayload,

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -19,6 +19,7 @@ from polylogue.core.refs import EvidenceRef
 from polylogue.insights.transforms import RecoveryWorkPacket, RecoveryWorkPacketEntry
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
 from polylogue.types import SessionId
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
@@ -808,6 +809,57 @@ class TestArchiveGenericToolSurfaces:
         assert payload["code"] == "not_found"
         assert payload["tool"] == "get_recovery_work_packet"
         mock_poly.recovery_work_packet.assert_awaited_once_with("missing")
+
+    @pytest.mark.asyncio
+    async def test_list_assertion_claims_reads_shared_facade_claims(
+        self: object, mcp_server: MCPServerUnderTest
+    ) -> None:
+        claim = ArchiveAssertionEnvelope(
+            assertion_id="claim-1",
+            scope_ref="repo:polylogue",
+            target_ref="session:session-1",
+            key=None,
+            kind="decision",
+            value=None,
+            body_text="Use shared assertion claim reads.",
+            author_ref="agent:codex",
+            author_kind="agent",
+            evidence_refs=["session-1::m1"],
+            status="active",
+            visibility="private",
+            confidence=0.8,
+            staleness=None,
+            context_policy={"inject": True},
+            supersedes=[],
+            created_at_ms=1_700_000_000_000,
+            updated_at_ms=1_700_000_000_100,
+        )
+        mock_poly = make_polylogue_mock()
+        mock_poly.list_assertion_claims.return_value = [claim]
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["list_assertion_claims"].fn,
+                kinds="decision,caveat",
+                target_ref="session:session-1",
+                statuses="active",
+                context_inject=True,
+                limit=5,
+            )
+
+        payload = json.loads(result)
+        assert payload["total"] == 1
+        assert payload["items"][0]["assertion_id"] == "claim-1"
+        assert payload["items"][0]["kind"] == "decision"
+        assert payload["items"][0]["context_policy"] == {"inject": True}
+        mock_poly.list_assertion_claims.assert_awaited_once_with(
+            kinds=("decision", "caveat"),
+            target_ref="session:session-1",
+            scope_ref=None,
+            statuses=("active",),
+            context_inject=True,
+            limit=5,
+        )
 
 
 class TestPromptSurfaces:


### PR DESCRIPTION
## Summary

Adds an MCP `list_assertion_claims` read tool over the Python facade assertion-claim helper that landed in #2086. The tool returns a typed `{items, total, limit}` envelope of assertion-backed lifecycle claims.

## Problem

#1883 assertion claims were available through `Polylogue.list_assertion_claims(...)`, and recovery work packets could consume them indirectly, but MCP callers had no direct way to read the shared assertion-claim contract. Agent consumers would otherwise have to rely on rendered recovery packets or invent a separate assertion view.

## Solution

- Add `MCPAssertionClaimPayload` and `MCPAssertionClaimListPayload` over `ArchiveAssertionEnvelope`.
- Register `list_assertion_claims` in the MCP read surface with kind, target, scope, status, context-injection, and limit filters.
- Route the tool through `Polylogue.list_assertion_claims(...)`; no MCP-only storage reader or alternate assertion shape is introduced.
- Add the tool to MCP discovery, envelope, mock facade, and registered-tool runtime tests.

## Verification

- `devtools test tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py -k 'server_surface_contract or assertion_claims or typed_envelope or envelope'` -> `39 passed, 61 deselected`
- `ruff check polylogue/mcp/server_tools.py polylogue/mcp/payloads.py tests/infra/mcp.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py` -> passed
- `mypy polylogue/mcp/server_tools.py polylogue/mcp/payloads.py tests/infra/mcp.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py` -> passed
- `devtools verify --quick` -> exit code 0

Ref #1883
Ref #1825