### PR TITLE
refactor(surface): validate public evidence refs (#1845)

### DIFF
--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -10,11 +10,12 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypeAlias, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import TypedDict
 
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document
+from polylogue.core.refs import normalize_object_ref_text, normalize_public_ref_text
 
 if TYPE_CHECKING:
     from collections.abc import Container
@@ -952,6 +953,21 @@ class AssertionQueryRowPayload(SurfacePayloadModel):
     created_at_ms: int
     updated_at_ms: int
 
+    @field_validator("target_ref")
+    @classmethod
+    def _validate_target_ref(cls, value: str) -> str:
+        return normalize_object_ref_text(value)
+
+    @field_validator("scope_ref", "author_ref")
+    @classmethod
+    def _validate_optional_object_ref(cls, value: str | None) -> str | None:
+        return normalize_object_ref_text(value) if value is not None else None
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
+
     @classmethod
     def from_row(cls, row: ArchiveAssertionQueryRow) -> AssertionQueryRowPayload:
         return cls(
@@ -995,6 +1011,21 @@ class AssertionClaimPayload(SurfacePayloadModel):
     supersedes: tuple[str, ...] = ()
     created_at_ms: int
     updated_at_ms: int
+
+    @field_validator("target_ref")
+    @classmethod
+    def _validate_claim_target_ref(cls, value: str) -> str:
+        return normalize_object_ref_text(value)
+
+    @field_validator("scope_ref", "author_ref")
+    @classmethod
+    def _validate_claim_optional_object_ref(cls, value: str | None) -> str | None:
+        return normalize_object_ref_text(value) if value is not None else None
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_claim_public_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
 
     @classmethod
     def from_envelope(cls, envelope: ArchiveAssertionEnvelope) -> AssertionClaimPayload:
@@ -1100,6 +1131,26 @@ class ObservedEventQueryRowPayload(SurfacePayloadModel):
     object_refs: tuple[str, ...]
     evidence_refs: tuple[str, ...]
 
+    @field_validator("event_ref")
+    @classmethod
+    def _validate_event_ref(cls, value: str) -> str:
+        return normalize_object_ref_text(value)
+
+    @field_validator("subject_ref")
+    @classmethod
+    def _validate_optional_subject_ref(cls, value: str | None) -> str | None:
+        return normalize_object_ref_text(value) if value is not None else None
+
+    @field_validator("object_refs")
+    @classmethod
+    def _validate_object_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_object_ref_text(ref) for ref in value)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_observed_event_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
+
 
 class ContextSnapshotQueryRowPayload(SurfacePayloadModel):
     """Shared terminal-query row for runtime-transform context snapshots."""
@@ -1115,6 +1166,21 @@ class ContextSnapshotQueryRowPayload(SurfacePayloadModel):
     segment_refs: tuple[str, ...]
     evidence_refs: tuple[str, ...]
     metadata: dict[str, str]
+
+    @field_validator("snapshot_ref", "run_ref")
+    @classmethod
+    def _validate_context_object_ref(cls, value: str) -> str:
+        return normalize_object_ref_text(value)
+
+    @field_validator("segment_refs")
+    @classmethod
+    def _validate_segment_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_object_ref_text(ref) for ref in value)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_context_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
 
 
 QueryUnitRowPayload: TypeAlias = (

--- a/tests/unit/surfaces/test_evidence_ref_payloads.py
+++ b/tests/unit/surfaces/test_evidence_ref_payloads.py
@@ -1,0 +1,105 @@
+"""Public evidence payload ref validation contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from polylogue.surfaces.payloads import (
+    AssertionClaimPayload,
+    AssertionQueryRowPayload,
+    ContextSnapshotQueryRowPayload,
+    ObservedEventQueryRowPayload,
+)
+
+
+def test_assertion_query_payload_rejects_unparseable_target_ref() -> None:
+    with pytest.raises(ValidationError, match="object ref must use"):
+        AssertionQueryRowPayload(
+            assertion_id="a1",
+            target_ref="claim-target",
+            kind="note",
+            value={"ok": True},
+            author_ref="user:local",
+            author_kind="user",
+            status="active",
+            visibility="private",
+            evidence_refs=("session:codex-session:s1::m1",),
+            staleness={},
+            context_policy={"inject": False},
+            created_at_ms=1,
+            updated_at_ms=1,
+        )
+
+
+def test_assertion_claim_payload_accepts_object_and_evidence_refs() -> None:
+    payload = AssertionClaimPayload(
+        assertion_id="a1",
+        scope_ref="workspace:polylogue",
+        target_ref="message:codex-session:s1:m1",
+        kind="note",
+        body_text="needs review",
+        author_ref="user:local",
+        evidence_refs=(
+            "session:codex-session:s1",
+            "codex-session:s1::m1",
+        ),
+        created_at_ms=1,
+        updated_at_ms=1,
+    )
+
+    assert payload.scope_ref == "workspace:polylogue"
+    assert payload.target_ref == "message:codex-session:s1:m1"
+    assert payload.evidence_refs == (
+        "session:codex-session:s1",
+        "codex-session:s1::m1",
+    )
+
+
+def test_observed_event_payload_rejects_unparseable_evidence_refs() -> None:
+    with pytest.raises(ValidationError, match="unsupported public ref"):
+        ObservedEventQueryRowPayload(
+            event_ref="observed-event:event-1",
+            session_id="s1",
+            origin="codex-session",
+            kind="review",
+            summary="review injected",
+            delivery_state="observed",
+            subject_ref="message:s1:m1",
+            object_refs=("tool-call:call-1",),
+            evidence_refs=("codex-session:s1::m1::-1",),
+        )
+
+
+def test_context_snapshot_payload_validates_run_segment_and_evidence_refs() -> None:
+    payload = ContextSnapshotQueryRowPayload(
+        snapshot_ref="context-snapshot:snap-1",
+        session_id="s1",
+        origin="codex-session",
+        run_ref="run:run-1",
+        boundary="review_injection",
+        inheritance_mode="copied",
+        segment_refs=("message:s1:m1", "block:s1:m1:0"),
+        evidence_refs=("codex-session:s1::m1::0",),
+        metadata={"source": "review"},
+    )
+
+    assert payload.snapshot_ref == "context-snapshot:snap-1"
+    assert payload.run_ref == "run:run-1"
+    assert payload.segment_refs == ("message:s1:m1", "block:s1:m1:0")
+    assert payload.evidence_refs == ("codex-session:s1::m1::0",)
+
+
+def test_context_snapshot_payload_rejects_unparseable_segment_ref() -> None:
+    with pytest.raises(ValidationError, match="object ref must use"):
+        ContextSnapshotQueryRowPayload(
+            snapshot_ref="context-snapshot:snap-1",
+            session_id="s1",
+            origin="codex-session",
+            run_ref="run:run-1",
+            boundary="review_injection",
+            inheritance_mode="copied",
+            segment_refs=("segment-1",),
+            evidence_refs=("codex-session:s1",),
+            metadata={},
+        )


### PR DESCRIPTION
## Summary

Validates public evidence references at the surface payload boundary for assertion rows, assertion claims, observed events, and context snapshots.

## Problem

#1845 defines `ObjectRef` / `EvidenceRef` as the shared addressing contract for evidence-bearing surfaces, but several public payload DTOs still accepted arbitrary strings for target/support refs. That lets bad refs leak into API/MCP/daemon/CLI rows instead of failing at the boundary that publishes them.

## Solution

- Normalizes assertion target/scope/author/evidence refs in `AssertionQueryRowPayload` and `AssertionClaimPayload`.
- Normalizes observed-event event/subject/object/evidence refs in `ObservedEventQueryRowPayload`.
- Adds the same validation for context-snapshot snapshot/run/segment/evidence refs.
- Adds focused surface tests covering accepted object/evidence refs and typed rejection of malformed refs.

This does not add speculative ref kinds or a resolver service; it only applies the existing ref helpers to surfaces that already emit those fields.

## Verification

- `ruff check polylogue/surfaces/payloads.py tests/unit/surfaces/test_evidence_ref_payloads.py`
- `devtools test tests/unit/surfaces/test_evidence_ref_payloads.py tests/unit/core/test_refs.py` → 43 passed
- `devtools verify --quick` → exit_code 0, run_id `20260619T002055Z-quick-3486210-4a9a63f0`
- pre-push `devtools verify --quick` → exit_code 0, run_id `20260619T002212Z-quick-3487707-21f5c559`

Ref #1845