### PR TITLE
refactor(daemon): table-drive route contract coverage (#1847)

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -72,10 +72,11 @@ By default `polylogued run` enables every component (watch, browser capture, HTT
 The HTTP API server runs by default. Pass `--no-api` to disable it. The endpoints below are exposed under the configured `--api-host:--api-port`.
 
 Route contract metadata lives in `polylogue/daemon/route_contracts.py`.
-Dispatch still happens in `polylogue/daemon/http.py`, but tests and docs use
-the metadata module as the durable route-classification source so stable
-routes, shell-only helpers, operational probes, and mutation routes do not drift
-silently.
+Dispatch still happens in `polylogue/daemon/http.py`, but the dispatcher now
+exposes its implemented route patterns from the routing tables used at runtime.
+The route-contract tests compare the two surfaces, so stable routes,
+shell-supported helpers, operational probes, and mutation routes must stay
+classified with explicit auth and response posture.
 
 | Route class | Auth policy | Examples |
 |-------------|-------------|----------|

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -8,12 +8,12 @@ import functools
 import json
 import os
 from collections.abc import Callable, Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import parse_qs, urlparse
 
 from polylogue.core.loopback import is_loopback_host, is_loopback_origin
@@ -65,6 +65,150 @@ if TYPE_CHECKING:
     from polylogue.surfaces.payloads import FacetBucketsPayload, RecoveryReportFormat, RecoveryReportKind
 
 logger = get_logger(__name__)
+
+RouteMethod = Literal["GET", "POST", "DELETE"]
+
+
+@dataclass(frozen=True)
+class _StaticGetRoute:
+    pattern: str
+    segments: tuple[str, ...]
+    handler_name: str
+    passes_params: bool = False
+
+
+@dataclass(frozen=True)
+class _ParameterizedGetRoute:
+    pattern: str
+    prefix: tuple[str, ...]
+    suffix: tuple[str, ...]
+    handler_name: str
+    passes_params: bool = False
+
+
+def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
+    return (
+        _StaticGetRoute("/api/health/check", ("api", "health", "check"), "_handle_health_check"),
+        _StaticGetRoute("/api/health", ("api", "health"), "_handle_health"),
+        _StaticGetRoute("/api/status", ("api", "status"), "_handle_status", passes_params=True),
+        _StaticGetRoute("/api/events", ("api", "events"), "_handle_events", passes_params=True),
+        _StaticGetRoute("/api/sessions", ("api", "sessions"), "_handle_list_sessions", passes_params=True),
+        _StaticGetRoute("/api/facets", ("api", "facets"), "_handle_facets", passes_params=True),
+        _StaticGetRoute("/api/query-units", ("api", "query-units"), "_handle_query_units", passes_params=True),
+        _StaticGetRoute(
+            "/api/query-completions", ("api", "query-completions"), "_handle_query_completions", passes_params=True
+        ),
+        _StaticGetRoute("/api/read-view-profiles", ("api", "read-view-profiles"), "_handle_read_view_profiles"),
+        _StaticGetRoute("/api/assertions", ("api", "assertions"), "_handle_assertions", passes_params=True),
+        _StaticGetRoute("/api/paste-browser", ("api", "paste-browser"), "_handle_paste_browser", passes_params=True),
+        _StaticGetRoute("/api/attachments", ("api", "attachments"), "_handle_attachment_library", passes_params=True),
+        _StaticGetRoute("/api/stack", ("api", "stack"), "_handle_stack", passes_params=True),
+        _StaticGetRoute("/api/compare", ("api", "compare"), "_handle_compare", passes_params=True),
+        _StaticGetRoute("/api/sources", ("api", "sources"), "_handle_sources"),
+        _StaticGetRoute(
+            "/api/thread-continue-templates",
+            ("api", "thread-continue-templates"),
+            "_handle_get_thread_continue_templates",
+        ),
+        _StaticGetRoute(
+            "/api/maintenance/operations", ("api", "maintenance", "operations"), "_handle_maintenance_operations"
+        ),
+    )
+
+
+def _parameterized_get_routes() -> tuple[_ParameterizedGetRoute, ...]:
+    return (
+        _ParameterizedGetRoute("/api/sessions/:id", ("api", "sessions"), (), "_handle_get_session"),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/messages", ("api", "sessions"), ("messages",), "_handle_get_messages", passes_params=True
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/recovery",
+            ("api", "sessions"),
+            ("recovery",),
+            "_handle_get_session_recovery",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/read", ("api", "sessions"), ("read",), "_handle_get_session_read", passes_params=True
+        ),
+        _ParameterizedGetRoute("/api/sessions/:id/raw", ("api", "sessions"), ("raw",), "_handle_get_session_raw"),
+        _ParameterizedGetRoute("/api/sessions/:id/cost", ("api", "sessions"), ("cost",), "_handle_get_session_cost"),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/provenance",
+            ("api", "sessions"),
+            ("provenance",),
+            "_handle_get_session_provenance",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/topology",
+            ("api", "sessions"),
+            ("topology",),
+            "_handle_get_session_topology",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/topology/parent-chain",
+            ("api", "sessions"),
+            ("topology", "parent-chain"),
+            "_handle_get_session_parent_chain",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/similar",
+            ("api", "sessions"),
+            ("similar",),
+            "_handle_get_session_similar",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute(
+            "/api/sessions/:id/attachments",
+            ("api", "sessions"),
+            ("attachments",),
+            "_handle_get_session_attachments",
+        ),
+        _ParameterizedGetRoute(
+            "/api/insights/sessions/:id",
+            ("api", "insights", "sessions"),
+            (),
+            "_handle_get_session_insights",
+            passes_params=True,
+        ),
+        _ParameterizedGetRoute("/api/raw_artifacts/:id", ("api", "raw_artifacts"), (), "_handle_get_raw_artifact"),
+        _ParameterizedGetRoute(
+            "/api/maintenance/status/:id",
+            ("api", "maintenance", "status"),
+            (),
+            "_handle_maintenance_status",
+        ),
+    )
+
+
+def implemented_daemon_route_patterns() -> tuple[tuple[RouteMethod, str], ...]:
+    """Return route patterns implemented by daemon HTTP dispatch."""
+
+    routes: list[tuple[RouteMethod, str]] = [
+        ("GET", "/"),
+        ("GET", "/s/:session_id"),
+        ("GET", "/w/:mode"),
+        ("GET", "/p"),
+        ("GET", "/a"),
+        ("GET", "/healthz/live"),
+        ("GET", "/healthz/ready"),
+        ("GET", "/metrics"),
+        ("POST", "/v1/traces"),
+        ("POST", "/v1/metrics"),
+        ("POST", "/v1/logs"),
+        ("POST", "/api/reset"),
+        ("POST", "/api/ingest"),
+        ("POST", "/api/maintenance/plan"),
+        ("POST", "/api/maintenance/run"),
+    ]
+    routes.extend(("GET", route.pattern) for route in _static_get_routes())
+    routes.extend(("GET", route.pattern) for route in _parameterized_get_routes())
+    routes.extend(user_state_http.user_state_route_patterns())
+    return tuple(routes)
 
 
 def _json_bytes(payload: object) -> bytes:
@@ -850,74 +994,37 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if not self._check_auth():
             return
 
-        if path == ["api", "health", "check"]:
-            self._handle_health_check()
-        elif path == ["api", "health"]:
-            self._handle_health()
-        elif path == ["api", "status"]:
-            self._handle_status(params)
-        elif path == ["api", "events"]:
-            self._handle_events(params)
-        elif path == ["api", "sessions"]:
-            self._handle_list_sessions(params)
-        elif path == ["api", "facets"]:
-            self._handle_facets(params)
-        elif path == ["api", "query-units"]:
-            self._handle_query_units(params)
-        elif path == ["api", "query-completions"]:
-            self._handle_query_completions(params)
-        elif path == ["api", "read-view-profiles"]:
-            self._handle_read_view_profiles()
-        elif path == ["api", "assertions"]:
-            self._handle_assertions(params)
-        elif path == ["api", "paste-browser"]:
-            self._handle_paste_browser(params)
-        elif path == ["api", "attachments"]:
-            self._handle_attachment_library(params)
-        elif path == ["api", "stack"]:
-            self._handle_stack(params)
-        elif path == ["api", "compare"]:
-            self._handle_compare(params)
-        elif workspace_routes.dispatch_get(self, path, params) or (
+        static_route = next((route for route in _static_get_routes() if tuple(path) == route.segments), None)
+        if static_route is not None:
+            handler = cast(Callable[..., None], getattr(self, static_route.handler_name))
+            if static_route.passes_params:
+                handler(params)
+            else:
+                handler()
+            return
+
+        if workspace_routes.dispatch_get(self, path, params) or (
             path[:2] == ["api", "user"] and user_state_http.dispatch_get(self, path[2:], params)
         ):
             return
-        elif path == ["api", "sources"]:
-            self._handle_sources()
-        elif len(path) == 3 and path[:2] == ["api", "sessions"] and path[2]:
-            self._handle_get_session(path[2])
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "messages":
-            self._handle_get_messages(path[2], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "recovery":
-            self._handle_get_session_recovery(path[2], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "read":
-            self._handle_get_session_read(path[2], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "raw":
-            self._handle_get_session_raw(path[2])
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "cost":
-            self._handle_get_session_cost(path[2])
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "provenance":
-            self._handle_get_session_provenance(path[2], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "topology":
-            self._handle_get_session_topology(path[2], params)
-        elif len(path) == 5 and path[:2] == ["api", "sessions"] and path[3] == "topology" and path[4] == "parent-chain":
-            self._handle_get_session_parent_chain(path[2], params)
-        elif path == ["api", "thread-continue-templates"]:
-            self._handle_get_thread_continue_templates()
-        elif len(path) == 4 and path[:3] == ["api", "insights", "sessions"]:
-            self._handle_get_session_insights(path[3], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "similar":
-            self._handle_get_session_similar(path[2], params)
-        elif len(path) == 4 and path[:2] == ["api", "sessions"] and path[3] == "attachments":
-            self._handle_get_session_attachments(path[2])
-        elif len(path) == 4 and path[:3] == ["api", "raw_artifacts"]:
-            self._handle_get_raw_artifact(path[3])
-        elif path == ["api", "maintenance", "operations"]:
-            self._handle_maintenance_operations()
-        elif len(path) == 4 and path[:3] == ["api", "maintenance", "status"]:
-            self._handle_maintenance_status(path[3])
-        else:
-            self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+
+        for route in _parameterized_get_routes():
+            expected_len = len(route.prefix) + 1 + len(route.suffix)
+            if (
+                len(path) == expected_len
+                and tuple(path[: len(route.prefix)]) == route.prefix
+                and path[len(route.prefix)]
+                and tuple(path[len(route.prefix) + 1 :]) == route.suffix
+            ):
+                handler = cast(Callable[..., None], getattr(self, route.handler_name))
+                identifier = path[len(route.prefix)]
+                if route.passes_params:
+                    handler(identifier, params)
+                else:
+                    handler(identifier)
+                return
+
+        self._send_error(HTTPStatus.NOT_FOUND, "not_found")
 
     # #1677: client disconnects (refresh, navigate, tab close) surface as
     # BrokenPipeError from wfile.write(). Stdlib lets that escape as a

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -86,6 +86,14 @@ class _ParameterizedGetRoute:
     passes_params: bool = False
 
 
+@dataclass(frozen=True)
+class _StaticPostRoute:
+    pattern: str
+    segments: tuple[str, ...]
+    handler_name: str
+    passes_path: bool = False
+
+
 def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
     return (
         _StaticGetRoute("/api/health/check", ("api", "health", "check"), "_handle_health_check"),
@@ -185,6 +193,23 @@ def _parameterized_get_routes() -> tuple[_ParameterizedGetRoute, ...]:
     )
 
 
+def _observability_post_routes() -> tuple[_StaticPostRoute, ...]:
+    return (
+        _StaticPostRoute("/v1/traces", ("v1", "traces"), "_handle_otlp_post", passes_path=True),
+        _StaticPostRoute("/v1/metrics", ("v1", "metrics"), "_handle_otlp_post", passes_path=True),
+        _StaticPostRoute("/v1/logs", ("v1", "logs"), "_handle_otlp_post", passes_path=True),
+    )
+
+
+def _authenticated_post_routes() -> tuple[_StaticPostRoute, ...]:
+    return (
+        _StaticPostRoute("/api/reset", ("api", "reset"), "_handle_reset"),
+        _StaticPostRoute("/api/ingest", ("api", "ingest"), "_handle_ingest"),
+        _StaticPostRoute("/api/maintenance/plan", ("api", "maintenance", "plan"), "_handle_maintenance_plan"),
+        _StaticPostRoute("/api/maintenance/run", ("api", "maintenance", "run"), "_handle_maintenance_run"),
+    )
+
+
 def implemented_daemon_route_patterns() -> tuple[tuple[RouteMethod, str], ...]:
     """Return route patterns implemented by daemon HTTP dispatch."""
 
@@ -197,16 +222,11 @@ def implemented_daemon_route_patterns() -> tuple[tuple[RouteMethod, str], ...]:
         ("GET", "/healthz/live"),
         ("GET", "/healthz/ready"),
         ("GET", "/metrics"),
-        ("POST", "/v1/traces"),
-        ("POST", "/v1/metrics"),
-        ("POST", "/v1/logs"),
-        ("POST", "/api/reset"),
-        ("POST", "/api/ingest"),
-        ("POST", "/api/maintenance/plan"),
-        ("POST", "/api/maintenance/run"),
     ]
     routes.extend(("GET", route.pattern) for route in _static_get_routes())
     routes.extend(("GET", route.pattern) for route in _parameterized_get_routes())
+    routes.extend(("POST", route.pattern) for route in _observability_post_routes())
+    routes.extend(("POST", route.pattern) for route in _authenticated_post_routes())
     routes.extend(user_state_http.user_state_route_patterns())
     return tuple(routes)
 
@@ -1076,7 +1096,10 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # the daemon is bound non-loopback we still require the
         # configured auth token — OTLP exporters that DO carry
         # credentials are the only safe non-loopback case.
-        if path == ["v1", "traces"] or path == ["v1", "metrics"] or path == ["v1", "logs"]:
+        observability_route = next(
+            (route for route in _observability_post_routes() if tuple(path) == route.segments), None
+        )
+        if observability_route is not None:
             from polylogue.config import load_polylogue_config
 
             if not load_polylogue_config().observability_enabled:
@@ -1084,7 +1107,11 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 return
             if not is_loopback_host(self._api_host) and not self._check_auth():
                 return
-            self._handle_otlp_post(path)
+            handler = cast(Callable[..., None], getattr(self, observability_route.handler_name))
+            if observability_route.passes_path:
+                handler(path)
+            else:
+                handler()
             return
 
         if not self._check_auth():
@@ -1092,17 +1119,15 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if not self._check_cross_origin():
             return
 
-        if path == ["api", "reset"]:
-            self._handle_reset()
-            return
-        if path == ["api", "ingest"]:
-            self._handle_ingest()
-            return
-        if path == ["api", "maintenance", "plan"]:
-            self._handle_maintenance_plan()
-            return
-        if path == ["api", "maintenance", "run"]:
-            self._handle_maintenance_run()
+        authenticated_route = next(
+            (route for route in _authenticated_post_routes() if tuple(path) == route.segments), None
+        )
+        if authenticated_route is not None:
+            handler = cast(Callable[..., None], getattr(self, authenticated_route.handler_name))
+            if authenticated_route.passes_path:
+                handler(path)
+            else:
+                handler()
             return
         if path[:2] == ["api", "user"] and user_state_http.dispatch_post(self, path[2:]):
             return

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -3,7 +3,8 @@
 This module is intentionally descriptive: dispatch still lives in
 ``polylogue.daemon.http``, but route classes, auth posture, and stability are
 owned here so docs, tests, OpenAPI generation, and future web-workbench code do
-not infer security semantics from a long if/elif chain.
+not infer security semantics from handler names. Tests compare this metadata
+against route patterns exposed by the live dispatcher tables.
 """
 
 from __future__ import annotations

--- a/polylogue/daemon/user_state_http.py
+++ b/polylogue/daemon/user_state_http.py
@@ -4,12 +4,54 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
+from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from polylogue.archive.query.spec import SessionQuerySpec
 from polylogue.core.user_state_targets import TARGET_SESSION, is_mark_type_supported, validate_target_kind
 from polylogue.surfaces.payloads import MutationResultPayload
+
+RouteMethod = Literal["GET", "POST", "DELETE"]
+
+
+@dataclass(frozen=True)
+class UserStateRoute:
+    method: RouteMethod
+    pattern: tuple[str, ...]
+    handler: Callable[..., None]
+    passes_params: bool = False
+
+
+def _pattern_matches(pattern: tuple[str, ...], path: list[str]) -> bool:
+    if len(pattern) != len(path):
+        return False
+    for expected, actual in zip(pattern, path, strict=True):
+        if expected.startswith(":"):
+            if not actual:
+                return False
+            continue
+        if expected != actual:
+            return False
+    return True
+
+
+def _pattern_path(pattern: tuple[str, ...]) -> str:
+    return "/api/user/" + "/".join(pattern)
+
+
+def _route_identifier(pattern: tuple[str, ...], path: list[str]) -> str | None:
+    for expected, actual in zip(pattern, path, strict=True):
+        if expected.startswith(":"):
+            return actual
+    return None
+
+
+def user_state_route_patterns() -> tuple[tuple[RouteMethod, str], ...]:
+    """Return the daemon paths implemented by this user-state adapter."""
+
+    return tuple((route.method, _pattern_path(route.pattern)) for route in _routes())
 
 
 def _read_json_body(handler: Any) -> dict[str, object] | None:
@@ -117,68 +159,15 @@ def _send_mutation_result(handler: Any, result: MutationResultPayload, *, create
 
 
 def dispatch_get(handler: Any, path: list[str], params: dict[str, list[str]]) -> bool:
-    if path == ["marks"]:
-        handler._handle_user_state(handle_list_marks, params)
-        return True
-    if path == ["annotations"]:
-        handler._handle_user_state(handle_list_annotations, params)
-        return True
-    if len(path) == 2 and path[0] == "annotations" and path[1]:
-        handler._handle_user_state(handle_get_annotation, path[1])
-        return True
-    if path == ["saved-views"]:
-        handler._handle_user_state(handle_list_saved_views)
-        return True
-    if len(path) == 2 and path[0] == "saved-views" and path[1]:
-        handler._handle_user_state(handle_get_saved_view, path[1])
-        return True
-    if path == ["recall-packs"]:
-        handler._handle_user_state(handle_list_recall_packs)
-        return True
-    if len(path) == 2 and path[0] == "recall-packs" and path[1]:
-        handler._handle_user_state(handle_get_recall_pack, path[1])
-        return True
-    if path == ["workspaces"]:
-        handler._handle_user_state(handle_list_workspaces)
-        return True
-    if len(path) == 2 and path[0] == "workspaces" and path[1]:
-        handler._handle_user_state(handle_get_workspace, path[1])
-        return True
-    return False
+    return _dispatch(handler, "GET", path, params)
 
 
 def dispatch_post(handler: Any, path: list[str]) -> bool:
-    routes: dict[tuple[str, ...], Any] = {
-        ("marks",): handle_create_mark,
-        ("annotations",): handle_save_annotation,
-        ("saved-views",): handle_save_view,
-        ("recall-packs",): handle_save_recall_pack,
-        ("workspaces",): handle_save_workspace,
-    }
-    route = routes.get(tuple(path))
-    if route is None:
-        return False
-    handler._handle_user_state(route)
-    return True
+    return _dispatch(handler, "POST", path, None)
 
 
 def dispatch_delete(handler: Any, path: list[str], params: dict[str, list[str]]) -> bool:
-    if path == ["marks"]:
-        handler._handle_user_state(handle_delete_mark, params)
-        return True
-    if len(path) == 2 and path[0] == "annotations" and path[1]:
-        handler._handle_user_state(handle_delete_annotation, path[1])
-        return True
-    if len(path) == 2 and path[0] == "saved-views" and path[1]:
-        handler._handle_user_state(handle_delete_saved_view, path[1])
-        return True
-    if len(path) == 2 and path[0] == "recall-packs" and path[1]:
-        handler._handle_user_state(handle_delete_recall_pack, path[1])
-        return True
-    if len(path) == 2 and path[0] == "workspaces" and path[1]:
-        handler._handle_user_state(handle_delete_workspace, path[1])
-        return True
-    return False
+    return _dispatch(handler, "DELETE", path, params)
 
 
 def handle_list_marks(handler: Any, params: dict[str, list[str]]) -> None:
@@ -600,3 +589,42 @@ def handle_delete_workspace(handler: Any, workspace_id: str) -> None:
 
     result = cast(MutationResultPayload, handler._sync_run(_delete))
     _send_mutation_result(handler, result)
+
+
+def _routes() -> tuple[UserStateRoute, ...]:
+    return (
+        UserStateRoute("GET", ("marks",), handle_list_marks, passes_params=True),
+        UserStateRoute("GET", ("annotations",), handle_list_annotations, passes_params=True),
+        UserStateRoute("GET", ("annotations", ":id"), handle_get_annotation),
+        UserStateRoute("GET", ("saved-views",), handle_list_saved_views),
+        UserStateRoute("GET", ("saved-views", ":id"), handle_get_saved_view),
+        UserStateRoute("GET", ("recall-packs",), handle_list_recall_packs),
+        UserStateRoute("GET", ("recall-packs", ":id"), handle_get_recall_pack),
+        UserStateRoute("GET", ("workspaces",), handle_list_workspaces),
+        UserStateRoute("GET", ("workspaces", ":id"), handle_get_workspace),
+        UserStateRoute("POST", ("marks",), handle_create_mark),
+        UserStateRoute("POST", ("annotations",), handle_save_annotation),
+        UserStateRoute("POST", ("saved-views",), handle_save_view),
+        UserStateRoute("POST", ("recall-packs",), handle_save_recall_pack),
+        UserStateRoute("POST", ("workspaces",), handle_save_workspace),
+        UserStateRoute("DELETE", ("marks",), handle_delete_mark, passes_params=True),
+        UserStateRoute("DELETE", ("annotations", ":id"), handle_delete_annotation),
+        UserStateRoute("DELETE", ("saved-views", ":id"), handle_delete_saved_view),
+        UserStateRoute("DELETE", ("recall-packs", ":id"), handle_delete_recall_pack),
+        UserStateRoute("DELETE", ("workspaces", ":id"), handle_delete_workspace),
+    )
+
+
+def _dispatch(handler: Any, method: RouteMethod, path: list[str], params: object | None) -> bool:
+    for route in _routes():
+        if route.method != method or not _pattern_matches(route.pattern, path):
+            continue
+        identifier = _route_identifier(route.pattern, path)
+        if identifier is not None:
+            handler._handle_user_state(route.handler, identifier)
+        elif route.passes_params:
+            handler._handle_user_state(route.handler, params)
+        else:
+            handler._handle_user_state(route.handler)
+        return True
+    return False

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 
 import pytest
 
+from polylogue.daemon.http import implemented_daemon_route_patterns
 from polylogue.daemon.route_contracts import ROUTE_CONTRACTS, route_contract_for, stable_route_contracts
 from tests.unit.daemon.test_daemon_http_security import (
     ENDPOINTS_DELETE,
@@ -21,6 +22,22 @@ def test_route_contract_patterns_are_unique_per_method() -> None:
 
     pairs = [(route.method, route.pattern) for route in ROUTE_CONTRACTS]
     assert len(pairs) == len(set(pairs))
+
+
+def test_implemented_daemon_routes_have_contract_metadata() -> None:
+    """Every implemented daemon route must declare kind, auth, and payload posture."""
+
+    declared = {(route.method, route.pattern) for route in ROUTE_CONTRACTS}
+    implemented = set(implemented_daemon_route_patterns())
+    assert implemented - declared == set()
+
+
+def test_route_contract_metadata_targets_live_daemon_routes() -> None:
+    """Route contracts should describe actual dispatcher routes, not stale docs."""
+
+    declared = {(route.method, route.pattern) for route in ROUTE_CONTRACTS}
+    implemented = set(implemented_daemon_route_patterns())
+    assert declared - implemented == set()
 
 
 def test_stable_routes_have_explicit_auth_and_response_contracts() -> None:

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -17,6 +17,12 @@ from tests.unit.daemon.test_daemon_http_security import (
 )
 
 
+def _implemented_route_set() -> set[tuple[str, str]]:
+    routes = implemented_daemon_route_patterns()
+    assert len(routes) == len(set(routes))
+    return set(routes)
+
+
 def test_route_contract_patterns_are_unique_per_method() -> None:
     """One method/pattern pair has exactly one contract owner."""
 
@@ -28,7 +34,7 @@ def test_implemented_daemon_routes_have_contract_metadata() -> None:
     """Every implemented daemon route must declare kind, auth, and payload posture."""
 
     declared = {(route.method, route.pattern) for route in ROUTE_CONTRACTS}
-    implemented = set(implemented_daemon_route_patterns())
+    implemented = _implemented_route_set()
     assert implemented - declared == set()
 
 
@@ -36,7 +42,7 @@ def test_route_contract_metadata_targets_live_daemon_routes() -> None:
     """Route contracts should describe actual dispatcher routes, not stale docs."""
 
     declared = {(route.method, route.pattern) for route in ROUTE_CONTRACTS}
-    implemented = set(implemented_daemon_route_patterns())
+    implemented = _implemented_route_set()
     assert declared - implemented == set()
 
 


### PR DESCRIPTION
## Summary

Refactors the daemon HTTP route boundary so implemented route patterns are exposed from the routing tables used at runtime, then checks those live routes against `ROUTE_CONTRACTS` in both directions. This keeps #1847's route-class/auth/payload metadata from drifting away from the dispatcher while preserving the existing auth behavior.

## Problem

#1847 already had route-contract metadata and route/security tests, but the daemon dispatcher still carried most routes in an ad hoc conditional chain. The security matrix derived from `ROUTE_CONTRACTS`, so a newly implemented route could still skip classification if a future edit touched dispatch but forgot the metadata. That weakens the web/API boundary exactly where #1847 is trying to make it explicit.

## Solution

- Move authenticated daemon GET dispatch into static and parameterized route tables in `polylogue/daemon/http.py`.
- Move durable user-state HTTP dispatch into a `UserStateRoute` table in `polylogue/daemon/user_state_http.py`.
- Expose `implemented_daemon_route_patterns()` from the live dispatcher tables and compare it against `ROUTE_CONTRACTS` in both directions.
- Preserve the existing empty-parameter behavior for user-state parameterized routes: empty `:id` segments do not route.
- Update daemon docs and route-contract module text to describe the checked dispatcher/contract relationship.

## Verification

- `devtools test tests/unit/daemon/test_route_contracts.py tests/unit/daemon/test_daemon_http_security.py tests/unit/daemon/test_web_reader.py -k 'route_contract or auth or cross_origin or read_view_execution or recovery_endpoint or assertions_endpoint'` -> `324 passed, 197 deselected`.
- Initial `devtools verify --seed-testmon --skip-slow` caught a route-table regression: `tests/unit/daemon/test_user_state_http.py::TestDispatchRouting::test_empty_id_in_get_path_does_not_route` failed because empty `:id` matched. Fixed the matcher.
- `devtools test tests/unit/daemon/test_user_state_http.py::TestDispatchRouting::test_empty_id_in_get_path_does_not_route tests/unit/daemon/test_route_contracts.py tests/unit/daemon/test_daemon_http_security.py` -> `404 passed`.
- `devtools verify --quick` -> `exit_code: 0`.
- `devtools verify --seed-testmon --skip-slow` -> `11493 passed, 1 xfailed`, `exit_code: 0`, peak pytest RSS `3419.1 MiB`.
- `devtools verify` -> `7 passed`, `exit_code: 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reworked daemon HTTP request routing to use table-driven, pattern-based dispatch for GET/POST endpoints, improving consistency across authentication, observability, and route handling.
* **Tests**
  * Added unit tests that verify route-contract metadata stays perfectly synchronized with the live implemented route patterns (no missing or stale entries).
* **Documentation**
  * Updated routing documentation to explain the separation between implemented dispatcher patterns and validated route-contract security/response posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->