### PR TITLE
fix(devtools): expose pytest selection during verify

### DIFF
--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -1,4 +1,4 @@
-"""Incremental pytest event ledger for ``devtools verify``.
+"""Incremental pytest event and selection ledgers for ``devtools verify``.
 
 The pytest-json-report and JUnit artifacts are written at session end. When a
 long verify run is killed for timeout or output stall, those reports may never
@@ -18,6 +18,8 @@ from typing import Any
 import pytest
 
 _EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
+_SELECTION_ENV = "POLYLOGUE_PYTEST_SELECTION_PATH"
+_DESELECTED_NODEIDS: list[str] = []
 
 
 def _write_event(payload: dict[str, Any]) -> None:
@@ -33,6 +35,50 @@ def _write_event(payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _write_selection(payload: dict[str, Any]) -> None:
+    raw_path = os.environ.get(_SELECTION_ENV)
+    if not raw_path:
+        return
+    payload = {
+        "updated_at": datetime.now(UTC).isoformat(),
+        **payload,
+    }
+    path = Path(raw_path)
+    with contextlib.suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        tmp.replace(path)
+
+
+@pytest.hookimpl
+def pytest_deselected(items: list[Any]) -> None:
+    """Track deselected node IDs so the final selection artifact explains scope."""
+    _DESELECTED_NODEIDS.extend(str(getattr(item, "nodeid", item)) for item in items)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session: Any, config: Any, items: list[Any]) -> None:
+    """Write the final selected test set after pytest/testmon deselection."""
+    del config
+    selected_nodeids = [str(getattr(item, "nodeid", item)) for item in items]
+    _write_selection(
+        {
+            "selected_count": len(selected_nodeids),
+            "deselected_count": len(_DESELECTED_NODEIDS),
+            "selected_nodeids": selected_nodeids,
+            "deselected_nodeids": list(_DESELECTED_NODEIDS),
+        }
+    )
+    _write_event(
+        {
+            "event": "collection_finished",
+            "selected_count": len(selected_nodeids),
+            "deselected_count": len(_DESELECTED_NODEIDS),
+        }
+    )
 
 
 @pytest.hookimpl
@@ -61,10 +107,10 @@ def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str])
 
 @pytest.hookimpl
 def pytest_runtest_logreport(report: Any) -> None:
-    """Append one test-call event when configured by ``devtools verify``."""
+    """Append one phase report so slow setup/call/teardown remains visible."""
     when = str(getattr(report, "when", ""))
     outcome = str(getattr(report, "outcome", ""))
-    if when != "call" and outcome not in {"failed", "error"}:
+    if when not in {"setup", "call", "teardown"}:
         return
     payload = {
         "event": "test_report",

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -34,6 +34,7 @@ from devtools.verify import (
     PYTEST_EVENTS_PATH,
     PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
+    PYTEST_SELECTION_PATH,
     _clear_pytest_report,
     _run_pytest_with_heartbeat,
 )
@@ -49,6 +50,7 @@ def _managed_env() -> dict[str, str]:
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
+    env["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(ROOT / PYTEST_SELECTION_PATH)
     return env
 
 
@@ -122,6 +124,7 @@ def main(argv: list[str] | None = None) -> int:
     if result.stderr:
         sys.stderr.write(result.stderr)
     sys.stderr.write(
-        f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
+        f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} selection={PYTEST_SELECTION_PATH} "
+        f"events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
     )
     return result.returncode

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -140,6 +140,7 @@ PYTEST_JUNIT_REPORT_DIR = Path(".cache/test-reports")
 PYTEST_JUNIT_REPORT_PATH = PYTEST_JUNIT_REPORT_DIR / "verify-latest.xml"
 PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
 PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
+PYTEST_SELECTION_PATH = PYTEST_REPORT_DIR / "current-pytest-selection.json"
 PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
@@ -310,6 +311,7 @@ def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
         *_pytest_artifact_paths(cmd),
         PYTEST_PROGRESS_PATH,
         PYTEST_EVENTS_PATH,
+        PYTEST_SELECTION_PATH,
         PYTEST_OUTPUT_PATH,
     ):
         with contextlib.suppress(FileNotFoundError):
@@ -615,6 +617,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
         metadata["events_path"] = str(PYTEST_EVENTS_PATH)
+        metadata["selection_path"] = str(PYTEST_SELECTION_PATH)
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
         junit_paths = [
             str(path) for path in _pytest_artifact_paths(cmd) if path.suffix == ".xml" or path.name.endswith(".xml")
@@ -643,6 +646,14 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             termination_reason = progress.get("termination_reason")
             if isinstance(termination_reason, str):
                 metadata["termination_reason"] = termination_reason
+        selection = _read_json_artifact(PYTEST_SELECTION_PATH)
+        if selection is not None:
+            selected_count = selection.get("selected_count")
+            deselected_count = selection.get("deselected_count")
+            if isinstance(selected_count, int):
+                metadata["selected_count"] = selected_count
+            if isinstance(deselected_count, int):
+                metadata["deselected_count"] = deselected_count
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -660,6 +671,7 @@ def _subprocess_env() -> dict[str, str]:
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(Path.cwd() / PYTEST_EVENTS_PATH)
+    env["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(Path.cwd() / PYTEST_SELECTION_PATH)
     return env
 
 

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -33,11 +33,12 @@ def test_progress_plugin_records_call_and_setup_failures(
 
     events = [json.loads(line) for line in events_path.read_text().splitlines()]
     assert [(event["nodeid"], event["when"], event["outcome"]) for event in events] == [
+        ("test_ok", "setup", "passed"),
         ("test_body", "call", "passed"),
         ("test_setup", "setup", "failed"),
     ]
-    assert events[0]["duration_s"] == 0.25
-    assert events[1]["longrepr"] == "fixture exploded"
+    assert events[1]["duration_s"] == 0.25
+    assert events[2]["longrepr"] == "fixture exploded"
 
 
 def test_progress_plugin_records_node_start_and_finish(
@@ -63,3 +64,40 @@ def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.Monkey
     monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
 
     pytest_progress_plugin.pytest_runtest_logreport(_Report("test_body", "call", "failed", longrepr="boom"))
+
+
+class _Item:
+    def __init__(self, nodeid: str) -> None:
+        self.nodeid = nodeid
+
+
+class _Session:
+    def __init__(self, nodeids: list[str]) -> None:
+        self.items = [_Item(nodeid) for nodeid in nodeids]
+
+
+def test_progress_plugin_records_final_selected_nodes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_path = tmp_path / "events.jsonl"
+    selection_path = tmp_path / "selection.json"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", str(events_path))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SELECTION_PATH", str(selection_path))
+    pytest_progress_plugin._DESELECTED_NODEIDS.clear()
+
+    pytest_progress_plugin.pytest_deselected([_Item("tests/a.py::test_skip")])
+    pytest_progress_plugin.pytest_collection_modifyitems(
+        _Session(["tests/a.py::test_keep"]),
+        object(),
+        [_Item("tests/a.py::test_keep")],
+    )
+
+    selection = json.loads(selection_path.read_text())
+    assert selection["selected_count"] == 1
+    assert selection["deselected_count"] == 1
+    assert selection["selected_nodeids"] == ["tests/a.py::test_keep"]
+    assert selection["deselected_nodeids"] == ["tests/a.py::test_skip"]
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    assert events[-1]["event"] == "collection_finished"
+    assert events[-1]["selected_count"] == 1


### PR DESCRIPTION
## Summary

Adds explicit pytest selection observability to the managed `devtools verify` / `devtools test` harness. Slow or stalled runs now leave a `current-pytest-selection.json` artifact alongside the existing progress, event, and output ledgers.

## Problem

The harness could report the active pytest node and terminate stalled child process groups, but it did not preserve the selected/deselected node set or phase-level timing. That made it hard to distinguish a genuinely slow test from a bad testmon selection, expensive collection, or fixture/setup hang.

## Solution

The pytest progress plugin now writes `.cache/verify/current-pytest-selection.json` with selected and deselected node IDs, emits a collection summary event, and records setup/call/teardown reports instead of only call reports and failures. `devtools verify` and `devtools test` both pass the selection path through their managed environments and surface the artifact path in metadata/output.

## Verification

- `devtools test tests/unit/devtools/test_pytest_progress_plugin.py tests/unit/devtools/test_run_tests.py -n 0`
- `devtools test tests/unit/devtools/test_pytest_progress_plugin.py -k records_node -n 0` and read back `.cache/verify/current-pytest-selection.json`
- `ruff format --check devtools/pytest_progress_plugin.py devtools/verify.py devtools/run_tests.py tests/unit/devtools/test_pytest_progress_plugin.py`
- `ruff check devtools/pytest_progress_plugin.py devtools/verify.py devtools/run_tests.py tests/unit/devtools/test_pytest_progress_plugin.py`
- `devtools verify --quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test selection diagnostics tracking with counts of selected and deselected tests
  * Enhanced test reporting to capture all test phases (setup, call, teardown) with outcomes and timing
  * Selection metadata now included in verification results and notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->