### PR TITLE
feat(api): unify user overlay mutation envelopes (#1847)

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -86,6 +86,11 @@ silently.
 | Browser-accessible mutations | bearer token plus same-origin browser request | `POST /api/user/marks`, `DELETE /api/user/saved-views/:id`, `POST /api/maintenance/run` |
 | Observability ingest | explicit config flag plus loopback-or-bearer policy | `POST /v1/traces`, `POST /v1/metrics`, `POST /v1/logs` |
 
+User overlay mutation routes return the shared mutation result envelope
+(`status`, `operation`, `affected_count`, and resource/target identity fields).
+Detailed overlay resources are read through the corresponding `GET
+/api/user/...` endpoints.
+
 ### GET /api/health
 
 Health check with database statistics.

--- a/docs/plans/web-workbench-1846-v0-plan.md
+++ b/docs/plans/web-workbench-1846-v0-plan.md
@@ -81,7 +81,7 @@ Browser capture/readiness:
 ## Remaining backend endpoints
 
 1. Shared read-view execution route now covers the supported single-session profiles (`messages`, `recovery`, `raw`). Broader profiles (`context`, `context-pack`, `neighbors`, `correlation`) still need dedicated execution semantics before the selector enables them.
-2. Typed overlay mutation envelopes for marks/annotations/saved views/recall/workspaces. Existing routes work, but #1847 should decide stability and shared mutation DTO guarantees.
+2. Typed overlay mutation envelopes for marks/annotations/saved views/recall/workspaces are #1847-owned. These routes should keep same-origin write auth and return the shared mutation result envelope; detailed resource state belongs on the corresponding read endpoints.
 3. Browser-capture readiness is satisfied by `GET /api/status`; add a dedicated adapter only if a future panel needs more than safe receiver state (`spool_ready`, `allowed_origins`, `auth_required`, component readiness).
 4. Bounded raw-preview contract promotion: this slice already prefers provenance `include_raw=1&bytes=` in the shell; #1847 can decide whether `/api/sessions/:id/raw` remains shell-supported only or becomes a narrower stable metadata route.
 5. Generated route/OpenAPI surface that includes stable routes and intentionally documented shell-supported workbench routes without implying public API stability.

--- a/docs/schemas/cli-output/mutation-result.schema.json
+++ b/docs/schemas/cli-output/mutation-result.schema.json
@@ -52,6 +52,30 @@
       "default": null,
       "title": "Key"
     },
+    "mark_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Mark Type"
+    },
+    "message_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Message Id"
+    },
     "operation": {
       "anyOf": [
         {
@@ -75,6 +99,30 @@
       ],
       "default": null,
       "title": "Outcome"
+    },
+    "resource_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Resource Id"
+    },
+    "resource_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Resource Type"
     },
     "session_count": {
       "anyOf": [
@@ -154,6 +202,30 @@
       ],
       "default": null,
       "title": "Tag Count"
+    },
+    "target_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target Id"
+    },
+    "target_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target Type"
     }
   },
   "required": [

--- a/polylogue/daemon/user_state_http.py
+++ b/polylogue/daemon/user_state_http.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 from polylogue.archive.query.spec import SessionQuerySpec
 from polylogue.core.user_state_targets import TARGET_SESSION, is_mark_type_supported, validate_target_kind
+from polylogue.surfaces.payloads import MutationResultPayload
 
 
 def _read_json_body(handler: Any) -> dict[str, object] | None:
@@ -92,6 +93,27 @@ def _default_saved_view_id(name: str, query_json: str) -> str:
 def _default_annotation_id(target_type: str, target_id: str, note_text: str) -> str:
     digest = hashlib.sha256(f"{target_type}\0{target_id}\0{note_text}".encode()).hexdigest()[:16]
     return f"annotation-{digest}"
+
+
+def _mutation_status(created_or_deleted: bool, *, missing_detail: str | None = None) -> tuple[str, str | None, int]:
+    if created_or_deleted:
+        return "ok", None, 1
+    if missing_detail is None:
+        return "unchanged", "already_present", 0
+    return "not_found", missing_detail, 0
+
+
+def _save_mutation_status(created: bool) -> tuple[str, str | None, int]:
+    if created:
+        return "ok", None, 1
+    return "ok", "updated", 1
+
+
+def _send_mutation_result(handler: Any, result: MutationResultPayload, *, created: bool = False) -> None:
+    handler._send_json(
+        HTTPStatus.CREATED if created else HTTPStatus.OK,
+        result.model_dump(mode="json", exclude_none=True),
+    )
 
 
 def dispatch_get(handler: Any, path: list[str], params: dict[str, list[str]]) -> bool:
@@ -200,7 +222,7 @@ def handle_create_mark(handler: Any) -> None:
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_target_type")
         return
 
-    async def _create(poly: Any) -> dict[str, object]:
+    async def _create(poly: Any) -> MutationResultPayload:
         created = await poly.add_mark(
             session_id,
             mark_type,
@@ -208,17 +230,20 @@ def handle_create_mark(handler: Any) -> None:
             target_id=target_id,
             message_id=message_id,
         )
-        return {
-            "target_type": target_type,
-            "target_id": target_id or message_id or session_id,
-            "session_id": session_id,
-            "message_id": message_id,
-            "mark_type": mark_type,
-            "created": created,
-        }
+        return MutationResultPayload(
+            status="ok" if created else "unchanged",
+            detail=None if created else "already_present",
+            operation="mark.add",
+            affected_count=1 if created else 0,
+            target_type=target_type,
+            target_id=target_id or message_id or session_id,
+            session_id=session_id,
+            message_id=message_id,
+            mark_type=mark_type,
+        )
 
-    result = cast(dict[str, object], handler._sync_run(_create))
-    handler._send_json(HTTPStatus.CREATED if result["created"] else HTTPStatus.OK, result)
+    result = cast(MutationResultPayload, handler._sync_run(_create))
+    _send_mutation_result(handler, result, created=result.status == "ok")
 
 
 def handle_delete_mark(handler: Any, params: dict[str, list[str]]) -> None:
@@ -231,7 +256,7 @@ def handle_delete_mark(handler: Any, params: dict[str, list[str]]) -> None:
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
         return
 
-    async def _delete(poly: Any) -> dict[str, object]:
+    async def _delete(poly: Any) -> MutationResultPayload:
         deleted = await poly.remove_mark(
             session_id,
             mark_type,
@@ -239,16 +264,20 @@ def handle_delete_mark(handler: Any, params: dict[str, list[str]]) -> None:
             target_id=target_id,
             message_id=message_id,
         )
-        return {
-            "target_type": target_type or TARGET_SESSION,
-            "target_id": target_id or message_id or session_id,
-            "session_id": session_id,
-            "message_id": message_id,
-            "mark_type": mark_type,
-            "deleted": deleted,
-        }
+        return MutationResultPayload(
+            status="deleted" if deleted else "not_found",
+            detail=None if deleted else "mark_not_present",
+            operation="mark.delete",
+            affected_count=1 if deleted else 0,
+            target_type=target_type or TARGET_SESSION,
+            target_id=target_id or message_id or session_id,
+            session_id=session_id,
+            message_id=message_id,
+            mark_type=mark_type,
+        )
 
-    handler._send_json(HTTPStatus.OK, handler._sync_run(_delete))
+    result = cast(MutationResultPayload, handler._sync_run(_delete))
+    _send_mutation_result(handler, result)
 
 
 def handle_list_annotations(handler: Any, params: dict[str, list[str]]) -> None:
@@ -303,8 +332,9 @@ def handle_save_annotation(handler: Any) -> None:
     resolved_target_id = target_id or message_id or session_id
     annotation_id = str(body.get("annotation_id") or _default_annotation_id(target_type, resolved_target_id, note_text))
 
-    async def _save(poly: Any) -> dict[str, object]:
-        created = await poly.save_annotation(
+    async def _save(poly: Any) -> MutationResultPayload:
+        existing = await poly.get_annotation(annotation_id)
+        await poly.save_annotation(
             annotation_id,
             session_id,
             note_text,
@@ -312,23 +342,40 @@ def handle_save_annotation(handler: Any) -> None:
             target_id=target_id,
             message_id=message_id,
         )
-        saved = await poly.get_annotation(annotation_id)
-        if saved is None:
-            return {"annotation_id": annotation_id, "created": created}
-        result: dict[str, object] = dict(saved)
-        result["created"] = created
-        return result
+        created = existing is None
+        status, detail, affected_count = _save_mutation_status(created)
+        return MutationResultPayload(
+            status=status,
+            detail=detail,
+            operation="annotation.save",
+            affected_count=affected_count,
+            resource_type="annotation",
+            resource_id=annotation_id,
+            target_type=target_type,
+            target_id=resolved_target_id,
+            session_id=session_id,
+            message_id=message_id,
+        )
 
-    result = cast(dict[str, object], handler._sync_run(_save))
-    handler._send_json(HTTPStatus.CREATED if result["created"] else HTTPStatus.OK, result)
+    result = cast(MutationResultPayload, handler._sync_run(_save))
+    _send_mutation_result(handler, result, created=result.detail is None)
 
 
 def handle_delete_annotation(handler: Any, annotation_id: str) -> None:
-    async def _delete(poly: Any) -> dict[str, object]:
+    async def _delete(poly: Any) -> MutationResultPayload:
         deleted = await poly.delete_annotation(annotation_id)
-        return {"annotation_id": annotation_id, "deleted": deleted}
+        status, detail, affected_count = _mutation_status(deleted, missing_detail="annotation_not_found")
+        return MutationResultPayload(
+            status="deleted" if status == "ok" else status,
+            detail=detail,
+            operation="annotation.delete",
+            affected_count=affected_count,
+            resource_type="annotation",
+            resource_id=annotation_id,
+        )
 
-    handler._send_json(HTTPStatus.OK, handler._sync_run(_delete))
+    result = cast(MutationResultPayload, handler._sync_run(_delete))
+    _send_mutation_result(handler, result)
 
 
 def handle_list_saved_views(handler: Any) -> None:
@@ -365,25 +412,39 @@ def handle_save_view(handler: Any) -> None:
     query_json = json.dumps(query, sort_keys=True, separators=(",", ":"))
     view_id = str(body.get("view_id") or _default_saved_view_id(name, query_json))
 
-    async def _save(poly: Any) -> dict[str, object]:
-        created = await poly.save_view(view_id, name, query_json)
-        saved = await poly.get_view(view_id)
-        if saved is None:
-            return {"view_id": view_id, "created": created}
-        result = _saved_view_payload(saved)
-        result["created"] = created
-        return result
+    async def _save(poly: Any) -> MutationResultPayload:
+        existing = await poly.get_view(view_id)
+        await poly.save_view(view_id, name, query_json)
+        created = existing is None
+        status, detail, affected_count = _save_mutation_status(created)
+        return MutationResultPayload(
+            status=status,
+            detail=detail,
+            operation="saved_view.save",
+            affected_count=affected_count,
+            resource_type="saved_view",
+            resource_id=view_id,
+        )
 
-    result = cast(dict[str, object], handler._sync_run(_save))
-    handler._send_json(HTTPStatus.CREATED if result["created"] else HTTPStatus.OK, result)
+    result = cast(MutationResultPayload, handler._sync_run(_save))
+    _send_mutation_result(handler, result, created=result.detail is None)
 
 
 def handle_delete_saved_view(handler: Any, view_id: str) -> None:
-    async def _delete(poly: Any) -> dict[str, object]:
+    async def _delete(poly: Any) -> MutationResultPayload:
         deleted = await poly.delete_view(view_id)
-        return {"view_id": view_id, "deleted": deleted}
+        status, detail, affected_count = _mutation_status(deleted, missing_detail="saved_view_not_found")
+        return MutationResultPayload(
+            status="deleted" if status == "ok" else status,
+            detail=detail,
+            operation="saved_view.delete",
+            affected_count=affected_count,
+            resource_type="saved_view",
+            resource_id=view_id,
+        )
 
-    handler._send_json(HTTPStatus.OK, handler._sync_run(_delete))
+    result = cast(MutationResultPayload, handler._sync_run(_delete))
+    _send_mutation_result(handler, result)
 
 
 def handle_list_recall_packs(handler: Any) -> None:
@@ -422,25 +483,39 @@ def handle_save_recall_pack(handler: Any) -> None:
         return
     payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
-    async def _save(poly: Any) -> dict[str, object]:
-        created = await poly.create_recall_pack(pack_id, label, payload_json)
-        saved = await poly.get_recall_pack(pack_id)
-        if saved is None:
-            return {"pack_id": pack_id, "created": created}
-        result = _recall_pack_payload(saved)
-        result["created"] = created
-        return result
+    async def _save(poly: Any) -> MutationResultPayload:
+        existing = await poly.get_recall_pack(pack_id)
+        await poly.create_recall_pack(pack_id, label, payload_json)
+        created = existing is None
+        status, detail, affected_count = _save_mutation_status(created)
+        return MutationResultPayload(
+            status=status,
+            detail=detail,
+            operation="recall_pack.save",
+            affected_count=affected_count,
+            resource_type="recall_pack",
+            resource_id=pack_id,
+        )
 
-    result = cast(dict[str, object], handler._sync_run(_save))
-    handler._send_json(HTTPStatus.CREATED if result["created"] else HTTPStatus.OK, result)
+    result = cast(MutationResultPayload, handler._sync_run(_save))
+    _send_mutation_result(handler, result, created=result.detail is None)
 
 
 def handle_delete_recall_pack(handler: Any, pack_id: str) -> None:
-    async def _delete(poly: Any) -> dict[str, object]:
+    async def _delete(poly: Any) -> MutationResultPayload:
         deleted = await poly.delete_recall_pack(pack_id)
-        return {"pack_id": pack_id, "deleted": deleted}
+        status, detail, affected_count = _mutation_status(deleted, missing_detail="recall_pack_not_found")
+        return MutationResultPayload(
+            status="deleted" if status == "ok" else status,
+            detail=detail,
+            operation="recall_pack.delete",
+            affected_count=affected_count,
+            resource_type="recall_pack",
+            resource_id=pack_id,
+        )
 
-    handler._send_json(HTTPStatus.OK, handler._sync_run(_delete))
+    result = cast(MutationResultPayload, handler._sync_run(_delete))
+    _send_mutation_result(handler, result)
 
 
 def handle_list_workspaces(handler: Any) -> None:
@@ -485,8 +560,9 @@ def handle_save_workspace(handler: Any) -> None:
         handler._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
         return
 
-    async def _save(poly: Any) -> dict[str, object]:
-        created = await poly.save_workspace(
+    async def _save(poly: Any) -> MutationResultPayload:
+        existing = await poly.get_workspace(workspace_id)
+        await poly.save_workspace(
             workspace_id,
             name,
             mode,
@@ -494,20 +570,33 @@ def handle_save_workspace(handler: Any) -> None:
             json.dumps(layout, sort_keys=True, separators=(",", ":")),
             json.dumps(active_target, sort_keys=True, separators=(",", ":")),
         )
-        saved = await poly.get_workspace(workspace_id)
-        if saved is None:
-            return {"workspace_id": workspace_id, "created": created}
-        result = _workspace_payload(saved)
-        result["created"] = created
-        return result
+        created = existing is None
+        status, detail, affected_count = _save_mutation_status(created)
+        return MutationResultPayload(
+            status=status,
+            detail=detail,
+            operation="workspace.save",
+            affected_count=affected_count,
+            resource_type="workspace",
+            resource_id=workspace_id,
+        )
 
-    result = cast(dict[str, object], handler._sync_run(_save))
-    handler._send_json(HTTPStatus.CREATED if result["created"] else HTTPStatus.OK, result)
+    result = cast(MutationResultPayload, handler._sync_run(_save))
+    _send_mutation_result(handler, result, created=result.detail is None)
 
 
 def handle_delete_workspace(handler: Any, workspace_id: str) -> None:
-    async def _delete(poly: Any) -> dict[str, object]:
+    async def _delete(poly: Any) -> MutationResultPayload:
         deleted = await poly.delete_workspace(workspace_id)
-        return {"workspace_id": workspace_id, "deleted": deleted}
+        status, detail, affected_count = _mutation_status(deleted, missing_detail="workspace_not_found")
+        return MutationResultPayload(
+            status="deleted" if status == "ok" else status,
+            detail=detail,
+            operation="workspace.delete",
+            affected_count=affected_count,
+            resource_type="workspace",
+            resource_id=workspace_id,
+        )
 
-    handler._send_json(HTTPStatus.OK, handler._sync_run(_delete))
+    result = cast(MutationResultPayload, handler._sync_run(_delete))
+    _send_mutation_result(handler, result)

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1696,7 +1696,7 @@ class ContextPreambleBlackboardNote(SurfacePayloadModel):
 
 
 class MutationResultPayload(SurfacePayloadModel):
-    """Shared result envelope for tag, metadata, and delete mutations.
+    """Shared result envelope for user-visible mutation surfaces.
 
     Carries idempotent status codes, context fields, and bulk-operation
     counts so that CLI, MCP, API, and daemon surfaces all expose the
@@ -1711,7 +1711,7 @@ class MutationResultPayload(SurfacePayloadModel):
     session_id: str | None = None
     detail: str | None = None
     """Machine-readable detail: ``already_present``, ``tag_not_present``,
-    ``key_not_found``, ``value_unchanged``, ``session_not_found``."""
+    ``updated``, ``key_not_found``, ``value_unchanged``, ``session_not_found``."""
 
     outcome: str | None = None
     """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
@@ -1720,13 +1720,18 @@ class MutationResultPayload(SurfacePayloadModel):
     skipped_count: int | None = None
     tag: str | None = None
     key: str | None = None
+    target_type: str | None = None
+    target_id: str | None = None
+    message_id: str | None = None
+    mark_type: str | None = None
+    resource_type: str | None = None
+    resource_id: str | None = None
     session_count: int | None = None
     tag_count: int | None = None
     applied_count: int | None = None
     operation: str | None = None
-    """CLI bulk-mutation discriminator: ``add_tag``, ``set_meta``, ``mutate``, or
-    ``delete``. ``None`` for the single-session MCP/daemon surfaces, whose
-    operation is implied by the calling tool/endpoint."""
+    """Mutation discriminator such as ``add_tag``, ``set_meta``,
+    ``annotation.save``, ``saved_view.delete``, ``mutate``, or ``delete``."""
     session_ids: tuple[str, ...] | None = None
     """Session ids enumerated by a CLI bulk operation (e.g. the delete dry-run
     preview lists the sessions that *would* be deleted). ``None`` for

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -38,6 +38,15 @@ def test_stable_routes_have_explicit_auth_and_response_contracts() -> None:
         assert route.response_contract
 
 
+def test_stable_user_overlay_mutations_use_shared_envelope_contract() -> None:
+    """Browser write routes expose the common mutation result payload (#1847)."""
+
+    for route in stable_route_contracts():
+        if route.kind == "user_overlay" and route.method in {"POST", "DELETE"}:
+            assert route.auth_policy == "bearer_and_same_origin"
+            assert route.response_contract == "mutation envelope"
+
+
 def test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary_stabilizes() -> None:
     """#1847 owns public daemon API stability for the new workbench routes."""
 

--- a/tests/unit/daemon/test_user_state_http.py
+++ b/tests/unit/daemon/test_user_state_http.py
@@ -299,17 +299,21 @@ class TestMarksContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
+        assert payload["status"] == "ok"
+        assert payload["operation"] == "mark.add"
+        assert payload["affected_count"] == 1
         assert payload["mark_type"] == "star"
         assert payload["session_id"] == conv_id
-        assert payload["created"] is True
 
-        # CREATE again — idempotent, ``created=False`` and OK (not CREATED)
+        # CREATE again — idempotent, unchanged and OK (not CREATED)
         handler = _make_handler("POST", "/api/user/marks", body=body)
         _, send_json = _capture(handler)
         handler.do_POST()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["created"] is False
+        assert payload["status"] == "unchanged"
+        assert payload["detail"] == "already_present"
+        assert payload["affected_count"] == 0
 
         # LIST — envelope shape, contains the mark
         handler = _make_handler("GET", "/api/user/marks")
@@ -328,7 +332,9 @@ class TestMarksContract:
         handler.do_DELETE()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["deleted"] is True
+        assert payload["status"] == "deleted"
+        assert payload["operation"] == "mark.delete"
+        assert payload["affected_count"] == 1
         assert payload["mark_type"] == "star"
 
     @pytest.mark.parametrize(
@@ -413,7 +419,11 @@ class TestAnnotationsContract:
         handler.do_POST()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["created"] is True
+        assert payload["status"] == "ok"
+        assert payload["operation"] == "annotation.save"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "annotation"
+        assert payload["resource_id"] == "ann-1"
 
         # GET
         handler = _make_handler("GET", "/api/user/annotations/ann-1")
@@ -431,13 +441,15 @@ class TestAnnotationsContract:
         _, payload = send_json.call_args.args
         assert payload["total"] >= 1
 
-        # Re-save — ``created=False``, status OK
+        # Re-save updates the existing resource and remains an affected mutation.
         handler = _make_handler("POST", "/api/user/annotations", body=body)
         _, send_json = _capture(handler)
         handler.do_POST()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["created"] is False
+        assert payload["status"] == "ok"
+        assert payload["detail"] == "updated"
+        assert payload["affected_count"] == 1
 
         # DELETE
         handler = _make_handler("DELETE", "/api/user/annotations/ann-1")
@@ -445,7 +457,11 @@ class TestAnnotationsContract:
         handler.do_DELETE()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["deleted"] is True
+        assert payload["status"] == "deleted"
+        assert payload["operation"] == "annotation.delete"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "annotation"
+        assert payload["resource_id"] == "ann-1"
 
     def test_get_missing_annotation_returns_404(
         self,
@@ -506,11 +522,13 @@ class TestSavedViewsContract:
         handler.do_POST()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["view_id"] == "v-1"
-        assert payload["created"] is True
-        # query is exposed both as parsed dict and as canonical JSON string
-        assert payload["query"] == {"limit": 10}
-        assert isinstance(payload["query_json"], str)
+        assert payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "saved_view.save",
+            "resource_type": "saved_view",
+            "resource_id": "v-1",
+        }
 
         # GET
         handler = _make_handler("GET", "/api/user/saved-views/v-1")
@@ -520,6 +538,8 @@ class TestSavedViewsContract:
         assert status == HTTPStatus.OK
         assert payload["view_id"] == "v-1"
         assert payload["name"] == "Recent stars"
+        assert payload["query"] == {"limit": 10}
+        assert isinstance(payload["query_json"], str)
 
         # LIST envelope
         handler = _make_handler("GET", "/api/user/saved-views")
@@ -529,13 +549,36 @@ class TestSavedViewsContract:
         assert payload["total"] >= 1
         assert all({"view_id", "name", "query", "query_json"} <= set(item.keys()) for item in payload["items"])
 
+        # Re-save updates the existing resource and remains an affected mutation.
+        updated_body = json.dumps(
+            {
+                "view_id": "v-1",
+                "name": "Recent stars",
+                "query": {"limit": 25},
+            }
+        ).encode()
+        handler = _make_handler("POST", "/api/user/saved-views", body=updated_body)
+        _, send_json = _capture(handler)
+        handler.do_POST()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["status"] == "ok"
+        assert payload["detail"] == "updated"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "saved_view"
+        assert payload["resource_id"] == "v-1"
+
         # DELETE
         handler = _make_handler("DELETE", "/api/user/saved-views/v-1")
         _, send_json = _capture(handler)
         handler.do_DELETE()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["deleted"] is True
+        assert payload["status"] == "deleted"
+        assert payload["operation"] == "saved_view.delete"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "saved_view"
+        assert payload["resource_id"] == "v-1"
 
     def test_get_missing_view_returns_404(
         self,
@@ -601,9 +644,13 @@ class TestRecallPacksContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["pack_id"] == "rp-1"
-        assert payload["label"] == "First pack"
-        assert payload["created"] is True
+        assert payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "recall_pack.save",
+            "resource_type": "recall_pack",
+            "resource_id": "rp-1",
+        }
 
         # GET
         handler = _make_handler("GET", "/api/user/recall-packs/rp-1")
@@ -628,7 +675,11 @@ class TestRecallPacksContract:
         handler.do_DELETE()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["deleted"] is True
+        assert payload["status"] == "deleted"
+        assert payload["operation"] == "recall_pack.delete"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "recall_pack"
+        assert payload["resource_id"] == "rp-1"
 
     def test_get_missing_pack_returns_404(
         self,
@@ -692,20 +743,23 @@ class TestWorkspacesContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["workspace_id"] == "ws-1"
-        assert payload["mode"] == "tabs"
-        assert isinstance(payload["open_targets"], list)
-        assert isinstance(payload["layout"], dict)
-        assert isinstance(payload["active_target"], dict)
-        assert payload["created"] is True
+        assert payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "workspace.save",
+            "resource_type": "workspace",
+            "resource_id": "ws-1",
+        }
 
-        # Resave (no changes) — created=False
+        # Resave (no changes) — unchanged
         handler = _make_handler("POST", "/api/user/workspaces", body=body)
         _, send_json = _capture(handler)
         handler.do_POST()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["created"] is False
+        assert payload["status"] == "ok"
+        assert payload["detail"] == "updated"
+        assert payload["affected_count"] == 1
 
         # GET
         handler = _make_handler("GET", "/api/user/workspaces/ws-1")
@@ -714,6 +768,10 @@ class TestWorkspacesContract:
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
         assert payload["workspace_id"] == "ws-1"
+        assert payload["mode"] == "tabs"
+        assert isinstance(payload["open_targets"], list)
+        assert isinstance(payload["layout"], dict)
+        assert isinstance(payload["active_target"], dict)
 
         # LIST
         handler = _make_handler("GET", "/api/user/workspaces")
@@ -728,7 +786,11 @@ class TestWorkspacesContract:
         handler.do_DELETE()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.OK
-        assert payload["deleted"] is True
+        assert payload["status"] == "deleted"
+        assert payload["operation"] == "workspace.delete"
+        assert payload["affected_count"] == 1
+        assert payload["resource_type"] == "workspace"
+        assert payload["resource_id"] == "ws-1"
 
     def test_get_missing_workspace_returns_404(
         self,

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -917,37 +917,38 @@ class TestReaderUserState:
             empty = _get_json(base_url, "/api/user/marks?session_id=claude-code-session:c1")
 
         marks_payload = cast(dict[str, object], marks)
+        created_payload = cast(dict[str, object], created)
+        duplicate_payload = cast(dict[str, object], duplicate)
+        deleted_payload = cast(dict[str, object], deleted)
         assert status == 201
-        assert created == {
-            "target_type": "session",
-            "target_id": "claude-code-session:c1",
-            "session_id": "claude-code-session:c1",
-            "message_id": None,
-            "mark_type": "star",
-            "created": True,
-        }
+        assert created_payload["status"] == "ok"
+        assert created_payload["operation"] == "mark.add"
+        assert created_payload["affected_count"] == 1
+        assert created_payload["target_type"] == "session"
+        assert created_payload["target_id"] == "claude-code-session:c1"
+        assert created_payload["session_id"] == "claude-code-session:c1"
+        assert created_payload["mark_type"] == "star"
         assert status2 == 200
-        assert duplicate == {
-            "target_type": "session",
-            "target_id": "claude-code-session:c1",
-            "session_id": "claude-code-session:c1",
-            "message_id": None,
-            "mark_type": "star",
-            "created": False,
-        }
+        assert duplicate_payload["status"] == "unchanged"
+        assert duplicate_payload["detail"] == "already_present"
+        assert duplicate_payload["operation"] == "mark.add"
+        assert duplicate_payload["affected_count"] == 0
+        assert duplicate_payload["target_type"] == "session"
+        assert duplicate_payload["target_id"] == "claude-code-session:c1"
+        assert duplicate_payload["session_id"] == "claude-code-session:c1"
+        assert duplicate_payload["mark_type"] == "star"
         mark_items = cast(list[dict[str, object]], marks_payload["items"])
         assert mark_items[0]["mark_type"] == "star"
         assert mark_items[0]["target_type"] == "session"
         assert mark_items[0]["target_id"] == "claude-code-session:c1"
         assert delete_status == 200
-        assert deleted == {
-            "target_type": "session",
-            "target_id": "claude-code-session:c1",
-            "session_id": "claude-code-session:c1",
-            "message_id": None,
-            "mark_type": "star",
-            "deleted": True,
-        }
+        assert deleted_payload["status"] == "deleted"
+        assert deleted_payload["operation"] == "mark.delete"
+        assert deleted_payload["affected_count"] == 1
+        assert deleted_payload["target_type"] == "session"
+        assert deleted_payload["target_id"] == "claude-code-session:c1"
+        assert deleted_payload["session_id"] == "claude-code-session:c1"
+        assert deleted_payload["mark_type"] == "star"
         assert empty == {"items": [], "total": 0}
 
     def test_message_marks_are_target_aware(self, workspace_env: dict[str, Path]) -> None:
@@ -968,6 +969,8 @@ class TestReaderUserState:
         marks_payload = cast(dict[str, object], marks)
         created_payload = cast(dict[str, object], created)
         assert status == 201
+        assert created_payload["status"] == "ok"
+        assert created_payload["operation"] == "mark.add"
         assert created_payload["target_type"] == "message"
         assert created_payload["target_id"] == "claude-code-session:c1:m-c1"
         assert created_payload["message_id"] == "claude-code-session:c1:m-c1"
@@ -1010,6 +1013,7 @@ class TestReaderUserState:
             listed = _get_json(base_url, "/api/user/annotations?session_id=claude-code-session:c1")
             fetched = _get_json(base_url, "/api/user/annotations/ann-m1")
             delete_status, deleted = _request_json(base_url, "DELETE", "/api/user/annotations/ann-c1")
+            missing_delete_status, missing_deleted = _request_json(base_url, "DELETE", "/api/user/annotations/ann-c1")
 
         listed_payload = cast(dict[str, object], listed)
         conv_note_payload = cast(dict[str, object], conv_note)
@@ -1017,15 +1021,40 @@ class TestReaderUserState:
         fetched_payload = cast(dict[str, object], fetched)
         items = cast(list[dict[str, object]], listed_payload["items"])
         assert conv_status == 201
+        assert conv_note_payload["status"] == "ok"
+        assert conv_note_payload["operation"] == "annotation.save"
+        assert conv_note_payload["affected_count"] == 1
+        assert conv_note_payload["resource_type"] == "annotation"
+        assert conv_note_payload["resource_id"] == "ann-c1"
         assert conv_note_payload["target_type"] == "session"
         assert conv_note_payload["target_id"] == "claude-code-session:c1"
         assert msg_status == 201
+        assert msg_note_payload["status"] == "ok"
+        assert msg_note_payload["operation"] == "annotation.save"
+        assert msg_note_payload["affected_count"] == 1
+        assert msg_note_payload["resource_type"] == "annotation"
+        assert msg_note_payload["resource_id"] == "ann-m1"
         assert msg_note_payload["target_type"] == "message"
         assert msg_note_payload["target_id"] == "claude-code-session:c1:m-c1"
         assert fetched_payload["note_text"] == "Important request"
         assert {item["annotation_id"] for item in items} == {"ann-c1", "ann-m1"}
         assert delete_status == 200
-        assert deleted == {"annotation_id": "ann-c1", "deleted": True}
+        assert deleted == {
+            "status": "deleted",
+            "affected_count": 1,
+            "operation": "annotation.delete",
+            "resource_type": "annotation",
+            "resource_id": "ann-c1",
+        }
+        assert missing_delete_status == 200
+        assert missing_deleted == {
+            "status": "not_found",
+            "detail": "annotation_not_found",
+            "affected_count": 0,
+            "operation": "annotation.delete",
+            "resource_type": "annotation",
+            "resource_id": "ann-c1",
+        }
 
     def test_saved_views_roundtrip_query_specs(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -1047,17 +1076,29 @@ class TestReaderUserState:
         listed_payload = cast(dict[str, object], listed)
         fetched_payload = cast(dict[str, object], fetched)
         assert status == 201
-        assert saved_payload["created"] is True
-        assert saved_payload["query"] == {"limit": 5, "origin": "claude-code-session", "query": "auth"}
+        assert saved_payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "saved_view.save",
+            "resource_type": "saved_view",
+            "resource_id": "view-auth",
+        }
         assert listed_payload["total"] == 1
         assert fetched_payload["view_id"] == "view-auth"
+        assert fetched_payload["query"] == {"limit": 5, "origin": "claude-code-session", "query": "auth"}
         assert json.loads(str(fetched_payload["query_json"])) == {
             "limit": 5,
             "origin": "claude-code-session",
             "query": "auth",
         }
         assert delete_status == 200
-        assert deleted == {"view_id": "view-auth", "deleted": True}
+        assert deleted == {
+            "status": "deleted",
+            "affected_count": 1,
+            "operation": "saved_view.delete",
+            "resource_type": "saved_view",
+            "resource_id": "view-auth",
+        }
 
     def test_saved_view_rejects_unknown_query_params(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -1104,7 +1145,13 @@ class TestReaderUserState:
         listed_payload = cast(dict[str, object], listed)
         fetched_payload = cast(dict[str, object], fetched)
         assert status == 201
-        assert saved_payload["created"] is True
+        assert saved_payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "recall_pack.save",
+            "resource_type": "recall_pack",
+            "resource_id": "pack-auth",
+        }
         assert listed_payload["total"] == 1
         assert fetched_payload["session_ids"] == ["claude-code-session:c1"]
         payload = cast(dict[str, object], fetched_payload["payload"])
@@ -1118,7 +1165,13 @@ class TestReaderUserState:
             ("message", "missing"),
         ]
         assert delete_status == 200
-        assert deleted == {"pack_id": "pack-auth", "deleted": True}
+        assert deleted == {
+            "status": "deleted",
+            "affected_count": 1,
+            "operation": "recall_pack.delete",
+            "resource_type": "recall_pack",
+            "resource_id": "pack-auth",
+        }
 
     def test_recall_pack_rejects_session_ids_compat_input(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -1178,7 +1231,13 @@ class TestReaderUserState:
         listed_payload = cast(dict[str, object], listed)
         fetched_payload = cast(dict[str, object], fetched)
         assert status == 201
-        assert saved_payload["created"] is True
+        assert saved_payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "workspace.save",
+            "resource_type": "workspace",
+            "resource_id": "workspace-auth",
+        }
         assert listed_payload["total"] == 1
         assert fetched_payload["mode"] == "compare"
         assert fetched_payload["layout"] == {"panes": [{"width": 0.5}, {"width": 0.5}]}
@@ -1195,7 +1254,13 @@ class TestReaderUserState:
         # over the full message id, so the session prefix appears twice.
         assert active_target["identity_key"] == f"message:{C1}:{M_C1}"
         assert delete_status == 200
-        assert deleted == {"workspace_id": "workspace-auth", "deleted": True}
+        assert deleted == {
+            "status": "deleted",
+            "affected_count": 1,
+            "operation": "workspace.delete",
+            "resource_type": "workspace",
+            "resource_id": "workspace-auth",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -2108,11 +2173,24 @@ class TestReaderSavedViewsUI:
         empty_payload = cast(dict[str, object], empty_listing)
         items = cast(list[dict[str, object]], listed_payload["items"])
         assert save_status == 201
-        assert saved_payload["name"] == "Reader UI flow"
+        assert saved_payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "saved_view.save",
+            "resource_type": "saved_view",
+            "resource_id": "view-ui",
+        }
         assert listed_payload["total"] == 1
         assert items[0]["view_id"] == "view-ui"
+        assert items[0]["name"] == "Reader UI flow"
         assert delete_status == 200
-        assert deleted == {"view_id": "view-ui", "deleted": True}
+        assert deleted == {
+            "status": "deleted",
+            "affected_count": 1,
+            "operation": "saved_view.delete",
+            "resource_type": "saved_view",
+            "resource_id": "view-ui",
+        }
         assert empty_payload == {"items": [], "total": 0}
 
 

--- a/tests/unit/daemon/test_web_shell_endpoint_contracts.py
+++ b/tests/unit/daemon/test_web_shell_endpoint_contracts.py
@@ -573,12 +573,13 @@ class TestWebShellWorkspaceAssetContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["workspace_id"] == "ws-toolbar"
-        assert payload["mode"] == "stack"
-        # The fields the toolbar reads off the response after save.
-        assert isinstance(payload["open_targets"], list)
-        assert isinstance(payload["layout"], dict)
-        assert isinstance(payload["active_target"], dict)
+        assert payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "workspace.save",
+            "resource_type": "workspace",
+            "resource_id": "ws-toolbar",
+        }
 
     def test_save_recall_pack_endpoint_accepts_toolbar_payload(
         self,
@@ -604,7 +605,13 @@ class TestWebShellWorkspaceAssetContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["pack_id"] == "pack-toolbar"
+        assert payload == {
+            "status": "ok",
+            "affected_count": 1,
+            "operation": "recall_pack.save",
+            "resource_type": "recall_pack",
+            "resource_id": "pack-toolbar",
+        }
 
     def test_save_view_endpoint_accepts_toolbar_payload(
         self,
@@ -618,5 +625,8 @@ class TestWebShellWorkspaceAssetContract:
         send_error.assert_not_called()
         status, payload = send_json.call_args.args
         assert status == HTTPStatus.CREATED
-        assert payload["name"] == "Toolbar view"
-        assert payload["query"] == {"limit": 20, "origin": "claude-code-session"}
+        assert payload["status"] == "ok"
+        assert payload["affected_count"] == 1
+        assert payload["operation"] == "saved_view.save"
+        assert payload["resource_type"] == "saved_view"
+        assert isinstance(payload["resource_id"], str)

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -211,16 +211,15 @@ def test_cursor_records_live_ingest_attempt_progress(tmp_path: Path) -> None:
             SELECT attempt_id, stage, payload_json
             FROM daemon_stage_events
             ORDER BY observed_at_ms DESC, event_id DESC
-            LIMIT 1
             """
         ).fetchall()
 
     assert running.status == "running"
     assert running.phase == "full_parse"
     assert running.current_path == str(source)
-    assert len(events) == 1
-    assert events[0][0:2] == (attempt_id, "full_parse")
-    assert str(source) in events[0][2]
+    matching_events = [event for event in events if event[0:2] == (attempt_id, "full_parse")]
+    assert matching_events
+    assert any(str(source) in event[2] for event in matching_events)
 
     store.finish_ingest_attempt(attempt_id, status="completed", phase="completed")
     completed = store.recent_ingest_attempts(limit=1)[0]


### PR DESCRIPTION
## Summary

Stabilizes the daemon user-overlay mutation routes by routing marks, annotations, saved views, recall packs, and workspaces through the shared `MutationResultPayload` envelope. Resource detail remains available from the corresponding read endpoints; POST/DELETE now report mutation outcome, affected count, operation, and target/resource identity consistently.

## Problem

`polylogue/daemon/route_contracts.py` already classified user-overlay writes as stable same-origin mutation routes with a `mutation envelope` response contract, but several handlers still returned ad hoc `{created: ...}` / `{deleted: ...}` dictionaries or full resource bodies. That made the stable route metadata more precise than the implementation and kept browser/UI tests coupled to mutation responses as if they were read payloads.

## Solution

- Extended `MutationResultPayload` with target and resource identity fields needed by user-overlay routes.
- Converted `POST`/`DELETE /api/user/{marks,annotations,saved-views,recall-packs,workspaces}` to emit the shared envelope.
- Kept detailed saved-view, annotation, recall-pack, and workspace state on the `GET /api/user/...` read routes.
- Added route-contract coverage for stable user-overlay mutations and updated daemon/UI tests to assert envelope behavior.
- Stabilized the live-watcher progress test to assert the `full_parse` event exists instead of relying on newest-event ordering.
- Regenerated the mutation-result output schema and updated daemon/workbench docs.

Ref #1847

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_route_contracts.py tests/unit/daemon/test_web_reader.py::TestReaderUserState tests/unit/daemon/test_web_reader.py::TestReaderBulkOperations::test_bulk_tag_drives_existing_marks_endpoint` → 89 passed.
- `nix develop --command devtools test tests/unit/daemon/test_user_state_http.py::TestMarksContract::test_create_then_list_then_delete_roundtrip tests/unit/daemon/test_user_state_http.py::TestAnnotationsContract::test_save_then_get_then_list_then_delete tests/unit/daemon/test_user_state_http.py::TestSavedViewsContract::test_save_then_get_then_list_then_delete tests/unit/daemon/test_user_state_http.py::TestRecallPacksContract::test_save_then_get_then_list_then_delete tests/unit/daemon/test_user_state_http.py::TestWorkspacesContract::test_save_then_get_then_list_then_delete tests/unit/daemon/test_web_shell_endpoint_contracts.py::TestWebShellWorkspaceAssetContract::test_save_workspace_endpoint_accepts_toolbar_payload tests/unit/daemon/test_web_shell_endpoint_contracts.py::TestWebShellWorkspaceAssetContract::test_save_recall_pack_endpoint_accepts_toolbar_payload tests/unit/daemon/test_web_shell_endpoint_contracts.py::TestWebShellWorkspaceAssetContract::test_save_view_endpoint_accepts_toolbar_payload tests/unit/daemon/test_web_reader.py::TestReaderSavedViewsUI::test_saved_views_endpoint_roundtrip_supports_ui_flow tests/unit/sources/test_live_watcher.py::test_cursor_records_live_ingest_attempt_progress` → 10 passed.
- `nix develop --command devtools verify --quick` → exit_code 0.
- `nix develop --command devtools verify --seed-testmon --skip-slow` → exit_code 0; 11,486 passed, 1 xfailed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mutation operations for marks, annotations, saved views, recall packs, and workspaces now return a standardized response envelope with status, operation type, affected item count, and resource identifiers.

* **Documentation**
  * Updated API documentation describing the standardized mutation response format, required authentication, and resource retrieval via corresponding read endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->