### PR TITLE
feat(daemon): publish stable read-view route envelope (#1847)

### DIFF
--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -36,6 +36,7 @@ from polylogue.surfaces.payloads import (
     QueryUnitEnvelope,
     SearchEnvelope,
     SessionListRowPayload,
+    SessionReadViewEnvelope,
     SessionSearchHitPayload,
 )
 
@@ -47,6 +48,7 @@ POLYLOGUE_API_VERSION = "1"
 _PUBLISHED_MODELS: tuple[type[BaseModel], ...] = (
     SearchEnvelope,
     QueryUnitEnvelope,
+    SessionReadViewEnvelope,
     SessionSearchHitPayload,
     SessionListRowPayload,
 )
@@ -417,6 +419,107 @@ def _build_openapi_document() -> dict[str, Any]:
                         "400": {
                             "description": "Malformed query or non-terminal session expression.",
                         },
+                    },
+                }
+            },
+            "/api/sessions/{session_id}/read": {
+                "get": {
+                    "summary": "Execute a session read-view",
+                    "description": (
+                        "Executes one supported single-session read profile and returns the "
+                        "stable ``SessionReadViewEnvelope``. Supported profiles currently "
+                        "include ``messages``, ``recovery``, ``raw``, ``context``, "
+                        "``context-pack``, ``neighbors``, and ``correlation``. The envelope "
+                        "shape is stable; individual ``payload`` content is the shared DTO "
+                        "for the selected read profile."
+                    ),
+                    "operationId": "readSessionView",
+                    "parameters": [
+                        {
+                            "name": "session_id",
+                            "in": "path",
+                            "description": "Resolved Polylogue session id.",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                        {
+                            "name": "view",
+                            "in": "query",
+                            "description": "Read-view id from /api/read-view-profiles.",
+                            "required": False,
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "messages",
+                                    "recovery",
+                                    "raw",
+                                    "context",
+                                    "context-pack",
+                                    "neighbors",
+                                    "correlation",
+                                ],
+                                "default": "messages",
+                            },
+                        },
+                        {
+                            "name": "format",
+                            "in": "query",
+                            "description": "Output format. JSON for all views; recovery work packets also support markdown.",
+                            "required": False,
+                            "schema": {"type": "string", "enum": ["json", "markdown"], "default": "json"},
+                        },
+                        {
+                            "name": "limit",
+                            "in": "query",
+                            "description": "Messages/neighbor page size where applicable.",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 1},
+                        },
+                        {
+                            "name": "offset",
+                            "in": "query",
+                            "description": "Message offset for the messages view.",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 0},
+                        },
+                        {
+                            "name": "report",
+                            "in": "query",
+                            "description": "Recovery report kind for the recovery view.",
+                            "required": False,
+                            "schema": {"type": "string", "enum": ["digest", "work-packet"], "default": "work-packet"},
+                        },
+                        {
+                            "name": "max_messages",
+                            "in": "query",
+                            "description": "Maximum messages per session for context-pack.",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 1},
+                        },
+                        {
+                            "name": "window_hours",
+                            "in": "query",
+                            "description": "Neighbor discovery window in hours.",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 1, "default": 24},
+                        },
+                        {
+                            "name": "since_hours",
+                            "in": "query",
+                            "description": "Correlation scan window on each side of the session.",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 1, "default": 2},
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Executed read-view envelope.",
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/SessionReadViewEnvelope"}}
+                            },
+                        },
+                        "400": {"description": "Unsupported view or format."},
+                        "404": {"description": "Session not found."},
                     },
                 }
             },

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -284,6 +284,104 @@ paths:
                 $ref: '#/components/schemas/QueryUnitEnvelope'
         '400':
           description: Malformed query or non-terminal session expression.
+  /api/sessions/{session_id}/read:
+    get:
+      summary: Execute a session read-view
+      description: Executes one supported single-session read profile and returns the stable ``SessionReadViewEnvelope``.
+        Supported profiles currently include ``messages``, ``recovery``, ``raw``, ``context``, ``context-pack``, ``neighbors``,
+        and ``correlation``. The envelope shape is stable; individual ``payload`` content is the shared DTO for the selected
+        read profile.
+      operationId: readSessionView
+      parameters:
+      - name: session_id
+        in: path
+        description: Resolved Polylogue session id.
+        required: true
+        schema:
+          type: string
+      - name: view
+        in: query
+        description: Read-view id from /api/read-view-profiles.
+        required: false
+        schema:
+          type: string
+          enum:
+          - messages
+          - recovery
+          - raw
+          - context
+          - context-pack
+          - neighbors
+          - correlation
+          default: messages
+      - name: format
+        in: query
+        description: Output format. JSON for all views; recovery work packets also support markdown.
+        required: false
+        schema:
+          type: string
+          enum:
+          - json
+          - markdown
+          default: json
+      - name: limit
+        in: query
+        description: Messages/neighbor page size where applicable.
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+      - name: offset
+        in: query
+        description: Message offset for the messages view.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: report
+        in: query
+        description: Recovery report kind for the recovery view.
+        required: false
+        schema:
+          type: string
+          enum:
+          - digest
+          - work-packet
+          default: work-packet
+      - name: max_messages
+        in: query
+        description: Maximum messages per session for context-pack.
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+      - name: window_hours
+        in: query
+        description: Neighbor discovery window in hours.
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 24
+      - name: since_hours
+        in: query
+        description: Correlation scan window on each side of the session.
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 2
+      responses:
+        '200':
+          description: Executed read-view envelope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionReadViewEnvelope'
+        '400':
+          description: Unsupported view or format.
+        '404':
+          description: Session not found.
 components:
   schemas:
     QueryMissDiagnosticsPayload:
@@ -1255,6 +1353,29 @@ components:
       - limit
       - offset
       title: QueryUnitEnvelope
+      type: object
+    SessionReadViewEnvelope:
+      additionalProperties: false
+      description: Stable daemon envelope for one executed session read-view.
+      properties:
+        session_id:
+          title: Session Id
+          type: string
+        view:
+          title: View
+          type: string
+        format:
+          title: Format
+          type: string
+        payload:
+          description: Profile-specific JSON payload for the selected read view.
+          title: Payload
+      required:
+      - session_id
+      - view
+      - format
+      - payload
+      title: SessionReadViewEnvelope
       type: object
     SessionFlagsPayload:
       additionalProperties: false

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -45,8 +45,10 @@ from polylogue.surfaces.payloads import (
     QueryErrorPayload,
     QueryMissDiagnosticsPayload,
     ReaderActionAvailabilityPayload,
+    SessionReadViewEnvelope,
     TargetRefPayload,
     _build_flags_from_session,
+    model_json_document,
     reader_anchor,
     reader_message_actions,
     reader_session_actions,
@@ -2741,15 +2743,13 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if payload is None:
             self._send_error(HTTPStatus.NOT_FOUND, "not_found")
             return
-        self._send_json(
-            HTTPStatus.OK,
-            {
-                "session_id": conv_id,
-                "view": view,
-                "format": output_format,
-                "payload": payload,
-            },
+        envelope = SessionReadViewEnvelope(
+            session_id=conv_id,
+            view=view,
+            format=output_format,
+            payload=payload,
         )
+        self._send_json(HTTPStatus.OK, model_json_document(envelope, exclude_none=True))
 
     # ------------------------------------------------------------------
     # Handlers: per-session embedding similarity (#1123)

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -197,10 +197,10 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "GET",
         "/api/sessions/:id/read",
         "read_detail",
-        "shell_supported",
+        "stable",
         "bearer_if_configured",
-        "session read-view execution envelope",
-        "Executes supported single-session read profiles over existing messages/recovery/raw handlers for the local workbench.",
+        "SessionReadViewEnvelope",
+        "Executes supported single-session read profiles over shared DTO/facade payload helpers.",
     ),
     RouteContract(
         "GET",

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1124,6 +1124,15 @@ class RecoveryReadPayload(SurfacePayloadModel):
         return cls(session_id=str(session_id), report="work-packet", format="markdown", markdown=markdown)
 
 
+class SessionReadViewEnvelope(SurfacePayloadModel):
+    """Stable daemon envelope for one executed session read-view."""
+
+    session_id: str
+    view: str
+    format: str
+    payload: Any = Field(description="Profile-specific JSON payload for the selected read view.")
+
+
 class ObservedEventQueryRowPayload(SurfacePayloadModel):
     """Shared terminal-query row for runtime-transform observed events."""
 
@@ -1887,6 +1896,7 @@ __all__ = [
     "SessionNeighborReasonPayload",
     "SessionSearchHitPayload",
     "SessionSearchMatchPayload",
+    "SessionReadViewEnvelope",
     "SessionSummaryPayload",
     "FacetBucketsPayload",
     "FacetTimeRange",

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -70,8 +70,8 @@ def test_stable_user_overlay_mutations_use_shared_envelope_contract() -> None:
             assert route.response_contract == "mutation envelope"
 
 
-def test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary_stabilizes() -> None:
-    """#1847 owns public daemon API stability for the new workbench routes."""
+def test_workbench_helper_routes_declare_current_stability() -> None:
+    """Workbench helper routes distinguish stable API from shell-only helpers."""
 
     assertion_route = route_contract_for("GET", "/api/assertions")
     recovery_route = route_contract_for("GET", "/api/sessions/codex-session:abc/recovery")
@@ -87,20 +87,20 @@ def test_web_workbench_first_slice_routes_are_shell_supported_until_api_boundary
     assert recovery_route.auth_policy == "bearer_if_configured"
     assert "Recovery" in recovery_route.response_contract
     assert read_route is not None
-    assert read_route.stability == "shell_supported"
+    assert read_route.stability == "stable"
     assert read_route.auth_policy == "bearer_if_configured"
+    assert read_route.response_contract == "SessionReadViewEnvelope"
 
 
-def test_web_workbench_candidate_routes_are_not_stable_public_api() -> None:
-    """New #1846 routes are real, but #1847 has not promoted them to stable API."""
+def test_read_view_execution_route_is_published_as_stable_api() -> None:
+    """The read-view route has a typed envelope and stable route contract."""
 
-    candidate_patterns = {"/api/assertions", "/api/sessions/:id/recovery", "/api/sessions/:id/read"}
     stable_patterns = {route.pattern for route in stable_route_contracts()}
-    assert candidate_patterns.isdisjoint(stable_patterns)
-    for pattern in candidate_patterns:
-        route = next(route for route in ROUTE_CONTRACTS if route.pattern == pattern)
-        assert route.stability == "shell_supported"
-        assert route.auth_policy == "bearer_if_configured"
+    assert "/api/sessions/:id/read" in stable_patterns
+    route = route_contract_for("GET", "/api/sessions/codex-session:abc/read")
+    assert route is not None
+    assert route.kind == "read_detail"
+    assert route.response_contract == "SessionReadViewEnvelope"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Promotes `GET /api/sessions/:id/read` from a web-shell helper to a stable daemon read API by wrapping every read-view execution response in a shared `SessionReadViewEnvelope` and publishing the route in OpenAPI.

## Problem

The web workbench can now execute `messages`, `recovery`, `raw`, `context`, `context-pack`, `neighbors`, and `correlation` through one route, but #1847 still needed a stable response contract before clients could treat that route as more than shell-supported glue.

## Solution

Added `SessionReadViewEnvelope` to the shared surface payload models, changed the daemon read-view handler to serialize through that envelope, promoted the route contract to `stable`, and published `/api/sessions/{session_id}/read` plus its query parameters in `docs/openapi/search.yaml`. The envelope shape is stable; the nested `payload` remains profile-specific JSON owned by each read view's existing DTO/helper.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_route_contracts.py -k "read_view or workbench or stable" tests/unit/daemon/test_web_reader.py -k "read_view_execution"` -> 3 passed, 200 deselected
- `nix develop --command devtools render openapi --check` -> `render openapi: sync OK: docs/openapi/search.yaml`
- `nix develop --command devtools verify --quick` -> exit_code 0