### PR TITLE
feat(work-packets): cite commit refs from git tools

### DIFF
--- a/polylogue/insights/run_projection.py
+++ b/polylogue/insights/run_projection.py
@@ -72,6 +72,9 @@ class _ToolSummaryLike(Protocol):
     @property
     def file_refs(self) -> Sequence[str]: ...
 
+    @property
+    def commit_refs(self) -> Sequence[str]: ...
+
 
 class _SubagentReportLike(Protocol):
     @property
@@ -411,6 +414,7 @@ def _tool_object_refs(tool: _ToolSummaryLike) -> tuple[ObjectRef, ...]:
         *(ObjectRef(kind="github-pr", object_id=ref) for ref in tool.pr_refs),
         *(ObjectRef(kind="github-issue", object_id=ref) for ref in tool.issue_refs if ref not in set(tool.pr_refs)),
         *(ObjectRef(kind="file", object_id=ref) for ref in tool.file_refs),
+        *(ObjectRef(kind="commit", object_id=ref) for ref in tool.commit_refs),
     )
 
 

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -67,6 +67,7 @@ _TEST_PASS_RE = re.compile(r"\b(?P<count>\d+)\s+passed\b", re.IGNORECASE)
 _TEST_FAIL_RE = re.compile(r"\b(?P<count>\d+)\s+failed\b", re.IGNORECASE)
 _CHECK_PASS_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_.() -]+)\s+\.\.\.\s+ok\b")
 _CHECK_FAIL_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_.() -]+)\s+\.\.\.\s+(?:FAIL|FAILED|failure)\b", re.IGNORECASE)
+_COMMIT_SHA_RE = re.compile(r"\b(?P<sha>[0-9a-f]{7,40})\b", re.IGNORECASE)
 _DECISION_RE = re.compile(r"\b(decision|decided|choose|chosen):?\s+(?P<text>.+)", re.IGNORECASE)
 _STATUS_HEADING_RE = re.compile(r"^\s*(goal|done|in flight|blockers?|next):\s*(?P<text>.+)$", re.IGNORECASE)
 _RUNSTATE_SECTION_RE = re.compile(
@@ -169,6 +170,7 @@ class ToolSummary(ArchiveInsightModel):
     issue_refs: tuple[str, ...] = ()
     test_evidence: tuple[str, ...] = ()
     file_refs: tuple[str, ...] = ()
+    commit_refs: tuple[str, ...] = ()
     raw_refs: tuple[TransformRawRef, ...]
 
     @model_validator(mode="after")
@@ -532,7 +534,10 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         object_refs = _object_refs_line(entry)
         if object_refs:
             lines.append(f"  - refs: {object_refs}")
-        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "review_refs", "issue_refs", "test_evidence"))
+        detail = _packet_metadata_line(
+            entry.metadata,
+            keys=("pr_refs", "review_refs", "issue_refs", "commit_refs", "test_evidence"),
+        )
         if detail:
             lines.append(f"  - details: {detail}")
     if not event_entries:
@@ -566,7 +571,10 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         object_refs = _object_refs_line(entry)
         if object_refs:
             lines.append(f"  - refs: {object_refs}")
-        detail = _packet_metadata_line(entry.metadata, keys=("pr_refs", "issue_refs", "file_refs", "test_evidence"))
+        detail = _packet_metadata_line(
+            entry.metadata,
+            keys=("pr_refs", "issue_refs", "file_refs", "commit_refs", "test_evidence"),
+        )
         if detail:
             lines.append(f"  - details: {detail}")
     if not tool_entries:
@@ -856,6 +864,8 @@ def _tool_packet_metadata(tool: ToolSummary) -> dict[str, str]:
         metadata["issue_refs"] = ", ".join(issue_refs)
     if tool.file_refs:
         metadata["file_refs"] = ", ".join(tool.file_refs)
+    if tool.commit_refs:
+        metadata["commit_refs"] = ", ".join(tool.commit_refs)
     if tool.test_evidence:
         metadata["test_evidence"] = " | ".join(tool.test_evidence)
     return metadata
@@ -869,6 +879,7 @@ def _tool_object_refs(tool: ToolSummary) -> tuple[ObjectRef, ...]:
         *_github_object_refs("github-pr", tool.pr_refs),
         *_github_object_refs("github-issue", issue_refs),
         *(ObjectRef(kind="file", object_id=ref) for ref in tool.file_refs),
+        *(ObjectRef(kind="commit", object_id=ref) for ref in tool.commit_refs),
     )
 
 
@@ -1201,6 +1212,7 @@ def _extract_tool_summaries(session: Session, messages: Sequence[Message]) -> It
                 issue_refs=tuple(_number_refs(_ISSUE_RE, output_text)),
                 test_evidence=tuple(_test_evidence(output_text)),
                 file_refs=tuple(_tool_file_refs(tool_name=tool_name, command=command, output_text=output_text)),
+                commit_refs=tuple(_tool_commit_refs(command=command, output_text=output_text)),
                 raw_refs=tuple(refs),
             )
 
@@ -1789,6 +1801,35 @@ def _tool_file_refs(
             cleaned = token.strip("`'\"(),:")
             if "/" in cleaned and "#" not in cleaned and not cleaned.startswith(("http://", "https://")):
                 yield cleaned
+
+
+def _tool_commit_refs(*, command: str | None, output_text: str) -> Iterable[str]:
+    """Return commit hashes from git-shaped tool evidence.
+
+    The detector is intentionally conservative: a bare 40-character hash in
+    arbitrary command output is not enough. Work packets cite commit refs only
+    when the command itself is git-shaped or the output line names commit-ish
+    context, keeping handoff packets small and avoiding random hex soup.
+    """
+
+    command_text = command or ""
+    should_scan_all_output = _command_invokes_git(command_text)
+    seen: set[str] = set()
+    for value in (command_text, output_text):
+        for line in value.splitlines() or [value]:
+            lowered = line.lower()
+            if not (should_scan_all_output or any(token in lowered for token in ("commit", "sha", "head"))):
+                continue
+            for match in _COMMIT_SHA_RE.finditer(line):
+                sha = match.group("sha").lower()
+                if sha in seen:
+                    continue
+                seen.add(sha)
+                yield sha
+
+
+def _command_invokes_git(command: str) -> bool:
+    return re.search(r"(?:^|[;&|({]\s*)git(?:\s|$)", command, re.IGNORECASE) is not None
 
 
 def _block_text(block: Mapping[str, object]) -> str:

--- a/tests/unit/core/test_refs.py
+++ b/tests/unit/core/test_refs.py
@@ -23,6 +23,7 @@ from polylogue.core.refs import (
         ("file:polylogue/insights/transforms.py", "file", "polylogue/insights/transforms.py", ()),
         ("branch:feature/demo", "branch", "feature/demo", ()),
         ("commit:abc1234", "commit", "abc1234", ()),
+        ("commit:a8cd1c1516b29068ec9ce1493f262d663407ffa5", "commit", "a8cd1c1516b29068ec9ce1493f262d663407ffa5", ()),
         ("check-run:ruff check", "check-run", "ruff check", ()),
         ("github-issue:Sinity/polylogue#1883", "github-issue", "Sinity/polylogue#1883", ()),
         ("github-review:1911", "github-review", "1911", ()),

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -91,6 +91,17 @@ def _session() -> Session:
                             "tool_id": "tool-read",
                             "text": "class ToolSummary\nhandler_kind: Literal",
                         },
+                        {
+                            "type": "tool_use",
+                            "id": "tool-commit",
+                            "name": "Bash",
+                            "tool_input": {"command": "git rev-parse HEAD"},
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-commit",
+                            "text": "a8cd1c1516b29068ec9ce1493f262d663407ffa5",
+                        },
                     ],
                 ),
                 Message(
@@ -161,7 +172,7 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert digest.size_metrics.resume_bundle_bytes >= digest.size_metrics.normal_read_bytes
     assert digest.role_counts == {"user": 1, "assistant": 2}
 
-    assert len(digest.tool_summaries) == 3
+    assert len(digest.tool_summaries) == 4
     tool = next(item for item in digest.tool_summaries if item.tool_name == "Bash")
     assert tool.tool_name == "Bash"
     assert tool.command == "devtools verify --quick"
@@ -181,6 +192,10 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     assert read_tool.command == "polylogue/insights/transforms.py"
     assert read_tool.line_count == 2
     assert read_tool.file_refs == ("polylogue/insights/transforms.py",)
+
+    commit_tool = next(item for item in digest.tool_summaries if item.command == "git rev-parse HEAD")
+    assert commit_tool.handler_kind == "git"
+    assert commit_tool.commit_refs == ("a8cd1c1516b29068ec9ce1493f262d663407ffa5",)
 
     assert len(digest.subagent_reports) == 1
     subagent = digest.subagent_reports[0]
@@ -231,6 +246,10 @@ def test_compile_recovery_digest_extracts_small_evidence_linked_bundle() -> None
     check_projection = next(event for event in projection.events if event.kind == "check_passed")
     assert check_projection.delivery_state == "observed"
     assert check_projection.object_refs == (ObjectRef(kind="check-run", object_id="ruff check"),)
+    commit_projection = next(event for event in projection.events if event.summary.endswith("git rev-parse HEAD"))
+    assert (
+        ObjectRef(kind="commit", object_id="a8cd1c1516b29068ec9ce1493f262d663407ffa5") in commit_projection.object_refs
+    )
     review_projection = next(event for event in projection.events if event.kind == "review_acted_on")
     assert review_projection.delivery_state == "acted_on"
     assert review_projection.object_refs == (ObjectRef(kind="github-review", object_id="#1911"),)
@@ -433,6 +452,15 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
         "file_refs": "polylogue/insights/transforms.py",
     }
     assert read_entry.object_refs == (ObjectRef(kind="file", object_id="polylogue/insights/transforms.py"),)
+    commit_entry = next(
+        entry for entry in packet.entries if entry.section == "tools" and entry.text == "git rev-parse HEAD"
+    )
+    assert commit_entry.metadata == {
+        "handler_kind": "git",
+        "status": "unknown",
+        "commit_refs": "a8cd1c1516b29068ec9ce1493f262d663407ffa5",
+    }
+    assert commit_entry.object_refs == (ObjectRef(kind="commit", object_id="a8cd1c1516b29068ec9ce1493f262d663407ffa5"),)
     for entry in packet.entries:
         for ref in entry.object_refs:
             assert ObjectRef.parse(ref.format()) == ref
@@ -457,8 +485,10 @@ def test_work_packet_exposes_storage_free_continuation_bundle() -> None:
     assert "refs: tool_id=tool-2, task_id=task-42, child_session_id=codex-session:child-42" in rendered
     assert "- [raw-evidence] Bash [test] (ok) — devtools verify --quick" in rendered
     assert "refs: file:polylogue/insights/transforms.py" in rendered
+    assert "refs: commit:a8cd1c1516b29068ec9ce1493f262d663407ffa5" in rendered
     assert "details: pr_refs=#1911; test_evidence=ruff check ... ok | 20 passed in 50.28s" in rendered
     assert "details: file_refs=polylogue/insights/transforms.py" in rendered
+    assert "details: commit_refs=a8cd1c1516b29068ec9ce1493f262d663407ffa5" in rendered
 
 
 def test_work_packet_marks_missing_evidence_explicitly() -> None:
@@ -474,6 +504,40 @@ def test_work_packet_marks_missing_evidence_explicitly() -> None:
     assert "## Evidence Gaps" in rendered
     assert "- [missing-evidence] run_state: No structured RunState section was extracted" in rendered
     assert "- [missing-evidence] tools: No tool execution summary was extracted." in rendered
+
+
+def test_work_packet_does_not_promote_random_hex_to_commit_ref() -> None:
+    session = Session(
+        id=SessionId("codex-session:hex-output"),
+        origin=Origin.CODEX_SESSION,
+        title="Random hex output",
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="m-hex",
+                    role=Role.ASSISTANT,
+                    text="Tool output contained opaque ids.",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "id": "tool-hex",
+                            "name": "Bash",
+                            "tool_input": {"command": "cat artefact-id.txt"},
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-hex",
+                            "text": "a8cd1c1516b29068ec9ce1493f262d663407ffa5",
+                        },
+                    ],
+                )
+            ]
+        ),
+    )
+
+    [tool] = compile_recovery_digest(session).tool_summaries
+
+    assert tool.commit_refs == ()
 
 
 def test_continue_report_renders_successor_boot_packet_with_evidence_refs() -> None:


### PR DESCRIPTION
## Summary

Adds commit refs to recovery tool summaries, run projections, and work-packet entries when git tool evidence contains commit SHAs.

## Problem

#1838 work packets already surface files, PRs, issues, checks, and raw refs, but git commands like `git rev-parse HEAD` were still plain text. That made handoff evidence less navigable even though `ObjectRef` now supports commit refs.

## Solution

- Extract commit hashes from git-shaped tool commands/output.
- Carry `commit_refs` through `ToolSummary`, run projection object refs, work-packet metadata, and markdown rendering.
- Keep extraction conservative: non-git output with random hex is not promoted to commit evidence.
- Adds short and full-SHA ref parsing coverage.

## Verification

- `nix develop --command devtools verify --quick` (exit 0, run id `20260618T175223Z-quick-1844290-66815dc3`)
- Focused refs/work-packet suite: `53 passed` in `tests/unit/core/test_refs.py` and `tests/unit/insights/test_transforms.py`

Ref #1838
Ref #1845