### PR TITLE
fix(devtools): expose pytest collection and phase timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,9 +497,12 @@ full-suite pass is expected and supervised.
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect
 `.cache/verify/current-pytest-progress.json`,
+`.cache/verify/current-pytest-selection.json`,
+`.cache/verify/current-pytest-summary.json`,
 `.cache/verify/current-pytest-events.jsonl`, and
 `.cache/verify/current-pytest-output.log` to see the active/latest test node,
-captured output, and termination reason if a focused run stalls.
+selected/deselected node IDs, collection duration, slowest setup/call/teardown
+phases, captured output, and termination reason if a focused run stalls.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -76,9 +76,12 @@ full-suite pass is expected and supervised.
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect
 `.cache/verify/current-pytest-progress.json`,
+`.cache/verify/current-pytest-selection.json`,
+`.cache/verify/current-pytest-summary.json`,
 `.cache/verify/current-pytest-events.jsonl`, and
 `.cache/verify/current-pytest-output.log` to see the active/latest test node,
-captured output, and termination reason if a focused run stalls.
+selected/deselected node IDs, collection duration, slowest setup/call/teardown
+phases, captured output, and termination reason if a focused run stalls.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,13 @@ import pytest
 
 _EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
 _SELECTION_ENV = "POLYLOGUE_PYTEST_SELECTION_PATH"
+_SUMMARY_ENV = "POLYLOGUE_PYTEST_SUMMARY_PATH"
 _DESELECTED_NODEIDS: list[str] = []
+_SELECTED_NODEIDS: list[str] = []
+_SLOWEST_REPORTS: list[dict[str, Any]] = []
+_COLLECTION_STARTED_AT: float | None = None
+_COLLECTION_DURATION_S: float | None = None
+_SLOW_REPORT_LIMIT = 20
 
 
 def _write_event(payload: dict[str, Any]) -> None:
@@ -53,6 +60,49 @@ def _write_selection(payload: dict[str, Any]) -> None:
         tmp.replace(path)
 
 
+def _write_summary(payload: dict[str, Any]) -> None:
+    raw_path = os.environ.get(_SUMMARY_ENV)
+    if not raw_path:
+        return
+    payload = {
+        "updated_at": datetime.now(UTC).isoformat(),
+        **payload,
+    }
+    path = Path(raw_path)
+    with contextlib.suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        tmp.replace(path)
+
+
+def _remember_report(payload: dict[str, Any]) -> None:
+    _SLOWEST_REPORTS.append(payload)
+    _SLOWEST_REPORTS.sort(key=lambda item: float(item.get("duration_s", 0.0)), reverse=True)
+    del _SLOWEST_REPORTS[_SLOW_REPORT_LIMIT:]
+
+
+@pytest.hookimpl
+def pytest_sessionstart(session: Any) -> None:
+    """Reset per-session ledgers when tests invoke pytest in-process."""
+    del session
+    global _COLLECTION_STARTED_AT, _COLLECTION_DURATION_S
+    _DESELECTED_NODEIDS.clear()
+    _SELECTED_NODEIDS.clear()
+    _SLOWEST_REPORTS.clear()
+    _COLLECTION_STARTED_AT = None
+    _COLLECTION_DURATION_S = None
+
+
+@pytest.hookimpl
+def pytest_collection(session: Any) -> None:
+    """Record collection start so selected-test runs expose import/collection cost."""
+    del session
+    global _COLLECTION_STARTED_AT
+    _COLLECTION_STARTED_AT = time.monotonic()
+    _write_event({"event": "collection_started"})
+
+
 @pytest.hookimpl
 def pytest_deselected(items: list[Any]) -> None:
     """Track deselected node IDs so the final selection artifact explains scope."""
@@ -63,20 +113,26 @@ def pytest_deselected(items: list[Any]) -> None:
 def pytest_collection_modifyitems(session: Any, config: Any, items: list[Any]) -> None:
     """Write the final selected test set after pytest/testmon deselection."""
     del config
+    global _COLLECTION_DURATION_S
+    if _COLLECTION_STARTED_AT is not None:
+        _COLLECTION_DURATION_S = round(time.monotonic() - _COLLECTION_STARTED_AT, 4)
     selected_nodeids = [str(getattr(item, "nodeid", item)) for item in items]
-    _write_selection(
-        {
-            "selected_count": len(selected_nodeids),
-            "deselected_count": len(_DESELECTED_NODEIDS),
-            "selected_nodeids": selected_nodeids,
-            "deselected_nodeids": list(_DESELECTED_NODEIDS),
-        }
-    )
+    _SELECTED_NODEIDS[:] = selected_nodeids
+    payload: dict[str, Any] = {
+        "selected_count": len(selected_nodeids),
+        "deselected_count": len(_DESELECTED_NODEIDS),
+        "selected_nodeids": selected_nodeids,
+        "deselected_nodeids": list(_DESELECTED_NODEIDS),
+    }
+    if _COLLECTION_DURATION_S is not None:
+        payload["collection_duration_s"] = _COLLECTION_DURATION_S
+    _write_selection(payload)
     _write_event(
         {
             "event": "collection_finished",
             "selected_count": len(selected_nodeids),
             "deselected_count": len(_DESELECTED_NODEIDS),
+            **({"duration_s": _COLLECTION_DURATION_S} if _COLLECTION_DURATION_S is not None else {}),
         }
     )
 
@@ -121,4 +177,20 @@ def pytest_runtest_logreport(report: Any) -> None:
     }
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
+    _remember_report(payload)
     _write_event(payload)
+
+
+@pytest.hookimpl
+def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
+    """Write a compact post-run diagnosis artifact independent of pytest-json-report."""
+    del session
+    payload: dict[str, Any] = {
+        "exitstatus": int(exitstatus),
+        "selected_count": len(_SELECTED_NODEIDS),
+        "deselected_count": len(_DESELECTED_NODEIDS),
+        "slowest_reports": list(_SLOWEST_REPORTS),
+    }
+    if _COLLECTION_DURATION_S is not None:
+        payload["collection_duration_s"] = _COLLECTION_DURATION_S
+    _write_summary(payload)

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -35,6 +35,7 @@ from devtools.verify import (
     PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
     PYTEST_SELECTION_PATH,
+    PYTEST_SUMMARY_PATH,
     _clear_pytest_report,
     _run_pytest_with_heartbeat,
 )
@@ -51,6 +52,7 @@ def _managed_env() -> dict[str, str]:
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
     env["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(ROOT / PYTEST_SELECTION_PATH)
+    env["POLYLOGUE_PYTEST_SUMMARY_PATH"] = str(ROOT / PYTEST_SUMMARY_PATH)
     return env
 
 
@@ -125,6 +127,6 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(result.stderr)
     sys.stderr.write(
         f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} selection={PYTEST_SELECTION_PATH} "
-        f"events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
+        f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
     )
     return result.returncode

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -141,6 +141,7 @@ PYTEST_JUNIT_REPORT_PATH = PYTEST_JUNIT_REPORT_DIR / "verify-latest.xml"
 PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
 PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
 PYTEST_SELECTION_PATH = PYTEST_REPORT_DIR / "current-pytest-selection.json"
+PYTEST_SUMMARY_PATH = PYTEST_REPORT_DIR / "current-pytest-summary.json"
 PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
@@ -312,6 +313,7 @@ def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
         PYTEST_PROGRESS_PATH,
         PYTEST_EVENTS_PATH,
         PYTEST_SELECTION_PATH,
+        PYTEST_SUMMARY_PATH,
         PYTEST_OUTPUT_PATH,
     ):
         with contextlib.suppress(FileNotFoundError):
@@ -618,6 +620,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
         metadata["events_path"] = str(PYTEST_EVENTS_PATH)
         metadata["selection_path"] = str(PYTEST_SELECTION_PATH)
+        metadata["summary_path"] = str(PYTEST_SUMMARY_PATH)
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
         junit_paths = [
             str(path) for path in _pytest_artifact_paths(cmd) if path.suffix == ".xml" or path.name.endswith(".xml")
@@ -654,6 +657,14 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
                 metadata["selected_count"] = selected_count
             if isinstance(deselected_count, int):
                 metadata["deselected_count"] = deselected_count
+            collection_duration_s = selection.get("collection_duration_s")
+            if isinstance(collection_duration_s, (int, float)):
+                metadata["collection_duration_s"] = collection_duration_s
+        summary = _read_json_artifact(PYTEST_SUMMARY_PATH)
+        if summary is not None:
+            slowest_reports = summary.get("slowest_reports")
+            if isinstance(slowest_reports, list):
+                metadata["slowest_report_count"] = len(slowest_reports)
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -672,6 +683,7 @@ def _subprocess_env() -> dict[str, str]:
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(Path.cwd() / PYTEST_EVENTS_PATH)
     env["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(Path.cwd() / PYTEST_SELECTION_PATH)
+    env["POLYLOGUE_PYTEST_SUMMARY_PATH"] = str(Path.cwd() / PYTEST_SUMMARY_PATH)
     return env
 
 

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from devtools import pytest_progress_plugin
+
+
+@pytest.fixture(autouse=True)
+def _restore_plugin_state() -> Iterator[None]:
+    selected_nodeids = list(pytest_progress_plugin._SELECTED_NODEIDS)
+    deselected_nodeids = list(pytest_progress_plugin._DESELECTED_NODEIDS)
+    slowest_reports = list(pytest_progress_plugin._SLOWEST_REPORTS)
+    collection_started_at = pytest_progress_plugin._COLLECTION_STARTED_AT
+    collection_duration_s = pytest_progress_plugin._COLLECTION_DURATION_S
+    yield
+    pytest_progress_plugin._SELECTED_NODEIDS[:] = selected_nodeids
+    pytest_progress_plugin._DESELECTED_NODEIDS[:] = deselected_nodeids
+    pytest_progress_plugin._SLOWEST_REPORTS[:] = slowest_reports
+    pytest_progress_plugin._COLLECTION_STARTED_AT = collection_started_at
+    pytest_progress_plugin._COLLECTION_DURATION_S = collection_duration_s
 
 
 @dataclass(frozen=True)
@@ -101,3 +117,41 @@ def test_progress_plugin_records_final_selected_nodes(
     events = [json.loads(line) for line in events_path.read_text().splitlines()]
     assert events[-1]["event"] == "collection_finished"
     assert events[-1]["selected_count"] == 1
+
+
+def test_progress_plugin_records_collection_duration_and_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_path = tmp_path / "events.jsonl"
+    selection_path = tmp_path / "selection.json"
+    summary_path = tmp_path / "summary.json"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", str(events_path))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SELECTION_PATH", str(selection_path))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SUMMARY_PATH", str(summary_path))
+    ticks = iter([10.0, 12.5])
+    monkeypatch.setattr("devtools.pytest_progress_plugin.time.monotonic", lambda: next(ticks))
+
+    pytest_progress_plugin.pytest_sessionstart(object())
+    pytest_progress_plugin.pytest_collection(object())
+    pytest_progress_plugin.pytest_deselected([_Item("tests/a.py::test_skip")])
+    pytest_progress_plugin.pytest_collection_modifyitems(
+        _Session(["tests/a.py::test_keep"]),
+        object(),
+        [_Item("tests/a.py::test_keep")],
+    )
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test_slow", "setup", "passed", duration=1.5))
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test_fast", "call", "passed", duration=0.1))
+    pytest_progress_plugin.pytest_sessionfinish(object(), 0)
+
+    selection = json.loads(selection_path.read_text())
+    assert selection["collection_duration_s"] == 2.5
+    summary = json.loads(summary_path.read_text())
+    assert summary["collection_duration_s"] == 2.5
+    assert summary["selected_count"] == 1
+    assert summary["deselected_count"] == 1
+    assert [report["nodeid"] for report in summary["slowest_reports"]] == ["test_slow", "test_fast"]
+    events = [json.loads(line) for line in events_path.read_text().splitlines()]
+    assert events[0]["event"] == "collection_started"
+    assert events[1]["event"] == "collection_finished"
+    assert events[1]["duration_s"] == 2.5

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 
 from devtools import run_tests
-from devtools.verify import PYTEST_EVENTS_PATH
+from devtools.verify import PYTEST_EVENTS_PATH, PYTEST_SELECTION_PATH, PYTEST_SUMMARY_PATH
 
 
 def test_build_pytest_cmd_defaults_to_single_process() -> None:
@@ -47,11 +47,14 @@ def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None
         return type("Result", (), {"returncode": 0, "stderr": ""})()
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
+    monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
     assert captured["env"]["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
+    assert captured["env"]["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / PYTEST_SELECTION_PATH)
+    assert captured["env"]["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / PYTEST_SUMMARY_PATH)
 
 
 def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,6 +62,7 @@ def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
         return type("Result", (), {"returncode": 5, "stderr": ""})()
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
+    monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
 
@@ -69,4 +73,6 @@ def test_managed_env_sets_repo_roots() -> None:
     assert env["POLYLOGUE_REPO_ROOT"] == str(run_tests.ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(run_tests.ROOT / ".cache" / "pycache")
     assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
+    assert env["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / PYTEST_SELECTION_PATH)
+    assert env["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / PYTEST_SUMMARY_PATH)
     assert Path(env["POLYLOGUE_ROOT"]).is_dir()


### PR DESCRIPTION
## Summary

Expose enough pytest harness evidence to distinguish slow collection, broad deselection, and genuinely slow setup/call/teardown phases during `devtools test` and `devtools verify` runs.

## Problem

The harness already streamed output and wrote progress/events, but a small selected test set could still look suspiciously slow because the artifacts did not show collection duration or a compact slow-phase summary. Harness unit tests could also erase the active wrapper artifacts while exercising cleanup paths in-process, which made post-run inspection misleading.

## Solution

`devtools.pytest_progress_plugin` now records collection start/finish timing, writes `current-pytest-selection.json` with collection duration, and writes `current-pytest-summary.json` with selected/deselected counts plus the slowest setup/call/teardown reports. `devtools verify` and `devtools test` export and report the summary path. The wrapper tests now avoid deleting the active run artifacts while testing mocked wrapper execution, and the plugin tests restore hook state after direct hook calls.

## Verification

- `devtools test tests/unit/devtools/test_pytest_progress_plugin.py tests/unit/devtools/test_run_tests.py tests/unit/devtools/test_verify.py -k "pytest_progress or summary or selection or heartbeat or timeout or run_tests" -n 0` -> 22 passed, 38 deselected.
- `devtools test tests/unit/devtools/test_failure_context.py -k missing_db -n 0` -> 1 passed, 9 deselected; artifacts reported `selected_count=1`, `deselected_count=9`, `collection_duration_s=0.0236`, slowest phase setup `0.6884s`.
- `devtools verify --quick` -> exit_code 0.