### PR TITLE
fix(cli): enforce read-view format profiles (#1838)

### DIFF
--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import click
 
-from polylogue.archive.viewport import read_view_choices
+from polylogue.archive.viewport import READ_VIEW_PROFILE_BY_ID, read_view_choices
 from polylogue.cli.shared.types import AppEnv
 
 if TYPE_CHECKING:
@@ -82,6 +82,14 @@ class ReadViewHandler:
             if not query_seed:
                 raise click.UsageError(
                     f"read --view {self.view_id} requires a seed (use --id, id:prefix, --latest, or a query)."
+                )
+        if invocation.output_format is not None:
+            profile = READ_VIEW_PROFILE_BY_ID[self.view_id]
+            if invocation.output_format not in profile.formats:
+                supported = ", ".join(profile.formats)
+                raise click.UsageError(
+                    f"read --view {self.view_id} does not support --format {invocation.output_format}. "
+                    f"Supported formats: {supported}."
                 )
 
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -516,6 +516,23 @@ def test_read_view_recovery_requires_session_id() -> None:
         )
 
 
+def test_read_view_rejects_format_outside_selected_profile() -> None:
+    env = SimpleNamespace(polylogue=SimpleNamespace())
+
+    with pytest.raises(click.UsageError, match="read --view context-pack does not support --format json"):
+        read_view_handlers.run_read_view(
+            cast(AppEnv, env),
+            RootModeRequest.from_params({}),
+            ReadViewInvocation(
+                view="context-pack",
+                session_id=None,
+                output_format="json",
+                destination="terminal",
+                out_path=None,
+            ),
+        )
+
+
 def test_resolve_target_session_id_uses_explicit_conv_id() -> None:
     request = RootModeRequest.from_params({"conv_id": "claude-code:abc123"})
     assert query_verbs._resolve_target_session_id(request) == "claude-code:abc123"


### PR DESCRIPTION
## Summary

Read-view profile metadata now constrains executable read-view behavior: `read --view <view> --format <format>` rejects formats not declared by the selected view profile before dispatching to the handler. This closes a wiring gap where completions/docs came from per-view profiles, but the runtime accepted the union of every read-view format.

## Problem

The iter-chain read-view handler extraction has already landed on master, so the remaining useful work was not to recreate a handler registry. The gap was that profile metadata was only partially executable: Click accepted all formats from all views, and selected handlers could silently ignore unsupported formats such as `read --view context-pack --format json`.

## Solution

`ReadViewHandler.validate()` now looks up the selected `SessionViewProfile` and raises a typed Click usage error when the requested format is outside that profile's declared formats. A focused runtime test covers the behavior through the existing handler entrypoint. No command-root deletion, hidden alias, compatibility shim, or absence test is introduced.

Ref #1838.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py -k 'read_view or read_format'` -> `10 passed, 20 deselected`.
- `devtools verify --quick` -> `exit_code: 0`.
- `devtools verify` was attempted after copying the main checkout testmon seed into this fresh worktree. Static gates passed, but pytest-testmon selected a near-full run and was intentionally aborted at 2% rather than burning an hour for this two-file read-view validation change. The exact branch behavior is covered by the focused runtime test above.

## Risk

Low. The change only rejects invalid view/format pairs that profile metadata already says are unsupported; valid formats keep the existing handler paths.