### PR TITLE
refactor(browser-capture): type receiver payloads (#1824)

### DIFF
--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -144,6 +144,49 @@ class BrowserCaptureEnvelope(BaseModel):
         return self.session.provider_session_id
 
 
+class BrowserCaptureReceiverStatusPayload(BaseModel):
+    """Receiver readiness payload returned by ``GET /v1/status``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = "polylogue-browser-capture"
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    spool_path: str
+    allowed_origins: list[str]
+    allow_remote: bool
+    active: bool
+    checked_at: str
+
+
+class BrowserCaptureArchiveStatePayload(BaseModel):
+    """Capture-state payload returned by ``GET /v1/archive-state``."""
+
+    provider: str
+    provider_session_id: str
+    captured: bool
+    artifact_path: str
+    capture_id: str | None = None
+    updated_at: str | None = None
+    artifact_readable: bool | None = None
+
+
+class BrowserCaptureAcceptedPayload(BaseModel):
+    """Accepted-capture payload returned by ``POST /v1/browser-captures``."""
+
+    ok: Literal[True] = True
+    provider: str
+    provider_session_id: str
+    artifact_path: str
+    bytes_written: int
+    replaced: bool
+
+
+class BrowserCaptureErrorPayload(BaseModel):
+    """Safe receiver error payload with no paths or stack traces."""
+
+    ok: Literal[False] = False
+    error: str
+
+
 def looks_like_browser_capture(payload: object) -> bool:
     """Return whether a payload is a browser-capture envelope."""
     if not isinstance(payload, dict):
@@ -159,9 +202,13 @@ def looks_like_browser_capture(payload: object) -> bool:
 __all__ = [
     "BROWSER_CAPTURE_KIND",
     "BROWSER_CAPTURE_SCHEMA_VERSION",
+    "BrowserCaptureAcceptedPayload",
+    "BrowserCaptureArchiveStatePayload",
     "BrowserCaptureAttachment",
     "BrowserCaptureEnvelope",
+    "BrowserCaptureErrorPayload",
     "BrowserCaptureProvenance",
+    "BrowserCaptureReceiverStatusPayload",
     "BrowserCaptureSession",
     "BrowserCaptureTurn",
     "looks_like_browser_capture",

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import orjson
 
-from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.models import (
+    BrowserCaptureArchiveStatePayload,
+    BrowserCaptureEnvelope,
+    BrowserCaptureReceiverStatusPayload,
+)
 from polylogue.core.hashing import hash_text_short
 from polylogue.paths import browser_capture_spool_root
 
@@ -94,16 +98,13 @@ def write_capture_envelope(
 
 def receiver_status_payload(config: BrowserCaptureReceiverConfig) -> dict[str, object]:
     """Return JSON status for extension health checks."""
-    return {
-        "ok": True,
-        "receiver": "polylogue-browser-capture",
-        "schema_version": 1,
-        "spool_path": str(config.spool_path),
-        "allowed_origins": sorted(config.allowed_origins),
-        "allow_remote": config.allow_remote,
-        "active": True,
-        "checked_at": datetime.now(UTC).isoformat(),
-    }
+    return BrowserCaptureReceiverStatusPayload(
+        spool_path=str(config.spool_path),
+        allowed_origins=sorted(config.allowed_origins),
+        allow_remote=config.allow_remote,
+        active=True,
+        checked_at=datetime.now(UTC).isoformat(),
+    ).model_dump(mode="json")
 
 
 def existing_capture_state(
@@ -128,20 +129,27 @@ def existing_capture_state(
         }
     )
     path = capture_artifact_path(envelope, spool_path)
-    state: dict[str, object] = {
-        "provider": envelope.provider.value,
-        "provider_session_id": envelope.provider_session_id,
-        "captured": path.exists(),
-        "artifact_path": str(path),
-    }
+    capture_id: str | None = None
+    updated_at: str | None = None
+    artifact_readable: bool | None = None
     if path.exists():
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-            state["capture_id"] = payload.get("capture_id")
-            state["updated_at"] = payload.get("session", {}).get("updated_at")
+            raw_capture_id = payload.get("capture_id")
+            raw_updated_at = payload.get("session", {}).get("updated_at")
+            capture_id = raw_capture_id if isinstance(raw_capture_id, str) else None
+            updated_at = raw_updated_at if isinstance(raw_updated_at, str) else None
         except (OSError, json.JSONDecodeError, AttributeError):
-            state["artifact_readable"] = False
-    return state
+            artifact_readable = False
+    return BrowserCaptureArchiveStatePayload(
+        provider=envelope.provider.value,
+        provider_session_id=envelope.provider_session_id,
+        captured=path.exists(),
+        artifact_path=str(path),
+        capture_id=capture_id,
+        updated_at=updated_at,
+        artifact_readable=artifact_readable,
+    ).model_dump(mode="json", exclude_none=True)
 
 
 __all__ = [

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -10,7 +10,11 @@ from urllib.parse import parse_qs, urlparse
 
 from pydantic import ValidationError
 
-from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.models import (
+    BrowserCaptureAcceptedPayload,
+    BrowserCaptureEnvelope,
+    BrowserCaptureErrorPayload,
+)
 from polylogue.browser_capture.receiver import (
     BrowserCaptureReceiverConfig,
     existing_capture_state,
@@ -85,7 +89,7 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
 
     def _safe_error(self, status: HTTPStatus, message: str) -> None:
         """Send a safe error response — no absolute paths or stack traces."""
-        self._send_json(status, {"ok": False, "error": message})
+        self._send_json(status, BrowserCaptureErrorPayload(error=message).model_dump(mode="json"))
 
     def _reject_origin(self) -> bool:
         origin = self.headers.get("Origin")
@@ -159,14 +163,13 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             return
         self._send_json(
             HTTPStatus.ACCEPTED,
-            {
-                "ok": True,
-                "provider": result.provider,
-                "provider_session_id": result.provider_session_id,
-                "artifact_path": str(result.path),
-                "bytes_written": result.bytes_written,
-                "replaced": result.replaced,
-            },
+            BrowserCaptureAcceptedPayload(
+                provider=result.provider,
+                provider_session_id=result.provider_session_id,
+                artifact_path=str(result.path),
+                bytes_written=result.bytes_written,
+                replaced=result.replaced,
+            ).model_dump(mode="json"),
         )
 
 

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -9,7 +9,13 @@ from typing import cast
 
 from click.testing import CliRunner
 
-from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.models import (
+    BrowserCaptureAcceptedPayload,
+    BrowserCaptureArchiveStatePayload,
+    BrowserCaptureEnvelope,
+    BrowserCaptureErrorPayload,
+    BrowserCaptureReceiverStatusPayload,
+)
 from polylogue.browser_capture.receiver import (
     capture_artifact_path,
     existing_capture_state,
@@ -66,9 +72,10 @@ def test_existing_capture_state_reports_written_artifact(tmp_path: Path) -> None
     write_capture_envelope(envelope, spool_path=tmp_path)
 
     state = existing_capture_state("chatgpt", "conv-123", spool_path=tmp_path)
+    typed = BrowserCaptureArchiveStatePayload.model_validate(state)
 
-    assert state["captured"] is True
-    assert state["provider"] == "chatgpt"
+    assert typed.captured is True
+    assert typed.provider == "chatgpt"
 
 
 def test_browser_capture_status_daemon_cli_json(cli_workspace: dict[str, Path]) -> None:
@@ -78,8 +85,9 @@ def test_browser_capture_status_daemon_cli_json(cli_workspace: dict[str, Path]) 
 
     assert result.exit_code == 0
     payload = json.loads(result.output)
+    typed = BrowserCaptureReceiverStatusPayload.model_validate(payload)
     assert payload["ok"] is True
-    assert payload["receiver"] == "polylogue-browser-capture"
+    assert typed.receiver == "polylogue-browser-capture"
 
 
 def test_receiver_http_accepts_capture_and_rejects_unknown_origin(tmp_path: Path) -> None:
@@ -92,8 +100,9 @@ def test_receiver_http_accepts_capture_and_rejects_unknown_origin(tmp_path: Path
         conn = HTTPConnection(host, port)
         conn.request("GET", "/v1/status", headers={"Origin": "https://evil.example"})
         response = conn.getresponse()
+        error = BrowserCaptureErrorPayload.model_validate(json.loads(response.read()))
         assert response.status == HTTPStatus.FORBIDDEN
-        response.read()
+        assert error.error == "origin_not_allowed"
         conn.close()
 
         conn = HTTPConnection(host, port)
@@ -104,10 +113,10 @@ def test_receiver_http_accepts_capture_and_rejects_unknown_origin(tmp_path: Path
             headers={"Content-Type": "application/json", "Origin": "https://chatgpt.com"},
         )
         response = conn.getresponse()
-        body = json.loads(response.read())
+        body = BrowserCaptureAcceptedPayload.model_validate(json.loads(response.read()))
         assert response.status == HTTPStatus.ACCEPTED
-        assert body["ok"] is True
-        assert Path(body["artifact_path"]).exists()
+        assert body.ok is True
+        assert Path(body.artifact_path).exists()
         conn.close()
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
Makes the browser-capture receiver endpoints return typed payload contracts for status, archive-state, accepted captures, and safe errors.

## Problem
#1824 asks for browser capture to be integrated into the same source/capture/status vocabulary instead of remaining a loose receiver island. The receiver had real behavior, auth/origin checks, and tests, but its `/v1/status`, `/v1/archive-state`, and `/v1/browser-captures` responses were ad hoc dicts rather than executable route payload contracts.

## Solution
- Added typed browser-capture receiver response models for status, archive-state, accepted-capture, and error payloads.
- Routed `receiver_status_payload`, `existing_capture_state`, and `BrowserCaptureHandler` responses through those models.
- Updated receiver tests to validate live CLI/HTTP responses against the typed payloads, including the origin-rejection error envelope.

This intentionally does not introduce a separate route registry. The actual receiver endpoints own the behavior and the typed models validate the transport shape.

## Verification
- `nix develop --command ruff format polylogue/browser_capture/models.py polylogue/browser_capture/receiver.py polylogue/browser_capture/server.py tests/unit/browser_capture/test_receiver.py`
- `nix develop --command ruff check polylogue/browser_capture/models.py polylogue/browser_capture/receiver.py polylogue/browser_capture/server.py tests/unit/browser_capture/test_receiver.py`
- `nix develop --command mypy polylogue/browser_capture/models.py polylogue/browser_capture/receiver.py polylogue/browser_capture/server.py tests/unit/browser_capture/test_receiver.py`
- `nix develop --command devtools test tests/unit/browser_capture/test_receiver.py tests/unit/browser_capture/test_receiver_contract.py` → 27 passed in 2.76s
- `nix develop --command devtools verify --quick` → exit_code 0

Ref #1824
Ref #1847