### PR TITLE
feat(query): pipe session scopes into terminal rows (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -83,6 +83,20 @@ polylogue observed-events where 'delivery_state:acted_on AND text:#2100'
 polylogue context-snapshots where 'boundary:session_start AND session.repo:polylogue'
 ```
 
+The first executable pipeline form scopes a terminal row query through a
+session source stage:
+
+```bash
+polylogue 'sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant'
+polylogue 'sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit'
+```
+
+The left stage is lowered into `session.<field>` predicates on the terminal
+unit query, so it uses the same row executor as direct `messages/actions/...`
+queries. For now the session stage accepts field/count/date predicates only;
+FTS, semantic, `exists`, lineage, and sequence stages are typed errors until
+they have dedicated unit-changing lowerers.
+
 Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as
 `messages where` are errors when malformed; they are not treated as ordinary

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -243,6 +243,7 @@ class QueryUnitSource:
 
     unit: QueryUnitName
     predicate: QueryPredicate
+    session_predicate: QueryPredicate | None = None
 
 
 ExplainClauseKind = Literal["field", "count", "count_range", "date", "date_range", "text", "json"]
@@ -1052,6 +1053,100 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
     return transformed
 
 
+def _split_pipeline_expression(expression: str) -> tuple[str, str] | None:
+    """Split ``left | right`` outside quotes and parentheses.
+
+    The first executable pipeline phase uses a single pipe between a
+    session-source predicate and a terminal unit-source predicate.  Values such
+    as ``origin:(codex-session|claude-code-session)`` must not split.
+    """
+
+    in_quote = False
+    escaped = False
+    depth = 0
+    for idx, char in enumerate(expression):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and in_quote:
+            escaped = True
+            continue
+        if char == '"':
+            in_quote = not in_quote
+            continue
+        if in_quote:
+            continue
+        if char == "(":
+            depth += 1
+            continue
+        if char == ")":
+            depth = max(0, depth - 1)
+            continue
+        if char == "|" and depth == 0:
+            left = expression[:idx].strip()
+            right = expression[idx + 1 :].strip()
+            if not left or not right:
+                raise ExpressionCompileError("pipeline requires non-empty stages around '|'", field=None)
+            return left, right
+    return None
+
+
+def _session_source_predicate(stage: str) -> QueryPredicate:
+    lower = stage.lower()
+    marker = "sessions where"
+    if lower == marker:
+        raise ExpressionCompileError("sessions where requires a predicate before pipeline '|'", field=None)
+    if not lower.startswith(marker) or not lower[len(marker)].isspace():
+        raise ExpressionCompileError(
+            "pipeline queries currently start with `sessions where ...`",
+            field=None,
+        )
+    return _parse_boolean_predicate(stage)
+
+
+def _scope_session_predicate(predicate: QueryPredicate) -> QueryPredicate:
+    if isinstance(predicate, QueryFieldPredicate):
+        if predicate.field.startswith("session."):
+            return predicate
+        if predicate.field not in _BOOLEAN_SUPPORTED_FIELDS:
+            raise ExpressionCompileError(
+                f"session pipeline stage cannot scope unsupported field {predicate.field!r}",
+                field=predicate.field,
+            )
+        return QueryFieldPredicate(field=f"session.{predicate.field}", values=predicate.values, op=predicate.op)
+    if isinstance(predicate, QueryBoolPredicate):
+        return QueryBoolPredicate(predicate.op, tuple(_scope_session_predicate(child) for child in predicate.children))
+    if isinstance(predicate, QueryNotPredicate):
+        return QueryNotPredicate(_scope_session_predicate(predicate.child))
+    raise ExpressionCompileError(
+        "pipeline session stages currently support field/count/date predicates only; "
+        "FTS, semantic, exists, lineage, and sequence stages need dedicated lowerers.",
+        field=None,
+    )
+
+
+def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
+    stages = _split_pipeline_expression(expression)
+    if stages is None:
+        return None
+    session_stage, terminal_stage = stages
+    session_predicate = _session_source_predicate(session_stage)
+    terminal_source = parse_unit_source_expression(terminal_stage)
+    if terminal_source is None:
+        raise ExpressionCompileError(
+            "pipeline terminal stage must be an executable `<unit>s where ...` query",
+            field=None,
+        )
+    scoped_session_predicate = _scope_session_predicate(session_predicate)
+    combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
+    _validate_predicate_context(combined, unit=terminal_source.unit)
+    return QueryUnitSource(
+        unit=terminal_source.unit,
+        predicate=combined,
+        session_predicate=session_predicate,
+    )
+
+
 def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
     """Parse explicit unit-source ``... where ...`` expressions as terminal row sources.
 
@@ -1061,6 +1156,9 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
     """
 
     stripped = expression.strip()
+    pipeline_source = _parse_pipeline_unit_source(stripped)
+    if pipeline_source is not None:
+        return pipeline_source
     lower = stripped.lower()
     source_match: tuple[str, QueryUnitName, str] | None = None
     for source, unit in _SOURCE_WHERE_SOURCES:
@@ -1321,10 +1419,13 @@ def _ast_payload(
     if predicate is not None:
         payload["predicate"] = predicate.to_payload()
     if unit_source is not None:
-        payload["unit_source"] = {
+        unit_payload: dict[str, object] = {
             "unit": unit_source.unit,
             "predicate": unit_source.predicate.to_payload(),
         }
+        if unit_source.session_predicate is not None:
+            unit_payload["session_predicate"] = unit_source.session_predicate.to_payload()
+        payload["unit_source"] = unit_payload
     return payload
 
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -422,6 +422,53 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_pipeline_session_source_scopes_terminal_unit_query(self) -> None:
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"
+        )
+
+        assert source is not None
+        assert source.unit == "message"
+        assert source.session_predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="repo", values=("polylogue",)),
+                QueryFieldPredicate(field="origin", values=("claude-code-session",)),
+            ),
+        )
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryBoolPredicate(
+                    op="and",
+                    children=(
+                        QueryFieldPredicate(field="session.repo", values=("polylogue",)),
+                        QueryFieldPredicate(field="session.origin", values=("claude-code-session",)),
+                    ),
+                ),
+                QueryFieldPredicate(field="role", values=("assistant",)),
+            ),
+        )
+
+    def test_pipeline_split_ignores_field_alternation_pipe(self) -> None:
+        source = parse_unit_source_expression(
+            "sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit"
+        )
+
+        assert source is not None
+        assert source.unit == "action"
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="session.origin", values=("codex-session", "claude-code-session")),
+                QueryFieldPredicate(field="action", values=("file_edit",)),
+            ),
+        )
+
+    def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="FTS, semantic, exists, lineage, and sequence"):
+            parse_unit_source_expression('sessions where ~"timeout" | messages where role:assistant')
+
     def test_assertion_source_where_lowers_to_structural_exists(self) -> None:
         ast = parse_expression_ast("assertions where kind:decision AND text:review")
 
@@ -885,6 +932,55 @@ class TestBooleanQueryExpression:
 
         assert [(row.session_id, row.message_id) for row in rows] == [
             ("claude-code-session:ext-hit", "claude-code-session:ext-hit:m-hit")
+        ]
+
+    def test_session_to_message_pipeline_executes_terminal_rows(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("pipeline hit")
+            .add_message("m-hit-user", role="user", text="please inspect")
+            .add_message("m-hit-assistant", role="assistant", text="the pipeline answer")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-repo")
+            .provider("claude-code")
+            .git_repository_url("sinex")
+            .title("pipeline wrong repo")
+            .add_message("m-wrong-repo", role="assistant", text="the pipeline answer")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "wrong-origin")
+            .provider("chatgpt")
+            .git_repository_url("polylogue")
+            .title("pipeline wrong origin")
+            .add_message("m-wrong-origin", role="assistant", text="the pipeline answer")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.session_id, row.message_id, row.text) for row in rows] == [
+            (
+                "claude-code-session:ext-hit",
+                "claude-code-session:ext-hit:m-hit-assistant",
+                "the pipeline answer",
+            )
         ]
 
     def test_exists_action_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:


### PR DESCRIPTION
## Summary

Adds the first executable query pipeline form for #2006: `sessions where ... | <unit>s where ...`. The session stage is parsed by the existing Lark Boolean predicate parser, scoped into `session.<field>` predicates, and executed by the existing terminal-unit row path.

## Problem

Polylogue already had executable terminal row queries like `messages where session.repo:polylogue AND role:assistant`, but the pipeline syntax described by #2006 still had no concrete implementation. Users had to manually repeat session scope inside each terminal unit query, and unsupported pipeline-looking strings had no explicit unit-changing lowerer boundary.

## Solution

- Extend `parse_unit_source_expression()` to recognize a single `sessions where <predicate> | <unit>s where <predicate>` pipeline.
- Split the pipe outside quotes and parentheses so alternations like `origin:(codex-session|claude-code-session)` remain field values.
- Lower the session stage into `session.<field>` predicates and combine it with the terminal unit predicate.
- Keep execution on the existing terminal row executors; no second query engine or browser/API-specific semantics.
- Fail typed for session-stage predicates that do not yet have row-scoping lowerers: FTS, semantic, `exists`, lineage, and sequence.
- Document the shipped pipeline form in `docs/search.md`.

Ref #2006.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k 'pipeline or parse_unit_source_expression_preserves_terminal_unit'` -> 4 passed, 255 deselected.
- `devtools test tests/unit/cli/test_query_expression.py -k 'pipeline or terminal_message_source_accepts_session_scoped_predicate'` -> 5 passed, 255 deselected.
- `devtools verify --quick` -> exit_code 0, run_id `20260619T165703Z-quick-1725126-8ccddbd3`.
- `devtools verify` -> exit_code 0, run_id `20260619T165825Z-testmon-1726932-7325125f`; pytest-testmon selected 368 affected tests, 368 passed in 111.98s; peak pytest PSS 835.0 MiB.