### PR TITLE
fix(query): reject terminal-only unit selectors (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -15,7 +15,7 @@ Quick links:
 - [Retrieval Lanes](#retrieval-lanes) — `dialogue`, `actions`, `hybrid`,
   `semantic`, and how `auto` elevates.
 - [Terminal Unit Queries](#terminal-unit-queries) — `messages/actions/blocks/
-  assertions/observed-events/context-snapshots where ...` row results.
+  assertions/runs/observed-events/context-snapshots where ...` row results.
 - [Ranking Policy](#ranking-policy) — current `mixed-bm25-rrf-vector`
   policy and version contract.
 - [SearchEnvelope Contract](#searchenvelope-contract) — the typed
@@ -33,7 +33,7 @@ through the same typed AST and query planner:
 ```text
 compact-query      ::= compact-clause*
 boolean-query      ::= ["sessions" "where"] predicate
-unit-query         ::= ("messages" | "actions" | "blocks" | "assertions" | "observed-events" | "context-snapshots") "where" predicate
+unit-query         ::= ("messages" | "actions" | "blocks" | "assertions" | "runs" | "observed-events" | "context-snapshots") "where" predicate
 
 compact-clause     ::= field-clause
                      | quoted-text | bare-text
@@ -52,7 +52,7 @@ predicate          ::= predicate "OR" predicate
                      | "exists" structural-unit "(" predicate ")"
                      | "seq" "(" sequence-step "->" sequence-step+ ")"
 
-structural-unit    ::= "message" | "action" | "block"
+structural-unit    ::= "message" | "action" | "block" | "assertion"
 ```
 
 Compact queries select sessions:
@@ -78,6 +78,7 @@ polylogue messages where 'role:assistant AND text:timeout'
 polylogue actions where 'session.repo:polylogue AND action:file_edit AND path:polylogue/archive'
 polylogue blocks where 'type:code AND text:sqlite'
 polylogue assertions where 'kind:decision AND status:active AND text:review'
+polylogue runs where 'role:subagent AND status:completed AND agent:Explore'
 polylogue observed-events where 'delivery_state:acted_on AND text:#2100'
 polylogue context-snapshots where 'boundary:session_start AND session.repo:polylogue'
 ```
@@ -143,9 +144,10 @@ one child row matching the nested predicate.
 | `message` | `action`, `command`, `output`, `path`, `role`, `text`, `tool`, `type`, `words` |
 | `action` | `action`, `command`, `output`, `path`, `text`, `tool`, `type` |
 | `block` | `action`, `command`, `path`, `text`, `tool`, `type` |
+| `assertion` | `author`, `author_kind`, `author_ref`, `body`, `context`, `evidence`, `key`, `kind`, `scope`, `scope_ref`, `status`, `target`, `target_ref`, `text`, `value`, `visibility` |
 
-All three structural units also accept `session.<field>` predicates for the
-owning session fields, such as `session.repo`, `session.origin`,
+Structural units also accept `session.<field>` predicates for the owning
+session fields, such as `session.repo`, `session.origin`,
 `session.tag`, `session.title`, `session.date`, `session.since`, and
 `session.until`. Count and date session fields accept compact comparison
 prefixes such as `session.messages:>=2`, `session.words:<=500`, and
@@ -185,6 +187,7 @@ polylogue --format json messages where role:assistant AND text:timeout
 polylogue --format ndjson actions where session.repo:polylogue AND action:file_edit AND path:polylogue/archive
 polylogue --format yaml blocks where type:code AND text:sqlite
 polylogue --format json assertions where kind:decision AND status:active AND text:review
+polylogue --format json runs where role:subagent AND status:completed AND agent:Explore
 polylogue --format json observed-events where delivery_state:acted_on AND text:#2100
 polylogue --format json context-snapshots where boundary:session_start AND session.repo:polylogue
 ```
@@ -192,7 +195,7 @@ polylogue --format json context-snapshots where boundary:session_start AND sessi
 The row shape is the shared `QueryUnitEnvelope` used by CLI JSON/NDJSON/YAML,
 Python `Polylogue.query_units()`, MCP `query_units`, and daemon
 `GET /api/query-units?expression=...`. Plain and CSV CLI output are
-transport-specific renderings of the same message/action/block/assertion/
+transport-specific renderings of the same message/action/block/assertion/run/
 observed-event/context-snapshot row payloads.
 Those surfaces share the same session-scoping filters for the row source
 where applicable, such as origin, tag, repo, title, date bounds, message-type
@@ -206,14 +209,15 @@ polylogue messages where session.origin:claude-code-session AND role:assistant
 polylogue actions where session.repo:polylogue AND action:file_edit
 polylogue blocks where session.since:7d AND session.words:<=500 AND type:code
 polylogue assertions where session.repo:polylogue AND kind:caveat
+polylogue runs where session.repo:polylogue AND role:subagent AND status:completed
 polylogue observed-events where session.origin:codex-session AND object_ref:github-review
 polylogue context-snapshots where session.messages:>=2 AND session.date:>=2026-01-02 AND boundary:subagent_start
 ```
 
-`observed-events` and `context-snapshots` are runtime-transform row sources.
-They return projected evidence from existing recovery/run-projection
+`runs`, `observed-events`, and `context-snapshots` are runtime-transform row
+sources. They return projected evidence from existing recovery/run-projection
 transforms, not durable SQL table rows, so they are terminal unit sources only;
-they do not act as `exists observed-event(...)` or
+they do not act as `exists run(...)`, `exists observed-event(...)`, or
 `exists context-snapshot(...)` session selectors.
 
 Session filters such as `--origin`, `--tag`, `--repo`, `--since`, and `--until`

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1081,12 +1081,23 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
     return QueryUnitSource(unit=unit, predicate=transformed)
 
 
+def _terminal_only_unit_source_error(unit: QueryUnitName) -> ExpressionCompileError:
+    source = f"{unit}s" if unit != "context-snapshot" else "context-snapshots"
+    if unit == "observed-event":
+        source = "observed-events"
+    return ExpressionCompileError(
+        f"{source} where expressions return terminal {unit} rows; "
+        "use query_units / /api/query-units or a CLI terminal-unit query instead of a session selector",
+        field=None,
+    )
+
+
 def _parse_source_where_predicate(expression: str) -> QueryExistsPredicate | None:
     source = parse_unit_source_expression(expression)
     if source is None:
         return None
-    if source.unit in {"observed-event", "context-snapshot"}:
-        return None
+    if source.unit in {"run", "observed-event", "context-snapshot"}:
+        raise _terminal_only_unit_source_error(source.unit)
     return QueryExistsPredicate(unit=cast(Any, source.unit), child=source.predicate)
 
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -269,6 +269,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "rebuild_index": ("archive_routed", "index", "rebuilds messages_fts from index.db"),
     "rebuild_insights": ("archive_routed", "index", "rebuilds insight tables"),
     "record_correction": ("archive_routed", "user", "writes corrections through user.db"),
+    "context_pack_payload": ("archive_routed", "index", "builds context-pack DTOs from archive-routed reads"),
     "recovery_digest": ("archive_routed", "index", "builds recovery digests from archive-routed session reads"),
     "recovery_report": ("archive_routed", "index", "renders recovery reports from archive-routed session reads"),
     "recovery_read_payload": (

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -203,6 +203,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "delete_annotation",
         "list_annotations",
         "neighbor_candidates",
+        "context_pack_payload",
         "recovery_report",
         "find_resume_candidates",
         "export_insight_bundle",

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -388,17 +388,17 @@
     "archive_facade_routes": {
       "checked": true,
       "source": "static_facade_route_catalog",
-      "total_method_count": 113,
-      "archive_ready_method_count": 112,
+      "total_method_count": 114,
+      "archive_ready_method_count": 113,
       "unsupported_method_count": 0,
       "route_counts": {
-        "archive_routed": 98,
+        "archive_routed": 99,
         "archive_direct": 14,
         "not_archive_runtime": 1
       },
       "tier_counts": {
         "user": 36,
-        "index": 73,
+        "index": 74,
         "none": 1,
         "source": 3
       },
@@ -453,6 +453,11 @@
           "route": "not_archive_runtime",
           "tier": "none",
           "detail": "resource lifecycle method"
+        },
+        "context_pack_payload": {
+          "route": "archive_routed",
+          "tier": "index",
+          "detail": "builds context-pack DTOs from archive-routed reads"
         },
         "cost_outlook": {
           "route": "archive_routed",
@@ -1032,7 +1037,7 @@
       ],
       "facade_tier_route_counts": {
         "user": 36,
-        "index": 73,
+        "index": 74,
         "none": 1,
         "source": 3
       },

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -492,6 +492,22 @@ class TestBooleanQueryExpression:
         assert explanation.lowering_plan is not None
         assert "compatibility_selector" not in explanation.lowering_plan
 
+    @pytest.mark.parametrize(
+        ("expression", "unit_text"),
+        (
+            ("runs where role:subagent", "terminal run rows"),
+            ("observed-events where kind:session_started", "terminal observed-event rows"),
+            ("context-snapshots where boundary:session_start", "terminal context-snapshot rows"),
+        ),
+    )
+    def test_terminal_only_unit_sources_do_not_compile_to_session_selectors(
+        self,
+        expression: str,
+        unit_text: str,
+    ) -> None:
+        with pytest.raises(ExpressionCompileError, match=unit_text):
+            compile_expression(expression)
+
     def test_parse_context_snapshot_source_expression_preserves_terminal_unit(self) -> None:
         source = parse_unit_source_expression(
             "context-snapshots where session.repo:polylogue AND boundary:session_start AND text:run"

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -2004,6 +2004,15 @@ class TestQueryNoResultsDiagnosticPath:
         assert "error" in body
         assert body.get("ok") is False
 
+    def test_session_list_rejects_terminal_only_unit_query(self, workspace_env: dict[str, Path]) -> None:
+        """Session-list queries must not lower runtime rows into broken EXISTS predicates."""
+        expression = quote("runs where role:subagent")
+        with _running_server(workspace_env) as (_, base_url):
+            status, body = _get_json_ex(base_url, f"/api/sessions?query={expression}")
+        assert status == 400
+        assert body.get("ok") is False
+        assert "terminal run rows" in str(body.get("detail") or body.get("message") or "")
+
     def test_list_with_no_match_returns_diagnostics(self, workspace_env: dict[str, Path]) -> None:
         """A list with a tag that doesn't exist returns items=[] with total=0."""
         with _running_server(workspace_env) as (_, base_url):


### PR DESCRIPTION
## Summary

This tightens the #2006 query grammar boundary for runtime-transform unit sources. `runs where ...`, `observed-events where ...`, and `context-snapshots where ...` remain valid terminal row queries, but session-selector paths now reject them with a typed error instead of manufacturing an unlowerable or ambiguous `exists ...` predicate. The branch also registers the `context_pack_payload` API method added by #2160 in the archive facade route catalog, which the broad seed surfaced.

## Problem

The full query DSL issue distinguishes terminal row sources from structural session selectors. Runtime-transform units are generated from recovery/run projections today; they do not have durable SQL lowerers that can support `exists run(...)`, `exists observed-event(...)`, or `exists context-snapshot(...)` session predicates. Before this change, `runs where ...` could leak into the session compiler as an `EXISTS` predicate that storage cannot lower, while observed-event/context-snapshot forms could fall through to weaker parse behavior.

#2160 also added a public async `Polylogue.context_pack_payload(...)` method without updating the archive-route catalog used by `polylogue ops status`, so facade coverage and the JSON status snapshot drifted.

## Solution

- Add a typed terminal-only error in `polylogue.archive.query.expression` for runtime-transform unit sources used as session selectors.
- Keep `parse_unit_source_expression(...)` behavior intact for terminal CLI/API/MCP/daemon query-unit routes.
- Document `runs` alongside the existing terminal units and clarify that runtime-transform units are terminal-only until real durable lowerers exist.
- Add focused parser and daemon HTTP coverage for the rejected session-selector path.
- Register `context_pack_payload` as an index-routed archive facade method and refresh the affected status snapshot.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/daemon/test_web_reader.py -k 'terminal_only_unit_sources_do_not_compile_to_session_selectors or session_list_rejects_terminal_only_unit_query or parse_run_source_expression_preserves_terminal_unit or query_units_endpoint_returns_run_rows'`
- `nix develop --command devtools test tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade tests/unit/api/test_facade_contracts.py::test_no_undiscovered_async_methods`
- `nix develop --command devtools test tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot --snapshot-update`
- `nix develop --command devtools test tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot`
- `nix develop --command devtools verify --quick`
- `git diff --check`

`nix develop --command devtools verify --seed-testmon --skip-slow` (detached to avoid foreground session SIGTERM): 11,504 selected, 11,503 passed, 1 xfailed; peak pytest RSS 3,168 MiB.
- `nix develop --command devtools verify`: 7 affected tests passed; peak pytest RSS 125 MiB.

Closes part of #2006.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended query DSL to support `runs` as a selectable terminal unit alongside other units.
  * Added new `context_pack_payload` method to the facade API.

* **Bug Fixes**
  * Improved error handling to provide clearer messages when terminal-only units are used incorrectly in session queries.

* **Documentation**
  * Updated query documentation with `runs` examples and expanded structural unit coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->