### PR TITLE
feat(mcp): expose recovery reports (#1825)

### DIFF
--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -834,6 +834,32 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("get_recovery_work_packet", run)
 
     @mcp.tool()
+    async def get_recovery_report(
+        session_id: str,
+        report: Literal["continue", "blame", "work-packet"] = "continue",
+    ) -> str:
+        """Return a shared deterministic recovery report for one session."""
+
+        async def run() -> str:
+            content = await hooks.get_polylogue().recovery_report(session_id, report)
+            if content is None:
+                return hooks.error_json(
+                    f"Session not found: {session_id}",
+                    code="not_found",
+                    tool="get_recovery_report",
+                )
+            return hooks.json_payload(
+                MCPRootPayload(
+                    root=cast(
+                        dict[str, object],
+                        {"session_id": session_id, "report": report, "content": content},
+                    )
+                )
+            )
+
+        return await hooks.async_safe_call("get_recovery_report", run)
+
+    @mcp.tool()
     async def explain_query_expression(expression: str) -> str:
         """Explain query DSL parsing and lowering through the shared grammar."""
 

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -49,6 +49,7 @@ EXPECTED_TOOL_NAMES = {
     "get_logical_session",
     "get_stats_by",
     "list_read_view_profiles",
+    "get_recovery_report",
     "get_recovery_work_packet",
     "explain_query_expression",
     "query_completions",
@@ -200,6 +201,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.get_logical_session = AsyncMock(return_value=None)
     poly.list_read_view_profiles = AsyncMock(return_value=[])
     poly.list_assertion_claims = AsyncMock(return_value=[])
+    poly.recovery_report = AsyncMock(return_value=None)
     poly.recovery_work_packet = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -84,6 +84,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     # ------- single record -------
     "get_session": "single_object",
     "get_session_summary": "single_object",
+    "get_recovery_report": "single_object",
     "get_recovery_work_packet": "single_object",
     "archive_get_session": "single_object",
     "get_metadata": "single_object",

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -792,6 +792,42 @@ class TestArchiveGenericToolSurfaces:
         mock_poly.recovery_work_packet.assert_awaited_once_with("session-1")
 
     @pytest.mark.asyncio
+    async def test_get_recovery_report_reads_shared_facade_report(self: object, mcp_server: MCPServerUnderTest) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.recovery_report.return_value = "# Continue: Recovery target"
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_recovery_report"].fn,
+                session_id="session-1",
+                report="continue",
+            )
+
+        payload = json.loads(result)
+        assert payload["session_id"] == "session-1"
+        assert payload["report"] == "continue"
+        assert payload["content"] == "# Continue: Recovery target"
+        mock_poly.recovery_report.assert_awaited_once_with("session-1", "continue")
+
+    @pytest.mark.asyncio
+    async def test_get_recovery_report_reports_missing_session(self: object, mcp_server: MCPServerUnderTest) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.recovery_report.return_value = None
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_recovery_report"].fn,
+                session_id="missing",
+                report="blame",
+            )
+
+        payload = json.loads(result)
+        assert payload["is_error"] is True
+        assert payload["code"] == "not_found"
+        assert payload["tool"] == "get_recovery_report"
+        mock_poly.recovery_report.assert_awaited_once_with("missing", "blame")
+
+    @pytest.mark.asyncio
     async def test_get_recovery_work_packet_reports_missing_session(
         self: object, mcp_server: MCPServerUnderTest
     ) -> None:

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -27,6 +27,7 @@ _SYNTHETIC_CONV_ID = "test:conv-discovery-nonexistent"
 #: for an empty archive, etc.).
 _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "search": {"query": "hello", "limit": 1},
+    "query_units": {"expression": "messages where text:hello", "limit": 1},
     "blackboard_list": {},
     "get_session": {"id": _SYNTHETIC_CONV_ID},
     "get_session_summary": {"id": _SYNTHETIC_CONV_ID},
@@ -70,6 +71,9 @@ _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "find_abandoned_sessions": {"limit": 1},
     "get_stats_by": {"group_by": "origin"},
     "list_read_view_profiles": {},
+    "list_assertion_claims": {"target_ref": f"session:{_SYNTHETIC_CONV_ID}", "limit": 1},
+    "get_recovery_report": {"session_id": "demo", "report": "continue"},
+    "get_recovery_work_packet": {"session_id": _SYNTHETIC_CONV_ID},
     "explain_query_expression": {"expression": "repo:polylogue"},
     "query_completions": {"kind": "field", "incomplete": "d"},
     "embedding_status": {},


### PR DESCRIPTION
## Summary
Adds a read-role MCP `get_recovery_report` tool that delegates to the shared `Polylogue.recovery_report(session_id, preset)` facade. Agents can now fetch the same deterministic Markdown recovery reports that CLI/Python use, including the `continue` report surfaced by #2094.

## Problem
MCP already exposed the structured recovery work-packet DTO, but not the shared recovery report presets. That left CLI/Python with `continue` / `blame` / `work-packet` report parity while MCP could only fetch one DTO shape.

## Solution
- Register `get_recovery_report(session_id, report="continue")` with `continue`, `blame`, and `work-packet` presets.
- Return the normal JSON root payload with `session_id`, `report`, and Markdown `content`.
- Preserve the standard MCP not-found error envelope.
- Wire the new tool through expected MCP tool names, envelope classification, and discovery smoke kwargs.
- Fill existing discovery smoke kwargs for `query_units`, `list_assertion_claims`, and `get_recovery_work_packet`, which were already registered read tools lacking minimal smoke coverage.

## Verification
- `devtools test tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_tool_discovery.py -k "recovery_report or recovery_work_packet or every_registered_tool_is_classified or no_stale_classifications or read_tools_have_known_minimal_kwargs"` -> 9 passed, 151 deselected.
- `python -m mypy polylogue/mcp/server_tools.py tests/infra/mcp.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_tool_discovery.py` -> Success.
- `devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` at `9316aef` -> exit_code 0.

Ref #1825
Ref #2006