### PR TITLE
feat(refs): normalize assertion public refs

### DIFF
--- a/polylogue/core/refs.py
+++ b/polylogue/core/refs.py
@@ -11,18 +11,27 @@ ObjectRefKind: TypeAlias = Literal[
     "block",
     "file",
     "branch",
+    "commit",
     "check-run",
     "workspace",
     "agent",
+    "user",
+    "repo",
+    "insight",
     "run",
     "context-snapshot",
     "observed-event",
+    "assertion",
+    "saved_view",
+    "recall_pack",
+    "transform",
     "github-issue",
     "github-pr",
     "github-review",
 ]
 
 EvidenceRefKind: TypeAlias = Literal["session", "message", "block"]
+PublicRef: TypeAlias = "ObjectRef | EvidenceRef"
 
 _OBJECT_REF_KINDS: Final[dict[str, ObjectRefKind]] = {
     "session": "session",
@@ -30,12 +39,20 @@ _OBJECT_REF_KINDS: Final[dict[str, ObjectRefKind]] = {
     "block": "block",
     "file": "file",
     "branch": "branch",
+    "commit": "commit",
     "check-run": "check-run",
     "workspace": "workspace",
     "agent": "agent",
+    "user": "user",
+    "repo": "repo",
+    "insight": "insight",
     "run": "run",
     "context-snapshot": "context-snapshot",
     "observed-event": "observed-event",
+    "assertion": "assertion",
+    "saved_view": "saved_view",
+    "recall_pack": "recall_pack",
+    "transform": "transform",
     "github-issue": "github-issue",
     "github-pr": "github-pr",
     "github-review": "github-review",
@@ -151,6 +168,30 @@ class EvidenceRef:
         return ObjectRef(kind="session", object_id=self.session_id)
 
 
+def parse_public_ref(value: str) -> ObjectRef | EvidenceRef:
+    """Parse a public object or raw evidence reference."""
+
+    try:
+        return ObjectRef.parse(value)
+    except ValueError as object_exc:
+        try:
+            return EvidenceRef.parse(value)
+        except ValueError:
+            raise ValueError(f"unsupported public ref: {value!r}") from object_exc
+
+
+def normalize_object_ref_text(value: str) -> str:
+    """Return canonical object-ref text or raise ``ValueError``."""
+
+    return ObjectRef.parse(value).format()
+
+
+def normalize_public_ref_text(value: str) -> str:
+    """Return canonical object/evidence-ref text or raise ``ValueError``."""
+
+    return parse_public_ref(value).format()
+
+
 def _parse_object_ref_kind(value: str) -> ObjectRefKind:
     try:
         return _OBJECT_REF_KINDS[value]
@@ -158,4 +199,13 @@ def _parse_object_ref_kind(value: str) -> ObjectRefKind:
         raise ValueError(f"unsupported object ref kind: {value!r}") from exc
 
 
-__all__ = ["EvidenceRef", "EvidenceRefKind", "ObjectRef", "ObjectRefKind"]
+__all__ = [
+    "EvidenceRef",
+    "EvidenceRefKind",
+    "ObjectRef",
+    "ObjectRefKind",
+    "PublicRef",
+    "normalize_object_ref_text",
+    "normalize_public_ref_text",
+    "parse_public_ref",
+]

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -16,6 +16,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Final
 
 from polylogue.core.json import JSONValue, require_json_value
+from polylogue.core.refs import ObjectRef, normalize_object_ref_text, normalize_public_ref_text
 
 if TYPE_CHECKING:
     from polylogue.insights.transforms import DecisionCandidate, RecoveryDigest, TransformRawRef
@@ -233,14 +234,14 @@ def assertion_id_for_transform_candidate(
 
 
 def _target_ref(target_type: str | None, target_id: str | None) -> str | None:
-    """Compose the assertions ``target_ref`` from a legacy ``(type, id)`` pair.
+    """Compose and validate an assertion ``target_ref`` from ``(type, id)``.
 
     Returns ``None`` when no archive target is attached (e.g. an unscoped
-    blackboard note); callers fall back to their own row identity for the
+    blackboard note); callers fall back to a typed assertion ref for the
     NOT NULL ``target_ref`` column.
     """
     if target_type and target_id:
-        return f"{target_type}:{target_id}"
+        return normalize_object_ref_text(f"{target_type}:{target_id}")
     return None
 
 
@@ -543,7 +544,7 @@ def upsert_blackboard_note(
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_blackboard_note(resolved_id),
-        target_ref=_target_ref(target_type, target_id) or resolved_id,
+        target_ref=_target_ref(target_type, target_id) or ObjectRef(kind="assertion", object_id=resolved_id).format(),
         kind=AssertionKind.NOTE,
         key=resolved_id,
         body_text=body,
@@ -738,11 +739,16 @@ def _blackboard_envelope_from_assertion(assertion: ArchiveAssertionEnvelope) -> 
     raw_target_type, raw_target_id = _split_target_ref(assertion.target_ref)
     target_type: str | None = raw_target_type
     target_id: str | None = raw_target_id
-    if raw_target_type == "":
+    note_id = str(assertion.key or assertion.target_ref)
+    if raw_target_type == "assertion":
+        note_id = raw_target_id
+        target_type = None
+        target_id = None
+    elif raw_target_type == "":
         target_type = None
         target_id = None
     return ArchiveBlackboardNoteEnvelope(
-        note_id=str(assertion.key or assertion.target_ref),
+        note_id=note_id,
         target_type=target_type,
         target_id=target_id,
         body=assertion.body_text or "",
@@ -803,12 +809,19 @@ def upsert_assertion(
     ).fetchone()
     created_at_ms = int(existing[0]) if existing is not None else timestamp
 
+    normalized_target_ref = normalize_object_ref_text(target_ref)
+    normalized_scope_ref = normalize_object_ref_text(scope_ref) if scope_ref is not None else None
+    normalized_author_ref = (
+        normalize_object_ref_text(_normalize_assertion_author_ref(author_ref))
+        if author_ref is not None
+        else ASSERTION_DEFAULT_AUTHOR_REF
+    )
+    normalized_evidence_refs = [normalize_public_ref_text(ref) for ref in evidence_refs or ()]
     resolved_status = _normalize_assertion_status(status)
     resolved_visibility = _normalize_assertion_visibility(visibility)
-    resolved_author_ref = _normalize_assertion_author_ref(author_ref)
     resolved_author_kind = _normalize_assertion_author_kind(author_kind)
     resolved_context_policy = _normalize_assertion_context_policy(context_policy)
-    evidence_refs_json = _dumps_optional(list(evidence_refs or ()))
+    evidence_refs_json = _dumps_optional(normalized_evidence_refs)
     supersedes_json = _dumps_optional(list(supersedes or ()))
 
     conn.execute(
@@ -838,13 +851,13 @@ def upsert_assertion(
         """,
         (
             assertion_id,
-            scope_ref,
-            target_ref,
+            normalized_scope_ref,
+            normalized_target_ref,
             key,
             kind,
             _dumps_optional(value),
             body_text,
-            resolved_author_ref,
+            normalized_author_ref,
             resolved_author_kind,
             evidence_refs_json,
             resolved_status,

--- a/tests/unit/core/test_refs.py
+++ b/tests/unit/core/test_refs.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from polylogue.core.refs import EvidenceRef, ObjectRef
+from polylogue.core.refs import (
+    EvidenceRef,
+    ObjectRef,
+    normalize_object_ref_text,
+    normalize_public_ref_text,
+    parse_public_ref,
+)
 
 
 @pytest.mark.parametrize(
@@ -16,9 +22,17 @@ from polylogue.core.refs import EvidenceRef, ObjectRef
         ("block:codex-session:demo:message-1:2", "block", "codex-session:demo:message-1", ("2",)),
         ("file:polylogue/insights/transforms.py", "file", "polylogue/insights/transforms.py", ()),
         ("branch:feature/demo", "branch", "feature/demo", ()),
+        ("commit:abc1234", "commit", "abc1234", ()),
         ("check-run:ruff check", "check-run", "ruff check", ()),
         ("github-issue:Sinity/polylogue#1883", "github-issue", "Sinity/polylogue#1883", ()),
         ("github-review:1911", "github-review", "1911", ()),
+        ("user:sinity", "user", "sinity", ()),
+        ("repo:polylogue", "repo", "polylogue", ()),
+        ("insight:session-1", "insight", "session-1", ()),
+        ("transform:recovery_digest_v0@v1", "transform", "recovery_digest_v0@v1", ()),
+        ("assertion:note-1", "assertion", "note-1", ()),
+        ("saved_view:view-1", "saved_view", "view-1", ()),
+        ("recall_pack:pack-1", "recall_pack", "pack-1", ()),
     ],
 )
 def test_object_ref_parses_and_formats_existing_assertion_ref_shapes(
@@ -71,3 +85,20 @@ def test_evidence_ref_parses_formats_and_projects_to_object_ref(
 def test_evidence_ref_rejects_unsupported_or_lossy_shapes(raw: str) -> None:
     with pytest.raises(ValueError):
         EvidenceRef.parse(raw)
+
+
+def test_public_ref_parser_prefers_object_refs_and_accepts_recovery_evidence_refs() -> None:
+    object_ref = parse_public_ref("session:codex-session:demo")
+    evidence_ref = parse_public_ref("codex-session:demo::m2::0")
+
+    assert isinstance(object_ref, ObjectRef)
+    assert object_ref.format() == "session:codex-session:demo"
+    assert isinstance(evidence_ref, EvidenceRef)
+    assert evidence_ref.to_object_ref().format() == "block:m2:0"
+    assert normalize_object_ref_text("repo:polylogue") == "repo:polylogue"
+    assert normalize_public_ref_text("codex-session:demo::m2") == "codex-session:demo::m2"
+
+
+def test_object_ref_normalizer_rejects_unscoped_raw_strings() -> None:
+    with pytest.raises(ValueError):
+        normalize_object_ref_text("demo-fixture-world")

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -189,18 +189,19 @@ def test_blackboard_note_write_through_scoped_and_unscoped(tmp_path: Path) -> No
     assert scoped_mirror[0].author_kind == "user"
 
     unscoped = upsert_blackboard_note(conn, "global body", now_ms=1_700_000_031_000)
-    # Unscoped note falls back to its own note_id as target_ref.
+    unscoped_target_ref = f"assertion:{unscoped.note_id}"
     unscoped_env = read_assertion_envelope(
         conn,
         next(
             r["assertion_id"]
             for r in conn.execute(
                 "SELECT assertion_id FROM assertions WHERE kind = ? AND target_ref = ?",
-                (AssertionKind.NOTE, unscoped.note_id),
+                (AssertionKind.NOTE, unscoped_target_ref),
             )
         ),
     )
     assert unscoped_env is not None
+    assert unscoped_env.target_ref == unscoped_target_ref
     assert unscoped_env.body_text == "global body"
 
     # Idempotency on the scoped note.

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
 from polylogue.archive.message.roles import Role
@@ -220,6 +222,30 @@ def test_legacy_null_lifecycle_assertions_read_as_active_private_no_inject(tmp_p
 
         assert [claim.assertion_id for claim in list_assertion_claims(conn, statuses=("active",))] == ["legacy-null"]
         assert [row.assertion_id for row in list_assertions_for_export(conn, statuses=("active",))] == ["legacy-null"]
+    finally:
+        conn.close()
+
+
+def test_assertion_write_rejects_unparseable_public_refs(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+    try:
+        with pytest.raises(ValueError, match="object ref must use"):
+            upsert_assertion(
+                conn,
+                assertion_id="bad-target",
+                target_ref="bare-target-id",
+                kind=AssertionKind.DECISION,
+                now_ms=1_700_000_000_000,
+            )
+        with pytest.raises(ValueError, match="unsupported public ref"):
+            upsert_assertion(
+                conn,
+                assertion_id="bad-evidence",
+                target_ref="session:session-1",
+                kind=AssertionKind.DECISION,
+                evidence_refs=("session-1::message-1::not-a-block-index",),
+                now_ms=1_700_000_000_000,
+            )
     finally:
         conn.close()
 

--- a/tests/unit/storage/test_blackboard_facade.py
+++ b/tests/unit/storage/test_blackboard_facade.py
@@ -91,7 +91,7 @@ async def test_list_decodes_assertion_backed_blackboard_body(workspace_env: dict
         upsert_assertion(
             conn,
             assertion_id=assertion_id_for_blackboard_note(posted.note_id),
-            target_ref=posted.note_id,
+            target_ref=f"assertion:{posted.note_id}",
             kind=AssertionKind.NOTE,
             body_text="[decision] asserted title\n\nassertion body\n\nscope_repo: polylogue",
             now_ms=1_700_000_000_000,


### PR DESCRIPTION
## Summary

Adds shared public-ref parsing and normalization for assertion-backed evidence surfaces, then routes assertion writes through those typed ref boundaries.

## Problem

#1845 needs ObjectRef/EvidenceRef strings to be durable evidence atoms rather than ad hoc text. Assertion writes were still accepting target, scope, author, and evidence refs as unchecked strings, which let malformed or inconsistently formatted refs enter user-tier evidence rows.

## Solution

- Extends the consumed public-ref vocabulary with assertion, commit, repo, user, insight, saved-view, recall-pack, and transform refs.
- Adds public-ref parsing/normalization helpers in `polylogue.core.refs`.
- Normalizes assertion target/scope/author/evidence refs on write, preserving #1883 lifecycle defaults.
- Updates assertion-backed blackboard tests so unscoped notes still project through the facade while stored refs remain explicit.

## Verification

- `nix develop --command devtools verify --quick` (exit 0, run id `20260618T173820Z-quick-1727106-7d6fa4e0`)
- Earlier focused stack check: `38 passed` for refs/assertion/blackboard storage nodes after resolving the #1883 stack rebase.

Ref #1845