### PR TITLE
refactor(context): read context-pack assertions through facade (#1883)

### DIFF
--- a/polylogue/context/assertion_claims.py
+++ b/polylogue/context/assertion_claims.py
@@ -2,33 +2,10 @@
 
 from __future__ import annotations
 
-import sqlite3
-from pathlib import Path
-
-from polylogue.storage.sqlite.archive_tiers.user_write import list_assertion_claims
-
 
 def context_claim_text(*, kind: str, body_text: str | None, target_ref: str) -> str:
     text = body_text or "(empty assertion)"
     return f"{kind}: {text} [{target_ref}]"
 
 
-def user_db_injectable_claim_texts(user_db_path: Path, *, session_id: str) -> list[str]:
-    """Read active, explicitly injectable assertion claims for a session."""
-    if not user_db_path.exists():
-        return []
-    uri = f"file:{user_db_path}?mode=ro"
-    with sqlite3.connect(uri, uri=True) as conn:
-        claims = list_assertion_claims(
-            conn,
-            target_ref=f"session:{session_id}",
-            statuses=("active",),
-            context_inject=True,
-            limit=20,
-        )
-    return [
-        context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref) for claim in claims
-    ]
-
-
-__all__ = ["context_claim_text", "user_db_injectable_claim_texts"]
+__all__ = ["context_claim_text"]

--- a/polylogue/context/pack.py
+++ b/polylogue/context/pack.py
@@ -9,7 +9,7 @@ import click
 
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.query.spec import SessionQuerySpec
-from polylogue.context.assertion_claims import context_claim_text, user_db_injectable_claim_texts
+from polylogue.context.assertion_claims import context_claim_text
 from polylogue.mcp.context_pack import (
     ContextPackDateRange,
     ContextPackDecisions,
@@ -266,7 +266,21 @@ def _build_archive_context_pack(
                 dates.append(str(conv.created_at))
             if conv.updated_at is not None:
                 dates.append(str(conv.updated_at))
-            assertion_decisions.extend(user_db_injectable_claim_texts(archive.user_db_path, session_id=conv_id))
+            try:
+                claims = run_coroutine_sync(
+                    env.polylogue.list_assertion_claim_payloads(
+                        target_ref=f"session:{conv_id}",
+                        statuses=("active",),
+                        context_inject=True,
+                        limit=20,
+                    )
+                )
+            except Exception:
+                claims = []
+            assertion_decisions.extend(
+                context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref)
+                for claim in claims
+            )
 
             messages: list[ContextPackMessage] = []
             try:

--- a/polylogue/mcp/server_context_tools.py
+++ b/polylogue/mcp/server_context_tools.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from polylogue.archive.query.spec import SessionQuerySpec
-from polylogue.context.assertion_claims import user_db_injectable_claim_texts
+from polylogue.context.assertion_claims import context_claim_text
 from polylogue.mcp.context_pack import (
     ContextPackDateRange,
     ContextPackDecisions,
@@ -31,6 +31,7 @@ from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
+    from polylogue.api import Polylogue
     from polylogue.mcp.server_support import ServerCallbacks
 
 _DEFAULT_MAX_SESSIONS = 5
@@ -57,6 +58,7 @@ def _truncate_text(text: str, max_length: int) -> str:
 async def _build_archive_context_pack_payload(
     *,
     archive_root: Path,
+    polylogue: Polylogue,
     clamp_limit: Callable[[int | object], int],
     project_path: str | None,
     project_repo: str | None,
@@ -93,7 +95,19 @@ async def _build_archive_context_pack_payload(
 
         for conv in sessions[:conv_limit]:
             conv_id = str(conv.id)
-            assertion_decisions.extend(user_db_injectable_claim_texts(archive.user_db_path, session_id=conv_id))
+            try:
+                claims = await polylogue.list_assertion_claim_payloads(
+                    target_ref=f"session:{conv_id}",
+                    statuses=("active",),
+                    context_inject=True,
+                    limit=20,
+                )
+            except Exception:
+                claims = []
+            assertion_decisions.extend(
+                context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref)
+                for claim in claims
+            )
             messages: list[ContextPackMessage] = []
             if include_messages:
                 try:
@@ -205,6 +219,7 @@ def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             config = hooks.get_config()
             payload = await _build_archive_context_pack_payload(
                 archive_root=config.archive_root,
+                polylogue=hooks.get_polylogue(),
                 clamp_limit=hooks.clamp_limit,
                 project_path=project_path,
                 project_repo=project_repo,


### PR DESCRIPTION
## Summary

Route the remaining context-pack assertion reads through the shared Polylogue assertion facade instead of opening `user.db` directly. This advances #1883's consumer-wiring scope for context surfaces without adding a new assertion model or compatibility layer.

## Problem

#1883's current remaining scope is not table creation; it is making context/profile/read consumers use the shared assertion lifecycle/read contract. The normal context-pack path and context preamble already call `list_assertion_claim_payloads`, but the archive-file-set context-pack path and MCP context-pack builder still used a local helper that opened `user.db` and queried assertion storage directly.

## Solution

- Remove the direct `user_db_injectable_claim_texts` helper from `polylogue.context.assertion_claims`.
- Route CLI archive-mode context-pack assertion decisions through `env.polylogue.list_assertion_claim_payloads(...)`.
- Route MCP `build_context_pack` assertion decisions through `hooks.get_polylogue().list_assertion_claim_payloads(...)`.
- Keep the existing context claim text formatter as the single local presentation helper.

## Verification

- `devtools test tests/unit/cli/test_context_pack_view.py tests/unit/cli/test_context_view.py tests/unit/mcp/test_context_pack.py -k 'assertion or context_pack or build_context_pack'` -> `15 passed, 2 deselected`
- `ruff format --check` / `ruff check` on touched context/MCP/test files -> passed
- `mypy` on touched context/MCP/test files -> passed
- `devtools verify --quick` -> `exit_code: 0`

Ref #1883
