### PR TITLE
refactor(tags): back user tags with assertions (#1842)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -523,24 +523,22 @@ Options:
 ## Tags
 
 ```text
-Usage: polylogue tags [OPTIONS] [SESSION_ID]
+Usage: polylogue tags [OPTIONS]
 
-  List all tags with session counts, or add/remove tags.
+  List user tags with session counts.
 
   Examples:
       polylogue tags                         # List all tags
       polylogue tags -o claude-ai-export     # Tags for Claude web sessions only
       polylogue tags --format json           # Machine-readable output
       polylogue tags -n 10                   # Top 10 tags
-      polylogue tags conv:abc --add-tag tps  # Add a tag
-      polylogue tags conv:abc --rm-tag tps   # Remove a tag
+      polylogue find id:abc then mark --tag-add tps
+      polylogue find id:abc then mark --tag-remove tps
 
 Options:
   -o, --origin TEXT    Filter tags by origin
   -f, --format [json]  Output format
   -n, --count INTEGER  Show top N tags
-  --add-tag TEXT       Add a tag to the given session
-  --remove-tag TEXT    Remove a tag from the given session
   --help               Show this message and exit.
 ```
 

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -8,32 +8,18 @@ from polylogue.cli.shared.machine_errors import emit_success
 from polylogue.cli.shared.types import AppEnv
 
 
-def _resolve_id(env: AppEnv, raw: str) -> str | None:
-    """Resolve a short or full session ID via get_session."""
-    from polylogue.api.sync.bridge import run_coroutine_sync
-
-    conv = run_coroutine_sync(env.polylogue.get_session(raw))
-    return str(conv.id) if conv is not None else None
-
-
 @click.command("tags")
-@click.argument("session_id", required=False)
 @click.option("--origin", "-o", default=None, help="Filter tags by origin")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None, help="Output format")
 @click.option("--count", "-n", type=int, default=None, help="Show top N tags")
-@click.option("--add-tag", "add_tag_name", type=str, default=None, help="Add a tag to the given session")
-@click.option("--remove-tag", "remove_tag_name", type=str, default=None, help="Remove a tag from the given session")
 @click.pass_obj
 def tags_command(
     env: AppEnv,
-    session_id: str | None,
     origin: str | None,
     output_format: str | None,
     count: int | None,
-    add_tag_name: str | None,
-    remove_tag_name: str | None,
 ) -> None:
-    """List all tags with session counts, or add/remove tags.
+    """List user tags with session counts.
 
     \b
     Examples:
@@ -41,58 +27,10 @@ def tags_command(
         polylogue tags -o claude-ai-export     # Tags for Claude web sessions only
         polylogue tags --format json           # Machine-readable output
         polylogue tags -n 10                   # Top 10 tags
-        polylogue tags conv:abc --add-tag tps  # Add a tag
-        polylogue tags conv:abc --rm-tag tps   # Remove a tag
+        polylogue find id:abc then mark --tag-add tps
+        polylogue find id:abc then mark --tag-remove tps
     """
     from polylogue.api.sync.bridge import run_coroutine_sync
-
-    if add_tag_name or remove_tag_name:
-        if not session_id:
-            raise click.UsageError("A session_id is required with --add-tag or --remove-tag")
-
-        resolved = _resolve_id(env, session_id)
-        if resolved is None:
-            raise click.ClickException(f"Session not found: {session_id}")
-
-        if add_tag_name:
-            result = run_coroutine_sync(env.polylogue.add_tag(resolved, add_tag_name))
-            status = "ok" if result.outcome == "added" else "unchanged"
-            if output_format == "json":
-                emit_success(
-                    {
-                        "status": status,
-                        "session_id": resolved,
-                        "tag": add_tag_name,
-                        "detail": result.detail,
-                        "outcome": result.outcome,
-                    }
-                )
-            else:
-                click.echo(
-                    f"Tag '{add_tag_name}' on {resolved}: {status} ({result.outcome})"
-                    + (f" ({result.detail})" if result.detail else "")
-                )
-
-        if remove_tag_name:
-            result = run_coroutine_sync(env.polylogue.remove_tag(resolved, remove_tag_name))
-            status = "ok" if result.outcome == "removed" else "not_found"
-            if output_format == "json":
-                emit_success(
-                    {
-                        "status": status,
-                        "session_id": resolved,
-                        "tag": remove_tag_name,
-                        "detail": result.detail,
-                        "outcome": result.outcome,
-                    }
-                )
-            else:
-                click.echo(
-                    f"Tag '{remove_tag_name}' on {resolved}: {status} ({result.outcome})"
-                    + (f" ({result.detail})" if result.detail else "")
-                )
-
-        return
 
     tags = run_coroutine_sync(env.polylogue.list_tags(origin=origin))
 
@@ -108,7 +46,7 @@ def tags_command(
             click.echo(f"No tags found for origin '{origin}'.")
         else:
             click.echo("No tags found.")
-        click.echo("Hint: use --add-tag <name> <session_id> to add a tag.")
+        click.echo("Hint: use `polylogue find QUERY then mark --tag-add <name>` to add a tag.")
         return
 
     max_width = max(len(t) for t in tags) if tags else 0

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1224,7 +1224,7 @@ class ArchiveStore:
                             (session_id, normalized_tag),
                         )
                         deleted = max(int(cursor.rowcount), 0)
-                        if deleted:
+                        if deleted and _table_exists(user_conn, "assertions"):
                             mark_assertion_status(
                                 user_conn,
                                 assertion_id_for_session_tag(session_id, normalized_tag, "user"),

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1187,6 +1187,14 @@ class ArchiveStore:
                         (session_id, normalized_tag),
                     ).fetchone()
                     if existing is not None:
+                        upsert_session_tag(
+                            user_conn,
+                            session_id=session_id,
+                            tag=tag,
+                            tag_source="user",
+                            method="cli",
+                            evidence={"source": "archive_query"},
+                        )
                         continue
                     upsert_session_tag(
                         user_conn,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -103,6 +103,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     assertion_id_for_mark,
     assertion_id_for_recall_pack,
     assertion_id_for_saved_view,
+    assertion_id_for_session_tag,
     assertion_id_for_workspace,
     correction_id_for,
     list_archive_blackboard_note_envelopes,
@@ -1222,7 +1223,14 @@ class ArchiveStore:
                             """,
                             (session_id, normalized_tag),
                         )
-                        removed += max(int(cursor.rowcount), 0)
+                        deleted = max(int(cursor.rowcount), 0)
+                        if deleted:
+                            mark_assertion_status(
+                                user_conn,
+                                assertion_id_for_session_tag(session_id, normalized_tag, "user"),
+                                "deleted",
+                            )
+                        removed += deleted
         finally:
             user_conn.close()
         self._attach_user_tier_if_present()

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -209,6 +209,12 @@ def assertion_id_for_blackboard_note(note_id: str) -> str:
     return _deterministic_id(f"assertion-{AssertionKind.NOTE}", note_id)
 
 
+def assertion_id_for_session_tag(session_id: str, tag: str, tag_source: str) -> str:
+    """Return the mirrored assertion id for one normalized session tag."""
+    normalized_tag = tag.strip().lower()
+    return _deterministic_id(f"assertion-{AssertionKind.TAG}", session_id, normalized_tag, tag_source)
+
+
 def assertion_id_for_transform_candidate(
     *,
     session_id: str,
@@ -396,6 +402,41 @@ def upsert_mark(
         now_ms=timestamp,
     )
     return read_archive_mark_envelope(conn, mark_id)
+
+
+def upsert_session_tag_assertion(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    tag: str,
+    tag_source: str,
+    method: str | None = None,
+    confidence: float | None = None,
+    evidence: dict[str, object] | None = None,
+    now_ms: int | None = None,
+) -> ArchiveAssertionEnvelope | None:
+    """Mirror one user session tag as a first-class tag assertion."""
+    if tag_source != "user":
+        return None
+    normalized_tag = tag.strip().lower()
+    timestamp = now_ms if now_ms is not None else _now_ms()
+    value: dict[str, object] = {"tag_source": tag_source}
+    if method is not None:
+        value["method"] = method
+    if evidence is not None:
+        value["evidence"] = evidence
+    return upsert_assertion(
+        conn,
+        assertion_id=assertion_id_for_session_tag(session_id, normalized_tag, tag_source),
+        target_ref=f"session:{session_id}",
+        kind=AssertionKind.TAG,
+        key=normalized_tag,
+        value=value,
+        body_text=normalized_tag,
+        author_kind="user",
+        confidence=confidence,
+        now_ms=timestamp,
+    )
 
 
 def upsert_annotation(
@@ -1195,6 +1236,7 @@ __all__ = [
     "assertion_id_for_mark",
     "assertion_id_for_recall_pack",
     "assertion_id_for_saved_view",
+    "assertion_id_for_session_tag",
     "assertion_id_for_suppression",
     "assertion_id_for_transform_candidate",
     "assertion_id_for_workspace",
@@ -1221,6 +1263,7 @@ __all__ = [
     "upsert_mark",
     "upsert_recall_pack",
     "upsert_saved_view",
+    "upsert_session_tag_assertion",
     "upsert_suppression",
     "upsert_transform_candidate_assertions",
     "upsert_workspace",

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -516,7 +516,52 @@ def upsert_session_tag(
                 _json_dumps(evidence) if evidence is not None else None,
             ),
         )
+        _mirror_session_tag_assertion_if_available(
+            conn,
+            session_id=session_id,
+            tag=normalized_tag,
+            tag_source=tag_source,
+            method=method,
+            confidence=confidence,
+            evidence=evidence,
+        )
     return read_session_tags(conn, session_id=session_id, tag_source=tag_source)[normalized_tag]
+
+
+def _mirror_session_tag_assertion_if_available(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    tag: str,
+    tag_source: str,
+    method: str | None,
+    confidence: float | None,
+    evidence: dict[str, object] | None,
+) -> None:
+    """Mirror user tag writes when the active tier owns assertions."""
+    if tag_source != "user" or not _table_exists(conn, "assertions"):
+        return
+    from polylogue.storage.sqlite.archive_tiers.user_write import upsert_session_tag_assertion
+
+    upsert_session_tag_assertion(
+        conn,
+        session_id=session_id,
+        tag=tag,
+        tag_source=tag_source,
+        method=method,
+        confidence=confidence,
+        evidence=evidence,
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
 
 
 def read_session_tags(

--- a/tests/baselines/showcase/help-tags.txt
+++ b/tests/baselines/showcase/help-tags.txt
@@ -1,19 +1,17 @@
-Usage: polylogue tags [OPTIONS] [SESSION_ID]
+Usage: polylogue tags [OPTIONS]
 
-  List all tags with session counts, or add/remove tags.
+  List user tags with session counts.
 
   Examples:
       polylogue tags                         # List all tags
       polylogue tags -o claude-ai-export     # Tags for Claude web sessions only
       polylogue tags --format json           # Machine-readable output
       polylogue tags -n 10                   # Top 10 tags
-      polylogue tags conv:abc --add-tag tps  # Add a tag
-      polylogue tags conv:abc --rm-tag tps   # Remove a tag
+      polylogue find id:abc then mark --tag-add tps
+      polylogue find id:abc then mark --tag-remove tps
 
 Options:
   -o, --origin TEXT    Filter tags by origin
   -f, --format [json]  Output format
   -n, --count INTEGER  Show top N tags
-  --add-tag TEXT       Add a tag to the given session
-  --remove-tag TEXT    Remove a tag from the given session
   -h, --help           Show this message and exit.

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1814,6 +1814,7 @@ async def test_archive_tiers_api_user_mutations_write_user_tier(tmp_path: Path) 
     from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.user_write import assertion_id_for_session_tag, read_assertion_envelope
 
     archive = _archive(tmp_path)
     session = ParsedSession(
@@ -1868,8 +1869,20 @@ async def test_archive_tiers_api_user_mutations_write_user_tier(tmp_path: Path) 
                 "SELECT key, value_json FROM session_metadata WHERE session_id = ? ORDER BY key",
                 (session_id,),
             ).fetchall()
+            review_assertion = read_assertion_envelope(
+                conn,
+                assertion_id_for_session_tag(session_id, "review", "user"),
+            )
+            bulk_a_assertion = read_assertion_envelope(
+                conn,
+                assertion_id_for_session_tag(session_id, "bulk-a", "user"),
+            )
         assert remaining_tags == 2
         assert remaining_metadata == [("priority", '"high"')]
+        assert review_assertion is not None
+        assert review_assertion.status == "deleted"
+        assert bulk_a_assertion is not None
+        assert bulk_a_assertion.status == "active"
     finally:
         await archive.close()
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -267,7 +267,7 @@ def test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts(cli_runner
     empty = cli_runner.invoke(tags_command, ["--origin", "chatgpt-export"], obj=env, catch_exceptions=False)
     assert empty.exit_code == 0
     assert "No tags found for origin 'chatgpt-export'." in empty.output
-    assert "Hint: use --add-tag" in empty.output
+    assert "polylogue find QUERY then mark --tag-add" in empty.output
     env.polylogue.list_tags.assert_awaited_with(origin="chatgpt-export")
 
     env.polylogue.list_tags = AsyncMock(return_value={"alpha": 5, "beta": 2})
@@ -287,4 +287,4 @@ def test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts(cli_runner
     generic_empty = cli_runner.invoke(tags_command, [], obj=env, catch_exceptions=False)
     assert generic_empty.exit_code == 0
     assert "No tags found." in generic_empty.output
-    assert "Hint: use --add-tag" in generic_empty.output
+    assert "polylogue find QUERY then mark --tag-add" in generic_empty.output

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -209,6 +209,43 @@ def test_archive_tiers_remove_user_tags_tolerates_legacy_user_db_without_asserti
     assert remaining == 0
 
 
+def test_archive_tiers_duplicate_user_tag_add_backfills_missing_assertion(tmp_path: Path) -> None:
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-tag-backfill",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="backfill taggable")],
+            )
+        ],
+    )
+    root = tmp_path / "archive"
+
+    with ArchiveStore(root) as facade:
+        session_id = facade.write_parsed(session)
+        assert facade.add_user_tags((session_id,), ("review",)) == 1
+
+    with sqlite3.connect(root / "user.db") as conn:
+        conn.execute(
+            "DELETE FROM assertions WHERE assertion_id = ?",
+            (assertion_id_for_session_tag(session_id, "review", "user"),),
+        )
+        conn.commit()
+
+    with ArchiveStore(root) as facade:
+        assert facade.add_user_tags((session_id,), ("review",)) == 0
+
+    with sqlite3.connect(root / "user.db") as conn:
+        assertion = read_assertion_envelope(
+            conn,
+            assertion_id_for_session_tag(session_id, "review", "user"),
+        )
+    assert assertion is not None
+    assert assertion.status == "active"
+
+
 def test_archive_tiers_archive_facade_deletes_archive_sessions_but_keeps_user_tags(tmp_path: Path) -> None:
     session = ParsedSession(
         source_name=Provider.CODEX,

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -8,6 +8,7 @@ from polylogue.archive.message.types import MessageType
 from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedPasteEvidence, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.user_write import assertion_id_for_session_tag, read_assertion_envelope
 from polylogue.storage.sqlite.archive_tiers.write import read_session_tags
 
 
@@ -155,6 +156,14 @@ def test_archive_tiers_archive_facade_adds_user_tags(tmp_path: Path) -> None:
     user_conn.row_factory = sqlite3.Row
     try:
         tags = read_session_tags(user_conn, session_id=session_id, tag_source="user")
+        review_assertion = read_assertion_envelope(
+            user_conn,
+            assertion_id_for_session_tag(session_id, "review", "user"),
+        )
+        ready_assertion = read_assertion_envelope(
+            user_conn,
+            assertion_id_for_session_tag(session_id, "ready", "user"),
+        )
     finally:
         user_conn.close()
 
@@ -163,6 +172,10 @@ def test_archive_tiers_archive_facade_adds_user_tags(tmp_path: Path) -> None:
     assert removed == 1
     assert sorted(tags) == ["review"]
     assert tag_counts == {"review": 1}
+    assert review_assertion is not None
+    assert review_assertion.status == "active"
+    assert ready_assertion is not None
+    assert ready_assertion.status == "deleted"
     assert [summary.session_id for summary in summaries] == [session_id]
 
 

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -179,6 +179,36 @@ def test_archive_tiers_archive_facade_adds_user_tags(tmp_path: Path) -> None:
     assert [summary.session_id for summary in summaries] == [session_id]
 
 
+def test_archive_tiers_remove_user_tags_tolerates_legacy_user_db_without_assertions(tmp_path: Path) -> None:
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-tag-legacy",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="legacy taggable")],
+            )
+        ],
+    )
+    root = tmp_path / "archive"
+
+    with ArchiveStore(root) as facade:
+        session_id = facade.write_parsed(session)
+        assert facade.add_user_tags((session_id,), ("legacy",)) == 1
+
+    with sqlite3.connect(root / "user.db") as conn:
+        conn.execute("DROP TABLE assertions")
+        conn.commit()
+
+    with ArchiveStore(root) as facade:
+        assert facade.remove_user_tags((session_id,), ("legacy",)) == 1
+
+    with sqlite3.connect(root / "user.db") as conn:
+        remaining = conn.execute("SELECT COUNT(*) FROM session_tags").fetchone()[0]
+    assert remaining == 0
+
+
 def test_archive_tiers_archive_facade_deletes_archive_sessions_but_keeps_user_tags(tmp_path: Path) -> None:
     session = ParsedSession(
         source_name=Provider.CODEX,

--- a/tests/unit/storage/test_archive_tiers_assertion_write_through.py
+++ b/tests/unit/storage/test_archive_tiers_assertion_write_through.py
@@ -11,6 +11,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     AssertionKind,
     assertion_id_for_annotation,
     assertion_id_for_mark,
+    assertion_id_for_session_tag,
     list_archive_blackboard_note_envelopes,
     list_assertions_for_target,
     read_archive_annotation_envelope,
@@ -31,6 +32,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     upsert_suppression,
     upsert_workspace,
 )
+from polylogue.storage.sqlite.archive_tiers.write import upsert_session_tag
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -67,6 +69,32 @@ def test_mark_write_through_mirrors_assertion(tmp_path: Path) -> None:
     assert env.value == {"scope": "alpha"}
     assert env.author_kind == "user"
     assert env.created_at_ms == 1_700_000_000_000
+
+
+def test_user_session_tag_write_through_mirrors_assertion(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "user.db")
+
+    upsert_session_tag(
+        conn,
+        session_id="session-1",
+        tag="Review",
+        tag_source="user",
+        method="cli",
+        confidence=0.9,
+        evidence={"source": "mark"},
+    )
+
+    mirrored = list_assertions_for_target(conn, "session:session-1", kind=AssertionKind.TAG)
+    assert len(mirrored) == 1
+    env = mirrored[0]
+    assert env.assertion_id == assertion_id_for_session_tag("session-1", "review", "user")
+    assert env.kind == AssertionKind.TAG
+    assert env.target_ref == "session:session-1"
+    assert env.key == "review"
+    assert env.body_text == "review"
+    assert env.value == {"evidence": {"source": "mark"}, "method": "cli", "tag_source": "user"}
+    assert env.confidence == 0.9
+    assert env.author_kind == "user"
 
 
 def test_mark_write_through_is_idempotent(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -276,13 +276,15 @@ async def test_tags_and_metadata_remain_table_backed_user_metadata(
             """,
             (session_id,),
         ).fetchone()
-        assertion_rows = conn.execute("SELECT kind FROM assertions WHERE kind IN ('tag', 'metadata')").fetchall()
+        assertion_rows = conn.execute(
+            "SELECT kind, target_ref, key, status FROM assertions WHERE kind IN ('tag', 'metadata')"
+        ).fetchall()
 
     assert tag_row == ("planning", "user", "cli")
     assert metadata_row is not None
     assert metadata_row[0] == "owner"
     assert json.loads(metadata_row[1]) == {"name": "sinity"}
-    assert assertion_rows == []
+    assert assertion_rows == [("tag", f"session:{session_id}", "planning", "active")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

User tag writes now mirror into the assertion substrate, and the root `tags` command is reduced to the live tag-count read surface. Tag mutation remains available through the query-first `find ... then mark --tag-add/--tag-remove` path, so #1842 can keep shrinking overlay roots without preserving a separate `polylogue tags SESSION --add-tag` workflow.

## Problem

#1842 explicitly blocks the user-overlay command cleanup on assertion-backed equivalence for `tags`, `blackboard`, `feedback`, and `user-state`. Before this change, user tags were table-only state: `upsert_session_tag` wrote `session_tags`, removals deleted only that table row, and the root `tags` command exposed its own add/remove path alongside query-first `mark` mutation. That kept user tags outside the assertion substrate and left two CLI mutation homes.

## Solution

- Mirror user `session_tags` writes into deterministic `kind=tag` assertions when the active tier owns the `assertions` table.
- Mark mirrored user-tag assertions `deleted` when `ArchiveStore.remove_user_tags` removes the user tag.
- Keep root `polylogue tags` as read-only live tag counts, with help/hints pointing tag mutation to `polylogue find QUERY then mark --tag-add/--tag-remove`.
- Update generated CLI help/reference and focused storage/API/CLI tests to prove the storage helper, archive facade, public `Polylogue.add_tag/remove_tag`, and CLI read path.

This does not delete the root `tags` command yet: it remains the live user-tag count view until that read capability has an equivalent home.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_assertion_write_through.py tests/unit/storage/test_archive_tiers_archive.py::test_archive_tiers_archive_facade_adds_user_tags tests/unit/storage/test_user_state_contracts.py::test_tags_and_metadata_remain_table_backed_user_metadata tests/unit/api/test_facade_contracts.py::test_archive_tiers_api_user_mutations_write_user_tier tests/unit/cli/test_command_aux_runtime.py::test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts tests/unit/cli/test_json_envelope_contract.py::TestTagsJsonEnvelope::test_tags_json_has_status_ok 'tests/unit/cli/test_json_envelope_contract.py::TestQueryShapedJsonMatrix::test_format_json_uses_success_envelope[args0-tags]' tests/unit/cli/test_deterministic_output.py::TestJsonOutputValidity::test_tags_json_is_valid tests/unit/cli/test_deterministic_output.py::TestJsonDeterminism::test_tags_json_deterministic 'tests/unit/cli/test_deterministic_output.py::TestJsonEnvelopeParametrized::test_json_only_commands_reject_other_formats[tags-yaml-rejected]'` -> 22 passed
- `devtools render all --check` -> sync OK
- `devtools lab scenario verify-baselines` -> 76 exercises, all baselines match
- `devtools verify --quick` -> exit_code 0
- `devtools verify --seed-testmon --skip-slow` -> terminated after the broad seed lane emitted multiple failures and then ran for ~88 minutes without a final report; branch-specific focused tests and `verify --quick` are green, but the fresh-worktree seed baseline is not green

Ref #1842


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Updated `polylogue tags` command to list tags only; tag add/remove operations now use `polylogue find ... then mark --tag-add/--tag-remove` workflow.

* **Documentation**
  * Updated CLI reference and help text to reflect simplified tag listing interface and new tag modification workflow.

* **Improvements**
  * Enhanced tag persistence and tracking in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->