### PR TITLE
fix(devtools): report active pytest node during verify

### DIFF
--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -15,21 +15,59 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 _EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
 
 
+def _write_event(payload: dict[str, Any]) -> None:
+    raw_path = os.environ.get(_EVENTS_ENV)
+    if not raw_path:
+        return
+    payload = {
+        "updated_at": datetime.now(UTC).isoformat(),
+        **payload,
+    }
+    path = Path(raw_path)
+    with contextlib.suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+@pytest.hookimpl
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    """Append one event when pytest starts running a test node."""
+    _write_event(
+        {
+            "event": "test_started",
+            "nodeid": nodeid,
+            "location": [location[0], location[1], location[2]],
+        }
+    )
+
+
+@pytest.hookimpl
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    """Append one event when pytest finishes running a test node."""
+    _write_event(
+        {
+            "event": "test_finished",
+            "nodeid": nodeid,
+            "location": [location[0], location[1], location[2]],
+        }
+    )
+
+
+@pytest.hookimpl
 def pytest_runtest_logreport(report: Any) -> None:
     """Append one test-call event when configured by ``devtools verify``."""
     when = str(getattr(report, "when", ""))
     outcome = str(getattr(report, "outcome", ""))
     if when != "call" and outcome not in {"failed", "error"}:
         return
-    raw_path = os.environ.get(_EVENTS_ENV)
-    if not raw_path:
-        return
     payload = {
         "event": "test_report",
-        "updated_at": datetime.now(UTC).isoformat(),
         "nodeid": str(getattr(report, "nodeid", "")),
         "when": when,
         "outcome": outcome,
@@ -37,8 +75,4 @@ def pytest_runtest_logreport(report: Any) -> None:
     }
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
-    path = Path(raw_path)
-    with contextlib.suppress(OSError):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    _write_event(payload)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -228,6 +228,26 @@ def _read_json_artifact(path: Path) -> dict[str, Any] | None:
     return raw if isinstance(raw, dict) else None
 
 
+def _read_latest_pytest_event(path: Path = PYTEST_EVENTS_PATH) -> dict[str, Any] | None:
+    """Return the latest valid pytest event from the live JSONL ledger."""
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - 65536))
+            lines = handle.read().splitlines()
+    except OSError:
+        return None
+    for raw in reversed(lines):
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            return event
+    return None
+
+
 def _pytest_metadata_from_report(report: dict[str, Any], *, report_path: Path) -> dict[str, Any]:
     """Project a pytest-json-report dict into verify-step metadata."""
     summary = report.get("summary")
@@ -340,6 +360,15 @@ def _write_pytest_progress(
         payload["cpu_pct"] = round(cpu_pct, 2)
     if termination_reason is not None:
         payload["termination_reason"] = termination_reason
+    latest_event = _read_latest_pytest_event()
+    if latest_event is not None:
+        payload["latest_test_event"] = {
+            key: latest_event[key]
+            for key in ("event", "nodeid", "when", "outcome", "duration_s", "updated_at")
+            if key in latest_event
+        }
+        if latest_event.get("event") == "test_started" and isinstance(latest_event.get("nodeid"), str):
+            payload["current_test_nodeid"] = latest_event["nodeid"]
     PYTEST_PROGRESS_PATH.parent.mkdir(parents=True, exist_ok=True)
     tmp = PYTEST_PROGRESS_PATH.with_name(f"{PYTEST_PROGRESS_PATH.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
     tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
@@ -506,9 +535,16 @@ def _run_pytest_with_heartbeat(
             rss_text = f", rss={int(rss) // 1024} MiB" if isinstance(rss, int) else ""
             cpu_text = f", cpu={cpu_pct:.0f}%" if cpu_pct is not None else ""
             state_text = f", state={status['state']}" if status["state"] is not None else ""
+            latest_event = _read_latest_pytest_event()
+            if latest_event is not None:
+                event = latest_event.get("event")
+                nodeid = latest_event.get("nodeid")
+                node_text = f", latest={event}:{nodeid}" if isinstance(event, str) and isinstance(nodeid, str) else ""
+            else:
+                node_text = ""
             sys.stderr.write(
                 f"    still running: pid={process.pid}, elapsed={sample_now - t0:.0f}s, "
-                f"idle={sample_now - last_output:.0f}s{state_text}{cpu_text}{rss_text}\n"
+                f"idle={sample_now - last_output:.0f}s{state_text}{cpu_text}{rss_text}{node_text}\n"
             )
             sys.stderr.flush()
             _write_pytest_progress(
@@ -623,7 +659,7 @@ def _subprocess_env() -> dict[str, str]:
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
-    env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
+    env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(Path.cwd() / PYTEST_EVENTS_PATH)
     return env
 
 

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -40,6 +40,25 @@ def test_progress_plugin_records_call_and_setup_failures(
     assert events[1]["longrepr"] == "fixture exploded"
 
 
+def test_progress_plugin_records_node_start_and_finish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", str(events_path))
+
+    location = ("tests/unit/test_example.py", 12, "test_example")
+    pytest_progress_plugin.pytest_runtest_logstart("tests/unit/test_example.py::test_example", location)
+    pytest_progress_plugin.pytest_runtest_logfinish("tests/unit/test_example.py::test_example", location)
+
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    assert [(event["event"], event["nodeid"]) for event in events] == [
+        ("test_started", "tests/unit/test_example.py::test_example"),
+        ("test_finished", "tests/unit/test_example.py::test_example"),
+    ]
+    assert events[0]["location"] == ["tests/unit/test_example.py", 12, "test_example"]
+
+
 def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -289,7 +289,7 @@ def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyP
     assert env["POLYLOGUE_ROOT"] == str(ROOT)
     assert env["POLYLOGUE_REPO_ROOT"] == str(ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(ROOT / ".cache" / "pycache")
-    assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(ROOT / PYTEST_EVENTS_PATH)
+    assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(Path.cwd() / PYTEST_EVENTS_PATH)
 
 
 def test_run_reads_structured_pytest_report() -> None:
@@ -338,6 +338,31 @@ def test_pytest_run_emits_heartbeat_for_long_silent_child(
     assert "command:" in captured.err
     assert "still running: pid=" in captured.err
     assert "elapsed=" in captured.err
+
+
+def test_pytest_run_heartbeat_reports_latest_test_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0.05")
+    nodeid = "tests/unit/example.py::test_slow_node"
+    script = (
+        "import json, os, pathlib, time; "
+        "path = pathlib.Path(os.environ['POLYLOGUE_PYTEST_EVENTS_PATH']); "
+        "path.parent.mkdir(parents=True, exist_ok=True); "
+        f"path.write_text(json.dumps({{'event': 'test_started', 'nodeid': {nodeid!r}}}) + '\\n'); "
+        "time.sleep(0.2)"
+    )
+
+    rc, _elapsed, _metadata = _run("pytest heartbeat", [sys.executable, "-c", script])
+
+    captured = capsys.readouterr()
+    progress = json.loads((tmp_path / PYTEST_PROGRESS_PATH).read_text())
+    assert rc == 0
+    assert f"latest=test_started:{nodeid}" in captured.err
+    assert progress["latest_test_event"]["nodeid"] == nodeid
 
 
 def test_pytest_run_streams_child_output_live(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
Make `devtools verify` expose the active pytest node while long testmon runs are in flight. The pytest progress plugin now writes start/finish events for each node, and verify heartbeats/progress JSON include the latest event/current node when available.

## Problem
A default `devtools verify` run for a two-file metadata/docstring branch selected a very broad testmon set, ran for over 35 minutes, wrote roughly 40 GB according to `/proc/<pid>/io`, and reported only percentage/process state. The live progress artifact did not name the active test node, and the advertised events ledger was missing because the plugin did not emit runtime events under real pytest.

## Solution
- Mark the pytest progress hooks explicitly and add node start/finish event writes.
- Keep completed-test report events, but route all writes through one helper.
- Read the latest JSONL event into `current-pytest-progress.json` and heartbeat output.
- Align the child events path with the verify working directory so progress/event artifacts refer to the same ledger.
- Add direct plugin tests and verify heartbeat coverage for current-node reporting.

## Verification
- `nix develop --command devtools test tests/unit/devtools/test_pytest_progress_plugin.py tests/unit/devtools/test_verify.py -k 'pytest_progress_plugin or heartbeat_reports_latest_test_node or emits_heartbeat_for_long_silent_child or writes_live_progress_artifact or forces_subprocesses'` -> 7 passed, 42 deselected.
- Runtime smoke: `POLYLOGUE_PYTEST_EVENTS_PATH=/tmp/polylogue-pytest-events-smoke.jsonl nix develop --command pytest -q -p devtools.pytest_progress_plugin tests/unit/core/test_query_descriptor_parity.py` -> 5 passed and emitted 10 start/finish events.
- `nix develop --command devtools verify --quick` -> exit_code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced test progress tracking to capture test start and finish events during pytest execution.
  * Added real-time visibility of the currently running test within progress reports during long test runs.

* **Improvements**
  * Refined progress reporting to display the latest test execution information in stderr output while tests are running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->