### PR TITLE
feat(insights): track review delivery events (#1882)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,8 +436,9 @@ devtools verify --seed-testmon --skip-slow
 
 # Focused inner-loop runs — prefer `devtools test` over raw pytest. It runs the
 # selection through the managed harness (repo env, single-process by default,
-# live output) and serializes overlapping runs from the same checkout so two
-# suites do not race. Any pytest arguments go after the command name.
+# live output, current-node progress artifacts, stall/runtime timeouts) and
+# serializes overlapping runs from the same checkout so two suites do not race.
+# Any pytest arguments go after the command name.
 devtools test tests/unit/storage/test_hybrid_laws.py
 devtools test -k "test_name"
 devtools test tests/unit/pipeline -x
@@ -492,6 +493,13 @@ pytest process group if the step exceeds
 for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
 variable to `0` only for an explicit diagnostic run where an unusually long
 full-suite pass is expected and supervised.
+
+`devtools test` uses the same pytest progress plugin and process supervisor for
+focused selections. During or after a run, inspect
+`.cache/verify/current-pytest-progress.json`,
+`.cache/verify/current-pytest-events.jsonl`, and
+`.cache/verify/current-pytest-output.log` to see the active/latest test node,
+captured output, and termination reason if a focused run stalls.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,8 +15,9 @@ devtools verify --seed-testmon --skip-slow
 
 # Focused inner-loop runs — prefer `devtools test` over raw pytest. It runs the
 # selection through the managed harness (repo env, single-process by default,
-# live output) and serializes overlapping runs from the same checkout so two
-# suites do not race. Any pytest arguments go after the command name.
+# live output, current-node progress artifacts, stall/runtime timeouts) and
+# serializes overlapping runs from the same checkout so two suites do not race.
+# Any pytest arguments go after the command name.
 devtools test tests/unit/storage/test_hybrid_laws.py
 devtools test -k "test_name"
 devtools test tests/unit/pipeline -x
@@ -71,6 +72,13 @@ pytest process group if the step exceeds
 for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
 variable to `0` only for an explicit diagnostic run where an unusually long
 full-suite pass is expected and supervised.
+
+`devtools test` uses the same pytest progress plugin and process supervisor for
+focused selections. During or after a run, inspect
+`.cache/verify/current-pytest-progress.json`,
+`.cache/verify/current-pytest-events.jsonl`, and
+`.cache/verify/current-pytest-output.log` to see the active/latest test node,
+captured output, and termination reason if a focused run stalls.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -9,6 +9,8 @@ This command forwards a selection (paths, ``-k``/``-m`` expressions, ``-x``,
 - a single-process worker default (``-n 0``) for fast focused runs, overridable
   with ``-n`` in the selection or ``POLYLOGUE_PYTEST_WORKERS``;
 - live, streamed output (unlike ``devtools verify``, which captures);
+- the same pytest progress ledger, heartbeat, and stall timeout used by
+  ``devtools verify``;
 - a checkout-scoped lock that serializes overlapping runs so two suites from
   the same checkout do not race and burn CPU. Concurrency is already
   *correctness*-safe at the conftest level (#1785, per-run tmpfs basetemp); the
@@ -23,10 +25,18 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import os
-import subprocess
 import sys
+import time
 from collections.abc import Iterator
 from pathlib import Path
+
+from devtools.verify import (
+    PYTEST_EVENTS_PATH,
+    PYTEST_OUTPUT_PATH,
+    PYTEST_PROGRESS_PATH,
+    _clear_pytest_report,
+    _run_pytest_with_heartbeat,
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 _LOCK_PATH = ROOT / ".cache" / "test-run.lock"
@@ -38,6 +48,7 @@ def _managed_env() -> dict[str, str]:
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
+    env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
     return env
 
 
@@ -56,7 +67,7 @@ def _worker_args(selection: list[str]) -> list[str]:
 
 def build_pytest_cmd(selection: list[str]) -> list[str]:
     """Compose the pytest command for a focused selection."""
-    return ["pytest", *selection, *_worker_args(selection)]
+    return ["pytest", "-p", "devtools.pytest_progress_plugin", *selection, *_worker_args(selection)]
 
 
 @contextlib.contextmanager
@@ -106,5 +117,11 @@ def main(argv: list[str] | None = None) -> int:
     cmd = build_pytest_cmd(selection)
     no_lock = os.environ.get("POLYLOGUE_TEST_NO_LOCK") == "1"
     with _run_lock(enabled=not no_lock):
-        result = subprocess.run(cmd, cwd=str(ROOT), env=_managed_env())
+        _clear_pytest_report(cmd)
+        result = _run_pytest_with_heartbeat(cmd, cwd=str(ROOT), env=_managed_env(), t0=time.monotonic())
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    sys.stderr.write(
+        f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
+    )
     return result.returncode

--- a/polylogue/core/refs.py
+++ b/polylogue/core/refs.py
@@ -19,6 +19,7 @@ ObjectRefKind: TypeAlias = Literal[
     "observed-event",
     "github-issue",
     "github-pr",
+    "github-review",
 ]
 
 EvidenceRefKind: TypeAlias = Literal["session", "message", "block"]
@@ -37,6 +38,7 @@ _OBJECT_REF_KINDS: Final[dict[str, ObjectRefKind]] = {
     "observed-event": "observed-event",
     "github-issue": "github-issue",
     "github-pr": "github-pr",
+    "github-review": "github-review",
 }
 
 

--- a/polylogue/insights/run_projection.py
+++ b/polylogue/insights/run_projection.py
@@ -26,13 +26,18 @@ ObservedEventKind = Literal[
     "subagent_finished",
     "pr_opened",
     "pr_merged",
+    "review_posted",
+    "review_seen_by_tool",
+    "review_injected_context",
+    "review_acknowledged",
+    "review_acted_on",
     "issue_closed",
     "check_passed",
     "check_failed",
     "test_passed",
     "test_failed",
 ]
-ObservedDeliveryState = Literal["observed", "unknown"]
+ObservedDeliveryState = Literal["observed", "seen_by_tool", "injected_context", "acknowledged", "acted_on", "unknown"]
 
 
 class _RawRefLike(Protocol):
@@ -257,6 +262,7 @@ def build_run_projection(
                 kind=event.kind,
                 run_ref=main_run_ref,
                 summary=event.summary,
+                delivery_state=_delivery_state_for_event(event.kind),
                 subject_ref=ObjectRef(kind="message", object_id=evidence_refs[0].message_id or session_id),
                 object_refs=_event_object_refs(event),
                 evidence_refs=evidence_refs,
@@ -342,6 +348,18 @@ def _event_ref(session_id: str, kind: str, index: int) -> ObjectRef:
     return ObjectRef(kind="observed-event", object_id=f"{session_id}:{kind}:{index}")
 
 
+def _delivery_state_for_event(kind: ObservedEventKind) -> ObservedDeliveryState:
+    if kind == "review_seen_by_tool":
+        return "seen_by_tool"
+    if kind == "review_injected_context":
+        return "injected_context"
+    if kind == "review_acknowledged":
+        return "acknowledged"
+    if kind == "review_acted_on":
+        return "acted_on"
+    return "observed"
+
+
 def _harness_for_origin(source_origin: str) -> RunHarness:
     if source_origin == "codex-session":
         return "codex"
@@ -381,6 +399,8 @@ def _tool_object_refs(tool: _ToolSummaryLike) -> tuple[ObjectRef, ...]:
 def _event_object_refs(event: _RecoveryEventLike) -> tuple[ObjectRef, ...]:
     if event.kind.startswith("pr_"):
         return tuple(ObjectRef(kind="github-pr", object_id=ref) for ref in _number_refs(event.summary))
+    if event.kind.startswith("review_"):
+        return tuple(ObjectRef(kind="github-review", object_id=ref) for ref in _number_refs(event.summary))
     if event.kind == "issue_closed":
         return tuple(ObjectRef(kind="github-issue", object_id=ref) for ref in _number_refs(event.summary))
     if event.kind.startswith("check_"):

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -57,6 +57,7 @@ _ISSUE_RE = re.compile(
     re.IGNORECASE,
 )
 _PR_RE = re.compile(r"(?:pull/|PR\s+#?)(?P<number>\d{3,6})", re.IGNORECASE)
+_REVIEW_PR_RE = re.compile(r"\b(?:review|comment|finding)s?\b.*(?:pull/|PR\s+#?)(?P<number>\d{3,6})", re.IGNORECASE)
 _CREATED_PR_RE = re.compile(
     r"\b(?:created|opened)\s+(?:pull\s+request|PR)\s+#?(?P<number>\d{3,6})\b",
     re.IGNORECASE,
@@ -221,6 +222,11 @@ class RecoveryEvent(ArchiveInsightModel):
     kind: Literal[
         "pr_opened",
         "pr_merged",
+        "review_posted",
+        "review_seen_by_tool",
+        "review_injected_context",
+        "review_acknowledged",
+        "review_acted_on",
         "issue_closed",
         "check_passed",
         "check_failed",
@@ -813,10 +819,13 @@ def _to_evidence_refs(refs: Sequence[TransformRawRef]) -> tuple[EvidenceRef, ...
 def _event_packet_metadata(event: RecoveryEvent) -> dict[str, str]:
     metadata: dict[str, str] = {}
     pr_refs = tuple(_number_refs(_PR_RE, event.summary)) if event.kind.startswith("pr_") else ()
+    review_refs = tuple(_number_refs(_PR_RE, event.summary)) if event.kind.startswith("review_") else ()
     issue_refs = tuple(_number_refs(_ISSUE_RE, event.summary)) if event.kind == "issue_closed" else ()
     test_evidence = (event.summary,) if event.kind.startswith(("check_", "test_")) else ()
     if pr_refs:
         metadata["pr_refs"] = ", ".join(pr_refs)
+    if review_refs:
+        metadata["review_refs"] = ", ".join(review_refs)
     if issue_refs:
         metadata["issue_refs"] = ", ".join(issue_refs)
     if test_evidence:
@@ -829,6 +838,8 @@ def _event_object_refs(event: RecoveryEvent) -> tuple[ObjectRef, ...]:
 
     if event.kind.startswith("pr_"):
         return _github_object_refs("github-pr", _number_refs(_PR_RE, event.summary))
+    if event.kind.startswith("review_"):
+        return _github_object_refs("github-review", _number_refs(_PR_RE, event.summary))
     if event.kind == "issue_closed":
         return _github_object_refs("github-issue", _number_refs(_ISSUE_RE, event.summary))
     if event.kind.startswith("check_"):
@@ -861,7 +872,9 @@ def _tool_object_refs(tool: ToolSummary) -> tuple[ObjectRef, ...]:
     )
 
 
-def _github_object_refs(kind: Literal["github-issue", "github-pr"], refs: Iterable[str]) -> tuple[ObjectRef, ...]:
+def _github_object_refs(
+    kind: Literal["github-issue", "github-pr", "github-review"], refs: Iterable[str]
+) -> tuple[ObjectRef, ...]:
     """Format GitHub number refs as opaque public object refs."""
 
     return tuple(ObjectRef(kind=kind, object_id=ref) for ref in refs)
@@ -1420,6 +1433,33 @@ def _events_from_text(text: str, ref: TransformRawRef) -> Iterable[RecoveryEvent
                 summary=f"PR #{created_pr_match.group('number')} opened",
                 raw_refs=(ref,),
             )
+        review_match = _REVIEW_PR_RE.search(line)
+        if review_match is not None:
+            number = review_match.group("number")
+            review_kind: Literal[
+                "review_posted",
+                "review_seen_by_tool",
+                "review_injected_context",
+                "review_acknowledged",
+                "review_acted_on",
+            ] = "review_posted"
+            if any(term in lowered for term in ("addressed", "acted on", "fixed", "resolved")):
+                review_kind = "review_acted_on"
+            elif any(term in lowered for term in ("acknowledged", "classified", "triaged")):
+                review_kind = "review_acknowledged"
+            elif any(term in lowered for term in ("injected", "context")):
+                review_kind = "review_injected_context"
+            elif any(term in lowered for term in ("read", "fetched", "inspected", "seen")):
+                review_kind = "review_seen_by_tool"
+            review_label = {
+                "review_posted": "posted",
+                "review_seen_by_tool": "seen by tool",
+                "review_injected_context": "injected into context",
+                "review_acknowledged": "acknowledged",
+                "review_acted_on": "acted on",
+            }[review_kind]
+            yield RecoveryEvent(kind=review_kind, summary=f"Review on PR #{number} {review_label}", raw_refs=(ref,))
+            continue
         if "pull/" in lowered or "pr " in lowered:
             pr_match = _PR_RE.search(line)
             if pr_match is not None:

--- a/tests/unit/core/test_refs.py
+++ b/tests/unit/core/test_refs.py
@@ -18,6 +18,7 @@ from polylogue.core.refs import EvidenceRef, ObjectRef
         ("branch:feature/demo", "branch", "feature/demo", ()),
         ("check-run:ruff check", "check-run", "ruff check", ()),
         ("github-issue:Sinity/polylogue#1883", "github-issue", "Sinity/polylogue#1883", ()),
+        ("github-review:1911", "github-review", "1911", ()),
     ],
 )
 def test_object_ref_parses_and_formats_existing_assertion_ref_shapes(

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from devtools import run_tests
+from devtools.verify import PYTEST_EVENTS_PATH
 
 
 def test_build_pytest_cmd_defaults_to_single_process() -> None:
     cmd = run_tests.build_pytest_cmd(["tests/unit/pipeline"])
-    assert cmd[0] == "pytest"
+    assert cmd[:3] == ["pytest", "-p", "devtools.pytest_progress_plugin"]
     assert "tests/unit/pipeline" in cmd
     assert cmd[-2:] == ["-n", "0"]
 
@@ -41,23 +41,25 @@ def test_main_requires_a_selection(capsys: pytest.CaptureFixture[str]) -> None:
 def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
         captured["cmd"] = cmd
-        return subprocess.CompletedProcess(cmd, 0)
+        captured["env"] = kwargs["env"]
+        return type("Result", (), {"returncode": 0, "stderr": ""})()
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
-    monkeypatch.setattr("devtools.run_tests.subprocess.run", _fake_run)
+    monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
+    assert captured["env"]["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
 
 
 def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
-        return subprocess.CompletedProcess(cmd, 5)
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        return type("Result", (), {"returncode": 5, "stderr": ""})()
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
-    monkeypatch.setattr("devtools.run_tests.subprocess.run", _fake_run)
+    monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
 
 
@@ -66,4 +68,5 @@ def test_managed_env_sets_repo_roots() -> None:
     assert env["POLYLOGUE_ROOT"] == str(run_tests.ROOT)
     assert env["POLYLOGUE_REPO_ROOT"] == str(run_tests.ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(run_tests.ROOT / ".cache" / "pycache")
+    assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
     assert Path(env["POLYLOGUE_ROOT"]).is_dir()

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -51,7 +51,12 @@ def _session() -> Session:
                 Message(
                     id="m2",
                     role=Role.ASSISTANT,
-                    text="Decision: keep benchmarks outside coverage-gate for scope, not flakiness.",
+                    text=(
+                        "Decision: keep benchmarks outside coverage-gate for scope, not flakiness.\n"
+                        "Review posted on PR #1911\n"
+                        "Read review on PR #1911\n"
+                        "Addressed review on PR #1911"
+                    ),
                     blocks=[
                         {
                             "type": "tool_use",
@@ -219,10 +224,16 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
         "subagent_started",
         "subagent_finished",
         "check_passed",
+        "review_posted",
+        "review_seen_by_tool",
+        "review_acted_on",
     } <= observed_kinds
     check_projection = next(event for event in projection.events if event.kind == "check_passed")
     assert check_projection.delivery_state == "observed"
     assert check_projection.object_refs == (ObjectRef(kind="check-run", object_id="ruff check"),)
+    review_projection = next(event for event in projection.events if event.kind == "review_acted_on")
+    assert review_projection.delivery_state == "acted_on"
+    assert review_projection.object_refs == (ObjectRef(kind="github-review", object_id="#1911"),)
 
     event_summaries = {event.summary for event in digest.events}
     assert "PR #1911 opened" in event_summaries
@@ -230,6 +241,9 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert "Issue #1818 closed" in event_summaries
     assert "20 tests passed" in event_summaries
     assert "ruff check passed" in event_summaries
+    assert "Review on PR #1911 posted" in event_summaries
+    assert "Review on PR #1911 seen by tool" in event_summaries
+    assert "Review on PR #1911 acted on" in event_summaries
 
     candidates = {candidate.text for candidate in digest.decision_candidates}
     assert "goal: burn down the backlog" in candidates
@@ -528,6 +542,39 @@ def test_github_cli_and_failed_check_events_are_extracted() -> None:
     assert ("pr_opened", "PR #1930 opened") in events
     assert ("check_failed", "showcase-verify failed") in events
     assert ("check_passed", "Analyze (python) passed") in events
+
+
+def test_review_delivery_events_are_extracted_and_projected() -> None:
+    session = Session(
+        id=SessionId("codex-session:review-events"),
+        origin=Origin.CODEX_SESSION,
+        title="Review event extraction",
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="m-review",
+                    role=Role.ASSISTANT,
+                    text=(
+                        "Review posted on PR #2100\n"
+                        "Read review on PR #2100\n"
+                        "Injected review into context for PR #2100\n"
+                        "Acknowledged review on PR #2100\n"
+                        "Addressed review on PR #2100"
+                    ),
+                )
+            ]
+        ),
+    )
+
+    digest = compile_recovery_digest(session)
+    event_by_kind = {event.kind: event for event in digest.run_projection.events}
+
+    assert event_by_kind["review_posted"].delivery_state == "observed"
+    assert event_by_kind["review_seen_by_tool"].delivery_state == "seen_by_tool"
+    assert event_by_kind["review_injected_context"].delivery_state == "injected_context"
+    assert event_by_kind["review_acknowledged"].delivery_state == "acknowledged"
+    assert event_by_kind["review_acted_on"].delivery_state == "acted_on"
+    assert event_by_kind["review_acted_on"].object_refs == (ObjectRef(kind="github-review", object_id="#2100"),)
 
 
 def test_claim_models_reject_missing_raw_refs() -> None:


### PR DESCRIPTION
## Summary
Adds explicit review-delivery observed events to the recovery digest/run projection path and makes focused `devtools test` runs observable with the same pytest progress artifacts and stall/runtime supervisor used by `devtools verify`.

## Problem
#1882 needs to distinguish whether a review was merely present, seen by the tool, injected into context, acknowledged, or acted on. The current recovery events modeled PRs/checks/tests but collapsed review handling into prose. Separately, after the stale-testmon fix, `devtools verify` is observable, but `devtools test` still used a plain subprocess wrapper, so a blocked focused selection could remain opaque.

## Solution
- Added `github-review` object refs and review event kinds: posted, seen by tool, injected into context, acknowledged, acted on.
- Projected review event kinds into explicit delivery states in `RunProjection`.
- Extracted review lines from recovery text before generic PR parsing, so review prose does not create fake PR-open events.
- Routed `devtools test` through the pytest progress plugin and heartbeat/stall runner, and documented the focused-run artifacts.

## Verification
- `nix develop --command ruff format devtools/run_tests.py polylogue/core/refs.py polylogue/insights/run_projection.py polylogue/insights/transforms.py tests/unit/core/test_refs.py tests/unit/devtools/test_run_tests.py tests/unit/insights/test_transforms.py`
- `nix develop --command ruff check devtools/run_tests.py polylogue/core/refs.py polylogue/insights/run_projection.py polylogue/insights/transforms.py tests/unit/core/test_refs.py tests/unit/devtools/test_run_tests.py tests/unit/insights/test_transforms.py`
- `nix develop --command mypy devtools/run_tests.py polylogue/core/refs.py polylogue/insights/run_projection.py polylogue/insights/transforms.py tests/unit/core/test_refs.py tests/unit/devtools/test_run_tests.py tests/unit/insights/test_transforms.py`
- `nix develop --command devtools test tests/unit/devtools/test_run_tests.py tests/unit/core/test_refs.py tests/unit/insights/test_transforms.py` → 47 passed in 0.81s
- `nix develop --command devtools verify --quick` → exit_code 0
- `nix develop --command devtools verify` → expected fast-fail in 1.4s because the local testmon seed was recorded for a different git head; this confirms the stale-seed long-run path no longer silently expands selection.

Ref #1882