### PR TITLE
feat(insights): render review refs in work packets (#1838)

### DIFF
--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -532,7 +532,7 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         object_refs = _object_refs_line(entry)
         if object_refs:
             lines.append(f"  - refs: {object_refs}")
-        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "issue_refs", "test_evidence"))
+        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "review_refs", "issue_refs", "test_evidence"))
         if detail:
             lines.append(f"  - details: {detail}")
     if not event_entries:

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -397,6 +397,12 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
     pr_event = next(entry for entry in packet.entries if entry.section == "events" and entry.label == "pr_opened")
     assert pr_event.metadata == {"pr_refs": "#1911"}
     assert pr_event.object_refs == (ObjectRef(kind="github-pr", object_id="#1911"),)
+    review_event = next(
+        entry for entry in packet.entries if entry.section == "events" and entry.label == "review_acted_on"
+    )
+    assert review_event.metadata == {"review_refs": "#1911"}
+    assert review_event.object_refs == (ObjectRef(kind="github-review", object_id="#1911"),)
+    assert "review_refs=#1911" in rendered
     issue_event = next(entry for entry in packet.entries if entry.section == "events" and entry.label == "issue_closed")
     assert issue_event.metadata == {"issue_refs": "#1818"}
     assert issue_event.object_refs == (ObjectRef(kind="github-issue", object_id="#1818"),)


### PR DESCRIPTION
## Summary
Makes work-packet Markdown render review refs from recovery events, so review posted/read/acted-on evidence is visible in successor-agent handoffs.

## Problem
#1838 requires work packets to preserve review/check/read/addressing distinctions. #2104 added review delivery events and typed `github-review` refs, but the work-packet renderer still only printed PR refs, issue refs, and test evidence for event rows. Review refs were present in event metadata/object refs but not visible in the Markdown handoff.

## Solution
- Includes `review_refs` in work-packet event detail rendering.
- Extends the coding-agent fixture to assert `review_acted_on` carries `review_refs`, emits a `github-review` object ref, and renders the review ref in Markdown.

## Verification
- `nix develop --command ruff format polylogue/insights/transforms.py tests/unit/insights/test_transforms.py`
- `nix develop --command ruff check polylogue/insights/transforms.py tests/unit/insights/test_transforms.py`
- `nix develop --command mypy polylogue/insights/transforms.py tests/unit/insights/test_transforms.py`
- `nix develop --command devtools test tests/unit/insights/test_transforms.py -k 'work_packet or review'` → 4 passed, 12 deselected
- `nix develop --command devtools verify --quick` → exit_code 0

Ref #1838
Ref #1845