### PR TITLE
fix(devtools): run verify baseline from grouped command

### DIFF
--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -86,7 +86,15 @@ class _DefaultCommandGroup(click.Group):
         context_settings: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(name=name, help=help, context_settings=context_settings)
+        self.no_args_is_help = False
+        default_command.hidden = True
         self.default_command = default_command
+        self.add_command(default_command, "_default")
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not args:
+            args = ["_default"]
+        return super().parse_args(ctx, args)
 
     def resolve_command(
         self,

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -80,6 +80,48 @@ def test_nested_render_command_dispatches_to_catalog_entry(monkeypatch: pytest.M
     assert captured == [["--check"]]
 
 
+def test_default_command_group_dispatches_bare_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[list[str] | None] = []
+
+    def fake_main(argv: list[str] | None) -> int:
+        captured.append(argv)
+        return 0
+
+    fake_module = ModuleType("_polylogue_devtools_test_verify_fake")
+    fake_module.__dict__["main"] = fake_main
+    monkeypatch.setitem(__import__("sys").modules, fake_module.__name__, fake_module)
+
+    monkeypatch.setitem(
+        COMMANDS,
+        "verify",
+        CommandSpec("verify", "verification", "fake verify", fake_module.__name__),
+    )
+
+    assert devtools_main.main(["verify"]) == 0
+    assert captured == [[]]
+
+
+def test_default_command_group_forwards_verify_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[list[str] | None] = []
+
+    def fake_main(argv: list[str] | None) -> int:
+        captured.append(argv)
+        return 0
+
+    fake_module = ModuleType("_polylogue_devtools_test_verify_flag_fake")
+    fake_module.__dict__["main"] = fake_main
+    monkeypatch.setitem(__import__("sys").modules, fake_module.__name__, fake_module)
+
+    monkeypatch.setitem(
+        COMMANDS,
+        "verify",
+        CommandSpec("verify", "verification", "fake verify", fake_module.__name__),
+    )
+
+    assert devtools_main.main(["verify", "--quick"]) == 0
+    assert captured == [["--quick"]]
+
+
 def test_nested_workspace_command_dispatches_to_catalog_entry(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[list[str] | None] = []
 


### PR DESCRIPTION
## Summary

Restores `devtools verify` as the documented default verification baseline after the verification checks were grouped under `devtools verify <check>`.

## Problem

The grouped devtools surface from #2148 preserved `devtools verify --quick`, but bare `devtools verify` fell through Click's no-argument group handling and printed command help with exit code 2. That broke the repository's documented pre-PR command.

## Solution

The `verify` group now installs the default verify runner as a hidden child command and rewrites the empty-argument case to that child. Calls with flags such as `devtools verify --quick` still use the existing fallback path, while concrete checks such as `devtools verify topology` continue resolving as grouped subcommands. Unit tests cover bare default dispatch and flag forwarding.

## Verification

- `devtools test tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_xtask.py -k "verify or list_commands or nested or auto_logs"` -> 10 passed, 32 deselected
- `devtools verify --quick` -> exit_code 0
