### PR TITLE
test(query): tighten descriptor parity metadata (#2006)

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2266,7 +2266,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
     @daemon_safe_handler
     def _handle_query_units(self, params: dict[str, list[str]]) -> None:
-        """``GET /api/query-units`` returns terminal message/action/block rows."""
+        """``GET /api/query-units`` returns terminal query-unit rows."""
 
         from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
         from polylogue.archive.query.spec import clamp_query_limit

--- a/tests/unit/core/test_query_descriptor_parity.py
+++ b/tests/unit/core/test_query_descriptor_parity.py
@@ -1,4 +1,4 @@
-"""Query descriptor parity tests for #621.
+"""Query descriptor parity tests for the shared query substrate.
 
 Proves that query-field names are consistent across CLI, MCP, and API surfaces.
 """
@@ -23,33 +23,20 @@ def test_descriptor_mcp_names_match_mcp_query_request_fields() -> None:
 
 
 def test_all_descriptors_have_mcp_or_api_name() -> None:
-    """Every descriptor with a selection_filter should declare at least one surface name.
-
-    This is currently informational: it collects gaps but doesn't fail.
-    The full parity enforcement lands when #621 is complete.
-    """
+    """Public selection filters declare at least one surface name."""
     missing = []
     for d in QUERY_FIELD_DESCRIPTORS:
         if d.selection_filter and not d.mcp_names and not d.api_names:
             missing.append(d.name)
-    legit_internal = {
-        "excluded_providers",
-        "excluded_tags",
-        "has_types",
-        "similar_text",
-        "session_id",
-        "latest",
+    internal_plan_only = {
         "parent_id",
         "continuation",
         "sidechain",
         "root",
         "has_branches",
         "predicates",
-        "exclude_text_terms",
-        "max_messages",
-        "until",
     }
-    actionable = [m for m in missing if m not in legit_internal]
+    actionable = [m for m in missing if m not in internal_plan_only]
     if actionable:
         raise AssertionError(f"Selection filters without surface names: {actionable}")
 


### PR DESCRIPTION
## Summary
Tighten the query descriptor parity tests around the now-shipped shared query metadata and fix stale daemon route wording for terminal query units.

## Problem
The #2006 metadata split and terminal query-unit work have already landed, but the descriptor parity test still described itself as an informational #621 placeholder and carried a stale allowlist of fields that now have real MCP/API names. The daemon `/api/query-units` handler docstring also still named only message/action/block rows even though assertions are now part of the terminal query-unit surface.

## Solution
- Reword descriptor parity coverage as shared query-substrate coverage.
- Reduce the allowlist to true internal plan-only descriptors (`parent_id`, lineage booleans, branch/predicate internals).
- Keep the test as positive metadata coverage: public selection filters must expose a surface name unless they are genuinely plan-only.
- Update the daemon handler docstring to describe terminal query-unit rows generically.

## Verification
- `nix develop --command devtools test tests/unit/core/test_query_descriptor_parity.py tests/unit/daemon/test_daemon_http.py -k 'descriptor or query_units'` -> 5 passed, 5 deselected.
- `nix develop --command devtools verify --quick` -> exit_code 0.

Default `devtools verify` selected a very broad testmon set for this two-file metadata/docstring change and was stopped after ~35 minutes at 97%; the run had already written roughly 40 GB and did not expose the active test node. PR #2100 fixes that harness observability gap so future long default verifies report the current node instead of only percentage/process state.