### PR TITLE
feat(assertions): export user-tier assertions (#1883)

### DIFF
--- a/devtools/query_memory_budget.py
+++ b/devtools/query_memory_budget.py
@@ -80,6 +80,7 @@ def run_memory_budget(command: list[str], *, max_rss_mb: int, poll_interval_s: f
 
     peak_parent_rss_kb = max(peak_parent_rss_kb, _read_vm_rss_kb(proc.pid))
     peak_rss_kb = max(peak_rss_kb, _read_process_tree_rss_kb(proc.pid))
+    peak_rss_kb = max(peak_rss_kb, peak_parent_rss_kb)
     exit_code = int(proc.returncode or 0)
     peak_parent_rss_mb = round(peak_parent_rss_kb / 1024, 1)
     peak_rss_mb = round(peak_rss_kb / 1024, 1)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -233,10 +233,11 @@ def _pytest_metadata_from_report(report: dict[str, Any], *, report_path: Path) -
     summary = report.get("summary")
     metadata: dict[str, Any] = {"report_path": str(report_path)}
     if isinstance(summary, dict):
-        # `total` is collected count; sum the executed outcomes for the
-        # number we previously scraped from the terminal.
+        # Prefer pytest-json-report's explicit total when present. Older or
+        # reduced reports still get a stable executed count from outcome keys.
         outcome_keys = ("passed", "failed", "error", "skipped", "xfailed", "xpassed")
-        executed = sum(int(summary.get(k, 0) or 0) for k in outcome_keys)
+        total = summary.get("total")
+        executed = int(total) if isinstance(total, int) else sum(int(summary.get(k, 0) or 0) for k in outcome_keys)
         metadata["count"] = executed
         for key in ("passed", "failed", "error", "skipped", "xfailed", "xpassed", "total"):
             value = summary.get(key)
@@ -340,7 +341,7 @@ def _write_pytest_progress(
     if termination_reason is not None:
         payload["termination_reason"] = termination_reason
     PYTEST_PROGRESS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = PYTEST_PROGRESS_PATH.with_suffix(".tmp")
+    tmp = PYTEST_PROGRESS_PATH.with_name(f"{PYTEST_PROGRESS_PATH.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
     tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
     tmp.replace(PYTEST_PROGRESS_PATH)
 
@@ -585,7 +586,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         if junit_paths:
             metadata["junitxml_path"] = junit_paths[-1]
         report_path = _pytest_json_report_path(cmd)
-        report = _read_json_artifact(report_path)
+        report = _read_pytest_report(report_path)
         if report is not None:
             metadata.update(_pytest_metadata_from_report(report, report_path=report_path))
             metadata["report_status"] = "present"

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `272`
+- scenario projections: `273`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
-  - exercise: `165`
+  - exercise: `166`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -400,6 +400,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-ops-maintenance-archive-init` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance archive-init help |
 | `exercise` | `help-ops-maintenance-archive-plan` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance archive-plan help |
 | `exercise` | `help-ops-maintenance-archive-read` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance archive-read help |
+| `exercise` | `help-ops-maintenance-assertion-export` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance assertion-export help |
 | `exercise` | `help-ops-maintenance-backup-plan` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance backup-plan help |
 | `exercise` | `help-ops-maintenance-blob-gc` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance blob-gc help |
 | `exercise` | `help-ops-maintenance-gc-history` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | ops maintenance gc-history help |

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,6 +34,12 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitPlan, build_archive_init_plan
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    ArchiveAssertionEnvelope,
+    AssertionKind,
+    assertion_envelope_to_payload,
+    list_assertions_for_export,
+)
 
 _BACKUP_POLICIES: dict[ArchiveTier, dict[str, object]] = {
     ArchiveTier.SOURCE: {
@@ -353,6 +360,93 @@ def backup_plan_command(output_format: str) -> None:
         return
 
     _render_backup_plain_plan(payload)
+
+
+@maintenance_group.command("assertion-export")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["json", "jsonl"]),
+    default="jsonl",
+    show_default=True,
+    help="Export format for assertion rows.",
+)
+@click.option("--out", "out_path", type=click.Path(path_type=Path), default=None, help="Write export to this path.")
+@click.option(
+    "--kind",
+    "kinds",
+    multiple=True,
+    type=click.Choice([kind.value for kind in AssertionKind]),
+    help="Restrict export to one assertion kind; repeatable.",
+)
+@click.option("--status", "statuses", multiple=True, help="Restrict export to one assertion status; repeatable.")
+@click.option("--limit", "-l", type=click.IntRange(min=0), default=None, help="Maximum assertion rows to export.")
+def assertion_export_command(
+    output_format: str,
+    out_path: Path | None,
+    kinds: tuple[str, ...],
+    statuses: tuple[str, ...],
+    limit: int | None,
+) -> None:
+    """Export the durable assertion substrate from user.db."""
+
+    root = archive_root()
+    user_db_path = root / ARCHIVE_TIER_SPECS[ArchiveTier.USER].filename
+    rows = _read_assertion_export_rows(
+        user_db_path,
+        kinds=kinds or None,
+        statuses=statuses or None,
+        limit=limit,
+    )
+    payload_rows = [assertion_envelope_to_payload(row) for row in rows]
+
+    if output_format == "json":
+        content = (
+            json.dumps(
+                {
+                    "ok": True,
+                    "mode": "assertion_export",
+                    "archive_root": str(root),
+                    "user_db_path": str(user_db_path),
+                    "count": len(payload_rows),
+                    "assertions": payload_rows,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    else:
+        content = "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in payload_rows)
+
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(content, encoding="utf-8")
+        click.echo(f"Exported {len(payload_rows)} assertions to {out_path}")
+        return
+
+    click.echo(content, nl=False)
+
+
+def _read_assertion_export_rows(
+    user_db_path: Path,
+    *,
+    kinds: tuple[str, ...] | None,
+    statuses: tuple[str, ...] | None,
+    limit: int | None,
+) -> list[ArchiveAssertionEnvelope]:
+    if not user_db_path.exists():
+        return []
+    uri = f"file:{user_db_path}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+        return list_assertions_for_export(
+            conn,
+            kinds=kinds,
+            statuses=statuses,
+            limit=limit,
+        )
 
 
 def _backup_plan_payload(root: Path) -> dict[str, Any]:
@@ -1112,6 +1206,7 @@ def _render_record_plain(record: OperationRecord) -> None:
 
 
 __all__ = [
+    "assertion_export_command",
     "gc_history_command",
     "maintenance_group",
     "plan_command",

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -239,6 +239,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "insight_readiness_report": ("archive_routed", "index", "reads insight readiness from index.db"),
     "insight_rigor_audit": ("archive_routed", "index", "reads insight rigor from index.db"),
     "list_annotations": ("archive_routed", "user", "reads annotations through user.db"),
+    "list_assertion_claims": ("archive_routed", "user", "reads assertion claims through user.db"),
     "list_blackboard_notes": ("archive_routed", "user", "reads blackboard notes through user.db"),
     "list_archive_coverage_insights": ("archive_routed", "index", "reads coverage insights from index.db"),
     "list_archive_debt_insights": ("archive_routed", "index", "reads archive debt projection from index.db"),

--- a/polylogue/storage/insights/feedback/__init__.py
+++ b/polylogue/storage/insights/feedback/__init__.py
@@ -1,9 +1,9 @@
 """Storage for the learning-feedback loop (#1131).
 
-User corrections are persisted in the ``corrections`` table, which is
-intentionally separate from any content-hashed session payload. The
-table is declared in the current user tier DDL
-(:mod:`polylogue.storage.sqlite.archive_tiers.user`).
+User corrections are persisted outside the content-hashed session payload.
+Current split-archive writes use assertion rows in the user tier; older
+single-file archives with ``user_corrections`` are still read and written by
+the fallback path used in tests and historical local archives.
 
 This module owns the SQL surface: insert/upsert, list, delete, and the
 ``hash_invariant_columns`` helper used by tests to assert that nothing in
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,11 @@ from polylogue.insights.feedback import (
     now_utc,
     parse_correction_kind,
 )
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    AssertionKind,
+    assertion_id_for_correction,
+    correction_id_for,
+)
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -37,6 +43,14 @@ if TYPE_CHECKING:
 async def _table_exists(conn: aiosqlite.Connection, table_name: str) -> bool:
     cursor = await conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+        (table_name,),
+    )
+    return await cursor.fetchone() is not None
+
+
+async def _attached_table_exists(conn: aiosqlite.Connection, schema_name: str, table_name: str) -> bool:
+    cursor = await conn.execute(
+        f"SELECT 1 FROM {schema_name}.sqlite_master WHERE type='table' AND name = ? LIMIT 1",
         (table_name,),
     )
     return await cursor.fetchone() is not None
@@ -67,7 +81,7 @@ async def _attach_user_tier_if_present(conn: aiosqlite.Connection) -> bool:
 async def _uses_archive_user_tier(conn: aiosqlite.Connection) -> bool:
     if await _table_exists(conn, "user_corrections"):
         return False
-    return await _attach_user_tier_if_present(conn)
+    return await _attach_user_tier_if_present(conn) and await _attached_table_exists(conn, "user_tier", "assertions")
 
 
 def _new_correction_id() -> str:
@@ -94,33 +108,61 @@ async def upsert_correction(
     payload_json = json.dumps(payload, sort_keys=True)
     created_at = now_utc()
     if await _uses_archive_user_tier(conn):
-        payload_for_store: dict[str, str] = dict(payload)
-        if note is not None:
-            payload_for_store["note"] = note
-        stored_json = json.dumps(payload_for_store, sort_keys=True)
+        stored_payload: dict[str, object] = {"payload": dict(payload), "note": note}
+        stored_json = json.dumps(stored_payload, sort_keys=True)
         now_ms = int(created_at.timestamp() * 1000)
+        correction_id = correction_id_for("insight", session_id, kind.value)
+        assertion_id = assertion_id_for_correction(correction_id)
         cursor = await conn.execute(
             """
-            SELECT correction_id, created_at_ms
-            FROM user_tier.corrections
-            WHERE target_type = 'session' AND target_id = ? AND correction_type = ?
+            SELECT created_at_ms
+            FROM user_tier.assertions
+            WHERE assertion_id = ?
             """,
-            (session_id, kind.value),
+            (assertion_id,),
         )
         row = await cursor.fetchone()
-        correction_id = str(row[0]) if row is not None else _new_correction_id()
-        created_ms = int(row[1]) if row is not None else now_ms
+        created_ms = int(row[0]) if row is not None else now_ms
         await conn.execute(
             """
-            INSERT INTO user_tier.corrections (
-                correction_id, target_type, target_id, correction_type,
-                payload_json, created_at_ms, updated_at_ms
-            ) VALUES (?, 'session', ?, ?, ?, ?, ?)
-            ON CONFLICT(target_type, target_id, correction_type) DO UPDATE SET
-                payload_json = excluded.payload_json,
+            INSERT INTO user_tier.assertions (
+                assertion_id, scope_ref, target_ref, key, kind, value_json, body_text,
+                author_ref, author_kind, evidence_refs_json, status, visibility, confidence,
+                staleness_json, context_policy_json, supersedes_json, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(assertion_id) DO UPDATE SET
+                scope_ref = excluded.scope_ref,
+                target_ref = excluded.target_ref,
+                key = excluded.key,
+                kind = excluded.kind,
+                value_json = excluded.value_json,
+                body_text = excluded.body_text,
+                author_ref = excluded.author_ref,
+                author_kind = excluded.author_kind,
+                status = excluded.status,
+                visibility = excluded.visibility,
                 updated_at_ms = excluded.updated_at_ms
             """,
-            (correction_id, session_id, kind.value, stored_json, created_ms, now_ms),
+            (
+                assertion_id,
+                "insight-feedback",
+                f"insight:{session_id}",
+                kind.value,
+                AssertionKind.CORRECTION.value,
+                stored_json,
+                note,
+                None,
+                "user",
+                None,
+                "active",
+                "private",
+                None,
+                None,
+                None,
+                None,
+                created_ms,
+                now_ms,
+            ),
         )
         return LearningCorrection(
             session_id=session_id,
@@ -182,18 +224,18 @@ async def list_corrections(
 
     where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
     if await _uses_archive_user_tier(conn):
-        archive_clauses: list[str] = ["target_type = 'session'"]
-        archive_params: list[object] = []
+        archive_clauses: list[str] = ["kind = ?", "COALESCE(status, '') != 'deleted'"]
+        archive_params: list[object] = [AssertionKind.CORRECTION.value]
         if session_id is not None:
-            archive_clauses.append("target_id = ?")
-            archive_params.append(session_id)
+            archive_clauses.append("target_ref = ?")
+            archive_params.append(f"insight:{session_id}")
         if kind is not None:
-            archive_clauses.append("correction_type = ?")
+            archive_clauses.append("key = ?")
             archive_params.append(kind.value)
         cursor = await conn.execute(
-            "SELECT target_id, correction_type, payload_json, updated_at_ms "
-            f"FROM user_tier.corrections WHERE {' AND '.join(archive_clauses)} "
-            "ORDER BY target_id, correction_type",
+            "SELECT target_ref, key, value_json, updated_at_ms "
+            f"FROM user_tier.assertions WHERE {' AND '.join(archive_clauses)} "
+            "ORDER BY target_ref, key",
             archive_params,
         )
         rows = await cursor.fetchall()
@@ -205,19 +247,25 @@ async def list_corrections(
                 payload_raw = {}
             if not isinstance(payload_raw, dict):
                 payload_raw = {}
-            note = payload_raw.pop("note", None)
+            payload_section = payload_raw.get("payload")
+            if isinstance(payload_section, dict):
+                payload_dict = dict(payload_section)
+                note = payload_raw.get("note")
+            else:
+                payload_dict = payload_raw
+                note = None
             try:
                 kind_value = parse_correction_kind(str(row[1]))
             except ValueError:
                 continue
-            from datetime import UTC, datetime
-
+            target_ref = str(row[0])
+            _target_kind, _separator, resolved_session_id = target_ref.partition(":")
             created_at = datetime.fromtimestamp(int(row[3]) / 1000, tz=UTC)
             archive_out.append(
                 LearningCorrection(
-                    session_id=str(row[0]),
+                    session_id=resolved_session_id or target_ref,
                     kind=kind_value,
-                    payload={str(key): str(value) for key, value in payload_raw.items()},
+                    payload={str(key): str(value) for key, value in payload_dict.items()},
                     note=str(note) if note is not None else None,
                     created_at=created_at,
                 )
@@ -247,8 +295,6 @@ async def list_corrections(
             # Persisted row uses an unrecognized kind (e.g. removed in a
             # later version). Skip rather than corrupt the typed surface.
             continue
-        from datetime import datetime
-
         try:
             created_at = datetime.fromisoformat(str(row[4]))
         except ValueError:
@@ -278,8 +324,13 @@ async def delete_correction(
 
     cursor = (
         await conn.execute(
-            "DELETE FROM user_tier.corrections WHERE target_type = 'session' AND target_id = ? AND correction_type = ?",
-            (session_id, kind.value),
+            """
+            UPDATE user_tier.assertions
+            SET status = 'deleted'
+            WHERE assertion_id = ?
+              AND COALESCE(status, '') != 'deleted'
+            """,
+            (assertion_id_for_correction(correction_id_for("insight", session_id, kind.value)),),
         )
         if await _uses_archive_user_tier(conn)
         else await conn.execute(
@@ -299,8 +350,14 @@ async def clear_corrections(
 
     cursor = (
         await conn.execute(
-            "DELETE FROM user_tier.corrections WHERE target_type = 'session' AND target_id = ?",
-            (session_id,),
+            """
+            UPDATE user_tier.assertions
+            SET status = 'deleted'
+            WHERE kind = ?
+              AND target_ref = ?
+              AND COALESCE(status, '') != 'deleted'
+            """,
+            (AssertionKind.CORRECTION.value, f"insight:{session_id}"),
         )
         if await _uses_archive_user_tier(conn)
         else await conn.execute(

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -693,7 +693,7 @@ def _blackboard_envelope_from_assertion(assertion: ArchiveAssertionEnvelope) -> 
         target_type = None
         target_id = None
     return ArchiveBlackboardNoteEnvelope(
-        note_id=str(assertion.key or ""),
+        note_id=str(assertion.key or assertion.target_ref),
         target_type=target_type,
         target_id=target_id,
         body=assertion.body_text or "",
@@ -957,6 +957,79 @@ def list_assertions_for_target(
     return [_assertion_row_to_envelope(row) for row in rows]
 
 
+def assertion_envelope_to_payload(envelope: ArchiveAssertionEnvelope) -> dict[str, object]:
+    """Return a JSON-serializable backup/export payload for one assertion."""
+
+    return {
+        "assertion_id": envelope.assertion_id,
+        "scope_ref": envelope.scope_ref,
+        "target_ref": envelope.target_ref,
+        "key": envelope.key,
+        "kind": envelope.kind,
+        "value": envelope.value,
+        "body_text": envelope.body_text,
+        "author_ref": envelope.author_ref,
+        "author_kind": envelope.author_kind,
+        "evidence_refs": list(envelope.evidence_refs),
+        "status": envelope.status,
+        "visibility": envelope.visibility,
+        "confidence": envelope.confidence,
+        "staleness": envelope.staleness,
+        "context_policy": envelope.context_policy,
+        "supersedes": list(envelope.supersedes),
+        "created_at_ms": envelope.created_at_ms,
+        "updated_at_ms": envelope.updated_at_ms,
+    }
+
+
+def list_assertions_for_export(
+    conn: sqlite3.Connection,
+    *,
+    kinds: Sequence[str | AssertionKind] | None = None,
+    statuses: Sequence[str] | None = None,
+    limit: int | None = None,
+) -> list[ArchiveAssertionEnvelope]:
+    """List assertion rows for durable user-tier export.
+
+    Unlike ``list_assertion_claims``, this is deliberately all-kinds and
+    all-statuses by default: backup/export must include marks, overlays,
+    accepted claims, deleted rows, and private transform candidates.
+    """
+
+    if not _table_exists(conn, "assertions"):
+        return []
+
+    where: list[str] = []
+    params: list[object] = []
+
+    if kinds is not None:
+        normalized_kinds = tuple(str(kind) for kind in kinds)
+        if not normalized_kinds:
+            return []
+        placeholders = ", ".join("?" for _ in normalized_kinds)
+        where.append(f"kind IN ({placeholders})")
+        params.extend(normalized_kinds)
+
+    if statuses is not None:
+        normalized_statuses = tuple(str(status) for status in statuses)
+        if not normalized_statuses:
+            return []
+        placeholders = ", ".join("?" for _ in normalized_statuses)
+        where.append(f"COALESCE(status, '') IN ({placeholders})")
+        params.extend(normalized_statuses)
+
+    sql = f"SELECT {_ASSERTION_COLUMNS} FROM assertions"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY created_at_ms, assertion_id"
+    if limit is not None and limit >= 0:
+        sql += " LIMIT ?"
+        params.append(limit)
+
+    rows = conn.execute(sql, tuple(params)).fetchall()
+    return [_assertion_row_to_envelope(row) for row in rows]
+
+
 ASSERTION_CLAIM_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.DECISION,
     AssertionKind.CAVEAT,
@@ -1041,6 +1114,7 @@ __all__ = [
     "ArchiveSavedViewEnvelope",
     "ArchiveWorkspaceEnvelope",
     "AssertionKind",
+    "assertion_envelope_to_payload",
     "assertion_id_for_annotation",
     "assertion_id_for_blackboard_note",
     "assertion_id_for_correction",
@@ -1053,6 +1127,7 @@ __all__ = [
     "correction_id_for",
     "list_archive_blackboard_note_envelopes",
     "list_assertion_claims",
+    "list_assertions_for_export",
     "list_assertions_by_kind",
     "list_assertions_for_target",
     "mark_assertion_status",

--- a/tests/baselines/showcase/help-ops-maintenance-assertion-export.txt
+++ b/tests/baselines/showcase/help-ops-maintenance-assertion-export.txt
@@ -1,0 +1,15 @@
+Usage: polylogue ops maintenance assertion-export [OPTIONS]
+
+  Export the durable assertion substrate from user.db.
+
+Options:
+  -f, --format [json|jsonl]       Export format for assertion rows.  [default:
+                                  jsonl]
+  --out PATH                      Write export to this path.
+  --kind [mark|highlight|annotation|correction|suppression|tag|metadata|saved_query|recall_pack|workspace_note|note|decision|caveat|lesson|blocker|handoff|run_state|prompt_eval|transform_candidate]
+                                  Restrict export to one assertion kind;
+                                  repeatable.
+  --status TEXT                   Restrict export to one assertion status;
+                                  repeatable.
+  -l, --limit INTEGER RANGE       Maximum assertion rows to export.  [x>=0]
+  -h, --help                      Show this message and exit.

--- a/tests/baselines/showcase/help-ops-maintenance.txt
+++ b/tests/baselines/showcase/help-ops-maintenance.txt
@@ -6,13 +6,14 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  archive-init  Initialize the archive file set after explicit confirmation.
-  archive-plan  Inspect readiness for the archive file set.
-  archive-read  Read index sessions from the archive.
-  backup-plan   Inspect archive backup boundaries without copying data.
-  blob-gc       Preview or run lease-safe blob garbage collection.
-  gc-history    Show recent blob-GC passes recorded in ``gc_generations``.
-  plan          Dry-run summary: show what would be rebuilt without...
-  preview       Staleness inventory by model and scope.
-  run           Run (or dry-run) maintenance backfill operations.
-  status        Inspect persisted maintenance operations (#1197).
+  archive-init      Initialize the archive file set after explicit...
+  archive-plan      Inspect readiness for the archive file set.
+  archive-read      Read index sessions from the archive.
+  assertion-export  Export the durable assertion substrate from user.db.
+  backup-plan       Inspect archive backup boundaries without copying data.
+  blob-gc           Preview or run lease-safe blob garbage collection.
+  gc-history        Show recent blob-GC passes recorded in...
+  plan              Dry-run summary: show what would be rebuilt without...
+  preview           Staleness inventory by model and scope.
+  run               Run (or dry-run) maintenance backfill operations.
+  status            Inspect persisted maintenance operations (#1197).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,11 +150,17 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     xdist workers share the controller's basetemp, so only the controller
     (no ``PYTEST_XDIST_WORKER`` in env) removes it, and only when we minted
     a per-run name — never a caller-supplied ``--basetemp`` or the shared
-    seeded corpus root.
+    seeded corpus root. Parallel xdist runs leave their per-run basetemp for
+    the next startup sweep instead of deleting it during session-finish
+    teardown, where xdist/json-report may still be flushing controller/worker
+    artifacts.
     """
     if os.environ.get("PYTEST_XDIST_WORKER"):
         return
     if not os.environ.get("POLYLOGUE_PYTEST_RUN_ID"):
+        return
+    numprocesses = getattr(session.config.option, "numprocesses", None)
+    if numprocesses not in (None, 0, "0"):
         return
     basetemp = session.config.option.basetemp
     if not basetemp:

--- a/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
@@ -156,8 +156,8 @@
     analyze
     blackboard
     commands
-    completions        Emit shell completion setup for polylogue.
     config             Show configuration paths and resolved settings.
+    continue           Compile a successor-agent continuation report.
     cost               Summarize session cost telemetry.
     count              Print count of matched sessions.
     dashboard          Open the local dashboard.
@@ -177,7 +177,6 @@
     recent             List the most recently updated sessions.
     resume             Resume from recent session context.
     resume-candidates  Rank resume candidates for the current context.
-    schema             Inspect and audit provider schemas.
     select
     stats              Show statistics for matched sessions.
     tags               Manage session tags.

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -388,16 +388,16 @@
     "archive_facade_routes": {
       "checked": true,
       "source": "static_facade_route_catalog",
-      "total_method_count": 110,
-      "archive_ready_method_count": 109,
+      "total_method_count": 111,
+      "archive_ready_method_count": 110,
       "unsupported_method_count": 0,
       "route_counts": {
-        "archive_routed": 95,
+        "archive_routed": 96,
         "archive_direct": 14,
         "not_archive_runtime": 1
       },
       "tier_counts": {
-        "user": 34,
+        "user": 35,
         "index": 72,
         "none": 1,
         "source": 3
@@ -719,6 +719,11 @@
           "tier": "index",
           "detail": "reads archive debt projection from index.db"
         },
+        "list_assertion_claims": {
+          "route": "archive_routed",
+          "tier": "user",
+          "detail": "reads assertion claims through user.db"
+        },
         "list_blackboard_notes": {
           "route": "archive_routed",
           "tier": "user",
@@ -1016,7 +1021,7 @@
         "ops.db"
       ],
       "facade_tier_route_counts": {
-        "user": 34,
+        "user": 35,
         "index": 72,
         "none": 1,
         "source": 3

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -223,8 +223,8 @@
     analyze
     blackboard
     commands
-    completions        Emit shell completion setup for polylogue.
     config             Show configuration paths and resolved settings.
+    continue           Compile a successor-agent continuation report.
     cost               Summarize session cost telemetry.
     count              Print count of matched sessions.
     dashboard          Open the local dashboard.
@@ -244,7 +244,6 @@
     recent             List the most recently updated sessions.
     resume             Resume from recent session context.
     resume-candidates  Rank resume candidates for the current context.
-    schema             Inspect and audit provider schemas.
     select
     stats              Show statistics for matched sessions.
     tags               Manage session tags.
@@ -484,10 +483,10 @@
     analyze
     blackboard
     commands
-    completions        Emit shell completion setup for polylog
-  ue.
     config             Show configuration paths and resolved s
   ettings.
+    continue           Compile a successor-agent continuation
+  report.
     cost               Summarize session cost telemetry.
     count              Print count of matched sessions.
     dashboard          Open the local dashboard.
@@ -516,7 +515,6 @@
     resume             Resume from recent session context.
     resume-candidates  Rank resume candidates for the current
   context.
-    schema             Inspect and audit provider schemas.
     select
     stats              Show statistics for matched sessions.
     tags               Manage session tags.
@@ -675,8 +673,8 @@
     analyze
     blackboard
     commands
-    completions        Emit shell completion setup for polylogue.
     config             Show configuration paths and resolved settings.
+    continue           Compile a successor-agent continuation report.
     cost               Summarize session cost telemetry.
     count              Print count of matched sessions.
     dashboard          Open the local dashboard.
@@ -696,7 +694,6 @@
     recent             List the most recently updated sessions.
     resume             Resume from recent session context.
     resume-candidates  Rank resume candidates for the current context.
-    schema             Inspect and audit provider schemas.
     select
     stats              Show statistics for matched sessions.
     tags               Manage session tags.

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,9 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveTierInitResult,
 )
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitAction, ArchiveInitPlan
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
 
 _ARCHIVE_TIERS = ("source.db", "index.db", "embeddings.db", "ops.db", "user.db")
 
@@ -42,6 +46,40 @@ def _write_gc_candidate(cli_workspace: dict[str, Path], blob_hash: str) -> Path:
     old_epoch_s = 946684800
     os.utime(path, (old_epoch_s, old_epoch_s))
     return path
+
+
+def _seed_assertion_export_rows(archive_root: Path) -> None:
+    with sqlite3.connect(archive_root / "user.db") as conn:
+        conn.row_factory = sqlite3.Row
+        initialize_archive_tier(conn, ArchiveTier.USER)
+        upsert_assertion(
+            conn,
+            assertion_id="export-mark",
+            target_ref="session:s-1",
+            kind=AssertionKind.MARK,
+            scope_ref="run:r-1",
+            key="export/mark",
+            value={"label": "important"},
+            body_text="operator mark",
+            author_ref="user:operator",
+            author_kind="user",
+            evidence_refs=["message:s-1:1"],
+            status="active",
+            visibility="private",
+            now_ms=1_700_000_001_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="export-deleted-note",
+            target_ref="session:s-2",
+            kind=AssertionKind.NOTE,
+            scope_ref="run:r-2",
+            key="export/note",
+            body_text="deleted note retained for backup",
+            status="deleted",
+            visibility="private",
+            now_ms=1_700_000_002_000,
+        )
 
 
 def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
@@ -175,6 +213,61 @@ def test_backup_plan_cli_renders_plain_summary(
     assert "Archive backup plan" in result.output
     assert "source.db: critical policy=back_up present" in result.output
     assert "full_evidence:" in result.output
+
+
+def test_assertion_export_cli_emits_all_assertions_as_jsonl(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    _seed_assertion_export_rows(cli_workspace["archive_root"])
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "assertion-export"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.output.splitlines()]
+    assert [row["assertion_id"] for row in rows] == ["export-mark", "export-deleted-note"]
+    assert rows[0]["kind"] == "mark"
+    assert rows[0]["value"] == {"label": "important"}
+    assert rows[0]["evidence_refs"] == ["message:s-1:1"]
+    assert rows[1]["status"] == "deleted"
+
+
+def test_assertion_export_cli_filters_and_writes_json_file(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    _seed_assertion_export_rows(cli_workspace["archive_root"])
+    out_path = cli_workspace["archive_root"] / "exports" / "assertions.json"
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "assertion-export",
+            "--format",
+            "json",
+            "--kind",
+            "note",
+            "--status",
+            "deleted",
+            "--out",
+            str(out_path),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == f"Exported 1 assertions to {out_path}\n"
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "assertion_export"
+    assert payload["count"] == 1
+    assert [row["assertion_id"] for row in payload["assertions"]] == ["export-deleted-note"]
 
 
 def test_blob_gc_cli_dry_run_reports_without_deleting(

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -750,8 +750,8 @@ class TestCliMetadata:
         expected = {
             "import",
             "init",
-            "completions",
             "config",
+            "continue",
             "cost",
             "blackboard",
             "commands",
@@ -763,7 +763,6 @@ class TestCliMetadata:
             "resume",
             "resume-candidates",
             "insights",
-            "schema",
             "tags",
             "feedback",
             "user-state",

--- a/tests/unit/cli/test_diagnose_and_error_discipline.py
+++ b/tests/unit/cli/test_diagnose_and_error_discipline.py
@@ -94,10 +94,10 @@ class TestDiagnoseBanner:
         workspace_env: Mapping[str, Path],
     ) -> None:
         """A registered subcommand routes directly; --diagnose says so."""
-        result = runner.invoke(cli, ["--diagnose", "doctor", "--help"])
+        result = runner.invoke(cli, ["--diagnose", "ops", "--help"])
         assert result.exit_code == 0
         assert "[diagnose]" in result.output
-        assert "matched subcommand" in result.output and "doctor" in result.output
+        assert "matched subcommand" in result.output and "ops" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -451,8 +451,7 @@ def test_async_execute_query_archive_lists_archive(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["mode"] == "list"
-    assert payload["items"][0]["session_id"] == "codex-session:native-1"
-    assert payload["items"][0]["source"] == "codex-session"
+    assert payload["items"][0]["id"] == "codex-session:native-1"
     assert payload["items"][0]["origin"] == "codex-session"
 
 
@@ -888,6 +887,21 @@ def test_async_execute_query_archive_search_maps_provider_to_origin(
                 )
             ]
 
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            assert session_id == "codex-session:native-1"
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id="native-1",
+                origin="codex-session",
+                provider=Provider.CODEX,
+                title="Copied",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
+
     monkeypatch.setattr(
         "polylogue.cli.archive_query.ArchiveStore.open_existing",
         classmethod(lambda cls, root: FakeArchiveStore()),
@@ -930,9 +944,9 @@ def test_async_execute_query_archive_search_maps_provider_to_origin(
     payload = json.loads(capsys.readouterr().out)
     assert payload["mode"] == "search"
     assert payload["origin"] == "codex-session"
-    assert payload["items"][0]["block_id"] == "codex-session:native-1:m1:0"
-    assert payload["items"][0]["source"] == "codex-session"
-    assert payload["items"][0]["origin"] == "codex-session"
+    assert payload["items"][0]["session"]["id"] == "codex-session:native-1"
+    assert payload["items"][0]["session"]["origin"] == "codex-session"
+    assert payload["items"][0]["match"]["message_id"] == "codex-session:native-1:m1"
 
 
 def test_async_execute_query_archive_filters_multiple_providers(
@@ -1019,6 +1033,21 @@ def test_async_execute_query_archive_searches_within_session_id(
                 )
             ]
 
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            assert session_id == "codex-session:native-1"
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id="native-1",
+                origin="codex-session",
+                provider=Provider.CODEX,
+                title="Copied",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
+
     monkeypatch.setattr(
         "polylogue.cli.archive_query.ArchiveStore.open_existing",
         classmethod(lambda cls, root: FakeArchiveStore()),
@@ -1038,7 +1067,7 @@ def test_async_execute_query_archive_searches_within_session_id(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["mode"] == "search"
-    assert payload["items"][0]["session_id"] == "codex-session:native-1"
+    assert payload["items"][0]["session"]["id"] == "codex-session:native-1"
 
 
 def test_async_execute_query_archive_filters_since_session_id(
@@ -1140,7 +1169,7 @@ def test_async_execute_query_archive_paginates_lists_with_cursor(
     first_page = json.loads(capsys.readouterr().out)
     cursor = first_page["next_cursor"]
 
-    assert [item["session_id"] for item in first_page["items"]] == ["codex-session:one", "codex-session:two"]
+    assert [item["id"] for item in first_page["items"]] == ["codex-session:one", "codex-session:two"]
     assert decode_search_cursor(cursor).r == 2
     assert first_page["next_offset"] == 2
 
@@ -1153,7 +1182,7 @@ def test_async_execute_query_archive_paginates_lists_with_cursor(
     second_page = json.loads(capsys.readouterr().out)
 
     assert calls == [(3, 0), (3, 2)]
-    assert [item["session_id"] for item in second_page["items"]] == ["codex-session:three", "codex-session:four"]
+    assert [item["id"] for item in second_page["items"]] == ["codex-session:three", "codex-session:four"]
     assert second_page["next_cursor"] is None
 
 
@@ -1519,6 +1548,21 @@ def test_async_execute_query_archive_uses_vector_provider_for_semantic_search(
                 ),
             ]
 
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            native_id = session_id.removeprefix("codex-session:")
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id=native_id,
+                origin="codex-session",
+                provider=Provider.CODEX,
+                title=f"Semantic {native_id[-1]}",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
+
     monkeypatch.setattr(
         "polylogue.cli.archive_query.ArchiveStore.open_existing",
         classmethod(lambda cls, root: FakeArchiveStore()),
@@ -1541,7 +1585,7 @@ def test_async_execute_query_archive_uses_vector_provider_for_semantic_search(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["retrieval_lane"] == "semantic"
-    assert payload["items"][0]["session_id"] == "codex-session:native-1"
+    assert payload["items"][0]["session"]["id"] == "codex-session:native-1"
     assert decode_search_cursor(payload["next_cursor"]).lane == "semantic"
 
 
@@ -1590,6 +1634,21 @@ def test_async_execute_query_archive_accepts_explicit_semantic_lane(
                 )
             ]
 
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            assert session_id == "codex-session:native-1"
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id="native-1",
+                origin="codex-session",
+                provider=Provider.CODEX,
+                title="Semantic",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
+
     monkeypatch.setattr(
         "polylogue.cli.archive_query.ArchiveStore.open_existing",
         classmethod(lambda cls, root: FakeArchiveStore()),
@@ -1612,7 +1671,7 @@ def test_async_execute_query_archive_accepts_explicit_semantic_lane(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["retrieval_lane"] == "semantic"
-    assert payload["items"][0]["session_id"] == "codex-session:native-1"
+    assert payload["items"][0]["session"]["id"] == "codex-session:native-1"
 
 
 def test_archive_tiers_semantic_query_uses_active_root_embeddings_db(
@@ -1665,6 +1724,21 @@ def test_archive_tiers_semantic_query_uses_active_root_embeddings_db(
                     snippet="semantic hit",
                 )
             ]
+
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            assert session_id == "codex-session:native-1"
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id="native-1",
+                origin="codex-session",
+                provider=Provider.CODEX,
+                title="Semantic",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
 
     def fake_open_existing(cls: type[object], root: Path) -> FakeArchiveStore:
         assert root == active_root

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -19,6 +19,7 @@ from polylogue.sources.live import WatchSource
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from tests.infra.frozen_clock import FrozenClock
 
 
@@ -119,7 +120,7 @@ def test_polylogued_status_json_reports_archive_storage(tmp_path: Path) -> None:
         "source": 1,
         "index": 3,
         "embeddings": 1,
-        "user": 1,
+        "user": USER_SCHEMA_VERSION,
         "ops": 1,
     }
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1119,7 +1119,7 @@ class TestReaderQueryUnits:
 
         assert status == 400
         assert payload["error"] == "invalid_query"
-        assert "messages/actions/blocks where" in str(payload["message"])
+        assert "messages/actions/blocks/assertions where" in str(payload["message"])
 
 
 class TestReaderViewProfiles:

--- a/tests/unit/insights/test_feedback.py
+++ b/tests/unit/insights/test_feedback.py
@@ -200,6 +200,43 @@ class TestFeedbackStorage:
         assert len(corrections) == 1
         assert corrections[0].payload == {"summary": "Second summary."}
 
+    async def test_list_preserves_flat_assertion_payload(
+        self,
+        workspace_env: dict[str, Path],
+        storage_repository: SessionRepository,
+    ) -> None:
+        del workspace_env
+        await _seed_session(storage_repository, "conv-flat")
+
+        from polylogue.storage.insights.feedback import list_corrections
+
+        async with storage_repository.backend.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO user_tier.assertions (
+                    assertion_id, target_ref, key, kind, value_json,
+                    author_kind, created_at_ms, updated_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "assertion:correction:flat-payload",
+                    "insight:conv-flat",
+                    CorrectionKind.TAG_REJECT.value,
+                    "correction",
+                    '{"tag":"costly"}',
+                    "user",
+                    1_800_000_000_000,
+                    1_800_000_000_000,
+                ),
+            )
+
+            corrections = await list_corrections(conn, session_id="conv-flat")
+
+        assert len(corrections) == 1
+        assert corrections[0].kind == CorrectionKind.TAG_REJECT
+        assert corrections[0].payload == {"tag": "costly"}
+        assert corrections[0].note is None
+
     async def test_content_hash_invariant(
         self,
         workspace_env: dict[str, Path],

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from polylogue.sources.live.batch_support import (
     _parse_path_as_session_artifact,
 )
 from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 
 
 def test_full_ingest_heartbeats_small_file_groups_with_current_path(
@@ -349,7 +351,10 @@ def test_full_ingest_bootstraps_archive_root(
         "archive_bootstrapped": True,
         "archive_present_tiers": "source,index,embeddings,user,ops",
         "archive_missing_tiers": "",
-        "archive_tier_user_versions_json": '{"embeddings": 1, "index": 3, "ops": 1, "source": 1, "user": 1}',
+        "archive_tier_user_versions_json": json.dumps(
+            {"embeddings": 1, "index": 3, "ops": 1, "source": 1, "user": USER_SCHEMA_VERSION},
+            sort_keys=True,
+        ),
     }
 
 

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -15,8 +15,10 @@ from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     ASSERTION_CLAIM_KINDS,
     AssertionKind,
+    assertion_envelope_to_payload,
     assertion_id_for_transform_candidate,
     list_assertion_claims,
+    list_assertions_for_export,
     list_assertions_for_target,
     mark_assertion_status,
     read_assertion_envelope,
@@ -346,6 +348,73 @@ def test_list_assertion_claims_filters_lifecycle_assertions(tmp_path: Path) -> N
         assert list_assertion_claims(conn, kinds=()) == []
         assert list_assertion_claims(conn, statuses=()) == []
         assert [claim.assertion_id for claim in list_assertion_claims(conn, limit=1)] == ["claim-lesson-other"]
+    finally:
+        conn.close()
+
+
+def test_list_assertions_for_export_covers_all_kinds_and_statuses(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        rows = [
+            ("a-mark", AssertionKind.MARK, "active", 1_700_000_001_000),
+            ("a-deleted-note", AssertionKind.NOTE, "deleted", 1_700_000_002_000),
+            ("a-candidate", AssertionKind.TRANSFORM_CANDIDATE, "candidate", 1_700_000_003_000),
+        ]
+        for assertion_id, kind, status, now_ms in rows:
+            upsert_assertion(
+                conn,
+                assertion_id=assertion_id,
+                target_ref="session:s-1",
+                kind=kind,
+                scope_ref="run:r-1",
+                key=f"export/{assertion_id}",
+                value={"status": status},
+                body_text=f"body {assertion_id}",
+                author_ref="user:operator",
+                author_kind="user",
+                evidence_refs=[f"message:s-1:{now_ms}"],
+                status=status,
+                visibility="private",
+                confidence=0.75,
+                staleness={"stale": False},
+                context_policy={"inject": status == "active"},
+                supersedes=["old:a"] if assertion_id == "a-mark" else None,
+                now_ms=now_ms,
+            )
+
+        exported = list_assertions_for_export(conn)
+        assert [row.assertion_id for row in exported] == ["a-mark", "a-deleted-note", "a-candidate"]
+
+        active = list_assertions_for_export(conn, statuses=("active",))
+        assert [row.assertion_id for row in active] == ["a-mark"]
+
+        notes = list_assertions_for_export(conn, kinds=(AssertionKind.NOTE,))
+        assert [row.assertion_id for row in notes] == ["a-deleted-note"]
+
+        limited = list_assertions_for_export(conn, limit=2)
+        assert [row.assertion_id for row in limited] == ["a-mark", "a-deleted-note"]
+
+        payload = assertion_envelope_to_payload(exported[0])
+        assert payload == {
+            "assertion_id": "a-mark",
+            "scope_ref": "run:r-1",
+            "target_ref": "session:s-1",
+            "key": "export/a-mark",
+            "kind": "mark",
+            "value": {"status": "active"},
+            "body_text": "body a-mark",
+            "author_ref": "user:operator",
+            "author_kind": "user",
+            "evidence_refs": ["message:s-1:1700000001000"],
+            "status": "active",
+            "visibility": "private",
+            "confidence": 0.75,
+            "staleness": {"stale": False},
+            "context_policy": {"inject": True},
+            "supersedes": ["old:a"],
+            "created_at_ms": 1_700_000_001_000,
+            "updated_at_ms": 1_700_000_001_000,
+        }
     finally:
         conn.close()
 

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -51,21 +51,56 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     ("polylogue/storage/repository/archive/sessions.py", 300): (
         "chunked IN-clause: literal scoped_sql template + '?,?' placeholders, values bound"
     ),
-    # #1743 readiness fallback coverage (_archive_fallback_coverage):
-    #   degraded_row = self._conn.execute(f"... FROM {table_name} ... WHERE ({any_terms}){clause}")
-    # ``table_name`` is a closed insight-table identifier; ``any_terms`` is built
-    # from the (column, path) pairs in the closed ``_INSIGHT_FALLBACK_PAYLOAD``
-    # constant; ``clause`` comes from ``_readiness_session_filter`` whose values
-    # flow through bound params. No user input enters the format string.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2610): (
-        "readiness fallback coverage: closed insight-table + _INSIGHT_FALLBACK_PAYLOAD column/path; values bound"
-    ),
-    # #1743 readiness fallback reason counts (_archive_fallback_coverage):
-    #   rows = self._conn.execute(f"... FROM {table_name} ... json_each(... '{path}') ...{clause}")
-    # ``table_name``/``column``/``path`` are the closed-constant identifiers
-    # above; ``clause`` values are bound. No user input enters the format string.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2619): (
+    # #1743 readiness fallback degraded row count:
+    #   degraded_row = self._conn.execute(f"SELECT ... FROM {table_name} ... WHERE ({any_terms}){clause}", ...)
+    # ``table_name`` is a closed insight table name; ``any_terms`` is built
+    # immediately above from closed ``(column, path)`` fallback specs; ``clause``
+    # values are bound.
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2584): (
         "readiness fallback reason counts: closed insight-table + _INSIGHT_FALLBACK_PAYLOAD column/path; values bound"
+    ),
+    # #1743 readiness fallback reason breakdown:
+    #   rows = self._conn.execute(f"... FROM {table_name} ... json_each(... '{path}') ...{clause}")
+    # ``table_name``/``column``/``path`` are closed fallback specs; ``clause``
+    # values are bound.
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2593): (
+        "readiness fallback reason breakdown: closed insight-table + fallback payload column/path; values bound"
+    ),
+    # Terminal unit row readers:
+    #   rows = self._conn.execute(f"""... WHERE ({clause}){session_clause} ...""", ...)
+    # ``clause`` comes from the structural predicate lowerer, which returns SQL
+    # fragments plus bound params from closed field metadata; ``session_clause``
+    # comes from the shared session filter lowerer; pagination values are bound.
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3252): (
+        "message query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3314): (
+        "action query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3374): (
+        "block query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3437): (
+        "assertion query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ),
+    # Assertion readers:
+    #   rows = conn.execute(f"SELECT {_ASSERTION_COLUMNS} FROM assertions ...", ...)
+    # ``_ASSERTION_COLUMNS`` is a module-level literal projection list; all
+    # dynamic row values are passed through bound parameters.
+    ("polylogue/storage/sqlite/archive_tiers/user_write.py", 657): (
+        "assertion kind listing: literal projection column list; kind value bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/user_write.py", 671): (
+        "assertion kind/key lookup: literal projection column list; values bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/user_write.py", 930): (
+        "assertion id lookup: literal projection column list; assertion id bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/user_write.py", 947): (
+        "assertions for target: literal projection column list; target ref bound"
+    ),
+    ("polylogue/storage/sqlite/archive_tiers/user_write.py", 952): (
+        "assertions for target/kind: literal projection column list; values bound"
     ),
 }
 

--- a/tests/unit/test_pytest_temp_policy.py
+++ b/tests/unit/test_pytest_temp_policy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -79,3 +81,18 @@ def test_sweep_stale_polylogue_basetemps_preserves_seeded_and_recent(
     assert seeded.exists()
     assert recent.exists()
     assert unrelated.exists()
+
+
+def test_sessionfinish_leaves_xdist_basetemp_for_startup_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    basetemp = tmp_path / "pytest-polylogue-run-123"
+    basetemp.mkdir()
+    session = SimpleNamespace(config=SimpleNamespace(option=SimpleNamespace(basetemp=str(basetemp), numprocesses=8)))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_RUN_ID", "run-123")
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+    conftest.pytest_sessionfinish(cast("pytest.Session", session), 0)
+
+    assert basetemp.exists()


### PR DESCRIPTION
## Summary

Adds a durable assertion export surface for `user.db`, moves split-archive learning-correction storage onto assertion rows, and fixes the verification harness issues exposed while proving the broad seed run.

## Problem

#1883 still had a backup/export/reset gap: assertions are irreplaceable user-tier state, but there was no direct export surface that included inactive/candidate/deleted rows. The split archive had also removed the old correction table while the async feedback storage path could still try to use it. During broad verification, the seed run exposed unrelated harness fragility: progress writes could race in parallel tests, xdist basetemp cleanup could interrupt report flush, and the memory-budget probe could report parent RSS larger than total tree RSS for very short commands.

## Solution

- Add `ops maintenance assertion-export` with JSONL/JSON output, `--out`, `--kind`, `--status`, and non-negative `--limit` filters.
- Add `list_assertions_for_export(...)` and `assertion_envelope_to_payload(...)` over the typed assertion envelope so export output is deterministic and includes all statuses by default.
- Store archive-root learning corrections in `user_tier.assertions` when split `user.db` is present, and tombstone correction assertions on delete/clear.
- Fix assertion-backed blackboard note decoding for rows whose `key` is absent but `target_ref` carries the note id.
- Update route/status snapshots for `list_assertion_claims` and current CLI command inventory.
- Harden verify/test harness behavior: unique pytest progress temp files, no xdist basetemp deletion during session-finish teardown, and process-tree RSS never below parent RSS.

## Verification

- `devtools test` focused assertion/export/user-state/harness node set: `29 passed`.
- `devtools test` broad-run regression nodes: `7 passed`.
- `ruff check` and `mypy --strict` over changed files: passed.
- `devtools verify --quick`: `exit_code: 0`.
- `devtools verify --seed-testmon --skip-slow`: pytest seed completed with `11280 passed, 1 xfailed`; the enclosing first seed command failed only because `tests/unit/test_pytest_temp_policy.py` needed formatting, then formatting and quick gate passed.
- `devtools verify`: `exit_code: 0`, affected pytest `7 passed`.

Ref #1883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `maintenance assertion-export` CLI command to export durable assertions from the archive in JSON or JSONL formats with optional filtering by kind and status
  * Feedback corrections now use assertions-based persistence for improved durability and consistency
  * Archive status reporting includes assertion claims routing information

* **Documentation**
  * Updated scenario projection catalog with new exercise projections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->