### PR TITLE
feat(web): expose recovery evidence in reader

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from polylogue.api import Polylogue
     from polylogue.archive.query.spec import SessionQuerySpec
     from polylogue.archive.semantic.content_projection import ContentProjectionSpec
+    from polylogue.insights.transforms import RecoveryReportPreset
     from polylogue.storage.sqlite.archive_tiers.archive import (
         ArchiveSessionSearchHit,
         ArchiveSessionSummary,
@@ -867,6 +868,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_query_completions(params)
         elif path == ["api", "read-view-profiles"]:
             self._handle_read_view_profiles()
+        elif path == ["api", "assertions"]:
+            self._handle_assertions(params)
         elif path == ["api", "paste-browser"]:
             self._handle_paste_browser(params)
         elif path == ["api", "attachments"]:
@@ -885,6 +888,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_get_session(path[2])
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "messages":
             self._handle_get_messages(path[2], params)
+        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "recovery":
+            self._handle_get_session_recovery(path[2], params)
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "raw":
             self._handle_get_session_raw(path[2])
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "cost":
@@ -2357,6 +2362,143 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         profiles = read_view_profile_payloads()
         self._send_json(HTTPStatus.OK, {"read_views": profiles, "total": len(profiles)})
+
+    @daemon_safe_handler
+    def _handle_assertions(self, params: dict[str, list[str]]) -> None:
+        """``GET /api/assertions`` lists assertion-backed overlay claims.
+
+        This is the web-workbench read side of #1883/#1846: the daemon
+        does not invent an overlay model, it routes through
+        ``Polylogue.list_assertion_claims`` and serializes the same
+        ``ArchiveAssertionEnvelope`` fields that MCP/API consumers see.
+        """
+
+        from polylogue.archive.query.spec import clamp_query_limit
+        from polylogue.surfaces.payloads import AssertionClaimPayload
+
+        kinds = _csv_values(params, "kind") + _csv_values(params, "kinds")
+        statuses = self._assertion_status_filter(params)
+        context_inject = None
+        if "context_inject" in params:
+            context_inject = self._get_bool(params, "context_inject")
+        limit = clamp_query_limit(self._get_int(params, "limit", 20), default=20)
+
+        async def _get(poly: Polylogue) -> object:
+            claims = await poly.list_assertion_claims(
+                kinds=tuple(dict.fromkeys(kinds)) or None,
+                target_ref=self._get_param(params, "target_ref"),
+                scope_ref=self._get_param(params, "scope_ref"),
+                statuses=statuses,
+                context_inject=context_inject,
+                limit=limit,
+            )
+            items = [AssertionClaimPayload.from_envelope(claim).model_dump(mode="json") for claim in claims]
+            return {"items": items, "total": len(items), "limit": limit}
+
+        self._send_json(HTTPStatus.OK, self._sync_run(_get))
+
+    def _assertion_status_filter(self, params: dict[str, list[str]]) -> tuple[str, ...] | None:
+        """Return status filters for ``GET /api/assertions``.
+
+        The default mirrors ``Polylogue.list_assertion_claims``
+        (``active,candidate``). ``status=all`` / ``statuses=all`` gives
+        the operator an explicit all-status read without special casing in
+        the underlying store.
+        """
+
+        raw_statuses = _csv_values(params, "status") + _csv_values(params, "statuses")
+        if not raw_statuses:
+            return ("active", "candidate")
+        normalized = tuple(dict.fromkeys(token.lower() for token in raw_statuses))
+        if normalized in {("all",), ("*",)}:
+            return None
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Handlers: recovery/work-packet read surface (#1846/#1838/#1845)
+    # ------------------------------------------------------------------
+
+    @daemon_safe_handler
+    def _handle_get_session_recovery(self, conv_id: str, params: dict[str, list[str]]) -> None:
+        """``GET /api/sessions/{id}/recovery`` exposes shared recovery DTOs.
+
+        Supported forms:
+        - ``?report=digest&format=json`` returns ``RecoveryDigest``.
+        - ``?report=work-packet&format=json`` returns ``RecoveryWorkPacket``.
+        - ``?report=work-packet&format=markdown`` returns rendered markdown.
+        - ``?report=continue|blame`` returns the corresponding recovery
+          report markdown in a JSON envelope.
+
+        Raw transcripts are not included; all support remains through the
+        recovery/work-packet evidence refs.
+        """
+
+        report = (self._get_param(params, "report", "work-packet") or "work-packet").strip().lower()
+        output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
+        if output_format not in {"json", "markdown"}:
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+            return
+        if report not in {"digest", "work-packet", "continue", "blame"}:
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_report")
+            return
+        if report == "digest" and output_format != "json":
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+            return
+
+        async def _get(poly: Polylogue) -> object:
+            return await self._do_get_session_recovery(poly, conv_id, report, output_format)
+
+        result = self._sync_run(_get)
+        if result is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+            return
+        self._send_json(HTTPStatus.OK, result)
+
+    async def _do_get_session_recovery(
+        self,
+        poly: Polylogue,
+        conv_id: str,
+        report: str,
+        output_format: str,
+    ) -> object | None:
+        if report == "digest":
+            digest = await poly.recovery_digest(conv_id)
+            if digest is None:
+                return None
+            return {
+                "session_id": digest.session_id,
+                "report": "digest",
+                "format": "json",
+                "digest": digest.model_dump(mode="json"),
+            }
+
+        if report == "work-packet":
+            packet = await poly.recovery_work_packet(conv_id)
+            if packet is None:
+                return None
+            if output_format == "markdown":
+                return {
+                    "session_id": packet.session_id,
+                    "report": "work-packet",
+                    "format": "markdown",
+                    "markdown": packet.render_markdown(),
+                }
+            return {
+                "session_id": packet.session_id,
+                "report": "work-packet",
+                "format": "json",
+                "work_packet": packet.model_dump(mode="json"),
+            }
+
+        markdown = await poly.recovery_report(conv_id, cast("RecoveryReportPreset", report))
+        if markdown is None:
+            return None
+        return {
+            "session_id": conv_id,
+            "report": report,
+            "format": "markdown",
+            "markdown": markdown,
+        }
 
     # ------------------------------------------------------------------
     # Handlers: per-session embedding similarity (#1123)

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -164,6 +164,15 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "bearer_if_configured",
         "read-view profile metadata",
     ),
+    RouteContract(
+        "GET",
+        "/api/assertions",
+        "user_overlay",
+        "stable",
+        "bearer_if_configured",
+        "assertion claim list envelope",
+        "Read-only assertion-backed overlay claims; writes stay on dedicated mutation routes.",
+    ),
     RouteContract("GET", "/api/sources", "read_detail", "shell_supported", "bearer_if_configured", "source list JSON"),
     RouteContract("GET", "/api/sessions/:id", "read_detail", "stable", "bearer_if_configured", "Session detail JSON"),
     RouteContract(
@@ -173,6 +182,15 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "stable",
         "bearer_if_configured",
         "session messages JSON",
+    ),
+    RouteContract(
+        "GET",
+        "/api/sessions/:id/recovery",
+        "read_detail",
+        "stable",
+        "bearer_if_configured",
+        "Recovery digest/work-packet envelope",
+        "Consumes shared recovery digest/work-packet DTOs; does not expose raw transcripts by default.",
     ),
     RouteContract(
         "GET",

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -276,6 +276,7 @@ __WORKSPACE_HTML__
       <button data-tab="cost">Cost</button>
       <button data-tab="lineage">Lineage</button>
       <button data-tab="insights">Insights</button>
+      <button data-tab="evidence">Evidence</button>
       <button data-tab="raw">Raw</button>
       <button data-tab="similar">Similar</button>
       <button data-tab="attachments">Attachments</button>
@@ -349,6 +350,11 @@ var state = {
   // Per-session collapsed-section toggles for the Insights tab.
   // Keyed as ``"<session_id>:<kind>"``; default = expanded.
   insightsCollapsed: {},
+  // Per-session evidence/work-packet panel cache (#1846). Keyed by
+  // session_id; populated from the new daemon recovery/assertion routes.
+  // This is intentionally a read-side cache over shared DTOs, not a web-only
+  // evidence model.
+  evidencePanels: {},
   // Per-session similarity panel cache (#1123). Keyed by
   // session_id; populated on demand when the Similar inspector
   // tab is opened. ``undefined`` means "not loaded yet"; the envelope
@@ -871,6 +877,7 @@ function renderInspector() {
   else if (tab === 'cost') renderInspectorCost(el, c);
   else if (tab === 'lineage') renderInspectorLineage(el, c);
   else if (tab === 'insights') renderInspectorInsights(el, c);
+  else if (tab === 'evidence') renderInspectorEvidence(el, c);
   else if (tab === 'raw') renderInspectorRaw(el, c);
   else if (tab === 'similar') renderInspectorSimilar(el, c);
   else if (tab === 'attachments') renderInspectorAttachments(el, c);
@@ -1155,6 +1162,72 @@ function renderInspectorCost(el, c) {
     });
     html += '</div>';
   }
+  el.innerHTML = html;
+}
+
+async function loadEvidencePanel(id) {
+  try {
+    var recovery = await fetchJSON('/api/sessions/' + id + '/recovery?report=work-packet&format=json');
+    var assertions = await fetchJSON('/api/assertions?target_ref=' + encodeURIComponent('session:' + id) + '&limit=20');
+    state.evidencePanels[id] = {recovery: recovery, assertions: assertions};
+  } catch(e) {
+    state.evidencePanels[id] = {error: String(e)};
+  }
+  if (state.selected && state.selected.id === id && state.inspectorTab === 'evidence') {
+    renderInspector();
+  }
+}
+
+function renderRefList(refs) {
+  if (!refs || !refs.length) return '<div class="inspector-empty">No refs surfaced</div>';
+  var html = '';
+  refs.slice(0, 12).forEach(function(ref) {
+    var label = (typeof ref === 'string') ? ref : (ref.ref || ref.object_ref || JSON.stringify(ref));
+    html += '<div class="user-state-row"><span class="label">ref</span><span class="value">' + esc(label) + '</span></div>';
+  });
+  if (refs.length > 12) html += '<div class="inspector-field"><span class="value muted">+' + (refs.length - 12) + ' more refs</span></div>';
+  return html;
+}
+
+function renderInspectorEvidence(el, c) {
+  var panel = state.evidencePanels[c.id];
+  if (panel === undefined) {
+    el.innerHTML = '<div class="inspector-empty">Loading evidence...</div>';
+    loadEvidencePanel(c.id);
+    return;
+  }
+  if (!panel || panel.error) {
+    el.innerHTML = '<div class="inspector-empty">Evidence surface unavailable</div>';
+    return;
+  }
+  var packet = (panel.recovery && panel.recovery.work_packet) || {};
+  var assertions = (panel.assertions && panel.assertions.items) || [];
+  var html = '<div class="inspector-section"><h4>Work packet</h4>'
+    + '<div class="inspector-field"><span class="label">entries</span><span class="value">' + esc(String((packet.entries || []).length)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">evidence refs</span><span class="value">' + esc(String((packet.evidence_refs || []).length)) + '</span></div>'
+    + '</div>';
+  if ((packet.entries || []).length) {
+    html += '<div class="inspector-section"><h4>Packet entries</h4>';
+    (packet.entries || []).slice(0, 8).forEach(function(entry) {
+      html += '<div class="annotation-item"><div class="meta">' + esc(entry.section || 'entry') + ' / ' + esc(entry.support || 'support') + '</div>'
+        + '<div class="note"><strong>' + esc(entry.label || 'entry') + '</strong><br>' + esc(entry.text || '') + '</div>'
+        + '</div>';
+    });
+    html += '</div>';
+  }
+  html += '<div class="inspector-section"><h4>Evidence refs</h4>' + renderRefList(packet.evidence_refs || []) + '</div>';
+  html += '<div class="inspector-section"><h4>Target refs</h4>' + renderRefList(packet.target_refs || []) + '</div>';
+  html += '<div class="inspector-section"><h4>Assertions</h4>';
+  if (assertions.length) {
+    assertions.forEach(function(claim) {
+      html += '<div class="annotation-item"><div class="meta">' + esc(claim.kind || 'claim') + ' / ' + esc(claim.status || '-') + '</div>'
+        + '<div class="note">' + esc(claim.body_text || claim.assertion_id || '') + '</div>'
+        + '<div class="meta">' + esc(claim.target_ref || '') + '</div></div>';
+    });
+  } else {
+    html += '<div class="inspector-empty">No assertion-backed overlays for this session</div>';
+  }
+  html += '</div>';
   el.innerHTML = html;
 }
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import RootModel
 from typing_extensions import TypedDict
@@ -39,6 +39,8 @@ from polylogue.mcp.context_pack import (
 )
 from polylogue.readiness import component_from_outcome_check
 from polylogue.surfaces.payloads import (
+    AssertionClaimListPayload,
+    AssertionClaimPayload,
     MutationResultPayload,
     SearchCursor,
     SearchEnvelope,
@@ -80,8 +82,10 @@ if TYPE_CHECKING:
     from polylogue.readiness import ReadinessCheck, ReadinessReport
     from polylogue.storage.runtime import RawSessionRecord
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
-    from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
+
+MCPAssertionClaimPayload: TypeAlias = AssertionClaimPayload
+MCPAssertionClaimListPayload: TypeAlias = AssertionClaimListPayload
 
 TRoot = TypeVar("TRoot")
 
@@ -141,60 +145,6 @@ class MCPBlackboardNoteListPayload(SurfacePayloadModel):
 
     items: tuple[MCPBlackboardNotePayload, ...]
     total: int
-
-
-class MCPAssertionClaimPayload(SurfacePayloadModel):
-    """One assertion-backed lifecycle claim."""
-
-    assertion_id: str
-    scope_ref: str | None = None
-    target_ref: str
-    key: str | None = None
-    kind: str
-    value: object | None = None
-    body_text: str | None = None
-    author_ref: str | None = None
-    author_kind: str | None = None
-    evidence_refs: tuple[str, ...] = ()
-    status: str | None = None
-    visibility: str | None = None
-    confidence: float | None = None
-    staleness: dict[str, Any] | None = None
-    context_policy: dict[str, Any] | None = None
-    supersedes: tuple[str, ...] = ()
-    created_at_ms: int
-    updated_at_ms: int
-
-    @classmethod
-    def from_envelope(cls, envelope: ArchiveAssertionEnvelope) -> MCPAssertionClaimPayload:
-        return cls(
-            assertion_id=envelope.assertion_id,
-            scope_ref=envelope.scope_ref,
-            target_ref=envelope.target_ref,
-            key=envelope.key,
-            kind=envelope.kind,
-            value=envelope.value,
-            body_text=envelope.body_text,
-            author_ref=envelope.author_ref,
-            author_kind=envelope.author_kind,
-            evidence_refs=tuple(envelope.evidence_refs),
-            status=envelope.status,
-            visibility=envelope.visibility,
-            confidence=envelope.confidence,
-            staleness=envelope.staleness,
-            context_policy=envelope.context_policy,
-            supersedes=tuple(envelope.supersedes),
-            created_at_ms=envelope.created_at_ms,
-            updated_at_ms=envelope.updated_at_ms,
-        )
-
-
-class MCPAssertionClaimListPayload(SurfacePayloadModel):
-    """Envelope for assertion-backed lifecycle claims."""
-
-    items: tuple[MCPAssertionClaimPayload, ...]
-    total: int
-    limit: int
 
 
 class MCPFencedCodeBlock(TypedDict):

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         ArchiveBlockQueryRow,
         ArchiveMessageQueryRow,
     )
+    from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
 
 
 def serialize_surface_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
@@ -973,6 +974,60 @@ class AssertionQueryRowPayload(SurfacePayloadModel):
         )
 
 
+class AssertionClaimPayload(SurfacePayloadModel):
+    """Shared payload for assertion-backed lifecycle claims."""
+
+    assertion_id: str
+    scope_ref: str | None = None
+    target_ref: str
+    key: str | None = None
+    kind: str
+    value: object | None = None
+    body_text: str | None = None
+    author_ref: str | None = None
+    author_kind: str | None = None
+    evidence_refs: tuple[str, ...] = ()
+    status: str | None = None
+    visibility: str | None = None
+    confidence: float | None = None
+    staleness: dict[str, Any] | None = None
+    context_policy: dict[str, Any] | None = None
+    supersedes: tuple[str, ...] = ()
+    created_at_ms: int
+    updated_at_ms: int
+
+    @classmethod
+    def from_envelope(cls, envelope: ArchiveAssertionEnvelope) -> AssertionClaimPayload:
+        return cls(
+            assertion_id=envelope.assertion_id,
+            scope_ref=envelope.scope_ref,
+            target_ref=envelope.target_ref,
+            key=envelope.key,
+            kind=envelope.kind,
+            value=envelope.value,
+            body_text=envelope.body_text,
+            author_ref=envelope.author_ref,
+            author_kind=envelope.author_kind,
+            evidence_refs=tuple(envelope.evidence_refs),
+            status=envelope.status,
+            visibility=envelope.visibility,
+            confidence=envelope.confidence,
+            staleness=envelope.staleness,
+            context_policy=envelope.context_policy,
+            supersedes=tuple(envelope.supersedes),
+            created_at_ms=envelope.created_at_ms,
+            updated_at_ms=envelope.updated_at_ms,
+        )
+
+
+class AssertionClaimListPayload(SurfacePayloadModel):
+    """Shared list envelope for assertion-backed lifecycle claims."""
+
+    items: tuple[AssertionClaimPayload, ...]
+    total: int
+    limit: int
+
+
 class ObservedEventQueryRowPayload(SurfacePayloadModel):
     """Shared terminal-query row for runtime-transform observed events."""
 
@@ -1607,6 +1662,8 @@ def validate_metadata_key(key: object) -> str | None:
 
 __all__ = [
     "ActionQueryRowPayload",
+    "AssertionClaimListPayload",
+    "AssertionClaimPayload",
     "BlockQueryRowPayload",
     "BulkTagMutationResult",
     "SessionDetailPayload",

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -46,10 +46,18 @@ def test_stable_routes_have_explicit_auth_and_response_contracts() -> None:
         ("GET", "/metrics", "/metrics", "operational", "unauthenticated_loopback"),
         ("GET", "/api/sessions", "/api/sessions", "read_query", "bearer_if_configured"),
         ("GET", "/api/query-units", "/api/query-units", "read_query", "bearer_if_configured"),
+        ("GET", "/api/assertions", "/api/assertions", "user_overlay", "bearer_if_configured"),
         (
             "GET",
             "/api/sessions/codex-session:abc/messages",
             "/api/sessions/:id/messages",
+            "read_detail",
+            "bearer_if_configured",
+        ),
+        (
+            "GET",
+            "/api/sessions/codex-session:abc/recovery",
+            "/api/sessions/:id/recovery",
             "read_detail",
             "bearer_if_configured",
         ),

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -214,6 +214,61 @@ def _seed_test_db(workspace: dict[str, Path]) -> None:
             )
 
 
+def _seed_assertion_claims(workspace: dict[str, Path]) -> None:
+    """Seed user-tier assertion claims for the web overlay endpoint."""
+
+    import sqlite3
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
+    user_db = workspace["archive_root"] / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    with sqlite3.connect(user_db) as conn:
+        upsert_assertion(
+            conn,
+            assertion_id="claim-web-workbench-decision",
+            target_ref=f"session:{C1}",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.DECISION,
+            body_text="Show assertion-backed overlays in the web workbench.",
+            author_ref="agent:poly-07",
+            author_kind="agent",
+            evidence_refs=[f"message:{M_C1}"],
+            status="active",
+            visibility="private",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-web-workbench-candidate",
+            target_ref=f"session:{C1}",
+            scope_ref="repo:polylogue",
+            kind=AssertionKind.CAVEAT,
+            body_text="Candidate caveat stays visible in default web claim reads.",
+            author_ref="agent:poly-07",
+            author_kind="agent",
+            evidence_refs=[f"message:{M_C1}"],
+            status="candidate",
+            visibility="private",
+            context_policy={"inject": False},
+            now_ms=1_700_000_000_100,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-web-workbench-deleted",
+            target_ref=f"session:{C1}",
+            kind=AssertionKind.DECISION,
+            body_text="Deleted claim is hidden by default.",
+            status="deleted",
+            visibility="private",
+            now_ms=1_700_000_000_200,
+        )
+        conn.commit()
+
+
 def _seed_archive_test_archive(workspace: dict[str, Path]) -> str:
     from polylogue.archive.message.roles import Role
     from polylogue.core.enums import BlockType, Provider
@@ -312,6 +367,10 @@ class TestReaderSearchState:
             "renderStackWorkspace",
             "renderCompareWorkspace",
             "renderInspector",
+            "renderInspectorEvidence",
+            "/api/assertions",
+            "/recovery?report=work-packet",
+            'data-tab="evidence"',
         ):
             assert region in body, f"web shell missing region hook {region!r}"
 
@@ -1178,6 +1237,68 @@ class TestReaderViewProfiles:
         assert profiles["raw"]["evidence_policy"] == "required"
         assert profiles["recovery"]["successor_handoff"] is True
         assert "markdown" in profiles["recovery"]["formats"]
+
+
+class TestReaderRecoveryEndpoint:
+    def test_recovery_endpoint_returns_shared_work_packet_json(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/recovery?report=work-packet&format=json"),
+            )
+
+        assert payload["report"] == "work-packet"
+        assert payload["format"] == "json"
+        packet = cast(dict[str, object], payload["work_packet"])
+        assert packet["session_id"] == C1
+        assert packet["evidence_refs"]
+        assert "raw_artifacts" not in json.dumps(payload)
+
+    def test_recovery_endpoint_returns_markdown_envelope(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/recovery?report=work-packet&format=markdown"),
+            )
+
+        assert payload["report"] == "work-packet"
+        assert payload["format"] == "markdown"
+        assert "markdown" in payload
+        assert C1 in str(payload["markdown"])
+
+
+class TestReaderAssertionEndpoint:
+    def test_assertions_endpoint_reads_shared_assertion_claims(self, workspace_env: dict[str, Path]) -> None:
+        _seed_assertion_claims(workspace_env)
+        target_ref = quote(f"session:{C1}", safe="")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(dict[str, object], _get_json(base_url, f"/api/assertions?target_ref={target_ref}&limit=5"))
+
+        assert payload["total"] == 2
+        items = cast(list[dict[str, object]], payload["items"])
+        assert {item["assertion_id"] for item in items} == {
+            "claim-web-workbench-decision",
+            "claim-web-workbench-candidate",
+        }
+        decision = next(item for item in items if item["kind"] == "decision")
+        assert decision["target_ref"] == f"session:{C1}"
+        assert decision["context_policy"] == {"inject": True}
+
+    def test_assertions_endpoint_can_explicitly_read_all_statuses(self, workspace_env: dict[str, Path]) -> None:
+        _seed_assertion_claims(workspace_env)
+        target_ref = quote(f"session:{C1}", safe="")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/assertions?target_ref={target_ref}&status=all&limit=5"),
+            )
+
+        items = cast(list[dict[str, object]], payload["items"])
+        assert {item["assertion_id"] for item in items} == {
+            "claim-web-workbench-decision",
+            "claim-web-workbench-candidate",
+            "claim-web-workbench-deleted",
+        }
 
 
 class TestReaderPrivacy:


### PR DESCRIPTION
## Summary

Adds a route-backed Evidence tab to the daemon web reader, powered by shared recovery/work-packet and assertion-claim payloads.

## Problem

#1846 needs the workbench to inspect support for a selected session without inventing a browser-only evidence model. The existing reader could show session details, raw data, cost, lineage, and insights, but not the recovery/work-packet evidence or assertion-backed claims that already exist in the archive surfaces.

## Solution

- Adds `GET /api/sessions/:id/recovery` for recovery digest/work-packet/report envelopes.
- Adds `GET /api/assertions` for read-only assertion-backed lifecycle claims.
- Registers both daemon route contracts with bearer-if-configured posture.
- Adds an Evidence inspector tab that consumes those routes for the selected session.
- Moves assertion-claim payload serialization into `polylogue.surfaces.payloads` so daemon and MCP share the payload shape instead of depending on storage write helpers.

## Verification

- `nix develop --command devtools verify --quick` (exit 0, run id `20260618T174128Z-quick-1769861-5c2241b5`)
- Focused route/surface suite: `168 passed` for `tests/unit/daemon/test_web_reader.py`, `tests/unit/daemon/test_route_contracts.py`, and the MCP assertion-claim tool node.

Ref #1846
Ref #1847