### PR TITLE
feat(web): complete reader operator flow (#1846)

### DIFF
--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -213,6 +213,15 @@ __ATTACHMENT_CSS__
 .saved-view-item { display: flex; justify-content: space-between; gap: 8px; align-items: center;
   border: 1px solid var(--border); border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); }
 .saved-view-item button { flex-shrink: 0; }
+.annotation-composer { display: flex; flex-direction: column; gap: 6px; border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); margin-bottom: 8px; }
+.annotation-composer label { color: var(--text-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.annotation-composer select, .annotation-composer textarea { width: 100%; background: var(--panel-elevated);
+  border: 1px solid var(--border); color: var(--text); border-radius: 3px; font: inherit; font-size: var(--small); }
+.annotation-composer select { padding: 4px 6px; }
+.annotation-composer textarea { min-height: 68px; resize: vertical; padding: 6px; line-height: 1.4; }
+.annotation-composer textarea:focus, .annotation-composer select:focus { outline: none; border-color: var(--accent); }
+.annotation-composer .annotation-actions { margin-top: 0; }
 .annotation-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
 .annotation-item { border: 1px solid var(--border); border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); }
 .annotation-item .meta { color: var(--text-dim); font-family: var(--font-mono); font-size: 10px; margin-bottom: 4px; }
@@ -1592,7 +1601,7 @@ function renderInspectorNotes(el, c) {
     html += '<div class="inspector-empty">' + esc(state.userStateError) + '</div>';
   }
   html += '</div><div class="inspector-section"><h4>Annotations</h4>'
-    + '<button class="user-action" onclick="saveAnnotation()">Add note</button>';
+    + renderAnnotationComposer(c);
   var annotations = annotationsFor(c.id);
   if (annotations.length) {
     html += '<div class="annotation-list">';
@@ -1654,18 +1663,79 @@ function findAnnotation(annotationId) {
   return annotations.find(function(a) { return a.annotation_id === annotationId; }) || null;
 }
 
+function messageTargetLabel(message) {
+  var role = message.role || message.author_role || 'message';
+  var text = (message.text || message.content || '').replace(/\s+/g, ' ').trim();
+  if (text.length > 54) text = text.slice(0, 51) + '...';
+  return role + (text ? ': ' + text : '');
+}
+
+function renderAnnotationComposer(c) {
+  var html = '<div id="annotation-composer" class="annotation-composer" data-editing-id="">'
+    + '<label for="annotation-target-select">Target</label>'
+    + '<select id="annotation-target-select">'
+    + '<option value="session::' + escAttr(c.id) + '">Session</option>';
+  (c.messages || []).forEach(function(message, idx) {
+    var messageId = message.id || message.message_id;
+    if (!messageId) return;
+    html += '<option value="message::' + escAttr(messageId) + '">Message ' + esc(String(idx + 1)) + ' - '
+      + esc(messageTargetLabel(message)) + '</option>';
+  });
+  html += '</select>'
+    + '<label for="annotation-note-input">Note</label>'
+    + '<textarea id="annotation-note-input" placeholder="Add an operator note for this target"></textarea>'
+    + '<div class="annotation-actions">'
+    + '<button class="user-action" onclick="saveAnnotation()">Save note</button>'
+    + '<button class="user-action" onclick="clearAnnotationComposer()">Clear</button>'
+    + '</div></div>';
+  return html;
+}
+
+function clearAnnotationComposer() {
+  var composer = document.getElementById('annotation-composer');
+  var target = document.getElementById('annotation-target-select');
+  var note = document.getElementById('annotation-note-input');
+  if (composer) composer.dataset.editingId = '';
+  if (target) target.selectedIndex = 0;
+  if (note) note.value = '';
+}
+
+function annotationTargetFromComposer() {
+  var target = document.getElementById('annotation-target-select');
+  var selected = target ? target.value : '';
+  var parts = selected.split('::');
+  var targetType = parts[0] || 'session';
+  var targetId = parts.slice(1).join('::') || (state.selected ? state.selected.id : '');
+  return {targetType: targetType, targetId: targetId};
+}
+
 async function saveAnnotation(annotationId) {
   if (!state.selected) return;
-  var existing = annotationId ? findAnnotation(annotationId) : null;
-  var note = window.prompt('Annotation note', existing ? existing.note_text : '');
-  if (!note) return;
-  var id = annotationId || ('annotation-' + Date.now().toString(36));
+  var composer = document.getElementById('annotation-composer');
+  var noteInput = document.getElementById('annotation-note-input');
+  var note = noteInput ? noteInput.value.trim() : '';
+  if (!note) {
+    state.userStateError = 'Annotation note is required';
+    renderInspector();
+    return;
+  }
+  var target = annotationTargetFromComposer();
+  var editingId = annotationId || (composer && composer.dataset.editingId) || '';
+  var id = editingId || ('annotation-' + Date.now().toString(36));
+  var payload = {
+    annotation_id: id,
+    session_id: state.selected.id,
+    note_text: note,
+    target_type: target.targetType
+  };
+  if (target.targetType === 'message') {
+    payload.message_id = target.targetId;
+  } else {
+    payload.target_id = state.selected.id;
+  }
   try {
-    await sendJSON('/api/user/annotations', 'POST', {
-      annotation_id: id,
-      session_id: state.selected.id,
-      note_text: note
-    });
+    await sendJSON('/api/user/annotations', 'POST', payload);
+    state.userStateError = '';
     await loadUserState();
   } catch(e) {
     state.userStateError = 'Failed to save annotation';
@@ -1674,7 +1744,19 @@ async function saveAnnotation(annotationId) {
 }
 
 function editAnnotation(annotationId) {
-  saveAnnotation(annotationId);
+  var existing = findAnnotation(annotationId);
+  if (!existing) return;
+  var composer = document.getElementById('annotation-composer');
+  var target = document.getElementById('annotation-target-select');
+  var note = document.getElementById('annotation-note-input');
+  if (composer) composer.dataset.editingId = annotationId;
+  if (note) note.value = existing.note_text || '';
+  if (target) {
+    var targetValue = existing.target_type === 'message'
+      ? ('message::' + (existing.message_id || existing.target_id || ''))
+      : ('session::' + existing.session_id);
+    target.value = targetValue;
+  }
 }
 
 async function deleteAnnotation(annotationId) {

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -482,7 +482,15 @@ def test_reader_overlay_mutation_flow_evidence(reader_workspace: ReaderWorkspace
     assert status == 200
     assert "text/html" in content_type
     assert_no_private_paths(shell, context="reader overlay mutation shell")
-    for phrase in ("toggleMark", "saveAnnotation", "/api/user/marks", "/api/user/annotations"):
+    for phrase in (
+        "toggleMark",
+        "saveAnnotation",
+        "annotation-composer",
+        "annotation-target-select",
+        "annotation-note-input",
+        "/api/user/marks",
+        "/api/user/annotations",
+    ):
         assert phrase in shell, f"missing overlay shell hook {phrase!r}"
 
     mark_payload = cast(dict[str, object], mark)
@@ -515,6 +523,100 @@ def test_reader_overlay_mutation_flow_evidence(reader_workspace: ReaderWorkspace
             "annotation_operation": annotation_payload["operation"],
             "archive_mark_visible": "archive" in mark_types,
             "message_annotation_visible": "reader-visual-flow-note" in annotation_ids,
+            "private_path_safe": True,
+        },
+    )
+
+
+def test_reader_operator_flow_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    """Representative workbench flow stays route-backed and privacy-bounded (#1846)."""
+
+    with running_reader_server(reader_workspace) as (_, base_url):
+        shell_status, content_type, shell = get_text(base_url, f"/s/{READER_C1}")
+        search = cast(dict[str, object], get_json(base_url, "/api/sessions?query=Hello&limit=5"))
+        messages = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/read?view=messages"))
+        recovery = cast(
+            dict[str, object],
+            get_json(base_url, f"/api/sessions/{READER_C1}/read?view=recovery&format=json"),
+        )
+        context = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/read?view=context"))
+        raw_view = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/read?view=raw"))
+        work_packet = cast(
+            dict[str, object],
+            get_json(base_url, f"/api/sessions/{READER_C1}/recovery?report=work-packet&format=json"),
+        )
+        assertions = cast(
+            dict[str, object],
+            get_json(base_url, f"/api/assertions?target_ref=session%3A{READER_C1}&limit=10"),
+        )
+        mark_status, mark = _send_json(
+            base_url,
+            "POST",
+            "/api/user/marks",
+            {"session_id": READER_C1, "mark_type": "star"},
+        )
+        annotation_status, annotation = _send_json(
+            base_url,
+            "POST",
+            "/api/user/annotations",
+            {
+                "annotation_id": "reader-operator-flow-message-note",
+                "session_id": READER_C1,
+                "target_type": "message",
+                "message_id": READER_C1_M1,
+                "note_text": "Operator flow note",
+            },
+        )
+        annotations = cast(dict[str, object], get_json(base_url, f"/api/user/annotations?session_id={READER_C1}"))
+        provenance = cast(dict[str, object], get_json(base_url, f"/api/sessions/{READER_C1}/provenance"))
+
+    assert shell_status == 200
+    assert "text/html" in content_type
+    assert_no_private_paths(shell, context="reader operator-flow shell")
+    for phrase in (
+        "read-profile-selector",
+        "renderReadViewExecution",
+        "renderInspectorEvidence",
+        "annotation-composer",
+        "loadRawData",
+    ):
+        assert phrase in shell
+
+    assert search["total"] == 1
+    assert messages["view"] == "messages"
+    assert recovery["view"] == "recovery"
+    assert context["view"] == "context"
+    assert raw_view["view"] == "raw"
+    assert work_packet["report"] == "work-packet"
+    assert isinstance(assertions["total"], int)
+    assert assertions["total"] >= 0
+    assert mark_status in {200, 201}
+    assert cast(dict[str, object], mark)["operation"] == "mark.add"
+    assert annotation_status == 201
+    annotation_payload = cast(dict[str, object], annotation)
+    assert annotation_payload["operation"] == "annotation.save"
+    assert annotation_payload["target_type"] == "message"
+    assert annotation_payload["target_id"] == READER_C1_M1
+
+    annotation_ids = {str(item["annotation_id"]) for item in cast(list[dict[str, object]], annotations["items"])}
+    assert "reader-operator-flow-message-note" in annotation_ids
+    assert_no_private_paths(json.dumps(raw_view), context="reader raw read-view JSON")
+    assert_no_private_paths(json.dumps(provenance), context="reader provenance JSON")
+
+    write_evidence_manifest(
+        tmp_path / "reader-operator-flow-evidence.json",
+        artifact_id="polylogue.local_reader.operator_flow",
+        route=f"/s/{READER_C1}",
+        fixture_id="reader-visual-synthetic-v1",
+        checks={
+            "shell_status": shell_status,
+            "search_total": search["total"],
+            "read_views": [messages["view"], recovery["view"], context["view"], raw_view["view"]],
+            "work_packet_report": work_packet["report"],
+            "mark_status": mark_status,
+            "annotation_status": annotation_status,
+            "annotation_target": annotation_payload["target_id"],
+            "raw_provenance_private_path_safe": True,
             "private_path_safe": True,
         },
     )


### PR DESCRIPTION
## Summary

Completes the remaining browser workbench operator-flow gap for #1846 by turning annotation editing into an inline, route-backed session/message composer and adding fixture-backed visual evidence for the full search -> open -> read/evidence -> overlay/raw-drilldown path.

## Problem

The web workbench already had the shared daemon routes for search, read profiles, recovery/work-packet evidence, assertions, marks, annotations, and raw/provenance drilldown. The remaining #1846 gap was that these pieces still behaved like isolated endpoint demos in places: annotation editing was a prompt-only session note, and the visual evidence did not prove the representative operator flow as one browser cockpit path.

## Solution

- Replaced prompt-only annotation editing in `polylogue/daemon/web_shell.py` with an inline inspector composer.
- The composer targets either the selected session or any loaded message and posts to the existing `/api/user/annotations` route using the shared `MutationResultPayload` path.
- Preserved route-backed overlay behavior: no browser-local annotation payload shape and no new web evidence vocabulary.
- Added `test_reader_operator_flow_evidence` to exercise search, `read?view=messages|recovery|context|raw`, recovery work-packet evidence, assertion reads, mark/annotation writes, and raw/provenance privacy posture together.

Closes #1846.

## Verification

- `devtools test tests/visual/test_reader_dom_smoke.py::test_reader_overlay_mutation_flow_evidence tests/visual/test_reader_dom_smoke.py::test_reader_operator_flow_evidence tests/visual/test_reader_dom_smoke.py::test_reader_evidence_panel_endpoint_and_shell_smoke` -> 3 passed in 8.51s.
- `devtools verify --quick` -> exit_code 0, run_id `20260619T165007Z-quick-1707398-d0d31fb2`.
- `devtools verify` -> exit_code 0, run_id `20260619T165032Z-testmon-1708827-8175f2f7`; pytest-testmon selected 12 visual tests, 12 passed in 18.28s; peak pytest PSS 587.8 MiB.
- Pre-push `devtools verify --quick` -> exit_code 0, run_id `20260619T165148Z-quick-1711722-54cb9961`.