### PR TITLE
fix(devtools): bound workload diagnostics and cleanup pytest temps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1459,8 +1459,13 @@ The report has a stable top-level shape carrying its `report_version`,
   Missing tables surface as `-1` rather than crashing the probe.
 - `archive_tiers` — archive inventory for `source.db`,
   `index.db`, `embeddings.db`, `user.db`, and `ops.db`: file presence,
-  durability/backup policy, `PRAGMA user_version`, `PRAGMA quick_check`,
-  missing backup-required tiers, and cheap table counts per tier.
+  durability/backup policy, `PRAGMA user_version`, missing backup-required
+  tiers, and cheap table counts per tier. It does not run SQLite
+  `PRAGMA quick_check` by default because that is a full-file integrity scan
+  on large archives; pass `--integrity-check` when the workload snapshot should
+  include that expensive evidence. It also avoids exact generated-text
+  reconciliation by default; pass `--exact-derived-counts` when diagnosing
+  FTS/source-row drift and the archive can afford the scan.
 - `blob_lease_state` — pending lease count, distinct lease operations,
   oldest `acquired_at`. See the lease/GC concurrency model above.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,

--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -59,7 +59,6 @@ _BOUNDARY_TABLES: tuple[str, ...] = (
     "session_repos",
     "session_commits",
     "blocks",
-    "messages_fts_data",
     "session_events",
     "session_links",
 )
@@ -85,7 +84,7 @@ _ARCHIVE_OBSERVABILITY_TABLES: dict[ArchiveTier, tuple[str, ...]] = {
         "sessions",
         "messages",
         "blocks",
-        "messages_fts_data",
+        "messages_fts_docsize",
         "session_events",
         "session_links",
         "threads",
@@ -158,6 +157,16 @@ def _scalar_int(conn: sqlite3.Connection, sql: str, params: tuple[object, ...] =
     except sqlite3.Error:
         return 0
     return int(row[0] or 0) if row is not None else 0
+
+
+def _presence_count(conn: sqlite3.Connection, table: str) -> int:
+    """Return 1 when a table has at least one row, without scanning it."""
+
+    try:
+        row = conn.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone()
+    except sqlite3.Error:
+        return 0
+    return 1 if row is not None else 0
 
 
 def _recent_attempts(conn: sqlite3.Connection, *, limit: int, ops_db: Path | None = None) -> list[dict[str, Any]]:
@@ -836,7 +845,13 @@ def _boundary_table_counts(
     return counts
 
 
-def _archive_tier_state(anchor_db: Path, *, observed_db: Path | None = None) -> dict[str, Any]:
+def _archive_tier_state(
+    anchor_db: Path,
+    *,
+    observed_db: Path | None = None,
+    integrity_check: bool = False,
+    exact_derived_counts: bool = False,
+) -> dict[str, Any]:
     """Report the archive database files around an archive root."""
 
     root = anchor_db.parent
@@ -854,7 +869,7 @@ def _archive_tier_state(anchor_db: Path, *, observed_db: Path | None = None) -> 
 
     for tier, spec in ARCHIVE_TIER_SPECS.items():
         path = root / spec.filename
-        tier_payload = _archive_single_tier_state(path, tier)
+        tier_payload = _archive_single_tier_state(path, tier, integrity_check=integrity_check)
         tier_payload.update(
             {
                 "tier": tier.value,
@@ -875,7 +890,7 @@ def _archive_tier_state(anchor_db: Path, *, observed_db: Path | None = None) -> 
                 missing_backup_required.append(tier.value)
         tiers[tier.value] = tier_payload
 
-    derived_readiness = _archive_derived_readiness(root)
+    derived_readiness = _archive_derived_readiness(root, exact_counts=exact_derived_counts)
     user_overlay_orphans = _archive_user_overlay_orphans(root)
     layout_readiness = _archive_layout_readiness(
         present_count=present_count,
@@ -962,7 +977,7 @@ def _archive_layout_readiness(
     }
 
 
-def _archive_single_tier_state(path: Path, tier: ArchiveTier) -> dict[str, Any]:
+def _archive_single_tier_state(path: Path, tier: ArchiveTier, *, integrity_check: bool = False) -> dict[str, Any]:
     if not path.exists():
         return {
             "path": str(path),
@@ -978,7 +993,7 @@ def _archive_single_tier_state(path: Path, tier: ArchiveTier) -> dict[str, Any]:
         "exists": True,
         "size_bytes": path.stat().st_size,
         "user_version": None,
-        "integrity": "unknown",
+        "integrity": "not_checked",
         "table_counts": {},
         "error": None,
     }
@@ -987,8 +1002,9 @@ def _archive_single_tier_state(path: Path, tier: ArchiveTier) -> dict[str, Any]:
         try:
             version_row = conn.execute("PRAGMA user_version").fetchone()
             payload["user_version"] = int(version_row[0] or 0) if version_row is not None else 0
-            integrity_row = conn.execute("PRAGMA quick_check").fetchone()
-            payload["integrity"] = str(integrity_row[0]) if integrity_row is not None else "unknown"
+            if integrity_check:
+                integrity_row = conn.execute("PRAGMA quick_check").fetchone()
+                payload["integrity"] = str(integrity_row[0]) if integrity_row is not None else "unknown"
             payload["table_counts"] = {
                 table: _scalar_int(conn, f"SELECT COUNT(*) FROM {table}") if _table_exists(conn, table) else -1
                 for table in _ARCHIVE_OBSERVABILITY_TABLES[tier]
@@ -1001,7 +1017,7 @@ def _archive_single_tier_state(path: Path, tier: ArchiveTier) -> dict[str, Any]:
     return payload
 
 
-def _archive_derived_readiness(root: Path) -> dict[str, Any]:
+def _archive_derived_readiness(root: Path, *, exact_counts: bool = False) -> dict[str, Any]:
     """Report cross-table readiness for derived surfaces."""
 
     index_db = root / ARCHIVE_TIER_SPECS[ArchiveTier.INDEX].filename
@@ -1024,12 +1040,18 @@ def _archive_derived_readiness(root: Path) -> dict[str, Any]:
             conn.execute("ATTACH DATABASE ? AS source_tier", (f"file:{source_db}?mode=ro",))
             source_attached = True
             source_check_available = _attached_table_exists(conn, "source_tier", "raw_sessions")
-        counts = _archive_derived_counts(conn, source_check_available=source_check_available)
+        counts = _archive_derived_counts(conn, source_check_available=source_check_available, exact_counts=exact_counts)
         materialization_counts = _archive_materialization_counts(conn)
         missing_materialization_counts = _archive_missing_materialization_counts(conn)
+        messages_fts_ready = (
+            counts["text_block_count"] == counts["messages_fts_count"]
+            if exact_counts
+            else _fts_trigger_state(conn)["all_present"]
+            and (counts["block_count"] == 0 or counts["messages_fts_count"] > 0)
+        )
         ready = {
             "raw_links_ready": counts["missing_raw_session_count"] == 0 if source_check_available else None,
-            "messages_fts_ready": counts["text_block_count"] == counts["messages_fts_count"],
+            "messages_fts_ready": messages_fts_ready,
             "profile_rows_ready": counts["missing_profile_row_count"] == 0 and counts["orphan_profile_row_count"] == 0,
             "profile_counts_ready": (
                 counts["profile_work_event_count_mismatch"] == 0 and counts["profile_phase_count_mismatch"] == 0
@@ -1072,7 +1094,9 @@ def _archive_derived_readiness(root: Path) -> dict[str, Any]:
         conn.close()
 
 
-def _archive_derived_counts(conn: sqlite3.Connection, *, source_check_available: bool) -> dict[str, int]:
+def _archive_derived_counts(
+    conn: sqlite3.Connection, *, source_check_available: bool, exact_counts: bool = False
+) -> dict[str, Any]:
     missing_raw = 0
     if source_check_available:
         missing_raw = _scalar_int(
@@ -1086,13 +1110,22 @@ def _archive_derived_counts(conn: sqlite3.Connection, *, source_check_available:
               )
             """,
         )
+    block_count = _scalar_int(conn, "SELECT COUNT(*) FROM blocks")
+    if exact_counts:
+        text_block_count = _scalar_int(conn, "SELECT COUNT(*) FROM blocks WHERE search_text != ''")
+        messages_fts_count = _scalar_int(conn, "SELECT COUNT(*) FROM messages_fts")
+    else:
+        text_block_count = block_count
+        messages_fts_count = _scalar_int(conn, "SELECT COUNT(*) FROM messages_fts_docsize")
     return {
         "session_count": _scalar_int(conn, "SELECT COUNT(*) FROM sessions"),
         "raw_link_count": _scalar_int(conn, "SELECT COUNT(*) FROM sessions WHERE raw_id IS NOT NULL"),
         "missing_raw_session_count": missing_raw,
         "message_count": _scalar_int(conn, "SELECT COUNT(*) FROM messages"),
-        "text_block_count": _scalar_int(conn, "SELECT COUNT(*) FROM blocks WHERE search_text != ''"),
-        "messages_fts_count": _scalar_int(conn, "SELECT COUNT(*) FROM messages_fts"),
+        "block_count": block_count,
+        "text_block_count": text_block_count,
+        "messages_fts_count": messages_fts_count,
+        "messages_fts_exact_counts": exact_counts,
         "profile_row_count": _scalar_int(conn, "SELECT COUNT(*) FROM session_profiles"),
         "missing_profile_row_count": _scalar_int(
             conn,
@@ -1119,7 +1152,10 @@ def _archive_derived_counts(conn: sqlite3.Connection, *, source_check_available:
         "thread_count": _scalar_int(conn, "SELECT COUNT(*) FROM threads"),
         "thread_session_count": _scalar_int(conn, "SELECT COUNT(*) FROM thread_sessions"),
         "session_tag_count": _scalar_int(conn, "SELECT COUNT(*) FROM session_tags"),
-        "action_count": _scalar_int(conn, "SELECT COUNT(*) FROM actions"),
+        "action_count": _scalar_int(conn, "SELECT COUNT(*) FROM actions")
+        if exact_counts
+        else _presence_count(conn, "actions"),
+        "action_count_exact": exact_counts,
         "cost_profile_count": _scalar_int(
             conn,
             """
@@ -1152,7 +1188,7 @@ def _archive_derived_counts(conn: sqlite3.Connection, *, source_check_available:
 
 
 def _archive_surface_readiness(
-    counts: dict[str, int],
+    counts: dict[str, Any],
     *,
     missing_materialization_counts: dict[str, int],
     source_check_available: bool,
@@ -1189,7 +1225,7 @@ def _archive_surface_readiness(
         raw_blockers.append("missing_source_raw_sessions")
 
     search_blockers: list[str] = []
-    if counts["text_block_count"] != counts["messages_fts_count"]:
+    if counts["messages_fts_exact_counts"] and counts["text_block_count"] != counts["messages_fts_count"]:
         search_blockers.append("messages_fts_row_mismatch")
 
     profile_ready = (
@@ -1241,6 +1277,7 @@ def _archive_surface_readiness(
             evidence={
                 "text_block_count": counts["text_block_count"],
                 "messages_fts_count": counts["messages_fts_count"],
+                "messages_fts_exact_counts": counts["messages_fts_exact_counts"],
             },
         ),
         "session_profiles": surface(
@@ -1286,7 +1323,7 @@ def _archive_surface_readiness(
         "tool_usage": surface(
             ready=True,
             blockers=[],
-            evidence={"action_count": counts["action_count"]},
+            evidence={"action_count": counts["action_count"], "action_count_exact": counts["action_count_exact"]},
         ),
         "session_costs": surface(
             ready=profile_ready,
@@ -1828,7 +1865,9 @@ def _archive_query_plans(root: Path) -> dict[str, Any]:
     return plans
 
 
-def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
+def probe(
+    db: Path, *, limit: int = 5, integrity_check: bool = False, exact_derived_counts: bool = False
+) -> dict[str, Any]:
     ops_db = db.with_name("ops.db")
     index_db = db.with_name("index.db")
     if not db.exists() and not index_db.exists() and not ops_db.exists():
@@ -1861,7 +1900,12 @@ def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
             "storage_route_counts": _storage_route_counts(conn, ops_db=ops_db),
             "convergence_stage_timings": _convergence_stage_timings(recent_attempts, conn),
             "boundary_table_counts": _boundary_table_counts(conn, ops_db=ops_db, source_db=db.with_name("source.db")),
-            "archive_tiers": _archive_tier_state(db, observed_db=observed_db),
+            "archive_tiers": _archive_tier_state(
+                db,
+                observed_db=observed_db,
+                integrity_check=integrity_check,
+                exact_derived_counts=exact_derived_counts,
+            ),
             "topology_quarantine_state": _topology_quarantine_state(conn),
             "blob_lease_state": _tier_state_or_current(conn, db.with_name("source.db"), _blob_lease_state),
             "gc_state": _tier_state_or_current(conn, db.with_name("source.db"), _gc_state),
@@ -2388,6 +2432,16 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     parser.add_argument("--limit", type=int, default=5, help="Recent attempt limit")
     parser.add_argument(
+        "--integrity-check",
+        action="store_true",
+        help="Run PRAGMA quick_check for each archive tier (can be expensive on large archives)",
+    )
+    parser.add_argument(
+        "--exact-derived-counts",
+        action="store_true",
+        help="Run exact derived-readiness reconciliation counts (can scan large archive tables)",
+    )
+    parser.add_argument(
         "--compare",
         nargs=2,
         metavar=("BEFORE", "AFTER"),
@@ -2415,7 +2469,12 @@ def main(argv: list[str] | None = None) -> int:
             print(_format_compare_human(diff))
         return 0 if diff.get("ok") else 1
 
-    payload = probe(args.db or active_index_db_path(), limit=max(1, args.limit))
+    payload = probe(
+        args.db or active_index_db_path(),
+        limit=max(1, args.limit),
+        integrity_check=args.integrity_check,
+        exact_derived_counts=args.exact_derived_counts,
+    )
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0 if payload.get("ok") else 1

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -47,6 +47,7 @@ from devtools.verify_runs import (
     ResourceSampler,
     VerifyRun,
     classify_pytest_result,
+    cleanup_managed_pytest_basetemp,
     copy_current_pytest_artifacts,
     env_for_pytest_step,
     latest_event_from_paths,
@@ -723,6 +724,7 @@ def _run(
         if run is not None and artifacts is not None:
             env = env_for_pytest_step(env, run=run, artifacts=artifacts)
         result = _run_pytest_with_heartbeat(cmd, cwd=cwd, env=env, t0=t0, run=run, artifacts=artifacts)
+        cleanup_managed_pytest_basetemp(root=ROOT, run_id=env.get("POLYLOGUE_PYTEST_RUN_ID", ""), env=env)
         if artifacts is not None:
             merge_worker_events(artifacts.events_dir, artifacts.events_merged_path)
             with contextlib.suppress(FileNotFoundError):

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -375,6 +375,25 @@ def pytest_basetemp_path(*, root: Path, run_id: str, env: dict[str, str]) -> Pat
     return scratch_root / f"pytest-polylogue-{checkout_hash(root)}-{run_id}"
 
 
+def cleanup_managed_pytest_basetemp(*, root: Path, run_id: str, env: dict[str, str]) -> Path | None:
+    """Remove the managed per-run pytest basetemp after pytest has exited.
+
+    The pytest sessionfinish hook intentionally does not delete xdist
+    basetemps while workers/reporters may still be flushing.  The supervisor is
+    outside that teardown window, so it can reclaim tmpfs-backed broad-run
+    basetemps immediately instead of waiting for the next pytest startup sweep.
+    """
+
+    basetemp = pytest_basetemp_path(root=root, run_id=run_id, env=env)
+    if not basetemp.name.startswith("pytest-polylogue-") or "-seeded-" in basetemp.name:
+        return None
+    with contextlib.suppress(OSError):
+        if basetemp.exists():
+            shutil.rmtree(basetemp, ignore_errors=True)
+            return basetemp
+    return None
+
+
 class ResourceSampler:
     """Samples host and process-tree resources for one subprocess tree."""
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -431,8 +431,13 @@ The report has a stable top-level shape carrying its `report_version`,
   Missing tables surface as `-1` rather than crashing the probe.
 - `archive_tiers` — archive inventory for `source.db`,
   `index.db`, `embeddings.db`, `user.db`, and `ops.db`: file presence,
-  durability/backup policy, `PRAGMA user_version`, `PRAGMA quick_check`,
-  missing backup-required tiers, and cheap table counts per tier.
+  durability/backup policy, `PRAGMA user_version`, missing backup-required
+  tiers, and cheap table counts per tier. It does not run SQLite
+  `PRAGMA quick_check` by default because that is a full-file integrity scan
+  on large archives; pass `--integrity-check` when the workload snapshot should
+  include that expensive evidence. It also avoids exact generated-text
+  reconciliation by default; pass `--exact-derived-counts` when diagnosing
+  FTS/source-row drift and the archive can afford the scan.
 - `blob_lease_state` — pending lease count, distinct lease operations,
   oldest `acquired_at`. See the lease/GC concurrency model above.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -23,6 +23,16 @@ def diagnostics_group() -> None:
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
 @click.option("--limit", "-l", type=int, default=5, help="Recent attempt limit.")
 @click.option(
+    "--integrity-check",
+    is_flag=True,
+    help="Run SQLite quick_check for each archive tier. This can be expensive on large archives.",
+)
+@click.option(
+    "--exact-derived-counts",
+    is_flag=True,
+    help="Run exact derived-readiness reconciliation counts. This can scan large archive tables.",
+)
+@click.option(
     "--compare",
     nargs=2,
     type=click.Path(path_type=Path),
@@ -34,6 +44,8 @@ def workload_command(
     db: Path | None,
     json_output: bool,
     limit: int,
+    integrity_check: bool,
+    exact_derived_counts: bool,
     compare: tuple[Path, Path] | None,
 ) -> None:
     """Inspect daemon ingest workload, convergence debt, and hot query plans."""
@@ -45,6 +57,10 @@ def workload_command(
     if json_output:
         argv.append("--json")
     argv.extend(("--limit", str(limit)))
+    if integrity_check:
+        argv.append("--integrity-check")
+    if exact_derived_counts:
+        argv.append("--exact-derived-counts")
     if compare is not None:
         before, after = compare
         argv.extend(("--compare", str(before), str(after)))

--- a/tests/baselines/showcase/help-ops-diagnostics-workload.txt
+++ b/tests/baselines/showcase/help-ops-diagnostics-workload.txt
@@ -6,6 +6,10 @@ Options:
   --db PATH               Archive SQLite database path.
   --json                  Emit machine-readable JSON.
   -l, --limit INTEGER     Recent attempt limit.
+  --integrity-check       Run SQLite quick_check for each archive tier. This
+                          can be expensive on large archives.
+  --exact-derived-counts  Run exact derived-readiness reconciliation counts.
+                          This can scan large archive tables.
   --compare BEFORE AFTER  Compare two saved probe reports and report
                           structured deltas.
   -h, --help              Show this message and exit.

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -338,11 +338,13 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert readiness["counts"]["missing_raw_session_count"] == 1
     assert readiness["counts"]["text_block_count"] == 1
     assert readiness["counts"]["messages_fts_count"] == 1
+    assert readiness["counts"]["messages_fts_exact_counts"] is False
     assert readiness["counts"]["profile_row_count"] == 1
     assert readiness["counts"]["missing_profile_row_count"] == 1
     assert readiness["counts"]["work_event_row_count"] == 1
     assert readiness["counts"]["session_tag_count"] == 0
     assert readiness["counts"]["action_count"] == 0
+    assert readiness["counts"]["action_count_exact"] is False
     assert readiness["materialization_counts"]["session_profile"] == 1
     assert readiness["missing_materialization_counts"]["session_profile"] == 1
     assert readiness["missing_materialization_counts"]["work_events"] == 2
@@ -355,6 +357,7 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert surfaces["raw_artifacts"]["ready"] is False
     assert surfaces["raw_artifacts"]["blockers"] == ["missing_source_raw_sessions"]
     assert surfaces["search"]["ready"] is True
+    assert surfaces["search"]["evidence"]["messages_fts_exact_counts"] is False
     assert surfaces["session_profiles"]["ready"] is False
     assert "missing_profile_rows" in surfaces["session_profiles"]["blockers"]
     assert "missing_session_profile_materialization" in surfaces["session_profiles"]["blockers"]
@@ -364,7 +367,13 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert surfaces["tag_rollups"]["evidence"]["session_tag_count"] == 0
     assert surfaces["tool_usage"]["ready"] is True
     assert surfaces["tool_usage"]["evidence"]["action_count"] == 0
+    assert surfaces["tool_usage"]["evidence"]["action_count_exact"] is False
     assert tiers["schema_mismatches"] == []
+    assert tiers["tiers"]["source"]["integrity"] == "not_checked"
+    expensive_payload = probe(db, integrity_check=True, exact_derived_counts=True)
+    assert expensive_payload["archive_tiers"]["tiers"]["source"]["integrity"] == "ok"
+    assert expensive_payload["archive_tiers"]["derived_readiness"]["counts"]["messages_fts_exact_counts"] is True
+    assert expensive_payload["archive_tiers"]["derived_readiness"]["counts"]["action_count_exact"] is True
     assert tiers["tiers"]["source"]["table_counts"]["raw_sessions"] == 1
     assert tiers["tiers"]["index"]["table_counts"]["sessions"] == 2
     assert tiers["tiers"]["user"]["table_counts"]["session_tags"] == 2
@@ -505,8 +514,14 @@ def test_probe_payload_carries_stable_top_level_shape(tmp_path: Path) -> None:
     counts = payload["boundary_table_counts"]
     assert counts["raw_sessions"] == 1
     assert counts["sessions"] == 1
+    assert counts["messages_fts_docsize"] >= 0
+    assert "messages_fts_data" not in counts
     assert counts["live_ingest_attempt"] == -1
     assert counts["ingest_attempts"] == 1
+
+    index_counts = payload["archive_tiers"]["tiers"]["index"]["table_counts"]
+    assert index_counts["messages_fts_docsize"] >= 0
+    assert "messages_fts_data" not in index_counts
 
     # FTS trigger state reports the full expected set.
     fts = payload["fts_trigger_state"]

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -32,7 +32,12 @@ from devtools.verify import (
     build_verify_steps,
     main,
 )
-from devtools.verify_runs import ResourceSampler, classify_pytest_result, pytest_basetemp_path
+from devtools.verify_runs import (
+    ResourceSampler,
+    classify_pytest_result,
+    cleanup_managed_pytest_basetemp,
+    pytest_basetemp_path,
+)
 
 
 def _pytest_marker_expr(command: list[str]) -> str:
@@ -377,6 +382,28 @@ def test_pytest_basetemp_path_tracks_tmpfs_opt_in(tmp_path: Path) -> None:
         assert path.parent == Path("/dev/shm")
     else:
         assert path.parent == Path("/realm/tmp/polylogue-pytest")
+
+
+def test_cleanup_managed_pytest_basetemp_removes_run_root(tmp_path: Path) -> None:
+    env = {"POLYLOGUE_PYTEST_BASETEMP_ROOT": str(tmp_path)}
+    basetemp = pytest_basetemp_path(root=tmp_path, run_id="run-1", env=env)
+    (basetemp / "worker-output").mkdir(parents=True)
+
+    cleaned = cleanup_managed_pytest_basetemp(root=tmp_path, run_id="run-1", env=env)
+
+    assert cleaned == basetemp
+    assert not basetemp.exists()
+
+
+def test_cleanup_managed_pytest_basetemp_keeps_seed_cache(tmp_path: Path) -> None:
+    env = {"POLYLOGUE_PYTEST_BASETEMP_ROOT": str(tmp_path)}
+    seeded = pytest_basetemp_path(root=tmp_path, run_id="seeded-cache", env=env)
+    seeded.mkdir()
+
+    cleaned = cleanup_managed_pytest_basetemp(root=tmp_path, run_id="seeded-cache", env=env)
+
+    assert cleaned is None
+    assert seeded.exists()
 
 
 def test_testmon_preflight_allows_seed_and_full_without_database(

--- a/tests/unit/test_pytest_temp_policy.py
+++ b/tests/unit/test_pytest_temp_policy.py
@@ -83,7 +83,7 @@ def test_sweep_stale_polylogue_basetemps_preserves_seeded_and_recent(
     assert unrelated.exists()
 
 
-def test_sessionfinish_leaves_xdist_basetemp_for_startup_sweep(
+def test_sessionfinish_leaves_xdist_basetemp_for_supervisor_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Bound the default daemon workload diagnostic path and made pytest temp cleanup supervisor-owned after managed runs. The default workload probe now returns promptly on the real archive instead of hanging on full SQLite/FTS scans, while expensive integrity and exact reconciliation checks remain available through explicit flags.

## Problem

Two memory/runtime issues were observable locally:

- `polylogue ops diagnostics workload --json` could sit resident around a few hundred MiB and emit no JSON on the live archive. Stack dumps showed it blocked in default table-count/integrity/readiness scans: `messages_fts_data`, `PRAGMA quick_check`, generated `blocks.search_text` reconciliation, and `actions` counts.
- Broad pytest seed/full lanes can use tmpfs for speed, but xdist runs intentionally skipped `pytest_sessionfinish` cleanup. A successful run could leave a multi-GiB `/dev/shm/pytest-polylogue-*` basetemp until another pytest startup sweep or manual cleanup.

## Solution

- Removed FTS internal `messages_fts_data` from workload boundary/tier counts and reports `messages_fts_docsize` instead.
- Changed archive tier integrity from implicit `PRAGMA quick_check` to default `integrity: not_checked`, with `--integrity-check` for explicit expensive runs.
- Changed derived readiness to use cheap default FTS/action evidence and added `--exact-derived-counts` for full reconciliation scans.
- Exposed both flags through `polylogue ops diagnostics workload`.
- Added `cleanup_managed_pytest_basetemp()` in the verify supervisor so managed per-run basetemps are reclaimed after pytest exits, including xdist seed/full runs.
- Updated docs and generated `AGENTS.md` for the new diagnostic contract.

## Verification

- `devtools test tests/unit/devtools/test_daemon_workload_probe.py tests/unit/devtools/test_verify.py::test_cleanup_managed_pytest_basetemp_removes_run_root tests/unit/devtools/test_verify.py::test_cleanup_managed_pytest_basetemp_keeps_seed_cache tests/unit/test_pytest_temp_policy.py -q` — 23 passed.
- `polylogue ops diagnostics workload --help` — shows `--integrity-check` and `--exact-derived-counts`.
- Live archive probe: `timeout 30s nix develop --command python -m devtools.daemon_workload_probe --json` returned status 0 in 3.132s, emitted 18,524 bytes, `ok=True`, `integrity=not_checked`, no `messages_fts_data` counts.
- `devtools render all --check` — clean after refreshing `.cache/site`.
- `devtools verify --quick` — exit 0.
- `devtools verify --seed-testmon --skip-slow` — 11,507 passed, 1 xfailed; peak pytest PSS 3,089.6 MiB; `/dev/shm` returned to seeded caches only afterward.
- `devtools verify` — 7 affected tests passed; peak pytest PSS 122.4 MiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--integrity-check` and `--exact-derived-counts` flags to the `diagnostics workload` CLI command for optional deep integrity validation and exact derived-counts reconciliation.

* **Documentation**
  * Clarified that expensive integrity and reconciliation checks are opt-in via new command flags.

* **Tests**
  * Added test coverage for new diagnostic flags and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->