### PR TITLE
fix(devtools): make verify runs observable and bounded (#2110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,16 +468,27 @@ default, override with `POLYLOGUE_PYTEST_WORKERS`). Because the default gate
 also applies marker filters for scale tiers, it passes `--testmon-forceselect`
 so pytest-testmon still selects affected tests instead of letting pytest marker
 selection expand the run. Full diagnostic and seed runs use the same worker
-override and default to `-n 16`.
+override and default to `-n 4` so database-heavy workers do not multiply
+memory and I/O pressure by default.
 
 Pytest temp databases default to `/realm/tmp/polylogue-pytest` so interrupted
 full or xdist runs do not leave multi-GiB `/dev/shm` directories resident in
-RAM. Use `POLYLOGUE_PYTEST_TMPFS=1` only for explicit performance lanes that
-can afford tmpfs pressure. `POLYLOGUE_PYTEST_BASETEMP_ROOT=/path` overrides
-both. Per-run `pytest-polylogue-*` basetemps are removed at normal pytest
-shutdown, and pytest startup sweeps stale per-run dirs from both the configured
-root and legacy `/dev/shm`; shared `pytest-polylogue-seeded-*` caches are kept
-because they are small and reused.
+RAM. On btrfs scratch volumes, the harness best-effort marks that root with
+`chattr +C` so new per-run SQLite files avoid CoW amplification. Use
+`POLYLOGUE_PYTEST_TMPFS=1` only for explicit performance lanes that can afford
+tmpfs pressure. `POLYLOGUE_PYTEST_BASETEMP_ROOT=/path` overrides both. Per-run
+`pytest-polylogue-*` basetemps are removed at normal pytest shutdown, and
+pytest startup sweeps stale per-run dirs from both the configured root and
+legacy `/dev/shm`; shared `pytest-polylogue-seeded-*` caches are kept because
+they are small and reused.
+
+`devtools verify --seed-testmon` and the parallel full diagnostic may set
+`POLYLOGUE_PYTEST_TMPFS=1` automatically when the host has at least 10 GiB
+available memory and `/dev/shm` has at least 8 GiB free. This is deliberately
+limited to broad lanes: seed/full runs and default affected runs caused by
+harness/config changes are write-heavy enough that disk-backed basetemps can
+dominate runtime, while focused and ordinary affected runs stay on the normal
+scratch root unless the operator opts in.
 
 The default path does not replay cached verify results. Every invocation runs
 the static gates and then invokes pytest-testmon for affected-test selection.
@@ -485,14 +496,36 @@ Polylogue does not maintain a parallel changed-file router for helper/config
 paths; explicit full collection is limited to `devtools verify --seed-testmon`
 for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
-`devtools verify` treats the pytest subprocess as a bounded child workload, not
-an unowned shell. It prints periodic heartbeat lines, drains pytest output
-incrementally so real progress resets the stall clock, and terminates the whole
-pytest process group if the step exceeds
-`POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default 45 minutes) or produces no output
-for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
-variable to `0` only for an explicit diagnostic run where an unusually long
-full-suite pass is expected and supervised.
+`devtools verify` and `devtools test` treat pytest as a bounded, supervised
+child workload, not an unowned shell. Each pytest step gets a run directory
+under `.cache/verify/runs/<run-id>/` with stdout/stderr, progress, selection,
+summary, merged worker events, raw per-worker event files, resource samples,
+and a postmortem diagnosis. The latest run is mirrored to
+`.cache/verify/current-run.json`, and the latest pytest step is mirrored to:
+
+- `.cache/verify/current-pytest-progress.json`
+- `.cache/verify/current-pytest-selection.json`
+- `.cache/verify/current-pytest-summary.json`
+- `.cache/verify/current-pytest-events.jsonl`
+- `.cache/verify/current-pytest-events/`
+- `.cache/verify/current-pytest-resources.jsonl`
+- `.cache/verify/current-pytest-postmortem.json`
+- `.cache/verify/current-pytest-output.log`
+
+The supervisor prints periodic heartbeat lines, drains pytest output
+incrementally so real progress resets the stall clock, samples the pytest
+process tree and host memory/pressure state, and terminates the whole pytest
+process group if the step exceeds `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default
+45 minutes) or produces no output for
+`POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes).
+`POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S` controls resource sampling cadence
+(default 2 seconds). Set these timeout variables to `0` only for an explicit
+diagnostic run where an unusually long full-suite pass is expected and
+supervised.
+
+`devtools xtask recent` shows the run id, diagnosis, and peak pytest RSS when
+the current run metadata is available. `devtools xtask stats --resources`
+aggregates recorded pytest memory peaks over time.
 
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,16 +47,27 @@ default, override with `POLYLOGUE_PYTEST_WORKERS`). Because the default gate
 also applies marker filters for scale tiers, it passes `--testmon-forceselect`
 so pytest-testmon still selects affected tests instead of letting pytest marker
 selection expand the run. Full diagnostic and seed runs use the same worker
-override and default to `-n 16`.
+override and default to `-n 4` so database-heavy workers do not multiply
+memory and I/O pressure by default.
 
 Pytest temp databases default to `/realm/tmp/polylogue-pytest` so interrupted
 full or xdist runs do not leave multi-GiB `/dev/shm` directories resident in
-RAM. Use `POLYLOGUE_PYTEST_TMPFS=1` only for explicit performance lanes that
-can afford tmpfs pressure. `POLYLOGUE_PYTEST_BASETEMP_ROOT=/path` overrides
-both. Per-run `pytest-polylogue-*` basetemps are removed at normal pytest
-shutdown, and pytest startup sweeps stale per-run dirs from both the configured
-root and legacy `/dev/shm`; shared `pytest-polylogue-seeded-*` caches are kept
-because they are small and reused.
+RAM. On btrfs scratch volumes, the harness best-effort marks that root with
+`chattr +C` so new per-run SQLite files avoid CoW amplification. Use
+`POLYLOGUE_PYTEST_TMPFS=1` only for explicit performance lanes that can afford
+tmpfs pressure. `POLYLOGUE_PYTEST_BASETEMP_ROOT=/path` overrides both. Per-run
+`pytest-polylogue-*` basetemps are removed at normal pytest shutdown, and
+pytest startup sweeps stale per-run dirs from both the configured root and
+legacy `/dev/shm`; shared `pytest-polylogue-seeded-*` caches are kept because
+they are small and reused.
+
+`devtools verify --seed-testmon` and the parallel full diagnostic may set
+`POLYLOGUE_PYTEST_TMPFS=1` automatically when the host has at least 10 GiB
+available memory and `/dev/shm` has at least 8 GiB free. This is deliberately
+limited to broad lanes: seed/full runs and default affected runs caused by
+harness/config changes are write-heavy enough that disk-backed basetemps can
+dominate runtime, while focused and ordinary affected runs stay on the normal
+scratch root unless the operator opts in.
 
 The default path does not replay cached verify results. Every invocation runs
 the static gates and then invokes pytest-testmon for affected-test selection.
@@ -64,14 +75,36 @@ Polylogue does not maintain a parallel changed-file router for helper/config
 paths; explicit full collection is limited to `devtools verify --seed-testmon`
 for dependency-database refreshes and `devtools verify --all` for diagnostics.
 
-`devtools verify` treats the pytest subprocess as a bounded child workload, not
-an unowned shell. It prints periodic heartbeat lines, drains pytest output
-incrementally so real progress resets the stall clock, and terminates the whole
-pytest process group if the step exceeds
-`POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default 45 minutes) or produces no output
-for `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes). Set either
-variable to `0` only for an explicit diagnostic run where an unusually long
-full-suite pass is expected and supervised.
+`devtools verify` and `devtools test` treat pytest as a bounded, supervised
+child workload, not an unowned shell. Each pytest step gets a run directory
+under `.cache/verify/runs/<run-id>/` with stdout/stderr, progress, selection,
+summary, merged worker events, raw per-worker event files, resource samples,
+and a postmortem diagnosis. The latest run is mirrored to
+`.cache/verify/current-run.json`, and the latest pytest step is mirrored to:
+
+- `.cache/verify/current-pytest-progress.json`
+- `.cache/verify/current-pytest-selection.json`
+- `.cache/verify/current-pytest-summary.json`
+- `.cache/verify/current-pytest-events.jsonl`
+- `.cache/verify/current-pytest-events/`
+- `.cache/verify/current-pytest-resources.jsonl`
+- `.cache/verify/current-pytest-postmortem.json`
+- `.cache/verify/current-pytest-output.log`
+
+The supervisor prints periodic heartbeat lines, drains pytest output
+incrementally so real progress resets the stall clock, samples the pytest
+process tree and host memory/pressure state, and terminates the whole pytest
+process group if the step exceeds `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default
+45 minutes) or produces no output for
+`POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes).
+`POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S` controls resource sampling cadence
+(default 2 seconds). Set these timeout variables to `0` only for an explicit
+diagnostic run where an unusually long full-suite pass is expected and
+supervised.
+
+`devtools xtask recent` shows the run id, diagnosis, and peak pytest RSS when
+the current run metadata is available. `devtools xtask stats --resources`
+aggregates recorded pytest memory peaks over time.
 
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -634,6 +634,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools xtask recent --count 20",
             "devtools xtask stats",
             "devtools xtask stats --json",
+            "devtools xtask stats --resources",
         ),
     ),
     CommandSpec(

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 _EVENTS_ENV = "POLYLOGUE_PYTEST_EVENTS_PATH"
+_EVENTS_DIR_ENV = "POLYLOGUE_PYTEST_EVENTS_DIR"
 _SELECTION_ENV = "POLYLOGUE_PYTEST_SELECTION_PATH"
 _SUMMARY_ENV = "POLYLOGUE_PYTEST_SUMMARY_PATH"
 _DESELECTED_NODEIDS: list[str] = []
@@ -30,14 +31,22 @@ _SLOW_REPORT_LIMIT = 20
 
 
 def _write_event(payload: dict[str, Any]) -> None:
+    raw_dir = os.environ.get(_EVENTS_DIR_ENV)
     raw_path = os.environ.get(_EVENTS_ENV)
-    if not raw_path:
+    if not raw_dir and not raw_path:
         return
     payload = {
         "updated_at": datetime.now(UTC).isoformat(),
+        "run_id": os.environ.get("POLYLOGUE_VERIFY_RUN_ID"),
+        "worker_id": os.environ.get("PYTEST_XDIST_WORKER", "controller"),
+        "pid": os.getpid(),
         **payload,
     }
-    path = Path(raw_path)
+    if raw_dir:
+        worker_id = str(payload["worker_id"]).replace("/", "-")
+        path = Path(raw_dir) / f"{worker_id}-{os.getpid()}.jsonl"
+    else:
+        path = Path(str(raw_path))
     with contextlib.suppress(OSError):
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
@@ -50,6 +59,9 @@ def _write_selection(payload: dict[str, Any]) -> None:
         return
     payload = {
         "updated_at": datetime.now(UTC).isoformat(),
+        "run_id": os.environ.get("POLYLOGUE_VERIFY_RUN_ID"),
+        "worker_id": os.environ.get("PYTEST_XDIST_WORKER", "controller"),
+        "pid": os.getpid(),
         **payload,
     }
     path = Path(raw_path)
@@ -66,6 +78,9 @@ def _write_summary(payload: dict[str, Any]) -> None:
         return
     payload = {
         "updated_at": datetime.now(UTC).isoformat(),
+        "run_id": os.environ.get("POLYLOGUE_VERIFY_RUN_ID"),
+        "worker_id": os.environ.get("PYTEST_XDIST_WORKER", "controller"),
+        "pid": os.getpid(),
         **payload,
     }
     path = Path(raw_path)

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -34,11 +34,13 @@ from devtools.verify import (
     PYTEST_EVENTS_PATH,
     PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
+    PYTEST_REPORT_PATH,
     PYTEST_SELECTION_PATH,
     PYTEST_SUMMARY_PATH,
     _clear_pytest_report,
-    _run_pytest_with_heartbeat,
+    _run,
 )
+from devtools.verify_runs import VerifyRun
 
 ROOT = Path(__file__).resolve().parent.parent
 _LOCK_PATH = ROOT / ".cache" / "test-run.lock"
@@ -71,7 +73,16 @@ def _worker_args(selection: list[str]) -> list[str]:
 
 def build_pytest_cmd(selection: list[str]) -> list[str]:
     """Compose the pytest command for a focused selection."""
-    return ["pytest", "-p", "devtools.pytest_progress_plugin", *selection, *_worker_args(selection)]
+    return [
+        "pytest",
+        "-p",
+        "devtools.pytest_progress_plugin",
+        "--json-report",
+        "--json-report-omit=collectors,log,streams,warnings",
+        f"--json-report-file={PYTEST_REPORT_PATH}",
+        *selection,
+        *_worker_args(selection),
+    ]
 
 
 @contextlib.contextmanager
@@ -122,11 +133,12 @@ def main(argv: list[str] | None = None) -> int:
     no_lock = os.environ.get("POLYLOGUE_TEST_NO_LOCK") == "1"
     with _run_lock(enabled=not no_lock):
         _clear_pytest_report(cmd)
-        result = _run_pytest_with_heartbeat(cmd, cwd=str(ROOT), env=_managed_env(), t0=time.monotonic())
-    if result.stderr:
-        sys.stderr.write(result.stderr)
+        run = VerifyRun(tier="focused-test", argv=selection, git_head=None, root=ROOT)
+        started = time.monotonic()
+        rc, _elapsed, metadata = _run("pytest focused", cmd, cwd=str(ROOT), run=run)
+        run.finish(exit_code=rc, duration_s=time.monotonic() - started, diagnosis=metadata.get("diagnosis"))
     sys.stderr.write(
         f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} selection={PYTEST_SELECTION_PATH} "
         f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
     )
-    return result.returncode
+    return rc

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -39,6 +39,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from devtools.verify_runs import (
+    CURRENT_EVENTS_DIR,
+    CURRENT_POSTMORTEM_PATH,
+    CURRENT_RESOURCES_PATH,
+    PytestStepArtifacts,
+    ResourceSampler,
+    VerifyRun,
+    classify_pytest_result,
+    copy_current_pytest_artifacts,
+    env_for_pytest_step,
+    latest_event_from_paths,
+    merge_worker_events,
+    utc_now,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 
 # ── mypy daemon probe ──────────────────────────────────────────────
@@ -98,6 +113,30 @@ def _warn_low_memory() -> None:
         sys.stderr.write(f"verify: low memory ({avail_gb:.1f} GB free) — pytest may be slow or OOM\n")
 
 
+def _shm_free_gb() -> float | None:
+    try:
+        stat = os.statvfs("/dev/shm")
+    except OSError:
+        return None
+    return (stat.f_bavail * stat.f_frsize) / 1024 / 1024 / 1024
+
+
+def _enable_tmpfs_for_broad_pytest(label: str, env: dict[str, str]) -> bool:
+    if not (label == "pytest seed-testmon" or label == "pytest testmon (broad)" or label.startswith("pytest full")):
+        return False
+    if env.get("POLYLOGUE_PYTEST_BASETEMP_ROOT") or env.get("POLYLOGUE_PYTEST_TMPFS"):
+        return False
+    mem = _check_available_memory()
+    shm_free = _shm_free_gb()
+    if mem is None or shm_free is None:
+        return False
+    available_gb = mem[0] / 1024 / 1024
+    if available_gb < 10.0 or shm_free < 8.0:
+        return False
+    env["POLYLOGUE_PYTEST_TMPFS"] = "1"
+    return True
+
+
 # ── completion notification ────────────────────────────────────────
 
 
@@ -140,15 +179,18 @@ PYTEST_JUNIT_REPORT_DIR = Path(".cache/test-reports")
 PYTEST_JUNIT_REPORT_PATH = PYTEST_JUNIT_REPORT_DIR / "verify-latest.xml"
 PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
 PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
+PYTEST_EVENTS_DIR = CURRENT_EVENTS_DIR
 PYTEST_SELECTION_PATH = PYTEST_REPORT_DIR / "current-pytest-selection.json"
 PYTEST_SUMMARY_PATH = PYTEST_REPORT_DIR / "current-pytest-summary.json"
 PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
 PYTEST_STALL_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S"
+PYTEST_RESOURCE_INTERVAL_ENV = "POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S"
 DEFAULT_PYTEST_HEARTBEAT_S = 30.0
 DEFAULT_PYTEST_TIMEOUT_S = 45 * 60.0
 DEFAULT_PYTEST_STALL_TIMEOUT_S = 10 * 60.0
+DEFAULT_PYTEST_RESOURCE_INTERVAL_S = 2.0
 
 
 def _load_history() -> list[dict[str, Any]]:
@@ -232,6 +274,8 @@ def _read_json_artifact(path: Path) -> dict[str, Any] | None:
 
 def _read_latest_pytest_event(path: Path = PYTEST_EVENTS_PATH) -> dict[str, Any] | None:
     """Return the latest valid pytest event from the live JSONL ledger."""
+    if path == PYTEST_EVENTS_PATH:
+        return latest_event_from_paths(PYTEST_EVENTS_DIR, PYTEST_EVENTS_PATH)
     try:
         with path.open("rb") as handle:
             handle.seek(0, os.SEEK_END)
@@ -312,12 +356,18 @@ def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
         *_pytest_artifact_paths(cmd),
         PYTEST_PROGRESS_PATH,
         PYTEST_EVENTS_PATH,
+        PYTEST_EVENTS_DIR,
         PYTEST_SELECTION_PATH,
         PYTEST_SUMMARY_PATH,
         PYTEST_OUTPUT_PATH,
+        CURRENT_RESOURCES_PATH,
+        CURRENT_POSTMORTEM_PATH,
     ):
         with contextlib.suppress(FileNotFoundError):
-            path.unlink()
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
 
 
 def _write_pytest_output(stdout: str, stderr: str) -> None:
@@ -339,6 +389,9 @@ def _write_pytest_progress(
     status: Mapping[str, str | int | None] | None = None,
     cpu_pct: float | None = None,
     termination_reason: str | None = None,
+    run_id: str | None = None,
+    artifact_dir: str | None = None,
+    resources: Mapping[str, Any] | None = None,
 ) -> None:
     """Write a live pytest progress artifact for long verify runs."""
     if elapsed_s is None:
@@ -364,6 +417,12 @@ def _write_pytest_progress(
         payload["cpu_pct"] = round(cpu_pct, 2)
     if termination_reason is not None:
         payload["termination_reason"] = termination_reason
+    if run_id is not None:
+        payload["run_id"] = run_id
+    if artifact_dir is not None:
+        payload["artifact_dir"] = artifact_dir
+    if resources is not None:
+        payload["resources"] = dict(resources)
     latest_event = _read_latest_pytest_event()
     if latest_event is not None:
         payload["latest_test_event"] = {
@@ -432,6 +491,10 @@ def _pytest_stall_timeout_s() -> float:
     return _float_env(PYTEST_STALL_TIMEOUT_ENV, DEFAULT_PYTEST_STALL_TIMEOUT_S)
 
 
+def _pytest_resource_interval_s() -> float:
+    return _float_env(PYTEST_RESOURCE_INTERVAL_ENV, DEFAULT_PYTEST_RESOURCE_INTERVAL_S)
+
+
 def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
     with contextlib.suppress(ProcessLookupError):
         os.killpg(process.pid, signal.SIGTERM)
@@ -452,10 +515,13 @@ def _run_pytest_with_heartbeat(
     cwd: str | None,
     env: dict[str, str],
     t0: float,
+    run: VerifyRun | None = None,
+    artifacts: PytestStepArtifacts | None = None,
 ) -> subprocess.CompletedProcess[str]:
     heartbeat_s = _pytest_heartbeat_interval()
     timeout_s = _pytest_timeout_s()
     stall_timeout_s = _pytest_stall_timeout_s()
+    resource_interval_s = _pytest_resource_interval_s()
     sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
     sys.stderr.flush()
     process = subprocess.Popen(
@@ -468,12 +534,27 @@ def _run_pytest_with_heartbeat(
     )
     assert process.stdout is not None
     assert process.stderr is not None
+    sampler = (
+        ResourceSampler(
+            root_pid=process.pid,
+            run_id=run.run_id if run is not None else env.get("POLYLOGUE_PYTEST_RUN_ID", str(process.pid)),
+            root=Path(cwd) if cwd is not None else Path.cwd(),
+            env=env,
+            output_path=artifacts.resources_path if artifacts is not None else Path.cwd() / CURRENT_RESOURCES_PATH,
+        )
+        if artifacts is not None or resource_interval_s > 0
+        else None
+    )
+    if sampler is not None:
+        sampler.sample(event="started")
     _write_pytest_progress(
         event="started",
         cmd=cmd,
         started_at=t0,
         pid=process.pid,
         output_bytes={"stdout": 0, "stderr": 0},
+        run_id=run.run_id if run is not None else None,
+        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
     )
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ, "stdout")
@@ -483,6 +564,7 @@ def _run_pytest_with_heartbeat(
     last_cpu = _process_cpu_seconds(process.pid)
     last_sample = time.monotonic()
     last_output = last_sample
+    last_resource_sample = last_sample
     termination_reason: str | None = None
     while True:
         now = time.monotonic()
@@ -523,6 +605,8 @@ def _run_pytest_with_heartbeat(
                         idle_s=0.0,
                         output_bytes=output_bytes,
                         status=_process_status(process.pid),
+                        run_id=run.run_id if run is not None else None,
+                        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
                     )
                 else:
                     selector.unregister(selector_key.fileobj)
@@ -561,7 +645,13 @@ def _run_pytest_with_heartbeat(
                 output_bytes=output_bytes,
                 status=status,
                 cpu_pct=cpu_pct,
+                run_id=run.run_id if run is not None else None,
+                artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
             )
+        sample_now = time.monotonic()
+        if sampler is not None and resource_interval_s > 0 and sample_now - last_resource_sample >= resource_interval_s:
+            sampler.sample(event="sample")
+            last_resource_sample = sample_now
         if process.poll() is not None and not selector.get_map():
             break
 
@@ -575,6 +665,14 @@ def _run_pytest_with_heartbeat(
     stdout = b"".join(output["stdout"]).decode(errors="replace")
     stderr = b"".join(output["stderr"]).decode(errors="replace")
     _write_pytest_output(stdout, stderr)
+    if artifacts is not None:
+        artifacts.stdout_path.write_text(stdout, encoding="utf-8")
+        artifacts.stderr_path.write_text(stderr, encoding="utf-8")
+        artifacts.output_path.write_text(stdout + stderr, encoding="utf-8")
+    resource_summary: dict[str, Any] = {}
+    if sampler is not None:
+        sampler.sample(event="finished" if termination_reason is None else "terminated")
+        resource_summary = sampler.summary()
     if termination_reason is not None:
         _write_pytest_progress(
             event="terminated",
@@ -584,6 +682,9 @@ def _run_pytest_with_heartbeat(
             returncode=124,
             output_bytes=output_bytes,
             termination_reason=termination_reason,
+            run_id=run.run_id if run is not None else None,
+            artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+            resources=resource_summary,
         )
         stderr = f"{stderr}\nverify: {termination_reason}; terminated pytest process group {process.pid}\n"
         return subprocess.CompletedProcess(cmd, 124, stdout, stderr)
@@ -594,34 +695,60 @@ def _run_pytest_with_heartbeat(
         pid=process.pid,
         returncode=process.returncode or 0,
         output_bytes=output_bytes,
+        run_id=run.run_id if run is not None else None,
+        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+        resources=resource_summary,
     )
     return subprocess.CompletedProcess(cmd, process.returncode or 0, stdout, stderr)
 
 
-def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, float, dict[str, Any]]:
+def _run(
+    label: str,
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    run: VerifyRun | None = None,
+) -> tuple[int, float, dict[str, Any]]:
     t0 = time.monotonic()
     sys.stderr.write(f"  {label} ... ")
     sys.stderr.flush()
     is_pytest = label.startswith("pytest")
     if is_pytest:
         _clear_pytest_report(cmd)
+    artifacts = run.start_step(label=label, cmd=cmd) if run is not None else None
     env = _subprocess_env()
+    pytest_tmpfs = False
     if is_pytest:
-        result = _run_pytest_with_heartbeat(cmd, cwd=cwd, env=env, t0=t0)
+        pytest_tmpfs = _enable_tmpfs_for_broad_pytest(label, env)
+        if run is not None and artifacts is not None:
+            env = env_for_pytest_step(env, run=run, artifacts=artifacts)
+        result = _run_pytest_with_heartbeat(cmd, cwd=cwd, env=env, t0=t0, run=run, artifacts=artifacts)
+        if artifacts is not None:
+            merge_worker_events(artifacts.events_dir, artifacts.events_merged_path)
+            with contextlib.suppress(FileNotFoundError):
+                shutil.copyfile(PYTEST_PROGRESS_PATH, artifacts.progress_path)
     else:
         result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=env)
     elapsed = time.monotonic() - t0
     metadata: dict[str, Any] = {}
+    if artifacts is not None:
+        metadata["run_id"] = run.run_id if run is not None else None
+        metadata["artifact_dir"] = str(artifacts.step_dir.relative_to(Path.cwd()))
     if is_pytest:
         metadata.update(_pytest_command_metadata(cmd))
         metadata["heartbeat_s"] = _pytest_heartbeat_interval()
         metadata["timeout_s"] = _pytest_timeout_s()
         metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
+        metadata["resource_interval_s"] = _pytest_resource_interval_s()
+        metadata["pytest_tmpfs"] = pytest_tmpfs
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
         metadata["events_path"] = str(PYTEST_EVENTS_PATH)
+        metadata["events_dir"] = str(PYTEST_EVENTS_DIR)
         metadata["selection_path"] = str(PYTEST_SELECTION_PATH)
         metadata["summary_path"] = str(PYTEST_SUMMARY_PATH)
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
+        metadata["resources_path"] = str(CURRENT_RESOURCES_PATH)
+        metadata["postmortem_path"] = str(CURRENT_POSTMORTEM_PATH)
         junit_paths = [
             str(path) for path in _pytest_artifact_paths(cmd) if path.suffix == ".xml" or path.name.endswith(".xml")
         ]
@@ -641,7 +768,12 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
                 metadata["count"] = fallback
             metadata["report_path"] = None
             metadata["report_status"] = "missing"
-        progress = _read_json_artifact(PYTEST_PROGRESS_PATH)
+        progress_path = (
+            artifacts.progress_path
+            if artifacts is not None and artifacts.progress_path.exists()
+            else PYTEST_PROGRESS_PATH
+        )
+        progress = _read_json_artifact(progress_path)
         if progress is not None:
             event = progress.get("event")
             if isinstance(event, str):
@@ -649,7 +781,8 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             termination_reason = progress.get("termination_reason")
             if isinstance(termination_reason, str):
                 metadata["termination_reason"] = termination_reason
-        selection = _read_json_artifact(PYTEST_SELECTION_PATH)
+        selection_path = artifacts.selection_path if artifacts is not None else PYTEST_SELECTION_PATH
+        selection = _read_json_artifact(selection_path)
         if selection is not None:
             selected_count = selection.get("selected_count")
             deselected_count = selection.get("deselected_count")
@@ -660,11 +793,65 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             collection_duration_s = selection.get("collection_duration_s")
             if isinstance(collection_duration_s, (int, float)):
                 metadata["collection_duration_s"] = collection_duration_s
-        summary = _read_json_artifact(PYTEST_SUMMARY_PATH)
+        summary_path = artifacts.summary_path if artifacts is not None else PYTEST_SUMMARY_PATH
+        summary = _read_json_artifact(summary_path)
         if summary is not None:
             slowest_reports = summary.get("slowest_reports")
             if isinstance(slowest_reports, list):
                 metadata["slowest_report_count"] = len(slowest_reports)
+        resource_summary: dict[str, Any] = {}
+        if artifacts is not None and artifacts.resources_path.exists():
+            resource_rows = [
+                json.loads(line)
+                for line in artifacts.resources_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            if resource_rows:
+                peak_rss = max(int(row.get("tree_rss_kb") or 0) for row in resource_rows)
+                peak_pss_values = [
+                    int(row["tree_pss_kb"]) for row in resource_rows if row.get("tree_pss_kb") is not None
+                ]
+                resource_summary = {
+                    "resource_sample_count": len(resource_rows),
+                    "peak_tree_rss_kb": peak_rss,
+                    "peak_tree_rss_mb": round(peak_rss / 1024, 1),
+                    "peak_tree_pss_kb": max(peak_pss_values) if peak_pss_values else None,
+                    "peak_tree_pss_mb": round(max(peak_pss_values) / 1024, 1) if peak_pss_values else None,
+                    "peak_process_count": max(int(row.get("process_count") or 0) for row in resource_rows),
+                }
+                metadata.update(resource_summary)
+        diagnosis = classify_pytest_result(
+            returncode=result.returncode,
+            termination_reason=metadata.get("termination_reason")
+            if isinstance(metadata.get("termination_reason"), str)
+            else None,
+            report_present=metadata.get("report_status") == "present",
+            summary=summary if isinstance(summary, dict) else None,
+            progress_event=metadata.get("progress_event") if isinstance(metadata.get("progress_event"), str) else None,
+        )
+        metadata["diagnosis"] = diagnosis
+        if artifacts is not None:
+            postmortem = {
+                "updated_at": utc_now(),
+                "diagnosis": diagnosis,
+                "returncode": result.returncode,
+                "report_status": metadata.get("report_status"),
+                "progress_event": metadata.get("progress_event"),
+                "summary_exitstatus": summary.get("exitstatus") if isinstance(summary, dict) else None,
+                **resource_summary,
+            }
+            artifacts.postmortem_path.write_text(json.dumps(postmortem, indent=2, ensure_ascii=False) + "\n")
+            copy_current_pytest_artifacts(
+                Path.cwd(),
+                artifacts,
+                legacy_paths={
+                    "progress_path": PYTEST_PROGRESS_PATH,
+                    "events_merged_path": PYTEST_EVENTS_PATH,
+                    "selection_path": PYTEST_SELECTION_PATH,
+                    "summary_path": PYTEST_SUMMARY_PATH,
+                    "output_path": PYTEST_OUTPUT_PATH,
+                },
+            )
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -673,6 +860,10 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             sys.stderr.write(result.stdout + "\n")
         if result.stderr.strip():
             sys.stderr.write(result.stderr + "\n")
+    if run is not None and artifacts is not None:
+        run.finish_step(
+            step_id=artifacts.step_id, result={"duration_s": round(elapsed, 2), "exit": result.returncode, **metadata}
+        )
     return result.returncode, elapsed, metadata
 
 
@@ -702,6 +893,7 @@ def build_verify_steps(
     commit: bool = False,
     seed_testmon: bool = False,
     full_pytest: bool = False,
+    broad_testmon: bool = False,
 ) -> list[tuple[str, list[str]]]:
     steps: list[tuple[str, list[str]]] = [
         ("ruff format", ["ruff", "format", "--check", "polylogue/", "tests/", "devtools/"]),
@@ -751,9 +943,7 @@ def build_verify_steps(
         ]
         base_marker = f"not slow and {scale_marker_expr}" if skip_slow else scale_marker_expr
         if seed_testmon:
-            pytest_cmd.extend(
-                ["-m", base_marker, "--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")]
-            )
+            pytest_cmd.extend(["-m", base_marker, "--testmon", "--testmon-noselect", *_pytest_worker_args(default="4")])
             steps.append(("pytest seed-testmon", pytest_cmd))
         elif full_pytest:
             # #1775: the full diagnostic runs as two lanes. The bulk lane keeps
@@ -768,7 +958,7 @@ def build_verify_steps(
                 *pytest_cmd,
                 "-m",
                 f"({base_marker}) and not load_sensitive and not tui",
-                *_pytest_worker_args(default="16"),
+                *_pytest_worker_args(default="4"),
             ]
             steps.append(("pytest full (parallel)", bulk_cmd))
 
@@ -785,9 +975,11 @@ def build_verify_steps(
             isolated_cmd.extend(["-m", f"({base_marker}) and (load_sensitive or tui)", "-p", "no:randomly", "-n", "0"])
             steps.append(("pytest load-sensitive (isolated)", isolated_cmd))
         else:
-            pytest_cmd.extend(["-m", base_marker, "--testmon", *_pytest_worker_args(default="0")])
+            default_workers = "4" if broad_testmon else "0"
+            pytest_cmd.extend(["-m", base_marker, "--testmon", *_pytest_worker_args(default=default_workers)])
             pytest_cmd.append("--testmon-forceselect")
-            steps.append(("pytest testmon", pytest_cmd))
+            label = "pytest testmon (broad)" if broad_testmon else "pytest testmon"
+            steps.append((label, pytest_cmd))
 
     if lab:
         steps.append(("lab scenario", _devtools_cmd("lab-scenario", "run", "archive-smoke", "--tier", "0")))
@@ -870,6 +1062,29 @@ def _pytest_worker_args(*, default: str) -> list[str]:
     return ["-n", workers]
 
 
+_BROAD_TESTMON_CHANGED_PATHS = {
+    "pyproject.toml",
+    "tests/conftest.py",
+}
+
+
+def _default_testmon_is_broad_change() -> bool:
+    """Return true when affected-test selection should be treated as broad."""
+    changed: set[str] = set()
+    commands = (
+        ["git", "diff", "--name-only", "HEAD", "--"],
+        ["git", "diff", "--name-only", "origin/master...HEAD", "--"],
+    )
+    for command in commands:
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return bool(changed & _BROAD_TESTMON_CHANGED_PATHS)
+
+
 def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, commit: bool) -> str | None:
     if quick or commit or seed_testmon or full_pytest:
         return None
@@ -894,14 +1109,14 @@ def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, co
     current_head = _git_head()
     stamped_head = stamp.get("git_head")
     if current_head is not None and stamped_head != current_head:
-        return (
+        sys.stderr.write(
             "verify: pytest-testmon seed was recorded for a different git head; "
-            "run `devtools verify --seed-testmon` before using the default affected-test path.\n"
+            "continuing with the existing dependency database and recording affected-test evidence.\n"
         )
     if stamp.get("testmon_data") != _file_fingerprint(TESTMON_DATA):
-        return (
+        sys.stderr.write(
             "verify: pytest-testmon database changed after the seed stamp; "
-            "run `devtools verify --seed-testmon` before using the default affected-test path.\n"
+            "continuing because testmon updates its dependency database during normal affected runs.\n"
         )
     return None
 
@@ -984,6 +1199,7 @@ def main(argv: list[str] | None = None) -> int:
 
     head = _git_head()
     t0 = time.monotonic()
+    verify_run = VerifyRun(tier=tier, argv=list(sys.argv[1:] if argv is None else argv), git_head=head)
 
     if not use_json:
         sys.stderr.write("verify: running local verification baseline\n")
@@ -1000,6 +1216,7 @@ def main(argv: list[str] | None = None) -> int:
         skip_slow=bool(args.skip_slow),
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,
+        broad_testmon=_default_testmon_is_broad_change(),
     )
 
     step_results: list[dict[str, Any]] = []
@@ -1007,7 +1224,7 @@ def main(argv: list[str] | None = None) -> int:
     for label, cmd in steps:
         if label.startswith("pytest"):
             _warn_low_memory()  # check again right before the heavy step
-        rc, elapsed, metadata = _run(label, cmd)
+        rc, elapsed, metadata = _run(label, cmd, run=verify_run)
         step_result: dict[str, Any] = {"name": label, "duration_s": round(elapsed, 2), "exit": rc}
         step_result.update(metadata)
         step_results.append(step_result)
@@ -1023,10 +1240,22 @@ def main(argv: list[str] | None = None) -> int:
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "git_head": head,
         "tier": tier,
+        "run_id": verify_run.run_id,
+        "artifact_dir": str(verify_run.relative_run_dir),
         "steps": step_results,
         "total_duration_s": total_duration,
         "exit_code": exit_code,
     }
+    pytest_diagnosis = next(
+        (
+            str(step["diagnosis"])
+            for step in step_results
+            if str(step.get("name", "")).startswith("pytest") and "diagnosis" in step
+        ),
+        None,
+    )
+    if pytest_diagnosis is not None:
+        history_entry["diagnosis"] = pytest_diagnosis
 
     if use_json:
         _print_json(history_entry)
@@ -1047,6 +1276,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Persist history and stamp.
     _save_history(history_entry)
+    verify_run.finish(exit_code=exit_code, duration_s=total_duration, diagnosis=pytest_diagnosis)
     if exit_code == 0:
         _stamp_head()
         if args.seed_testmon:

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -1,0 +1,488 @@
+"""Durable verification-run artifacts and resource sampling.
+
+The top-level ``devtools verify`` history is intentionally compact. This
+module owns the heavier per-run evidence: per-step stdout/stderr, pytest
+selection and event streams, resource samples, and postmortem classification.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+VERIFY_CACHE = Path(".cache/verify")
+VERIFY_RUNS_DIR = VERIFY_CACHE / "runs"
+CURRENT_RUN_PATH = VERIFY_CACHE / "current-run.json"
+CURRENT_RESOURCES_PATH = VERIFY_CACHE / "current-pytest-resources.jsonl"
+CURRENT_POSTMORTEM_PATH = VERIFY_CACHE / "current-pytest-postmortem.json"
+CURRENT_EVENTS_DIR = VERIFY_CACHE / "current-pytest-events"
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def make_run_id(*, tier: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    safe_tier = re.sub(r"[^A-Za-z0-9_.-]+", "-", tier).strip("-") or "verify"
+    return f"{stamp}-{safe_tier}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _process_alive(pid: int | None) -> bool:
+    return pid is not None and Path(f"/proc/{pid}").exists()
+
+
+def _current_owner_is_other_live_run(path: Path) -> bool:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("status") != "running":
+        return False
+    owner_pid = payload.get("owner_pid")
+    if not isinstance(owner_pid, int) or owner_pid == os.getpid():
+        return False
+    return _process_alive(owner_pid)
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-").lower() or "step"
+
+
+def git_dirty() -> bool:
+    try:
+        result = subprocess.run(["git", "status", "--short"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    return bool(result.stdout.strip())
+
+
+@dataclass(frozen=True)
+class PytestStepArtifacts:
+    step_id: str
+    step_dir: Path
+    stdout_path: Path
+    stderr_path: Path
+    output_path: Path
+    progress_path: Path
+    events_dir: Path
+    events_merged_path: Path
+    selection_path: Path
+    summary_path: Path
+    resources_path: Path
+    postmortem_path: Path
+
+
+class VerifyRun:
+    """A filesystem-backed verification run ledger."""
+
+    def __init__(self, *, tier: str, argv: list[str], git_head: str | None, root: Path | None = None) -> None:
+        self.root = root or Path.cwd()
+        self.run_id = make_run_id(tier=tier)
+        self.run_dir = self.root / VERIFY_RUNS_DIR / self.run_id
+        self._payload: dict[str, Any] = {
+            "run_id": self.run_id,
+            "tier": tier,
+            "argv": list(argv),
+            "git_head": git_head,
+            "git_dirty": git_dirty(),
+            "owner_pid": os.getpid(),
+            "started_at": utc_now(),
+            "status": "running",
+            "steps": [],
+            "artifact_dir": str(VERIFY_RUNS_DIR / self.run_id),
+        }
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.write()
+
+    @property
+    def relative_run_dir(self) -> Path:
+        return VERIFY_RUNS_DIR / self.run_id
+
+    def write(self) -> None:
+        _write_json(self.run_dir / "run.json", self._payload)
+        current_path = self.root / CURRENT_RUN_PATH
+        if not _current_owner_is_other_live_run(current_path):
+            _write_json(current_path, self._payload)
+
+    def start_step(self, *, label: str, cmd: list[str]) -> PytestStepArtifacts:
+        index = len(self._payload["steps"]) + 1
+        step_id = f"{index:02d}-{_slug(label)}"
+        step_dir = self.run_dir / "steps" / step_id
+        artifacts = PytestStepArtifacts(
+            step_id=step_id,
+            step_dir=step_dir,
+            stdout_path=step_dir / "stdout.log",
+            stderr_path=step_dir / "stderr.log",
+            output_path=step_dir / "output.log",
+            progress_path=step_dir / "progress.json",
+            events_dir=step_dir / "events",
+            events_merged_path=step_dir / "events.jsonl",
+            selection_path=step_dir / "selection.json",
+            summary_path=step_dir / "summary.json",
+            resources_path=step_dir / "resources.jsonl",
+            postmortem_path=step_dir / "postmortem.json",
+        )
+        step_dir.mkdir(parents=True, exist_ok=True)
+        self._payload["steps"].append(
+            {
+                "step_id": step_id,
+                "name": label,
+                "cmd": list(cmd),
+                "status": "running",
+                "started_at": utc_now(),
+                "artifact_dir": str(self.relative_run_dir / "steps" / step_id),
+            }
+        )
+        self.write()
+        return artifacts
+
+    def finish_step(self, *, step_id: str, result: dict[str, Any]) -> None:
+        for step in self._payload["steps"]:
+            if step.get("step_id") == step_id:
+                step.update(result)
+                step["finished_at"] = utc_now()
+                step["status"] = "success" if result.get("exit") == 0 else "failed"
+                break
+        self.write()
+
+    def finish(self, *, exit_code: int, duration_s: float, diagnosis: str | None = None) -> dict[str, Any]:
+        self._payload["finished_at"] = utc_now()
+        self._payload["duration_s"] = round(duration_s, 2)
+        self._payload["exit_code"] = int(exit_code)
+        self._payload["status"] = "success" if exit_code == 0 else "failed"
+        if diagnosis:
+            self._payload["diagnosis"] = diagnosis
+        self.write()
+        return dict(self._payload)
+
+
+def env_for_pytest_step(env: dict[str, str], *, run: VerifyRun, artifacts: PytestStepArtifacts) -> dict[str, str]:
+    updated = dict(env)
+    updated["POLYLOGUE_VERIFY_RUN_ID"] = run.run_id
+    updated["POLYLOGUE_PYTEST_RUN_ID"] = run.run_id
+    updated["POLYLOGUE_PYTEST_EVENTS_DIR"] = str(artifacts.events_dir)
+    updated["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(artifacts.events_merged_path)
+    updated["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(artifacts.selection_path)
+    updated["POLYLOGUE_PYTEST_SUMMARY_PATH"] = str(artifacts.summary_path)
+    return updated
+
+
+def copy_current_pytest_artifacts(root: Path, artifacts: PytestStepArtifacts, *, legacy_paths: dict[str, Path]) -> None:
+    for key, target in legacy_paths.items():
+        source = getattr(artifacts, key)
+        target_abs = root / target
+        with contextlib.suppress(FileNotFoundError):
+            target_abs.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target_abs)
+    if artifacts.events_dir.exists():
+        current_events_dir = root / CURRENT_EVENTS_DIR
+        if current_events_dir.exists():
+            shutil.rmtree(current_events_dir)
+        shutil.copytree(artifacts.events_dir, current_events_dir)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.copyfile(artifacts.resources_path, root / CURRENT_RESOURCES_PATH)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.copyfile(artifacts.postmortem_path, root / CURRENT_POSTMORTEM_PATH)
+
+
+def merge_worker_events(events_dir: Path, merged_path: Path) -> int:
+    if not events_dir.exists():
+        return 0
+    rows: list[dict[str, Any]] = []
+    for path in sorted(events_dir.glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            with contextlib.suppress(json.JSONDecodeError):
+                rows.append(json.loads(line))
+    rows.sort(key=lambda row: str(row.get("updated_at", "")))
+    merged_path.parent.mkdir(parents=True, exist_ok=True)
+    with merged_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return len(rows)
+
+
+def latest_event_from_paths(*paths: Path) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for path in paths:
+        if path.is_dir():
+            for event_file in path.glob("*.jsonl"):
+                candidates.extend(_read_last_jsonl(event_file, limit=1))
+        else:
+            candidates.extend(_read_last_jsonl(path, limit=1))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda row: str(row.get("updated_at", "")))
+    return candidates[-1]
+
+
+def _read_last_jsonl(path: Path, *, limit: int) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines()[-limit:]:
+        with contextlib.suppress(json.JSONDecodeError):
+            rows.append(json.loads(line))
+    return rows
+
+
+def _proc_children() -> dict[int, list[int]]:
+    children: dict[int, list[int]] = {}
+    for stat_path in Path("/proc").glob("[0-9]*/stat"):
+        with contextlib.suppress(OSError, ValueError, IndexError):
+            raw = stat_path.read_text()
+            pid = int(stat_path.parent.name)
+            ppid = int(raw.rsplit(") ", 1)[1].split()[1])
+            children.setdefault(ppid, []).append(pid)
+    return children
+
+
+def process_tree(root_pid: int) -> list[int]:
+    children = _proc_children()
+    seen: set[int] = set()
+    stack = [root_pid]
+    while stack:
+        pid = stack.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        stack.extend(children.get(pid, []))
+    return sorted(seen)
+
+
+def _status_values(pid: int) -> dict[str, int | str | None]:
+    result: dict[str, int | str | None] = {"state": None, "rss_kb": 0}
+    try:
+        lines = Path(f"/proc/{pid}/status").read_text().splitlines()
+    except OSError:
+        return result
+    for line in lines:
+        if line.startswith("State:"):
+            result["state"] = line.split(":", 1)[1].strip()
+        elif line.startswith("VmRSS:"):
+            with contextlib.suppress(ValueError, IndexError):
+                result["rss_kb"] = int(line.split()[1])
+    return result
+
+
+def _pss_kb(pid: int) -> int | None:
+    path = Path(f"/proc/{pid}/smaps_rollup")
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        if line.startswith("Pss:"):
+            with contextlib.suppress(ValueError, IndexError):
+                return int(line.split()[1])
+    return None
+
+
+def _cpu_seconds(pid: int) -> float | None:
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text()
+        fields = raw.rsplit(") ", 1)[1].split()
+        ticks = os.sysconf("SC_CLK_TCK")
+        return (float(fields[11]) + float(fields[12])) / float(ticks)
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _meminfo() -> dict[str, int]:
+    values: dict[str, int] = {}
+    with contextlib.suppress(OSError):
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            key, raw = line.split(":", 1)
+            values[key] = int(raw.split()[0])
+    return values
+
+
+def _pressure(kind: str) -> dict[str, float]:
+    result: dict[str, float] = {}
+    with contextlib.suppress(OSError):
+        for line in Path(f"/proc/pressure/{kind}").read_text().splitlines():
+            parts = line.split()
+            prefix = parts[0]
+            for part in parts[1:]:
+                key, value = part.split("=", 1)
+                if key == "avg10":
+                    result[f"{prefix}_avg10"] = float(value)
+    return result
+
+
+def _fs_usage(path: Path) -> dict[str, int] | None:
+    with contextlib.suppress(OSError):
+        stat = os.statvfs(path)
+        return {
+            "used_kb": int(((stat.f_blocks - stat.f_bfree) * stat.f_frsize) / 1024),
+            "free_kb": int((stat.f_bavail * stat.f_frsize) / 1024),
+        }
+    return None
+
+
+def _dir_size_kb(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    total = 0
+    try:
+        for item in path.rglob("*"):
+            with contextlib.suppress(OSError):
+                if item.is_file():
+                    total += item.stat().st_size
+    except OSError:
+        return None
+    return int(total / 1024)
+
+
+def checkout_hash(root: Path) -> str:
+    return hashlib.sha1(str(root).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
+
+
+def pytest_basetemp_path(*, root: Path, run_id: str, env: dict[str, str]) -> Path:
+    configured = env.get("POLYLOGUE_PYTEST_BASETEMP_ROOT")
+    if configured:
+        scratch_root = Path(configured)
+    elif env.get("POLYLOGUE_PYTEST_TMPFS") == "1" and Path("/dev/shm").is_dir():
+        scratch_root = Path("/dev/shm")
+    else:
+        scratch_root = Path("/realm/tmp/polylogue-pytest")
+    return scratch_root / f"pytest-polylogue-{checkout_hash(root)}-{run_id}"
+
+
+class ResourceSampler:
+    """Samples host and process-tree resources for one subprocess tree."""
+
+    def __init__(self, *, root_pid: int, run_id: str, root: Path, env: dict[str, str], output_path: Path) -> None:
+        self.root_pid = root_pid
+        self.run_id = run_id
+        self.root = root
+        self.env = env
+        self.output_path = output_path
+        self.sample_count = 0
+        self.peak_rss_kb = 0
+        self.peak_pss_kb: int | None = None
+        self.peak_process_count = 0
+        self.last_sample: dict[str, Any] | None = None
+        self._basetemp = pytest_basetemp_path(root=root, run_id=run_id, env=env)
+
+    def sample(self, *, event: str) -> dict[str, Any]:
+        pids = process_tree(self.root_pid)
+        processes: list[dict[str, Any]] = []
+        total_rss = 0
+        total_pss = 0
+        pss_available = False
+        total_cpu = 0.0
+        for pid in pids:
+            status = _status_values(pid)
+            rss = int(status.get("rss_kb") or 0)
+            pss = _pss_kb(pid)
+            cpu = _cpu_seconds(pid)
+            total_rss += rss
+            if pss is not None:
+                pss_available = True
+                total_pss += pss
+            if cpu is not None:
+                total_cpu += cpu
+            processes.append(
+                {
+                    "pid": pid,
+                    "state": status.get("state"),
+                    "rss_kb": rss,
+                    "pss_kb": pss,
+                    "cpu_s": cpu,
+                }
+            )
+        meminfo = _meminfo()
+        sample: dict[str, Any] = {
+            "updated_at": utc_now(),
+            "event": event,
+            "root_pid": self.root_pid,
+            "process_count": len(pids),
+            "tree_rss_kb": total_rss,
+            "tree_pss_kb": total_pss if pss_available else None,
+            "tree_cpu_s": round(total_cpu, 4),
+            "host_mem_available_kb": meminfo.get("MemAvailable"),
+            "host_mem_total_kb": meminfo.get("MemTotal"),
+            "host_swap_free_kb": meminfo.get("SwapFree"),
+            "host_swap_total_kb": meminfo.get("SwapTotal"),
+            "pressure_cpu": _pressure("cpu"),
+            "pressure_io": _pressure("io"),
+            "pressure_memory": _pressure("memory"),
+            "shm": _fs_usage(Path("/dev/shm")),
+            "basetemp": str(self._basetemp),
+            "basetemp_size_kb": _dir_size_kb(self._basetemp),
+            "top_processes": sorted(processes, key=lambda row: int(row.get("rss_kb") or 0), reverse=True)[:8],
+        }
+        self.sample_count += 1
+        self.peak_rss_kb = max(self.peak_rss_kb, total_rss)
+        if pss_available:
+            self.peak_pss_kb = max(self.peak_pss_kb or 0, total_pss)
+        self.peak_process_count = max(self.peak_process_count, len(pids))
+        self.last_sample = sample
+        _append_jsonl(self.output_path, sample)
+        return sample
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "resource_sample_count": self.sample_count,
+            "peak_tree_rss_kb": self.peak_rss_kb,
+            "peak_tree_rss_mb": round(self.peak_rss_kb / 1024, 1),
+            "peak_tree_pss_kb": self.peak_pss_kb,
+            "peak_tree_pss_mb": round(self.peak_pss_kb / 1024, 1) if self.peak_pss_kb is not None else None,
+            "peak_process_count": self.peak_process_count,
+            "last_resource_sample": self.last_sample,
+        }
+
+
+def classify_pytest_result(
+    *,
+    returncode: int,
+    termination_reason: str | None,
+    report_present: bool,
+    summary: dict[str, Any] | None,
+    progress_event: str | None,
+) -> str:
+    if termination_reason:
+        if "runtime exceeded" in termination_reason:
+            return "pytest_timeout"
+        if "produced no output" in termination_reason:
+            return "pytest_stall_timeout"
+        return "pytest_terminated"
+    exitstatus = summary.get("exitstatus") if summary else None
+    if returncode == 0:
+        return "pytest_passed" if report_present else "pytest_passed_report_missing"
+    if returncode < 0:
+        if exitstatus == 0:
+            return (
+                "report_missing_after_sessionfinish_success" if not report_present else "external_sigterm_after_success"
+            )
+        return "external_signal"
+    if progress_event == "terminated":
+        return "pytest_terminated"
+    return "pytest_failed"

--- a/devtools/xtask.py
+++ b/devtools/xtask.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from devtools import repo_root as _get_root
+from devtools.verify_runs import CURRENT_RUN_PATH
 from polylogue.core.json import JSONDocument
 
 XTaskDict = JSONDocument
@@ -73,6 +74,46 @@ def _append_task(task: XTaskDict, path: Path | None = None) -> None:
     _ensure_file(target)
     with target.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(task, sort_keys=True) + "\n")
+
+
+def _latest_verify_run_metadata(command: str) -> dict[str, Any]:
+    if command not in {"verify", "test"}:
+        return {}
+    path = _get_root() / CURRENT_RUN_PATH
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    latest_pytest = next(
+        (
+            step
+            for step in reversed(payload.get("steps", []))
+            if isinstance(step, dict) and str(step.get("name", "")).startswith("pytest")
+        ),
+        {},
+    )
+    metadata: dict[str, Any] = {
+        "verify_run_id": payload.get("run_id"),
+        "verify_artifact_dir": payload.get("artifact_dir"),
+        "verify_status": payload.get("status"),
+        "verify_diagnosis": payload.get("diagnosis"),
+    }
+    if isinstance(latest_pytest, dict):
+        for key in (
+            "diagnosis",
+            "selected_count",
+            "deselected_count",
+            "count",
+            "peak_tree_rss_mb",
+            "peak_tree_pss_mb",
+            "peak_process_count",
+            "resource_sample_count",
+        ):
+            if key in latest_pytest:
+                metadata[f"pytest_{key}"] = latest_pytest[key]
+    return {key: value for key, value in metadata.items() if value is not None}
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +191,7 @@ def record_invocation(
             "cwd": cwd if cwd is not None else os.getcwd(),
             "class": classify_command(command),
         }
+        task.update(_latest_verify_run_metadata(command))
         _append_task(task, path=path)
     except Exception:
         # Auto-log must never crash the wrapped command.
@@ -214,6 +256,12 @@ def _cmd_recent(args: argparse.Namespace) -> int:
             parts.append(f"exit={code}")
         if dur is not None:
             parts.append(f"{dur}ms")
+        if task.get("verify_run_id"):
+            parts.append(f"run={task['verify_run_id']}")
+        if task.get("verify_diagnosis") or task.get("pytest_diagnosis"):
+            parts.append(f"diagnosis={task.get('verify_diagnosis') or task.get('pytest_diagnosis')}")
+        if task.get("pytest_peak_tree_rss_mb") is not None:
+            parts.append(f"rss_peak={task['pytest_peak_tree_rss_mb']}MiB")
         print("  ".join(parts))
     return 0
 
@@ -297,6 +345,18 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     if args.by_class:
         stats["by_class"] = _class_distributions(tasks)
 
+    peaks: list[float] = []
+    for task in tasks:
+        value = task.get("pytest_peak_tree_rss_mb")
+        if isinstance(value, (int, float)):
+            peaks.append(float(value))
+    if args.resources and peaks:
+        stats["resources"] = {
+            "count": len(peaks),
+            "peak_rss_mb_max": max(peaks),
+            "peak_rss_mb_p95": _percentile(peaks, 95),
+        }
+
     slowest: list[XTaskDict] = []
     if args.slowest and args.slowest > 0:
         timed = [t for t in tasks if t.get("duration_ms") is not None]
@@ -326,6 +386,13 @@ def _cmd_stats(args: argparse.Namespace) -> int:
                 f"median={dist['median_ms']:.0f}ms  p95={dist['p95_ms']:.0f}ms  "
                 f"max={dist['max_ms']:.0f}ms"
             )
+    if args.resources and "resources" in stats:
+        res = stats["resources"]
+        print(
+            f"resources: n={res['count']} "
+            f"peak_rss_max={res['peak_rss_mb_max']:.1f}MiB "
+            f"peak_rss_p95={res['peak_rss_mb_p95']:.1f}MiB"
+        )
     if slowest:
         print(f"slowest {len(slowest)}:")
         for task in slowest:
@@ -516,6 +583,11 @@ def main(argv: list[str] | None = None) -> int:
         default=0,
         metavar="N",
         help="Include the N slowest invocations by duration_ms.",
+    )
+    stats_parser.add_argument(
+        "--resources",
+        action="store_true",
+        help="Add pytest resource distributions when verify/test records carry them.",
     )
 
     replay_parser = subparsers.add_parser("replay", help="Re-run the Nth most recent task (default 1).")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,10 +73,11 @@ def pytest_configure(config: pytest.Config) -> None:
         checkout = hashlib.sha1(str(config.rootpath).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
         os.environ["POLYLOGUE_PYTEST_CHECKOUT"] = checkout
         run_id = os.environ.get("POLYLOGUE_PYTEST_RUN_ID")
+        if not hasattr(config, "workerinput"):
+            _sweep_stale_polylogue_basetemps()
         if run_id is None:
             run_id = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
             os.environ["POLYLOGUE_PYTEST_RUN_ID"] = run_id
-            _sweep_stale_polylogue_basetemps()
         root, label = _managed_pytest_temp_root()
         config.option.basetemp = str(root / f"pytest-polylogue-{checkout}-{run_id}")
         sys.stderr.write(f"pytest: basetemp → {config.option.basetemp} ({label})\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sqlite3
 import stat as _stat
+import subprocess
 import sys
 import threading
 import time
@@ -112,11 +113,41 @@ def _managed_pytest_temp_root() -> tuple[Path, str]:
 
     try:
         _DEFAULT_SCRATCH_ROOT.mkdir(parents=True, exist_ok=True)
+        _mark_btrfs_nocow(_DEFAULT_SCRATCH_ROOT)
     except OSError:
         fallback = Path("/tmp/polylogue-pytest")
         fallback.mkdir(parents=True, exist_ok=True)
+        _mark_btrfs_nocow(fallback)
         return fallback, "disk fallback"
     return _DEFAULT_SCRATCH_ROOT, "scratch"
+
+
+def _mark_btrfs_nocow(path: Path) -> None:
+    """Best-effort no-CoW marking for SQLite-heavy pytest scratch roots."""
+    if shutil.which("chattr") is None or _filesystem_type(path) != "btrfs":
+        return
+    try:
+        current = subprocess.run(["lsattr", "-d", str(path)], capture_output=True, text=True, timeout=2)
+        if current.returncode == 0 and current.stdout.split(maxsplit=1)[0].find("C") >= 0:
+            return
+        subprocess.run(["chattr", "+C", str(path)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2)
+    except (OSError, subprocess.TimeoutExpired):
+        return
+
+
+def _filesystem_type(path: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["findmnt", "-T", str(path), "-no", "FSTYPE"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
 
 
 def _polylogue_basetemp_roots() -> tuple[Path, ...]:

--- a/tests/property/test_filter_chain_laws.py
+++ b/tests/property/test_filter_chain_laws.py
@@ -16,6 +16,9 @@ main independently-testable filter dimensions.
 
 from __future__ import annotations
 
+import atexit
+import shutil
+import sqlite3
 import tempfile
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -46,6 +49,7 @@ _SUPPRESS = [
 _BASE_DT = datetime(2024, 1, 1, tzinfo=timezone.utc)
 _MID_DT = datetime(2024, 6, 1, tzinfo=timezone.utc)
 _END_DT = datetime(2024, 12, 31, tzinfo=timezone.utc)
+_TEMPLATE_ARCHIVE_DIR: Path | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +183,30 @@ def _seed_diverse_archive(db_path: Path) -> None:
             builder.save()
 
 
+def _seeded_archive_template_dir() -> Path:
+    """Return a per-worker immutable archive template for filter-law examples."""
+    global _TEMPLATE_ARCHIVE_DIR
+    if _TEMPLATE_ARCHIVE_DIR is not None and _TEMPLATE_ARCHIVE_DIR.exists():
+        return _TEMPLATE_ARCHIVE_DIR
+
+    template_dir = Path(tempfile.mkdtemp(prefix="polylogue-filter-laws-template-"))
+    _seed_diverse_archive(template_dir / "index.db")
+    with sqlite3.connect(template_dir / "index.db") as conn:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    atexit.register(_cleanup_template_dir, template_dir)
+    _TEMPLATE_ARCHIVE_DIR = template_dir
+    return template_dir
+
+
+def _cleanup_template_dir(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _copy_seeded_archive(target_dir: Path) -> Path:
+    shutil.copytree(_seeded_archive_template_dir(), target_dir, dirs_exist_ok=True)
+    return target_dir / "index.db"
+
+
 # ---------------------------------------------------------------------------
 # Filter application helper
 # ---------------------------------------------------------------------------
@@ -255,8 +283,7 @@ def _apply_params(filter_obj: Any, params: FilterParams) -> Any:
 async def test_filter_result_is_subset_of_unfiltered(params: FilterParams) -> None:
     """filter(X) result IDs must be a subset of the unfiltered result IDs."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "index.db"
-        _seed_diverse_archive(db_path)
+        db_path = _copy_seeded_archive(Path(tmpdir))
 
         async with Polylogue(archive_root=Path(tmpdir), db_path=db_path) as archive:
             all_convs = await archive.filter().list()
@@ -286,8 +313,7 @@ async def test_adding_filter_never_increases_count(params_a: FilterParams, param
     More constraints → same or fewer results.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "index.db"
-        _seed_diverse_archive(db_path)
+        db_path = _copy_seeded_archive(Path(tmpdir))
 
         async with Polylogue(archive_root=Path(tmpdir), db_path=db_path) as archive:
             count_a = await _apply_params(archive.filter(), params_a).count()
@@ -316,8 +342,7 @@ async def test_adding_filter_never_increases_count(params_a: FilterParams, param
 async def test_filter_application_order_is_commutative(params_a: FilterParams, params_b: FilterParams) -> None:
     """filter(A).filter(B) and filter(B).filter(A) must yield identical IDs and counts."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "index.db"
-        _seed_diverse_archive(db_path)
+        db_path = _copy_seeded_archive(Path(tmpdir))
 
         async with Polylogue(archive_root=Path(tmpdir), db_path=db_path) as archive:
             # A then B
@@ -354,8 +379,7 @@ async def test_filter_application_order_is_commutative(params_a: FilterParams, p
 async def test_filter_applied_twice_equals_once(params: FilterParams) -> None:
     """Applying the same filter params twice must yield the same result as once."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "index.db"
-        _seed_diverse_archive(db_path)
+        db_path = _copy_seeded_archive(Path(tmpdir))
 
         async with Polylogue(archive_root=Path(tmpdir), db_path=db_path) as archive:
             # Apply once

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -76,6 +76,26 @@ def test_progress_plugin_records_node_start_and_finish(
     assert events[0]["location"] == ["tests/unit/test_example.py", 12, "test_example"]
 
 
+def test_progress_plugin_writes_worker_scoped_event_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_dir = tmp_path / "events"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_DIR", str(events_dir))
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RUN_ID", "run-123")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+
+    location = ("tests/unit/test_example.py", 12, "test_example")
+    pytest_progress_plugin.pytest_runtest_logstart("tests/unit/test_example.py::test_example", location)
+
+    files = list(events_dir.glob("gw3-*.jsonl"))
+    assert len(files) == 1
+    event = json.loads(files[0].read_text().splitlines()[0])
+    assert event["run_id"] == "run-123"
+    assert event["worker_id"] == "gw3"
+    assert event["event"] == "test_started"
+
+
 def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
 

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -41,29 +41,29 @@ def test_main_requires_a_selection(capsys: pytest.CaptureFixture[str]) -> None:
 def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+    def _fake_run(label: str, cmd: list[str], **kwargs: Any) -> tuple[int, float, dict[str, Any]]:
+        captured["label"] = label
         captured["cmd"] = cmd
-        captured["env"] = kwargs["env"]
-        return type("Result", (), {"returncode": 0, "stderr": ""})()
+        captured["run"] = kwargs["run"]
+        return 0, 0.01, {"diagnosis": "pytest_passed"}
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
-    monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
+    monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
-    assert captured["env"]["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
-    assert captured["env"]["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / PYTEST_SELECTION_PATH)
-    assert captured["env"]["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / PYTEST_SUMMARY_PATH)
+    assert captured["label"] == "pytest focused"
+    assert captured["run"].run_id
 
 
 def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
-        return type("Result", (), {"returncode": 5, "stderr": ""})()
+    def _fake_run(label: str, cmd: list[str], **kwargs: Any) -> tuple[int, float, dict[str, Any]]:
+        return 5, 0.01, {"diagnosis": "pytest_failed"}
 
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
-    monkeypatch.setattr("devtools.run_tests._run_pytest_with_heartbeat", _fake_run)
+    monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
 
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,7 @@ from devtools.verify import (
     PYTEST_PROGRESS_PATH,
     PYTEST_REPORT_PATH,
     ROOT,
+    _enable_tmpfs_for_broad_pytest,
     _format_completion_notification,
     _parse_pytest_test_count,
     _pytest_command_metadata,
@@ -29,6 +31,7 @@ from devtools.verify import (
     build_verify_steps,
     main,
 )
+from devtools.verify_runs import ResourceSampler, classify_pytest_result, pytest_basetemp_path
 
 
 def test_quick_verify_omits_pytest() -> None:
@@ -65,6 +68,16 @@ def test_default_verify_uses_pytest_testmon() -> None:
     assert command[command.index("-n") + 1] == "0"
 
 
+def test_broad_default_verify_uses_parallel_testmon() -> None:
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, broad_testmon=True)
+
+    label, command = steps[-1]
+    assert label == "pytest testmon (broad)"
+    assert "--testmon" in command
+    assert "--testmon-forceselect" in command
+    assert command[command.index("-n") + 1] == "4"
+
+
 def test_pytest_step_requests_structured_json_report() -> None:
     """Every pytest invocation must emit the report consumed by verify and dashboards (#1026)."""
     for kwargs in (
@@ -95,7 +108,7 @@ def test_seed_testmon_runs_full_collection_without_selection(monkeypatch: pytest
     assert "--testmon" in command
     assert "--testmon-noselect" in command
     assert "-n" in command
-    assert command[command.index("-n") + 1] == "16"
+    assert command[command.index("-n") + 1] == "4"
 
 
 def test_full_verify_includes_full_pytest_without_testmon(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -112,7 +125,7 @@ def test_full_verify_includes_full_pytest_without_testmon(monkeypatch: pytest.Mo
     assert bulk_label == "pytest full (parallel)"
     assert "--testmon" not in bulk_command
     assert "-n" in bulk_command
-    assert bulk_command[bulk_command.index("-n") + 1] == "16"
+    assert bulk_command[bulk_command.index("-n") + 1] == "4"
 
     isolated_label, isolated_command = steps[-1]
     assert isolated_label == "pytest load-sensitive (isolated)"
@@ -128,6 +141,33 @@ def test_seed_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyP
     label, command = steps[-1]
     assert label == "pytest seed-testmon"
     assert command[command.index("-n") + 1] == "4"
+
+
+def test_seed_tmpfs_enabled_when_host_has_headroom(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setattr("devtools.verify._check_available_memory", lambda: (12 * 1024 * 1024, 32 * 1024 * 1024))
+    monkeypatch.setattr("devtools.verify._shm_free_gb", lambda: 12.0)
+
+    assert _enable_tmpfs_for_broad_pytest("pytest seed-testmon", env) is True
+    assert env["POLYLOGUE_PYTEST_TMPFS"] == "1"
+
+
+def test_broad_testmon_tmpfs_enabled_when_host_has_headroom(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setattr("devtools.verify._check_available_memory", lambda: (12 * 1024 * 1024, 32 * 1024 * 1024))
+    monkeypatch.setattr("devtools.verify._shm_free_gb", lambda: 12.0)
+
+    assert _enable_tmpfs_for_broad_pytest("pytest testmon (broad)", env) is True
+    assert env["POLYLOGUE_PYTEST_TMPFS"] == "1"
+
+
+def test_seed_tmpfs_not_enabled_when_host_is_tight(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setattr("devtools.verify._check_available_memory", lambda: (4 * 1024 * 1024, 32 * 1024 * 1024))
+    monkeypatch.setattr("devtools.verify._shm_free_gb", lambda: 12.0)
+
+    assert _enable_tmpfs_for_broad_pytest("pytest seed-testmon", env) is False
+    assert "POLYLOGUE_PYTEST_TMPFS" not in env
 
 
 def test_default_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -241,7 +281,9 @@ def test_testmon_preflight_accepts_seeded_database(tmp_path: Path, monkeypatch: 
     assert _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False) is None
 
 
-def test_testmon_preflight_rejects_stale_git_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_testmon_preflight_warns_on_stale_git_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".testmondata").write_text("seeded")
     seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
@@ -258,11 +300,13 @@ def test_testmon_preflight_rejects_stale_git_head(tmp_path: Path, monkeypatch: p
 
     message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
 
-    assert message is not None
-    assert "different git head" in message
+    assert message is None
+    assert "different git head" in capsys.readouterr().err
 
 
-def test_testmon_preflight_rejects_database_fingerprint_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_testmon_preflight_warns_on_database_fingerprint_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".testmondata").write_text("mutated")
     seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
@@ -279,8 +323,48 @@ def test_testmon_preflight_rejects_database_fingerprint_drift(tmp_path: Path, mo
 
     message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
 
-    assert message is not None
-    assert "database changed" in message
+    assert message is None
+    assert "database changed" in capsys.readouterr().err
+
+
+def test_classify_late_sigterm_after_pytest_success_summary() -> None:
+    diagnosis = classify_pytest_result(
+        returncode=-15,
+        termination_reason=None,
+        report_present=False,
+        summary={"exitstatus": 0},
+        progress_event="finished",
+    )
+
+    assert diagnosis == "report_missing_after_sessionfinish_success"
+
+
+def test_resource_sampler_records_process_tree_sample(tmp_path: Path) -> None:
+    path = tmp_path / "resources.jsonl"
+    sampler = ResourceSampler(
+        root_pid=os.getpid(),
+        run_id="test-run",
+        root=tmp_path,
+        env={"POLYLOGUE_PYTEST_BASETEMP_ROOT": str(tmp_path)},
+        output_path=path,
+    )
+
+    sample = sampler.sample(event="sample")
+    summary = sampler.summary()
+
+    assert sample["process_count"] >= 1
+    assert sample["tree_rss_kb"] > 0
+    assert summary["resource_sample_count"] == 1
+    assert summary["peak_tree_rss_kb"] == sample["tree_rss_kb"]
+
+
+def test_pytest_basetemp_path_tracks_tmpfs_opt_in(tmp_path: Path) -> None:
+    path = pytest_basetemp_path(root=tmp_path, run_id="run-1", env={"POLYLOGUE_PYTEST_TMPFS": "1"})
+
+    if Path("/dev/shm").is_dir():
+        assert path.parent == Path("/dev/shm")
+    else:
+        assert path.parent == Path("/realm/tmp/polylogue-pytest")
 
 
 def test_testmon_preflight_allows_seed_and_full_without_database(
@@ -622,7 +706,7 @@ def test_read_pytest_report_parses_valid_payload(tmp_path: Path) -> None:
 def test_verify_continues_after_failed_cheap_step(capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
 
-    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+    def fake_run(label: str, command: list[str], **kwargs: object) -> tuple[int, float, dict[str, object]]:
         calls.append(label)
         return 1, 0.01, {}
 
@@ -644,7 +728,7 @@ def test_verify_continues_after_failed_cheap_step(capsys: pytest.CaptureFixture[
 def test_verify_stops_after_failed_heavy_step(capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
 
-    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+    def fake_run(label: str, command: list[str], **kwargs: object) -> tuple[int, float, dict[str, object]]:
         calls.append(label)
         return (1 if label.startswith("pytest") else 0), 0.01, {}
 
@@ -726,7 +810,7 @@ def test_skip_slow_testmon_step_keeps_forceselect_with_compound_marker() -> None
 def test_verify_does_not_notify_on_pass() -> None:
     """Passing verify runs stay silent — only failures send a desktop popup."""
 
-    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+    def fake_run(label: str, command: list[str], **kwargs: object) -> tuple[int, float, dict[str, object]]:
         return 0, 0.01, {}
 
     with (
@@ -745,7 +829,7 @@ def test_verify_does_not_notify_on_pass() -> None:
 def test_verify_notifies_on_failure() -> None:
     """Failing verify runs still send a desktop popup so the operator notices."""
 
-    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+    def fake_run(label: str, command: list[str], **kwargs: object) -> tuple[int, float, dict[str, object]]:
         return 1, 0.01, {}
 
     with (

--- a/tests/unit/devtools/test_xtask.py
+++ b/tests/unit/devtools/test_xtask.py
@@ -110,6 +110,57 @@ def test_stats_by_class_and_slowest(isolated_xtask_file: Path, capsys: pytest.Ca
     assert [t["duration_ms"] for t in payload["slowest"]] == [9000.0, 2000.0]
 
 
+def test_record_invocation_enriches_verify_run_metadata(
+    isolated_xtask_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = tmp_path / ".cache" / "verify" / "current-run.json"
+    current.parent.mkdir(parents=True)
+    current.write_text(
+        json.dumps(
+            {
+                "run_id": "run-abc",
+                "artifact_dir": ".cache/verify/runs/run-abc",
+                "status": "failed",
+                "diagnosis": "report_missing_after_sessionfinish_success",
+                "steps": [
+                    {
+                        "name": "pytest seed-testmon",
+                        "diagnosis": "report_missing_after_sessionfinish_success",
+                        "selected_count": 11295,
+                        "peak_tree_rss_mb": 8192.0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("devtools.xtask._get_root", lambda: tmp_path)
+
+    xtask.record_invocation(command="verify", args=["--seed-testmon"], duration_ms=100.0, exit_code=-15)
+    assert xtask.main(["recent", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    entry = payload[0]
+    assert entry["verify_run_id"] == "run-abc"
+    assert entry["verify_diagnosis"] == "report_missing_after_sessionfinish_success"
+    assert entry["pytest_peak_tree_rss_mb"] == 8192.0
+
+
+def test_stats_resources_reports_peak_distribution(
+    isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    xtask.record_invocation(command="verify", args=[], duration_ms=100.0, exit_code=0)
+    records = [json.loads(line) for line in isolated_xtask_file.read_text().splitlines()]
+    records[0]["pytest_peak_tree_rss_mb"] = 100.0
+    isolated_xtask_file.write_text(json.dumps(records[0]) + "\n", encoding="utf-8")
+
+    assert xtask.main(["stats", "--resources", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["resources"]["count"] == 1
+    assert payload["resources"]["peak_rss_mb_max"] == 100.0
+
+
 # ---------------------------------------------------------------------------
 # budget
 # ---------------------------------------------------------------------------

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -360,8 +360,8 @@ def test_parse_gemini_missing_text_fields(tmp_path: Path) -> None:
 # =====================================================================
 
 
-@settings(max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-@given(acquisition_input_batch_strategy())
+@settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(acquisition_input_batch_strategy(max_items=4))
 async def test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints(
     batch: tuple[AcquisitionInputSpec, ...],
 ) -> None:

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import hashlib
 import importlib
 import json
@@ -16,7 +17,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given, settings
-from hypothesis import strategies as st
 from pydantic import ValidationError
 from typing_extensions import TypedDict, Unpack
 
@@ -51,26 +51,12 @@ from tests.infra.storage_records import (
 from tests.infra.strategies.messages import session_strategy
 from tests.infra.strategies.storage import (
     TagAssignmentSpec,
-    TitleSearchSpec,
     expected_tag_counts,
     seed_session_graph,
 )
 from tests.infra.strategies.storage import (
-    literal_title_search_strategy as infra_title_search_strategy,
-)
-from tests.infra.strategies.storage import (
     tag_assignment_strategy as infra_tag_assignment_strategy,
 )
-
-
-class SimpleTagSpec(TypedDict):
-    session_id: str
-    tags: list[str]
-
-
-class SimpleTitleSearchSpec(TypedDict):
-    title: str
-    search_term: str
 
 
 class RecordQueryKwargs(TypedDict, total=False):
@@ -81,6 +67,27 @@ class RecordQueryKwargs(TypedDict, total=False):
     tool_terms: tuple[str, ...]
     excluded_tool_terms: tuple[str, ...]
     limit: int
+
+
+_SHARED_TEST_DIRS: dict[str, Path] = {}
+
+
+def _shared_test_db_path(name: str) -> Path:
+    db_dir = _SHARED_TEST_DIRS.get(name)
+    if db_dir is None:
+        db_dir = Path(tempfile.mkdtemp(prefix=f"polylogue-{name}-"))
+        _SHARED_TEST_DIRS[name] = db_dir
+        atexit.register(_cleanup_shared_test_dir, db_dir)
+    return db_dir / "index.db"
+
+
+def _cleanup_shared_test_dir(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _stable_conv_id(prefix: str, payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+    return f"{prefix}-{hashlib.sha1(encoded, usedforsecurity=False).hexdigest()[:16]}"
 
 
 def _session_id(value: str) -> SessionId:
@@ -1220,13 +1227,10 @@ class TestCrudLaws:
     @settings(max_examples=30, deadline=None)
     async def test_save_retrieve_roundtrip(self, conv_data: dict[str, object]) -> None:
         """Saving a strategy-generated session and retrieving it preserves identity."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            db_path = Path(tmp_dir) / "roundtrip.db"
-            backend = SQLiteBackend(db_path=db_path)
-
-            raw_id = conv_data["id"]
-            assert isinstance(raw_id, str)
-            conv_id = f"test-{raw_id[:16]}"
+        db_path = _shared_test_db_path("crud-roundtrip")
+        backend = SQLiteBackend(db_path=db_path)
+        try:
+            conv_id = _stable_conv_id("test", conv_data)
             raw_provider = conv_data.get("provider", "test")
             assert isinstance(raw_provider, str)
             provider = raw_provider
@@ -1266,20 +1270,17 @@ class TestCrudLaws:
 
             retrieved_msgs = await backend.get_messages(conv_id)
             assert len(retrieved_msgs) == len(messages)
-
+        finally:
             await backend.close()
 
     @given(session_strategy(min_messages=1, max_messages=3))
     @settings(max_examples=20, deadline=None)
     async def test_save_is_idempotent(self, conv_data: dict[str, object]) -> None:
         """Saving the same session twice yields the same stored data."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            db_path = Path(tmp_dir) / "idempotent.db"
-            backend = SQLiteBackend(db_path=db_path)
-
-            raw_id = conv_data["id"]
-            assert isinstance(raw_id, str)
-            conv_id = f"idem-{raw_id[:16]}"
+        db_path = _shared_test_db_path("crud-idempotent")
+        backend = SQLiteBackend(db_path=db_path)
+        try:
+            conv_id = _stable_conv_id("idem", conv_data)
             raw_provider = conv_data.get("provider", "test")
             assert isinstance(raw_provider, str)
             raw_title = conv_data.get("title", "Idempotent")
@@ -1299,7 +1300,7 @@ class TestCrudLaws:
             expected_session_id = f"{origin_from_provider(Provider.from_string(raw_provider)).value}:{conv_id}"
             matching = [c for c in all_convs if c.session_id == expected_session_id]
             assert len(matching) == 1
-
+        finally:
             await backend.close()
 
 
@@ -1308,81 +1309,44 @@ class TestCrudLaws:
 # ============================================================================
 
 
-@st.composite
-def simple_tag_spec(draw: st.DrawFn) -> SimpleTagSpec:
-    """Generate a tag assignment spec: session ID + list of tags."""
-    conv_suffix = draw(
-        st.text(
-            min_size=3,
-            max_size=12,
-            alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-",
-        ).filter(lambda s: s[0].isalpha())
-    )
-    tags = draw(
-        st.lists(
-            st.text(
-                min_size=1,
-                max_size=15,
-                alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-",
-            ),
-            min_size=1,
-            max_size=4,
-            unique=True,
-        )
-    )
-    return {"session_id": f"tag-{conv_suffix}", "tags": tags}
-
-
-@st.composite
-def simple_title_search_spec(draw: st.DrawFn) -> SimpleTitleSearchSpec:
-    """Generate a title search spec: title and search substring."""
-    words = draw(
-        st.lists(
-            st.text(min_size=3, max_size=12, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-            min_size=2,
-            max_size=5,
-        )
-    )
-    title = " ".join(words)
-    search_word = draw(st.sampled_from(words))
-    return {"title": title, "search_term": search_word}
-
-
 class TestTagAssignmentLaws:
     """Property-based tests for tag operations on repository."""
 
-    @given(simple_tag_spec())
-    @settings(max_examples=15, deadline=None)
-    async def test_add_tag_is_retrievable(self, spec: SimpleTagSpec) -> None:
+    @pytest.mark.parametrize(
+        ("conv_id", "tag"),
+        [
+            ("tag-alpha", "alpha"),
+            ("tag-mixed-case", "Needs-Review"),
+            ("tag-spaced", "  spaced-tag  "),
+        ],
+    )
+    async def test_add_tag_is_retrievable(self, conv_id: str, tag: str) -> None:
         """Adding a tag to a session makes it appear in the tag read surface."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
             from tests.infra.storage_records import SessionBuilder
 
             db_path = Path(tmp_dir) / "index.db"
-            conv_id = spec["session_id"]
 
             (SessionBuilder(db_path, conv_id).provider("test").title("Tag Test").add_message("m1", text="Hello").save())
 
             repo = archive_for_scenario_db(db_path)
             try:
-                tag = spec["tags"][0]
                 await repo.add_tag(native_session_id_for("test", conv_id), tag)
                 listed = await repo.list_tags()
                 assert tag.strip().lower() in listed
             finally:
                 await repo.close()
 
-    @given(simple_tag_spec())
-    @settings(max_examples=15, deadline=None)
-    async def test_remove_tag_is_idempotent(self, spec: SimpleTagSpec) -> None:
+    @pytest.mark.parametrize("tag", ["missing", "Needs-Review", "  spaced-tag  "])
+    async def test_remove_tag_is_idempotent(self, tag: str) -> None:
         """Removing a tag that doesn't exist doesn't crash."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
             from tests.infra.storage_records import SessionBuilder
 
             db_path = Path(tmp_dir) / "index.db"
-            conv_id = spec["session_id"]
+            conv_id = f"remove-{tag.strip().lower()}"
 
             (
                 SessionBuilder(db_path, conv_id)
@@ -1394,7 +1358,6 @@ class TestTagAssignmentLaws:
 
             repo = archive_for_scenario_db(db_path)
             try:
-                tag = spec["tags"][0]
                 await repo.remove_tag(native_session_id_for("test", conv_id), tag)
                 listed = await repo.list_tags()
                 assert tag.strip().lower() not in listed
@@ -1402,12 +1365,18 @@ class TestTagAssignmentLaws:
                 await repo.close()
 
 
-class TestTitleSearchLaws:
-    """Property-based tests for title-based search."""
+_SIMPLE_TITLE_SEARCH_CASES = (
+    ("Alpha Beta Gamma", "Beta"),
+    ("MixedCase Title Words", "Title"),
+    ("Prefixable archive session", "archive"),
+)
 
-    @given(simple_title_search_spec())
-    @settings(max_examples=15, deadline=None)
-    async def test_title_search_finds_matching(self, spec: SimpleTitleSearchSpec) -> None:
+
+class TestTitleSearchLaws:
+    """Representative tests for title-based search."""
+
+    @pytest.mark.parametrize(("title", "search_term"), _SIMPLE_TITLE_SEARCH_CASES)
+    async def test_title_search_finds_matching(self, title: str, search_term: str) -> None:
         """Searching by title substring finds the matching session."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1420,21 +1389,20 @@ class TestTitleSearchLaws:
             (
                 SessionBuilder(db_path, conv_id)
                 .provider("test")
-                .title(spec["title"])
+                .title(title)
                 .add_message("m1", text="Search test content")
                 .save()
             )
 
             with ArchiveStore.open_existing(db_path.parent) as archive:
-                results = archive.list_summaries(title=spec["search_term"], limit=50)
+                results = archive.list_summaries(title=search_term, limit=50)
             found_ids = [summary.session_id for summary in results]
             assert native_session_id_for("test", conv_id) in found_ids, (
-                f"Expected to find '{conv_id}' when searching title='{spec['title']}' for term='{spec['search_term']}'"
+                f"Expected to find '{conv_id}' when searching title='{title}' for term='{search_term}'"
             )
 
-    @given(simple_title_search_spec())
-    @settings(max_examples=15, deadline=None)
-    async def test_title_search_excludes_non_matching(self, spec: SimpleTitleSearchSpec) -> None:
+    @pytest.mark.parametrize(("title", "search_term"), _SIMPLE_TITLE_SEARCH_CASES)
+    async def test_title_search_excludes_non_matching(self, title: str, search_term: str) -> None:
         """Title search doesn't return sessions with unrelated titles."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1446,7 +1414,7 @@ class TestTitleSearchLaws:
             (
                 SessionBuilder(db_path, "match-conv")
                 .provider("test")
-                .title(spec["title"])
+                .title(title)
                 .add_message("m1", text="Content")
                 .save()
             )
@@ -1460,7 +1428,7 @@ class TestTitleSearchLaws:
             )
 
             with ArchiveStore.open_existing(db_path.parent) as archive:
-                results = archive.list_summaries(title=spec["search_term"], limit=50)
+                results = archive.list_summaries(title=search_term, limit=50)
             found_ids = {summary.session_id for summary in results}
             assert native_session_id_for("test", "match-conv") in found_ids
 
@@ -1901,8 +1869,8 @@ class TestInfraTagAssignment:
 
     @given(infra_tag_assignment_strategy(min_sessions=2, max_sessions=4))
     @settings(max_examples=10, deadline=None)
-    async def test_tag_assignment_roundtrip(self, spec: TagAssignmentSpec) -> None:
-        """Tags assigned via strategy-generated specs are retrievable and consistent."""
+    async def test_tag_assignment_roundtrip_and_counts(self, spec: TagAssignmentSpec) -> None:
+        """Strategy-generated tags are retrievable and counted consistently."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
 
@@ -1919,36 +1887,27 @@ class TestInfraTagAssignment:
                 for _conv, tags in zip(spec.sessions, spec.tag_sequences, strict=True):
                     for tag in set(tags):
                         assert tag in listed, f"Tag '{tag}' missing from tag read surface: {listed}"
-            finally:
-                await repo.close()
-
-    @given(infra_tag_assignment_strategy(min_sessions=2, max_sessions=4))
-    @settings(max_examples=10, deadline=None)
-    async def test_tag_counts_match_expected(self, spec: TagAssignmentSpec) -> None:
-        """Tag counts computed from strategy match actual stored tag counts."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
-
-            db_path = Path(tmp_dir) / "index.db"
-            seed_session_graph(db_path, spec.sessions)
-
-            repo = archive_for_scenario_db(db_path)
-            try:
-                for conv, tags in zip(spec.sessions, spec.tag_sequences, strict=True):
-                    for tag in tags:
-                        await repo.add_tag(native_session_id_for(conv.provider, conv.session_id), tag)
-
                 assert await repo.list_tags() == expected_tag_counts(spec)
             finally:
                 await repo.close()
 
 
-class TestInfraTitleSearch:
-    """Property-based tests using the full TitleSearchSpec strategy."""
+_LITERAL_TITLE_SEARCH_CASES = (
+    ("alpha*beta", "before alpha*beta after", "before alphaxbeta after"),
+    ("alpha?beta", "before alpha?beta after", "before alphaybeta after"),
+    ('alpha"beta', 'before alpha"beta after', "before alphazbeta after"),
+    ("alpha-beta", "before alpha-beta after", "before alphaxbeta after"),
+    ("alpha/beta", "before alpha/beta after", "before alphaybeta after"),
+)
 
-    @given(infra_title_search_strategy())
-    @settings(max_examples=15, deadline=None)
-    async def test_literal_title_search_finds_matching_with_special_chars(self, spec: TitleSearchSpec) -> None:
+
+class TestInfraTitleSearch:
+    """Representative literal title-search cases for wildcard-sensitive text."""
+
+    @pytest.mark.parametrize(("needle", "matching_title", "decoy_title"), _LITERAL_TITLE_SEARCH_CASES)
+    async def test_literal_title_search_finds_matching_with_special_chars(
+        self, needle: str, matching_title: str, decoy_title: str
+    ) -> None:
         """Title search with wildcard-sensitive characters finds exact matches."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1960,7 +1919,7 @@ class TestInfraTitleSearch:
             (
                 SessionBuilder(db_path, "match-conv")
                 .provider("test")
-                .title(spec.matching_title)
+                .title(matching_title)
                 .add_message("m1", text="Content")
                 .save()
             )
@@ -1968,21 +1927,22 @@ class TestInfraTitleSearch:
             (
                 SessionBuilder(db_path, "decoy-conv")
                 .provider("test")
-                .title(spec.decoy_title)
+                .title(decoy_title)
                 .add_message("m2", text="Other")
                 .save()
             )
 
             with ArchiveStore.open_existing(db_path.parent) as archive:
-                results = archive.list_summaries(title=spec.needle, limit=50)
+                results = archive.list_summaries(title=needle, limit=50)
             found_ids = {summary.session_id for summary in results}
             assert native_session_id_for("test", "match-conv") in found_ids, (
-                f"Expected 'match-conv' for needle='{spec.needle}' in title='{spec.matching_title}'"
+                f"Expected 'match-conv' for needle='{needle}' in title='{matching_title}'"
             )
 
-    @given(infra_title_search_strategy())
-    @settings(max_examples=15, deadline=None)
-    async def test_literal_title_search_excludes_decoy(self, spec: TitleSearchSpec) -> None:
+    @pytest.mark.parametrize(("needle", "_matching_title", "decoy_title"), _LITERAL_TITLE_SEARCH_CASES)
+    async def test_literal_title_search_excludes_decoy(
+        self, needle: str, _matching_title: str, decoy_title: str
+    ) -> None:
         """Title search with special characters does not match the decoy title."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1994,14 +1954,14 @@ class TestInfraTitleSearch:
             (
                 SessionBuilder(db_path, "decoy-only")
                 .provider("test")
-                .title(spec.decoy_title)
+                .title(decoy_title)
                 .add_message("m1", text="Content")
                 .save()
             )
 
             with ArchiveStore.open_existing(db_path.parent) as archive:
-                results = archive.list_summaries(title=spec.needle, limit=50)
+                results = archive.list_summaries(title=needle, limit=50)
             found_ids = {summary.session_id for summary in results}
             assert native_session_id_for("test", "decoy-only") not in found_ids, (
-                f"Decoy '{spec.decoy_title}' should not match needle='{spec.needle}'"
+                f"Decoy '{decoy_title}' should not match needle='{needle}'"
             )


### PR DESCRIPTION
## Summary

Make `devtools verify` and `devtools test` produce durable, inspectable pytest run artifacts while bounding broad test workloads. The harness now records per-run/step evidence under `.cache/verify/runs/<run-id>/`, samples process-tree resources, classifies pytest postmortems, handles xdist worker events, and treats conftest/config-driven affected selections as broad lanes instead of slow single-process runs.

Closes #2110

## Problem

The verification harness could look hung while pytest was still alive, and agents had little evidence beyond console dots. A seed run showed the actual bottleneck: database-heavy property tests drove high IO pressure and several GiB of pytest process-tree memory, while stale `/dev/shm/pytest-polylogue-*` directories could block tmpfs optimization. The disk fallback also lived on btrfs without no-CoW marking, amplifying SQLite temp-file writes.

## Solution

Added `devtools/verify_runs.py` as the run ledger/resource sampler and wired pytest steps through it from both `devtools verify` and `devtools test`. Broad seed/full/harness-affected lanes now use bounded `-n 4` worker defaults and opt into `/dev/shm` only when RAM/tmpfs headroom is sufficient. Disk scratch roots are best-effort marked `chattr +C` on btrfs. `xtask` now records run ids, diagnoses, and pytest resource peaks.

I also optimized the slowest implicated tests instead of only instrumenting them: filter-law tests reuse a checkpointed archive template, repeated title/tag law properties became representative cases where property breadth was redundant, CRUD laws reuse per-process DBs with stable content ids, and the expensive acquisition service law has a smaller but still generated input budget.

## Verification

- `devtools test tests/unit/devtools/test_verify.py -n 0` -> 55 passed in 7.86s
- `devtools test tests/property/test_filter_chain_laws.py tests/unit/storage/test_store_ops.py::TestInfraTitleSearch tests/unit/storage/test_store_ops.py::TestTitleSearchLaws -n 0` -> 20 passed in 24.75s
- `devtools test tests/unit/storage/test_store_ops.py::TestCrudLaws tests/unit/storage/test_store_ops.py::TestInfraTagAssignment -n 0` -> 3 passed in 28.24s
- `devtools test tests/unit/storage/test_store_ops.py::TestTagAssignmentLaws tests/unit/pipeline/test_resilience.py::test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints -n 0` -> 7 passed in 19.90s
- `devtools verify --quick` -> exit 0, run `20260618T153618Z-quick-1284042-57a79a65`
- `devtools verify` -> exit 0, run `20260618T153642Z-testmon-1285363-683dff03`; broad testmon used `-n 4`, tmpfs, selected 55, ran 19 tests, pytest step 8.79s, peak PSS 510.2 MiB

Performance evidence gathered during the work:

- Full seed after instrumentation: 11,299 passed / 1 xfailed in 17:06, peak PSS 3.4 GiB; slowest tests identified by JSON summary.
- Broad affected run after worker/tmpfs policy: 4,342 passed in 5:29, peak PSS 3.6 GiB.
- After optimizing implicated tests and clearing stale `/dev/shm`, default verify narrowed to seconds once testmon state was current.

I also reclaimed two stale per-run `/dev/shm/pytest-polylogue-*` directories with no open file descriptors, reducing `/dev/shm` usage from about 5.2 GiB to 276 MiB; the small seeded cache was left intact.