### PR TITLE
refactor(devtools): group release commands (#2126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync --extra dev --frozen
-      - run: uv run devtools verify-distribution-surface --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
+      - run: uv run devtools release verify-distribution --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Triggered by pushing an annotated tag matching `vX.Y.Z`. Builds the
-# wheel + sdist, smokes them through verify-distribution-surface on the
+# wheel + sdist, smokes them through release verify-distribution on the
 # build host, runs an installed-wheel smoke matrix across supported
 # Python versions on Linux + macOS, signs the artifacts with Sigstore
 # keyless OIDC, emits a CycloneDX SBOM, then:
@@ -52,7 +52,7 @@ jobs:
       - name: Install dev dependencies (frozen lockfile)
         run: uv sync --extra dev --frozen
       - name: Build wheel + sdist and smoke installed entrypoints
-        run: uv run devtools verify-distribution-surface --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
+        run: uv run devtools release verify-distribution --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
       - name: twine check (PyPI metadata long-description renderability)
@@ -146,7 +146,7 @@ jobs:
           # `analyze` against an empty XDG archive must not crash on first-run
           # (covers schema bootstrap on a fresh database).
           polylogue --plain analyze
-          # `--plain analyze --count` is the smoke parity with verify-distribution-surface.
+          # `--plain analyze --count` is the smoke parity with release verify-distribution.
           polylogue --plain analyze --count
           python -m polylogue --version
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,7 +399,7 @@ paths; use `devtools verify --seed-testmon` when you intentionally want to
 refresh the dependency database and `devtools verify --all` for an explicit full
 diagnostic.
 
-Add `devtools build-package` or `nix flake check` when touching packaging or
+Add `devtools release build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
 for details.
 
@@ -1541,7 +1541,7 @@ devtools lab-scenario verify-baselines
 
 - `.cache/`: disposable caches (hypothesis, pytest, mypy, ruff)
 - `.local/`: untracked outputs (campaigns, showcases, build artifacts)
-- `.local/result`: out-link for `devtools build-package`
+- `.local/result`: out-link for `devtools release build-package`
 <!-- end include: docs/internals.md -->
 <!-- begin include: docs/devtools.md -->
 # Developer Tools
@@ -1637,6 +1637,14 @@ These are the commands worth remembering during normal repo work:
 | `devtools render topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
 
+### Release
+
+| Command | Description |
+| --- | --- |
+| `devtools release build-package` | Build the default Nix package with the out-link under .local/result. |
+| `devtools release readiness` | Validate the externally-presentable release gate definition. |
+| `devtools release verify-distribution` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
+
 ### Verification
 
 | Command | Description |
@@ -1650,7 +1658,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
-| `devtools release-readiness` | Validate the externally-presentable release gate definition. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools schema-audit` | Run committed provider schema package quality checks. |
@@ -1661,7 +1668,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |
-| `devtools verify-distribution-surface` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
 | `devtools verify-doc-commands` | Verify README/docs command examples resolve to live polylogue, polylogued, and devtools commands. |
 | `devtools verify-lane-assertions` | Verify scenario lanes classified as SEMANTIC_OUTPUT carry semantic assertions. |
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
@@ -1687,7 +1693,6 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
-| `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
 | `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
@@ -1712,7 +1717,7 @@ Campaign outputs live under `.local/`, not in tracked docs trees.
 - `.cache/`: disposable cache state.
 - `.local/`: untracked local outputs such as campaigns, showcases, and reports.
 - `.venv/` and `.direnv/`: kept at the repo root because their tooling expects those locations.
-- `.local/result`: preferred repo-local out-link for `devtools build-package`; a top-level `result` symlink is just Nix's default ad-hoc out-link.
+- `.local/result`: preferred repo-local out-link for `devtools release build-package`; a top-level `result` symlink is just Nix's default ad-hoc out-link.
 
 Keep new repo-local outputs in `.cache/` or `.local/` instead of adding new
 top-level output roots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ documentation polish do not require an entry.
 ### Added
 
 - Broad-distribution packaging readiness (#953): the
-  `verify-distribution-surface` gate now runs as a `distribution` job in
+  `release verify-distribution` gate now runs as a `distribution` job in
   `ci.yml` on every push, a new `release.yml` workflow publishes wheel
   and sdist to PyPI via OIDC Trusted Publishing on `vX.Y.Z` tag push,
   and a multi-stage `Containerfile` produces an OCI image that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ paths; use `devtools verify --seed-testmon` when you intentionally want to
 refresh the dependency database and `devtools verify --all` for an explicit full
 diagnostic.
 
-Add `devtools build-package` or `nix flake check` when touching packaging or
+Add `devtools release build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
 for details.
 

--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -23,6 +23,7 @@ from devtools.command_catalog import (
 
 GROUP_HELP: dict[str, str] = {
     "render": "Render and check generated repository surfaces.",
+    "release": "Build, smoke, and validate release/distribution readiness.",
 }
 
 

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -20,6 +20,7 @@ VERIFICATION_LAB_COMMAND_NAMES: tuple[str, ...] = (
 CATEGORY_ORDER: tuple[str, ...] = (
     "core",
     "generated surfaces",
+    "release",
     "verification",
     "campaigns",
     "maintenance",
@@ -165,8 +166,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
-        "release-readiness",
-        "verification",
+        "release readiness",
+        "release",
         "Validate the externally-presentable release gate definition.",
         "devtools.release_readiness",
         use_when=(
@@ -174,9 +175,9 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "and release PR evidence template are still coherent before touching a release PR."
         ),
         examples=(
-            "devtools release-readiness",
-            "devtools release-readiness --json",
-            "devtools release-readiness --release-body-file /tmp/release-pr-body.md",
+            "devtools release readiness",
+            "devtools release readiness --json",
+            "devtools release readiness --release-body-file /tmp/release-pr-body.md",
         ),
     ),
     CommandSpec(
@@ -476,15 +477,15 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-test-clock-hygiene", "devtools verify-test-clock-hygiene --json"),
     ),
     CommandSpec(
-        "verify-distribution-surface",
-        "verification",
+        "release verify-distribution",
+        "release",
         "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",
         "devtools.verify_distribution_surface",
         use_when=(
             "Build wheel and sdist artifacts, rebuild a wheel from an unpacked sdist without .git, "
             "and smoke installed runtime console scripts."
         ),
-        examples=("devtools verify-distribution-surface",),
+        examples=("devtools release verify-distribution",),
     ),
     CommandSpec(
         "pipeline-probe",
@@ -594,12 +595,12 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "build-package",
-        "maintenance",
+        "release build-package",
+        "release",
         "Build the default Nix package with the out-link under .local/result.",
         "devtools.build_package",
         use_when="Produce the Nix package artifact with its out-link kept under the repo-local output root.",
-        examples=("devtools build-package",),
+        examples=("devtools release build-package",),
     ),
     CommandSpec(
         "mutmut-campaign",

--- a/devtools/project_motd.py
+++ b/devtools/project_motd.py
@@ -157,7 +157,7 @@ def status_snapshot(cwd: Path, *, verify_generated: bool = False) -> StatusSnaps
             "status": control_plane_command("status", "--json"),
             "render_all_check": control_plane_command("render all", "--check"),
             "verify_quick": control_plane_command("verify", "--quick"),
-            "build_package": control_plane_command("build-package"),
+            "build_package": control_plane_command("release build-package"),
             "test_baseline": "pytest -q --ignore=tests/integration",
         },
         "local_state": {

--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -28,7 +28,7 @@ REQUIRED_COMMANDS: tuple[GateCommand, ...] = (
     GateCommand(("devtools", "verify", "--quick"), True, "static/generated baseline"),
     GateCommand(("devtools", "verify", "--lab"), True, "verification-lab baseline"),
     GateCommand(("devtools", "release", "build-package"), True, "wheel/sdist/Nix package smoke"),
-    GateCommand(("devtools", "render pages"), True, "documentation site build"),
+    GateCommand(("devtools", "render", "pages"), True, "documentation site build"),
     GateCommand(("devtools", "verify-doc-commands"), True, "README/docs command examples"),
 )
 
@@ -102,6 +102,21 @@ def _issue_refs(lines: list[str]) -> set[str]:
     return refs
 
 
+def _catalog_command_name(argv: tuple[str, ...], commands: set[str]) -> str:
+    """Return the devtools command path before command-local arguments."""
+
+    command_parts: list[str] = []
+    for part in argv[1:]:
+        if part.startswith("-"):
+            break
+        command_parts.append(part)
+    for end in range(len(command_parts), 0, -1):
+        candidate = " ".join(command_parts[:end])
+        if candidate in commands:
+            return candidate
+    return " ".join(command_parts)
+
+
 def _read_text_file(path: Path, *, label: str, errors: list[str]) -> str | None:
     try:
         return path.read_text(encoding="utf-8")
@@ -154,7 +169,7 @@ def build_report(
         command_text = " ".join(command.argv)
         if command.required and command_text not in text:
             errors.append(f"required command missing from gate document: {command_text}")
-        if command.argv[0] == "devtools" and command.argv[1] not in COMMANDS:
+        if command.argv[0] == "devtools" and _catalog_command_name(command.argv, set(COMMANDS)) not in COMMANDS:
             errors.append(f"unknown devtools command in release gate: {command_text}")
 
     if STATUS_SATISFIED_HEADING not in text:

--- a/devtools/release_readiness.py
+++ b/devtools/release_readiness.py
@@ -24,10 +24,10 @@ class GateCommand:
 
 
 REQUIRED_COMMANDS: tuple[GateCommand, ...] = (
-    GateCommand(("devtools", "release-readiness"), True, "release gate definition"),
+    GateCommand(("devtools", "release", "readiness"), True, "release gate definition"),
     GateCommand(("devtools", "verify", "--quick"), True, "static/generated baseline"),
     GateCommand(("devtools", "verify", "--lab"), True, "verification-lab baseline"),
-    GateCommand(("devtools", "build-package"), True, "wheel/sdist/Nix package smoke"),
+    GateCommand(("devtools", "release", "build-package"), True, "wheel/sdist/Nix package smoke"),
     GateCommand(("devtools", "render pages"), True, "documentation site build"),
     GateCommand(("devtools", "verify-doc-commands"), True, "README/docs command examples"),
 )
@@ -203,7 +203,7 @@ def build_report(
 
 def _print_human(report: dict[str, Any]) -> None:
     status = "ok" if report["ok"] else "FAIL"
-    print(f"release-readiness: {status}")
+    print(f"release readiness: {status}")
     print(f"gate doc: {report['gate_doc']}")
     print("required commands:")
     for command in report["required_commands"]:

--- a/devtools/verify_distribution_surface.py
+++ b/devtools/verify_distribution_surface.py
@@ -49,17 +49,17 @@ def main(argv: list[str] | None = None) -> int:
     try:
         verify_distribution_surface(work_dir)
     except DistributionVerificationError as exc:
-        print(f"verify-distribution-surface: FAILED: {exc}", file=sys.stderr)
+        print(f"release verify-distribution: FAILED: {exc}", file=sys.stderr)
         if not cleanup:
-            print(f"verify-distribution-surface: work dir: {work_dir}", file=sys.stderr)
+            print(f"release verify-distribution: work dir: {work_dir}", file=sys.stderr)
         return 1
     finally:
         if cleanup:
             shutil.rmtree(work_dir, ignore_errors=True)
 
     if args.keep_work_dir or args.work_dir is not None:
-        print(f"verify-distribution-surface: work dir: {work_dir}", file=sys.stderr)
-    print("verify-distribution-surface: ok", file=sys.stderr)
+        print(f"release verify-distribution: work dir: {work_dir}", file=sys.stderr)
+    print("release verify-distribution: ok", file=sys.stderr)
     return 0
 
 
@@ -171,7 +171,7 @@ def _run(
     env: dict[str, str] | None = None,
 ) -> None:
     rendered = " ".join(cmd)
-    print(f"verify-distribution-surface: {rendered}", file=sys.stderr)
+    print(f"release verify-distribution: {rendered}", file=sys.stderr)
     result = subprocess.run(tuple(cmd), cwd=cwd, env=env, text=True, capture_output=True, check=False)
     if result.returncode == 0:
         return

--- a/devtools/xtask.py
+++ b/devtools/xtask.py
@@ -139,7 +139,7 @@ _CLASS_PREFIXES: tuple[tuple[str, str], ...] = (
     ("regression-capture", "query"),
     ("scenario-projections", "query"),
     ("coverage-gate", "verify"),
-    ("build-package", "render"),
+    ("release build-package", "render"),
     ("status", "query"),
     ("xtask", "query"),
 )

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -104,7 +104,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
-| `devtools release-readiness` | Validate the externally-presentable release gate definition. |
+| `devtools release readiness` | Validate the externally-presentable release gate definition. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools schema-audit` | Run committed provider schema package quality checks. |
@@ -115,7 +115,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |
-| `devtools verify-distribution-surface` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
+| `devtools release verify-distribution` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
 | `devtools verify-doc-commands` | Verify README/docs command examples resolve to live polylogue, polylogued, and devtools commands. |
 | `devtools verify-lane-assertions` | Verify scenario lanes classified as SEMANTIC_OUTPUT carry semantic assertions. |
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
@@ -141,7 +141,7 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
-| `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
+| `devtools release build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
 | `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
@@ -166,7 +166,7 @@ Campaign outputs live under `.local/`, not in tracked docs trees.
 - `.cache/`: disposable cache state.
 - `.local/`: untracked local outputs such as campaigns, showcases, and reports.
 - `.venv/` and `.direnv/`: kept at the repo root because their tooling expects those locations.
-- `.local/result`: preferred repo-local out-link for `devtools build-package`; a top-level `result` symlink is just Nix's default ad-hoc out-link.
+- `.local/result`: preferred repo-local out-link for `devtools release build-package`; a top-level `result` symlink is just Nix's default ad-hoc out-link.
 
 Keep new repo-local outputs in `.cache/` or `.local/` instead of adding new
 top-level output roots.

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -91,6 +91,14 @@ These are the commands worth remembering during normal repo work:
 | `devtools render topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
 
+### Release
+
+| Command | Description |
+| --- | --- |
+| `devtools release build-package` | Build the default Nix package with the out-link under .local/result. |
+| `devtools release readiness` | Validate the externally-presentable release gate definition. |
+| `devtools release verify-distribution` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
+
 ### Verification
 
 | Command | Description |
@@ -104,7 +112,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
-| `devtools release readiness` | Validate the externally-presentable release gate definition. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools schema-audit` | Run committed provider schema package quality checks. |
@@ -115,7 +122,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |
-| `devtools release verify-distribution` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
 | `devtools verify-doc-commands` | Verify README/docs command examples resolve to live polylogue, polylogued, and devtools commands. |
 | `devtools verify-lane-assertions` | Verify scenario lanes classified as SEMANTIC_OUTPUT carry semantic assertions. |
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
@@ -141,7 +147,6 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
-| `devtools release build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
 | `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -513,4 +513,4 @@ devtools lab-scenario verify-baselines
 
 - `.cache/`: disposable caches (hypothesis, pytest, mypy, ruff)
 - `.local/`: untracked outputs (campaigns, showcases, build artifacts)
-- `.local/result`: out-link for `devtools build-package`
+- `.local/result`: out-link for `devtools release build-package`

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -20,9 +20,9 @@ artifacts:
     description: Python wheel distribution (bdist_wheel)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: devtools verify-distribution-surface
+    build_command: devtools release verify-distribution
     install_command: pip install polylogue
-    verification_command: devtools verify-distribution-surface
+    verification_command: devtools release verify-distribution
     ci_build: true
     ci_test: true
     notes: >
@@ -37,9 +37,9 @@ artifacts:
     description: Python source distribution (sdist)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: devtools verify-distribution-surface
+    build_command: devtools release verify-distribution
     install_command: pip install polylogue
-    verification_command: devtools verify-distribution-surface
+    verification_command: devtools release verify-distribution
     ci_build: true
     ci_test: true
     notes: >
@@ -100,7 +100,7 @@ artifacts:
       (XDG_CONFIG_HOME) are declared. Build + push to GHCR runs from
       release.yml::publish-container on `vX.Y.Z` tag push. Pre-tag CI
       does not build the image to keep ci.yml fast; the
-      verify-distribution-surface gate exercises the same wheel that
+      release verify-distribution gate exercises the same wheel that
       the Containerfile installs.
 
   browser_extension:
@@ -167,7 +167,7 @@ coverage_gaps:
     declared_at: "2026-05-02"
     review_after: "2026-08-01"
     issue: 593
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution
   - id: distribution.macos-ci
     platform: macos
     gap: No macOS CI runner
@@ -176,7 +176,7 @@ coverage_gaps:
     declared_at: "2026-05-02"
     review_after: "2026-08-01"
     issue: 593
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution
   - id: distribution.windows-ci
     platform: windows
     gap: No Windows CI runner
@@ -185,7 +185,7 @@ coverage_gaps:
     declared_at: "2026-05-02"
     review_after: "2026-08-01"
     issue: 593
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution
   - id: distribution.nix-wheel-parity
     concern: install_parity
     gap: Local gate smokes wheel and sdist-built wheel, but exact Nix/devshell parity is not yet compared in CI
@@ -194,7 +194,7 @@ coverage_gaps:
     declared_at: "2026-05-02"
     review_after: "2026-08-01"
     issue: 593
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution
   - id: distribution.container-ci-build
     artifact: oci_container
     gap: Containerfile is built+pushed only on tag (release.yml). No pre-tag CI build means image-only regressions surface at release time.
@@ -203,7 +203,7 @@ coverage_gaps:
     declared_at: "2026-05-17"
     review_after: "2026-08-01"
     issue: 953
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution
   - id: distribution.browser-extension-store
     artifact: browser_extension
     gap: Packed .zip/.xpi ship on GitHub releases (#1238), but Chrome Web Store / Mozilla AMO submission still requires non-engineering store sign-up + review.
@@ -212,4 +212,4 @@ coverage_gaps:
     declared_at: "2026-05-17"
     review_after: "2026-08-01"
     issue: 953
-    next_evidence: devtools verify-distribution-surface
+    next_evidence: devtools release verify-distribution

--- a/docs/plans/release-readiness-gate.md
+++ b/docs/plans/release-readiness-gate.md
@@ -24,11 +24,11 @@ shipped product behavior.
 Run these from a clean checkout inside the devshell:
 
 ```bash
-devtools release-readiness
-devtools release-readiness --release-body-file /tmp/release-pr-body.md
+devtools release readiness
+devtools release readiness --release-body-file /tmp/release-pr-body.md
 devtools verify --quick
 devtools verify --lab
-devtools build-package
+devtools release build-package
 devtools render pages
 devtools verify-doc-commands
 ```
@@ -61,11 +61,11 @@ nix flake check
 | Web/API | Any advertised web/API surface has stable DTOs, auth posture, and route vocabulary. | #1847, #1846 |
 | Static/docs surface | Generated docs, pages, media, and topology status are current. | #1848, #1849 |
 | CI reliability | Known benchmark/test flakes are resolved or explicitly excluded from the release gate with rationale. | #1878 |
-| Packaging | Wheel/sdist/Nix package expose only supported runtime entrypoints. | `devtools build-package`, `nix flake check` |
+| Packaging | Wheel/sdist/Nix package expose only supported runtime entrypoints. | `devtools release build-package`, `nix flake check` |
 
 ## Manual Release Review
 
-Before merging a release PR, record the answers in the PR body and run `devtools release-readiness --release-body-file <path>` against that exact body text:
+Before merging a release PR, record the answers in the PR body and run `devtools release readiness --release-body-file <path>` against that exact body text:
 
 | Question | Required Answer |
 | --- | --- |

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,7 +56,7 @@ anything different; release-please consumes the existing history.
 3. The tag push triggers [`release.yml`](../.github/workflows/release.yml),
    which runs, in order:
    - `build-and-smoke` — builds wheel + sdist, runs
-     `devtools verify-distribution-surface`, and verifies PyPI long-description
+     `devtools release verify-distribution`, and verifies PyPI long-description
      renderability with `twine check`.
    - `installed-smoke` matrix — installs the freshly-built wheel into a fresh
      `python -m venv` on `{ubuntu-latest, macos-latest} × py{3.11, 3.12, 3.13}`

--- a/tests/integration/test_installed_package_smoke.py
+++ b/tests/integration/test_installed_package_smoke.py
@@ -11,7 +11,7 @@ The test asserts that:
   (no leakage into ``$HOME`` or other host paths).
 
 This closes #1265 (slice D of #869): the existing
-``devtools verify-distribution-surface`` smoke only exercised ``--help``/
+``devtools release verify-distribution`` smoke only exercised ``--help``/
 ``--version``/``analyze --count``; daemon status under fresh XDG paths was not covered.
 """
 

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -24,7 +24,7 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
     assert "regression-capture" in commands
     assert "scenario-projections" in commands
     assert "render devtools-reference" in commands
-    assert "release-readiness" in commands
+    assert "release readiness" in commands
     assert "status" in commands
 
 

--- a/tests/unit/devtools/test_generated_surfaces.py
+++ b/tests/unit/devtools/test_generated_surfaces.py
@@ -9,7 +9,8 @@ def test_generated_surfaces_use_public_devtools_commands() -> None:
     assert GENERATED_SURFACES
     for surface in GENERATED_SURFACES:
         assert surface.command[0] == "devtools"
-        assert len(surface.command) == 2
+        assert len(surface.command) >= 2
+        assert all(part and " " not in part for part in surface.command)
         assert callable(surface.main)
 
 

--- a/tests/unit/devtools/test_project_motd.py
+++ b/tests/unit/devtools/test_project_motd.py
@@ -34,7 +34,9 @@ def test_render_motd_contains_expected_sections(
     assert "worktree   dirty · 1 staged · 2 modified · 3 untracked" in rendered
     assert f"generated  {surface_count}/{surface_count} generated unchecked" in rendered
     assert "head       docs: tighten repo guides" in rendered
-    assert "ready      devtools render all --check · devtools verify --quick · devtools build-package" in rendered
+    assert (
+        "ready      devtools render all --check · devtools verify --quick · devtools release build-package" in rendered
+    )
     assert "test       pytest -q --ignore=tests/integration" in rendered
     assert "roots      keep .venv/ .direnv/ · cache .cache/ · outputs .local/ · build .local/result" in rendered
     assert "dirty · 1 staged · 2 modified · 3 untracked" in rendered
@@ -58,7 +60,7 @@ def test_status_snapshot_includes_machine_readable_commands(
     assert snapshot["commands"]["discover"] == "devtools --list-commands --json"
     assert snapshot["commands"]["status"] == "devtools status --json"
     assert snapshot["commands"]["verify_quick"] == "devtools verify --quick"
-    assert snapshot["commands"]["build_package"] == "devtools build-package"
+    assert snapshot["commands"]["build_package"] == "devtools release build-package"
     assert snapshot["generated_surfaces"]
     assert snapshot["generated_checked"] is False
     assert set(snapshot["generated_surfaces"].values()) == {"unchecked"}

--- a/tests/unit/devtools/test_release_readiness.py
+++ b/tests/unit/devtools/test_release_readiness.py
@@ -47,7 +47,7 @@ def test_release_readiness_report_validates_committed_gate() -> None:
     assert report["ok"] is True
     assert report["gate_doc"] == "docs/plans/release-readiness-gate.md"
     assert ["devtools", "verify", "--quick"] in [command["argv"] for command in report["required_commands"]]
-    assert ["devtools", "build-package"] in [command["argv"] for command in report["required_commands"]]
+    assert ["devtools", "release", "build-package"] in [command["argv"] for command in report["required_commands"]]
     assert "- Known caveats scoped out:" in report["required_release_body_fields"]
     assert report["release_status"]["satisfied"]
     assert report["release_status"]["blocking_external_claims"]
@@ -59,7 +59,7 @@ def test_release_readiness_json_cli(capsys: pytest.CaptureFixture[str]) -> None:
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["required_commands"][0]["argv"] == ["devtools", "release-readiness"]
+    assert payload["required_commands"][0]["argv"] == ["devtools", "release", "readiness"]
     assert "release_status" in payload
 
 
@@ -127,7 +127,7 @@ def _valid_release_body_text() -> str:
 {fields}
 
 Verification:
-- devtools release-readiness -- key output line
+- devtools release readiness -- key output line
 """
 
 


### PR DESCRIPTION
## Summary

Moves Polylogue's release/distribution control-plane commands under a single `devtools release ...` group as the first concrete slice of #2126. The live command catalog remains the sole authority; this does not add a placement ledger, custom verifier, or compatibility aliases.

## Problem

#2126 identifies devtools command sprawl: release readiness, package build, and distribution verification were split across flat top-level command names and unrelated catalog categories. That made release workflow ownership harder to scan and kept generated docs teaching the old flat surface.

## Solution

- Renamed the release-owned devtools paths to `devtools release readiness`, `devtools release build-package`, and `devtools release verify-distribution`.
- Updated the Click dispatcher/tests to support grouped command paths directly from `CommandSpec`.
- Updated CI/release workflows, release gate docs, generated devtools docs, AGENTS mirror, installed-package smoke references, and release-readiness validation.
- Kept #2126 open for the remaining devtools groups (`lab`, `bench`, `workspace`, archive diagnostics ownership, duplicate/noise audit).

## Verification

- `devtools test tests/unit/devtools/test_release_readiness.py tests/unit/devtools/test_generated_surfaces.py tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_project_motd.py` → 23 passed.
- `devtools verify --quick` → exit_code 0.
- `devtools verify --seed-testmon --skip-slow` was attempted after the quick gate to seed the affected-test database, but the broad seed run had already recorded multiple failures by ~15% and was terminated to avoid burning the workstation on a doomed full-suite seed. The partial pytest output did not emit failing node details before termination.

Ref #2126