### PR TITLE
test(query): cover runtime query units across surfaces (#2006)

### DIFF
--- a/docs/plans/query-pipeline-substrate.md
+++ b/docs/plans/query-pipeline-substrate.md
@@ -11,9 +11,17 @@ already present in the project. The Lark grammar in
 clauses and explicit Boolean predicates are entry shapes in that grammar, not
 separate floor/ceiling languages.
 
-## Current limitation
+## Current state
 
-The current implemented query substrate already handles compact session filters, grouped Boolean predicates, message/action/block `exists` predicates, ordered action sequences, FTS predicates, lineage predicates, and a semantic seed plus residual filter. Remaining scope is broader unit coverage and pipeline execution: runs/events/assertions, aggregation, unit-changing traversal, terminal read/analyze/bundle stages, and shared completion/query-builder metadata.
+The current implemented query substrate already handles compact session filters,
+grouped Boolean predicates, message/action/block/assertion `exists`
+predicates, ordered action sequences, FTS predicates, lineage predicates, a
+semantic seed plus residual filter, and terminal row-producing
+`messages/actions/blocks/assertions/runs/observed-events/context-snapshots
+where ...` queries. Runtime-transform terminal rows for runs, observed events,
+and context snapshots lower through the recovery/run projection rather than a
+SQL table, so unsupported scoped session fields must fail closed instead of
+broadening results.
 
 ## Design decision
 
@@ -24,9 +32,11 @@ Predicate nodes: And, Or, Not, Leaf, Fts, Semantic, Structural, Sequence, Lineag
 Pipeline stages: source or filter, traverse, transform, aggregate, sort/limit,
 and terminal action or view.
 
-Implemented units: session, message, action, block, lineage.
+Implemented units: session, message, action, block, assertion, run, observed
+event, context snapshot, lineage.
 
-Target units still needing real lowerers: run, observed event, assertion, context snapshot, bundle/work packet, external work refs, phase, thread, span.
+Target units still needing real lowerers: bundle/work packet, external work
+refs, phase, thread, span.
 
 ## Surface ladder
 
@@ -43,7 +53,8 @@ micro-slices. Each phase should land useful executable queries and tests.
    path.
 2. Extend explain output to show terminal unit sources, unsupported
    unit/pipeline stages, and the concrete lowerer/execution legs selected.
-3. Add run/event/assertion/context units only with real lowerers and fixtures.
+3. Keep runtime-transform unit execution covered across CLI, Python API, MCP,
+   daemon, docs, generated schemas, and completions as new fields are added.
 4. Add traversal stages that change the active unit and lower to SQL/recursive
    CTEs or existing read models.
 5. Add aggregation/sort/limit stages over supported units.

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1424,6 +1424,54 @@ class TestReaderQueryUnits:
         assert items[0]["status"] == "completed"
         assert items[0]["agent_ref"] == "agent:codex/Explore"
 
+    def test_query_units_endpoint_returns_observed_event_rows(self, workspace_env: dict[str, Path]) -> None:
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "daemon-event")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .title("Daemon observed event query")
+            .add_message("m-event", role="user", text="Daemon observed event seed")
+            .save()
+        )
+
+        expression = quote("observed-events where session.repo:polylogue AND kind:session_started")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(dict[str, object], _get_json(base_url, f"/api/query-units?expression={expression}"))
+
+        assert payload["unit"] == "observed-event"
+        items = cast(list[dict[str, object]], payload["items"])
+        assert len(items) == 1
+        assert items[0]["unit"] == "observed-event"
+        assert items[0]["session_id"] == "codex-session:ext-daemon-event"
+        assert items[0]["kind"] == "session_started"
+
+    def test_query_units_endpoint_returns_context_snapshot_rows(self, workspace_env: dict[str, Path]) -> None:
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "daemon-context")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .title("Daemon context query")
+            .add_message("m-context", role="user", text="Daemon context snapshot seed")
+            .save()
+        )
+
+        expression = quote("context-snapshots where session.repo:polylogue AND boundary:session_start AND text:context")
+        with _running_server(workspace_env) as (_, base_url):
+            payload = cast(dict[str, object], _get_json(base_url, f"/api/query-units?expression={expression}"))
+
+        assert payload["unit"] == "context-snapshot"
+        items = cast(list[dict[str, object]], payload["items"])
+        assert len(items) == 1
+        assert items[0]["unit"] == "context-snapshot"
+        assert items[0]["session_id"] == "codex-session:ext-daemon-context"
+        assert items[0]["boundary"] == "session_start"
+
     def test_query_units_endpoint_rejects_session_expression(self, workspace_env: dict[str, Path]) -> None:
         expression = quote("repo:polylogue")
         with _running_server(workspace_env) as (_, base_url):
@@ -1431,7 +1479,7 @@ class TestReaderQueryUnits:
 
         assert status == 400
         assert payload["error"] == "invalid_query"
-        assert "messages/actions/blocks/assertions/runs" in str(payload["message"])
+        assert "messages/actions/blocks/assertions/runs/observed-events/context-snapshots" in str(payload["message"])
 
 
 class TestReaderViewProfiles:

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -710,6 +710,80 @@ class TestArchiveGenericToolSurfaces:
         assert item["agent_ref"] == "agent:codex/Explore"
 
     @pytest.mark.asyncio
+    async def test_query_units_tool_returns_observed_event_rows_without_archive_operations(
+        self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        with ArchiveStore(archive_root) as archive:
+            session_id = _write_archive_session(
+                archive,
+                native_id="tool-query-units-event",
+                title="Tool query units event",
+                text="observed event terminal row",
+                working_directories=["/realm/project/polylogue"],
+            )
+
+        with (
+            patch("polylogue.mcp.server._get_config") as mock_get_config,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        ):
+            mock_get_config.return_value = SimpleNamespace(
+                archive_root=archive_root,
+                db_path=archive_root / "index.db",
+            )
+            mock_get_polylogue.side_effect = AssertionError("query_units tool must not open archive operations")
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["query_units"].fn,
+                expression="observed-events where session.repo:polylogue AND kind:session_started",
+            )
+
+        payload = json.loads(result)
+        assert payload["mode"] == "query-unit"
+        assert payload["unit"] == "observed-event"
+        [item] = payload["items"]
+        assert item["unit"] == "observed-event"
+        assert item["session_id"] == session_id
+        assert item["kind"] == "session_started"
+        assert item["subject_ref"] == f"session:{session_id}"
+
+    @pytest.mark.asyncio
+    async def test_query_units_tool_returns_context_snapshot_rows_without_archive_operations(
+        self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        with ArchiveStore(archive_root) as archive:
+            session_id = _write_archive_session(
+                archive,
+                native_id="tool-query-units-context",
+                title="Tool query units context",
+                text="review injection context for PR #2100",
+                working_directories=["/realm/project/polylogue"],
+            )
+
+        with (
+            patch("polylogue.mcp.server._get_config") as mock_get_config,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        ):
+            mock_get_config.return_value = SimpleNamespace(
+                archive_root=archive_root,
+                db_path=archive_root / "index.db",
+            )
+            mock_get_polylogue.side_effect = AssertionError("query_units tool must not open archive operations")
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["query_units"].fn,
+                expression="context-snapshots where session.repo:polylogue AND boundary:session_start AND text:context",
+            )
+
+        payload = json.loads(result)
+        assert payload["mode"] == "query-unit"
+        assert payload["unit"] == "context-snapshot"
+        [item] = payload["items"]
+        assert item["unit"] == "context-snapshot"
+        assert item["session_id"] == session_id
+        assert item["boundary"] == "session_start"
+        assert item["evidence_refs"] == [session_id]
+
+    @pytest.mark.asyncio
     async def test_query_units_tool_accepts_inline_session_scope(
         self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
Adds missing cross-surface coverage for the runtime-transform terminal query units that already exist in #2006: `observed-events where ...` and `context-snapshots where ...`. The branch also updates the query-pipeline plan and #2006 issue body so they no longer describe run/event/assertion/context-snapshot lowerers as future work.

## Problem
The codebase now executes runtime-transform query units for runs, observed events, and context snapshots, but the durable plan text and some cross-surface tests still lagged behind that implementation. That mismatch makes future agents re-open already solved scope and leaves MCP/daemon parity less explicit than the CLI/API coverage.

## Solution
- Updated `docs/plans/query-pipeline-substrate.md` to distinguish implemented terminal row units from the remaining bundle/file/external-ref/phase/thread/span lowerers.
- Added daemon `/api/query-units` tests for `observed-events where ...` and `context-snapshots where ...` rows.
- Added MCP `query_units` tests for the same runtime-transform units, including the archive-file-set path that must not open the high-level `Polylogue` facade.
- Updated the invalid-query error assertion to include the full supported terminal-unit set.
- Updated #2006's issue body with the current implementation state.

## Verification
- `devtools test tests/unit/mcp/test_server_surfaces.py::TestArchiveGenericToolSurfaces::test_query_units_tool_returns_observed_event_rows_without_archive_operations tests/unit/mcp/test_server_surfaces.py::TestArchiveGenericToolSurfaces::test_query_units_tool_returns_context_snapshot_rows_without_archive_operations tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits::test_query_units_endpoint_returns_observed_event_rows tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits::test_query_units_endpoint_returns_context_snapshot_rows tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits::test_query_units_endpoint_rejects_session_expression` -> `5 passed`.
- `devtools verify --quick` -> `exit_code: 0`.
- `devtools verify --seed-testmon --skip-slow` -> `11497 passed, 1 xfailed`, diagnosis `pytest_passed`, peak pytest tree RSS 3008.4 MiB.

Ref #2006
