### PR TITLE
fix(devtools): reject stale testmon verify seeds

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -849,12 +849,37 @@ def _pytest_worker_args(*, default: str) -> list[str]:
 def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, commit: bool) -> str | None:
     if quick or commit or seed_testmon or full_pytest:
         return None
-    if TESTMON_DATA.exists() and TESTMON_SEED_STAMP.exists():
-        return None
-    return (
+    seed_message = (
         "verify: pytest-testmon is not seeded; run `devtools verify --seed-testmon` "
         "to create .testmondata and .cache/testmon/seed.json before using the default affected-test path.\n"
     )
+    if not TESTMON_DATA.exists() or not TESTMON_SEED_STAMP.exists():
+        return seed_message
+    try:
+        stamp = json.loads(TESTMON_SEED_STAMP.read_text())
+    except (OSError, json.JSONDecodeError):
+        return (
+            "verify: pytest-testmon seed stamp is unreadable; run `devtools verify --seed-testmon` "
+            "to refresh .testmondata and .cache/testmon/seed.json.\n"
+        )
+    if not isinstance(stamp, dict):
+        return (
+            "verify: pytest-testmon seed stamp has an invalid shape; run `devtools verify --seed-testmon` "
+            "to refresh .testmondata and .cache/testmon/seed.json.\n"
+        )
+    current_head = _git_head()
+    stamped_head = stamp.get("git_head")
+    if current_head is not None and stamped_head != current_head:
+        return (
+            "verify: pytest-testmon seed was recorded for a different git head; "
+            "run `devtools verify --seed-testmon` before using the default affected-test path.\n"
+        )
+    if stamp.get("testmon_data") != _file_fingerprint(TESTMON_DATA):
+        return (
+            "verify: pytest-testmon database changed after the seed stamp; "
+            "run `devtools verify --seed-testmon` before using the default affected-test path.\n"
+        )
+    return None
 
 
 def _write_testmon_seed_stamp(result: dict[str, Any]) -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -227,9 +228,59 @@ def test_testmon_preflight_accepts_seeded_database(tmp_path: Path, monkeypatch: 
     (tmp_path / ".testmondata").write_text("seeded")
     seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
     seed_stamp.parent.mkdir(parents=True)
-    seed_stamp.write_text("{}")
+    seed_stamp.write_text(
+        json.dumps(
+            {
+                "git_head": "current-head",
+                "testmon_data": hashlib.sha256(b"seeded").hexdigest(),
+            }
+        )
+    )
+    monkeypatch.setattr("devtools.verify._git_head", lambda: "current-head")
 
     assert _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False) is None
+
+
+def test_testmon_preflight_rejects_stale_git_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".testmondata").write_text("seeded")
+    seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
+    seed_stamp.parent.mkdir(parents=True)
+    seed_stamp.write_text(
+        json.dumps(
+            {
+                "git_head": "old-head",
+                "testmon_data": hashlib.sha256(b"seeded").hexdigest(),
+            }
+        )
+    )
+    monkeypatch.setattr("devtools.verify._git_head", lambda: "current-head")
+
+    message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
+
+    assert message is not None
+    assert "different git head" in message
+
+
+def test_testmon_preflight_rejects_database_fingerprint_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".testmondata").write_text("mutated")
+    seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
+    seed_stamp.parent.mkdir(parents=True)
+    seed_stamp.write_text(
+        json.dumps(
+            {
+                "git_head": "current-head",
+                "testmon_data": hashlib.sha256(b"seeded").hexdigest(),
+            }
+        )
+    )
+    monkeypatch.setattr("devtools.verify._git_head", lambda: "current-head")
+
+    message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
+
+    assert message is not None
+    assert "database changed" in message
 
 
 def test_testmon_preflight_allows_seed_and_full_without_database(


### PR DESCRIPTION
## Summary

Make the default `devtools verify` pytest-testmon path validate the seed stamp before it starts pytest. The preflight now rejects missing, unreadable, wrong-head, and fingerprint-drifted `.cache/testmon/seed.json` state instead of accepting any old `.testmondata` file.

## Problem

A diagnostic default verify run accepted a seed from `a1a4f9f` recorded on 2026-06-06, while current master was `28e95ab` after 245 first-parent commits. That stale seed selected a very broad pseudo-full run: the bounded diagnostic reached 900s, emitted 1,406 test starts, and was still progressing through MCP archive-surface tests. The harness was observable after #2100, but the preflight still allowed stale affected-test metadata to waste the gate.

## Solution

`_testmon_preflight` now reads `.cache/testmon/seed.json`, compares its `git_head` to the current checkout, and compares its recorded `.testmondata` fingerprint to the current file. If either check fails, default verify exits immediately with reseed instructions. `--seed-testmon`, `--all`, `--quick`, and commit/pre-push quick paths remain unaffected.

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_verify.py -k 'testmon_preflight'` → 6 passed, 42 deselected
- `nix develop --command ruff check --fix devtools/verify.py tests/unit/devtools/test_verify.py` → fixed import order, 0 remaining
- `nix develop --command ruff format --check devtools/verify.py tests/unit/devtools/test_verify.py` → 2 files already formatted
- `nix develop --command devtools verify --quick` → exit_code 0
- `nix develop --command devtools verify` with stale local seed → exits in ~1s with: `pytest-testmon seed was recorded for a different git head`