### PR TITLE
fix(daemon): resume large live files from archived prefixes (#2167)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1451,16 +1451,20 @@ The report has a stable top-level shape carrying its `report_version`,
   parse/convergence timings, and source-path bundles.
 - `convergence_stage_timings` — min/max/sum/mean parse/convergence/read-
   amplification stats over completed attempts.
-- `boundary_table_counts` — row counts for the daemon-relevant tables
+- `boundary_table_counts` — cheap planner-estimated counts for the
+  daemon-relevant tables by default
   (`raw_sessions`, `sessions`, `messages`, `blocks`,
   `artifact_observations`, `messages_fts_docsize`, `actions`,
   `message_embeddings`, `session_profile`,
   `live_ingest_attempt`, `live_convergence_debt`, `pending_blob_refs`).
-  Missing tables surface as `-1` rather than crashing the probe.
+  Missing tables surface as `-1` and tables without SQLite planner
+  statistics surface as `-2` rather than crashing the probe. Pass
+  `--exact-table-counts` when a before/after evidence run needs exact
+  arithmetic and the archive can afford the scans.
 - `archive_tiers` — archive inventory for `source.db`,
   `index.db`, `embeddings.db`, `user.db`, and `ops.db`: file presence,
   durability/backup policy, `PRAGMA user_version`, missing backup-required
-  tiers, and cheap table counts per tier. It does not run SQLite
+  tiers, and cheap planner-estimated table counts per tier. It does not run SQLite
   `PRAGMA quick_check` by default because that is a full-file integrity scan
   on large archives; pass `--integrity-check` when the workload snapshot should
   include that expensive evidence. It also avoids exact generated-text

--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -28,7 +28,8 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
 # The compare path uses this to refuse incompatible inputs loudly.
-REPORT_VERSION = 10  # v10 renames archive readiness payloads to archive terms.
+REPORT_VERSION = 11  # v11 makes large-table diagnostic counts estimated by default.
+UNKNOWN_TABLE_COUNT = -2
 
 _EXPECTED_FTS_TRIGGERS: tuple[str, ...] = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
 
@@ -157,6 +158,29 @@ def _scalar_int(conn: sqlite3.Connection, sql: str, params: tuple[object, ...] =
     except sqlite3.Error:
         return 0
     return int(row[0] or 0) if row is not None else 0
+
+
+def _table_count(conn: sqlite3.Connection, table: str, *, exact: bool) -> int:
+    """Return an exact or cheap estimated table count."""
+
+    if not _table_exists(conn, table):
+        return -1
+    if exact:
+        return _scalar_int(conn, f"SELECT COUNT(*) FROM {table}")
+    with suppress(sqlite3.Error, ValueError, IndexError):
+        row = conn.execute(
+            """
+            SELECT stat
+            FROM sqlite_stat1
+            WHERE tbl = ?
+            ORDER BY idx IS NOT NULL, idx
+            LIMIT 1
+            """,
+            (table,),
+        ).fetchone()
+        if row is not None and row[0] is not None:
+            return max(0, int(str(row[0]).split()[0]))
+    return UNKNOWN_TABLE_COUNT
 
 
 def _presence_count(conn: sqlite3.Connection, table: str) -> int:
@@ -807,23 +831,17 @@ def _boundary_table_counts(
     *,
     ops_db: Path | None = None,
     source_db: Path | None = None,
+    exact: bool = False,
 ) -> dict[str, int]:
     counts: dict[str, int] = {}
     for table in _BOUNDARY_TABLES:
-        if _table_exists(conn, table):
-            counts[table] = _scalar_int(conn, f"SELECT COUNT(*) FROM {table}")
-        else:
-            counts[table] = -1
+        counts[table] = _table_count(conn, table, exact=exact)
     if source_db is not None and source_db.exists():
         try:
             source_conn = open_readonly_connection(source_db)
             try:
                 for table in ("raw_sessions",):
-                    counts[table] = (
-                        _scalar_int(source_conn, f"SELECT COUNT(*) FROM {table}")
-                        if _table_exists(source_conn, table)
-                        else -1
-                    )
+                    counts[table] = _table_count(source_conn, table, exact=exact)
             finally:
                 source_conn.close()
         except sqlite3.Error:
@@ -833,10 +851,7 @@ def _boundary_table_counts(
             ops_conn = open_readonly_connection(ops_db)
             try:
                 for table in _OPS_BOUNDARY_TABLES:
-                    if _table_exists(ops_conn, table):
-                        counts[table] = _scalar_int(ops_conn, f"SELECT COUNT(*) FROM {table}")
-                    else:
-                        counts[table] = -1
+                    counts[table] = _table_count(ops_conn, table, exact=exact)
             finally:
                 ops_conn.close()
         except sqlite3.Error:
@@ -851,6 +866,7 @@ def _archive_tier_state(
     observed_db: Path | None = None,
     integrity_check: bool = False,
     exact_derived_counts: bool = False,
+    exact_table_counts: bool = False,
 ) -> dict[str, Any]:
     """Report the archive database files around an archive root."""
 
@@ -869,7 +885,12 @@ def _archive_tier_state(
 
     for tier, spec in ARCHIVE_TIER_SPECS.items():
         path = root / spec.filename
-        tier_payload = _archive_single_tier_state(path, tier, integrity_check=integrity_check)
+        tier_payload = _archive_single_tier_state(
+            path,
+            tier,
+            integrity_check=integrity_check,
+            exact_table_counts=exact_table_counts,
+        )
         tier_payload.update(
             {
                 "tier": tier.value,
@@ -908,6 +929,7 @@ def _archive_tier_state(
         "present_count": present_count,
         "expected_count": len(ARCHIVE_TIER_SPECS),
         "observed_tier": observed_tier,
+        "table_count_mode": "exact" if exact_table_counts else "estimated",
         "schema_mismatches": schema_mismatches,
         "missing_backup_required": missing_backup_required,
         "layout_readiness": layout_readiness,
@@ -977,7 +999,13 @@ def _archive_layout_readiness(
     }
 
 
-def _archive_single_tier_state(path: Path, tier: ArchiveTier, *, integrity_check: bool = False) -> dict[str, Any]:
+def _archive_single_tier_state(
+    path: Path,
+    tier: ArchiveTier,
+    *,
+    integrity_check: bool = False,
+    exact_table_counts: bool = False,
+) -> dict[str, Any]:
     if not path.exists():
         return {
             "path": str(path),
@@ -1006,7 +1034,7 @@ def _archive_single_tier_state(path: Path, tier: ArchiveTier, *, integrity_check
                 integrity_row = conn.execute("PRAGMA quick_check").fetchone()
                 payload["integrity"] = str(integrity_row[0]) if integrity_row is not None else "unknown"
             payload["table_counts"] = {
-                table: _scalar_int(conn, f"SELECT COUNT(*) FROM {table}") if _table_exists(conn, table) else -1
+                table: _table_count(conn, table, exact=exact_table_counts)
                 for table in _ARCHIVE_OBSERVABILITY_TABLES[tier]
             }
         finally:
@@ -1866,7 +1894,12 @@ def _archive_query_plans(root: Path) -> dict[str, Any]:
 
 
 def probe(
-    db: Path, *, limit: int = 5, integrity_check: bool = False, exact_derived_counts: bool = False
+    db: Path,
+    *,
+    limit: int = 5,
+    integrity_check: bool = False,
+    exact_derived_counts: bool = False,
+    exact_table_counts: bool = False,
 ) -> dict[str, Any]:
     ops_db = db.with_name("ops.db")
     index_db = db.with_name("index.db")
@@ -1899,12 +1932,19 @@ def probe(
             "recent_attempts": recent_attempts,
             "storage_route_counts": _storage_route_counts(conn, ops_db=ops_db),
             "convergence_stage_timings": _convergence_stage_timings(recent_attempts, conn),
-            "boundary_table_counts": _boundary_table_counts(conn, ops_db=ops_db, source_db=db.with_name("source.db")),
+            "boundary_table_count_mode": "exact" if exact_table_counts else "estimated",
+            "boundary_table_counts": _boundary_table_counts(
+                conn,
+                ops_db=ops_db,
+                source_db=db.with_name("source.db"),
+                exact=exact_table_counts,
+            ),
             "archive_tiers": _archive_tier_state(
                 db,
                 observed_db=observed_db,
                 integrity_check=integrity_check,
                 exact_derived_counts=exact_derived_counts,
+                exact_table_counts=exact_table_counts,
             ),
             "topology_quarantine_state": _topology_quarantine_state(conn),
             "blob_lease_state": _tier_state_or_current(conn, db.with_name("source.db"), _blob_lease_state),
@@ -2442,6 +2482,11 @@ def _parser() -> argparse.ArgumentParser:
         help="Run exact derived-readiness reconciliation counts (can scan large archive tables)",
     )
     parser.add_argument(
+        "--exact-table-counts",
+        action="store_true",
+        help="Run exact boundary/archive table counts instead of cheap planner estimates",
+    )
+    parser.add_argument(
         "--compare",
         nargs=2,
         metavar=("BEFORE", "AFTER"),
@@ -2474,6 +2519,7 @@ def main(argv: list[str] | None = None) -> int:
         limit=max(1, args.limit),
         integrity_check=args.integrity_check,
         exact_derived_counts=args.exact_derived_counts,
+        exact_table_counts=args.exact_table_counts,
     )
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -2493,7 +2539,12 @@ def main(argv: list[str] | None = None) -> int:
     if table_counts:
         print("  boundary table counts:")
         for table, count in table_counts.items():
-            shown = "missing" if count < 0 else str(count)
+            if count == -1:
+                shown = "missing"
+            elif count == UNKNOWN_TABLE_COUNT:
+                shown = "unknown"
+            else:
+                shown = str(count)
             print(f"    {table}: {shown}")
     archive_tiers = payload.get("archive_tiers") or {}
     if archive_tiers.get("present"):

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -423,16 +423,20 @@ The report has a stable top-level shape carrying its `report_version`,
   parse/convergence timings, and source-path bundles.
 - `convergence_stage_timings` — min/max/sum/mean parse/convergence/read-
   amplification stats over completed attempts.
-- `boundary_table_counts` — row counts for the daemon-relevant tables
+- `boundary_table_counts` — cheap planner-estimated counts for the
+  daemon-relevant tables by default
   (`raw_sessions`, `sessions`, `messages`, `blocks`,
   `artifact_observations`, `messages_fts_docsize`, `actions`,
   `message_embeddings`, `session_profile`,
   `live_ingest_attempt`, `live_convergence_debt`, `pending_blob_refs`).
-  Missing tables surface as `-1` rather than crashing the probe.
+  Missing tables surface as `-1` and tables without SQLite planner
+  statistics surface as `-2` rather than crashing the probe. Pass
+  `--exact-table-counts` when a before/after evidence run needs exact
+  arithmetic and the archive can afford the scans.
 - `archive_tiers` — archive inventory for `source.db`,
   `index.db`, `embeddings.db`, `user.db`, and `ops.db`: file presence,
   durability/backup policy, `PRAGMA user_version`, missing backup-required
-  tiers, and cheap table counts per tier. It does not run SQLite
+  tiers, and cheap planner-estimated table counts per tier. It does not run SQLite
   `PRAGMA quick_check` by default because that is a full-file integrity scan
   on large archives; pass `--integrity-check` when the workload snapshot should
   include that expensive evidence. It also avoids exact generated-text

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -423,12 +423,16 @@ class LiveWatcher:
     def _needs_work_from_state(self, path: Path, *, stat: os.stat_result, cursor: CursorRecord | None) -> bool:
         size = stat.st_size
         if cursor is None:
-            return not self._reconcile_archived_cursor(path, stat=stat)
+            if not self._reconcile_archived_cursor(path, stat=stat):
+                return True
+            cursor = self._cursor.get_record(path)
+            return cursor is not None and size > cursor.byte_offset
         if cursor.excluded:
             return False
         if cursor.failure_count > 0:
             if self._reconcile_archived_cursor(path, stat=stat):
-                return False
+                cursor = self._cursor.get_record(path)
+                return cursor is not None and size > cursor.byte_offset
             return _retry_due(cursor.next_retry_at)
         parser_matches = cursor.parser_fingerprint == _PARSER_FINGERPRINT
         if not parser_matches:
@@ -461,9 +465,10 @@ class LiveWatcher:
         A daemon interruption can leave the archive source tier populated but
         the live cursor absent. Without this repair, startup catch-up replays
         the whole source file through the archive writer again. The archive row
-        is enough to prove the file was already stored only when the exact
-        path and byte size match the current source file; tail hashing then
-        preserves the usual cheap drift check for future scans.
+        proves the stored prefix for the exact source path; if the live file
+        has grown since that row was written, the cursor is restored to the
+        archived prefix so catch-up can take the append path instead of
+        parsing the whole active JSONL again.
         """
         archive_root = Path(getattr(self._polylogue, "archive_root", self._cursor._db_path.parent))
         source_db = archive_root / "source.db"
@@ -487,7 +492,9 @@ class LiveWatcher:
         if row is None:
             return False
         blob_hash, blob_size = row
-        if int(blob_size or 0) != int(stat.st_size):
+        archived_size = int(blob_size or 0)
+        current_size = int(stat.st_size)
+        if archived_size <= 0 or archived_size > current_size:
             return False
         if isinstance(blob_hash, bytes):
             content_fingerprint = blob_hash.hex()
@@ -496,14 +503,18 @@ class LiveWatcher:
         else:
             return False
         try:
-            tail_hash, last_complete_newline, _bytes_read = tail_hash_and_last_complete_newline_from_path(
-                path, stat.st_size
-            )
+            if archived_size == current_size:
+                tail_hash, last_complete_newline, _bytes_read = tail_hash_and_last_complete_newline_from_path(
+                    path, current_size
+                )
+            else:
+                tail_hash, _bytes_read = tail_hash_from_path(path, archived_size)
+                last_complete_newline = archived_size
         except FileNotFoundError:
             return False
         self._cursor.set(
             path,
-            stat.st_size,
+            archived_size,
             byte_offset=last_complete_newline,
             last_complete_newline=last_complete_newline,
             parser_fingerprint=_PARSER_FINGERPRINT,

--- a/tests/integration/test_daemon_convergence_evidence.py
+++ b/tests/integration/test_daemon_convergence_evidence.py
@@ -172,7 +172,7 @@ def test_daemon_convergence_evidence_full_archive_state(
         pass
 
     # ── BEFORE snapshot ──────────────────────────────────────────────
-    before = probe(db_path)
+    before = probe(db_path, exact_table_counts=True)
     assert before["ok"] is True, before.get("error")
     assert before["report_version"] == REPORT_VERSION
 
@@ -214,7 +214,7 @@ def test_daemon_convergence_evidence_full_archive_state(
     )
 
     # ── AFTER snapshot ──────────────────────────────────────────────
-    after = probe(db_path)
+    after = probe(db_path, exact_table_counts=True)
     assert after["ok"] is True, after.get("error")
     assert after["report_version"] == REPORT_VERSION
 

--- a/tests/integration/test_live_read_amplification.py
+++ b/tests/integration/test_live_read_amplification.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
+from hashlib import sha256
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -35,9 +37,11 @@ import pytest
 
 import polylogue.sources.live.watcher as live_watcher
 from polylogue.sources.live.batch import LiveBatchProcessor
-from polylogue.sources.live.batch_support import _AppendResult, _FullIngestResult
+from polylogue.sources.live.batch_support import _AppendResult, _DeferredAppend, _FullIngestResult
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.sources.live.watcher import LiveWatcher, WatchSource
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.io_counter import ReadCounter, read_counter
 
 # ---------------------------------------------------------------------------
@@ -81,6 +85,34 @@ def _append_jsonl(path: Path, records: list[dict[str, object]]) -> int:
     with path.open("ab") as handle:
         handle.write(payload)
     return len(payload)
+
+
+def _seed_source_raw_prefix(archive_root: Path, *, path: Path, raw_bytes: bytes) -> str:
+    """Seed an archived raw row for the exact prefix stored before a restart."""
+    source_db = archive_root / "source.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    raw_id = sha256(raw_bytes).hexdigest()
+    with sqlite3.connect(source_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index,
+                blob_hash, blob_size, acquired_at_ms
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "claude-code-session",
+                path.stem,
+                str(path),
+                0,
+                bytes.fromhex(raw_id),
+                len(raw_bytes),
+                1_770_000_000_000,
+            ),
+        )
+    return raw_id
 
 
 @contextmanager
@@ -300,6 +332,58 @@ class TestMtimeDriftCatchUp:
         assert counter.calls_by_site.get("fingerprint_file", 0) == 0, (
             f"mtime-drift catch-up rehashed the file: {counter.summary()}"
         )
+
+
+class TestRestartedCursorReconcile:
+    """A missing cursor for a grown archived JSONL should resume from the archive prefix.
+
+    This pins the daemon-memory failure mode observed on the live archive: a
+    large active JSONL had an archived raw row, grew while the daemon cursor was
+    absent/stale, and startup catch-up fell back to a full parse of the entire
+    file. Reconciliation should instead restore the cursor at the archived
+    prefix and leave only the appended tail for the append path.
+    """
+
+    def test_missing_cursor_reconciles_archived_prefix_for_append(self, tmp_path: Path) -> None:
+        root = tmp_path / "projects"
+        root.mkdir()
+        db_path = tmp_path / "index.db"
+        cursor = CursorStore(db_path)
+        polylogue = SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path), config=None)
+        path = root / "session-abc.jsonl"
+        prefix_records = [_claude_code_record(session_id="abc", uuid=f"m-{i}") for i in range(3)]
+        _write_jsonl(path, prefix_records)
+        prefix_bytes = path.read_bytes()
+        raw_id = _seed_source_raw_prefix(tmp_path, path=path, raw_bytes=prefix_bytes)
+        appended_bytes = _append_jsonl(
+            path,
+            [_claude_code_record(session_id="abc", uuid="m-appended", text="new tail")],
+        )
+        sources = (WatchSource(name="claude-code", root=root),)
+        watcher = LiveWatcher(cast(Any, polylogue), sources, cursor=cursor, debounce_s=0.0)
+
+        needs_work = watcher._needs_work_from_state(path, stat=path.stat(), cursor=None)
+
+        assert needs_work is True
+        restored = cursor.get_record(path)
+        assert restored is not None
+        assert restored.byte_offset == len(prefix_bytes)
+        assert restored.byte_size == len(prefix_bytes)
+        assert restored.content_fingerprint == raw_id
+
+        proc = LiveBatchProcessor(
+            cast(Any, polylogue),
+            sources,
+            cursor=cursor,
+            parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        )
+        with patch.object(proc, "_existing_provider_session_id", return_value="abc"):
+            append_plan = proc._append_plan(path, cursor=restored)
+
+        assert append_plan is not None
+        assert not isinstance(append_plan, _DeferredAppend)
+        assert append_plan.start_offset == len(prefix_bytes)
+        assert append_plan.bytes_read == appended_bytes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -9,6 +9,8 @@ import pytest
 
 from devtools.daemon_workload_probe import (
     REPORT_VERSION,
+    UNKNOWN_TABLE_COUNT,
+    _table_count,
     compare,
     main,
     probe,
@@ -114,7 +116,7 @@ def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -
     source = tmp_path / "session.jsonl"
     _seed_minimal_archive(db, source)
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
 
     assert payload["ok"] is True
     assert payload["attempt_counts"]["total"] == 1
@@ -122,6 +124,39 @@ def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -
     source_plan = payload["query_plans"]["source_path_lookup"]
     assert source_plan["hazards"] == []
     assert any("idx_raw_sessions_source_path" in item for item in source_plan["plan"])
+
+
+def test_daemon_workload_probe_defaults_to_estimated_table_counts(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    _seed_minimal_archive(db, tmp_path / "session.jsonl")
+
+    default_payload = probe(db)
+    exact_payload = probe(db, exact_table_counts=True)
+
+    assert default_payload["boundary_table_count_mode"] == "estimated"
+    assert default_payload["archive_tiers"]["table_count_mode"] == "estimated"
+    assert default_payload["boundary_table_counts"]["sessions"] == UNKNOWN_TABLE_COUNT
+    assert exact_payload["boundary_table_count_mode"] == "exact"
+    assert exact_payload["archive_tiers"]["table_count_mode"] == "exact"
+    assert exact_payload["boundary_table_counts"]["raw_sessions"] == 1
+    assert exact_payload["boundary_table_counts"]["sessions"] == 1
+
+
+def test_daemon_workload_probe_table_count_uses_sqlite_stats_for_estimates(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "stats.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE sample (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.executemany("INSERT INTO sample(value) VALUES (?)", [("a",), ("b",), ("c",)])
+
+        assert _table_count(conn, "sample", exact=False) == UNKNOWN_TABLE_COUNT
+        assert _table_count(conn, "sample", exact=True) == 3
+
+        conn.execute("ANALYZE")
+
+        assert _table_count(conn, "sample", exact=False) == 3
+        assert _table_count(conn, "missing", exact=False) == -1
 
 
 def test_daemon_workload_probe_reports_missing_database(tmp_path: Path) -> None:
@@ -185,7 +220,7 @@ def test_daemon_workload_probe_reports_ops_tier_from_db_anchor(tmp_path: Path) -
             sampled_at_ms=1_770_000_040_000,
         )
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
 
     assert payload["ok"] is True
     assert payload["attempt_counts"]["total"] == 1
@@ -307,7 +342,7 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
             """
         )
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
     tiers = payload["archive_tiers"]
 
     assert tiers["present"] is True
@@ -370,7 +405,12 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert surfaces["tool_usage"]["evidence"]["action_count_exact"] is False
     assert tiers["schema_mismatches"] == []
     assert tiers["tiers"]["source"]["integrity"] == "not_checked"
-    expensive_payload = probe(db, integrity_check=True, exact_derived_counts=True)
+    expensive_payload = probe(
+        db,
+        integrity_check=True,
+        exact_derived_counts=True,
+        exact_table_counts=True,
+    )
     assert expensive_payload["archive_tiers"]["tiers"]["source"]["integrity"] == "ok"
     assert expensive_payload["archive_tiers"]["derived_readiness"]["counts"]["messages_fts_exact_counts"] is True
     assert expensive_payload["archive_tiers"]["derived_readiness"]["counts"]["action_count_exact"] is True
@@ -385,7 +425,7 @@ def test_daemon_workload_probe_reports_layout_ready_for_clean_five_tier_archive(
     for tier in ArchiveTier:
         initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
 
     layout = payload["archive_tiers"]["layout_readiness"]
     assert layout == {
@@ -458,7 +498,7 @@ def test_daemon_workload_probe_reports_archive_source_path_churn(tmp_path: Path)
             source_paths_json=json.dumps([source_path]),
         )
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
 
     assert payload["ok"] is True
     assert payload["source_path_churn"] == [
@@ -486,7 +526,7 @@ def test_probe_payload_carries_stable_top_level_shape(tmp_path: Path) -> None:
     db = tmp_path / "archive.sqlite"
     _seed_minimal_archive(db, tmp_path / "session.jsonl")
 
-    payload = probe(db)
+    payload = probe(db, exact_table_counts=True)
 
     expected_keys = {
         "ok",
@@ -497,6 +537,7 @@ def test_probe_payload_carries_stable_top_level_shape(tmp_path: Path) -> None:
         "storage_route_counts",
         "recent_attempts",
         "convergence_stage_timings",
+        "boundary_table_count_mode",
         "boundary_table_counts",
         "archive_tiers",
         "blob_lease_state",
@@ -509,6 +550,8 @@ def test_probe_payload_carries_stable_top_level_shape(tmp_path: Path) -> None:
     }
     assert expected_keys.issubset(payload.keys())
     assert payload["report_version"] == REPORT_VERSION
+    assert payload["boundary_table_count_mode"] == "exact"
+    assert payload["archive_tiers"]["table_count_mode"] == "exact"
 
     # Boundary counts cover the daemon-relevant tables.
     counts = payload["boundary_table_counts"]
@@ -651,7 +694,7 @@ def test_compare_computes_structured_delta(tmp_path: Path) -> None:
     source = tmp_path / "session.jsonl"
     _seed_minimal_archive(db, source)
 
-    before_payload = probe(db)
+    before_payload = probe(db, exact_table_counts=True)
 
     # Simulate a convergence cycle that added a second raw + session +
     # ran a second live attempt.
@@ -695,7 +738,7 @@ def test_compare_computes_structured_delta(tmp_path: Path) -> None:
         cursor_fingerprint_read_bytes=0,
     )
 
-    after_payload = probe(db)
+    after_payload = probe(db, exact_table_counts=True)
 
     diff = compare(before_payload, after_payload)
     assert diff["ok"] is True
@@ -718,7 +761,7 @@ def test_compare_reports_archive_derived_readiness_deltas(tmp_path: Path) -> Non
     db = tmp_path / "index.db"
     initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
 
-    before_payload = probe(db)
+    before_payload = probe(db, exact_table_counts=True)
     with sqlite3.connect(tmp_path / "index.db") as conn:
         conn.execute(
             """
@@ -728,7 +771,7 @@ def test_compare_reports_archive_derived_readiness_deltas(tmp_path: Path) -> Non
             """,
             (b"y" * 32,),
         )
-    after_payload = probe(db)
+    after_payload = probe(db, exact_table_counts=True)
 
     diff = compare(before_payload, after_payload)
 


### PR DESCRIPTION
## Summary

Fixes the daemon memory spike path for large active JSONL files after cursor loss and makes `polylogue ops diagnostics workload` bounded by default on large archives.

## Problem

The live daemon had modest current memory but high recorded peaks in ops telemetry, and the live workload probe could fail to emit JSON under a 25s timeout against the 18.9 GiB archive. Source inspection found the ingest-side trigger: when a cursor was missing or stale, `LiveWatcher` only reconciled an archived raw row if the archived size exactly matched the current source file. If the active JSONL had grown since the archived prefix was written, startup catch-up treated the whole current file as new work and could full-parse very large Codex/Claude session files.

The diagnostics probe also did exact boundary/archive `COUNT(*)` scans by default, so operator diagnostics paid large-table scan cost before producing any output.

## Solution

- Restore missing/failed live cursors from matching `source.db.raw_sessions` prefixes when `archived_size <= current_size`.
- Keep grown files queued after prefix reconciliation so the batch processor uses the append path from the archived byte offset.
- Change workload-probe boundary/archive table counts to cheap SQLite planner estimates by default, with `--exact-table-counts` for evidence runs that need arithmetic deltas.
- Bump the probe report version and document `-1` missing vs `-2` unknown table-count values.
- Update exact-count convergence tests to opt into exact mode, and add unit coverage for estimated/default count behavior.

## Verification

- `devtools test tests/integration/test_live_read_amplification.py -k "RestartedCursorReconcile or MtimeDriftCatchUp"` → 2 passed.
- `devtools test tests/unit/devtools/test_daemon_workload_probe.py` → 18 passed.
- `devtools test tests/integration/test_daemon_convergence_evidence.py -k full_archive_state` → 1 passed.
- `timeout 25s polylogue ops diagnostics workload --json` against the live archive → rc 0, emitted JSON in ~4.1s with `boundary_table_count_mode=estimated`.
- `devtools verify --quick` → exit_code 0 on run `20260619T151421Z-quick-1434656-bd943e4b`.
- Pre-push `devtools verify --quick` → exit_code 0 on committed SHA `bbe000788`.

Closes #2167