### PR TITLE
feat(web): execute context preamble read view (#1846)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1418,6 +1418,22 @@ class PolylogueArchiveMixin:
             seed_session_id=seed_session_id,
         )
 
+    async def context_preamble_payload(
+        self,
+        session_id: str,
+        *,
+        related_limit: int = 5,
+    ) -> Any:
+        """Build the shared typed context-preamble payload for one session."""
+        from polylogue.context.preamble import build_context_preamble_payload
+
+        return await build_context_preamble_payload(
+            self,
+            session_id=session_id,
+            related_limit=related_limit,
+            source_tool_calls={"context_preamble_payload": "polylogue-api"},
+        )
+
     async def explain_query_expression(self, expression: str) -> JSONDocument:
         """Explain query DSL parsing, AST metadata, and lowering details."""
         from polylogue.archive.query.expression import explain_expression

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -270,6 +270,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "rebuild_insights": ("archive_routed", "index", "rebuilds insight tables"),
     "record_correction": ("archive_routed", "user", "writes corrections through user.db"),
     "context_pack_payload": ("archive_routed", "index", "builds context-pack DTOs from archive-routed reads"),
+    "context_preamble_payload": ("archive_routed", "index", "builds context preamble DTOs from archive-routed reads"),
     "recovery_digest": ("archive_routed", "index", "builds recovery digests from archive-routed session reads"),
     "recovery_report": ("archive_routed", "index", "renders recovery reports from archive-routed session reads"),
     "recovery_read_payload": (

--- a/polylogue/context/preamble.py
+++ b/polylogue/context/preamble.py
@@ -6,93 +6,133 @@ import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from polylogue.surfaces.payloads import (
+    ContextPreamble,
+    ContextPreambleAssertionGuidance,
+    ContextPreambleGuidance,
+    ContextPreambleLineage,
+    ContextPreambleProjectState,
+    ContextPreambleSession,
+)
+
 if TYPE_CHECKING:
     from polylogue.cli.shared.types import AppEnv
+
+
+async def build_context_preamble_payload(
+    polylogue: object,
+    *,
+    session_id: str | None,
+    related_limit: int = 5,
+    repo_path: str | None = None,
+    cwd: str | None = None,
+    recent_files: tuple[str, ...] = (),
+    source_tool_calls: dict[str, str] | None = None,
+    require_session: bool = True,
+) -> ContextPreamble | None:
+    """Build the shared typed context preamble payload for one seed session.
+
+    CLI, MCP, API, and daemon read-view routes all use this builder so the
+    context view does not fork into separate browser/MCP/CLI payload shapes.
+    """
+
+    conv = await polylogue.get_session(session_id) if session_id else None  # type: ignore[attr-defined]
+    if conv is None and require_session:
+        return None
+
+    lineage: ContextPreambleLineage | None = None
+    if session_id:
+        try:
+            topology = await polylogue.get_session_topology(session_id)  # type: ignore[attr-defined]
+            if topology:
+                lineage = ContextPreambleLineage(
+                    logical_session_root=getattr(topology, "logical_session_id", None),
+                    parent_session_id=getattr(topology, "parent_session_id", None),
+                )
+        except Exception:
+            pass
+
+    related: list[ContextPreambleSession] = []
+    try:
+        repo = repo_path or (getattr(conv, "git_repository_url", None) if conv is not None else None) or "."
+        candidates = await polylogue.find_resume_candidates(  # type: ignore[attr-defined]
+            repo_path=str(repo),
+            cwd=cwd,
+            recent_files=recent_files,
+            limit=max(1, related_limit),
+        )
+        for c in candidates:
+            cid = getattr(c, "logical_session_id", None) or getattr(c, "session_id", "") or "?"
+            related.append(
+                ContextPreambleSession(
+                    session_id=str(cid),
+                    title=getattr(c, "title", None),
+                    date=getattr(c, "date", None),
+                    terminal_state=getattr(c, "terminal_state", None),
+                    summary=getattr(c, "summary", None),
+                    origin=getattr(c, "origin", None),
+                )
+            )
+    except Exception:
+        pass
+
+    project: ContextPreambleProjectState | None = None
+    git_repo = getattr(conv, "git_repository_url", None) if conv is not None else None
+    git_branch = getattr(conv, "git_branch", None) if conv is not None else None
+    if git_repo or git_branch:
+        project = ContextPreambleProjectState(
+            repo=str(git_repo) if git_repo else None,
+            branch=str(git_branch) if git_branch else None,
+        )
+
+    assertion_guidance: list[ContextPreambleAssertionGuidance] = []
+    if session_id:
+        try:
+            claims = await polylogue.list_assertion_claim_payloads(  # type: ignore[attr-defined]
+                target_ref=f"session:{session_id}",
+                statuses=("active",),
+                context_inject=True,
+                limit=20,
+            )
+            assertion_guidance = [
+                ContextPreambleAssertionGuidance(
+                    kind=claim.kind,
+                    text=claim.body_text,
+                    target_ref=claim.target_ref,
+                    scope_ref=claim.scope_ref,
+                    evidence_refs=list(claim.evidence_refs),
+                )
+                for claim in claims
+            ]
+        except Exception:
+            pass
+
+    guidance = ContextPreambleGuidance(assertions=assertion_guidance) if assertion_guidance else None
+    return ContextPreamble(
+        preamble_version="1.0",
+        injected_at=datetime.now(timezone.utc).isoformat(),
+        source_tool_calls=source_tool_calls or {},
+        session_lineage=lineage,
+        recent_related_sessions=related,
+        open_issues=[],
+        project_state=project,
+        guidance=guidance,
+    )
 
 
 def compose_context_preamble(env: AppEnv, *, session_id: str, related_limit: int = 5) -> str:
     """Compose a context preamble JSON document for a seed session (#1494)."""
     from polylogue.api.sync.bridge import run_coroutine_sync
 
-    conv = run_coroutine_sync(env.polylogue.get_session(session_id))
-    if conv is None:
+    preamble = run_coroutine_sync(
+        build_context_preamble_payload(
+            env.polylogue,
+            session_id=session_id,
+            related_limit=related_limit,
+            source_tool_calls={"compose_context_preamble": "polylogue-cli"},
+        )
+    )
+    if preamble is None:
         env.ui.error(f"Session not found: {session_id}")
         raise SystemExit(1)
-
-    lineage: dict[str, object] = {}
-    try:
-        topology = run_coroutine_sync(env.polylogue.get_session_topology(session_id))
-        if topology:
-            lineage = {
-                "logical_session_root": getattr(topology, "logical_session_id", None),
-                "parent_session_id": getattr(topology, "parent_session_id", None),
-            }
-    except Exception:
-        pass
-
-    related: list[dict[str, object]] = []
-    try:
-        repo: object = getattr(conv, "git_repository_url", None)
-        candidates = run_coroutine_sync(
-            env.polylogue.find_resume_candidates(
-                repo_path=str(repo) if repo else ".",
-                limit=related_limit,
-            )
-        )
-        for c in candidates:
-            related.append(
-                {
-                    "session_id": getattr(c, "logical_session_id", None) or getattr(c, "session_id", "?"),
-                    "title": getattr(c, "title", None),
-                    "terminal_state": getattr(c, "terminal_state", None),
-                }
-            )
-    except Exception:
-        pass
-
-    project: dict[str, object] = {}
-    git_repo = getattr(conv, "git_repository_url", None)
-    git_branch = getattr(conv, "git_branch", None)
-    if git_repo or git_branch:
-        project = {
-            "repo": str(git_repo) if git_repo else None,
-            "branch": str(git_branch) if git_branch else None,
-        }
-
-    assertion_guidance: list[dict[str, object]] = []
-    try:
-        claims = run_coroutine_sync(
-            env.polylogue.list_assertion_claim_payloads(
-                target_ref=f"session:{session_id}",
-                statuses=("active",),
-                context_inject=True,
-                limit=20,
-            )
-        )
-        assertion_guidance = [
-            {
-                "kind": claim.kind,
-                "text": claim.body_text,
-                "target_ref": claim.target_ref,
-                "scope_ref": claim.scope_ref,
-                "evidence_refs": list(claim.evidence_refs),
-            }
-            for claim in claims
-        ]
-    except Exception:
-        pass
-
-    guidance: dict[str, object] | None = None
-    if assertion_guidance:
-        guidance = {"assertions": assertion_guidance}
-
-    preamble: dict[str, object] = {
-        "preamble_version": "1.0",
-        "injected_at": datetime.now(timezone.utc).isoformat(),
-        "session_lineage": lineage or None,
-        "recent_related_sessions": related,
-        "open_issues": [],
-        "project_state": project or None,
-        "guidance": guidance,
-    }
-    return json.dumps(preamble, indent=2, default=str)
+    return json.dumps(preamble.model_dump(mode="json", exclude_none=True), indent=2, default=str)

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2628,7 +2628,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         view = (self._get_param(params, "view", "messages") or "messages").strip().lower()
         output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
-        if view not in {"messages", "recovery", "raw", "context-pack"}:
+        if view not in {"messages", "recovery", "raw", "context", "context-pack"}:
             self._send_error(HTTPStatus.BAD_REQUEST, "unsupported_read_view")
             return
         if output_format != "json" and not (view == "recovery" and output_format == "markdown"):
@@ -2661,6 +2661,21 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 return await self._do_get_session_recovery(poly, conv_id, report, output_format)
 
             payload = self._sync_run(_get)
+        elif view == "context":
+            if output_format != "json":
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+                return
+
+            async def _get_context(poly: Polylogue) -> dict[str, object] | None:
+                context_payload = await poly.context_preamble_payload(
+                    conv_id,
+                    related_limit=self._get_int(params, "related_limit", 5),
+                )
+                if context_payload is None:
+                    return None
+                return dict(context_payload.model_dump(mode="json", exclude_none=True))
+
+            payload = self._sync_run(_get_context)
         elif view == "context-pack":
             if output_format != "json":
                 self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -769,8 +769,8 @@ function renderFacets() {
 function renderReadViewSelector(c) {
   if (!c) return '';
   var profiles = state.readViewProfiles || [];
-  var supported = {messages: true, recovery: true, raw: true, 'context-pack': true};
-  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', 'context-pack': 'Context Pack'};
+  var supported = {messages: true, recovery: true, raw: true, context: true, 'context-pack': true};
+  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', context: 'Context', 'context-pack': 'Context Pack'};
   if (!profiles.length) {
     var fallback = state.readViewProfileError || 'Read profiles loading';
     return '<div id="read-profile-selector" class="read-profile-selector muted">' + esc(fallback) + '</div>';
@@ -920,6 +920,7 @@ function renderReadViewExecution(c, viewId) {
   var payload = envelope.payload || {};
   if (viewId === 'recovery') return renderRecoveryReadView(payload);
   if (viewId === 'raw') return renderRawReadView(payload);
+  if (viewId === 'context') return renderContextReadView(payload);
   if (viewId === 'context-pack') return renderContextPackReadView(payload);
   return '<div class="main-empty"><h3>Unsupported read view</h3><p>' + esc(viewId) + '</p></div>';
 }
@@ -951,6 +952,34 @@ function renderRawReadView(payload) {
   });
   if (!artifacts.length) html += '<div class="inspector-empty">No raw artifact metadata surfaced for this session.</div>';
   html += '</div>';
+  return html;
+}
+
+function renderContextReadView(payload) {
+  var lineage = payload.session_lineage || {};
+  var related = payload.recent_related_sessions || [];
+  var project = payload.project_state || {};
+  var guidance = payload.guidance || {};
+  var assertions = guidance.assertions || [];
+  var html = '<div class="read-view-panel"><h3>Context preamble</h3>'
+    + '<p class="muted">Read through /api/sessions/:id/read using the shared ContextPreamble DTO.</p>'
+    + '<div class="inspector-field"><span class="label">root</span><span class="value">' + esc(lineage.logical_session_root || '-') + '</span></div>'
+    + '<div class="inspector-field"><span class="label">parent</span><span class="value">' + esc(lineage.parent_session_id || '-') + '</span></div>'
+    + '<div class="inspector-field"><span class="label">repo</span><span class="value">' + esc(project.repo || '-') + '</span></div>'
+    + '<div class="inspector-field"><span class="label">branch</span><span class="value">' + esc(project.branch || '-') + '</span></div>';
+  html += '<div class="inspector-section"><h4>Related sessions</h4>';
+  related.slice(0, 8).forEach(function(session) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(session.terminal_state || session.origin || 'related') + '</div>'
+      + '<div class="note"><strong>' + esc(session.title || 'Untitled') + '</strong><br>' + esc(session.session_id || '') + '</div></div>';
+  });
+  if (!related.length) html += '<div class="inspector-empty">No related sessions surfaced for this seed.</div>';
+  html += '</div><div class="inspector-section"><h4>Guidance</h4>';
+  assertions.slice(0, 8).forEach(function(claim) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(claim.kind || 'assertion') + ' / ' + esc(claim.scope_ref || '') + '</div>'
+      + '<div class="note">' + esc(claim.text || '') + '</div></div>';
+  });
+  if (!assertions.length) html += '<div class="inspector-empty">No injectable assertion guidance for this session.</div>';
+  html += '</div></div>';
   return html;
 }
 

--- a/polylogue/mcp/server_context_tools.py
+++ b/polylogue/mcp/server_context_tools.py
@@ -104,41 +104,30 @@ def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         """
 
         async def run() -> str:
-            from datetime import datetime, timezone
-
-            from polylogue.surfaces.payloads import (
-                ContextPreamble,
-                ContextPreambleProjectState,
-                ContextPreambleSession,
-            )
+            from polylogue.context.preamble import build_context_preamble_payload
+            from polylogue.surfaces.payloads import ContextPreamble, ContextPreambleProjectState
 
             poly = hooks.get_polylogue()
+            preamble = await build_context_preamble_payload(
+                poly,
+                session_id="",
+                related_limit=hooks.clamp_limit(limit),
+                repo_path=repo_path,
+                cwd=cwd,
+                recent_files=recent_files,
+                source_tool_calls={"compose_context_preamble": "polylogue-mcp"},
+                require_session=False,
+            )
 
-            # Recent related sessions from resume candidates.
-            recent: list[ContextPreambleSession] = []
-            try:
-                candidates = await poly.find_resume_candidates(
-                    repo_path=repo_path or ".",
-                    cwd=cwd,
-                    recent_files=recent_files,
-                    limit=hooks.clamp_limit(limit),
+            # ``compose_context_preamble`` for SessionStart may run before a
+            # seed session exists. Keep the project/recent-session behavior
+            # useful by returning an empty payload enriched with git state.
+            if preamble is None:
+                preamble = ContextPreamble(
+                    preamble_version="1.0",
+                    source_tool_calls={"compose_context_preamble": "polylogue-mcp"},
                 )
-                for c in candidates:
-                    cid: str = getattr(c, "logical_session_id", None) or getattr(c, "session_id", "") or "?"
-                    recent.append(
-                        ContextPreambleSession(
-                            session_id=cid,
-                            title=getattr(c, "title", None),
-                            date=getattr(c, "date", None),
-                            terminal_state=getattr(c, "terminal_state", None),
-                            summary=getattr(c, "summary", None),
-                            origin=getattr(c, "origin", None),
-                        )
-                    )
-            except Exception:
-                pass
 
-            # Project state from git.
             project: ContextPreambleProjectState | None = None
             try:
                 import subprocess
@@ -168,13 +157,10 @@ def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             except Exception:
                 pass
 
-            preamble = ContextPreamble(
-                preamble_version="1.0",
-                injected_at=datetime.now(timezone.utc).isoformat(),
-                source_tool_calls={"compose_context_preamble": "polylogue-mcp"},
-                recent_related_sessions=recent,
-                project_state=project,
-            )
+            if project is not None:
+                payload = preamble.model_dump(mode="json", exclude_none=True)
+                payload["project_state"] = project.model_dump(mode="json", exclude_none=True)
+                preamble = ContextPreamble.model_validate(payload)
             return hooks.json_payload(preamble, exclude_none=True)
 
         return await hooks.async_safe_call("compose_context_preamble", run)

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1668,6 +1668,26 @@ class FacetsResponse(SurfacePayloadModel):
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
 
+class ContextPreambleAssertionGuidance(SurfacePayloadModel):
+    """Assertion guidance eligible for explicit context injection."""
+
+    kind: str
+    text: str | None = None
+    target_ref: str | None = None
+    scope_ref: str | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ContextPreambleGuidance(SurfacePayloadModel):
+    """Structured guidance carried by context preamble payloads."""
+
+    assertions: list[ContextPreambleAssertionGuidance] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
 class ContextPreamble(SurfacePayloadModel):
     """Typed delivery envelope for SessionStart context injection (#1696).
 
@@ -1685,7 +1705,7 @@ class ContextPreamble(SurfacePayloadModel):
     open_issues: list[ContextPreambleIssue] = Field(default_factory=list)
     project_state: ContextPreambleProjectState | None = None
     blackboard_notes: list[ContextPreambleBlackboardNote] = Field(default_factory=list)
-    guidance: str | None = None
+    guidance: str | ContextPreambleGuidance | None = None
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -1730,6 +1750,7 @@ class ContextPreambleIssue(SurfacePayloadModel):
 class ContextPreambleProjectState(SurfacePayloadModel):
     """Current project state for the context preamble."""
 
+    repo: str | None = None
     branch: str | None = None
     recent_commits: list[str] = Field(default_factory=list)
     active_worktrees: list[str] = Field(default_factory=list)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -204,6 +204,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "list_annotations",
         "neighbor_candidates",
         "context_pack_payload",
+        "context_preamble_payload",
         "recovery_report",
         "find_resume_candidates",
         "export_insight_bundle",

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -388,17 +388,17 @@
     "archive_facade_routes": {
       "checked": true,
       "source": "static_facade_route_catalog",
-      "total_method_count": 114,
-      "archive_ready_method_count": 113,
+      "total_method_count": 115,
+      "archive_ready_method_count": 114,
       "unsupported_method_count": 0,
       "route_counts": {
-        "archive_routed": 99,
+        "archive_routed": 100,
         "archive_direct": 14,
         "not_archive_runtime": 1
       },
       "tier_counts": {
         "user": 36,
-        "index": 74,
+        "index": 75,
         "none": 1,
         "source": 3
       },
@@ -458,6 +458,11 @@
           "route": "archive_routed",
           "tier": "index",
           "detail": "builds context-pack DTOs from archive-routed reads"
+        },
+        "context_preamble_payload": {
+          "route": "archive_routed",
+          "tier": "index",
+          "detail": "builds context preamble DTOs from archive-routed reads"
         },
         "cost_outlook": {
           "route": "archive_routed",
@@ -1037,7 +1042,7 @@
       ],
       "facade_tier_route_counts": {
         "user": 36,
-        "index": 74,
+        "index": 75,
         "none": 1,
         "source": 3
       },

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1497,7 +1497,7 @@ class TestReaderViewProfiles:
         assert profiles["recovery"]["successor_handoff"] is True
         assert "markdown" in profiles["recovery"]["formats"]
 
-    def test_read_view_execution_route_returns_messages_recovery_raw_and_context_pack(
+    def test_read_view_execution_route_returns_messages_recovery_raw_context_and_context_pack(
         self,
         workspace_env: dict[str, Path],
     ) -> None:
@@ -1511,6 +1511,7 @@ class TestReaderViewProfiles:
                 _get_json(base_url, f"/api/sessions/{C1}/read?view=recovery&report=work-packet"),
             )
             raw = cast(dict[str, object], _get_json(base_url, f"/api/sessions/{C1}/read?view=raw"))
+            context = cast(dict[str, object], _get_json(base_url, f"/api/sessions/{C1}/read?view=context"))
             context_pack = cast(
                 dict[str, object],
                 _get_json(base_url, f"/api/sessions/{C1}/read?view=context-pack&max_messages=5"),
@@ -1525,6 +1526,9 @@ class TestReaderViewProfiles:
         assert raw["view"] == "raw"
         raw_payload = cast(dict[str, object], raw["payload"])
         assert raw_payload["id"] == C1
+        assert context["view"] == "context"
+        context_payload = cast(dict[str, object], context["payload"])
+        assert context_payload["preamble_version"] == "1.0"
         assert context_pack["view"] == "context-pack"
         context_payload = cast(dict[str, object], context_pack["payload"])
         assert context_payload["total_sessions"] == 1
@@ -1535,7 +1539,7 @@ class TestReaderViewProfiles:
 
     def test_read_view_execution_rejects_unknown_view_or_format(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
-            view_status, view_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=context")
+            view_status, view_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=neighbors")
             format_status, format_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=messages&format=html")
 
         assert view_status == 400

--- a/tests/unit/mcp/test_compose_context_preamble.py
+++ b/tests/unit/mcp/test_compose_context_preamble.py
@@ -409,6 +409,35 @@ class TestContextPreambleModel:
         data = json.loads(preamble.model_dump_json(exclude_none=True))
         assert data["guidance"] == "Focus on #1721 test coverage gaps."
 
+    def test_preamble_with_structured_guidance_and_repo_state(self) -> None:
+        """ContextPreamble carries structured assertion guidance across surfaces."""
+        from polylogue.surfaces.payloads import (
+            ContextPreamble,
+            ContextPreambleAssertionGuidance,
+            ContextPreambleGuidance,
+            ContextPreambleProjectState,
+        )
+
+        preamble = ContextPreamble(
+            preamble_version="1.0",
+            project_state=ContextPreambleProjectState(repo="https://github.com/Sinity/polylogue", branch="master"),
+            guidance=ContextPreambleGuidance(
+                assertions=[
+                    ContextPreambleAssertionGuidance(
+                        kind="decision",
+                        text="Use the shared context-preamble builder.",
+                        target_ref="session:target",
+                        scope_ref="repo:polylogue",
+                        evidence_refs=["target::m1"],
+                    )
+                ]
+            ),
+        )
+
+        data = json.loads(preamble.model_dump_json(exclude_none=True))
+        assert data["project_state"]["repo"] == "https://github.com/Sinity/polylogue"
+        assert data["guidance"]["assertions"][0]["kind"] == "decision"
+
     def test_preamble_default_construction(self) -> None:
         """Default ContextPreamble has sensible empty values."""
         from polylogue.surfaces.payloads import ContextPreamble

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -391,6 +391,10 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
             dict[str, object],
             get_json(base_url, f"/api/assertions?target_ref=session%3A{READER_C1}&limit=10"),
         )
+        context = cast(
+            dict[str, object],
+            get_json(base_url, f"/api/sessions/{READER_C1}/read?view=context"),
+        )
         context_pack = cast(
             dict[str, object],
             get_json(base_url, f"/api/sessions/{READER_C1}/read?view=context-pack&max_messages=5"),
@@ -404,6 +408,7 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
         "renderInspectorEvidence",
         "renderBrowserCaptureChip",
         "renderReadViewExecution",
+        "renderContextReadView",
         "renderContextPackReadView",
         "loadEvidencePanel",
         "/api/assertions?target_ref=",
@@ -421,11 +426,14 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
     claim_items = cast(list[dict[str, object]], assertions["items"])
     assert [item["assertion_id"] for item in claim_items] == ["reader-evidence-decision"]
     assert claim_items[0]["target_ref"] == f"session:{READER_C1}"
+    assert context["view"] == "context"
+    context_payload = cast(dict[str, object], context["payload"])
+    assert context_payload["preamble_version"] == "1.0"
     assert context_pack["view"] == "context-pack"
-    context_payload = cast(dict[str, object], context_pack["payload"])
-    context_sessions = cast(list[dict[str, object]], context_payload["sessions"])
+    context_pack_payload = cast(dict[str, object], context_pack["payload"])
+    context_sessions = cast(list[dict[str, object]], context_pack_payload["sessions"])
     assert context_sessions[0]["session_id"] == READER_C1
-    context_provenance = cast(dict[str, object], context_payload["provenance"])
+    context_provenance = cast(dict[str, object], context_pack_payload["provenance"])
     assert context_provenance["redacted"] is True
 
     write_evidence_manifest(
@@ -438,7 +446,7 @@ def test_reader_evidence_panel_endpoint_and_shell_smoke(reader_workspace: Reader
             "recovery_report": recovery["report"],
             "work_packet_evidence_refs": len(cast(list[object], packet["evidence_refs"])),
             "assertion_count": assertions["total"],
-            "context_pack_sessions": context_payload["total_sessions"],
+            "context_pack_sessions": context_pack_payload["total_sessions"],
             "raw_artifacts_absent_from_recovery": True,
             "private_path_safe": True,
         },


### PR DESCRIPTION
## Summary

Adds executable `context` read support to the daemon workbench by routing `/api/sessions/:id/read?view=context` through the same typed `ContextPreamble` contract used by CLI/MCP/API surfaces. The web shell now enables and renders the context preamble profile instead of treating it as a pending browser-only placeholder.

## Problem

#1846 tracks the workbench as a browser cockpit over existing archive contracts. After #2160, `context-pack` was route-backed, but `context` remained disabled in the reader even though the context preamble already existed as a real CLI/MCP-facing payload. That left the workbench fragmented: browser code could show profile metadata but not execute one of the concrete read profiles without inventing a separate shape.

## Solution

- Added `build_context_preamble_payload(...)` in `polylogue/context/preamble.py` as the shared async builder for context preamble DTOs.
- Exposed `Polylogue.context_preamble_payload(...)` and registered it in the facade route catalog.
- Routed daemon `read?view=context&format=json` through the shared builder and rendered it in `web_shell.py`.
- Reused the builder from MCP `compose_context_preamble` while preserving seedless SessionStart behavior.
- Extended `ContextPreamble` with typed assertion guidance so injectable assertion claims remain structured across API, daemon, MCP, and shell surfaces.

Closes part of #1846. The issue remains open for the broader operator-flow polish, remaining read profiles (`neighbors`, `correlation`), overlay UX, and visual end-to-end flow completion.

## Verification

- `devtools test tests/unit/cli/test_context_view.py tests/unit/mcp/test_compose_context_preamble.py tests/unit/daemon/test_web_reader.py::TestReaderViewProfiles tests/visual/test_reader_dom_smoke.py::test_reader_evidence_panel_endpoint_and_shell_smoke tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade tests/unit/api/test_facade_contracts.py::test_no_undiscovered_async_methods`
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot --snapshot-update`
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot`
- `devtools verify --quick`
- `devtools verify --seed-testmon --skip-slow` (11505 passed, 1 xfailed; peak pytest RSS 3449.3 MiB)
- `devtools verify` (7 affected tests passed)
