### PR TITLE
feat(query): describe structural DSL fields (#2006)

### DIFF
--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -14,6 +14,7 @@ from polylogue.archive.query.metadata import (
     count_query_operators,
     date_query_fields,
     date_query_operators,
+    structural_query_field_info,
     structural_query_fields,
     structural_query_units,
 )
@@ -171,6 +172,12 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
     for field_name in structural_query_fields(unit):
         if current and not field_name.startswith(current):
             continue
+        info = structural_query_field_info(unit, field_name)
+        description = f"Field accepted inside exists {unit}(...)."
+        if info is not None:
+            description = info.description
+            if info.example:
+                description = f"{description} Example: {info.example}"
         candidates.append(
             QueryCompletionCandidate(
                 value=field_name,
@@ -178,7 +185,7 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
                 display=f"{field_name}:",
                 kind="query-structural-field",
                 group=f"{unit} structural fields",
-                description=f"Field accepted inside exists {unit}(...).",
+                description=description,
                 source="STRUCTURAL_QUERY_UNIT_REGISTRY",
             )
         )

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -261,18 +261,34 @@ _ASSERTION_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "visibility": _field_info("visibility", "Assertion visibility.", "visibility:private"),
 }
 
+_SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
+    "action": "session.action:file_edit",
+    "cwd": "session.cwd:/realm/project",
+    "has": "session.has:tools",
+    "id": "session.id:abc123",
+    "messages": "session.messages:10",
+    "origin": "session.origin:claude-code-session",
+    "path": "session.path:polylogue/cli",
+    "repo": "session.repo:polylogue",
+    "since": "session.since:7d",
+    "tag": "session.tag:review",
+    "title": "session.title:refactor",
+    "tool": "session.tool:bash",
+    "until": "session.until:2024-01-15",
+    "words": "session.words:200",
+}
+
 
 def _session_scoped_field_info() -> tuple[StructuralQueryFieldInfo, ...]:
     fields: list[StructuralQueryFieldInfo] = []
-    for field in sorted(_BOOLEAN_SUPPORTED_FIELDS):
+    for field, example in sorted(_SESSION_SCOPED_STRUCTURAL_EXAMPLES.items()):
         info = EXPRESSION_FIELD_REGISTRY.get(field)
         description = info["description"] if info is not None else f"Owning session {field} predicate."
-        example = info.get("example", f"{field}:value") if info is not None else f"{field}:value"
         fields.append(
             _field_info(
                 f"session.{field}",
                 f"Owning session scope: {description}",
-                f"session.{example}",
+                example,
             )
         )
     return tuple(fields)

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -186,7 +186,15 @@ _ASSERTION_STRUCTURAL_FIELDS = {
     "context",
 }
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_ASSERTION_STRUCTURAL_FIELDS)
-_SCOPED_SESSION_STRUCTURAL_FIELDS = tuple(f"session.{field}" for field in sorted(_BOOLEAN_SUPPORTED_FIELDS))
+
+
+@dataclass(frozen=True)
+class StructuralQueryFieldInfo:
+    """Completion/query-builder metadata for one structural predicate field."""
+
+    name: str
+    description: str
+    example: str
 
 
 @dataclass(frozen=True)
@@ -194,7 +202,7 @@ class StructuralQueryUnitInfo:
     """Completion/query-builder metadata for one ``exists <unit>(...)`` unit."""
 
     description: str
-    fields: tuple[str, ...]
+    fields: tuple[StructuralQueryFieldInfo, ...]
     example: str
 
 
@@ -218,25 +226,91 @@ class DateQueryFieldInfo:
     example: str
 
 
+def _field_info(name: str, description: str, example: str) -> StructuralQueryFieldInfo:
+    return StructuralQueryFieldInfo(name=name, description=description, example=example)
+
+
+_COMMON_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
+    "action": _field_info("action", "Semantic action category on tool/action evidence.", "action:file_edit"),
+    "command": _field_info("command", "Tool command or invocation text substring.", 'command:"pytest"'),
+    "output": _field_info("output", "Tool output substring.", "output:FAILED"),
+    "path": _field_info("path", "Referenced file or artifact path substring.", "path:polylogue/archive"),
+    "role": _field_info("role", "Message role.", "role:assistant"),
+    "text": _field_info("text", "Text/content substring for the selected unit.", "text:timeout"),
+    "tool": _field_info("tool", "Normalized tool name.", "tool:bash"),
+    "type": _field_info("type", "Unit-specific type token.", "type:code"),
+    "words": _field_info("words", "Word-count predicate for the selected unit.", "words:>=200"),
+}
+
+_ASSERTION_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
+    "author": _field_info("author", "Assertion author display/name substring.", "author:codex"),
+    "author_kind": _field_info("author_kind", "Assertion author kind.", "author_kind:agent"),
+    "author_ref": _field_info("author_ref", "Assertion author ObjectRef.", "author_ref:agent:codex"),
+    "body": _field_info("body", "Assertion body text substring.", "body:review"),
+    "context": _field_info("context", "Assertion context JSON/text substring.", "context:branch"),
+    "evidence": _field_info("evidence", "Assertion evidence ref substring.", "evidence:session:"),
+    "key": _field_info("key", "Assertion key string.", "key:lesson.query"),
+    "kind": _field_info("kind", "Assertion kind.", "kind:decision"),
+    "scope": _field_info("scope", "Assertion scope string.", "scope:repo:polylogue"),
+    "scope_ref": _field_info("scope_ref", "Assertion scope ObjectRef.", "scope_ref:repo:polylogue"),
+    "status": _field_info("status", "Assertion status.", "status:active"),
+    "target": _field_info("target", "Assertion target string.", "target:session"),
+    "target_ref": _field_info("target_ref", "Assertion target ObjectRef.", "target_ref:session:abc"),
+    "text": _field_info("text", "Assertion body/value/evidence text substring.", "text:query"),
+    "value": _field_info("value", "Assertion value JSON/text substring.", "value:priority"),
+    "visibility": _field_info("visibility", "Assertion visibility.", "visibility:private"),
+}
+
+
+def _session_scoped_field_info() -> tuple[StructuralQueryFieldInfo, ...]:
+    fields: list[StructuralQueryFieldInfo] = []
+    for field in sorted(_BOOLEAN_SUPPORTED_FIELDS):
+        info = EXPRESSION_FIELD_REGISTRY.get(field)
+        description = info["description"] if info is not None else f"Owning session {field} predicate."
+        example = info.get("example", f"{field}:value") if info is not None else f"{field}:value"
+        fields.append(
+            _field_info(
+                f"session.{field}",
+                f"Owning session scope: {description}",
+                f"session.{example}",
+            )
+        )
+    return tuple(fields)
+
+
+_SCOPED_SESSION_STRUCTURAL_FIELD_INFO = _session_scoped_field_info()
+_SCOPED_SESSION_STRUCTURAL_FIELDS = tuple(field.name for field in _SCOPED_SESSION_STRUCTURAL_FIELD_INFO)
+
+
+def _structural_field_infos(*names: str) -> tuple[StructuralQueryFieldInfo, ...]:
+    infos = [_COMMON_STRUCTURAL_FIELD_INFO[name] for name in names]
+    return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+
+
+def _assertion_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
+    infos = [_ASSERTION_STRUCTURAL_FIELD_INFO[name] for name in sorted(_ASSERTION_STRUCTURAL_FIELDS)]
+    return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+
+
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
-        fields=tuple(sorted((*_ACTION_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        fields=_structural_field_infos(*_ACTION_STRUCTURAL_FIELDS),
         example="exists action(session.repo:polylogue AND tool:bash AND text:pytest)",
     ),
     "block": StructuralQueryUnitInfo(
         description="Match sessions with at least one parsed message block satisfying the child predicate.",
-        fields=tuple(sorted((*_BLOCK_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        fields=_structural_field_infos(*_BLOCK_STRUCTURAL_FIELDS),
         example="exists block(session.origin:codex-session AND type:code AND text:timeout)",
     ),
     "message": StructuralQueryUnitInfo(
         description="Match sessions with at least one message satisfying the child predicate.",
-        fields=tuple(sorted((*_MESSAGE_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        fields=_structural_field_infos(*_MESSAGE_STRUCTURAL_FIELDS),
         example="exists message(session.repo:polylogue AND role:assistant AND text:timeout)",
     ),
     "assertion": StructuralQueryUnitInfo(
         description="Match sessions with at least one session-targeted assertion satisfying the child predicate.",
-        fields=tuple(sorted((*_ASSERTION_STRUCTURAL_FIELDS, *_SCOPED_SESSION_STRUCTURAL_FIELDS))),
+        fields=_assertion_field_infos(),
         example="exists assertion(kind:decision AND status:active AND text:review)",
     ),
 }
@@ -278,7 +352,20 @@ def structural_query_fields(unit: str) -> tuple[str, ...]:
     info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit.lower())
     if info is None:
         return ()
-    return info.fields
+    return tuple(field.name for field in info.fields)
+
+
+def structural_query_field_info(unit: str, field: str) -> StructuralQueryFieldInfo | None:
+    """Return metadata for a structural field accepted by *unit*."""
+
+    info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit.lower())
+    if info is None:
+        return None
+    normalized = field.lower()
+    for field_info in info.fields:
+        if field_info.name == normalized:
+            return field_info
+    return None
 
 
 def count_query_fields() -> tuple[str, ...]:
@@ -319,6 +406,7 @@ __all__ = [
     "EXPRESSION_FIELD_REGISTRY",
     "QueryUnitName",
     "STRUCTURAL_QUERY_UNIT_REGISTRY",
+    "StructuralQueryFieldInfo",
     "StructuralQueryUnitInfo",
     "_BOOLEAN_SUPPORTED_FIELDS",
     "_ACTION_STRUCTURAL_FIELDS",
@@ -331,6 +419,7 @@ __all__ = [
     "count_query_operators",
     "date_query_fields",
     "date_query_operators",
+    "structural_query_field_info",
     "structural_query_fields",
     "structural_query_units",
 ]

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -190,6 +190,16 @@ def test_query_structural_field_candidates_come_from_expression_registry() -> No
     assert "session.origin:claude-code-session" in origin_candidate.description
 
 
+def test_query_structural_session_field_examples_are_executable() -> None:
+    from polylogue.archive.query.expression import compile_expression
+    from polylogue.archive.query.metadata import structural_query_field_info
+
+    for field in ("session.messages", "session.words", "session.since", "session.origin"):
+        info = structural_query_field_info("message", field)
+        assert info is not None
+        compile_expression(f"exists message({info.example} AND role:assistant)")
+
+
 def test_query_count_operator_candidates_come_from_expression_registry() -> None:
     candidates = shell_completion_values.query_count_operator_candidates("messages", "b")
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -180,6 +180,14 @@ def test_query_structural_field_candidates_come_from_expression_registry() -> No
     assert type_candidate.insert == "type:"
     assert type_candidate.kind == "query-structural-field"
     assert type_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
+    assert "Unit-specific type token" in type_candidate.description
+    assert "type:code" in type_candidate.description
+
+    session_candidates = shell_completion_values.query_structural_field_candidates("message", "session.or")
+    origin_candidate = next(candidate for candidate in session_candidates if candidate.value == "session.origin")
+    assert origin_candidate.insert == "session.origin:"
+    assert "Owning session scope" in origin_candidate.description
+    assert "session.origin:claude-code-session" in origin_candidate.description
 
 
 def test_query_count_operator_candidates_come_from_expression_registry() -> None:


### PR DESCRIPTION
## Summary

Adds typed metadata for executable structural query fields so query completions and query-builder consumers can describe `messages/actions/blocks/assertions where ...` fields precisely instead of emitting generic field text.

## Problem

The #2006 DSL substrate already executes structural unit predicates and inline owning-session scope such as `messages where session.origin:codex-session AND text:needle`, but `STRUCTURAL_QUERY_UNIT_REGISTRY` exposed each unit's fields as bare strings. That kept completion payloads technically correct but low-value for agents and web/query-builder surfaces that need to know what a field means.

## Solution

`polylogue.archive.query.metadata` now models structural fields as `StructuralQueryFieldInfo` records with a name, description, and executable example. Existing callers still get the compatible string tuple through `structural_query_fields()`, while richer callers use `structural_query_field_info()`. Query completions now include the field-specific description/example for unit fields and `session.*` scope fields derived from the existing session field registry.

This intentionally adds metadata only for fields already accepted and lowered by the current grammar/storage path; it does not add parser-only vocabulary.

## Verification

- `devtools test tests/unit/cli/test_command_aux_runtime.py -k 'query_structural_field or query_structural_unit or query_field_candidates'` -> 5 passed, 8 deselected
- `devtools test tests/unit/cli/test_query_expression.py -k 'Descriptor or descriptor or structural or completion or terminal_message_source_accepts_session_scoped_predicate or exists_action_session_scoped_predicate_executes_against_archive'` -> 29 passed, 215 deselected
- `python -m mypy polylogue/archive/query/metadata.py polylogue/archive/query/completions.py tests/unit/cli/test_command_aux_runtime.py` -> Success: no issues found
- `devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_click_app.py -k 'Descriptor or descriptor or structural or query_completions_json_outputs_structured_candidates or query_field_candidates'` -> 37 passed, 288 deselected
- `devtools verify --quick` -> exit_code 0

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query field completions now display enhanced descriptions and practical examples for each field.

* **Tests**
  * Extended test coverage for structural query field validation and example expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->