### PR TITLE
feat(context): feed assertion claims into recovery context (#1883)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -240,7 +240,7 @@
 
           if [ "$agents_hash" != "$agents_last_hash" ]; then
             echo "devshell: regenerating AGENTS.md (sources changed)" >&2
-            devtools render-agents >/dev/null
+            devtools render agents >/dev/null
             printf '%s' "$agents_hash" > "$agents_hash_file"
           fi
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1244,16 +1244,38 @@ class PolylogueArchiveMixin:
     ) -> RecoveryContextCompilation:
         """Compile one recovery-context view without making callers branch on bundle shape."""
         from polylogue.context.compiler import compile_recovery_context
+        from polylogue.surfaces.payloads import AssertionClaimPayload
 
         packet: RecoveryWorkPacket | None = None
+        target_ref = f"session:{digest.session_id}"
         if report == "work-packet":
-            packet = await self._recovery_work_packet_from_digest(digest)
-        return compile_recovery_context(digest, report=report, work_packet=packet)
+            claims = await self.list_assertion_claims(target_ref=target_ref, limit=20)
+            packet = await self._recovery_work_packet_from_digest(digest, claims=claims)
+        else:
+            claims = await self.list_assertion_claims(
+                target_ref=target_ref,
+                statuses=("active",),
+                context_inject=True,
+                limit=20,
+            )
+        assertion_claims = tuple(AssertionClaimPayload.from_envelope(claim) for claim in claims)
+        return compile_recovery_context(
+            digest,
+            report=report,
+            work_packet=packet,
+            assertion_claims=assertion_claims,
+        )
 
-    async def _recovery_work_packet_from_digest(self, digest: RecoveryDigest) -> RecoveryWorkPacket:
+    async def _recovery_work_packet_from_digest(
+        self,
+        digest: RecoveryDigest,
+        *,
+        claims: Sequence[ArchiveAssertionEnvelope] | None = None,
+    ) -> RecoveryWorkPacket:
         """Build the assertion-enriched work-packet bundle for a digest."""
         packet = digest.work_packet()
-        claims = await self.list_assertion_claims(target_ref=f"session:{digest.session_id}", limit=20)
+        if claims is None:
+            claims = await self.list_assertion_claims(target_ref=f"session:{digest.session_id}", limit=20)
         assertion_entries = _archive_assertion_work_packet_entries(claims, digest.session_id)
         if not assertion_entries:
             return packet

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -8,13 +8,16 @@ shape that CLI/API/MCP surfaces can share.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Literal, cast
 
 from pydantic import model_validator
 
+from polylogue.context.assertion_claims import context_claim_text
 from polylogue.core.refs import EvidenceRef, ObjectRef
 from polylogue.insights.archive_models import ArchiveInsightModel
 from polylogue.insights.transforms import RecoveryDigest, RecoveryReportPreset, RecoveryWorkPacket
+from polylogue.surfaces.payloads import AssertionClaimPayload
 
 RecoveryContextKind = Literal["recovery_digest", "recovery_report", "work_packet"]
 
@@ -41,6 +44,7 @@ class RecoveryContextCompilation(ArchiveInsightModel):
     evidence_refs: tuple[EvidenceRef, ...] = ()
     object_refs: tuple[ObjectRef, ...] = ()
     caveats: tuple[str, ...] = ()
+    assertion_claims: tuple[AssertionClaimPayload, ...] = ()
 
     @model_validator(mode="after")
     def _validate_requested_shape(self) -> RecoveryContextCompilation:
@@ -58,6 +62,7 @@ def compile_recovery_context(
     *,
     report: RecoveryReportPreset | str | None = None,
     work_packet: RecoveryWorkPacket | None = None,
+    assertion_claims: Sequence[AssertionClaimPayload] = (),
 ) -> RecoveryContextCompilation:
     """Compile a recovery digest into the requested successor-context view.
 
@@ -67,7 +72,10 @@ def compile_recovery_context(
     * ``RecoveryReportPreset`` for continue/blame/work-packet rendering;
     * ``RecoveryWorkPacket`` for Bundle(kind=work_packet) handoff material;
     * ``EvidenceRef``/``ObjectRef`` for addressable support and targets.
+    * ``AssertionClaimPayload`` for explicit context-injection claims.
     """
+
+    claims = tuple(assertion_claims)
 
     if report is None:
         if work_packet is not None:
@@ -76,10 +84,11 @@ def compile_recovery_context(
             kind="recovery_digest",
             session_id=digest.session_id,
             digest=digest,
-            markdown=digest.resume_markdown,
+            markdown=_append_assertion_claims_markdown(digest.resume_markdown, claims),
             evidence_refs=_digest_evidence_refs(digest),
             object_refs=_digest_object_refs(digest),
             caveats=_digest_caveats(digest),
+            assertion_claims=claims,
         )
 
     if report not in _SUPPORTED_REPORTS:
@@ -97,6 +106,7 @@ def compile_recovery_context(
             evidence_refs=packet.evidence_refs,
             object_refs=packet.target_refs,
             caveats=_packet_caveats(packet),
+            assertion_claims=claims,
         )
 
     if work_packet is not None:
@@ -106,10 +116,11 @@ def compile_recovery_context(
         session_id=digest.session_id,
         report=preset,
         digest=digest,
-        markdown=digest.report_markdown(preset),
+        markdown=_append_assertion_claims_markdown(digest.report_markdown(preset), claims),
         evidence_refs=_digest_evidence_refs(digest),
         object_refs=_digest_object_refs(digest),
         caveats=_digest_caveats(digest),
+        assertion_claims=claims,
     )
 
 
@@ -139,6 +150,15 @@ def _digest_caveats(digest: RecoveryDigest) -> tuple[str, ...]:
 
 def _packet_caveats(packet: RecoveryWorkPacket) -> tuple[str, ...]:
     return tuple(entry.label for entry in packet.entries if entry.support in {"caveat", "missing_evidence"})
+
+
+def _append_assertion_claims_markdown(markdown: str, claims: Sequence[AssertionClaimPayload]) -> str:
+    if not claims:
+        return markdown
+    lines = [markdown.rstrip(), "", "## Assertion Claims"]
+    for claim in claims:
+        lines.append(f"- {context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref)}")
+    return "\n".join(lines) + "\n"
 
 
 __all__ = [

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -822,6 +822,20 @@ async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) ->
             visibility="private",
             now_ms=1_700_000_000_000,
         )
+        upsert_assertion(
+            conn,
+            assertion_id="recovery-decision-injected-alpha",
+            target_ref="session:claude-ai-export:conv-alpha",
+            kind=AssertionKind.DECISION,
+            body_text="Resume with the assertion-aware continuation context.",
+            author_ref="agent:test",
+            author_kind="agent",
+            evidence_refs=["claude-ai-export:conv-alpha"],
+            status="active",
+            visibility="private",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_100,
+        )
     try:
         continue_report = await archive.recovery_report("claude-ai-export:conv-alpha", "continue")
         blame_report = await archive.recovery_report("claude-ai-export:conv-alpha", "blame")
@@ -838,15 +852,20 @@ async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) ->
         assert work_packet.session_id == "claude-ai-export:conv-alpha"
         assert work_packet.render_markdown() == work_packet_report
         assertion_entries = [entry for entry in work_packet.entries if entry.section == "assertions"]
-        assert [(entry.label, entry.support, entry.text) for entry in assertion_entries] == [
-            ("caveat", "caveat", "Review findings have not been read yet.")
+        assert sorted((entry.label, entry.support, entry.text) for entry in assertion_entries) == [
+            ("caveat", "caveat", "Review findings have not been read yet."),
+            ("decision", "assertion", "Resume with the assertion-aware continuation context."),
         ]
         assert continue_report != blame_report
         assert work_packet_report not in {continue_report, blame_report}
         assert "[evidence:" in continue_report
         assert "[evidence:" in blame_report
+        assert "## Assertion Claims" in continue_report
+        assert "decision: Resume with the assertion-aware continuation context." in continue_report
+        assert "Review findings have not been read yet." not in continue_report
         assert "## Assertion Claims" in work_packet_report
         assert "- [caveat] caveat: Review findings have not been read yet." in work_packet_report
+        assert "- [assertion] decision: Resume with the assertion-aware continuation context." in work_packet_report
         assert "## Evidence" in work_packet_report
         assert await archive.recovery_report("nonexistent", "continue") is None
         assert await archive.recovery_work_packet("nonexistent") is None


### PR DESCRIPTION
## Summary
Recovery context compilation now carries policy-aware assertion claims, and continuation-style recovery reports include explicitly injectable assertion claims. Work-packet compilation reuses the same assertion read so the compiled context object and rendered packet agree.

## Problem
#1883 had already moved assertion storage, read facades, MCP/web payloads, and recovery work-packets forward, but the generic recovery context compiler still only knew about transform-derived digest/work-packet content. That left `continue`/`blame` context reports unable to consume explicitly injectable assertion decisions through the shared assertion facade.

The #2127 devtools regrouping also left the devshell AGENTS regeneration hook calling the old `devtools render-agents` command. This branch updates that caller to the grouped `devtools render agents` command rather than restoring an alias.

## Solution
- Added `assertion_claims` to `RecoveryContextCompilation` using the existing shared `AssertionClaimPayload` shape.
- Taught `compile_recovery_context(...)` to append injectable assertion claims to digest/continue/blame markdown via the existing `context_claim_text` formatter.
- Updated `PolylogueArchiveMixin._compile_recovery_context_from_digest(...)` to read assertion claims through `list_assertion_claims(...)`:
  - `continue`/`blame`/digest context gets active `context_inject=True` claims only;
  - work-packet context gets the active/candidate lifecycle claims already used for evidence bundles.
- Reused loaded claims when building the assertion-enriched work packet, avoiding a second user-tier read.
- Updated `flake.nix` devshell AGENTS regeneration to call `devtools render agents`.

## Verification
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k 'recovery_report_renders_seeded_session_presets or list_assertion_claims_filters_lifecycle_claims'` -> `2 passed, 199 deselected`.
- `nix develop --command devtools verify --quick` -> `exit_code: 0`.
- `git push` pre-push hook reran `devtools verify --quick` at `b9db9546` -> `exit_code: 0`.

Closes #1883