### PR TITLE
feat(web): execute context-pack workbench reads (#1846)

### DIFF
--- a/docs/plans/web-workbench-1846-v0-plan.md
+++ b/docs/plans/web-workbench-1846-v0-plan.md
@@ -12,7 +12,7 @@ Backend:
 
 - `GET /api/sessions/:id/recovery?report=digest&format=json`
 - `GET /api/sessions/:id/recovery?report=work-packet&format=json|markdown`
-- `GET /api/sessions/:id/read?view=messages|recovery|raw&format=json`
+- `GET /api/sessions/:id/read?view=messages|recovery|context-pack|raw&format=json`
 - `GET /api/assertions?target_ref=&scope_ref=&kind=&status=&context_inject=&limit=`
 
 Route contracts:
@@ -35,6 +35,7 @@ Web shell:
 - Loads `GET /api/read-view-profiles` and renders a small profile selector from shared read-view metadata.
 - Executes supported single-session profiles through `GET /api/sessions/:id/read`.
 - Keeps raw data behind an explicit opt-in drawer: metadata loads first from provenance; bounded preview requires a separate click.
+- Uses the existing user-state routes for overlay mutation flows: mark toggles, annotations, saved views, recall packs, and workspaces all return the shared mutation result envelope.
 
 Explicit non-exposure:
 
@@ -62,7 +63,7 @@ Search and query:
 Reader:
 
 - read-view profile payloads from `GET /api/read-view-profiles`.
-- read-view execution envelopes from `GET /api/sessions/:id/read`.
+- read-view execution envelopes from `GET /api/sessions/:id/read`, including the shared context-pack DTO.
 - session detail payload from `GET /api/sessions/:id`.
 - session message payloads from `GET /api/sessions/:id/messages`.
 - provenance/raw payloads from `/provenance` and `/raw`, still explicit opt-in.
@@ -80,8 +81,8 @@ Browser capture/readiness:
 
 ## Remaining backend endpoints
 
-1. Shared read-view execution route now covers the supported single-session profiles (`messages`, `recovery`, `raw`). Broader profiles (`context`, `context-pack`, `neighbors`, `correlation`) still need dedicated execution semantics before the selector enables them.
-2. Typed overlay mutation envelopes for marks/annotations/saved views/recall/workspaces are #1847-owned. These routes should keep same-origin write auth and return the shared mutation result envelope; detailed resource state belongs on the corresponding read endpoints.
+1. Shared read-view execution route now covers the supported single-session profiles (`messages`, `recovery`, `context-pack`, `raw`). Broader profiles (`context`, `neighbors`, `correlation`) still need dedicated execution semantics before the selector enables them.
+2. Overlay mutation envelopes for marks/annotations/saved views/recall/workspaces are implemented through `polylogue/daemon/user_state_http.py` and route through the shared mutation result envelope. Remaining work here is browser-flow polish, not another DTO family.
 3. Browser-capture readiness is satisfied by `GET /api/status`; add a dedicated adapter only if a future panel needs more than safe receiver state (`spool_ready`, `allowed_origins`, `auth_required`, component readiness).
 4. Bounded raw-preview contract promotion: this slice already prefers provenance `include_raw=1&bytes=` in the shell; #1847 can decide whether `/api/sessions/:id/raw` remains shell-supported only or becomes a narrower stable metadata route.
 5. Generated route/OpenAPI surface that includes stable routes and intentionally documented shell-supported workbench routes without implying public API stability.
@@ -90,7 +91,7 @@ Browser capture/readiness:
 
 PR-1846-B, landed by this slice: recovery/work-packet HTTP, assertion-read HTTP, route contracts, web evidence panel, focused reader tests.
 
-PR-1846-C: promote one overlay mutation path to shared mutation/error envelopes and keep same-origin/bearer tests strict.
+PR-1846-C, landed before this map refresh: overlay mutation paths use shared mutation/error envelopes and same-origin/bearer tests remain strict under #1847.
 
 PR-1846-D, partially landed after the first evidence slice: execute supported single-session read profiles over HTTP instead of only displaying profile metadata.
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1382,6 +1382,42 @@ class PolylogueArchiveMixin:
 
         return list(read_view_profile_payloads())
 
+    async def context_pack_payload(
+        self,
+        *,
+        project_path: str | None = None,
+        project_repo: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        origin: str | None = None,
+        query: str | None = None,
+        max_sessions: int = 5,
+        max_messages_per_session: int = 20,
+        max_text: int = 200,
+        include_messages: bool = True,
+        redact_paths: bool = True,
+        seed_session_id: str | None = None,
+    ) -> Any:
+        """Build the shared archive-backed context-pack payload."""
+        from polylogue.context.pack import build_archive_context_pack_payload
+
+        return await build_archive_context_pack_payload(
+            archive_root=self.config.archive_root,
+            polylogue=self,
+            project_path=project_path,
+            project_repo=project_repo,
+            since=since,
+            until=until,
+            origin=origin,
+            query=query,
+            conv_limit=max(1, min(max_sessions, 20)),
+            msg_limit=max(1, min(max_messages_per_session, 100)),
+            max_text=max_text,
+            include_messages=include_messages,
+            redact_paths=redact_paths,
+            seed_session_id=seed_session_id,
+        )
+
     async def explain_query_expression(self, expression: str) -> JSONDocument:
         """Explain query DSL parsing, AST metadata, and lowering details."""
         from polylogue.archive.query.expression import explain_expression

--- a/polylogue/context/pack.py
+++ b/polylogue/context/pack.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +46,184 @@ def _clamp_context_pack_limit(value: int | object) -> int:
     if isinstance(value, str | bytes | bytearray):
         return max(1, min(int(value), 20))
     return 1
+
+
+def _truncate_text(text: str, max_length: int) -> str:
+    """Truncate context-pack message text for compact cross-surface payloads."""
+    if max_length > 0 and len(text) > max_length:
+        return text[:max_length] + "..."
+    return text
+
+
+def _date_text(value: object) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
+
+
+async def build_archive_context_pack_payload(
+    *,
+    archive_root: Path,
+    polylogue: Any,
+    clamp_limit: Callable[[int | object], int] = _clamp_context_pack_limit,
+    project_path: str | None = None,
+    project_repo: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    origin: str | None = None,
+    query: str | None = None,
+    conv_limit: int = _DEFAULT_MAX_SESSIONS,
+    msg_limit: int = _DEFAULT_MAX_MESSAGES,
+    max_text: int = 200,
+    include_messages: bool = True,
+    redact_paths: bool = True,
+    seed_session_id: str | None = None,
+) -> ContextPackPayload:
+    """Build the shared archive-backed context-pack payload.
+
+    MCP, daemon HTTP, and future API consumers use this helper instead of
+    maintaining separate context-pack serializers.
+    """
+
+    with ArchiveStore.open_existing(archive_root) as archive:
+
+        async def query_sessions(spec: SessionQuerySpec) -> list[Any]:
+            return query_archive_context_pack(archive, spec, default_limit=_DEFAULT_MAX_SESSIONS)
+
+        envelope_by_id: dict[str, Any] = {}
+        if seed_session_id is not None:
+            try:
+                seed_envelope = archive.read_session(seed_session_id)
+            except Exception:
+                seed_envelope = None
+            if seed_envelope is None:
+                sessions = []
+            else:
+                envelope_by_id[seed_session_id] = seed_envelope
+                sessions = [
+                    SimpleNamespace(
+                        id=seed_envelope.session_id,
+                        origin=seed_envelope.origin,
+                        title=seed_envelope.title,
+                        created_at=seed_envelope.created_at,
+                        updated_at=seed_envelope.updated_at,
+                        message_count=len(seed_envelope.messages),
+                    )
+                ]
+            query_total: int | None = len(sessions)
+            match_strategy = "session-id"
+            relaxed_filters: list[str] = []
+        else:
+            selection = await select_context_pack_sessions(
+                query_sessions,
+                clamp_limit,
+                project_path=project_path,
+                project_repo=project_repo,
+                since=since,
+                until=until,
+                origin=origin,
+                query=query,
+                limit=conv_limit,
+            )
+            sessions = selection.sessions
+            query_total = selection.query_total
+            match_strategy = selection.match_strategy
+            relaxed_filters = list(selection.relaxed_filters)
+        dates = [
+            d for conv in sessions for d in (_date_text(conv.created_at), _date_text(conv.updated_at)) if d is not None
+        ]
+        pack_sessions: list[ContextPackSession] = []
+        assertion_decisions: list[str] = []
+
+        for conv in sessions[:conv_limit]:
+            conv_id = str(conv.id)
+            try:
+                claims = await polylogue.list_assertion_claim_payloads(
+                    target_ref=f"session:{conv_id}",
+                    statuses=("active",),
+                    context_inject=True,
+                    limit=20,
+                )
+            except Exception:
+                claims = []
+            assertion_decisions.extend(
+                context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref)
+                for claim in claims
+            )
+
+            messages: list[ContextPackMessage] = []
+            if include_messages:
+                envelope = envelope_by_id.get(conv_id)
+                if envelope is None:
+                    try:
+                        envelope = archive.read_session(conv_id)
+                    except Exception:
+                        envelope = None
+                if envelope is not None:
+                    for message in envelope.messages[:msg_limit]:
+                        text = "\n".join(block.text or "" for block in message.blocks if block.text)
+                        messages.append(
+                            ContextPackMessage(
+                                role=message.role,
+                                text=_truncate_text(text, max_text),
+                                has_tool_use=getattr(message, "has_tool_use", False),
+                                has_thinking=getattr(message, "has_thinking", False),
+                            )
+                        )
+
+            session_origin = str(conv.origin) if getattr(conv, "origin", None) is not None else "unknown"
+            pack_sessions.append(
+                ContextPackSession(
+                    session_id=conv_id,
+                    origin=session_origin,
+                    title=conv.title,
+                    created_at=_date_text(conv.created_at),
+                    updated_at=_date_text(conv.updated_at),
+                    message_count=int(conv.message_count),
+                    tool_use_count=None,
+                    messages=messages,
+                )
+            )
+
+    total_matching = len(sessions)
+    return ContextPackPayload(
+        decisions=ContextPackDecisions(items=assertion_decisions),
+        project=_build_project_context((), redact=redact_paths),
+        date_range=ContextPackDateRange(
+            since=since,
+            until=until,
+            earliest=min(dates) if dates else None,
+            latest=max(dates) if dates else None,
+            session_count_in_range=total_matching,
+        ),
+        query_context=ContextPackQueryContext(
+            total_matching_sessions=total_matching,
+            sessions_included=min(total_matching, conv_limit),
+            project_path=project_path,
+            project_repo=project_repo,
+            origin=origin,
+            query=query,
+            query_matched=total_matching,
+            query_total=query_total if query_total is not None else total_matching,
+            match_strategy=match_strategy,
+            relaxed_filters=relaxed_filters,
+        ),
+        sessions=pack_sessions,
+        action_summaries=[],
+        provenance=ContextPackProvenance(
+            generated_at=datetime.now(UTC).isoformat(),
+            redacted=redact_paths,
+            archive_runtime="archive_file_set",
+            archive_root=str(archive_root),
+            active_db_path=str(archive_root / "index.db"),
+        ),
+        total_sessions=total_matching,
+        total_messages=sum(int(conv.message_count) for conv in sessions[:conv_limit]),
+        total_tool_calls=0,
+    )
 
 
 def run_context_pack_view(

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2628,7 +2628,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         view = (self._get_param(params, "view", "messages") or "messages").strip().lower()
         output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
-        if view not in {"messages", "recovery", "raw"}:
+        if view not in {"messages", "recovery", "raw", "context-pack"}:
             self._send_error(HTTPStatus.BAD_REQUEST, "unsupported_read_view")
             return
         if output_format != "json" and not (view == "recovery" and output_format == "markdown"):
@@ -2659,6 +2659,26 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
             async def _get(poly: Polylogue) -> object | None:
                 return await self._do_get_session_recovery(poly, conv_id, report, output_format)
+
+            payload = self._sync_run(_get)
+        elif view == "context-pack":
+            if output_format != "json":
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+                return
+
+            async def _get(poly: Polylogue) -> object:
+                include_messages = True
+                if self._get_param(params, "include_messages") is not None:
+                    include_messages = self._get_bool(params, "include_messages")
+                context_payload = await poly.context_pack_payload(
+                    seed_session_id=conv_id,
+                    max_sessions=1,
+                    max_messages_per_session=self._get_int(params, "max_messages", 20),
+                    max_text=self._get_int(params, "max_text", 200),
+                    include_messages=include_messages,
+                    redact_paths=not self._get_bool(params, "no_redact"),
+                )
+                return context_payload.model_dump(mode="json", exclude_none=True)
 
             payload = self._sync_run(_get)
         else:

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -769,8 +769,8 @@ function renderFacets() {
 function renderReadViewSelector(c) {
   if (!c) return '';
   var profiles = state.readViewProfiles || [];
-  var supported = {messages: true, recovery: true, raw: true};
-  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw'};
+  var supported = {messages: true, recovery: true, raw: true, 'context-pack': true};
+  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', 'context-pack': 'Context Pack'};
   if (!profiles.length) {
     var fallback = state.readViewProfileError || 'Read profiles loading';
     return '<div id="read-profile-selector" class="read-profile-selector muted">' + esc(fallback) + '</div>';
@@ -920,6 +920,7 @@ function renderReadViewExecution(c, viewId) {
   var payload = envelope.payload || {};
   if (viewId === 'recovery') return renderRecoveryReadView(payload);
   if (viewId === 'raw') return renderRawReadView(payload);
+  if (viewId === 'context-pack') return renderContextPackReadView(payload);
   return '<div class="main-empty"><h3>Unsupported read view</h3><p>' + esc(viewId) + '</p></div>';
 }
 
@@ -949,6 +950,27 @@ function renderRawReadView(payload) {
       + '<div class="note">' + esc(artifact.raw_id || artifact.artifact_id || 'raw artifact') + '</div></div>';
   });
   if (!artifacts.length) html += '<div class="inspector-empty">No raw artifact metadata surfaced for this session.</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderContextPackReadView(payload) {
+  var query = payload.query_context || {};
+  var sessions = payload.sessions || [];
+  var provenance = payload.provenance || {};
+  var html = '<div class="read-view-panel"><h3>Context pack</h3>'
+    + '<p class="muted">Read through /api/sessions/:id/read using the shared context-pack DTO.</p>'
+    + '<div class="inspector-field"><span class="label">sessions</span><span class="value">' + esc(String(payload.total_sessions || sessions.length || 0)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">messages</span><span class="value">' + esc(String(payload.total_messages || 0)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">strategy</span><span class="value">' + esc(query.match_strategy || 'session-id') + '</span></div>'
+    + '<div class="inspector-field"><span class="label">redacted</span><span class="value">' + esc(String(provenance.redacted !== false)) + '</span></div>';
+  sessions.slice(0, 5).forEach(function(session) {
+    var messages = session.messages || [];
+    html += '<div class="annotation-item"><div class="meta">' + esc(session.origin || 'origin') + ' / ' + esc(session.session_id || 'session') + '</div>'
+      + '<div class="note"><strong>' + esc(session.title || 'Untitled') + '</strong><br>'
+      + esc(String(messages.length)) + ' messages included</div></div>';
+  });
+  if (!sessions.length) html += '<div class="inspector-empty">No context-pack sessions surfaced for this selection.</div>';
   html += '</div>';
   return html;
 }

--- a/polylogue/mcp/server_context_tools.py
+++ b/polylogue/mcp/server_context_tools.py
@@ -7,31 +7,13 @@ archive tables.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from datetime import UTC, datetime
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from polylogue.archive.query.spec import SessionQuerySpec
-from polylogue.context.assertion_claims import context_claim_text
-from polylogue.mcp.context_pack import (
-    ContextPackDateRange,
-    ContextPackDecisions,
-    ContextPackMessage,
-    ContextPackPayload,
-    ContextPackProvenance,
-    ContextPackQueryContext,
-    ContextPackSession,
-    _build_project_context,
-    query_archive_context_pack,
-    select_context_pack_sessions,
-)
-from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.context.pack import build_archive_context_pack_payload
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
-    from polylogue.api import Polylogue
     from polylogue.mcp.server_support import ServerCallbacks
 
 _DEFAULT_MAX_SESSIONS = 5
@@ -46,136 +28,6 @@ _DETAIL_DEFAULTS: dict[str, tuple[int, bool]] = {
 def _get_detail_settings(detail_level: str) -> tuple[int, bool]:
     """Return (max_text_length, include_messages) for a detail level."""
     return _DETAIL_DEFAULTS.get(detail_level, _DETAIL_DEFAULTS["compact"])
-
-
-def _truncate_text(text: str, max_length: int) -> str:
-    """Truncate text to max_length, appending ellipsis if truncated."""
-    if max_length > 0 and len(text) > max_length:
-        return text[:max_length] + "..."
-    return text
-
-
-async def _build_archive_context_pack_payload(
-    *,
-    archive_root: Path,
-    polylogue: Polylogue,
-    clamp_limit: Callable[[int | object], int],
-    project_path: str | None,
-    project_repo: str | None,
-    since: str | None,
-    until: str | None,
-    origin: str | None,
-    query: str | None,
-    conv_limit: int,
-    msg_limit: int,
-    max_text: int,
-    include_messages: bool,
-    redact_paths: bool,
-) -> ContextPackPayload:
-    with ArchiveStore.open_existing(archive_root) as archive:
-
-        async def query_sessions(spec: SessionQuerySpec) -> list[Any]:
-            return query_archive_context_pack(archive, spec, default_limit=_DEFAULT_MAX_SESSIONS)
-
-        selection = await select_context_pack_sessions(
-            query_sessions,
-            clamp_limit,
-            project_path=project_path,
-            project_repo=project_repo,
-            since=since,
-            until=until,
-            origin=origin,
-            query=query,
-            limit=conv_limit,
-        )
-        sessions = selection.sessions
-        dates = [d for conv in sessions for d in (conv.created_at, conv.updated_at) if d is not None]
-        pack_sessions: list[ContextPackSession] = []
-        assertion_decisions: list[str] = []
-
-        for conv in sessions[:conv_limit]:
-            conv_id = str(conv.id)
-            try:
-                claims = await polylogue.list_assertion_claim_payloads(
-                    target_ref=f"session:{conv_id}",
-                    statuses=("active",),
-                    context_inject=True,
-                    limit=20,
-                )
-            except Exception:
-                claims = []
-            assertion_decisions.extend(
-                context_claim_text(kind=claim.kind, body_text=claim.body_text, target_ref=claim.target_ref)
-                for claim in claims
-            )
-            messages: list[ContextPackMessage] = []
-            if include_messages:
-                try:
-                    envelope = archive.read_session(conv_id)
-                except Exception:
-                    envelope = None
-                if envelope is not None:
-                    for message in envelope.messages[:msg_limit]:
-                        text = "\n".join(block.text or "" for block in message.blocks if block.text)
-                        messages.append(
-                            ContextPackMessage(
-                                role=message.role,
-                                text=_truncate_text(text, max_text),
-                                has_tool_use=message.has_tool_use,
-                                has_thinking=message.has_thinking,
-                            )
-                        )
-
-            session_origin = str(conv.origin) if getattr(conv, "origin", None) is not None else "unknown"
-            pack_sessions.append(
-                ContextPackSession(
-                    session_id=conv_id,
-                    origin=session_origin,
-                    title=conv.title,
-                    created_at=conv.created_at.isoformat() if conv.created_at else None,
-                    updated_at=conv.updated_at.isoformat() if conv.updated_at else None,
-                    message_count=int(conv.message_count),
-                    tool_use_count=None,
-                    messages=messages,
-                )
-            )
-
-    total_matching = len(sessions)
-    return ContextPackPayload(
-        decisions=ContextPackDecisions(items=assertion_decisions),
-        project=_build_project_context((), redact=redact_paths),
-        date_range=ContextPackDateRange(
-            since=since,
-            until=until,
-            earliest=min(dates).isoformat() if dates else None,
-            latest=max(dates).isoformat() if dates else None,
-            session_count_in_range=total_matching,
-        ),
-        query_context=ContextPackQueryContext(
-            total_matching_sessions=total_matching,
-            sessions_included=min(total_matching, conv_limit),
-            project_path=project_path,
-            project_repo=project_repo,
-            origin=origin,
-            query=query,
-            query_matched=total_matching,
-            query_total=selection.query_total,
-            match_strategy=selection.match_strategy,
-            relaxed_filters=list(selection.relaxed_filters),
-        ),
-        sessions=pack_sessions,
-        action_summaries=[],
-        provenance=ContextPackProvenance(
-            generated_at=datetime.now(UTC).isoformat(),
-            redacted=redact_paths,
-            archive_runtime="archive_file_set",
-            archive_root=str(archive_root),
-            active_db_path=str(archive_root / "index.db"),
-        ),
-        total_sessions=total_matching,
-        total_messages=sum(int(conv.message_count) for conv in sessions[:conv_limit]),
-        total_tool_calls=0,
-    )
 
 
 def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
@@ -217,7 +69,7 @@ def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             max_text, include_messages = _get_detail_settings(valid_detail)
 
             config = hooks.get_config()
-            payload = await _build_archive_context_pack_payload(
+            payload = await build_archive_context_pack_payload(
                 archive_root=config.archive_root,
                 polylogue=hooks.get_polylogue(),
                 clamp_limit=hooks.clamp_limit,

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1497,7 +1497,7 @@ class TestReaderViewProfiles:
         assert profiles["recovery"]["successor_handoff"] is True
         assert "markdown" in profiles["recovery"]["formats"]
 
-    def test_read_view_execution_route_returns_messages_recovery_and_raw(
+    def test_read_view_execution_route_returns_messages_recovery_raw_and_context_pack(
         self,
         workspace_env: dict[str, Path],
     ) -> None:
@@ -1511,6 +1511,10 @@ class TestReaderViewProfiles:
                 _get_json(base_url, f"/api/sessions/{C1}/read?view=recovery&report=work-packet"),
             )
             raw = cast(dict[str, object], _get_json(base_url, f"/api/sessions/{C1}/read?view=raw"))
+            context_pack = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/read?view=context-pack&max_messages=5"),
+            )
 
         assert messages["view"] == "messages"
         message_payload = cast(dict[str, object], messages["payload"])
@@ -1521,6 +1525,13 @@ class TestReaderViewProfiles:
         assert raw["view"] == "raw"
         raw_payload = cast(dict[str, object], raw["payload"])
         assert raw_payload["id"] == C1
+        assert context_pack["view"] == "context-pack"
+        context_payload = cast(dict[str, object], context_pack["payload"])
+        assert context_payload["total_sessions"] == 1
+        context_query = cast(dict[str, object], context_payload["query_context"])
+        assert context_query["query_matched"] == 1
+        context_sessions = cast(list[dict[str, object]], context_payload["sessions"])
+        assert context_sessions[0]["session_id"] == C1
 
     def test_read_view_execution_rejects_unknown_view_or_format(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -2299,10 +2310,10 @@ class TestReaderSavedViewsUI:
 class TestReaderBulkOperations:
     """``polylogue.local_reader.bulk``: selection toolbar + per-session envelope.
 
-    The bulk surface is composed client-side over existing daemon
-    endpoints (``/api/user/marks`` for tag mutations, ``/api/sessions/{id}``
-    for export). Delete and re-embed are exposed only through a preview
-    overlay because the daemon has no corresponding mutation routes yet.
+    The bulk surface composes existing daemon routes: ``/api/user/marks``
+    carries route-backed overlay mutations, and ``/api/sessions/{id}``
+    carries export reads. Delete and re-embed are exposed only through a
+    preview overlay because the daemon has no corresponding mutation routes yet.
 
     These tests assert the shipped HTML carries every load-bearing region
     hook and that the underlying tag endpoint accepts the per-session

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import cast
+from urllib.request import Request, urlopen
 
 from polylogue.surfaces.payloads import reader_anchor
 from tests.visual.conftest import (
@@ -20,6 +21,14 @@ from tests.visual.conftest import (
     seed_reader_assertion_claims,
     write_evidence_manifest,
 )
+
+
+def _send_json(base_url: str, method: str, path: str, payload: dict[str, object] | None = None) -> tuple[int, object]:
+    body = json.dumps(payload or {}).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    req = Request(f"{base_url}{path}", data=body, headers=headers, method=method)
+    with urlopen(req, timeout=10) as resp:
+        return resp.status, json.loads(resp.read())
 
 
 def test_reader_search_shell_dom_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
@@ -382,6 +391,10 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
             dict[str, object],
             get_json(base_url, f"/api/assertions?target_ref=session%3A{READER_C1}&limit=10"),
         )
+        context_pack = cast(
+            dict[str, object],
+            get_json(base_url, f"/api/sessions/{READER_C1}/read?view=context-pack&max_messages=5"),
+        )
 
     assert status == 200
     assert "text/html" in content_type
@@ -391,6 +404,7 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
         "renderInspectorEvidence",
         "renderBrowserCaptureChip",
         "renderReadViewExecution",
+        "renderContextPackReadView",
         "loadEvidencePanel",
         "/api/assertions?target_ref=",
         "/recovery?report=work-packet&format=json",
@@ -407,6 +421,12 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
     claim_items = cast(list[dict[str, object]], assertions["items"])
     assert [item["assertion_id"] for item in claim_items] == ["reader-evidence-decision"]
     assert claim_items[0]["target_ref"] == f"session:{READER_C1}"
+    assert context_pack["view"] == "context-pack"
+    context_payload = cast(dict[str, object], context_pack["payload"])
+    context_sessions = cast(list[dict[str, object]], context_payload["sessions"])
+    assert context_sessions[0]["session_id"] == READER_C1
+    context_provenance = cast(dict[str, object], context_payload["provenance"])
+    assert context_provenance["redacted"] is True
 
     write_evidence_manifest(
         tmp_path / "reader-evidence-panel-dom-evidence.json",
@@ -418,7 +438,75 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
             "recovery_report": recovery["report"],
             "work_packet_evidence_refs": len(cast(list[object], packet["evidence_refs"])),
             "assertion_count": assertions["total"],
+            "context_pack_sessions": context_payload["total_sessions"],
             "raw_artifacts_absent_from_recovery": True,
+            "private_path_safe": True,
+        },
+    )
+
+
+def test_reader_overlay_mutation_flow_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    """Reader overlay actions use route-backed mutation envelopes (#1846)."""
+
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, shell = get_text(base_url, f"/s/{READER_C1}")
+        mark_status, mark = _send_json(
+            base_url,
+            "POST",
+            "/api/user/marks",
+            {"session_id": READER_C1, "mark_type": "archive"},
+        )
+        annotation_status, annotation = _send_json(
+            base_url,
+            "POST",
+            "/api/user/annotations",
+            {
+                "annotation_id": "reader-visual-flow-note",
+                "session_id": READER_C1,
+                "target_type": "message",
+                "message_id": READER_C1_M1,
+                "note_text": "Visual smoke overlay note",
+            },
+        )
+        marks = cast(dict[str, object], get_json(base_url, f"/api/user/marks?session_id={READER_C1}"))
+        annotations = cast(dict[str, object], get_json(base_url, f"/api/user/annotations?session_id={READER_C1}"))
+
+    assert status == 200
+    assert "text/html" in content_type
+    assert_no_private_paths(shell, context="reader overlay mutation shell")
+    for phrase in ("toggleMark", "saveAnnotation", "/api/user/marks", "/api/user/annotations"):
+        assert phrase in shell, f"missing overlay shell hook {phrase!r}"
+
+    mark_payload = cast(dict[str, object], mark)
+    annotation_payload = cast(dict[str, object], annotation)
+    assert mark_status == 201
+    assert mark_payload["operation"] == "mark.add"
+    assert mark_payload["affected_count"] == 1
+    assert mark_payload["target_id"] == READER_C1
+    assert annotation_status == 201
+    assert annotation_payload["operation"] == "annotation.save"
+    assert annotation_payload["affected_count"] == 1
+    assert annotation_payload["target_type"] == "message"
+    assert annotation_payload["target_id"] == READER_C1_M1
+
+    mark_types = {str(item["mark_type"]) for item in cast(list[dict[str, object]], marks["items"])}
+    assert "archive" in mark_types
+    annotation_ids = {str(item["annotation_id"]) for item in cast(list[dict[str, object]], annotations["items"])}
+    assert "reader-visual-flow-note" in annotation_ids
+
+    write_evidence_manifest(
+        tmp_path / "reader-overlay-mutation-flow-evidence.json",
+        artifact_id="polylogue.local_reader.overlay_mutations",
+        route=f"/s/{READER_C1}",
+        fixture_id="reader-visual-synthetic-v1",
+        checks={
+            "shell_status": status,
+            "mark_status": mark_status,
+            "annotation_status": annotation_status,
+            "mark_operation": mark_payload["operation"],
+            "annotation_operation": annotation_payload["operation"],
+            "archive_mark_visible": "archive" in mark_types,
+            "message_annotation_visible": "reader-visual-flow-note" in annotation_ids,
             "private_path_safe": True,
         },
     )


### PR DESCRIPTION
## Summary
Executes the `context-pack` read view through the daemon workbench route, shares the archive context-pack payload builder across MCP/API/daemon, and adds fixture-backed evidence for both context-pack reads and route-backed overlay mutations.

## Problem
#1846 had the browser shell reading profile metadata from `/api/read-view-profiles`, but `context-pack` remained disabled in `/api/sessions/:id/read` even though the project already had a typed `ContextPackPayload`. MCP also owned a private archive context-pack builder, so the workbench/API route could not reuse the same payload without duplicating serialization. Separately, the #1846 map still described overlay mutation DTOs as future work even though user-state routes already return shared mutation envelopes.

## Solution
Moved the archive-backed context-pack payload builder into `polylogue.context.pack`, reused it from MCP, exposed it via `Polylogue.context_pack_payload(...)`, and wired `/api/sessions/:id/read?view=context-pack` to exact-session seeded payloads. The web shell now enables and renders `context-pack` from the same read-view selector. Added visual/daemon coverage for context-pack execution and overlay mark/annotation mutation envelopes, then updated the #1846 workbench map and issue body to reflect current scope.

## Verification
- `.venv/bin/python -m devtools test tests/unit/daemon/test_web_reader.py tests/visual/test_reader_dom_smoke.py -k 'read_view_execution_route_returns_messages_recovery_raw_and_context_pack or test_reader_evidence_panel_endpoint_and_shell_smoke or test_reader_overlay_mutation_flow_evidence'` -> `3 passed`
- `.venv/bin/python -m devtools verify --quick` -> `exit_code: 0`

Ref #1846