### PR TITLE
refactor(devtools): group workspace commands (#2126)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,9 +523,9 @@ process group if the step exceeds `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default
 diagnostic run where an unusually long full-suite pass is expected and
 supervised.
 
-`devtools xtask recent` shows the run id, diagnosis, and peak pytest RSS when
-the current run metadata is available. `devtools xtask stats --resources`
-aggregates recorded pytest memory peaks over time.
+`devtools workspace tasks recent` shows the run id, diagnosis, and peak pytest
+RSS when the current run metadata is available. `devtools workspace tasks stats
+--resources` aggregates recorded pytest memory peaks over time.
 
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect
@@ -1688,14 +1688,19 @@ These are the commands worth remembering during normal repo work:
 | `devtools mutmut-campaign` | Run focused mutation campaigns and maintain their local index. |
 | `devtools run-benchmark-campaigns` | Run synthetic benchmark campaigns over generated archives. |
 
+### Workspace
+
+| Command | Description |
+| --- | --- |
+| `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
+| `devtools workspace tasks` | Record and query local agent task execution history. |
+| `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
+
 ### Maintenance
 
 | Command | Description |
 | --- | --- |
 | `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
-| `devtools failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
-| `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
-| `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
 
 <!-- END GENERATED: devtools-command-catalog -->
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -102,9 +102,9 @@ process group if the step exceeds `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default
 diagnostic run where an unusually long full-suite pass is expected and
 supervised.
 
-`devtools xtask recent` shows the run id, diagnosis, and peak pytest RSS when
-the current run metadata is available. `devtools xtask stats --resources`
-aggregates recorded pytest memory peaks over time.
+`devtools workspace tasks recent` shows the run id, diagnosis, and peak pytest
+RSS when the current run metadata is available. `devtools workspace tasks stats
+--resources` aggregates recorded pytest memory peaks over time.
 
 `devtools test` uses the same pytest progress plugin and process supervisor for
 focused selections. During or after a run, inspect

--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -24,6 +24,7 @@ from devtools.command_catalog import (
 GROUP_HELP: dict[str, str] = {
     "render": "Render and check generated repository surfaces.",
     "release": "Build, smoke, and validate release/distribution readiness.",
+    "workspace": "Inspect and maintain local agent workspace state.",
 }
 
 
@@ -208,9 +209,9 @@ def main(argv: list[str] | None = None) -> int:
 
     Converts argv to Click invocation and returns the exit code.  Every
     invocation appends a JSONL record to ``.agent/xtask/tasks.jsonl`` so
-    agent task history is self-populating (see ``devtools xtask``).  Set
+    agent task history is self-populating (see ``devtools workspace tasks``).  Set
     ``POLYLOGUE_XTASK_DISABLE=1`` to opt out (also suppressed during a
-    ``devtools xtask replay`` to avoid double-logging the outer wrapper).
+    ``devtools workspace tasks replay`` to avoid double-logging the outer wrapper).
     """
     import os
     import time

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -23,6 +23,7 @@ CATEGORY_ORDER: tuple[str, ...] = (
     "release",
     "verification",
     "campaigns",
+    "workspace",
     "maintenance",
 )
 
@@ -265,8 +266,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "worktree-gc",
-        "maintenance",
+        "workspace worktree-gc",
+        "workspace",
         "Safe worktree garbage collection — list and remove merged or abandoned git worktrees.",
         "devtools.worktree_gc",
         use_when=(
@@ -275,10 +276,10 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "Never removes dirty worktrees or the main worktree."
         ),
         examples=(
-            "devtools worktree-gc",
-            "devtools worktree-gc --json",
-            "devtools worktree-gc --apply",
-            "devtools worktree-gc --apply --force",
+            "devtools workspace worktree-gc",
+            "devtools workspace worktree-gc --json",
+            "devtools workspace worktree-gc --apply",
+            "devtools workspace worktree-gc --apply --force",
         ),
     ),
     CommandSpec(
@@ -631,23 +632,23 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.run_campaign",
     ),
     CommandSpec(
-        "xtask",
-        "maintenance",
-        "Record and query agent task execution history (.agent/xtask/tasks.jsonl).",
+        "workspace tasks",
+        "workspace",
+        "Record and query local agent task execution history.",
         "devtools.xtask",
         use_when="Log, view recent, or summarize agent task execution history during development sessions.",
         examples=(
-            "devtools xtask log --command 'devtools render all' --duration-ms 3200 --exit-code 0",
-            "devtools xtask recent",
-            "devtools xtask recent --count 20",
-            "devtools xtask stats",
-            "devtools xtask stats --json",
-            "devtools xtask stats --resources",
+            "devtools workspace tasks log --command 'devtools render all' --duration-ms 3200 --exit-code 0",
+            "devtools workspace tasks recent",
+            "devtools workspace tasks recent --count 20",
+            "devtools workspace tasks stats",
+            "devtools workspace tasks stats --json",
+            "devtools workspace tasks stats --resources",
         ),
     ),
     CommandSpec(
-        "failure-context",
-        "maintenance",
+        "workspace failure-context",
+        "workspace",
         "Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope.",
         "devtools.failure_context",
         use_when=(
@@ -656,8 +657,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "all in one structured envelope."
         ),
         examples=(
-            "devtools failure-context tests/unit/storage/test_foo.py::test_bar",
-            "devtools failure-context tests/unit/storage/test_foo.py::test_bar --days 14",
+            "devtools workspace failure-context tests/unit/storage/test_foo.py::test_bar",
+            "devtools workspace failure-context tests/unit/storage/test_foo.py::test_bar --days 14",
         ),
     ),
     CommandSpec(

--- a/devtools/failure_context.py
+++ b/devtools/failure_context.py
@@ -5,9 +5,9 @@ witnesses into a single JSON envelope keyed by a pytest failure ID
 (e.g. ``tests/unit/storage/test_foo.py::test_bar``).
 
 Usage:
-  devtools failure-context tests/unit/storage/test_foo.py::test_bar
-  devtools failure-context tests/unit/storage/test_foo.py::test_bar --json
-  devtools failure-context tests/unit/storage/test_foo.py::test_bar --days 14
+  devtools workspace failure-context tests/unit/storage/test_foo.py::test_bar
+  devtools workspace failure-context tests/unit/storage/test_foo.py::test_bar --json
+  devtools workspace failure-context tests/unit/storage/test_foo.py::test_bar --days 14
 """
 
 from __future__ import annotations

--- a/devtools/xtask.py
+++ b/devtools/xtask.py
@@ -1,4 +1,4 @@
-"""Agent-visible task execution history (xtask).
+"""Agent-visible task execution history.
 
 Maintains an append-only JSONL log of task executions under
 ``.agent/xtask/tasks.jsonl`` for use by agents and operators.
@@ -124,6 +124,7 @@ def _latest_verify_run_metadata(command: str) -> dict[str, Any]:
 _CLASS_PREFIXES: tuple[tuple[str, str], ...] = (
     ("verify", "verify"),
     ("render", "render"),
+    ("release build-package", "render"),
     ("lab", "lab"),
     ("witness", "witness"),
     ("mutmut", "campaign"),
@@ -139,9 +140,10 @@ _CLASS_PREFIXES: tuple[tuple[str, str], ...] = (
     ("regression-capture", "query"),
     ("scenario-projections", "query"),
     ("coverage-gate", "verify"),
-    ("release build-package", "render"),
+    ("workspace tasks", "query"),
+    ("workspace failure-context", "query"),
+    ("workspace worktree-gc", "query"),
     ("status", "query"),
-    ("xtask", "query"),
 )
 
 
@@ -153,8 +155,10 @@ def classify_command(command_name: str) -> str:
     """
     if not command_name:
         return "other"
-    head = command_name.split()[0] if " " in command_name else command_name
     for prefix, klass in _CLASS_PREFIXES:
+        if command_name == prefix or command_name.startswith(f"{prefix} "):
+            return klass
+        head = command_name.split()[0]
         if head == prefix or head.startswith(f"{prefix}-") or head.startswith(f"{prefix}_"):
             return klass
     return "other"
@@ -552,7 +556,7 @@ def _cmd_prune(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="devtools xtask", description="Task execution history.")
+    parser = argparse.ArgumentParser(prog="devtools workspace tasks", description="Task execution history.")
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     log_parser = subparsers.add_parser("log", help="Append a task record.")

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -142,14 +142,19 @@ These are the commands worth remembering during normal repo work:
 | `devtools mutmut-campaign` | Run focused mutation campaigns and maintain their local index. |
 | `devtools run-benchmark-campaigns` | Run synthetic benchmark campaigns over generated archives. |
 
+### Workspace
+
+| Command | Description |
+| --- | --- |
+| `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
+| `devtools workspace tasks` | Record and query local agent task execution history. |
+| `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
+
 ### Maintenance
 
 | Command | Description |
 | --- | --- |
 | `devtools archive-space-report` | Report SQLite archive file/page/object space by table and index. |
-| `devtools failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
-| `devtools worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |
-| `devtools xtask` | Record and query agent task execution history (.agent/xtask/tasks.jsonl). |
 
 <!-- END GENERATED: devtools-command-catalog -->
 

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -25,6 +25,7 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
     assert "scenario-projections" in commands
     assert "render devtools-reference" in commands
     assert "release readiness" in commands
+    assert "workspace tasks" in commands
     assert "status" in commands
 
 
@@ -83,6 +84,27 @@ def test_nested_render_command_dispatches_to_catalog_entry(monkeypatch: pytest.M
 
     assert devtools_main.main(["render", "all", "--check"]) == 0
     assert captured == [["--check"]]
+
+
+def test_nested_workspace_command_dispatches_to_catalog_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[list[str] | None] = []
+
+    def fake_main(argv: list[str] | None) -> int:
+        captured.append(argv)
+        return 0
+
+    fake_module = ModuleType("_polylogue_devtools_test_workspace_fake")
+    fake_module.__dict__["main"] = fake_main
+    monkeypatch.setitem(__import__("sys").modules, fake_module.__name__, fake_module)
+
+    monkeypatch.setitem(
+        COMMANDS,
+        "workspace tasks",
+        CommandSpec("workspace tasks", "workspace", "fake workspace tasks", fake_module.__name__),
+    )
+
+    assert devtools_main.main(["workspace", "tasks", "recent", "--json"]) == 0
+    assert captured == [["recent", "--json"]]
 
 
 def test_help_output_includes_devtools_prog_name(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_failure_context.py
+++ b/tests/unit/devtools/test_failure_context.py
@@ -141,7 +141,7 @@ def test_main_rejects_bad_failure_id(capsys: pytest.CaptureFixture[str]) -> None
 def test_command_registered_in_catalog() -> None:
     from devtools.command_catalog import COMMANDS
 
-    assert "failure-context" in COMMANDS
-    spec = COMMANDS["failure-context"]
+    assert "workspace failure-context" in COMMANDS
+    spec = COMMANDS["workspace failure-context"]
     assert spec.module == "devtools.failure_context"
     assert callable(spec.resolve_main())

--- a/tests/unit/devtools/test_xtask.py
+++ b/tests/unit/devtools/test_xtask.py
@@ -1,4 +1,4 @@
-"""Tests for ``devtools xtask`` task-history surface and harness wiring."""
+"""Tests for ``devtools workspace tasks`` task-history surface and harness wiring."""
 
 from __future__ import annotations
 
@@ -40,7 +40,10 @@ def isolated_xtask_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
         ("run-benchmark-campaigns", "campaign"),
         ("daemon-workload-probe", "query"),
         ("status", "query"),
-        ("xtask", "query"),
+        ("workspace tasks", "query"),
+        ("workspace failure-context", "query"),
+        ("workspace worktree-gc", "query"),
+        ("release build-package", "render"),
         ("totally-unknown-command", "other"),
         ("", "other"),
     ],


### PR DESCRIPTION
## Summary

Groups local workspace-maintenance devtools under `devtools workspace`: worktree GC, failure-context envelopes, and agent task-history inspection. The visible task-history command is now `devtools workspace tasks` instead of exposing `xtask` as public vocabulary.

## Problem

#2126 is collapsing the flat devtools command surface into owner groups. After the release grouping, local agent/workspace utilities still lived as unrelated top-level maintenance commands, and `xtask` remained visible jargon instead of an operator-readable task-history surface.

## Solution

- Move `worktree-gc`, `failure-context`, and task-history inspection into the `workspace` group in the command catalog.
- Teach the Click dispatcher the `workspace` group and preserve nested-command argument forwarding.
- Rename public docs/examples to `devtools workspace tasks`, `devtools workspace failure-context`, and `devtools workspace worktree-gc`.
- Update task-history classification and focused devtools tests without adding old-name absence assertions.
- Regenerate `docs/devtools.md` and `AGENTS.md`.

The internal task-history module and local JSONL storage path are unchanged in this slice; this PR only removes the old name from the public devtools command surface.

## Verification

- `devtools test tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_xtask.py tests/unit/devtools/test_worktree_gc.py tests/unit/devtools/test_failure_context.py tests/unit/devtools/test_generated_surfaces.py tests/unit/devtools/test_project_motd.py` — 81 passed.
- `devtools verify --quick` — exit_code 0, run_id `20260618T224916Z-quick-2933113-138932eb`.
- pre-push `devtools verify --quick` — exit_code 0, run_id `20260618T225001Z-quick-2954258-26a28ddb`.

Ref #2126