### PR TITLE
test(daemon): strengthen browser-capture shell assertions (#1824)

### DIFF
--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -671,6 +671,8 @@ class TestReaderSessionState:
         workspace_env: dict[str, Path],
     ) -> None:
         session_id, unsafe_text = _seed_browser_capture_reader_archive(workspace_env)
+        dangerous_fragment = "<script>alert('captured')</script>"
+        prose_fragment = "Browser capture prose"
 
         with _running_server_without_seed() as (_, base_url):
             detail = _get_json(base_url, f"/api/sessions/{session_id}")
@@ -690,6 +692,10 @@ class TestReaderSessionState:
         assert "https://chatgpt.com/c/xss-reader" not in json.dumps(detail)
         assert unsafe_text not in root_shell
         assert unsafe_text not in link_shell
+        assert dangerous_fragment not in root_shell
+        assert dangerous_fragment not in link_shell
+        assert prose_fragment not in root_shell
+        assert prose_fragment not in link_shell
         assert "function esc" in root_shell
         assert "'<div class=\"msg-text\">' + esc(parts[0].body)" in root_shell
 


### PR DESCRIPTION
## Summary
Addresses the Codex review finding from #2131 by making the browser-capture shell non-inlining assertions check each captured text fragment separately.

## Problem
#2131 added the missing browser-capture reader boundary test, but the shell checks asserted only the exact two-line `unsafe_text`. Codex correctly pointed out that a regression could inline the same captured content as escaped JSON or split nodes without matching that exact raw string.

## Solution
The test now checks both the dangerous `<script>` fragment and the plain prose fragment independently against the root and session-deep-link shell responses. The API assertions still require the reader JSON to preserve the captured text exactly.

Ref #1824.

## Verification
- `devtools test tests/unit/daemon/test_web_reader.py::TestReaderSessionState::test_browser_capture_reader_boundary_keeps_text_and_escapes_shell` -> 1 passed.
- `devtools verify --quick` -> `exit_code: 0`.