### PR TITLE
feat(query): complete terminal query-unit fields (#2006)

### DIFF
--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -17,6 +17,10 @@ from polylogue.archive.query.metadata import (
     structural_query_field_info,
     structural_query_fields,
     structural_query_units,
+    terminal_query_field_info,
+    terminal_query_fields,
+    terminal_query_sources,
+    terminal_query_unit,
 )
 from polylogue.operations.action_contracts import ACTION_CONTRACTS, CliActionContract
 
@@ -27,6 +31,8 @@ QUERY_COMPLETION_KINDS: tuple[str, ...] = (
     "field",
     "structural-unit",
     "structural-field",
+    "terminal-source",
+    "terminal-field",
     "count-operator",
     "date-operator",
     "action",
@@ -192,6 +198,65 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
     return candidates
 
 
+def query_terminal_source_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return ``<source> where`` candidates for terminal row queries."""
+
+    current = incomplete.strip().lower()
+    candidates: list[QueryCompletionCandidate] = []
+    for source in terminal_query_sources():
+        if current and not source.startswith(current):
+            continue
+        unit = terminal_query_unit(source)
+        info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit or "")
+        description = "Terminal query row source."
+        if info is not None:
+            description = info.description
+            if info.example:
+                description = f"{description} Example: {info.example}"
+        candidates.append(
+            QueryCompletionCandidate(
+                value=source,
+                insert=f"{source} where ",
+                display=f"{source} where",
+                kind="query-terminal-source",
+                group="query terminal sources",
+                description=description,
+                source="_SOURCE_WHERE_SOURCES",
+            )
+        )
+    return candidates
+
+
+def query_terminal_field_candidates(source: str, incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return field candidates accepted after ``<source> where``."""
+
+    current = incomplete.strip().lstrip("-").lower()
+    if ":" in current:
+        return []
+    candidates: list[QueryCompletionCandidate] = []
+    for field_name in terminal_query_fields(source):
+        if current and not field_name.startswith(current):
+            continue
+        info = terminal_query_field_info(source, field_name)
+        description = f"Field accepted after {source} where."
+        if info is not None:
+            description = info.description
+            if info.example:
+                description = f"{description} Example: {info.example}"
+        candidates.append(
+            QueryCompletionCandidate(
+                value=field_name,
+                insert=f"{field_name}:",
+                display=f"{field_name}:",
+                kind="query-terminal-field",
+                group=f"{source} terminal fields",
+                description=description,
+                source="_SOURCE_WHERE_SOURCES/STRUCTURAL_QUERY_UNIT_REGISTRY",
+            )
+        )
+    return candidates
+
+
 def query_count_operator_candidates(field: str, incomplete: str) -> list[QueryCompletionCandidate]:
     """Return readable count operators accepted by the query grammar."""
 
@@ -302,6 +367,12 @@ def query_completion_candidates(
         if unit is None:
             raise QueryCompletionError("--unit is required for structural-field completion")
         return query_structural_field_candidates(unit, incomplete)
+    if kind == "terminal-source":
+        return query_terminal_source_candidates(incomplete)
+    if kind == "terminal-field":
+        if unit is None:
+            raise QueryCompletionError("--unit is required for terminal-field completion")
+        return query_terminal_field_candidates(unit, incomplete)
     if kind == "count-operator":
         if field is None:
             raise QueryCompletionError("--field is required for count-operator completion")
@@ -346,4 +417,6 @@ __all__ = [
     "query_field_candidates",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",
+    "query_terminal_field_candidates",
+    "query_terminal_source_candidates",
 ]

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -467,6 +467,40 @@ def structural_query_field_info(unit: str, field: str) -> StructuralQueryFieldIn
     return None
 
 
+def terminal_query_sources() -> tuple[str, ...]:
+    """Return source tokens accepted by the ``<source> where ...`` grammar."""
+
+    return tuple(sorted(source for source, _unit in _SOURCE_WHERE_SOURCES))
+
+
+def terminal_query_unit(source: str) -> QueryUnitName | None:
+    """Return the canonical query unit for a terminal source token."""
+
+    normalized = source.lower()
+    for source_name, unit in _SOURCE_WHERE_SOURCES:
+        if source_name == normalized:
+            return unit
+    return None
+
+
+def terminal_query_fields(source: str) -> tuple[str, ...]:
+    """Return field names accepted after ``<source> where``."""
+
+    unit = terminal_query_unit(source)
+    if unit is None:
+        return ()
+    return structural_query_fields(unit)
+
+
+def terminal_query_field_info(source: str, field: str) -> StructuralQueryFieldInfo | None:
+    """Return metadata for a field accepted after ``<source> where``."""
+
+    unit = terminal_query_unit(source)
+    if unit is None:
+        return None
+    return structural_query_field_info(unit, field)
+
+
 def count_query_fields() -> tuple[str, ...]:
     """Return count fields with readable comparison/range syntax."""
 
@@ -523,4 +557,8 @@ __all__ = [
     "structural_query_field_info",
     "structural_query_fields",
     "structural_query_units",
+    "terminal_query_field_info",
+    "terminal_query_fields",
+    "terminal_query_sources",
+    "terminal_query_unit",
 ]

--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -189,9 +189,17 @@ class QueryFirstGroupBase(click.Group):
     """Custom Click group that routes to query mode by default."""
 
     def shell_complete(self, ctx: click.Context, incomplete: str) -> list[click.shell_completion.CompletionItem]:
-        items = list(super().shell_complete(ctx, incomplete))
-        from polylogue.cli.shell_completion_values import complete_query_actions, complete_query_expression_fields
+        from polylogue.cli.shell_completion_values import (
+            complete_query_actions,
+            complete_query_expression_context_fields,
+            complete_query_expression_fields,
+        )
 
+        context_items = complete_query_expression_context_fields(ctx, None, incomplete)
+        if context_items is not None:
+            return context_items
+
+        items = list(super().shell_complete(ctx, incomplete))
         replacement_items = [
             *complete_query_actions(ctx, None, incomplete),
             *complete_query_expression_fields(ctx, None, incomplete),

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -251,7 +251,8 @@ def _complete_structural_query_context(incomplete: str) -> list[CompletionItem] 
 def _terminal_completion_context(incomplete: str) -> tuple[str, str] | None:
     stripped = incomplete.strip()
     lower = stripped.lower()
-    for source in terminal_query_sources():
+    sources = terminal_query_sources()
+    for source in sources:
         prefix = f"{source} where "
         if lower.startswith(prefix):
             return source, stripped[len(prefix) :].rsplit(" ", 1)[-1]
@@ -265,13 +266,10 @@ def _terminal_completion_context(incomplete: str) -> tuple[str, str] | None:
         words = words[1:]
     if not words:
         return None
-    if words[-1].lower() == "where" and len(words) >= 2:
-        source = words[-2].lower()
-        if source in terminal_query_sources():
-            return source, stripped
-    if len(words) >= 3 and words[-2].lower() == "where":
-        source = words[-3].lower()
-        if source in terminal_query_sources():
+    lowered_words = tuple(word.lower() for word in words)
+    for index, word in enumerate(lowered_words[:-1]):
+        if lowered_words[index + 1] == "where" and word in sources:
+            source = word
             return source, stripped
     return None
 
@@ -295,7 +293,7 @@ def complete_query_expression_context_fields(
     """Complete only when the cursor is already inside query syntax."""
 
     if incomplete.startswith("--"):
-        return []
+        return None
     terminal_items = _complete_terminal_query_context(incomplete)
     if terminal_items is not None:
         return terminal_items

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -25,11 +25,14 @@ from polylogue.archive.query.completions import (
     query_field_candidates,
     query_structural_field_candidates,
     query_structural_unit_candidates,
+    query_terminal_field_candidates,
+    query_terminal_source_candidates,
 )
 from polylogue.archive.query.fields import QUERY_FIELD_DESCRIPTORS, CompletionSource
 from polylogue.archive.query.metadata import (
     EXPRESSION_FIELD_REGISTRY,
     structural_query_units,
+    terminal_query_sources,
 )
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
 from polylogue.paths import active_index_db_path
@@ -245,6 +248,65 @@ def _complete_structural_query_context(incomplete: str) -> list[CompletionItem] 
     ]
 
 
+def _terminal_completion_context(incomplete: str) -> tuple[str, str] | None:
+    stripped = incomplete.strip()
+    lower = stripped.lower()
+    for source in terminal_query_sources():
+        prefix = f"{source} where "
+        if lower.startswith(prefix):
+            return source, stripped[len(prefix) :].rsplit(" ", 1)[-1]
+        if lower == f"{source} where":
+            return source, ""
+
+    words = _completion_words()
+    if not words:
+        return None
+    if words[0] == "find":
+        words = words[1:]
+    if not words:
+        return None
+    if words[-1].lower() == "where" and len(words) >= 2:
+        source = words[-2].lower()
+        if source in terminal_query_sources():
+            return source, stripped
+    if len(words) >= 3 and words[-2].lower() == "where":
+        source = words[-3].lower()
+        if source in terminal_query_sources():
+            return source, stripped
+    return None
+
+
+def _complete_terminal_query_context(incomplete: str) -> list[CompletionItem] | None:
+    context = _terminal_completion_context(incomplete)
+    if context is None:
+        return None
+    source, prefix = context
+    return [
+        query_completion_candidate_to_click_item(candidate)
+        for candidate in query_terminal_field_candidates(source, prefix)
+    ]
+
+
+def complete_query_expression_context_fields(
+    ctx: click.Context,
+    param: click.Parameter | None,
+    incomplete: str,
+) -> list[CompletionItem] | None:
+    """Complete only when the cursor is already inside query syntax."""
+
+    if incomplete.startswith("--"):
+        return []
+    terminal_items = _complete_terminal_query_context(incomplete)
+    if terminal_items is not None:
+        return terminal_items
+    structural_items = _complete_structural_query_context(incomplete)
+    if structural_items is not None:
+        return structural_items
+    if ":" in incomplete:
+        return _complete_query_expression_values(ctx, param, incomplete)
+    return None
+
+
 def complete_query_expression_fields(
     ctx: click.Context,
     param: click.Parameter | None,
@@ -252,15 +314,15 @@ def complete_query_expression_fields(
 ) -> list[CompletionItem]:
     """Complete query DSL field tokens from the canonical grammar registry."""
 
-    if incomplete.startswith("--"):
-        return []
-    structural_items = _complete_structural_query_context(incomplete)
-    if structural_items is not None:
-        return structural_items
-    if ":" in incomplete:
-        return _complete_query_expression_values(ctx, param, incomplete)
+    context_items = complete_query_expression_context_fields(ctx, param, incomplete)
+    if context_items is not None:
+        return context_items
     del ctx, param
-    return [query_completion_candidate_to_click_item(candidate) for candidate in query_field_candidates(incomplete)]
+    candidates = [
+        *query_terminal_source_candidates(incomplete),
+        *query_field_candidates(incomplete),
+    ]
+    return [query_completion_candidate_to_click_item(candidate) for candidate in candidates]
 
 
 def complete_query_actions(
@@ -271,6 +333,8 @@ def complete_query_actions(
     """Complete root query actions from public action contracts."""
 
     del ctx, param
+    if _terminal_completion_context(incomplete) is not None or _structural_completion_context(incomplete) is not None:
+        return []
     return [query_completion_candidate_to_click_item(candidate) for candidate in query_action_candidates(incomplete)]
 
 
@@ -455,6 +519,7 @@ __all__ = [
     "complete_action_sequence_values",
     "complete_action_values",
     "complete_query_actions",
+    "complete_query_expression_context_fields",
     "complete_query_expression_fields",
     "complete_session_ids",
     "complete_cwd_prefix_values",
@@ -472,5 +537,7 @@ __all__ = [
     "query_completion_candidate_to_click_item",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",
+    "query_terminal_field_candidates",
+    "query_terminal_source_candidates",
     "QueryCompletionCandidate",
 ]

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -800,6 +800,14 @@ async def test_query_completions_exposes_shared_completion_payload(tmp_path: Pat
         description = date_candidate["description"]
         assert isinstance(description, str)
         assert "date between 2026-01-01 and 2026-02-01" in description
+
+        terminal_payload = await archive.query_completions("terminal-field", unit="observed-events", incomplete="del")
+        assert terminal_payload["kind"] == "terminal-field"
+        terminal_candidates = terminal_payload["candidates"]
+        assert isinstance(terminal_candidates, list)
+        terminal_candidate_payloads = [cast(dict[str, object], candidate) for candidate in terminal_candidates]
+        assert [candidate["value"] for candidate in terminal_candidate_payloads] == ["delivery_state"]
+        assert terminal_candidate_payloads[0]["insert"] == "delivery_state:"
     finally:
         await archive.close()
 

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from typing import cast
 
 
 def test_query_completions_do_not_import_expression_parser() -> None:
@@ -27,3 +28,26 @@ print(json.dumps({
     payload = json.loads(result.stdout)
     assert "repo" in payload["values"]
     assert payload["expression_loaded"] is False
+
+
+def test_terminal_query_completion_payloads_are_lightweight() -> None:
+    from polylogue.archive.query.completions import query_completion_payload
+
+    source_payload = query_completion_payload("terminal-source", incomplete="observed")
+    source_candidates = [
+        cast(dict[str, object], candidate) for candidate in cast(list[object], source_payload["candidates"])
+    ]
+    source_values = [candidate["value"] for candidate in source_candidates]
+    assert "observed-events" in source_values
+    source_candidate = next(candidate for candidate in source_candidates if candidate["value"] == "observed-events")
+    assert source_candidate["insert"] == "observed-events where "
+    assert source_candidate["kind"] == "query-terminal-source"
+
+    field_payload = query_completion_payload("terminal-field", unit="context-snapshots", incomplete="bound")
+    field_candidates = [
+        cast(dict[str, object], candidate) for candidate in cast(list[object], field_payload["candidates"])
+    ]
+    assert [candidate["value"] for candidate in field_candidates] == ["boundary"]
+    field_candidate = field_candidates[0]
+    assert field_candidate["insert"] == "boundary:"
+    assert field_candidate["kind"] == "query-terminal-field"

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -241,6 +241,27 @@ def test_query_expression_completion_handles_structural_contexts() -> None:
     assert {"text:", "type:"}.issubset(values)
 
 
+def test_query_expression_completion_handles_terminal_contexts() -> None:
+    ctx, param = _ctx_param()
+
+    source_items = shell_completion_values.complete_query_expression_fields(ctx, param, "observed")
+    assert "observed-events where " in {item.value for item in source_items}
+
+    event_field_items = shell_completion_values.complete_query_expression_fields(
+        ctx,
+        param,
+        "observed-events where d",
+    )
+    assert [item.value for item in event_field_items] == ["delivery_state:"]
+
+    snapshot_field_items = shell_completion_values.complete_query_expression_fields(
+        ctx,
+        param,
+        "context-snapshots where bound",
+    )
+    assert [item.value for item in snapshot_field_items] == ["boundary:"]
+
+
 def test_query_action_candidates_come_from_action_contracts_with_danger_metadata() -> None:
     candidates = shell_completion_values.query_action_candidates("de")
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -261,6 +261,13 @@ def test_query_expression_completion_handles_terminal_contexts() -> None:
     )
     assert [item.value for item in snapshot_field_items] == ["boundary:"]
 
+    chained_snapshot_items = shell_completion_values.complete_query_expression_fields(
+        ctx,
+        param,
+        "context-snapshots where boundary:session_start AND sess",
+    )
+    assert "session.repo:" in {item.value for item in chained_snapshot_items}
+
 
 def test_query_action_candidates_come_from_action_contracts_with_danger_metadata() -> None:
     candidates = shell_completion_values.query_action_candidates("de")

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -237,6 +237,43 @@ def test_query_structural_field_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_terminal_source_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root query completion suggests terminal row sources."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["find"], "context")
+    values = {value for value, _ in items}
+    assert "context-snapshots where " in values
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_terminal_field_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``<source> where``, completion suggests terminal-unit fields."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, ["find", "observed-events", "where"], "d")
+    item_map = dict(items)
+    assert item_map == {"delivery_state:": item_map["delivery_state:"]}
+    assert "Observed-event delivery state" in (item_map["delivery_state:"] or "")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_count_operator_completion_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -274,6 +274,47 @@ def test_query_terminal_field_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_query_terminal_field_completion_after_connector_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal-unit field completion keeps source context after connectors."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(
+        shell,
+        comp_cls,
+        ["find", "context-snapshots", "where", "boundary:session_start", "AND"],
+        "sess",
+    )
+    item_map = dict(items)
+    assert "session.repo:" in item_map
+    assert "Owning session scope" in (item_map["session.repo:"] or "")
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+def test_root_option_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root option completion still belongs to Click outside query syntax."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = _run_completion_for_partial(shell, comp_cls, [], "--")
+    assert "--help" in {value for value, _ in items}
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_count_operator_completion_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1229,7 +1229,8 @@ class TestReaderQueryCompletions:
             payload = _get_json(base_url, "/api/query-completions?kind=field&incomplete=d")
 
         assert isinstance(payload, dict)
-        envelope = payload["query_completions"]
+        payload_dict = cast(dict[str, object], payload)
+        envelope = payload_dict["query_completions"]
         assert isinstance(envelope, dict)
         assert envelope["kind"] == "field"
         candidates = envelope["candidates"]
@@ -1246,6 +1247,24 @@ class TestReaderQueryCompletions:
         assert status == 400
         assert payload["error"] == "invalid_query_completion"
         assert "--unit is required" in str(payload["message"])
+
+    def test_query_completions_endpoint_exposes_terminal_fields(self) -> None:
+        with _running_server_without_seed() as (_server, base_url):
+            payload = _get_json(
+                base_url,
+                "/api/query-completions?kind=terminal-field&unit=context-snapshots&incomplete=bound",
+            )
+
+        payload_dict = cast(dict[str, object], payload)
+        envelope = payload_dict["query_completions"]
+        assert isinstance(envelope, dict)
+        envelope_payload = cast(dict[str, object], envelope)
+        assert envelope_payload["kind"] == "terminal-field"
+        candidates = envelope_payload["candidates"]
+        assert isinstance(candidates, list)
+        candidate_payloads = [cast(dict[str, object], candidate) for candidate in cast(list[object], candidates)]
+        assert [candidate["value"] for candidate in candidate_payloads] == ["boundary"]
+        assert candidate_payloads[0]["insert"] == "boundary:"
 
 
 class TestReaderQueryUnits:


### PR DESCRIPTION
## Summary
Adds shared completion support for terminal query-unit sources and fields. Executable query forms such as `observed-events where ...` and `context-snapshots where ...` now expose the same unit/field metadata through shared completion payloads, shell completion, the Python facade, and the daemon endpoint.

## Problem
#2006 had already made terminal row units executable, but completion/query-builder metadata still stopped at root session fields and `exists ...` structural predicates. That left runtime-transform units discoverable only by docs or memory, and Click could merge root commands like `delete` into an in-progress terminal field completion.

## Solution
- Added terminal source/field metadata helpers in `polylogue.archive.query.metadata`, backed by the existing `_SOURCE_WHERE_SOURCES` and structural field registries.
- Added `terminal-source` and `terminal-field` completion kinds in `polylogue.archive.query.completions`.
- Taught shell completion to suggest `<source> where ` and then unit-specific fields after `<source> where`.
- Split query-context completion from root candidate blending so root commands do not leak into terminal/structural field contexts.
- Covered shared payload, shell completion, Python facade, daemon endpoint, and MCP delegation behavior.

Ref #2006

## Verification
- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py tests/unit/api/test_facade_contracts.py::test_query_completions_exposes_shared_completion_payload tests/unit/daemon/test_web_reader.py::TestReaderQueryCompletions tests/unit/mcp/test_tool_contracts.py::TestQueryCompletionsTool` -> `116 passed in 36.16s`.
- `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 13.64`.
- pre-push `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 13.44`.