### PR TITLE
feat(query): expose observed-events terminal unit (#2006)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -965,6 +965,66 @@ components:
       - text
       title: MessageQueryRowPayload
       type: object
+    ObservedEventQueryRowPayload:
+      additionalProperties: false
+      description: Shared terminal-query row for runtime-transform observed events.
+      properties:
+        unit:
+          const: observed-event
+          default: observed-event
+          title: Unit
+          type: string
+        event_ref:
+          title: Event Ref
+          type: string
+        session_id:
+          title: Session Id
+          type: string
+        origin:
+          title: Origin
+          type: string
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Title
+        kind:
+          title: Kind
+          type: string
+        summary:
+          title: Summary
+          type: string
+        delivery_state:
+          title: Delivery State
+          type: string
+        subject_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Subject Ref
+        object_refs:
+          items:
+            type: string
+          title: Object Refs
+          type: array
+        evidence_refs:
+          items:
+            type: string
+          title: Evidence Refs
+          type: array
+      required:
+      - event_ref
+      - session_id
+      - origin
+      - kind
+      - summary
+      - delivery_state
+      - object_refs
+      - evidence_refs
+      title: ObservedEventQueryRowPayload
+      type: object
     QueryUnitEnvelope:
       additionalProperties: false
       description: Shared envelope for explicit terminal unit-source query results.
@@ -980,6 +1040,7 @@ components:
           - action
           - block
           - assertion
+          - observed-event
           title: Unit
           type: string
         query:
@@ -992,6 +1053,7 @@ components:
             - $ref: '#/components/schemas/ActionQueryRowPayload'
             - $ref: '#/components/schemas/BlockQueryRowPayload'
             - $ref: '#/components/schemas/AssertionQueryRowPayload'
+            - $ref: '#/components/schemas/ObservedEventQueryRowPayload'
           title: Items
           type: array
         total:

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -422,6 +422,92 @@
       ],
       "title": "MessageQueryRowPayload",
       "type": "object"
+    },
+    "ObservedEventQueryRowPayload": {
+      "additionalProperties": false,
+      "description": "Shared terminal-query row for runtime-transform observed events.",
+      "properties": {
+        "delivery_state": {
+          "title": "Delivery State",
+          "type": "string"
+        },
+        "event_ref": {
+          "title": "Event Ref",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "object_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Object Refs",
+          "type": "array"
+        },
+        "origin": {
+          "title": "Origin",
+          "type": "string"
+        },
+        "session_id": {
+          "title": "Session Id",
+          "type": "string"
+        },
+        "subject_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subject Ref"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "unit": {
+          "const": "observed-event",
+          "default": "observed-event",
+          "title": "Unit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "event_ref",
+        "session_id",
+        "origin",
+        "kind",
+        "summary",
+        "delivery_state",
+        "object_refs",
+        "evidence_refs"
+      ],
+      "title": "ObservedEventQueryRowPayload",
+      "type": "object"
     }
   },
   "$id": "https://polylogue.dev/schemas/cli-output/query-unit-envelope.schema.json",
@@ -443,6 +529,9 @@
           },
           {
             "$ref": "#/$defs/AssertionQueryRowPayload"
+          },
+          {
+            "$ref": "#/$defs/ObservedEventQueryRowPayload"
           }
         ]
       },
@@ -488,7 +577,8 @@
         "message",
         "action",
         "block",
-        "assertion"
+        "assertion",
+        "observed-event"
       ],
       "title": "Unit",
       "type": "string"

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -92,6 +92,7 @@ from polylogue.archive.query.metadata import (
     _BLOCK_STRUCTURAL_FIELDS,
     _BOOLEAN_SUPPORTED_FIELDS,
     _MESSAGE_STRUCTURAL_FIELDS,
+    _OBSERVED_EVENT_STRUCTURAL_FIELDS,
     _SOURCE_WHERE_SOURCES,
     _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS,
     COUNT_QUERY_FIELD_REGISTRY,
@@ -713,8 +714,11 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         elif unit == "block":
             supported = _BLOCK_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
-        else:
+        elif unit == "assertion":
             supported = _ASSERTION_STRUCTURAL_FIELDS
+            effective_field = session_field or predicate.field
+        else:
+            supported = _OBSERVED_EVENT_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
         if session_field is not None and unit != "session":
             supported = _BOOLEAN_SUPPORTED_FIELDS
@@ -749,6 +753,12 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 "value",
                 "evidence",
                 "context",
+                "delivery_state",
+                "subject",
+                "subject_ref",
+                "object",
+                "object_ref",
+                "summary",
             }
             and not predicate.values
         ):
@@ -885,7 +895,9 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
         unit_value = str(unit).lower()
         if unit_value not in {"message", "action", "block", "assertion"}:
             raise ExpressionCompileError(f"unsupported structural query unit {unit_value!r}", field=None)
-        return QueryExistsPredicate(unit=cast(QueryUnitName, unit_value), child=child)
+        return QueryExistsPredicate(
+            unit=cast(Literal["message", "action", "block", "assertion"], unit_value), child=child
+        )
 
     def sequence_step(self, token: Token) -> QueryPredicate:
         predicate = _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
@@ -949,6 +961,8 @@ def _source_where_unit(source: str) -> QueryUnitName:
         return "block"
     if normalized in {"assertion", "assertions"}:
         return "assertion"
+    if normalized in {"observed-event", "observed-events"}:
+        return "observed-event"
     raise ExpressionCompileError(f"unsupported query source {source!r}", field=None)
 
 
@@ -1018,6 +1032,8 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
 def _parse_source_where_predicate(expression: str) -> QueryExistsPredicate | None:
     source = parse_unit_source_expression(expression)
     if source is None:
+        return None
+    if source.unit == "observed-event":
         return None
     return QueryExistsPredicate(unit=source.unit, child=source.predicate)
 
@@ -1297,15 +1313,20 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
         )
     unit_source = parse_unit_source_expression(stripped)
     if unit_source is not None:
-        lowered = SessionQuerySpec(
-            boolean_predicate=QueryExistsPredicate(unit=unit_source.unit, child=unit_source.predicate)
+        lowered = (
+            SessionQuerySpec()
+            if unit_source.unit == "observed-event"
+            else SessionQuerySpec(
+                boolean_predicate=QueryExistsPredicate(unit=unit_source.unit, child=unit_source.predicate)
+            )
         )
         selected_units = (unit_source.unit,)
         execution_legs = _explain_unit_source_execution_legs(unit_source)
-        plan_description = (
-            f"terminal unit source: {unit_source.unit}",
-            f"compatibility session selector: exists {unit_source.unit}(...)",
-        )
+        plan_description = (f"terminal unit source: {unit_source.unit}",)
+        compatibility_selector = None
+        if unit_source.unit != "observed-event":
+            compatibility_selector = f"exists {unit_source.unit}(...)"
+            plan_description = (*plan_description, f"compatibility session selector: {compatibility_selector}")
         lowerer = "lark-query-unit-source-to-terminal-unit"
         return QueryExpressionExplanation(
             source_text=source_text,
@@ -1322,7 +1343,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
                 selected_units=selected_units,
                 execution_legs=execution_legs,
                 plan_description=plan_description,
-                compatibility_selector=f"exists {unit_source.unit}(...)",
+                compatibility_selector=compatibility_selector,
             ),
         )
     ast = parse_expression_ast(stripped)

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-QueryUnitName = Literal["message", "action", "block", "assertion"]
+QueryUnitName = Literal["message", "action", "block", "assertion", "observed-event"]
 
 #: Recognized DSL field tokens and a short human description.
 #: ``spec_field`` values correspond to :class:`~polylogue.archive.query.spec.SessionQuerySpec`
@@ -134,6 +134,8 @@ _SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = (
     ("blocks", "block"),
     ("assertion", "assertion"),
     ("assertions", "assertion"),
+    ("observed-event", "observed-event"),
+    ("observed-events", "observed-event"),
 )
 _BOOLEAN_SUPPORTED_FIELDS = {
     "repo",
@@ -185,7 +187,19 @@ _ASSERTION_STRUCTURAL_FIELDS = {
     "evidence",
     "context",
 }
+_OBSERVED_EVENT_STRUCTURAL_FIELDS = {
+    "kind",
+    "summary",
+    "text",
+    "delivery_state",
+    "subject",
+    "subject_ref",
+    "object",
+    "object_ref",
+    "evidence",
+}
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_ASSERTION_STRUCTURAL_FIELDS)
+_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_OBSERVED_EVENT_STRUCTURAL_FIELDS)
 
 
 @dataclass(frozen=True)
@@ -261,6 +275,22 @@ _ASSERTION_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "visibility": _field_info("visibility", "Assertion visibility.", "visibility:private"),
 }
 
+_OBSERVED_EVENT_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
+    "delivery_state": _field_info(
+        "delivery_state",
+        "Observed-event delivery state, such as acted_on or acknowledged.",
+        "delivery_state:acted_on",
+    ),
+    "evidence": _field_info("evidence", "Observed-event evidence ref substring.", "evidence:message:"),
+    "kind": _field_info("kind", "Observed-event kind.", "kind:review_acted_on"),
+    "object": _field_info("object", "Observed-event object ref substring.", "object:#2100"),
+    "object_ref": _field_info("object_ref", "Observed-event object ref substring.", "object_ref:github-review:#2100"),
+    "subject": _field_info("subject", "Observed-event subject ref substring.", "subject:message"),
+    "subject_ref": _field_info("subject_ref", "Observed-event subject ref substring.", "subject_ref:message:"),
+    "summary": _field_info("summary", "Observed-event summary substring.", "summary:review"),
+    "text": _field_info("text", "Observed-event summary/ref substring.", "text:review"),
+}
+
 _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "action": "session.action:file_edit",
     "cwd": "session.cwd:/realm/project",
@@ -308,6 +338,11 @@ def _assertion_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
     return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
 
 
+def _observed_event_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
+    infos = [_OBSERVED_EVENT_STRUCTURAL_FIELD_INFO[name] for name in sorted(_OBSERVED_EVENT_STRUCTURAL_FIELDS)]
+    return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+
+
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
@@ -328,6 +363,11 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
         description="Match sessions with at least one session-targeted assertion satisfying the child predicate.",
         fields=_assertion_field_infos(),
         example="exists assertion(kind:decision AND status:active AND text:review)",
+    ),
+    "observed-event": StructuralQueryUnitInfo(
+        description="Return runtime-transform observed events satisfying the child predicate.",
+        fields=_observed_event_field_infos(),
+        example="observed-events where session.repo:polylogue AND delivery_state:acted_on",
     ),
 }
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, cast
 
+from polylogue.archive.query.archive_execution import _session_to_session
 from polylogue.archive.query.expression import QueryUnitSource
+from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate, QueryNotPredicate, QueryPredicate
 from polylogue.archive.query.spec import (
     normalize_action_sequence,
     normalize_action_terms,
@@ -15,12 +18,16 @@ from polylogue.archive.query.spec import (
     parse_query_date,
     split_csv,
 )
-from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.core.refs import EvidenceRef, ObjectRef
+from polylogue.insights.run_projection import ObservedEvent
+from polylogue.insights.transforms import compile_recovery_digest
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary, ArchiveStore
 from polylogue.surfaces.payloads import (
     ActionQueryRowPayload,
     AssertionQueryRowPayload,
     BlockQueryRowPayload,
     MessageQueryRowPayload,
+    ObservedEventQueryRowPayload,
     QueryUnitEnvelope,
     build_query_unit_envelope,
 )
@@ -100,6 +107,135 @@ def query_unit_session_filters(**params: object) -> dict[str, object]:
     }
 
 
+def _object_ref_text(ref: ObjectRef | None) -> str | None:
+    return ref.format() if ref is not None else None
+
+
+def _evidence_ref_text(ref: EvidenceRef) -> str:
+    return ref.format()
+
+
+def _contains_value(haystacks: Iterable[str | None], needles: Sequence[str]) -> bool:
+    if not needles:
+        return True
+    lowered_haystacks = [value.lower() for value in haystacks if value]
+    return any(any(needle.lower() in haystack for haystack in lowered_haystacks) for needle in needles)
+
+
+def _exact_or_contains(value: str | None, needles: Sequence[str], *, exact: bool = False) -> bool:
+    if not needles:
+        return True
+    if value is None:
+        return False
+    lowered = value.lower()
+    if exact:
+        return any(lowered == needle.lower() for needle in needles)
+    return any(needle.lower() in lowered for needle in needles)
+
+
+def _summary_field_matches(summary: ArchiveSessionSummary, field: str, values: Sequence[str]) -> bool:
+    if field == "id":
+        return _exact_or_contains(str(summary.session_id), values)
+    if field == "origin":
+        return _exact_or_contains(str(summary.origin), values, exact=True)
+    if field == "repo":
+        return _exact_or_contains(summary.git_repository_url, values)
+    if field == "title":
+        return _exact_or_contains(summary.title, values)
+    return True
+
+
+def _observed_event_field_matches(
+    event: ObservedEvent,
+    summary: ArchiveSessionSummary,
+    predicate: QueryFieldPredicate,
+) -> bool:
+    field = predicate.field
+    if field.startswith("session."):
+        return _summary_field_matches(summary, field.removeprefix("session."), predicate.values)
+    if field == "kind":
+        return _exact_or_contains(event.kind, predicate.values, exact=True)
+    if field == "delivery_state":
+        return _exact_or_contains(event.delivery_state, predicate.values, exact=True)
+    if field == "summary":
+        return _contains_value((event.summary,), predicate.values)
+    if field == "text":
+        return _contains_value(
+            (
+                event.summary,
+                _object_ref_text(event.subject_ref),
+                *(_object_ref_text(ref) for ref in event.object_refs),
+                *(_evidence_ref_text(ref) for ref in event.evidence_refs),
+            ),
+            predicate.values,
+        )
+    if field in {"subject", "subject_ref"}:
+        return _contains_value((_object_ref_text(event.subject_ref),), predicate.values)
+    if field in {"object", "object_ref"}:
+        return _contains_value((_object_ref_text(ref) for ref in event.object_refs), predicate.values)
+    if field == "evidence":
+        return _contains_value((_evidence_ref_text(ref) for ref in event.evidence_refs), predicate.values)
+    return False
+
+
+def _observed_event_matches(
+    event: ObservedEvent,
+    summary: ArchiveSessionSummary,
+    predicate: QueryPredicate,
+) -> bool:
+    if isinstance(predicate, QueryFieldPredicate):
+        return _observed_event_field_matches(event, summary, predicate)
+    if isinstance(predicate, QueryNotPredicate):
+        return not _observed_event_matches(event, summary, predicate.child)
+    if isinstance(predicate, QueryBoolPredicate):
+        if predicate.op == "and":
+            return all(_observed_event_matches(event, summary, child) for child in predicate.children)
+        return any(_observed_event_matches(event, summary, child) for child in predicate.children)
+    return False
+
+
+def _observed_event_row(summary: ArchiveSessionSummary, event: ObservedEvent) -> ObservedEventQueryRowPayload:
+    return ObservedEventQueryRowPayload(
+        event_ref=event.event_ref.format(),
+        session_id=str(summary.session_id),
+        origin=str(summary.origin),
+        title=summary.title,
+        kind=event.kind,
+        summary=event.summary,
+        delivery_state=event.delivery_state,
+        subject_ref=_object_ref_text(event.subject_ref),
+        object_refs=tuple(ref.format() for ref in event.object_refs),
+        evidence_refs=tuple(ref.format() for ref in event.evidence_refs),
+    )
+
+
+def _query_observed_events(
+    archive: ArchiveStore,
+    source: QueryUnitSource,
+    *,
+    limit: int,
+    offset: int,
+    session_filters: Mapping[str, object] | None,
+) -> tuple[ObservedEventQueryRowPayload, ...]:
+    rows: list[ObservedEventQueryRowPayload] = []
+    target_count = limit + 1
+    skipped = 0
+    summaries = cast(Any, archive.list_summaries)(limit=1_000_000, **dict(session_filters or {}))
+    for summary in summaries:
+        session = _session_to_session(archive.read_session(str(summary.session_id)))
+        digest = compile_recovery_digest(session)
+        for event in digest.run_projection.events:
+            if not _observed_event_matches(event, summary, source.predicate):
+                continue
+            if skipped < offset:
+                skipped += 1
+                continue
+            rows.append(_observed_event_row(summary, event))
+            if len(rows) >= target_count:
+                return tuple(rows)
+    return tuple(rows)
+
+
 def query_unit_rows(
     archive: ArchiveStore,
     source: QueryUnitSource,
@@ -112,6 +248,22 @@ def query_unit_rows(
     """Execute an explicit unit-source query."""
 
     fetch_limit = limit + 1
+    if source.unit == "observed-event":
+        event_rows = _query_observed_events(
+            archive,
+            source,
+            limit=limit,
+            offset=offset,
+            session_filters=session_filters,
+        )
+        return build_query_unit_envelope(
+            event_rows[:limit],
+            unit=source.unit,
+            query=query,
+            limit=limit,
+            offset=offset,
+            has_next=len(event_rows) > limit,
+        )
     if source.unit == "message":
         message_rows = archive.query_messages(
             source.predicate,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -829,7 +829,7 @@ class SearchEnvelope(SurfacePayloadModel):
     diagnostics: QueryMissDiagnosticsPayload | None = None
 
 
-QueryUnitKind: TypeAlias = Literal["message", "action", "block", "assertion"]
+QueryUnitKind: TypeAlias = Literal["message", "action", "block", "assertion", "observed-event"]
 """Terminal query source unit exposed by query-unit envelopes."""
 
 
@@ -973,8 +973,28 @@ class AssertionQueryRowPayload(SurfacePayloadModel):
         )
 
 
+class ObservedEventQueryRowPayload(SurfacePayloadModel):
+    """Shared terminal-query row for runtime-transform observed events."""
+
+    unit: Literal["observed-event"] = "observed-event"
+    event_ref: str
+    session_id: str
+    origin: str
+    title: str | None = None
+    kind: str
+    summary: str
+    delivery_state: str
+    subject_ref: str | None = None
+    object_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+
+
 QueryUnitRowPayload: TypeAlias = (
-    MessageQueryRowPayload | ActionQueryRowPayload | BlockQueryRowPayload | AssertionQueryRowPayload
+    MessageQueryRowPayload
+    | ActionQueryRowPayload
+    | BlockQueryRowPayload
+    | AssertionQueryRowPayload
+    | ObservedEventQueryRowPayload
 )
 """Union of terminal row payloads returned by explicit unit-source queries."""
 
@@ -1611,6 +1631,7 @@ __all__ = [
     "QueryUnitRowPayload",
     "QueryMissDiagnosticsPayload",
     "QueryMissReasonPayload",
+    "ObservedEventQueryRowPayload",
     "RANKING_POLICY_MIXED",
     "RANKING_POLICY_VERSION",
     "ReaderActionAvailabilityPayload",

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -449,6 +449,28 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_parse_observed_event_source_expression_preserves_terminal_unit(self) -> None:
+        source = parse_unit_source_expression(
+            "observed-events where session.repo:polylogue AND delivery_state:acted_on AND text:#2100"
+        )
+
+        assert source is not None
+        assert source.unit == "observed-event"
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="session.repo", values=("polylogue",)),
+                QueryFieldPredicate(field="delivery_state", values=("acted_on",)),
+                QueryFieldPredicate(field="text", values=("#2100",)),
+            ),
+        )
+        explanation = explain_expression(
+            "observed-events where session.repo:polylogue AND delivery_state:acted_on AND text:#2100"
+        )
+        assert explanation.selected_units == ("observed-event",)
+        assert explanation.lowering_plan is not None
+        assert "compatibility_selector" not in explanation.lowering_plan
+
     def test_action_source_where_lowers_to_structural_exists(self) -> None:
         ast = parse_expression_ast("actions where action:file_edit AND path:archive/query")
 
@@ -1220,6 +1242,55 @@ class TestBooleanQueryExpression:
         assert rows[0].evidence_refs == ("session:codex-session:ext-hit#message:m-hit",)
         assert rows[0].staleness == {"policy": "manual"}
         assert rows[0].context_policy == {"inject": False}
+
+    def test_terminal_observed_event_source_returns_runtime_rows(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import ObservedEventQueryRowPayload
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .title("review handled")
+            .add_message("m-hit", role="assistant", text="Addressed review on PR #2100")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-repo")
+            .provider("codex")
+            .git_repository_url("sinex")
+            .title("review elsewhere")
+            .add_message("m-wrong-repo", role="assistant", text="Addressed review on PR #2100")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "observed-events where session.repo:polylogue AND delivery_state:acted_on AND text:#2100"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(archive_root) as archive:
+            envelope = query_unit_rows(
+                archive,
+                source,
+                query="observed-events where session.repo:polylogue AND delivery_state:acted_on AND text:#2100",
+                limit=10,
+            )
+
+        assert envelope.unit == "observed-event"
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        assert isinstance(row, ObservedEventQueryRowPayload)
+        assert (row.kind, row.delivery_state, row.session_id) == (
+            "review_acted_on",
+            "acted_on",
+            "codex-session:ext-hit",
+        )
+        assert row.object_refs == ("github-review:#2100",)
+        assert row.evidence_refs == ("codex-session:ext-hit::codex-session:ext-hit:m-hit",)
 
     def test_exists_block_tool_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary

Adds `observed-events where ...` as a real terminal query-unit source. The DSL can now return runtime-transform observed-event rows, including review delivery events from the #1882 projection, through the existing `QueryUnitEnvelope` surfaces.

## Problem

The query DSL had terminal row execution for messages, actions, blocks, and assertions, but run/ObservedEvent evidence remained reachable only through recovery/work-packet transforms. That left review/check/run events disconnected from query-unit API/daemon/MCP/CLI surfaces and kept #2006's unit-source graph incomplete.

## Solution

`observed-event` is now a terminal source in the query metadata and parser context. `query_unit_rows` derives run projections from matching archive sessions, filters events by event fields plus `session.*` scope, and returns typed `ObservedEventQueryRowPayload` rows. The payload union and generated CLI/OpenAPI schemas were regenerated. The session-selector form `exists observed-event(...)` is intentionally not accepted in this PR because observed events are transform-derived rather than indexed SQL rows; accepting it before a materialized/session lowerer exists would be parser-only vocabulary.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k observed_event -n 0`
- `devtools verify --quick`