### PR TITLE
perf(daemon): bound SQLite cache pressure (#2172)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1274,6 +1274,13 @@ SQLite WAL behavior for the archive database (see also
 
 - **Journal mode**: WAL on the write profile. Set once per database
   the first time a writer opens it; persists in the file header.
+- **Connection cache profiles**: high-throughput ingest writes use the
+  full write profile (`128 MiB` SQLite cache, `1 GiB` mmap allowance).
+  Long-running daemon/ops writes use the daemon write profile (`16 MiB`
+  cache, `64 MiB` mmap allowance) so small telemetry, cursor, heartbeat,
+  OTLP, and maintenance writes do not keep batch-sized SQLite page-cache
+  pressure charged to `polylogued.service`. Read-only daemon probes use
+  the read profile (`query_only=ON`) instead of opening write connections.
 - **Autocheckpoint threshold**: `WAL_AUTOCHECKPOINT_PAGES = 10000` =
   40 MiB. When the WAL crosses this, SQLite runs a PASSIVE checkpoint
   inline with the next commit.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -239,6 +239,13 @@ SQLite WAL behavior for the archive database (see also
 
 - **Journal mode**: WAL on the write profile. Set once per database
   the first time a writer opens it; persists in the file header.
+- **Connection cache profiles**: high-throughput ingest writes use the
+  full write profile (`128 MiB` SQLite cache, `1 GiB` mmap allowance).
+  Long-running daemon/ops writes use the daemon write profile (`16 MiB`
+  cache, `64 MiB` mmap allowance) so small telemetry, cursor, heartbeat,
+  OTLP, and maintenance writes do not keep batch-sized SQLite page-cache
+  pressure charged to `polylogued.service`. Read-only daemon probes use
+  the read profile (`query_only=ON`) instead of opening write connections.
 - **Autocheckpoint threshold**: `WAL_AUTOCHECKPOINT_PAGES = 10000` =
   40 MiB. When the WAL crosses this, SQLite runs a PASSIVE checkpoint
   inline with the next commit.

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -125,9 +125,9 @@ def _active_index_db_path() -> Path:
 
 def _heartbeat_counts(db: Path) -> tuple[int, int, str]:
     """Return session and message counts for the current archive."""
-    from polylogue.storage.sqlite.connection_profile import open_connection
+    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
-    conn = open_connection(db, timeout=5.0)
+    conn = open_readonly_connection(db, timeout=5.0)
     try:
         tables = {
             str(row[0])
@@ -342,7 +342,7 @@ async def _periodic_db_optimize() -> None:
     considers planner-stat maintenance; otherwise a large archive can pay
     broad read IO at the exact moment live catch-up already needs the disk.
     """
-    from polylogue.storage.sqlite.connection_profile import open_connection
+    from polylogue.storage.sqlite.connection_profile import open_daemon_connection
 
     while True:
         await asyncio.sleep(86_400)  # 24 hours; no startup optimize.
@@ -350,7 +350,7 @@ async def _periodic_db_optimize() -> None:
         if not db.exists():
             continue
         try:
-            conn = open_connection(db, timeout=30.0)
+            conn = open_daemon_connection(db, timeout=30.0)
             try:
                 conn.execute("PRAGMA optimize")
                 logger.info("daemon: DB optimize completed")

--- a/polylogue/daemon/cursor_lag_baseline.py
+++ b/polylogue/daemon/cursor_lag_baseline.py
@@ -49,7 +49,7 @@ from polylogue.storage.sqlite.archive_tiers.ops_write import (
     record_cursor_lag_sample as record_archive_cursor_lag_sample,
 )
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
+from polylogue.storage.sqlite.connection_profile import open_daemon_connection, open_readonly_connection
 
 
 def ensure_lag_sample_table(conn: sqlite3.Connection) -> None:
@@ -219,7 +219,7 @@ def _record_archive_cursor_lag_samples(
         return 0
     ops_db.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with closing(open_connection(ops_db, timeout=0.1)) as conn:
+        with closing(open_daemon_connection(ops_db, timeout=0.1)) as conn:
             initialize_archive_tier(conn, ArchiveTier.OPS)
             for family, source_path, max_lag_s, stuck_file_count, p50_s, p95_s in rows:
                 record_archive_cursor_lag_sample(
@@ -250,7 +250,7 @@ def _gc_archive_cursor_lag_samples(
         return 0
     cutoff_ms = _epoch_ms((now or datetime.now(UTC)) - timedelta(days=retention_days))
     try:
-        with closing(open_connection(ops_db, timeout=0.1)) as conn:
+        with closing(open_daemon_connection(ops_db, timeout=0.1)) as conn:
             initialize_archive_tier(conn, ArchiveTier.OPS)
             cur = conn.execute("DELETE FROM cursor_lag_samples WHERE sampled_at_ms < ?", (cutoff_ms,))
             conn.commit()

--- a/polylogue/daemon/embedding_backlog.py
+++ b/polylogue/daemon/embedding_backlog.py
@@ -238,7 +238,9 @@ def _upsert_archive_embedding_catchup_run(
     from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
     ops_db.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(ops_db, timeout=30.0) as conn:
+    from polylogue.storage.sqlite.connection_profile import open_daemon_connection
+
+    with open_daemon_connection(ops_db, timeout=30.0) as conn:
         initialize_archive_tier(conn, ArchiveTier.OPS)
         return upsert_embedding_catchup_run(
             conn,

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from polylogue.paths import active_index_db_path
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.connection_profile import open_connection
+from polylogue.storage.sqlite.connection_profile import open_daemon_connection
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -40,7 +40,7 @@ def _ensure_events_db() -> sqlite3.Connection:
     path = _events_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     initialize_archive_database(path, ArchiveTier.OPS)
-    conn = open_connection(path)
+    conn = open_daemon_connection(path)
     conn.executescript(_DAEMON_EVENTS_DDL)
     return conn
 

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -437,8 +437,10 @@ def _active_bulk_ingest_attempt(
 def _archive_active_bulk_ingest_attempt(ops_db: Path | None, *, now_iso: str) -> tuple[str, str, str] | None:
     if ops_db is None or not ops_db.exists():
         return None
+    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
     try:
-        conn = sqlite3.connect(str(ops_db))
+        conn = open_readonly_connection(ops_db)
         try:
             has_table = bool(
                 conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='ingest_attempts'").fetchone()
@@ -1013,8 +1015,10 @@ def _archive_repeated_stage_failure_info(
 ) -> tuple[int, int, sqlite3.Row | tuple[object, ...] | None] | None:
     if not ops_db.exists():
         return None
+    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
     try:
-        conn = sqlite3.connect(str(ops_db))
+        conn = open_readonly_connection(ops_db)
         try:
             has_table = bool(
                 conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='ingest_attempts'").fetchone()

--- a/polylogue/daemon/otlp_receiver.py
+++ b/polylogue/daemon/otlp_receiver.py
@@ -37,7 +37,6 @@ Design notes:
 from __future__ import annotations
 
 import json
-import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime, timezone
 from pathlib import Path
@@ -133,7 +132,9 @@ def store_telemetry(db_path: str, row: OtlpTelemetryRow) -> None:
     try:
         ops_db = _ops_db_path(db_path)
         initialize_archive_database(ops_db, ArchiveTier.OPS)
-        conn = sqlite3.connect(ops_db)
+        from polylogue.storage.sqlite.connection_profile import open_daemon_connection
+
+        conn = open_daemon_connection(ops_db)
         try:
             conn.execute(
                 "INSERT INTO otlp_telemetry (received_at_ms, signal_type, content_type, payload, resource_count, span_count, metric_count, log_record_count) "

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -3,6 +3,8 @@
 Factories
 ---------
 ``open_connection(path)`` returns a read-write connection with write pragmas applied.
+``open_daemon_connection(path)`` returns a read-write connection with a smaller
+daemon/ops cache profile.
 ``open_readonly_connection(path)`` returns a uri=ro connection with read pragmas applied.
 ``connection_context(path)`` is a context manager for a single-use read-write connection.
 
@@ -71,8 +73,10 @@ class SQLiteConnectionProfile:
 DB_TIMEOUT = 30
 READ_DB_TIMEOUT = 1
 WRITE_CACHE_SIZE_KIB = 131072  # 128 MiB
+DAEMON_WRITE_CACHE_SIZE_KIB = 16384  # 16 MiB
 READ_CACHE_SIZE_KIB = 32768  # 32 MiB
 WRITE_MMAP_SIZE_BYTES = 1073741824  # 1 GiB
+DAEMON_WRITE_MMAP_SIZE_BYTES = 67108864  # 64 MiB
 READ_MMAP_SIZE_BYTES = 134217728  # 128 MiB
 WAL_AUTOCHECKPOINT_PAGES = 10000
 # #1614: soft cap on the WAL file. After any checkpoint that frees
@@ -98,6 +102,19 @@ WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
     journal_size_limit_bytes=WAL_JOURNAL_SIZE_LIMIT_BYTES,
 )
 
+DAEMON_WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
+    role="write",
+    timeout_seconds=DB_TIMEOUT,
+    busy_timeout_ms=DB_TIMEOUT * 1000,
+    cache_size_kib=DAEMON_WRITE_CACHE_SIZE_KIB,
+    mmap_size_bytes=DAEMON_WRITE_MMAP_SIZE_BYTES,
+    foreign_keys=True,
+    journal_mode="WAL",
+    synchronous="NORMAL",
+    wal_autocheckpoint_pages=WAL_AUTOCHECKPOINT_PAGES,
+    journal_size_limit_bytes=WAL_JOURNAL_SIZE_LIMIT_BYTES,
+)
+
 READ_CONNECTION_PROFILE = SQLiteConnectionProfile(
     role="read",
     timeout_seconds=READ_DB_TIMEOUT,
@@ -112,6 +129,7 @@ READ_CONNECTION_PROFILE = SQLiteConnectionProfile(
     query_only=True,
 )
 
+DAEMON_WRITE_CONNECTION_PRAGMA_STATEMENTS = DAEMON_WRITE_CONNECTION_PROFILE.pragma_statements
 WRITE_CONNECTION_PRAGMA_STATEMENTS = WRITE_CONNECTION_PROFILE.pragma_statements
 READ_CONNECTION_PRAGMA_STATEMENTS = READ_CONNECTION_PROFILE.pragma_statements
 
@@ -184,6 +202,25 @@ def open_connection(path: str | Path, *, timeout: float = DB_TIMEOUT) -> sqlite3
     return conn
 
 
+def open_daemon_connection(path: str | Path, *, timeout: float = DB_TIMEOUT) -> sqlite3.Connection:
+    """Open a read-write SQLite connection for daemon maintenance/ops writes.
+
+    Long-running daemon loops write small status, cursor, telemetry, and
+    maintenance rows. They should not inherit the full batch-ingest cache and
+    mmap profile, because systemd charges their SQLite page cache to the
+    service cgroup for the lifetime of the process.
+    """
+    conn = sqlite3.connect(str(path), timeout=timeout)
+    try:
+        for stmt in DAEMON_WRITE_CONNECTION_PRAGMA_STATEMENTS:
+            conn.execute(stmt)
+        _attach_sibling_tiers(conn)
+    except BaseException:
+        conn.close()
+        raise
+    return conn
+
+
 def open_readonly_connection(path: str | Path, *, timeout: float = READ_DB_TIMEOUT) -> sqlite3.Connection:
     """Open a read-only SQLite connection with canonical read pragmas applied.
 
@@ -216,6 +253,10 @@ def connection_context(path: str | Path, *, timeout: float = DB_TIMEOUT) -> Iter
 
 __all__ = [
     "DB_TIMEOUT",
+    "DAEMON_WRITE_CACHE_SIZE_KIB",
+    "DAEMON_WRITE_CONNECTION_PRAGMA_STATEMENTS",
+    "DAEMON_WRITE_CONNECTION_PROFILE",
+    "DAEMON_WRITE_MMAP_SIZE_BYTES",
     "READ_CACHE_SIZE_KIB",
     "READ_CONNECTION_PRAGMA_STATEMENTS",
     "READ_CONNECTION_PROFILE",
@@ -228,6 +269,7 @@ __all__ = [
     "WRITE_CONNECTION_PROFILE",
     "WRITE_MMAP_SIZE_BYTES",
     "connection_context",
+    "open_daemon_connection",
     "open_connection",
     "open_readonly_connection",
 ]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1019,6 +1019,54 @@ def test_daemon_cli_heartbeat_counts_archive(tmp_path: Path) -> None:
     assert daemon_cli._heartbeat_counts(archive_root / "index.db") == (1, 1, "sessions")
 
 
+def test_daemon_cli_heartbeat_counts_uses_read_only_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None = None, rows: list[tuple[object, ...]] | None = None) -> None:
+            self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
+
+    class ReadOnlyConnection:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def execute(self, sql: str) -> FakeCursor:
+            normalized = " ".join(sql.split())
+            assert not normalized.upper().startswith(("INSERT", "UPDATE", "DELETE", "CREATE", "PRAGMA JOURNAL_MODE"))
+            if "FROM sqlite_master" in normalized:
+                return FakeCursor(rows=[("sessions",), ("messages",)])
+            if normalized == "SELECT COUNT(*) FROM sessions":
+                return FakeCursor((7,))
+            if normalized == "SELECT COUNT(*) FROM messages":
+                return FakeCursor((42,))
+            raise AssertionError(f"unexpected heartbeat query: {normalized}")
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = ReadOnlyConnection()
+
+    def open_readonly(path: Path, *, timeout: float) -> ReadOnlyConnection:
+        assert path == tmp_path / "index.db"
+        assert timeout == 5.0
+        return conn
+
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_readonly_connection", open_readonly)
+
+    assert daemon_cli._heartbeat_counts(tmp_path / "index.db") == (7, 42, "sessions")
+    assert conn.closed is True
+
+
 def test_ensure_fts_startup_readiness_handles_archive(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/storage/test_wal_journal_size_limit.py
+++ b/tests/unit/storage/test_wal_journal_size_limit.py
@@ -24,10 +24,14 @@ from pathlib import Path
 import pytest
 
 from polylogue.storage.sqlite.connection_profile import (
+    DAEMON_WRITE_CACHE_SIZE_KIB,
+    DAEMON_WRITE_CONNECTION_PROFILE,
+    DAEMON_WRITE_MMAP_SIZE_BYTES,
     READ_CONNECTION_PROFILE,
     WAL_JOURNAL_SIZE_LIMIT_BYTES,
     WRITE_CONNECTION_PROFILE,
     open_connection,
+    open_daemon_connection,
     open_readonly_connection,
 )
 
@@ -55,6 +59,15 @@ def test_read_profile_includes_query_only_pragma() -> None:
     assert "PRAGMA query_only = ON" in statements, (
         f"#1614: read profile must signal read-only intent; statements were {statements}"
     )
+
+
+def test_daemon_write_profile_uses_bounded_cache_and_mmap() -> None:
+    """Daemon maintenance writes should not inherit the batch-ingest cache."""
+    assert DAEMON_WRITE_CONNECTION_PROFILE.cache_size_kib == DAEMON_WRITE_CACHE_SIZE_KIB
+    assert DAEMON_WRITE_CONNECTION_PROFILE.mmap_size_bytes == DAEMON_WRITE_MMAP_SIZE_BYTES
+    assert DAEMON_WRITE_CONNECTION_PROFILE.cache_size_kib < WRITE_CONNECTION_PROFILE.cache_size_kib
+    assert DAEMON_WRITE_CONNECTION_PROFILE.mmap_size_bytes < WRITE_CONNECTION_PROFILE.mmap_size_bytes
+    assert DAEMON_WRITE_CONNECTION_PROFILE.journal_size_limit_bytes == WAL_JOURNAL_SIZE_LIMIT_BYTES
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +105,17 @@ def test_open_readonly_connection_applies_query_only(tmp_path: Path) -> None:
         # Any DML attempt must be rejected at parse time.
         with pytest.raises(sqlite3.OperationalError):
             conn.execute("INSERT INTO t (id) VALUES (1)")
+    finally:
+        conn.close()
+
+
+def test_open_daemon_connection_applies_bounded_cache_and_mmap(tmp_path: Path) -> None:
+    db_path = tmp_path / "ops.db"
+    conn = open_daemon_connection(db_path)
+    try:
+        assert _pragma_int(conn, "cache_size") == -DAEMON_WRITE_CACHE_SIZE_KIB
+        assert _pragma_int(conn, "mmap_size") == DAEMON_WRITE_MMAP_SIZE_BYTES
+        assert _pragma_int(conn, "journal_size_limit") == WAL_JOURNAL_SIZE_LIMIT_BYTES
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Bound daemon-side SQLite cache pressure by separating long-running daemon/ops writes from the batch-ingest write profile, and by moving recurring daemon read probes onto the read-only profile.

## Problem

The live memory snapshot after #2171 showed a different pressure shape from the pytest harness issue: `polylogued.service` was near 950 MiB current cgroup memory with a 2.9 GiB peak, but the daemon process itself was only about 235 MiB PSS. `memory.stat` attributed most current usage to file cache rather than anonymous heap. Several daemon loops still opened the full write profile for small ops/maintenance work, and heartbeat counts opened a write-profile connection for read-only counts.

## Solution

Added an explicit daemon write profile in `polylogue/storage/sqlite/connection_profile.py` with a 16 MiB SQLite cache and 64 MiB mmap allowance, leaving the existing 128 MiB / 1 GiB batch-ingest write profile untouched. Moved small daemon/ops writes (`daemon_events`, cursor-lag samples, embedding catch-up rows, OTLP telemetry, daily optimize) to `open_daemon_connection`, and moved heartbeat plus two ops health probes to `open_readonly_connection`.

The existing status/metrics memory reporting already distinguishes RSS, cgroup current/peak, cgroup file, and inactive file, so this change relies on that live observability rather than adding another reporting layer.

## Verification

- `devtools test tests/unit/storage/test_wal_journal_size_limit.py::test_daemon_write_profile_uses_bounded_cache_and_mmap tests/unit/storage/test_wal_journal_size_limit.py::test_open_daemon_connection_applies_bounded_cache_and_mmap tests/unit/daemon/test_daemon_cli.py::test_daemon_cli_heartbeat_counts_uses_read_only_probe tests/unit/daemon/test_daemon_cli.py::test_daemon_cli_heartbeat_counts_archive tests/unit/daemon/test_cursor_lag_baseline.py tests/unit/daemon/test_cursor_lag_integration.py tests/unit/daemon/test_otlp_receiver.py tests/unit/daemon/test_metrics_endpoint.py::TestFormatMetricsReadsArchiveState::test_fts_freshness_and_memory_state` — 46 passed.
- `devtools verify --quick` — exit 0.
- `devtools verify` — run `20260619T163716Z-testmon-1662720-33dfc22a`; 505 passed in 256.73s, selected_count=1247, peak_tree_pss=2813.7 MiB, diagnosis=`pytest_passed`.

Closes #2172
