### PR TITLE
feat(query): honor scoped session summary comparisons (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -147,8 +147,11 @@ one child row matching the nested predicate.
 All three structural units also accept `session.<field>` predicates for the
 owning session fields, such as `session.repo`, `session.origin`,
 `session.tag`, `session.title`, `session.date`, `session.since`, and
-`session.until`. This lets a unit query carry its session scope inline instead
-of splitting selection between the query string and parallel parameters.
+`session.until`. Count and date session fields accept compact comparison
+prefixes such as `session.messages:>=2`, `session.words:<=500`, and
+`session.date:>=2026-01-02`. This lets a unit query carry its session scope
+inline instead of splitting selection between the query string and parallel
+parameters.
 
 Examples:
 
@@ -201,10 +204,10 @@ by their owning session:
 ```bash
 polylogue messages where session.origin:claude-code-session AND role:assistant
 polylogue actions where session.repo:polylogue AND action:file_edit
-polylogue blocks where session.since:7d AND type:code
+polylogue blocks where session.since:7d AND session.words:<=500 AND type:code
 polylogue assertions where session.repo:polylogue AND kind:caveat
 polylogue observed-events where session.origin:codex-session AND object_ref:github-review
-polylogue context-snapshots where session.repo:polylogue AND boundary:subagent_start
+polylogue context-snapshots where session.messages:>=2 AND session.date:>=2026-01-02 AND boundary:subagent_start
 ```
 
 `observed-events` and `context-snapshots` are runtime-transform row sources.

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -113,6 +113,7 @@ from polylogue.archive.query.metadata import (
 )
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
+    QueryCompareOp,
     QueryExistsPredicate,
     QueryFieldPredicate,
     QueryLineagePredicate,
@@ -618,6 +619,26 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
         values = tuple(value.strip().lower() for value in values if value.strip())
     elif validation_field in {"since", "until"} and values:
         values = (_parse_relative_date(values[-1]),)
+    elif validation_field in {"messages", "words"}:
+        if not values:
+            raise ExpressionCompileError(f"field {field_name!r} requires a numeric value", field=field_name)
+        match = re.fullmatch(r"(>=|<=|=)?(\d+)", values[-1].strip())
+        if match is None:
+            raise ExpressionCompileError(f"field {field_name!r} requires a numeric value", field=field_name)
+        raw_op = match.group(1) or "="
+        op_text: QueryCompareOp = ">=" if raw_op == ">=" else "<=" if raw_op == "<=" else "="
+        values = (match.group(2),)
+        count_predicate = QueryFieldPredicate(field=field_name, values=values, op=op_text)
+        return QueryNotPredicate(count_predicate) if token.negated else count_predicate
+    elif validation_field == "date" and values:
+        raw_value = values[-1].strip()
+        match = re.fullmatch(r"(>=|<=|>|<)?(.+)", raw_value)
+        if match is not None:
+            raw_op = match.group(1) or "="
+            normalized_op: QueryCompareOp = ">=" if raw_op in {">", ">="} else "<=" if raw_op in {"<", "<="} else "="
+            values = (_parse_relative_date(match.group(2).strip()),)
+            date_predicate = QueryFieldPredicate(field=field_name, values=values, op=normalized_op)
+            return QueryNotPredicate(date_predicate) if token.negated else date_predicate
     elif validation_field == "lineage":
         if token.negated:
             raise ExpressionCompileError("negation is not supported for 'lineage'", field=field_name)

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -330,7 +330,7 @@ _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "cwd": "session.cwd:/realm/project",
     "has": "session.has:tools",
     "id": "session.id:abc123",
-    "messages": "session.messages:10",
+    "messages": "session.messages:>=10",
     "origin": "session.origin:claude-code-session",
     "repo": "session.repo:polylogue",
     "since": "session.since:7d",
@@ -338,7 +338,7 @@ _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "title": "session.title:refactor",
     "tool": "session.tool:bash",
     "until": "session.until:2024-01-15",
-    "words": "session.words:200",
+    "words": "session.words:<=200",
 }
 
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -136,7 +136,37 @@ def _exact_or_contains(value: str | None, needles: Sequence[str], *, exact: bool
     return any(needle.lower() in lowered for needle in needles)
 
 
-def _summary_field_matches(summary: ArchiveSessionSummary, field: str, values: Sequence[str]) -> bool:
+def _numeric_field_matches(value: int | None, predicate: QueryFieldPredicate) -> bool:
+    if value is None or not predicate.values:
+        return False
+    try:
+        target = int(predicate.values[-1])
+    except ValueError:
+        return False
+    if predicate.op == ">=":
+        return value >= target
+    if predicate.op == "<=":
+        return value <= target
+    return value == target
+
+
+def _summary_timestamp_matches(summary: ArchiveSessionSummary, field: str, predicate: QueryFieldPredicate) -> bool:
+    if not predicate.values:
+        return False
+    timestamp = _summary_updated_or_created_ms(summary)
+    target = _epoch_ms(field, predicate.values[-1])
+    if timestamp is None or target is None:
+        return False
+    if predicate.op == ">=":
+        return timestamp >= target
+    if predicate.op == "<=":
+        return timestamp <= target
+    return timestamp == target
+
+
+def _summary_field_matches(summary: ArchiveSessionSummary, predicate: QueryFieldPredicate) -> bool:
+    field = predicate.field.removeprefix("session.")
+    values = predicate.values
     if field == "id":
         return _exact_or_contains(str(summary.session_id), values)
     if field == "origin":
@@ -155,17 +185,15 @@ def _summary_field_matches(summary: ArchiveSessionSummary, field: str, values: S
         # treating path as cwd and broadening/missing results unpredictably.
         return False
     if field == "messages":
-        return _exact_or_contains(str(summary.message_count), values, exact=True)
+        return _numeric_field_matches(summary.message_count, predicate)
     if field == "words":
-        return _exact_or_contains(str(summary.word_count), values, exact=True)
+        return _numeric_field_matches(summary.word_count, predicate)
+    if field == "date":
+        return _summary_timestamp_matches(summary, field, predicate)
     if field == "since":
-        threshold = _epoch_ms("since", values[0]) if values else None
-        updated = _summary_updated_or_created_ms(summary)
-        return threshold is not None and updated is not None and updated >= threshold
+        return _summary_timestamp_matches(summary, field, QueryFieldPredicate(field=field, values=values, op=">="))
     if field == "until":
-        threshold = _epoch_ms("until", values[0]) if values else None
-        updated = _summary_updated_or_created_ms(summary)
-        return threshold is not None and updated is not None and updated <= threshold
+        return _summary_timestamp_matches(summary, field, QueryFieldPredicate(field=field, values=values, op="<="))
     return False
 
 
@@ -180,7 +208,7 @@ def _observed_event_field_matches(
 ) -> bool:
     field = predicate.field
     if field.startswith("session."):
-        return _summary_field_matches(summary, field.removeprefix("session."), predicate.values)
+        return _summary_field_matches(summary, predicate)
     if field == "kind":
         return _exact_or_contains(event.kind, predicate.values, exact=True)
     if field == "delivery_state":
@@ -248,7 +276,7 @@ def _context_snapshot_field_matches(
 ) -> bool:
     field = predicate.field
     if field.startswith("session."):
-        return _summary_field_matches(summary, field.removeprefix("session."), predicate.values)
+        return _summary_field_matches(summary, predicate)
     if field == "boundary":
         return _exact_or_contains(snapshot.boundary, predicate.values, exact=True)
     if field == "inheritance_mode":

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -1460,6 +1460,61 @@ class TestBooleanQueryExpression:
         assert isinstance(row, ContextSnapshotQueryRowPayload)
         assert row.session_id == "codex-session:ext-created-only"
 
+    def test_context_snapshot_session_summary_comparisons(self, workspace_env: dict[str, Path]) -> None:
+        """Runtime-transform rows honor scoped session count/date predicates."""
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import ContextSnapshotQueryRowPayload
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "summary-hit")
+            .provider("codex")
+            .created_at("2026-01-03T00:00:00+00:00")
+            .updated_at("2026-01-03T00:00:00+00:00")
+            .title("summary comparison hit")
+            .add_message("m-hit-1", role="user", text="one two")
+            .add_message("m-hit-2", role="assistant", text="three four")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "summary-control")
+            .provider("codex")
+            .created_at("2026-01-01T00:00:00+00:00")
+            .updated_at("2026-01-01T00:00:00+00:00")
+            .title("summary comparison control")
+            .add_message("m-control", role="user", text="one two three four five")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "context-snapshots where session.messages:>=2 "
+            "AND session.words:<=4 "
+            "AND session.date:>=2026-01-02 "
+            "AND boundary:session_start"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(archive_root) as archive:
+            envelope = query_unit_rows(
+                archive,
+                source,
+                query=(
+                    "context-snapshots where session.messages:>=2 "
+                    "AND session.words:<=4 "
+                    "AND session.date:>=2026-01-02 "
+                    "AND boundary:session_start"
+                ),
+                limit=10,
+            )
+
+        assert envelope.unit == "context-snapshot"
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        assert isinstance(row, ContextSnapshotQueryRowPayload)
+        assert row.session_id == "codex-session:ext-summary-hit"
+
     def test_context_snapshot_unit_source_paginates_session_summaries(
         self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Mines the relevant remaining piece from the #2006 query-DSL patch: runtime terminal units now honor compact comparison predicates on owning-session summary fields.

## Problem
`observed-events` and `context-snapshots` execute as runtime-transform row sources over archive session summaries. They accepted `session.<field>` predicates, but `session.messages`, `session.words`, and date-like fields were still effectively exact string/threshold checks in the runtime matcher. That left useful DSL forms such as `context-snapshots where session.messages:>=2 ...` only partially wired.

## Solution
- Normalize scoped `session.messages:*`, `session.words:*`, and `session.date:*` compact field clauses into typed `QueryFieldPredicate(op=...)` nodes.
- Evaluate runtime summary fields through numeric/date helpers instead of exact string matching.
- Refresh query metadata examples and docs to teach comparison forms for scoped count/date fields.
- Add a context-snapshot fixture proving `session.messages:>=2`, `session.words:<=4`, and `session.date:>=...` select the intended runtime row.

This deliberately does not apply the stale #2006 turbo patch wholesale; current master already has terminal units, assertion/event/context-snapshot rows, and query metadata split. This PR lands one remaining executable gap.

Ref #2006.

## Verification
- `.venv/bin/python -m devtools test tests/unit/cli/test_query_expression.py -k 'context_snapshot_session_summary_comparisons or context_snapshot_session_since_uses_created_at_fallback or terminal_context_snapshot_source_returns_runtime_rows'` -> 3 passed.
- `.venv/bin/python -m devtools test tests/unit/cli/test_command_aux_runtime.py::test_query_structural_session_field_examples_are_executable` -> 1 passed.
- `.venv/bin/python -m devtools verify --quick` -> `exit_code: 0`.
- Pre-push `devtools verify --quick` -> `exit_code: 0`.