### PR TITLE
feat(query): add terminal pipeline window stages (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -89,13 +89,17 @@ session source stage:
 ```bash
 polylogue 'sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant'
 polylogue 'sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit'
+polylogue 'sessions where repo:polylogue | messages where role:assistant | limit 10 | offset 20'
 ```
 
 The left stage is lowered into `session.<field>` predicates on the terminal
 unit query, so it uses the same row executor as direct `messages/actions/...`
 queries. For now the session stage accepts field/count/date predicates only;
 FTS, semantic, `exists`, lineage, and sequence stages are typed errors until
-they have dedicated unit-changing lowerers.
+they have dedicated unit-changing lowerers. Terminal pipeline stages currently
+support `limit N` and `offset N`; query-string limits narrow the surface limit
+instead of expanding caller/API caps, and query-string offsets are added to the
+caller offset.
 
 Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -244,6 +244,8 @@ class QueryUnitSource:
     unit: QueryUnitName
     predicate: QueryPredicate
     session_predicate: QueryPredicate | None = None
+    limit: int | None = None
+    offset: int | None = None
 
 
 ExplainClauseKind = Literal["field", "count", "count_range", "date", "date_range", "text", "json"]
@@ -1053,14 +1055,15 @@ def _parse_boolean_predicate(expression: str) -> QueryPredicate:
     return transformed
 
 
-def _split_pipeline_expression(expression: str) -> tuple[str, str] | None:
-    """Split ``left | right`` outside quotes and parentheses.
+def _split_pipeline_stages(expression: str) -> tuple[str, ...]:
+    """Split ``|`` stages outside quotes and parentheses.
 
-    The first executable pipeline phase uses a single pipe between a
-    session-source predicate and a terminal unit-source predicate.  Values such
-    as ``origin:(codex-session|claude-code-session)`` must not split.
+    Values such as ``origin:(codex-session|claude-code-session)`` must not
+    split.
     """
 
+    stages: list[str] = []
+    stage_start = 0
     in_quote = False
     escaped = False
     depth = 0
@@ -1083,12 +1086,17 @@ def _split_pipeline_expression(expression: str) -> tuple[str, str] | None:
             depth = max(0, depth - 1)
             continue
         if char == "|" and depth == 0:
-            left = expression[:idx].strip()
-            right = expression[idx + 1 :].strip()
-            if not left or not right:
+            stage = expression[stage_start:idx].strip()
+            if not stage:
                 raise ExpressionCompileError("pipeline requires non-empty stages around '|'", field=None)
-            return left, right
-    return None
+            stages.append(stage)
+            stage_start = idx + 1
+    final = expression[stage_start:].strip()
+    if stages and not final:
+        raise ExpressionCompileError("pipeline requires non-empty stages around '|'", field=None)
+    if stages:
+        stages.append(final)
+    return tuple(stages)
 
 
 def _session_source_predicate(stage: str) -> QueryPredicate:
@@ -1125,11 +1133,45 @@ def _scope_session_predicate(predicate: QueryPredicate) -> QueryPredicate:
     )
 
 
-def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
-    stages = _split_pipeline_expression(expression)
-    if stages is None:
+def _parse_non_negative_int_stage(stage: str, keyword: str) -> int | None:
+    lower = stage.lower()
+    prefix = f"{keyword} "
+    if not lower.startswith(prefix):
         return None
-    session_stage, terminal_stage = stages
+    raw_value = stage[len(prefix) :].strip()
+    if not raw_value:
+        raise ExpressionCompileError(f"pipeline `{keyword}` stage requires an integer", field=keyword)
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ExpressionCompileError(f"pipeline `{keyword}` stage requires an integer", field=keyword) from exc
+    if value < 0:
+        raise ExpressionCompileError(f"pipeline `{keyword}` stage must be non-negative", field=keyword)
+    return value
+
+
+def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSource:
+    limit = _parse_non_negative_int_stage(stage, "limit")
+    if limit is not None:
+        if limit == 0:
+            raise ExpressionCompileError("pipeline `limit` stage must be greater than zero", field="limit")
+        return replace(source, limit=limit)
+    offset = _parse_non_negative_int_stage(stage, "offset")
+    if offset is not None:
+        return replace(source, offset=offset)
+    raise ExpressionCompileError(
+        f"unsupported pipeline stage {stage!r}; supported terminal stages are `limit N` and `offset N`",
+        field=None,
+    )
+
+
+def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
+    stages = _split_pipeline_stages(expression)
+    if not stages:
+        return None
+    if len(stages) < 2:
+        return None
+    session_stage, terminal_stage, *tail_stages = stages
     session_predicate = _session_source_predicate(session_stage)
     terminal_source = parse_unit_source_expression(terminal_stage)
     if terminal_source is None:
@@ -1140,11 +1182,16 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
     scoped_session_predicate = _scope_session_predicate(session_predicate)
     combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
     _validate_predicate_context(combined, unit=terminal_source.unit)
-    return QueryUnitSource(
+    source = QueryUnitSource(
         unit=terminal_source.unit,
         predicate=combined,
         session_predicate=session_predicate,
+        limit=terminal_source.limit,
+        offset=terminal_source.offset,
     )
+    for stage in tail_stages:
+        source = _apply_pipeline_stage(source, stage)
+    return source
 
 
 def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
@@ -1425,6 +1472,10 @@ def _ast_payload(
         }
         if unit_source.session_predicate is not None:
             unit_payload["session_predicate"] = unit_source.session_predicate.to_payload()
+        if unit_source.limit is not None:
+            unit_payload["limit"] = unit_source.limit
+        if unit_source.offset is not None:
+            unit_payload["offset"] = unit_source.offset
         payload["unit_source"] = unit_payload
     return payload
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -561,6 +561,11 @@ def query_unit_rows(
 ) -> QueryUnitEnvelope:
     """Execute an explicit unit-source query."""
 
+    caller_offset = offset
+    if source.limit is not None:
+        limit = min(limit, source.limit)
+    if source.offset is not None:
+        offset += source.offset
     fetch_limit = limit + 1
     if source.unit == "observed-event":
         event_rows = _query_observed_events(
@@ -575,7 +580,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(event_rows) > limit,
         )
     if source.unit == "run":
@@ -591,7 +596,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(run_rows) > limit,
         )
     if source.unit == "context-snapshot":
@@ -607,7 +612,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(snapshot_rows) > limit,
         )
     if source.unit == "message":
@@ -622,7 +627,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(message_rows) > limit,
         )
     if source.unit == "action":
@@ -637,7 +642,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(action_rows) > limit,
         )
     if source.unit == "assertion":
@@ -652,7 +657,7 @@ def query_unit_rows(
             unit=source.unit,
             query=query,
             limit=limit,
-            offset=offset,
+            offset=caller_offset,
             has_next=len(assertion_rows) > limit,
         )
     block_rows = archive.query_blocks(
@@ -666,7 +671,7 @@ def query_unit_rows(
         unit=source.unit,
         query=query,
         limit=limit,
-        offset=offset,
+        offset=caller_offset,
         has_next=len(block_rows) > limit,
     )
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -465,6 +465,21 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_pipeline_limit_and_offset_stages_are_parsed(self) -> None:
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue | messages where role:assistant | limit 2 | offset 3"
+        )
+
+        assert source is not None
+        assert source.limit == 2
+        assert source.offset == 3
+
+    def test_pipeline_rejects_unknown_terminal_stage(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="unsupported pipeline stage"):
+            parse_unit_source_expression(
+                "sessions where repo:polylogue | messages where role:assistant | group by role"
+            )
+
     def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
         with pytest.raises(ExpressionCompileError, match="FTS, semantic, exists, lineage, and sequence"):
             parse_unit_source_expression('sessions where ~"timeout" | messages where role:assistant')
@@ -982,6 +997,55 @@ class TestBooleanQueryExpression:
                 "the pipeline answer",
             )
         ]
+
+    def test_session_to_message_pipeline_limit_offset_executes_terminal_window(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("pipeline window")
+            .add_message("m-1", role="assistant", text="first")
+            .add_message("m-2", role="assistant", text="second")
+            .add_message("m-3", role="assistant", text="third")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue | messages where role:assistant | limit 1 | offset 1"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="pipeline-window", limit=20)
+
+        assert envelope.limit == 1
+        assert envelope.offset == 0
+        assert envelope.next_offset == 1
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        from polylogue.surfaces.payloads import MessageQueryRowPayload
+
+        assert isinstance(row, MessageQueryRowPayload)
+        assert row.message_id == "claude-code-session:ext-hit:m-2"
+        assert row.text == "second"
+
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            next_page = query_unit_rows(archive, source, query="pipeline-window", limit=20, offset=envelope.next_offset)
+
+        assert next_page.offset == 1
+        assert next_page.next_offset is None
+        assert len(next_page.items) == 1
+        next_row = next_page.items[0]
+        assert isinstance(next_row, MessageQueryRowPayload)
+        assert next_row.message_id == "claude-code-session:ext-hit:m-3"
+        assert next_row.text == "third"
 
     def test_exists_action_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary

Adds executable terminal pipeline window stages to the #2006 query DSL. A query such as `sessions where repo:polylogue | messages where role:assistant | limit 10 | offset 20` now carries its row window inside the parsed query source and applies it at unit-row execution time.

## Problem

The first pipeline stage let session predicates scope terminal units, but paging still lived only in caller parameters. That made saved query strings less complete and left the pipeline without a basic downstream row-window operation.

## Solution

- Generalize pipeline splitting to multiple `|` stages without splitting grouped values such as `origin:(codex-session|claude-code-session)`.
- Add `limit` and `offset` fields to `QueryUnitSource`, expose them in explain payloads, and apply them in `query_unit_rows`.
- Keep caller caps authoritative: query-string `limit N` narrows the caller/API limit with `min(...)`, and query-string `offset N` is added to the caller offset.
- Document the supported terminal stages and add parser plus archive-execution coverage.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k pipeline` -> 7 passed / 256 deselected.
- `devtools verify --quick` -> exit_code 0.
- `devtools verify` -> 371 affected tests passed in 111.80s; peak pytest PSS 831.4 MiB.

Ref #2006