### PR TITLE
fix(query): explain runtime terminal unit lowering (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1300,7 +1300,11 @@ def _explain_execution_legs(spec: SessionQuerySpec) -> tuple[str, ...]:
 
 
 def _explain_unit_source_execution_legs(source: QueryUnitSource) -> tuple[str, ...]:
-    legs = {"sql", f"terminal-{source.unit}-rows", *_predicate_execution_legs(source.predicate)}
+    legs = {f"terminal-{source.unit}-rows", *_predicate_execution_legs(source.predicate)}
+    if source.unit in {"run", "observed-event", "context-snapshot"}:
+        legs.add("runtime-transform")
+    else:
+        legs.add("sql")
     return tuple(sorted(legs))
 
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -787,6 +787,25 @@ async def test_explain_query_expression_exposes_terminal_unit_payload(tmp_path: 
         await archive.close()
 
 
+async def test_explain_query_expression_exposes_runtime_transform_unit_payload(tmp_path: Path) -> None:
+    """Runtime-transform unit-source explain output names its projection leg."""
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_query_expression(
+            "context-snapshots where session.repo:polylogue AND boundary:session_start"
+        )
+
+        assert payload["lowerer"] == "lark-query-unit-source-to-terminal-unit"
+        assert payload["selected_units"] == ["context-snapshot"]
+        assert payload["execution_legs"] == ["runtime-transform", "sql", "terminal-context-snapshot-rows"]
+        assert payload["plan_description"] == ["terminal unit source: context-snapshot"]
+        lowering_plan = cast(dict[str, object], payload["lowering_plan"])
+        assert "compatibility_selector" not in lowering_plan
+        assert payload["predicate"]
+    finally:
+        await archive.close()
+
+
 async def test_query_completions_exposes_shared_completion_payload(tmp_path: Path) -> None:
     """``query_completions`` exposes registry-backed query metadata."""
     archive = _archive(tmp_path)

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -272,6 +272,29 @@ def test_root_query_explain_json_outputs_terminal_unit_payload(cli_runner: CliRu
     assert payload["predicate"]["kind"] == "and"
 
 
+def test_root_query_explain_json_marks_runtime_transform_unit_payload(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "find",
+            "runs where session.repo:polylogue AND status:completed",
+            "--explain",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["lowerer"] == "lark-query-unit-source-to-terminal-unit"
+    assert payload["selected_units"] == ["run"]
+    assert payload["execution_legs"] == ["runtime-transform", "sql", "terminal-run-rows"]
+    assert payload["plan_description"] == ["terminal unit source: run"]
+    assert "compatibility_selector" not in payload["lowering_plan"]
+    assert payload["ast"]["unit_source"]["unit"] == "run"
+
+
 def test_root_query_explain_plain_outputs_plan(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(click_cli, ["--plain", "find", 'repo:polylogue "json envelope"', "--explain"])
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -487,7 +487,7 @@ class TestBooleanQueryExpression:
         explanation = explain_expression("runs where session.repo:polylogue AND role:subagent AND agent:Explore")
         assert explanation.lowerer == "lark-query-unit-source-to-terminal-unit"
         assert explanation.selected_units == ("run",)
-        assert explanation.execution_legs == ("sql", "terminal-run-rows")
+        assert explanation.execution_legs == ("runtime-transform", "sql", "terminal-run-rows")
         assert explanation.plan_description == ("terminal unit source: run",)
         assert explanation.lowering_plan is not None
         assert "compatibility_selector" not in explanation.lowering_plan


### PR DESCRIPTION
## Summary

Updates query explain output for runtime-transform terminal units so `runs`, `observed-events`, and `context-snapshots` report the projection leg they actually use, instead of looking like ordinary SQL-backed terminal sources.

## Problem

#2006 now has executable runtime-transform terminal row sources. Those units do not have compatibility session-selector lowerers and execute through recovery/run projection, but `--explain` only reported generic SQL plus `terminal-*-rows`. That blurred the distinction from SQL-backed `messages/actions/blocks/assertions` unit sources.

## Solution

- Mark runtime-transform terminal units with a `runtime-transform` execution leg in `explain_expression(...)`.
- Keep SQL legs when predicates include SQL-backed session scope such as `session.repo`.
- Add CLI and facade explain tests for `runs where ...` and `context-snapshots where ...`.
- Assert runtime-transform unit-source explain payloads do not claim a compatibility `exists ...` session selector.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_click_app.py -k "explain_json" tests/unit/api/test_facade_contracts.py -k "explain_query_expression"` -> `4 passed`
- `nix develop --command devtools verify --quick` -> `exit_code 0`

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Query explanations now correctly identify and report the appropriate execution transformations in the pipeline for different unit source types.

* **Tests**
  * Added and updated comprehensive test coverage for query explanation functionality across API and CLI interfaces, including validation of runtime-transform unit sources and JSON output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->