### PR TITLE
feat(web): execute workbench read views (#1846)

### DIFF
--- a/docs/plans/web-workbench-1846-v0-plan.md
+++ b/docs/plans/web-workbench-1846-v0-plan.md
@@ -12,11 +12,13 @@ Backend:
 
 - `GET /api/sessions/:id/recovery?report=digest&format=json`
 - `GET /api/sessions/:id/recovery?report=work-packet&format=json|markdown`
+- `GET /api/sessions/:id/read?view=messages|recovery|raw&format=json`
 - `GET /api/assertions?target_ref=&scope_ref=&kind=&status=&context_inject=&limit=`
 
 Route contracts:
 
 - `/api/sessions/:id/recovery` is `read_detail`, `shell_supported`, `bearer_if_configured`.
+- `/api/sessions/:id/read` is `read_detail`, `shell_supported`, `bearer_if_configured`.
 - `/api/assertions` is `user_overlay`, `shell_supported`, `bearer_if_configured`.
 - Both are real workbench routes, but not advertised as stable public API until #1847 promotes the daemon DTO boundary.
 
@@ -31,6 +33,7 @@ Web shell:
 - Adds an `Evidence` inspector tab.
 - Fetches `RecoveryWorkPacket` and assertion claims for the selected session.
 - Loads `GET /api/read-view-profiles` and renders a small profile selector from shared read-view metadata.
+- Executes supported single-session profiles through `GET /api/sessions/:id/read`.
 - Keeps raw data behind an explicit opt-in drawer: metadata loads first from provenance; bounded preview requires a separate click.
 
 Explicit non-exposure:
@@ -59,6 +62,7 @@ Search and query:
 Reader:
 
 - read-view profile payloads from `GET /api/read-view-profiles`.
+- read-view execution envelopes from `GET /api/sessions/:id/read`.
 - session detail payload from `GET /api/sessions/:id`.
 - session message payloads from `GET /api/sessions/:id/messages`.
 - provenance/raw payloads from `/provenance` and `/raw`, still explicit opt-in.
@@ -72,13 +76,13 @@ Evidence:
 
 Browser capture/readiness:
 
-- Browser capture remains a separate #1824/#1847 capability boundary. The workbench may display capture readiness later, but must not call receiver write routes as generic archive mutations.
+- Browser capture remains a separate #1824/#1847 capability boundary. The workbench displays read-only readiness from `/api/status.browser_capture` and `component_readiness.browser_capture`; it does not call receiver write routes as generic archive mutations.
 
 ## Remaining backend endpoints
 
-1. Shared read-view execution route: either `GET /api/sessions/:id/read?view=&format=` or an explicit route map for every profile. Current slice only displays profiles and maps supported ones to existing routes.
+1. Shared read-view execution route now covers the supported single-session profiles (`messages`, `recovery`, `raw`). Broader profiles (`context`, `context-pack`, `neighbors`, `correlation`) still need dedicated execution semantics before the selector enables them.
 2. Typed overlay mutation envelopes for marks/annotations/saved views/recall/workspaces. Existing routes work, but #1847 should decide stability and shared mutation DTO guarantees.
-3. Browser-capture read-only readiness adapter if `GET /api/status` is not enough for the workbench panel.
+3. Browser-capture readiness is satisfied by `GET /api/status`; add a dedicated adapter only if a future panel needs more than safe receiver state (`spool_ready`, `allowed_origins`, `auth_required`, component readiness).
 4. Bounded raw-preview contract promotion: this slice already prefers provenance `include_raw=1&bytes=` in the shell; #1847 can decide whether `/api/sessions/:id/raw` remains shell-supported only or becomes a narrower stable metadata route.
 5. Generated route/OpenAPI surface that includes stable routes and intentionally documented shell-supported workbench routes without implying public API stability.
 
@@ -88,11 +92,11 @@ PR-1846-B, landed by this slice: recovery/work-packet HTTP, assertion-read HTTP,
 
 PR-1846-C: promote one overlay mutation path to shared mutation/error envelopes and keep same-origin/bearer tests strict.
 
-PR-1846-D: execute read profiles over HTTP instead of only displaying profile metadata.
+PR-1846-D, partially landed after the first evidence slice: execute supported single-session read profiles over HTTP instead of only displaying profile metadata.
 
 PR-1846-E, partially landed by this slice: raw drawer hardening via provenance metadata, no automatic raw fetch, bounded preview button, and explicit privacy posture in the UI.
 
-PR-1846-F: browser-capture/readiness panel consuming #1824/#1847 DTOs without merging receiver auth with archive auth.
+PR-1846-F, landed after the first evidence slice: browser-capture/readiness panel consumes #1824/#1847 status DTOs without merging receiver auth with archive auth.
 
 PR-1846-G, partly landed by this slice: fixture-backed DOM smoke covers shell hooks plus recovery/assertion endpoint payloads. A full browser click-through remains useful once the visual lane is stable in every checkout.
 
@@ -101,13 +105,16 @@ PR-1846-G, partly landed by this slice: fixture-backed DOM smoke covers shell ho
 Landed tests:
 
 - route-contract lookup for `/api/assertions` and `/api/sessions/:id/recovery`.
+- route-contract lookup for `/api/sessions/:id/read`.
 - check that these routes stay `shell_supported`, not stable public API.
 - recovery endpoint tests for digest JSON, work-packet JSON, work-packet markdown, invalid report/format pairs, and missing sessions.
+- read-view execution route tests for `messages`, `recovery`, `raw`, unsupported views, and unsupported formats.
 - assertion endpoint tests for default `active,candidate`, kind/context filters, `status=all`, and token-gated reads.
 - shell smoke checks for `Evidence`, `read-view`, recovery/assertion endpoint hooks, and explicit raw opt-in copy.
 - visual/DOM smoke checks for the evidence tab hooks plus recovery/assertion endpoint payloads over the reader fixture.
 - raw drawer smoke checks that the shell uses provenance and only fetches bounded preview after an explicit button.
 - no-local-path leak checks for the new reader JSON routes.
+- browser-capture readiness chip wiring over `/api/status.browser_capture`, including safe-field checks that the web workbench never receives a receiver spool path.
 
 Still needed:
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -890,6 +890,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_get_messages(path[2], params)
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "recovery":
             self._handle_get_session_recovery(path[2], params)
+        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "read":
+            self._handle_get_session_read(path[2], params)
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "raw":
             self._handle_get_session_raw(path[2])
         elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "cost":
@@ -2478,6 +2480,74 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if payload is None:
             return None
         return payload.model_dump(mode="json", exclude_none=True)
+
+    # ------------------------------------------------------------------
+    # Handlers: shared single-session read-view execution (#1846)
+    # ------------------------------------------------------------------
+
+    @daemon_safe_handler
+    def _handle_get_session_read(self, conv_id: str, params: dict[str, list[str]]) -> None:
+        """``GET /api/sessions/{id}/read`` executes supported read profiles.
+
+        This is a thin workbench adapter over existing read handlers. Accepted
+        ``view`` values must already exist in ``/api/read-view-profiles``; the
+        route does not introduce a second read-view registry.
+        """
+
+        view = (self._get_param(params, "view", "messages") or "messages").strip().lower()
+        output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
+        if view not in {"messages", "recovery", "raw"}:
+            self._send_error(HTTPStatus.BAD_REQUEST, "unsupported_read_view")
+            return
+        if output_format != "json" and not (view == "recovery" and output_format == "markdown"):
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+            return
+
+        if view == "messages":
+            limit = self._get_int(params, "limit", 50)
+            offset = self._get_int(params, "offset", 0)
+            projection = _content_projection_from_params(params)
+            archive_root = _web_reader_archive_root()
+            if archive_root is not None:
+                payload: object | None = self._do_archive_get_messages(archive_root, conv_id, limit, offset, projection)
+            else:
+
+                async def _get(poly: Polylogue) -> object:
+                    return await self._do_get_messages(poly, conv_id, limit, offset, projection)
+
+                payload = self._sync_run(_get)
+        elif view == "recovery":
+            report = (self._get_param(params, "report", "work-packet") or "work-packet").strip().lower()
+            if report not in {"digest", "work-packet"}:
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_report")
+                return
+            if report == "digest" and output_format != "json":
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+                return
+
+            async def _get(poly: Polylogue) -> object | None:
+                return await self._do_get_session_recovery(poly, conv_id, report, output_format)
+
+            payload = self._sync_run(_get)
+        else:
+
+            async def _get(poly: Polylogue) -> object | None:
+                return await self._do_get_session_raw(poly, conv_id)
+
+            payload = self._sync_run(_get)
+
+        if payload is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+            return
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "session_id": conv_id,
+                "view": view,
+                "format": output_format,
+                "payload": payload,
+            },
+        )
 
     # ------------------------------------------------------------------
     # Handlers: per-session embedding similarity (#1123)

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -194,6 +194,15 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
     ),
     RouteContract(
         "GET",
+        "/api/sessions/:id/read",
+        "read_detail",
+        "shell_supported",
+        "bearer_if_configured",
+        "session read-view execution envelope",
+        "Executes supported single-session read profiles over existing messages/recovery/raw handlers for the local workbench.",
+    ),
+    RouteContract(
+        "GET",
         "/api/sessions/:id/raw",
         "read_detail",
         "shell_supported",

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -256,6 +256,7 @@ __ATTACHMENT_CSS__
     <span class="chip" id="status-semantic" title="Semantic readiness">semantic: --</span>
     <span class="chip" id="status-insights" title="Session insight freshness" style="display:none">insights: --</span>
     <span class="chip" id="status-ingest" style="display:none">live</span>
+    <span class="chip" id="status-browser-capture" title="Browser capture readiness" style="display:none">capture: --</span>
     <span class="chip" id="status-live" title="Realtime channel">live: --</span>
   </div>
   <div id="sidebar">
@@ -364,9 +365,11 @@ var state = {
   evidencePanels: {},
   // Shared read-view profile inventory (#1846/#1838). Loaded from
   // /api/read-view-profiles so the shell does not grow a second profile
-  // registry. selectedReadView controls which existing route/inspector affordance
-  // is foregrounded; unsupported profiles remain disabled until HTTP execution exists.
+  // registry. selectedReadView controls the main reader pane. Supported
+  // single-session profiles execute through /api/sessions/{id}/read; unsupported
+  // profiles remain disabled until HTTP execution exists.
   readViewProfiles: [], selectedReadView: 'messages', readViewProfileError: '',
+  readViewPayloads: {}, readViewErrors: {},
   // Per-session similarity panel cache (#1123). Keyed by
   // session_id; populated on demand when the Similar inspector
   // tab is opened. ``undefined`` means "not loaded yet"; the envelope
@@ -537,6 +540,7 @@ async function loadStatus() {
     renderSemanticChip(readiness.embeddings || null);
     renderInsightChip(readiness.session_profiles || null, s.insight_freshness || {});
     renderIngestChip(readiness.daemon_ingest || null, s.live || {});
+    renderBrowserCaptureChip(readiness.browser_capture || null, s.browser_capture || {});
   } catch(e) {}
 }
 
@@ -631,6 +635,33 @@ function renderIngestChip(component, live) {
     el.textContent = 'live: ' + live.existing_source_count + ' srcs';
     setChipQuality(el, 'canonical');
   } else { el.style.display = 'none'; }
+}
+
+function renderBrowserCaptureChip(component, capture) {
+  var el = document.getElementById('status-browser-capture');
+  if (!el) return;
+  if (!component && !capture) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  var state = component ? (component.state || 'unknown') : 'unknown';
+  var active = state === 'ready';
+  var spoolReady = !!(capture && capture.spool_ready);
+  var authRequired = !!(capture && capture.auth_required);
+  var origins = (capture && capture.allowed_origins) || [];
+  if (active && spoolReady) {
+    el.textContent = 'capture: ready';
+    setChipQuality(el, 'canonical');
+  } else if (spoolReady) {
+    el.textContent = 'capture: off';
+    setChipQuality(el, 'unavailable');
+  } else {
+    el.textContent = 'capture: unavailable';
+    setChipQuality(el, 'unavailable');
+  }
+  var originText = origins.length ? origins.join(', ') : 'no origins';
+  el.title = 'Browser capture: ' + (active ? 'running' : 'not running')
+    + '; spool ' + (spoolReady ? 'ready' : 'unavailable')
+    + '; auth ' + (authRequired ? 'required' : 'not required')
+    + '; origins ' + originText;
 }
 
 function renderSidebarState(kind, msg) {
@@ -774,6 +805,25 @@ function applyReadViewSelection(viewId) {
   renderInspector();
 }
 
+function readViewCacheKey(id, viewId) {
+  return id + '::' + (viewId || 'messages');
+}
+
+async function loadReadViewExecution(id, viewId) {
+  if (!id || !viewId || viewId === 'messages') return;
+  var key = readViewCacheKey(id, viewId);
+  try {
+    var payload = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/read?view=' + encodeURIComponent(viewId) + '&format=json');
+    state.readViewPayloads[key] = payload;
+    delete state.readViewErrors[key];
+  } catch(e) {
+    state.readViewErrors[key] = String(e);
+  }
+  if (state.selected && state.selected.id === id && state.selectedReadView === viewId) {
+    renderMain();
+  }
+}
+
 function renderMain() {
   renderWorkspaceToolbar();
   if (state.mode === 'stack') { renderStackWorkspace(); return; }
@@ -842,6 +892,10 @@ function renderMain() {
   headerEl.innerHTML = headerHtml;
 
   var readViewSelector = renderReadViewSelector(c);
+  if (state.selectedReadView && state.selectedReadView !== 'messages') {
+    msgEl.innerHTML = readViewSelector + renderReadViewExecution(c, state.selectedReadView);
+    return;
+  }
   if (!c.messages) {
     msgEl.innerHTML = readViewSelector + '<div class="main-empty"><h3>Loading messages...</h3></div>';
     return;
@@ -851,6 +905,52 @@ function renderMain() {
     return;
   }
   msgEl.innerHTML = readViewSelector + messageBlocksHtml(c.messages);
+}
+
+function renderReadViewExecution(c, viewId) {
+  var key = readViewCacheKey(c.id, viewId);
+  if (state.readViewErrors[key]) {
+    return '<div class="main-empty"><h3>Read view unavailable</h3><p>' + esc(state.readViewErrors[key]) + '</p></div>';
+  }
+  var envelope = state.readViewPayloads[key];
+  if (envelope === undefined) {
+    loadReadViewExecution(c.id, viewId);
+    return '<div class="main-empty"><h3>Loading ' + esc(viewId) + '...</h3></div>';
+  }
+  var payload = envelope.payload || {};
+  if (viewId === 'recovery') return renderRecoveryReadView(payload);
+  if (viewId === 'raw') return renderRawReadView(payload);
+  return '<div class="main-empty"><h3>Unsupported read view</h3><p>' + esc(viewId) + '</p></div>';
+}
+
+function renderRecoveryReadView(payload) {
+  var packet = payload.work_packet || {};
+  var entries = packet.entries || [];
+  var html = '<div class="read-view-panel"><h3>Recovery work packet</h3>'
+    + '<p class="muted">Read through /api/sessions/:id/read using the shared recovery DTO.</p>'
+    + '<div class="inspector-field"><span class="label">entries</span><span class="value">' + esc(String(entries.length)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">evidence refs</span><span class="value">' + esc(String((packet.evidence_refs || []).length)) + '</span></div>';
+  entries.slice(0, 10).forEach(function(entry) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(entry.section || 'entry') + ' / ' + esc(entry.support || 'support') + '</div>'
+      + '<div class="note"><strong>' + esc(entry.label || 'entry') + '</strong><br>' + esc(entry.text || '') + '</div></div>';
+  });
+  if (!entries.length) html += '<div class="inspector-empty">No recovery entries surfaced for this session.</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderRawReadView(payload) {
+  var artifacts = payload.raw_artifacts || [];
+  var html = '<div class="read-view-panel"><h3>Raw evidence</h3>'
+    + '<p class="muted">Raw bytes stay behind explicit artifact preview; this view lists sanitized artifact metadata.</p>'
+    + '<div class="inspector-field"><span class="label">artifacts</span><span class="value">' + esc(String(payload.raw_artifacts_total || artifacts.length || 0)) + '</span></div>';
+  artifacts.slice(0, 12).forEach(function(artifact) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(artifact.artifact_kind || artifact.provider || 'artifact') + '</div>'
+      + '<div class="note">' + esc(artifact.raw_id || artifact.artifact_id || 'raw artifact') + '</div></div>';
+  });
+  if (!artifacts.length) html += '<div class="inspector-empty">No raw artifact metadata surfaced for this session.</div>';
+  html += '</div>';
+  return html;
 }
 
 function messageBlocksHtml(messages) {

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -43,6 +43,7 @@ def test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary
 
     assertion_route = route_contract_for("GET", "/api/assertions")
     recovery_route = route_contract_for("GET", "/api/sessions/codex-session:abc/recovery")
+    read_route = route_contract_for("GET", "/api/sessions/codex-session:abc/read")
 
     assert assertion_route is not None
     assert assertion_route.stability == "shell_supported"
@@ -53,12 +54,15 @@ def test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary
     assert recovery_route.stability == "shell_supported"
     assert recovery_route.auth_policy == "bearer_if_configured"
     assert "Recovery" in recovery_route.response_contract
+    assert read_route is not None
+    assert read_route.stability == "shell_supported"
+    assert read_route.auth_policy == "bearer_if_configured"
 
 
 def test_web_workbench_candidate_routes_are_not_stable_public_api() -> None:
     """New #1846 routes are real, but #1847 has not promoted them to stable API."""
 
-    candidate_patterns = {"/api/assertions", "/api/sessions/:id/recovery"}
+    candidate_patterns = {"/api/assertions", "/api/sessions/:id/recovery", "/api/sessions/:id/read"}
     stable_patterns = {route.pattern for route in stable_route_contracts()}
     assert candidate_patterns.isdisjoint(stable_patterns)
     for pattern in candidate_patterns:
@@ -87,6 +91,13 @@ def test_web_workbench_candidate_routes_are_not_stable_public_api() -> None:
             "GET",
             "/api/sessions/codex-session:abc/recovery",
             "/api/sessions/:id/recovery",
+            "read_detail",
+            "bearer_if_configured",
+        ),
+        (
+            "GET",
+            "/api/sessions/codex-session:abc/read",
+            "/api/sessions/:id/read",
             "read_detail",
             "bearer_if_configured",
         ),

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -408,10 +408,13 @@ class TestReaderSearchState:
             "renderCompareWorkspace",
             "renderInspector",
             "renderInspectorEvidence",
+            "renderBrowserCaptureChip",
+            "renderReadViewExecution",
             "loadReadViewProfiles",
             "renderReadViewSelector",
             "applyReadViewSelection",
             "/api/read-view-profiles",
+            "/read?view=",
             "/api/assertions",
             "/recovery?report=work-packet",
             "Load artifact list",
@@ -1332,6 +1335,41 @@ class TestReaderViewProfiles:
         assert profiles["recovery"]["successor_handoff"] is True
         assert "markdown" in profiles["recovery"]["formats"]
 
+    def test_read_view_execution_route_returns_messages_recovery_and_raw(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            messages = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/read?view=messages&limit=5"),
+            )
+            recovery = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/read?view=recovery&report=work-packet"),
+            )
+            raw = cast(dict[str, object], _get_json(base_url, f"/api/sessions/{C1}/read?view=raw"))
+
+        assert messages["view"] == "messages"
+        message_payload = cast(dict[str, object], messages["payload"])
+        assert message_payload["total"] == 1
+        assert recovery["view"] == "recovery"
+        recovery_payload = cast(dict[str, object], recovery["payload"])
+        assert recovery_payload["report"] == "work-packet"
+        assert raw["view"] == "raw"
+        raw_payload = cast(dict[str, object], raw["payload"])
+        assert raw_payload["id"] == C1
+
+    def test_read_view_execution_rejects_unknown_view_or_format(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            view_status, view_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=context")
+            format_status, format_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=messages&format=html")
+
+        assert view_status == 400
+        assert view_payload["error"] == "unsupported_read_view"
+        assert format_status == 400
+        assert format_payload["error"] == "invalid_format"
+
 
 class TestReaderRecoveryEndpoint:
     def test_recovery_endpoint_returns_digest_json(self, workspace_env: dict[str, Path]) -> None:
@@ -1514,6 +1552,8 @@ class TestReaderPrivacy:
             "/api/sessions",
             "/api/sessions/claude-code-session:c1",
             "/api/sessions/claude-code-session:c1/messages",
+            "/api/sessions/claude-code-session:c1/read?view=messages",
+            "/api/sessions/claude-code-session:c1/read?view=recovery",
             "/api/sessions/claude-code-session:c1/recovery?report=work-packet&format=json",
             "/api/assertions?target_ref=session%3Aclaude-code-session%3Ac1",
         ],
@@ -1551,6 +1591,7 @@ class TestReaderAuthSurface:
         "path",
         [
             "/api/sessions/claude-code-session:c1/recovery?report=work-packet&format=json",
+            "/api/sessions/claude-code-session:c1/read?view=recovery",
             "/api/assertions?target_ref=session%3Aclaude-code-session%3Ac1",
         ],
     )
@@ -1886,8 +1927,10 @@ class TestReaderInformability:
         assert "renderSemanticChip(readiness.embeddings || null)" in body
         assert "renderInsightChip(readiness.session_profiles || null, s.insight_freshness || {})" in body
         assert "renderIngestChip(readiness.daemon_ingest || null, s.live || {})" in body
+        assert "renderBrowserCaptureChip(readiness.browser_capture || null, s.browser_capture || {})" in body
         assert "function renderComponentReadinessChip(" in body
         assert "function readinessQuality(" in body
+        assert "function renderBrowserCaptureChip(" in body
 
     def test_fts_chip_keeps_legacy_tri_state_fallback(self, workspace_env: dict[str, Path]) -> None:
         """``renderFtsChip`` must still distinguish ok / partial /
@@ -1914,6 +1957,29 @@ class TestReaderInformability:
         assert "function renderIngestChip(" in body
         assert "'semantic'" in body
         assert "'ingest'" in body
+
+    def test_browser_capture_readiness_chip_consumes_safe_status_payload(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        """The web workbench displays browser-capture readiness from the
+        daemon status envelope without learning the receiver's local spool path.
+        """
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+            status = cast(dict[str, object], _get_json(base_url, "/api/status"))
+
+        capture = cast(dict[str, object], status["browser_capture"])
+        readiness = cast(dict[str, object], status["component_readiness"])
+
+        assert 'id="status-browser-capture"' in body
+        assert "function renderBrowserCaptureChip(" in body
+        assert "spool_ready" in capture
+        assert "allowed_origins" in capture
+        assert "auth_required" in capture
+        assert "spool_path" not in capture
+        assert "artifact_path" not in capture
+        assert "browser_capture" in readiness
 
     def test_insight_freshness_chip_keeps_legacy_fallback(self, workspace_env: dict[str, Path]) -> None:
         """Session insight freshness gets its own status-strip chip. It now

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -37,6 +37,7 @@ def test_reader_search_shell_dom_evidence(reader_workspace: ReaderWorkspace, tmp
         "app",
         "status-strip",
         "status-dot",
+        "status-browser-capture",
         "sidebar",
         "search",
         "facet-bar",
@@ -388,9 +389,12 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
     for phrase in (
         'data-tab="evidence"',
         "renderInspectorEvidence",
+        "renderBrowserCaptureChip",
+        "renderReadViewExecution",
         "loadEvidencePanel",
         "/api/assertions?target_ref=",
         "/recovery?report=work-packet&format=json",
+        "/read?view=",
     ):
         assert phrase in shell, f"missing evidence shell hook {phrase!r}"
 


### PR DESCRIPTION
## Summary

Adds a broader #1846 web-workbench vertical: the daemon now exposes a shared single-session read execution route for the supported `messages`, `recovery`, and `raw` profiles; the web shell selector executes that route for recovery/raw views; and the shell displays browser-capture readiness from the safe daemon status DTO.

## Problem

The workbench had evidence routes and read-view metadata, but the selector still only changed local UI state. Browser-capture readiness was also present in daemon status after #1847 work, but the web shell did not consume it. That left adjacent read/status surfaces fragmented despite the contracts already existing.

## Solution

- Add `GET /api/sessions/:id/read?view=&format=` as a shell-supported adapter over existing messages, recovery, and raw handlers.
- Register the route contract as `shell_supported` / `bearer_if_configured` rather than stable public API.
- Make the web read-view selector execute the shared read route for recovery/raw and render storage-free work-packet/raw-metadata panels.
- Add a browser-capture status chip driven by `/api/status.browser_capture` and `component_readiness.browser_capture` without exposing receiver spool paths.
- Update the #1846 workbench map to mark supported read execution and browser-capture readiness as landed while keeping broader profiles/mutations as remaining scope.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_route_contracts.py::test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary_stabilizes tests/unit/daemon/test_route_contracts.py::test_web_workbench_candidate_routes_are_not_stable_public_api tests/unit/daemon/test_route_contracts.py::test_route_contract_lookup_matches_static_and_parameterized_routes tests/unit/daemon/test_web_reader.py::TestReaderSearchState::test_root_returns_html_with_required_regions tests/unit/daemon/test_web_reader.py::TestReaderViewProfiles::test_read_view_profiles_endpoint_exposes_shared_profile_semantics tests/unit/daemon/test_web_reader.py::TestReaderViewProfiles::test_read_view_execution_route_returns_messages_recovery_and_raw tests/unit/daemon/test_web_reader.py::TestReaderViewProfiles::test_read_view_execution_rejects_unknown_view_or_format tests/unit/daemon/test_web_reader.py::TestReaderInformability::test_status_strip_consumes_component_readiness tests/unit/daemon/test_web_reader.py::TestReaderInformability::test_browser_capture_readiness_chip_consumes_safe_status_payload tests/visual/test_reader_dom_smoke.py::test_reader_search_shell_dom_evidence tests/visual/test_reader_dom_smoke.py::test_reader_evidence_panel_endpoint_and_shell_smoke` → `22 passed`
- `nix develop --command devtools verify --quick` → `exit_code: 0`
- pre-push `devtools verify --quick` → `exit_code: 0`

Closes part of #1846.