### PR TITLE
fix(browser-capture): hide local paths from receiver DTOs (#1847)

### DIFF
--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -26,7 +26,9 @@ the same component status in archive health output with `polylogue ops doctor
 Accepted captures are typed browser-capture envelopes and are written
 atomically under the configured capture spool at `<provider>/...json`.
 The filename is deterministic from provider and provider session id, so repeated
-observation of the same web session replaces the same source artifact.
+observation of the same web session replaces the same source artifact. Receiver
+responses expose this artifact as an `artifact_ref` relative to the spool root;
+absolute filesystem paths stay inside the receiver process.
 
 The extension lives in `browser-extension/` and can be loaded unpacked in
 Chrome. It includes ChatGPT and Claude.ai DOM adapters, a popup control panel,
@@ -72,12 +74,11 @@ of dropping content silently.
 Fixed in this slice: default web origins no longer cross the local receiver
 boundary unauthenticated; receiver routes have a small executable contract;
 valid and malformed receiver payloads are tested at the HTTP boundary; accepted
-and error DTOs carry receiver/schema/source identity.
+and error DTOs carry receiver/schema/source identity; accepted and archive-state
+DTOs use bounded artifact refs instead of local filesystem paths.
 
 Still outside this slice: browser-capture artifacts still enter the archive as
 provider sessions (`chatgpt`, `claude-ai`) rather than a distinct acquisition
 source family; the daemon web API exposes status/read surfaces but not a full
 web workbench flow; extension-id pinning is still operator policy rather than a
-default because unpacked extension ids are local-install specific; accepted and
-archive-state DTOs still expose the local artifact path to the trusted extension
-context.
+default because unpacked extension ids are local-install specific.

--- a/polylogue/browser_capture/__init__.py
+++ b/polylogue/browser_capture/__init__.py
@@ -13,6 +13,7 @@ from polylogue.browser_capture.receiver import (
     BrowserCaptureReceiverConfig,
     BrowserCaptureWriteResult,
     capture_artifact_path,
+    capture_artifact_ref,
     receiver_status_payload,
     write_capture_envelope,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "BrowserCaptureSession",
     "BrowserCaptureTurn",
     "BrowserCaptureWriteResult",
+    "capture_artifact_ref",
     "capture_artifact_path",
     "receiver_status_payload",
     "write_capture_envelope",

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -153,7 +153,7 @@ class BrowserCaptureReceiverStatusPayload(BaseModel):
     ok: Literal[True] = True
     receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
     schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
-    spool_path: str
+    spool_ready: bool
     allowed_origins: list[str]
     allow_remote: bool
     auth_required: bool
@@ -167,7 +167,7 @@ class BrowserCaptureArchiveStatePayload(BaseModel):
     provider: str
     provider_session_id: str
     captured: bool
-    artifact_path: str
+    artifact_ref: str
     capture_id: str | None = None
     updated_at: str | None = None
     artifact_readable: bool | None = None
@@ -183,7 +183,7 @@ class BrowserCaptureAcceptedPayload(BaseModel):
     capture_id: str
     provider: str
     provider_session_id: str
-    artifact_path: str
+    artifact_ref: str
     bytes_written: int
     replaced: bool
 

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -57,6 +57,7 @@ class BrowserCaptureWriteResult:
     provider: str
     provider_session_id: str
     path: Path
+    artifact_ref: str
     bytes_written: int
     replaced: bool
 
@@ -79,6 +80,12 @@ def capture_artifact_path(envelope: BrowserCaptureEnvelope, spool_path: Path | N
     return root / provider / f"{session}-{suffix}.json"
 
 
+def capture_artifact_ref(envelope: BrowserCaptureEnvelope, spool_path: Path | None = None) -> str:
+    """Return the bounded receiver-facing artifact reference for an envelope."""
+    root = spool_path if spool_path is not None else BrowserCaptureReceiverConfig.default().spool_path
+    return capture_artifact_path(envelope, root).relative_to(root).as_posix()
+
+
 def write_capture_envelope(
     envelope: BrowserCaptureEnvelope,
     *,
@@ -99,6 +106,7 @@ def write_capture_envelope(
         provider=envelope.provider.value,
         provider_session_id=envelope.provider_session_id,
         path=target,
+        artifact_ref=capture_artifact_ref(envelope, spool_path),
         bytes_written=target.stat().st_size,
         replaced=replaced,
     )
@@ -107,7 +115,7 @@ def write_capture_envelope(
 def receiver_status_payload(config: BrowserCaptureReceiverConfig) -> dict[str, object]:
     """Return JSON status for extension health checks."""
     return BrowserCaptureReceiverStatusPayload(
-        spool_path=str(config.spool_path),
+        spool_ready=True,
         allowed_origins=sorted(config.allowed_origins),
         allow_remote=config.allow_remote,
         auth_required=config.auth_token is not None,
@@ -154,7 +162,7 @@ def existing_capture_state(
         provider=envelope.provider.value,
         provider_session_id=envelope.provider_session_id,
         captured=path.exists(),
-        artifact_path=str(path),
+        artifact_ref=capture_artifact_ref(envelope, spool_path),
         capture_id=capture_id,
         updated_at=updated_at,
         artifact_readable=artifact_readable,
@@ -164,6 +172,7 @@ def existing_capture_state(
 __all__ = [
     "BrowserCaptureReceiverConfig",
     "BrowserCaptureWriteResult",
+    "capture_artifact_ref",
     "_is_extension_origin_pattern",
     "capture_artifact_path",
     "existing_capture_state",

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -45,7 +45,7 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "bearer_if_configured",
         "provider + provider_session_id query parameters",
         "BrowserCaptureArchiveStatePayload",
-        "Reports whether a captured provider session is already spooled or archived.",
+        "Reports whether a provider session is spooled, using a receiver-local artifact ref.",
     ),
     BrowserCaptureRouteContract(
         "POST",
@@ -54,7 +54,7 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "bearer_if_web_origin",
         "BrowserCaptureEnvelope",
         "BrowserCaptureAcceptedPayload | BrowserCaptureErrorPayload",
-        "Extension-origin requests are accepted by default; extra web origins require bearer auth.",
+        "Accepts captures and returns a receiver-local artifact ref; extra web origins require bearer auth.",
     ),
 )
 

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -180,7 +180,7 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 capture_id=envelope.capture_id or f"{result.provider}:{result.provider_session_id}",
                 provider=result.provider,
                 provider_session_id=result.provider_session_id,
-                artifact_path=str(result.path),
+                artifact_ref=result.artifact_ref,
                 bytes_written=result.bytes_written,
                 replaced=result.replaced,
             ).model_dump(mode="json"),

--- a/polylogue/daemon/browser_capture.py
+++ b/polylogue/daemon/browser_capture.py
@@ -26,7 +26,7 @@ def status_command(spool_path: Path | None, output_format: str | None) -> None:
         click.echo(dumps(payload))
         return
     click.echo("Browser capture receiver")
-    click.echo(f"Spool: {payload['spool_path']}")
+    click.echo(f"Spool: {'ready' if payload.get('spool_ready') else 'unavailable'}")
     origins = payload.get("allowed_origins", [])
     origin_text = ", ".join(str(item) for item in origins) if isinstance(origins, list) else str(origins)
     click.echo(f"Allowed origins: {origin_text}")

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1939,7 +1939,8 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
                     lines.append(f"  {source.get('name')}: {source.get('root')} ({state})")
     browser_capture = payload.get("browser_capture")
     if isinstance(browser_capture, dict):
-        lines.append(f"Browser capture spool: {browser_capture.get('spool_path')}")
+        spool_state = "ready" if browser_capture.get("spool_ready") else "unavailable"
+        lines.append(f"Browser capture spool: {spool_state}")
         origins = browser_capture.get("allowed_origins", [])
         origin_text = ", ".join(str(item) for item in origins) if isinstance(origins, list) else str(origins)
         lines.append(f"Browser capture origins: {origin_text}")

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -21,6 +21,7 @@ from polylogue.browser_capture.models import (
 )
 from polylogue.browser_capture.receiver import (
     capture_artifact_path,
+    capture_artifact_ref,
     existing_capture_state,
     write_capture_envelope,
 )
@@ -102,10 +103,13 @@ def test_capture_artifact_path_is_deterministic(tmp_path: Path) -> None:
 
     first = capture_artifact_path(envelope, tmp_path)
     second = capture_artifact_path(envelope, tmp_path)
+    artifact_ref = capture_artifact_ref(envelope, tmp_path)
 
     assert first == second
     assert first.parent.name == "chatgpt"
     assert "with-spaces" in first.name
+    assert artifact_ref == first.relative_to(tmp_path).as_posix()
+    assert Path(artifact_ref).is_absolute() is False
 
 
 def test_write_capture_envelope_replaces_same_artifact(tmp_path: Path) -> None:
@@ -129,6 +133,8 @@ def test_existing_capture_state_reports_written_artifact(tmp_path: Path) -> None
 
     assert typed.captured is True
     assert typed.provider == "chatgpt"
+    assert typed.artifact_ref == capture_artifact_ref(envelope, tmp_path)
+    assert Path(typed.artifact_ref).is_absolute() is False
 
 
 def test_browser_capture_status_daemon_cli_json(cli_workspace: dict[str, Path]) -> None:
@@ -141,8 +147,10 @@ def test_browser_capture_status_daemon_cli_json(cli_workspace: dict[str, Path]) 
     typed = BrowserCaptureReceiverStatusPayload.model_validate(payload)
     assert payload["ok"] is True
     assert typed.receiver == "polylogue-browser-capture"
+    assert typed.spool_ready is True
     assert typed.auth_required is False
     assert typed.allowed_origins == ["chrome-extension://*"]
+    assert "spool_path" not in payload
 
 
 def test_browser_capture_route_contracts_cover_receiver_boundary() -> None:
@@ -186,7 +194,9 @@ def test_receiver_accepts_extension_capture_and_reports_typed_dto(tmp_path: Path
     assert body.source == "browser-extension"
     assert body.schema_version == 1
     assert body.capture_id == "chatgpt:conv-123"
-    assert Path(body.artifact_path).exists()
+    assert body.artifact_ref == capture_artifact_ref(BrowserCaptureEnvelope.model_validate(_payload()), tmp_path)
+    assert Path(body.artifact_ref).is_absolute() is False
+    assert (tmp_path / body.artifact_ref).exists()
 
 
 @pytest.mark.parametrize(
@@ -262,3 +272,4 @@ def test_receiver_allows_extra_web_origin_only_with_token(tmp_path: Path) -> Non
 
     assert response.status == HTTPStatus.ACCEPTED
     assert body.ok is True
+    assert Path(body.artifact_ref).is_absolute() is False

--- a/tests/unit/browser_capture/test_receiver_contract.py
+++ b/tests/unit/browser_capture/test_receiver_contract.py
@@ -174,6 +174,8 @@ class TestReceiverAcceptsValidPayload:
         assert result.provider_session_id == "conv-123"
         assert result.bytes_written > 0
         assert result.path.exists()
+        assert result.artifact_ref == result.path.relative_to(tmp_path).as_posix()
+        assert Path(result.artifact_ref).is_absolute() is False
         assert result.replaced is False
 
     def test_write_capture_envelope_is_idempotent(self, tmp_path: Path) -> None:
@@ -181,6 +183,7 @@ class TestReceiverAcceptsValidPayload:
         first = write_capture_envelope(envelope, spool_path=tmp_path)
         second = write_capture_envelope(envelope, spool_path=tmp_path)
         assert first.path == second.path
+        assert first.artifact_ref == second.artifact_ref
         assert first.replaced is False
         assert second.replaced is True
 

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -256,7 +256,7 @@ def test_check_daemon_json_uses_shared_daemon_status(cli_runner: CliRunner) -> N
         "ok": True,
         "daemon": "polylogued",
         "live": {"source_count": 1, "existing_source_count": 1, "sources": []},
-        "browser_capture": {"spool_path": "/tmp/captures"},
+        "browser_capture": {"spool_ready": True},
     }
 
     with patch("polylogue.cli.shared.check_workflow.daemon_status_payload", return_value=daemon_report):
@@ -267,7 +267,8 @@ def test_check_daemon_json_uses_shared_daemon_status(cli_runner: CliRunner) -> N
     daemon = json_object_field(payload, "daemon", context="check payload")
     assert daemon.get("daemon") == "polylogued"
     browser_capture = json_object_field(daemon, "browser_capture", context="daemon")
-    assert browser_capture.get("spool_path") == "/tmp/captures"
+    assert browser_capture.get("spool_ready") is True
+    assert "spool_path" not in browser_capture
 
 
 def test_check_daemon_plain_renders_component_status(cli_runner: CliRunner) -> None:
@@ -279,7 +280,7 @@ def test_check_daemon_plain_renders_component_status(cli_runner: CliRunner) -> N
             "existing_source_count": 1,
             "sources": [{"name": "codex", "root": "/tmp/codex", "exists": True}],
         },
-        "browser_capture": {"spool_path": "/tmp/captures"},
+        "browser_capture": {"spool_ready": True},
     }
 
     with patch("polylogue.cli.shared.check_workflow.daemon_status_payload", return_value=daemon_report):
@@ -289,7 +290,7 @@ def test_check_daemon_plain_renders_component_status(cli_runner: CliRunner) -> N
     assert "Daemon Components:" in result.output
     assert "Live sources: 1/1 available" in result.output
     assert "codex: /tmp/codex (available)" in result.output
-    assert "Browser capture spool: /tmp/captures" in result.output
+    assert "Browser capture spool: ready" in result.output
 
 
 def test_check_plain_preview_summarizes_changes_not_issues(

--- a/tests/unit/cli/test_check_rendering_plain_runtime.py
+++ b/tests/unit/cli/test_check_rendering_plain_runtime.py
@@ -179,7 +179,7 @@ def test_build_report_lines_renders_all_sections_and_breakdowns() -> None:
                     {"name": "claude-code", "root": "/tmp/claude", "exists": False},
                 ],
             },
-            "browser_capture": {"spool_path": "/tmp/captures"},
+            "browser_capture": {"spool_ready": True},
         },
     )
 
@@ -200,7 +200,7 @@ def test_build_report_lines_renders_all_sections_and_breakdowns() -> None:
     assert "Daemon Components:" in rendered
     assert "Live sources: 1/2 available" in rendered
     assert "codex: /tmp/codex (available)" in rendered
-    assert "Browser capture spool: /tmp/captures" in rendered
+    assert "Browser capture spool: ready" in rendered
 
 
 def test_emit_maintenance_output_handles_preview_empty_selection_and_vacuum_modes() -> None:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -68,7 +68,8 @@ def test_polylogued_status_json_reports_daemon_components(
     assert payload["daemon"] == "polylogued"
     assert live["source_count"] == 2
     assert live["existing_source_count"] == 1
-    assert browser_capture["spool_path"] == str(tmp_path / "captures")
+    assert browser_capture["spool_ready"] is True
+    assert "spool_path" not in browser_capture
 
 
 def test_polylogued_status_plain_reports_daemon_components(tmp_path: Path) -> None:
@@ -81,7 +82,7 @@ def test_polylogued_status_plain_reports_daemon_components(tmp_path: Path) -> No
     assert "Polylogue daemon" in result.output
     assert "Live sources: 1/1 available" in result.output
     assert f"exists: {tmp_path} (available)" in result.output
-    assert "Browser capture spool:" in result.output
+    assert "Browser capture spool: ready" in result.output
 
 
 def test_polylogued_status_json_reports_archive_storage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Browser-capture receiver DTOs now return stable receiver-local artifact references instead of absolute local filesystem paths. The status payload likewise reports whether the spool is ready without exposing the spool root, while internal write helpers still keep the concrete `Path` needed to persist captures.

## Problem

#1847 calls out the browser-accessible route boundary as a real local security surface. The stale browser-capture patch had already landed most auth and DTO work, but current master still returned absolute capture artifact paths through `POST /v1/browser-captures`, `GET /v1/archive-state`, and `GET /v1/status`. That taught extension/web-facing clients local filesystem layout they do not need.

## Solution

- Replaced public `artifact_path` fields with `artifact_ref` on `BrowserCaptureAcceptedPayload` and `BrowserCaptureArchiveStatePayload`.
- Added `capture_artifact_ref(...)` as the bounded relative-spool identifier while keeping absolute `Path` values internal to `BrowserCaptureWriteResult`.
- Changed receiver status from `spool_path` to `spool_ready`, and updated daemon/browser-capture status rendering plus `ops doctor --daemon` fixtures.
- Updated receiver route notes and browser-capture docs to describe refs and the remaining #1847 residuals accurately.
- Added boundary assertions that receiver DTOs do not expose absolute local paths.

## Verification

- `nix develop --command devtools test tests/unit/browser_capture/test_receiver.py tests/unit/browser_capture/test_receiver_contract.py tests/unit/daemon/test_daemon_cli.py::test_polylogued_status_json_reports_daemon_components tests/unit/daemon/test_daemon_cli.py::test_polylogued_status_plain_reports_daemon_components tests/unit/cli/test_check.py::test_check_daemon_json_uses_shared_daemon_status tests/unit/cli/test_check.py::test_check_daemon_plain_renders_component_status tests/unit/cli/test_check_rendering_plain_runtime.py::test_build_report_lines_renders_all_sections_and_breakdowns` -> `40 passed`
- `nix develop --command devtools verify --quick` -> `exit_code: 0`
- pre-push quick gate at `b32b77378` -> `exit_code: 0`

Ref #1847