### PR TITLE
fix(devtools): validate release PR evidence bodies

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -170,7 +170,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "Check that the release-readiness gate document, required local commands, "
             "and release PR evidence template are still coherent before touching a release PR."
         ),
-        examples=("devtools release-readiness", "devtools release-readiness --json"),
+        examples=(
+            "devtools release-readiness",
+            "devtools release-readiness --json",
+            "devtools release-readiness --release-body-file /tmp/release-pr-body.md",
+        ),
     ),
     CommandSpec(
         "test",

--- a/devtools/generated_surfaces.py
+++ b/devtools/generated_surfaces.py
@@ -39,6 +39,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         command=control_plane_argv("render-agents"),
         main=render_agents.main,
         inputs=(
+            "devtools/render_agents.py",
             "CLAUDE.md",
             "CONTRIBUTING.md",
             "TESTING.md",
@@ -83,7 +84,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Render the generated command catalog inside docs/devtools.md.",
         command=control_plane_argv("render-devtools-reference"),
         main=render_devtools_reference.main,
-        inputs=("devtools/command_catalog.py",),
+        inputs=("devtools/command_catalog.py", "devtools/render_devtools_reference.py"),
     ),
     GeneratedSurface(
         name="quality-reference",
@@ -91,7 +92,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Render docs/test-quality-workflows.md from quality registries.",
         command=control_plane_argv("render-quality-reference"),
         main=render_quality_reference.main,
-        inputs=("devtools/run_validation_lanes.py", "pyproject.toml"),
+        inputs=("devtools/render_quality_reference.py", "devtools/run_validation_lanes.py", "pyproject.toml"),
     ),
     GeneratedSurface(
         name="docs-surface",
@@ -99,7 +100,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Render docs/README.md and the generated docs table in README.md.",
         command=control_plane_argv("render-docs-surface"),
         main=render_docs_surface.main,
-        inputs=("docs/", "README.md"),
+        inputs=("devtools/render_docs_surface.py", "docs/", "README.md"),
     ),
     GeneratedSurface(
         name="topology-status",
@@ -107,7 +108,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Render docs/topology-status.md from the topology projection and realized tree.",
         command=control_plane_argv("render-topology-status"),
         main=render_topology_status.main,
-        inputs=("docs/plans/topology-target.yaml",),
+        inputs=("devtools/render_topology_status.py", "docs/plans/topology-target.yaml"),
     ),
     GeneratedSurface(
         name="pages",
@@ -115,7 +116,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Build the GitHub Pages documentation site into .cache/site/.",
         command=control_plane_argv("render-pages"),
         main=render_pages.main,
-        inputs=("docs/", "README.md", "polylogue/", "pyproject.toml"),
+        inputs=("devtools/render_pages.py", "docs/", "README.md", "polylogue/", "pyproject.toml"),
     ),
 )
 

--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -56,6 +56,8 @@ REQUIRED_DOC_HEADINGS: tuple[str, ...] = (
     "## Release PR Body Requirements",
 )
 
+REQUIRED_RELEASE_BODY_HEADINGS: tuple[str, ...] = ("Release gate:", "Verification:")
+
 REQUIRED_RELEASE_BODY_FIELDS: tuple[str, ...] = (
     "- Command floor:",
     "- Machine output:",
@@ -100,7 +102,34 @@ def _issue_refs(lines: list[str]) -> set[str]:
     return refs
 
 
-def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
+def _read_text_file(path: Path, *, label: str, errors: list[str]) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"could not read {label}: {path}: {exc}")
+        return None
+
+
+def _validate_release_body(text: str, *, errors: list[str]) -> dict[str, Any]:
+    missing_headings = [heading for heading in REQUIRED_RELEASE_BODY_HEADINGS if heading not in text]
+    missing_fields = [field for field in REQUIRED_RELEASE_BODY_FIELDS if field not in text]
+    for heading in missing_headings:
+        errors.append(f"release PR body missing heading: {heading}")
+    for field in missing_fields:
+        errors.append(f"release PR body missing field: {field}")
+    return {
+        "checked": True,
+        "missing_headings": missing_headings,
+        "missing_fields": missing_fields,
+    }
+
+
+def build_report(
+    *,
+    gate_doc: Path = GATE_DOC,
+    release_body_file: Path | None = None,
+    release_body_text: str | None = None,
+) -> dict[str, Any]:
     """Return a JSON-serializable release-gate definition report."""
     from devtools.command_catalog import COMMANDS
 
@@ -114,6 +143,9 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
     for heading in REQUIRED_DOC_HEADINGS:
         if heading not in text:
             errors.append(f"gate document missing heading: {heading}")
+    for heading in REQUIRED_RELEASE_BODY_HEADINGS:
+        if heading not in text:
+            errors.append(f"release PR template missing heading: {heading}")
     for field in REQUIRED_RELEASE_BODY_FIELDS:
         if field not in text:
             errors.append(f"release PR template missing field: {field}")
@@ -142,12 +174,25 @@ def build_report(*, gate_doc: Path = GATE_DOC) -> dict[str, Any]:
                 f"{', '.join(overlapping_refs)} without scoped-out/caveat wording"
             )
 
+    release_body_report: dict[str, Any] = {"checked": False}
+    if release_body_text is not None and release_body_file is not None:
+        errors.append("pass either release_body_text or release_body_file, not both")
+    elif release_body_text is not None:
+        release_body_report = _validate_release_body(release_body_text, errors=errors)
+    elif release_body_file is not None:
+        body_text = _read_text_file(release_body_file, label="release PR body", errors=errors)
+        if body_text is not None:
+            release_body_report = _validate_release_body(body_text, errors=errors)
+            release_body_report["path"] = str(release_body_file)
+
     return {
         "ok": not errors,
         "gate_doc": str(gate_doc.relative_to(ROOT) if gate_doc.is_relative_to(ROOT) else gate_doc),
         "required_commands": [command.to_dict() for command in REQUIRED_COMMANDS],
         "focused_commands": [command.to_dict() for command in FOCUSED_COMMANDS],
+        "required_release_body_headings": list(REQUIRED_RELEASE_BODY_HEADINGS),
         "required_release_body_fields": list(REQUIRED_RELEASE_BODY_FIELDS),
+        "release_body": release_body_report,
         "release_status": {
             "satisfied": satisfied,
             "blocking_external_claims": blocking,
@@ -169,6 +214,13 @@ def _print_human(report: dict[str, Any]) -> None:
     print("release status:")
     print(f"  satisfied: {len(report['release_status']['satisfied'])}")
     print(f"  blocking external claims: {len(report['release_status']['blocking_external_claims'])}")
+    body = report.get("release_body")
+    if isinstance(body, dict) and body.get("checked"):
+        print("release PR body: checked")
+        if body.get("missing_headings"):
+            print(f"  missing headings: {len(body['missing_headings'])}")
+        if body.get("missing_fields"):
+            print(f"  missing fields: {len(body['missing_fields'])}")
     if report["errors"]:
         print("errors:")
         for error in report["errors"]:
@@ -178,9 +230,14 @@ def _print_human(report: dict[str, Any]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit the gate-definition report as JSON.")
+    parser.add_argument(
+        "--release-body-file",
+        type=Path,
+        help="Validate an actual release PR body against the gate evidence template.",
+    )
     args = parser.parse_args(argv)
 
-    report = build_report()
+    report = build_report(release_body_file=args.release_body_file)
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -25,6 +25,7 @@ Run these from a clean checkout inside the devshell:
 
 ```bash
 devtools release-readiness
+devtools release-readiness --release-body-file /tmp/release-pr-body.md
 devtools verify --quick
 devtools verify --lab
 devtools build-package
@@ -64,7 +65,7 @@ nix flake check
 
 ## Manual Release Review
 
-Before merging a release PR, record the answers in the PR body:
+Before merging a release PR, record the answers in the PR body and run `devtools release-readiness --release-body-file <path>` against that exact body text:
 
 | Question | Required Answer |
 | --- | --- |

--- a/tests/unit/devtools/test_generated_surfaces.py
+++ b/tests/unit/devtools/test_generated_surfaces.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from devtools.generated_surfaces import GENERATED_SURFACES
 
 
@@ -14,3 +16,10 @@ def test_generated_surfaces_use_public_devtools_commands() -> None:
 def test_generated_surface_names_and_labels_are_unique() -> None:
     assert len({surface.name for surface in GENERATED_SURFACES}) == len(GENERATED_SURFACES)
     assert len({surface.label for surface in GENERATED_SURFACES}) == len(GENERATED_SURFACES)
+
+
+def test_generated_surface_cache_inputs_include_renderer_module() -> None:
+    """Renderer edits must invalidate normal render-all stamps, not only --check."""
+    for surface in GENERATED_SURFACES:
+        renderer_path = Path(*surface.main.__module__.split(".")).with_suffix(".py").as_posix()
+        assert renderer_path in surface.inputs, surface.name

--- a/tests/unit/devtools/test_release_readiness.py
+++ b/tests/unit/devtools/test_release_readiness.py
@@ -17,6 +17,7 @@ def _valid_gate_text() -> str:
     headings = "\n\n".join(release_readiness.REQUIRED_DOC_HEADINGS)
     commands = "\n".join(" ".join(command.argv) for command in release_readiness.REQUIRED_COMMANDS)
     fields = "\n".join(release_readiness.REQUIRED_RELEASE_BODY_FIELDS)
+    body_headings = "\n".join(release_readiness.REQUIRED_RELEASE_BODY_HEADINGS)
     return f"""# Release Readiness Gate
 
 {headings}
@@ -34,6 +35,7 @@ Still blocking external release claims:
 - #2 blocks a release claim.
 
 ```text
+{body_headings}
 {fields}
 ```
 """
@@ -117,3 +119,60 @@ def test_release_readiness_allows_satisfied_issue_in_scoped_caveat(tmp_path: Pat
     report = release_readiness.build_report(gate_doc=gate_doc)
 
     assert report["ok"] is True
+
+
+def _valid_release_body_text() -> str:
+    fields = "\n".join(f"{field} satisfied" for field in release_readiness.REQUIRED_RELEASE_BODY_FIELDS)
+    return f"""Release gate:
+{fields}
+
+Verification:
+- devtools release-readiness -- key output line
+"""
+
+
+def test_release_readiness_can_validate_release_pr_body_text(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(gate_doc, _valid_gate_text())
+
+    report = release_readiness.build_report(
+        gate_doc=gate_doc,
+        release_body_text=_valid_release_body_text(),
+    )
+
+    assert report["ok"] is True
+    assert report["release_body"] == {
+        "checked": True,
+        "missing_headings": [],
+        "missing_fields": [],
+    }
+
+
+def test_release_readiness_rejects_release_pr_body_without_gate_evidence(tmp_path: Path) -> None:
+    gate_doc = tmp_path / "release-readiness-gate.md"
+    _write_gate(gate_doc, _valid_gate_text())
+
+    report = release_readiness.build_report(
+        gate_doc=gate_doc,
+        release_body_text="This release is too large to preview in the pull request body.",
+    )
+
+    assert report["ok"] is False
+    assert report["release_body"]["checked"] is True
+    assert "release PR body missing heading: Release gate:" in report["errors"]
+    assert "release PR body missing heading: Verification:" in report["errors"]
+    assert "release PR body missing field: - Command floor:" in report["errors"]
+
+
+def test_release_readiness_cli_validates_release_body_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    body = tmp_path / "body.md"
+    body.write_text(_valid_release_body_text(), encoding="utf-8")
+
+    assert release_readiness.main(["--json", "--release-body-file", str(body)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["release_body"]["checked"] is True
+    assert payload["release_body"]["path"] == str(body)


### PR DESCRIPTION
## Summary

Tightens release-readiness around the actual release PR body and generated-surface stamp inputs.

## Problem

`devtools release-readiness` could prove the committed gate template was coherent while the release PR body being merged omitted the required evidence. Separately, renderer-only changes could miss generated-surface stamp invalidation when the renderer module was not listed as an input.

## Solution

- Add `--release-body-file` to validate a concrete release PR body against the existing release-gate evidence headings/fields.
- Document the body-file check and include it in the command catalog example.
- Add renderer modules to generated-surface cache inputs.
- Cover both behaviors with ordinary unit tests.

## Verification

- `devtools test tests/unit/devtools/test_release_readiness.py tests/unit/devtools/test_generated_surfaces.py` -> 13 passed.
- `devtools verify --quick` -> exit 0, `run_id=20260618T175917Z-quick-1883441-a02f32c5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--release-body-file` flag to release-readiness command to validate PR body text against required headings and fields.

* **Documentation**
  * Updated release readiness gate documentation to require `--release-body-file` argument during manual review process.

* **Tests**
  * Added test coverage for PR body validation, including validation success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->