### PR TITLE
feat(query): expose run terminal query rows (#2006)

### DIFF
--- a/devtools/render_cli_output_schemas.py
+++ b/devtools/render_cli_output_schemas.py
@@ -135,7 +135,7 @@ SCHEMAS: tuple[CliOutputSchema, ...] = (
         title="Query Unit Envelope",
         description=(
             "Terminal row envelope for explicit "
-            "`messages/actions/blocks/assertions/observed-events/context-snapshots where ...` "
+            "`messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...` "
             "query-unit expressions. "
             "Shared by CLI JSON output, Python API, MCP, and daemon HTTP."
         ),

--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -199,7 +199,7 @@ def _build_openapi_document() -> dict[str, Any]:
                     "summary": "Terminal query-unit rows",
                     "description": (
                         "Returns terminal row results for explicit "
-                        "``messages/actions/blocks/assertions/observed-events/context-snapshots where ...`` expressions. "
+                        "``messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`` expressions. "
                         "This endpoint shares the ``QueryUnitEnvelope`` contract "
                         "with CLI JSON output, MCP ``query_units``, and "
                         "``Polylogue.query_units()``."

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -120,7 +120,7 @@ Get messages for a session. Query params: `limit`, `offset`.
 
 Return terminal rows for explicit query-unit expressions. Query params:
 `expression`, `limit`, `offset`. `expression` must be a
-`messages/actions/blocks/assertions/observed-events/context-snapshots where ...` query and returns the shared
+`messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...` query and returns the shared
 `QueryUnitEnvelope`.
 
 ### GET /api/facets

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -89,7 +89,7 @@ paths:
   /api/query-units:
     get:
       summary: Terminal query-unit rows
-      description: Returns terminal row results for explicit ``messages/actions/blocks/assertions/observed-events/context-snapshots
+      description: Returns terminal row results for explicit ``messages/actions/blocks/assertions/runs/observed-events/context-snapshots
         where ...`` expressions. This endpoint shares the ``QueryUnitEnvelope`` contract with CLI JSON output, MCP ``query_units``,
         and ``Polylogue.query_units()``.
       operationId: queryUnits
@@ -1087,6 +1087,116 @@ components:
       - evidence_refs
       title: ObservedEventQueryRowPayload
       type: object
+    RunQueryRowPayload:
+      additionalProperties: false
+      description: Shared terminal-query row for runtime-transform runs.
+      properties:
+        unit:
+          const: run
+          default: run
+          title: Unit
+          type: string
+        run_ref:
+          title: Run Ref
+          type: string
+        session_id:
+          title: Session Id
+          type: string
+        origin:
+          title: Origin
+          type: string
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Title
+        native_session_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Native Session Id
+        native_parent_session_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Native Parent Session Id
+        parent_run_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Parent Run Ref
+        agent_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Agent Ref
+        lineage_refs:
+          items:
+            type: string
+          title: Lineage Refs
+          type: array
+        provider_origin:
+          title: Provider Origin
+          type: string
+        harness:
+          title: Harness
+          type: string
+        role:
+          title: Role
+          type: string
+        cwd:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Cwd
+        git_branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Git Branch
+        status:
+          title: Status
+          type: string
+        confidence:
+          title: Confidence
+          type: string
+        transcript_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Transcript Ref
+        evidence_refs:
+          items:
+            type: string
+          title: Evidence Refs
+          type: array
+        context_snapshot_ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Context Snapshot Ref
+      required:
+      - run_ref
+      - session_id
+      - origin
+      - lineage_refs
+      - provider_origin
+      - harness
+      - role
+      - status
+      - confidence
+      - evidence_refs
+      title: RunQueryRowPayload
+      type: object
     QueryUnitEnvelope:
       additionalProperties: false
       description: Shared envelope for explicit terminal unit-source query results.
@@ -1102,6 +1212,7 @@ components:
           - action
           - block
           - assertion
+          - run
           - observed-event
           - context-snapshot
           title: Unit
@@ -1116,6 +1227,7 @@ components:
             - $ref: '#/components/schemas/ActionQueryRowPayload'
             - $ref: '#/components/schemas/BlockQueryRowPayload'
             - $ref: '#/components/schemas/AssertionQueryRowPayload'
+            - $ref: '#/components/schemas/RunQueryRowPayload'
             - $ref: '#/components/schemas/ObservedEventQueryRowPayload'
             - $ref: '#/components/schemas/ContextSnapshotQueryRowPayload'
           title: Items

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -590,12 +590,192 @@
       ],
       "title": "ObservedEventQueryRowPayload",
       "type": "object"
+    },
+    "RunQueryRowPayload": {
+      "additionalProperties": false,
+      "description": "Shared terminal-query row for runtime-transform runs.",
+      "properties": {
+        "agent_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Ref"
+        },
+        "confidence": {
+          "title": "Confidence",
+          "type": "string"
+        },
+        "context_snapshot_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Context Snapshot Ref"
+        },
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cwd"
+        },
+        "evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "git_branch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Git Branch"
+        },
+        "harness": {
+          "title": "Harness",
+          "type": "string"
+        },
+        "lineage_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Lineage Refs",
+          "type": "array"
+        },
+        "native_parent_session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Native Parent Session Id"
+        },
+        "native_session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Native Session Id"
+        },
+        "origin": {
+          "title": "Origin",
+          "type": "string"
+        },
+        "parent_run_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Run Ref"
+        },
+        "provider_origin": {
+          "title": "Provider Origin",
+          "type": "string"
+        },
+        "role": {
+          "title": "Role",
+          "type": "string"
+        },
+        "run_ref": {
+          "title": "Run Ref",
+          "type": "string"
+        },
+        "session_id": {
+          "title": "Session Id",
+          "type": "string"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "transcript_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transcript Ref"
+        },
+        "unit": {
+          "const": "run",
+          "default": "run",
+          "title": "Unit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "run_ref",
+        "session_id",
+        "origin",
+        "lineage_refs",
+        "provider_origin",
+        "harness",
+        "role",
+        "status",
+        "confidence",
+        "evidence_refs"
+      ],
+      "title": "RunQueryRowPayload",
+      "type": "object"
     }
   },
   "$id": "https://polylogue.dev/schemas/cli-output/query-unit-envelope.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "Terminal row envelope for explicit `messages/actions/blocks/assertions/observed-events/context-snapshots where ...` query-unit expressions. Shared by CLI JSON output, Python API, MCP, and daemon HTTP.\n\nGenerated from `polylogue.surfaces.payloads.QueryUnitEnvelope` by `devtools render cli-output-schemas`. Do not edit by hand.",
+  "description": "Terminal row envelope for explicit `messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...` query-unit expressions. Shared by CLI JSON output, Python API, MCP, and daemon HTTP.\n\nGenerated from `polylogue.surfaces.payloads.QueryUnitEnvelope` by `devtools render cli-output-schemas`. Do not edit by hand.",
   "properties": {
     "items": {
       "items": {
@@ -611,6 +791,9 @@
           },
           {
             "$ref": "#/$defs/AssertionQueryRowPayload"
+          },
+          {
+            "$ref": "#/$defs/RunQueryRowPayload"
           },
           {
             "$ref": "#/$defs/ObservedEventQueryRowPayload"
@@ -663,6 +846,7 @@
         "action",
         "block",
         "assertion",
+        "run",
         "observed-event",
         "context-snapshot"
       ],

--- a/docs/search.md
+++ b/docs/search.md
@@ -4,7 +4,7 @@
 
 Polylogue uses a query-first grammar over archive units. Bare tokens are
 full-text terms, field clauses narrow the selected unit, explicit
-`sessions/messages/actions/blocks/assertions/observed-events/context-snapshots where ...`
+`sessions/messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`
 forms opt into Boolean predicates,
 and trailing CLI verbs render or mutate the selected session set. The same
 query semantics — filters, retrieval lanes, ranking policy, and typed response

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1432,7 +1432,7 @@ class PolylogueArchiveMixin:
         source = parse_unit_source_expression(expression)
         if source is None:
             raise ExpressionCompileError(
-                "query_units requires an explicit messages/actions/blocks/assertions/observed-events/context-snapshots where expression",
+                "query_units requires an explicit messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
                 field=None,
             )
         session_filters = query_unit_session_filters(

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -41,7 +41,7 @@ and explicit Boolean session predicates:
     actions where action:file_edit AND path:polylogue/archive
     blocks where type:code AND text:timeout
 
-Unit-scoped ``messages/actions/blocks/assertions/observed-events/context-snapshots where ...`` predicates are executable
+Unit-scoped ``messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`` predicates are executable
 in two shared paths: ``compile_expression`` keeps the compatibility session
 selector behavior by lowering them to correlated ``exists <unit>(...)``
 predicates, while terminal query-unit surfaces preserve the selected unit and
@@ -94,6 +94,7 @@ from polylogue.archive.query.metadata import (
     _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS,
     _MESSAGE_STRUCTURAL_FIELDS,
     _OBSERVED_EVENT_STRUCTURAL_FIELDS,
+    _RUN_STRUCTURAL_FIELDS,
     _SOURCE_WHERE_SOURCES,
     _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS,
     COUNT_QUERY_FIELD_REGISTRY,
@@ -742,8 +743,11 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         elif unit == "observed-event":
             supported = _OBSERVED_EVENT_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
-        else:
+        elif unit == "context-snapshot":
             supported = _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS
+            effective_field = session_field or predicate.field
+        else:
+            supported = _RUN_STRUCTURAL_FIELDS
             effective_field = session_field or predicate.field
         if session_field is not None and unit != "session":
             supported = _BOOLEAN_SUPPORTED_FIELDS
@@ -784,6 +788,27 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 "object",
                 "object_ref",
                 "summary",
+                "agent",
+                "agent_ref",
+                "branch",
+                "context_snapshot",
+                "context_snapshot_ref",
+                "confidence",
+                "cwd",
+                "git_branch",
+                "harness",
+                "lineage",
+                "lineage_ref",
+                "native_parent_session_id",
+                "native_session_id",
+                "origin",
+                "parent",
+                "parent_run_ref",
+                "provider_origin",
+                "run",
+                "run_ref",
+                "transcript",
+                "transcript_ref",
             }
             and not predicate.values
         ):
@@ -1342,7 +1367,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
     if unit_source is not None:
         lowered = (
             SessionQuerySpec()
-            if unit_source.unit in {"observed-event", "context-snapshot"}
+            if unit_source.unit in {"run", "observed-event", "context-snapshot"}
             else SessionQuerySpec(
                 boolean_predicate=QueryExistsPredicate(unit=cast(Any, unit_source.unit), child=unit_source.predicate)
             )
@@ -1351,7 +1376,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
         execution_legs = _explain_unit_source_execution_legs(unit_source)
         plan_description = (f"terminal unit source: {unit_source.unit}",)
         compatibility_selector = None
-        if unit_source.unit not in {"observed-event", "context-snapshot"}:
+        if unit_source.unit not in {"run", "observed-event", "context-snapshot"}:
             compatibility_selector = f"exists {unit_source.unit}(...)"
             plan_description = (*plan_description, f"compatibility session selector: {compatibility_selector}")
         lowerer = "lark-query-unit-source-to-terminal-unit"

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-QueryUnitName = Literal["message", "action", "block", "assertion", "observed-event", "context-snapshot"]
+QueryUnitName = Literal["message", "action", "block", "assertion", "run", "observed-event", "context-snapshot"]
 
 #: Recognized DSL field tokens and a short human description.
 #: ``spec_field`` values correspond to :class:`~polylogue.archive.query.spec.SessionQuerySpec`
@@ -134,6 +134,8 @@ _SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = (
     ("blocks", "block"),
     ("assertion", "assertion"),
     ("assertions", "assertion"),
+    ("run", "run"),
+    ("runs", "run"),
     ("observed-event", "observed-event"),
     ("observed-events", "observed-event"),
     ("context-snapshot", "context-snapshot"),
@@ -211,9 +213,38 @@ _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS = {
     "metadata",
     "text",
 }
+_RUN_STRUCTURAL_FIELDS = {
+    "agent",
+    "agent_ref",
+    "branch",
+    "context_snapshot",
+    "context_snapshot_ref",
+    "confidence",
+    "cwd",
+    "evidence",
+    "git_branch",
+    "harness",
+    "lineage",
+    "lineage_ref",
+    "native_parent_session_id",
+    "native_session_id",
+    "origin",
+    "parent",
+    "parent_run_ref",
+    "provider_origin",
+    "role",
+    "run",
+    "run_ref",
+    "status",
+    "text",
+    "title",
+    "transcript",
+    "transcript_ref",
+}
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_ASSERTION_STRUCTURAL_FIELDS)
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_OBSERVED_EVENT_STRUCTURAL_FIELDS)
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS)
+_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS.update(_RUN_STRUCTURAL_FIELDS)
 
 
 @dataclass(frozen=True)
@@ -325,6 +356,53 @@ _CONTEXT_SNAPSHOT_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "text": _field_info("text", "Context snapshot ref/run/segment/evidence/metadata substring.", "text:session_start"),
 }
 
+_RUN_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
+    "agent": _field_info("agent", "Run agent ObjectRef substring.", "agent:agent:codex"),
+    "agent_ref": _field_info("agent_ref", "Run agent ObjectRef substring.", "agent_ref:agent:codex"),
+    "branch": _field_info("branch", "Run git branch substring.", "branch:feature"),
+    "context_snapshot": _field_info(
+        "context_snapshot",
+        "Run context snapshot ObjectRef substring.",
+        "context_snapshot:context-snapshot:",
+    ),
+    "context_snapshot_ref": _field_info(
+        "context_snapshot_ref",
+        "Run context snapshot ObjectRef substring.",
+        "context_snapshot_ref:context-snapshot:",
+    ),
+    "confidence": _field_info("confidence", "Run confidence source, such as raw or inferred.", "confidence:raw"),
+    "cwd": _field_info("cwd", "Run working directory substring.", "cwd:/realm/project"),
+    "evidence": _field_info("evidence", "Run evidence ref substring.", "evidence:session:"),
+    "git_branch": _field_info("git_branch", "Run git branch substring.", "git_branch:feature"),
+    "harness": _field_info("harness", "Run harness/runtime family.", "harness:codex"),
+    "lineage": _field_info("lineage", "Run lineage ObjectRef substring.", "lineage:run:"),
+    "lineage_ref": _field_info("lineage_ref", "Run lineage ObjectRef substring.", "lineage_ref:run:"),
+    "native_parent_session_id": _field_info(
+        "native_parent_session_id",
+        "Provider-native parent session id substring.",
+        "native_parent_session_id:abc",
+    ),
+    "native_session_id": _field_info(
+        "native_session_id",
+        "Provider-native session id substring.",
+        "native_session_id:abc",
+    ),
+    "origin": _field_info("origin", "Run provider-origin token.", "origin:codex-session"),
+    "parent": _field_info("parent", "Parent run ObjectRef substring.", "parent:run:"),
+    "parent_run_ref": _field_info("parent_run_ref", "Parent run ObjectRef substring.", "parent_run_ref:run:"),
+    "provider_origin": _field_info("provider_origin", "Run provider-origin token.", "provider_origin:codex-session"),
+    "role": _field_info("role", "Run role, such as main or subagent.", "role:main"),
+    "run": _field_info("run", "Run ObjectRef substring.", "run:run:"),
+    "run_ref": _field_info("run_ref", "Run ObjectRef substring.", "run_ref:run:"),
+    "status": _field_info("status", "Run status token.", "status:completed"),
+    "text": _field_info("text", "Run title/ref/agent/lineage/evidence substring.", "text:review"),
+    "title": _field_info("title", "Run title substring.", "title:review"),
+    "transcript": _field_info("transcript", "Run transcript evidence ref substring.", "transcript:session:"),
+    "transcript_ref": _field_info(
+        "transcript_ref", "Run transcript evidence ref substring.", "transcript_ref:session:"
+    ),
+}
+
 _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "action": "session.action:file_edit",
     "cwd": "session.cwd:/realm/project",
@@ -381,6 +459,11 @@ def _context_snapshot_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
     return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
 
 
+def _run_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
+    infos = [_RUN_STRUCTURAL_FIELD_INFO[name] for name in sorted(_RUN_STRUCTURAL_FIELDS)]
+    return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+
+
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     "action": StructuralQueryUnitInfo(
         description="Match sessions with at least one action row satisfying the child predicate.",
@@ -401,6 +484,11 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
         description="Match sessions with at least one session-targeted assertion satisfying the child predicate.",
         fields=_assertion_field_infos(),
         example="exists assertion(kind:decision AND status:active AND text:review)",
+    ),
+    "run": StructuralQueryUnitInfo(
+        description="Return runtime-transform runs satisfying the child predicate.",
+        fields=_run_field_infos(),
+        example="runs where session.repo:polylogue AND role:main",
     ),
     "observed-event": StructuralQueryUnitInfo(
         description="Return runtime-transform observed events satisfying the child predicate.",
@@ -548,6 +636,7 @@ __all__ = [
     "_CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS",
     "_MESSAGE_STRUCTURAL_FIELDS",
     "_OBSERVED_EVENT_STRUCTURAL_FIELDS",
+    "_RUN_STRUCTURAL_FIELDS",
     "_SOURCE_WHERE_SOURCES",
     "_STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS",
     "count_query_fields",

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -19,7 +19,7 @@ from polylogue.archive.query.spec import (
     split_csv,
 )
 from polylogue.core.refs import EvidenceRef, ObjectRef
-from polylogue.insights.run_projection import ContextSnapshot, ObservedEvent
+from polylogue.insights.run_projection import ContextSnapshot, ObservedEvent, ProjectedRun
 from polylogue.insights.transforms import compile_recovery_digest
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary, ArchiveStore
 from polylogue.surfaces.payloads import (
@@ -30,6 +30,7 @@ from polylogue.surfaces.payloads import (
     MessageQueryRowPayload,
     ObservedEventQueryRowPayload,
     QueryUnitEnvelope,
+    RunQueryRowPayload,
     build_query_unit_envelope,
 )
 
@@ -321,6 +322,116 @@ def _context_snapshot_matches(
     return False
 
 
+def _run_field_matches(
+    run: ProjectedRun,
+    summary: ArchiveSessionSummary,
+    predicate: QueryFieldPredicate,
+) -> bool:
+    field = predicate.field
+    if field.startswith("session."):
+        return _summary_field_matches(summary, predicate)
+    if field in {"run", "run_ref"}:
+        return _contains_value((_object_ref_text(run.run_ref),), predicate.values)
+    if field in {"parent", "parent_run_ref"}:
+        return _contains_value((_object_ref_text(run.parent_run_ref),), predicate.values)
+    if field in {"agent", "agent_ref"}:
+        return _contains_value((_object_ref_text(run.agent_ref),), predicate.values)
+    if field in {"lineage", "lineage_ref"}:
+        return _contains_value((_object_ref_text(ref) for ref in run.lineage_refs), predicate.values)
+    if field in {"context_snapshot", "context_snapshot_ref"}:
+        return _contains_value((_object_ref_text(run.context_snapshot_ref),), predicate.values)
+    if field in {"transcript", "transcript_ref"}:
+        return (
+            _contains_value((_evidence_ref_text(run.transcript_ref),), predicate.values)
+            if run.transcript_ref
+            else False
+        )
+    if field == "evidence":
+        return _contains_value((_evidence_ref_text(ref) for ref in run.evidence_refs), predicate.values)
+    if field == "native_session_id":
+        return _exact_or_contains(run.native_session_id, predicate.values)
+    if field == "native_parent_session_id":
+        return _exact_or_contains(run.native_parent_session_id, predicate.values)
+    if field in {"origin", "provider_origin"}:
+        return _exact_or_contains(run.provider_origin, predicate.values, exact=True)
+    if field == "harness":
+        return _exact_or_contains(run.harness, predicate.values, exact=True)
+    if field == "role":
+        return _exact_or_contains(run.role, predicate.values, exact=True)
+    if field == "status":
+        return _exact_or_contains(run.status, predicate.values, exact=True)
+    if field == "confidence":
+        return _exact_or_contains(run.confidence, predicate.values, exact=True)
+    if field == "cwd":
+        return _contains_value((run.cwd,), predicate.values)
+    if field in {"branch", "git_branch"}:
+        return _contains_value((run.git_branch,), predicate.values)
+    if field == "title":
+        return _contains_value((run.title,), predicate.values)
+    if field == "text":
+        return _contains_value(
+            (
+                _object_ref_text(run.run_ref),
+                _object_ref_text(run.parent_run_ref),
+                _object_ref_text(run.agent_ref),
+                *(_object_ref_text(ref) for ref in run.lineage_refs),
+                run.provider_origin,
+                run.harness,
+                run.role,
+                run.title,
+                run.cwd,
+                run.git_branch,
+                run.status,
+                run.confidence,
+                _evidence_ref_text(run.transcript_ref) if run.transcript_ref else None,
+                *(_evidence_ref_text(ref) for ref in run.evidence_refs),
+                _object_ref_text(run.context_snapshot_ref),
+            ),
+            predicate.values,
+        )
+    return False
+
+
+def _run_matches(
+    run: ProjectedRun,
+    summary: ArchiveSessionSummary,
+    predicate: QueryPredicate,
+) -> bool:
+    if isinstance(predicate, QueryFieldPredicate):
+        return _run_field_matches(run, summary, predicate)
+    if isinstance(predicate, QueryNotPredicate):
+        return not _run_matches(run, summary, predicate.child)
+    if isinstance(predicate, QueryBoolPredicate):
+        if predicate.op == "and":
+            return all(_run_matches(run, summary, child) for child in predicate.children)
+        return any(_run_matches(run, summary, child) for child in predicate.children)
+    return False
+
+
+def _run_row(summary: ArchiveSessionSummary, run: ProjectedRun) -> RunQueryRowPayload:
+    return RunQueryRowPayload(
+        run_ref=run.run_ref.format(),
+        session_id=str(summary.session_id),
+        origin=str(summary.origin),
+        title=summary.title,
+        native_session_id=run.native_session_id,
+        native_parent_session_id=run.native_parent_session_id,
+        parent_run_ref=_object_ref_text(run.parent_run_ref),
+        agent_ref=_object_ref_text(run.agent_ref),
+        lineage_refs=tuple(ref.format() for ref in run.lineage_refs),
+        provider_origin=run.provider_origin,
+        harness=run.harness,
+        role=run.role,
+        cwd=run.cwd,
+        git_branch=run.git_branch,
+        status=run.status,
+        confidence=run.confidence,
+        transcript_ref=_evidence_ref_text(run.transcript_ref) if run.transcript_ref else None,
+        evidence_refs=tuple(ref.format() for ref in run.evidence_refs),
+        context_snapshot_ref=_object_ref_text(run.context_snapshot_ref),
+    )
+
+
 def _context_snapshot_row(
     summary: ArchiveSessionSummary,
     snapshot: ContextSnapshot,
@@ -387,6 +498,32 @@ def _query_context_snapshots(
     return tuple(rows)
 
 
+def _query_runs(
+    archive: ArchiveStore,
+    source: QueryUnitSource,
+    *,
+    limit: int,
+    offset: int,
+    session_filters: Mapping[str, object] | None,
+) -> tuple[RunQueryRowPayload, ...]:
+    rows: list[RunQueryRowPayload] = []
+    target_count = limit + 1
+    skipped = 0
+    for summary in _iter_filtered_summaries(archive, session_filters):
+        session = _session_to_session(archive.read_session(str(summary.session_id)))
+        digest = compile_recovery_digest(session)
+        for run in digest.run_projection.runs:
+            if not _run_matches(run, summary, source.predicate):
+                continue
+            if skipped < offset:
+                skipped += 1
+                continue
+            rows.append(_run_row(summary, run))
+            if len(rows) >= target_count:
+                return tuple(rows)
+    return tuple(rows)
+
+
 def _query_observed_events(
     archive: ArchiveStore,
     source: QueryUnitSource,
@@ -440,6 +577,22 @@ def query_unit_rows(
             limit=limit,
             offset=offset,
             has_next=len(event_rows) > limit,
+        )
+    if source.unit == "run":
+        run_rows = _query_runs(
+            archive,
+            source,
+            limit=limit,
+            offset=offset,
+            session_filters=session_filters,
+        )
+        return build_query_unit_envelope(
+            run_rows[:limit],
+            unit=source.unit,
+            query=query,
+            limit=limit,
+            offset=offset,
+            has_next=len(run_rows) > limit,
         )
     if source.unit == "context-snapshot":
         snapshot_rows = _query_context_snapshots(

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2292,7 +2292,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 HTTPStatus.BAD_REQUEST,
                 {
                     "error": "invalid_query",
-                    "message": "query-units requires a messages/actions/blocks/assertions where expression",
+                    "message": "query-units requires a messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
                 },
             )
             return

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -1240,7 +1240,7 @@ def _extract_tool_summaries(session: Session, messages: Sequence[Message]) -> It
                 continue
             if _is_subagent_tool(block):
                 continue
-            tool_id = _optional_text(block.get("id") or block.get("tool_id"))
+            tool_id = _optional_text(block.get("tool_id") or block.get("id"))
             result_block: dict[str, object] | None = None
             result_ref: TransformRawRef | None = None
             if tool_id and tool_id in result_by_tool_id:
@@ -1284,7 +1284,7 @@ def _extract_subagent_reports(session: Session, messages: Sequence[Message]) -> 
                 continue
             if not _is_subagent_tool(block):
                 continue
-            tool_id = _optional_text(block.get("id") or block.get("tool_id"))
+            tool_id = _optional_text(block.get("tool_id") or block.get("id"))
             result_block: dict[str, object] | None = None
             result_ref: TransformRawRef | None = None
             if tool_id and tool_id in result_by_tool_id:

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -405,7 +405,7 @@ def archive_query_unit_payload(
     source = parse_unit_source_expression(expression)
     if source is None:
         raise ExpressionCompileError(
-            "query_units requires an explicit messages/actions/blocks/assertions/observed-events/context-snapshots where expression",
+            "query_units requires an explicit messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
             field=None,
         )
     return query_unit_rows(

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -831,7 +831,15 @@ class SearchEnvelope(SurfacePayloadModel):
     diagnostics: QueryMissDiagnosticsPayload | None = None
 
 
-QueryUnitKind: TypeAlias = Literal["message", "action", "block", "assertion", "observed-event", "context-snapshot"]
+QueryUnitKind: TypeAlias = Literal[
+    "message",
+    "action",
+    "block",
+    "assertion",
+    "run",
+    "observed-event",
+    "context-snapshot",
+]
 """Terminal query source unit exposed by query-unit envelopes."""
 
 
@@ -1183,11 +1191,57 @@ class ContextSnapshotQueryRowPayload(SurfacePayloadModel):
         return tuple(normalize_public_ref_text(ref) for ref in value)
 
 
+class RunQueryRowPayload(SurfacePayloadModel):
+    """Shared terminal-query row for runtime-transform runs."""
+
+    unit: Literal["run"] = "run"
+    run_ref: str
+    session_id: str
+    origin: str
+    title: str | None = None
+    native_session_id: str | None = None
+    native_parent_session_id: str | None = None
+    parent_run_ref: str | None = None
+    agent_ref: str | None = None
+    lineage_refs: tuple[str, ...]
+    provider_origin: str
+    harness: str
+    role: str
+    cwd: str | None = None
+    git_branch: str | None = None
+    status: str
+    confidence: str
+    transcript_ref: str | None = None
+    evidence_refs: tuple[str, ...]
+    context_snapshot_ref: str | None = None
+
+    @field_validator("run_ref", "parent_run_ref", "agent_ref", "context_snapshot_ref")
+    @classmethod
+    def _validate_optional_run_object_refs(cls, value: str | None) -> str | None:
+        return normalize_object_ref_text(value) if value is not None else None
+
+    @field_validator("lineage_refs")
+    @classmethod
+    def _validate_lineage_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_object_ref_text(ref) for ref in value)
+
+    @field_validator("transcript_ref")
+    @classmethod
+    def _validate_optional_transcript_ref(cls, value: str | None) -> str | None:
+        return normalize_public_ref_text(value) if value is not None else None
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_run_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
+
+
 QueryUnitRowPayload: TypeAlias = (
     MessageQueryRowPayload
     | ActionQueryRowPayload
     | BlockQueryRowPayload
     | AssertionQueryRowPayload
+    | RunQueryRowPayload
     | ObservedEventQueryRowPayload
     | ContextSnapshotQueryRowPayload
 )
@@ -1831,6 +1885,7 @@ __all__ = [
     "QueryUnitEnvelope",
     "QueryUnitKind",
     "QueryUnitRowPayload",
+    "RunQueryRowPayload",
     "QueryMissDiagnosticsPayload",
     "QueryMissReasonPayload",
     "ContextSnapshotQueryRowPayload",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1456,6 +1456,64 @@ async def test_query_units_returns_context_snapshot_rows(tmp_path: Path) -> None
         await archive.close()
 
 
+async def test_query_units_returns_run_rows(tmp_path: Path) -> None:
+    """``query_units()`` exposes runtime run projection rows through the facade."""
+    from polylogue.surfaces.payloads import RunQueryRowPayload
+    from tests.infra.storage_records import SessionBuilder
+
+    archive = _archive(tmp_path)
+    try:
+        index_db = archive.config.archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "facade-run-v1")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .git_branch("feature/query-runs")
+            .working_directories(["/realm/project/polylogue"])
+            .title("Facade run query")
+            .add_message(
+                "m-run",
+                role="assistant",
+                text="Subagent finished the facade run query wiring.",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "id": "tool-run",
+                        "name": "Task",
+                        "tool_input": {
+                            "subagent_type": "Explore",
+                            "taskId": "task-run",
+                            "child_session_id": "codex-session:facade-run-child",
+                            "prompt": "Map facade run query wiring.",
+                        },
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-run",
+                        "text": "Subagent done: facade run query wired.\n4 passed in 0.31s",
+                    },
+                ],
+            )
+            .save()
+        )
+
+        envelope = await archive.query_units(
+            "runs where session.repo:polylogue AND role:subagent AND status:completed AND agent:Explore"
+        )
+
+        assert envelope.unit == "run"
+        [item] = envelope.items
+        assert isinstance(item, RunQueryRowPayload)
+        assert item.session_id == "codex-session:ext-facade-run-v1"
+        assert item.role == "subagent"
+        assert item.status == "completed"
+        assert item.agent_ref == "agent:codex/Explore"
+        assert item.parent_run_ref == "run:codex-session:ext-facade-run-v1"
+        assert item.run_ref == "run:codex-session:facade-run-child"
+    finally:
+        await archive.close()
+
+
 async def test_query_units_rejects_session_expression(tmp_path: Path) -> None:
     """``query_units()`` is only for terminal source expressions."""
     from polylogue.archive.query.expression import ExpressionCompileError

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -471,6 +471,27 @@ class TestBooleanQueryExpression:
         assert explanation.lowering_plan is not None
         assert "compatibility_selector" not in explanation.lowering_plan
 
+    def test_parse_run_source_expression_preserves_terminal_unit(self) -> None:
+        source = parse_unit_source_expression("runs where session.repo:polylogue AND role:subagent AND agent:Explore")
+
+        assert source is not None
+        assert source.unit == "run"
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="session.repo", values=("polylogue",)),
+                QueryFieldPredicate(field="role", values=("subagent",)),
+                QueryFieldPredicate(field="agent", values=("Explore",)),
+            ),
+        )
+        explanation = explain_expression("runs where session.repo:polylogue AND role:subagent AND agent:Explore")
+        assert explanation.lowerer == "lark-query-unit-source-to-terminal-unit"
+        assert explanation.selected_units == ("run",)
+        assert explanation.execution_legs == ("sql", "terminal-run-rows")
+        assert explanation.plan_description == ("terminal unit source: run",)
+        assert explanation.lowering_plan is not None
+        assert "compatibility_selector" not in explanation.lowering_plan
+
     def test_parse_context_snapshot_source_expression_preserves_terminal_unit(self) -> None:
         source = parse_unit_source_expression(
             "context-snapshots where session.repo:polylogue AND boundary:session_start AND text:run"
@@ -1313,6 +1334,105 @@ class TestBooleanQueryExpression:
         )
         assert row.object_refs == ("github-review:#2100",)
         assert row.evidence_refs == ("codex-session:ext-hit::codex-session:ext-hit:m-hit",)
+
+    def test_terminal_run_source_returns_runtime_rows(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import RunQueryRowPayload
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .git_branch("feature/query-runs")
+            .working_directories(["/realm/project/polylogue"])
+            .title("run projection hit")
+            .add_message("m-user", role="user", text="Coordinate the query DSL branch.")
+            .add_message(
+                "m-subagent",
+                role="assistant",
+                text="Subagent finished the run-query audit.",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "id": "tool-run",
+                        "name": "Task",
+                        "tool_input": {
+                            "subagent_type": "Explore",
+                            "taskId": "task-run",
+                            "child_session_id": "codex-session:child-run",
+                            "prompt": "Map the remaining run query substrate.",
+                        },
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-run",
+                        "text": "Subagent done: run query substrate mapped.\n4 passed in 0.31s",
+                    },
+                ],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-repo")
+            .provider("codex")
+            .git_repository_url("sinex")
+            .title("run projection wrong repo")
+            .add_message(
+                "m-wrong",
+                role="assistant",
+                text="Subagent finished elsewhere.",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "id": "tool-wrong",
+                        "name": "Task",
+                        "tool_input": {
+                            "subagent_type": "Explore",
+                            "taskId": "task-wrong",
+                            "child_session_id": "codex-session:child-wrong",
+                            "prompt": "Map another repository.",
+                        },
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-wrong",
+                        "text": "Subagent done elsewhere.",
+                    },
+                ],
+            )
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "runs where session.repo:polylogue AND role:subagent AND agent:Explore AND status:completed"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(archive_root) as archive:
+            envelope = query_unit_rows(
+                archive,
+                source,
+                query="runs where session.repo:polylogue AND role:subagent AND agent:Explore AND status:completed",
+                limit=10,
+            )
+
+        assert envelope.unit == "run"
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        assert isinstance(row, RunQueryRowPayload)
+        assert row.session_id == "codex-session:ext-hit"
+        assert row.role == "subagent"
+        assert row.status == "completed"
+        assert row.harness == "codex"
+        assert row.agent_ref == "agent:codex/Explore"
+        assert row.parent_run_ref == "run:codex-session:ext-hit"
+        assert row.run_ref == "run:codex-session:child-run"
+        assert row.git_branch == "feature/query-runs"
+        assert row.cwd == "/realm/project/polylogue"
+        assert row.context_snapshot_ref == "context-snapshot:codex-session:child-run:subagent_start"
 
     def test_terminal_context_snapshot_source_returns_runtime_rows(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.archive.query.unit_results import query_unit_rows

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1375,6 +1375,55 @@ class TestReaderQueryUnits:
         items = cast(list[dict[str, object]], payload["items"])
         assert [item["session_id"] for item in items] == [C2]
 
+    def test_query_units_endpoint_returns_run_rows(self, workspace_env: dict[str, Path]) -> None:
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "daemon-run")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .working_directories(["/realm/project/polylogue"])
+            .title("Daemon run query")
+            .add_message(
+                "m-run",
+                role="assistant",
+                text="Subagent finished daemon run query wiring.",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "id": "tool-run",
+                        "name": "Task",
+                        "tool_input": {
+                            "subagent_type": "Explore",
+                            "taskId": "task-run",
+                            "child_session_id": "codex-session:daemon-run-child",
+                            "prompt": "Map daemon run query wiring.",
+                        },
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-run",
+                        "text": "Subagent done: daemon run query wired.\n2 passed in 0.10s",
+                    },
+                ],
+            )
+            .save()
+        )
+
+        expression = quote("runs where session.repo:polylogue AND role:subagent AND status:completed")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(dict[str, object], _get_json(base_url, f"/api/query-units?expression={expression}"))
+
+        assert payload["unit"] == "run"
+        items = cast(list[dict[str, object]], payload["items"])
+        assert len(items) == 1
+        assert items[0]["unit"] == "run"
+        assert items[0]["session_id"] == "codex-session:ext-daemon-run"
+        assert items[0]["role"] == "subagent"
+        assert items[0]["status"] == "completed"
+        assert items[0]["agent_ref"] == "agent:codex/Explore"
+
     def test_query_units_endpoint_rejects_session_expression(self, workspace_env: dict[str, Path]) -> None:
         expression = quote("repo:polylogue")
         with _running_server(workspace_env) as (_, base_url):
@@ -1382,7 +1431,7 @@ class TestReaderQueryUnits:
 
         assert status == 400
         assert payload["error"] == "invalid_query"
-        assert "messages/actions/blocks/assertions where" in str(payload["message"])
+        assert "messages/actions/blocks/assertions/runs" in str(payload["message"])
 
 
 class TestReaderViewProfiles:

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -47,7 +48,13 @@ def _write_archive_session(
     title: str = "Native session",
     text: str = "archive message",
     working_directories: list[str] | None = None,
+    blocks: list[dict[str, Any]] | None = None,
 ) -> str:
+    parsed_blocks = (
+        [ParsedContentBlock.model_validate(block) for block in blocks]
+        if blocks is not None
+        else [ParsedContentBlock(type=BlockType.TEXT, text=text)]
+    )
     return archive.write_parsed(
         ParsedSession(
             source_name=provider,
@@ -59,7 +66,7 @@ def _write_archive_session(
                     provider_message_id=f"{native_id}-m1",
                     role=Role.USER,
                     text=text,
-                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                    blocks=parsed_blocks,
                 )
             ],
         )
@@ -645,6 +652,62 @@ class TestArchiveGenericToolSurfaces:
 
         payload = json.loads(result)
         assert [item["session_id"] for item in payload["items"]] == [kept_id]
+
+    @pytest.mark.asyncio
+    async def test_query_units_tool_returns_run_rows_without_archive_operations(
+        self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        with ArchiveStore(archive_root) as archive:
+            session_id = _write_archive_session(
+                archive,
+                native_id="tool-query-units-run",
+                title="Tool query units run",
+                text="subagent run terminal row",
+                working_directories=["/realm/project/polylogue"],
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_id": "task-use",
+                        "tool_name": "Task",
+                        "tool_input": {
+                            "subagent_type": "Explore",
+                            "taskId": "task-run",
+                            "child_session_id": "codex-session:tool-query-units-run-child",
+                            "prompt": "Map run query unit wiring.",
+                        },
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "task-use",
+                        "text": "Subagent done: run query unit wired.\n3 passed in 0.12s",
+                    },
+                ],
+            )
+
+        with (
+            patch("polylogue.mcp.server._get_config") as mock_get_config,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        ):
+            mock_get_config.return_value = SimpleNamespace(
+                archive_root=archive_root,
+                db_path=archive_root / "index.db",
+            )
+            mock_get_polylogue.side_effect = AssertionError("query_units tool must not open archive operations")
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["query_units"].fn,
+                expression="runs where role:subagent AND status:completed AND agent:Explore",
+            )
+
+        payload = json.loads(result)
+        assert payload["mode"] == "query-unit"
+        assert payload["unit"] == "run"
+        [item] = payload["items"]
+        assert item["unit"] == "run"
+        assert item["session_id"] == session_id
+        assert item["role"] == "subagent"
+        assert item["status"] == "completed"
+        assert item["agent_ref"] == "agent:codex/Explore"
 
     @pytest.mark.asyncio
     async def test_query_units_tool_accepts_inline_session_scope(


### PR DESCRIPTION
## Summary

Adds `runs where ...` as an executable terminal query-unit source in the shared query DSL. Run rows now flow through the same `QueryUnitEnvelope` contract as messages/actions/blocks/assertions/observed-events/context-snapshots, with Python API, MCP, daemon HTTP, generated schemas, and docs updated together.

## Problem

#2006 explicitly lists `runs` as a core query unit, but runtime-transform runs were only reachable indirectly through recovery projections. Agents and the web/API surfaces could ask for context snapshots and observed events, but not the run rows that own those projections. While wiring this, normalized archive blocks exposed a real recovery-transform bug: persisted tool-use blocks carry both a stable block `id` and provider `tool_id`, and the extractor preferred `id`, so tool results could fail to associate with normalized tool calls and subagent runs lost completion evidence.

## Solution

- Adds `RunQueryRowPayload` and extends `QueryUnitKind` / generated query-unit schema with `run` rows.
- Extends the shared Lark-backed query metadata with `run` / `runs where ...`, run-specific fields, completion metadata, and explain output (`terminal-run-rows`).
- Executes run terminal queries by compiling each matching session's recovery digest and filtering `ProjectedRun` rows with the shared predicate semantics, including scoped `session.<field>` filters.
- Fixes normalized recovery transform association by preferring `tool_id` over normalized block `id` for tool-use/result joins.
- Wires user-facing contract text through API, MCP, daemon HTTP, OpenAPI, CLI output schema generation, and search/daemon docs.
- Adds cross-surface coverage for CLI/query execution, Python `Polylogue.query_units()`, MCP `query_units`, and daemon `GET /api/query-units`.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/daemon/test_web_reader.py -k 'run_source or terminal_run_source or query_units_returns_run_rows or query_units_tool_returns_run_rows or query_units_endpoint_returns_run_rows or observed_event_source or context_snapshot_source'`
  - `9 passed, 633 deselected`
- `nix develop --command devtools render all --check`
  - `render cli-output-schemas: sync OK`, `render openapi: sync OK`, `render agents: sync OK`
- `nix develop --command devtools verify --quick`
  - `exit_code: 0`
- `nix develop --command devtools verify --seed-testmon --skip-slow`
  - `11491 passed, 1 xfailed, 8 warnings in 224.73s`
  - pytest diagnosis: `pytest_passed`, peak pytest RSS: `3107.7 MiB`

Closes part of #2006.