### PR TITLE
feat(web): execute neighbor and correlation read views (#1846)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2496,6 +2496,82 @@ class PolylogueArchiveMixin:
                 ),
             )
 
+    async def neighbor_candidate_payloads(
+        self,
+        *,
+        session_id: str | None = None,
+        query: str | None = None,
+        provider: str | None = None,
+        limit: int = 10,
+        window_hours: int = 24,
+    ) -> list[JSONDocument]:
+        """Return neighboring-session candidates as shared surface payloads."""
+
+        from polylogue.surfaces.payloads import SessionNeighborCandidatePayload, model_json_document
+
+        candidates = await self.neighbor_candidates(
+            session_id=session_id,
+            query=query,
+            provider=provider,
+            limit=limit,
+            window_hours=window_hours,
+        )
+        return [
+            model_json_document(SessionNeighborCandidatePayload.from_candidate(candidate), exclude_none=True)
+            for candidate in candidates
+        ]
+
+    async def session_correlation_payload(
+        self,
+        session_id: str,
+        *,
+        repo_path: str | None = None,
+        since_hours: int = 2,
+        confidence_threshold: float = 0.3,
+    ) -> JSONDocument | None:
+        """Return git/GitHub correlation evidence as a JSON surface payload."""
+
+        from polylogue.insights.session_commit import build_correlation_result, correlation_result_to_payload
+
+        session = await self.get_session(session_id)
+        if session is None:
+            return None
+        if session.created_at is None or session.updated_at is None:
+            raise SessionNotFoundError("Session has no timestamp data.")
+
+        repo = repo_path
+        if not repo:
+            repo_url = getattr(session, "git_repository_url", None)
+            if isinstance(repo_url, str) and repo_url:
+                repo = repo_url
+            else:
+                directories = getattr(session, "working_directories", ()) or ()
+                repo = str(directories[0]) if directories else "."
+
+        messages: list[dict[str, object]] = []
+        for message in session.messages:
+            content_blocks = list(message.blocks) if getattr(message, "blocks", ()) else []
+            messages.append(
+                {
+                    "id": message.id,
+                    "role": message.role.value if hasattr(message.role, "value") else str(message.role),
+                    "text": message.text,
+                    "content_blocks": content_blocks,
+                }
+            )
+
+        result = build_correlation_result(
+            session_id=session_id,
+            messages=messages,
+            session_created_at=session.created_at,
+            session_updated_at=session.updated_at,
+            repo_path=repo,
+            before_hours=since_hours,
+            after_hours=since_hours,
+            confidence_threshold=confidence_threshold,
+        )
+        return cast(JSONDocument, correlation_result_to_payload(result))
+
     async def get_session_tree(self, session_id: str) -> list[Session]:
         """Return the full session tree (parent + children) for a session."""
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2628,7 +2628,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         view = (self._get_param(params, "view", "messages") or "messages").strip().lower()
         output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
-        if view not in {"messages", "recovery", "raw", "context", "context-pack"}:
+        if view not in {"messages", "recovery", "raw", "context", "context-pack", "neighbors", "correlation"}:
             self._send_error(HTTPStatus.BAD_REQUEST, "unsupported_read_view")
             return
         if output_format != "json" and not (view == "recovery" and output_format == "markdown"):
@@ -2694,6 +2694,41 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     redact_paths=not self._get_bool(params, "no_redact"),
                 )
                 return context_payload.model_dump(mode="json", exclude_none=True)
+
+            payload = self._sync_run(_get)
+        elif view == "neighbors":
+            if output_format != "json":
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+                return
+
+            async def _get(poly: Polylogue) -> object:
+                return {
+                    "neighbors": await poly.neighbor_candidate_payloads(
+                        session_id=conv_id,
+                        limit=max(1, self._get_int(params, "limit", 10)),
+                        window_hours=max(1, self._get_int(params, "window_hours", 24)),
+                    )
+                }
+
+            payload = self._sync_run(_get)
+        elif view == "correlation":
+            if output_format != "json":
+                self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
+                return
+
+            confidence = 0.3
+            raw_confidence = self._get_param(params, "confidence_threshold")
+            if raw_confidence is not None:
+                with contextlib.suppress(ValueError, TypeError):
+                    confidence = float(raw_confidence)
+
+            async def _get(poly: Polylogue) -> object | None:
+                return await poly.session_correlation_payload(
+                    conv_id,
+                    repo_path=self._get_param(params, "repo_path"),
+                    since_hours=max(1, self._get_int(params, "since_hours", 2)),
+                    confidence_threshold=max(0.0, min(confidence, 1.0)),
+                )
 
             payload = self._sync_run(_get)
         else:

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -769,8 +769,8 @@ function renderFacets() {
 function renderReadViewSelector(c) {
   if (!c) return '';
   var profiles = state.readViewProfiles || [];
-  var supported = {messages: true, recovery: true, raw: true, context: true, 'context-pack': true};
-  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', context: 'Context', 'context-pack': 'Context Pack'};
+  var supported = {messages: true, recovery: true, raw: true, context: true, 'context-pack': true, neighbors: true, correlation: true};
+  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', context: 'Context', 'context-pack': 'Context Pack', neighbors: 'Neighbors', correlation: 'Correlation'};
   if (!profiles.length) {
     var fallback = state.readViewProfileError || 'Read profiles loading';
     return '<div id="read-profile-selector" class="read-profile-selector muted">' + esc(fallback) + '</div>';
@@ -922,6 +922,8 @@ function renderReadViewExecution(c, viewId) {
   if (viewId === 'raw') return renderRawReadView(payload);
   if (viewId === 'context') return renderContextReadView(payload);
   if (viewId === 'context-pack') return renderContextPackReadView(payload);
+  if (viewId === 'neighbors') return renderNeighborsReadView(payload);
+  if (viewId === 'correlation') return renderCorrelationReadView(payload);
   return '<div class="main-empty"><h3>Unsupported read view</h3><p>' + esc(viewId) + '</p></div>';
 }
 
@@ -1000,6 +1002,53 @@ function renderContextPackReadView(payload) {
       + esc(String(messages.length)) + ' messages included</div></div>';
   });
   if (!sessions.length) html += '<div class="inspector-empty">No context-pack sessions surfaced for this selection.</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderNeighborsReadView(payload) {
+  var neighbors = payload.neighbors || [];
+  var html = '<div class="read-view-panel"><h3>Neighbor sessions</h3>'
+    + '<p class="muted">Read through /api/sessions/:id/read using the shared neighbor-candidate DTO.</p>'
+    + '<div class="inspector-field"><span class="label">candidates</span><span class="value">' + esc(String(neighbors.length)) + '</span></div>';
+  neighbors.slice(0, 10).forEach(function(candidate) {
+    var session = candidate.session || {};
+    var reasons = candidate.reasons || [];
+    var reasonText = reasons.map(function(reason) {
+      return (reason.kind || 'reason') + ': ' + (reason.detail || '');
+    }).join(' / ');
+    html += '<div class="annotation-item"><div class="meta">rank ' + esc(String(candidate.rank || '?'))
+      + ' / score ' + esc(String(candidate.score || 0)) + '</div>'
+      + '<div class="note"><strong>' + esc(session.display_title || session.title || session.id || 'Untitled') + '</strong><br>'
+      + esc(session.id || session.session_id || '') + '<br><span class="muted">' + esc(reasonText || 'No reasons reported') + '</span></div></div>';
+  });
+  if (!neighbors.length) html += '<div class="inspector-empty">No neighboring sessions surfaced for this seed.</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderCorrelationReadView(payload) {
+  var commits = payload.commits || [];
+  var issues = payload.issue_refs || [];
+  var prs = payload.pr_refs || [];
+  var files = payload.file_paths || [];
+  var html = '<div class="read-view-panel"><h3>Correlation evidence</h3>'
+    + '<p class="muted">Read through /api/sessions/:id/read using the shared correlation payload.</p>'
+    + '<div class="inspector-field"><span class="label">window</span><span class="value">' + esc((payload.window_start || '-') + ' -> ' + (payload.window_end || '-')) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">commits</span><span class="value">' + esc(String(commits.length)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">issues / PRs</span><span class="value">' + esc(String(issues.length + prs.length)) + '</span></div>'
+    + '<div class="inspector-field"><span class="label">files</span><span class="value">' + esc(String(files.length)) + '</span></div>';
+  commits.slice(0, 8).forEach(function(commit) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(commit.detection_method || 'commit') + ' / confidence ' + esc(String(commit.confidence || 0)) + '</div>'
+      + '<div class="note"><strong>' + esc(commit.short_sha || commit.commit_sha || 'commit') + '</strong><br>' + esc(commit.object_ref || '') + '</div></div>';
+  });
+  issues.concat(prs).slice(0, 8).forEach(function(ref) {
+    html += '<div class="annotation-item"><div class="meta">' + esc(ref.kind || 'ref') + '</div>'
+      + '<div class="note"><strong>' + esc(ref.object_ref || ref.raw_match || 'ref') + '</strong><br>' + esc(ref.url || '') + '</div></div>';
+  });
+  if (!commits.length && !issues.length && !prs.length && !files.length) {
+    html += '<div class="inspector-empty">No commit, issue, PR, or file evidence surfaced in this session window.</div>';
+  }
   html += '</div>';
   return html;
 }

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -227,7 +227,9 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "post_blackboard_note",
         # Shared web/MCP payload DTO helpers covered by daemon/MCP surface tests.
         "list_assertion_claim_payloads",
+        "neighbor_candidate_payloads",
         "recovery_read_payload",
+        "session_correlation_payload",
     }
 )
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1516,6 +1516,14 @@ class TestReaderViewProfiles:
                 dict[str, object],
                 _get_json(base_url, f"/api/sessions/{C1}/read?view=context-pack&max_messages=5"),
             )
+            neighbors = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/read?view=neighbors&limit=2"),
+            )
+            correlation = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/sessions/{C1}/read?view=correlation&since_hours=1"),
+            )
 
         assert messages["view"] == "messages"
         message_payload = cast(dict[str, object], messages["payload"])
@@ -1536,10 +1544,23 @@ class TestReaderViewProfiles:
         assert context_query["query_matched"] == 1
         context_sessions = cast(list[dict[str, object]], context_payload["sessions"])
         assert context_sessions[0]["session_id"] == C1
+        assert neighbors["view"] == "neighbors"
+        neighbor_payload = cast(dict[str, object], neighbors["payload"])
+        neighbor_rows = cast(list[dict[str, object]], neighbor_payload["neighbors"])
+        assert neighbor_rows
+        neighbor_session = cast(dict[str, object], neighbor_rows[0]["session"])
+        assert neighbor_session["id"] in {C2, C3}
+        neighbor_reasons = cast(list[dict[str, object]], neighbor_rows[0]["reasons"])
+        assert {reason["kind"] for reason in neighbor_reasons} & {"nearby_time", "query_match", "content_similarity"}
+        assert correlation["view"] == "correlation"
+        correlation_payload = cast(dict[str, object], correlation["payload"])
+        assert correlation_payload["session_id"] == C1
+        assert "window_start" in correlation_payload
+        assert "object_refs" in correlation_payload
 
     def test_read_view_execution_rejects_unknown_view_or_format(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
-            view_status, view_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=neighbors")
+            view_status, view_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=timeline")
             format_status, format_payload = _get_json_ex(base_url, f"/api/sessions/{C1}/read?view=messages&format=html")
 
         assert view_status == 400


### PR DESCRIPTION
## Summary

Adds route-backed workbench execution for the remaining disabled read profiles from #1846: `neighbors` and `correlation`. The web shell now enables both profiles from `/api/read-view-profiles` and renders their shared payloads instead of treating them as pending HTTP routes.

## Problem

#1846 identified `neighbors` and `correlation` as the remaining read profiles that still needed explicit daemon execution semantics before the browser reader could enable them. The CLI/API substrate already had the real behavior, but `/api/sessions/:id/read` and the web shell only executed `messages`, `recovery`, `raw`, `context`, and `context-pack`.

## Solution

- Added `Polylogue.neighbor_candidate_payloads(...)` and `Polylogue.session_correlation_payload(...)` as shared facade payload helpers.
- Wired `GET /api/sessions/:id/read?view=neighbors|correlation` through those helpers.
- Kept correlation conservative for the web route: JSON-only, local correlation payload, no GitHub API enrichment or OTLP side effects.
- Enabled `neighbors` and `correlation` in the browser read-view selector and rendered candidate/reason and correlation evidence summaries.
- Updated daemon route tests and facade method categorization to cover the new surface.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k "read_view_execution"` -> `2 passed`
- `nix develop --command devtools test tests/visual/test_reader_dom_smoke.py -k "read_view or evidence_panel"` -> `1 passed`
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k "undiscovered or return_annotation"` -> `1 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`
- `nix develop --command devtools verify` -> `1245 passed, 1 xfailed`, diagnosis `pytest_passed`, peak pytest PSS `395.4 MiB`

Ref #1846
Ref #1847