### PR TITLE
test(daemon): cover browser-capture reader boundary (#1824)

### DIFF
--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -296,6 +296,47 @@ def _seed_archive_test_archive(workspace: dict[str, Path]) -> str:
         )
 
 
+def _seed_browser_capture_reader_archive(workspace: dict[str, Path]) -> tuple[str, str]:
+    from polylogue.core.enums import Provider
+    from polylogue.sources.dispatch import parse_payload
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    unsafe_text = "<script>alert('captured')</script>\nBrowser capture prose"
+    payload: dict[str, object] = {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "capture_id": "chatgpt:xss-reader",
+        "provenance": {
+            "source_url": "https://chatgpt.com/c/xss-reader",
+            "page_title": "Browser Capture XSS",
+            "captured_at": "2026-04-24T00:00:00+00:00",
+            "adapter_name": "chatgpt-dom-v1",
+            "capture_mode": "snapshot",
+        },
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": "xss-reader",
+            "title": "Browser Capture XSS",
+            "updated_at": "2026-04-24T00:00:01+00:00",
+            "turns": [
+                {
+                    "provider_turn_id": "xss-m1",
+                    "role": "assistant",
+                    "text": unsafe_text,
+                    "ordinal": 0,
+                }
+            ],
+        },
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "browser-capture-xss.json")
+    assert len(parsed) == 1
+    workspace["archive_root"].mkdir(parents=True, exist_ok=True)
+    with ArchiveStore(workspace["archive_root"]) as archive:
+        session_id = archive.write_parsed(parsed[0])
+    return session_id, unsafe_text
+
+
 def _index_db_path(workspace: dict[str, Path]) -> Path:
     return workspace["data_root"] / "polylogue" / "index.db"
 
@@ -624,6 +665,33 @@ class TestReaderSessionState:
         assert isinstance(messages, dict)
         assert messages["total"] == 1
         assert messages["messages"][0]["target_ref"]["identity_key"].startswith(f"message:{session_id}:")
+
+    def test_browser_capture_reader_boundary_keeps_text_and_escapes_shell(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        session_id, unsafe_text = _seed_browser_capture_reader_archive(workspace_env)
+
+        with _running_server_without_seed() as (_, base_url):
+            detail = _get_json(base_url, f"/api/sessions/{session_id}")
+            messages = _get_json(base_url, f"/api/sessions/{session_id}/messages")
+            root_status, root_content_type, root_shell = _get_text(base_url, "/")
+            link_status, link_content_type, link_shell = _get_text(base_url, f"/s/{session_id}")
+
+        assert root_status == 200
+        assert link_status == 200
+        assert "text/html" in root_content_type
+        assert "text/html" in link_content_type
+        assert isinstance(detail, dict)
+        assert detail["origin"] == "chatgpt-export"
+        assert detail["messages"][0]["text"] == unsafe_text
+        assert isinstance(messages, dict)
+        assert messages["messages"][0]["text"] == unsafe_text
+        assert "https://chatgpt.com/c/xss-reader" not in json.dumps(detail)
+        assert unsafe_text not in root_shell
+        assert unsafe_text not in link_shell
+        assert "function esc" in root_shell
+        assert "'<div class=\"msg-text\">' + esc(parts[0].body)" in root_shell
 
     def test_unknown_session_yields_404(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):


### PR DESCRIPTION
## Summary
Adds the missing browser-capture reader boundary proof for #1824: a browser-capture payload with script-shaped message text is parsed into the archive, served through the daemon reader APIs, and checked against the shipped shell escaping boundary.

## Problem
The browser-capture DTO/auth/status/parser work was already present on `master`, but #1824 still had one acceptance criterion that was only indirectly covered: captured page text needed a concrete web/API redaction and XSS boundary check. Without that, the issue closure would rely on generic reader tests rather than proving the browser-capture route feeds the same safe reader path.

## Solution
- Seed a daemon reader archive from the browser-capture parser with `<script>`-shaped captured text.
- Assert `/api/sessions/:id` and `/api/sessions/:id/messages` preserve the captured message text as JSON data.
- Assert browser capture provenance stays out of the public session envelope.
- Assert root and deep-link shell HTML do not inline the captured text and still route message body rendering through the escaping renderer.

#1824 acceptance matrix:
- Public browser-capture status vocabulary: already covered by `tests/unit/browser_capture/test_receiver.py` and status payload DTOs.
- Raw/native metadata boundary: already covered by browser-capture parser tests and this PR's provenance non-promotion assertion.
- Readiness/status surface: already covered by daemon/browser-capture status tests.
- Current docs/commands: already covered by `polylogued browser-capture serve/status` docs and command tests.
- Web/API captured-text redaction/XSS: covered by this PR.
- Receiver auth/origin boundary: already covered by `tests/unit/browser_capture/test_receiver.py`.

Closes #1824.

## Verification
- `devtools test tests/unit/daemon/test_web_reader.py::TestReaderSessionState::test_browser_capture_reader_boundary_keeps_text_and_escapes_shell tests/unit/browser_capture tests/unit/sources/test_browser_capture.py tests/unit/sources/parsers/test_origin_regression_pack.py::test_browser_capture_snapshot_dispatches_to_chatgpt_export_origin tests/unit/daemon/test_daemon_cli.py::test_polylogued_browser_capture_help_lists_service_commands tests/unit/daemon/test_daemon_cli.py::test_run_daemon_services_closes_browser_capture_server_on_failure` -> 43 passed.
- `devtools verify --quick` -> `exit_code: 0`.