### PR TITLE
fix(devtools): clear stale pytest reports on verify timeout (#1807)

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -228,10 +228,10 @@ def _read_json_artifact(path: Path) -> dict[str, Any] | None:
     return raw if isinstance(raw, dict) else None
 
 
-def _pytest_metadata_from_report(report: dict[str, Any]) -> dict[str, Any]:
+def _pytest_metadata_from_report(report: dict[str, Any], *, report_path: Path) -> dict[str, Any]:
     """Project a pytest-json-report dict into verify-step metadata."""
     summary = report.get("summary")
-    metadata: dict[str, Any] = {"report_path": str(PYTEST_REPORT_PATH)}
+    metadata: dict[str, Any] = {"report_path": str(report_path)}
     if isinstance(summary, dict):
         # `total` is collected count; sum the executed outcomes for the
         # number we previously scraped from the terminal.
@@ -265,11 +265,22 @@ def _pytest_command_metadata(cmd: list[str]) -> dict[str, Any]:
 
 
 def _pytest_artifact_paths(cmd: Sequence[str]) -> tuple[Path, ...]:
-    paths: list[Path] = [PYTEST_REPORT_PATH, PYTEST_JUNIT_REPORT_PATH]
+    json_paths: list[Path] = []
+    junit_paths: list[Path] = []
     for arg in cmd:
-        if arg.startswith("--json-report-file=") or arg.startswith("--junitxml="):
-            paths.append(Path(arg.split("=", 1)[1]))
+        if arg.startswith("--json-report-file="):
+            json_paths.append(Path(arg.split("=", 1)[1]))
+        elif arg.startswith("--junitxml="):
+            junit_paths.append(Path(arg.split("=", 1)[1]))
+    paths = [*(json_paths or [PYTEST_REPORT_PATH]), *(junit_paths or [PYTEST_JUNIT_REPORT_PATH])]
     return tuple(dict.fromkeys(paths))
+
+
+def _pytest_json_report_path(cmd: Sequence[str]) -> Path:
+    for arg in reversed(cmd):
+        if arg.startswith("--json-report-file="):
+            return Path(arg.split("=", 1)[1])
+    return PYTEST_REPORT_PATH
 
 
 def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
@@ -573,9 +584,10 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         ]
         if junit_paths:
             metadata["junitxml_path"] = junit_paths[-1]
-        report = _read_pytest_report()
+        report_path = _pytest_json_report_path(cmd)
+        report = _read_json_artifact(report_path)
         if report is not None:
-            metadata.update(_pytest_metadata_from_report(report))
+            metadata.update(_pytest_metadata_from_report(report, report_path=report_path))
             metadata["report_status"] = "present"
         else:
             # Fallback: terminal scraping when the structured report is

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -34,7 +34,7 @@ import signal
 import subprocess
 import sys
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -136,6 +136,8 @@ TESTMON_DATA = Path(".testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
+PYTEST_JUNIT_REPORT_DIR = Path(".cache/test-reports")
+PYTEST_JUNIT_REPORT_PATH = PYTEST_JUNIT_REPORT_DIR / "verify-latest.xml"
 PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
 PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
 PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
@@ -218,6 +220,14 @@ def _read_pytest_report(path: Path = PYTEST_REPORT_PATH) -> dict[str, Any] | Non
     return raw
 
 
+def _read_json_artifact(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
 def _pytest_metadata_from_report(report: dict[str, Any]) -> dict[str, Any]:
     """Project a pytest-json-report dict into verify-step metadata."""
     summary = report.get("summary")
@@ -254,9 +264,22 @@ def _pytest_command_metadata(cmd: list[str]) -> dict[str, Any]:
     return metadata
 
 
-def _clear_pytest_report() -> None:
+def _pytest_artifact_paths(cmd: Sequence[str]) -> tuple[Path, ...]:
+    paths: list[Path] = [PYTEST_REPORT_PATH, PYTEST_JUNIT_REPORT_PATH]
+    for arg in cmd:
+        if arg.startswith("--json-report-file=") or arg.startswith("--junitxml="):
+            paths.append(Path(arg.split("=", 1)[1]))
+    return tuple(dict.fromkeys(paths))
+
+
+def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
     """Remove a stale report before a pytest step runs."""
-    for path in (PYTEST_REPORT_PATH, PYTEST_PROGRESS_PATH, PYTEST_EVENTS_PATH, PYTEST_OUTPUT_PATH):
+    for path in (
+        *_pytest_artifact_paths(cmd),
+        PYTEST_PROGRESS_PATH,
+        PYTEST_EVENTS_PATH,
+        PYTEST_OUTPUT_PATH,
+    ):
         with contextlib.suppress(FileNotFoundError):
             path.unlink()
 
@@ -529,7 +552,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
     sys.stderr.flush()
     is_pytest = label.startswith("pytest")
     if is_pytest:
-        _clear_pytest_report()
+        _clear_pytest_report(cmd)
     env = _subprocess_env()
     if is_pytest:
         result = _run_pytest_with_heartbeat(cmd, cwd=cwd, env=env, t0=t0)
@@ -545,9 +568,15 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
         metadata["events_path"] = str(PYTEST_EVENTS_PATH)
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
+        junit_paths = [
+            str(path) for path in _pytest_artifact_paths(cmd) if path.suffix == ".xml" or path.name.endswith(".xml")
+        ]
+        if junit_paths:
+            metadata["junitxml_path"] = junit_paths[-1]
         report = _read_pytest_report()
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report))
+            metadata["report_status"] = "present"
         else:
             # Fallback: terminal scraping when the structured report is
             # missing (pytest crashed before writing it, or the plugin is
@@ -556,6 +585,15 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             if fallback is not None:
                 metadata["count"] = fallback
             metadata["report_path"] = None
+            metadata["report_status"] = "missing"
+        progress = _read_json_artifact(PYTEST_PROGRESS_PATH)
+        if progress is not None:
+            event = progress.get("event")
+            if isinstance(event, str):
+                metadata["progress_event"] = event
+            termination_reason = progress.get("termination_reason")
+            if isinstance(termination_reason, str):
+                metadata["termination_reason"] = termination_reason
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -616,7 +654,7 @@ def build_verify_steps(
         )
 
     if not quick and not commit:
-        _report_dir = Path(".cache/test-reports")
+        _report_dir = PYTEST_JUNIT_REPORT_DIR
         _report_dir.mkdir(parents=True, exist_ok=True)
         PYTEST_REPORT_DIR.mkdir(parents=True, exist_ok=True)
         # Scale-tier policy (issue #1183): default verify includes

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -10,6 +10,7 @@ import pytest
 
 from devtools.verify import (
     PYTEST_EVENTS_PATH,
+    PYTEST_JUNIT_REPORT_PATH,
     PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
     PYTEST_REPORT_PATH,
@@ -363,6 +364,28 @@ def test_pytest_run_writes_live_progress_artifact(tmp_path: Path, monkeypatch: p
     assert "pytest-progress" in (tmp_path / PYTEST_OUTPUT_PATH).read_text()
 
 
+def test_pytest_run_removes_stale_reports_before_child_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    stale_json = tmp_path / PYTEST_REPORT_PATH
+    stale_junit = tmp_path / PYTEST_JUNIT_REPORT_PATH
+    stale_json.parent.mkdir(parents=True)
+    stale_junit.parent.mkdir(parents=True)
+    stale_json.write_text('{"summary": {"failed": 99, "total": 99}}')
+    stale_junit.write_text("<testsuite failures='99'/>")
+
+    rc, _elapsed, metadata = _run("pytest stale", [sys.executable, "-c", "print('ok')"])
+
+    assert rc == 0
+    assert metadata["report_path"] is None
+    assert metadata["report_status"] == "missing"
+    assert metadata["junitxml_path"] == str(PYTEST_JUNIT_REPORT_PATH)
+    assert not stale_json.exists()
+    assert not stale_junit.exists()
+
+
 def test_pytest_run_terminates_after_runtime_budget(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -378,6 +401,10 @@ def test_pytest_run_terminates_after_runtime_budget(
     assert metadata["stall_timeout_s"] == 0.0
     assert metadata["events_path"] == str(PYTEST_EVENTS_PATH)
     assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
+    assert metadata["report_path"] is None
+    assert metadata["report_status"] == "missing"
+    assert metadata["progress_event"] == "terminated"
+    assert metadata["termination_reason"] == "pytest runtime exceeded 0.15s"
     assert "pytest runtime exceeded 0.15s" in captured.err
     assert "terminated pytest process group" in captured.err
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -386,6 +386,44 @@ def test_pytest_run_removes_stale_reports_before_child_starts(
     assert not stale_junit.exists()
 
 
+def test_pytest_run_preserves_other_lane_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    primary_json = tmp_path / PYTEST_REPORT_PATH
+    primary_junit = tmp_path / PYTEST_JUNIT_REPORT_PATH
+    isolated_json = tmp_path / ".cache/pytest/last-pytest-isolated.json"
+    isolated_junit = tmp_path / ".cache/test-reports/verify-latest-isolated.xml"
+    primary_json.parent.mkdir(parents=True)
+    primary_junit.parent.mkdir(parents=True)
+    isolated_json.parent.mkdir(parents=True)
+    primary_json.write_text('{"summary": {"passed": 7, "total": 7}}')
+    primary_junit.write_text("<testsuite tests='7'/>")
+    isolated_json.write_text('{"summary": {"failed": 99, "total": 99}}')
+    isolated_junit.write_text("<testsuite failures='99'/>")
+
+    rc, _elapsed, metadata = _run(
+        "pytest isolated",
+        [
+            sys.executable,
+            "-c",
+            "print('ok')",
+            f"--json-report-file={isolated_json}",
+            f"--junitxml={isolated_junit}",
+        ],
+    )
+
+    assert rc == 0
+    assert primary_json.exists()
+    assert primary_junit.exists()
+    assert not isolated_json.exists()
+    assert not isolated_junit.exists()
+    assert metadata["report_path"] is None
+    assert metadata["report_status"] == "missing"
+    assert metadata["junitxml_path"] == str(isolated_junit)
+
+
 def test_pytest_run_terminates_after_runtime_budget(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -479,7 +517,7 @@ def test_pytest_command_metadata_reports_worker_and_selection_policy() -> None:
 
 def test_pytest_metadata_handles_empty_summary() -> None:
     """Robustness: a malformed/empty report still yields a metadata dict."""
-    assert _pytest_metadata_from_report({}) == {"report_path": str(PYTEST_REPORT_PATH)}
+    assert _pytest_metadata_from_report({}, report_path=PYTEST_REPORT_PATH) == {"report_path": str(PYTEST_REPORT_PATH)}
 
 
 def test_read_pytest_report_returns_none_for_missing_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
`devtools verify` now clears stale pytest JSON/JUnit/progress/output artifacts before each pytest step and records explicit timeout/missing-report metadata when pytest is killed before final report generation.

## Problem
While validating #2089, default `devtools verify` reached the 2700s pytest-testmon timeout at 83%. The live progress artifact showed the timeout, but no current JSON report was produced and the stale JUnit file on disk described old failures from another run. That made the timeout look like a current test failure set and wasted diagnosis time.

## Solution
- clear the command's JSON and JUnit report paths before launching a pytest step;
- clear progress/events/output artifacts at the same boundary;
- include `junitxml_path`, `report_status`, `progress_event`, and `termination_reason` in pytest step metadata;
- keep missing JSON reports explicit instead of making callers infer it from `report_path: null`;
- add unit coverage for stale-report cleanup and timeout metadata.

## Verification
- `devtools test tests/unit/devtools/test_verify.py -k 'pytest_run_removes_stale_reports or pytest_run_terminates_after_runtime_budget or pytest_run_writes_live_progress_artifact or pytest_metadata'` -> 4 passed, 40 deselected.
- `devtools test tests/unit/devtools/test_verify.py` -> 44 passed.
- `devtools verify --quick` -> exit_code 0.

Ref #1807