### PR TITLE
feat(query): sort terminal pipeline rows by time (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -90,6 +90,7 @@ session source stage:
 polylogue 'sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant'
 polylogue 'sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit'
 polylogue 'sessions where repo:polylogue | messages where role:assistant | limit 10 | offset 20'
+polylogue 'sessions where repo:polylogue | messages where role:assistant | sort by time desc | limit 10'
 ```
 
 The left stage is lowered into `session.<field>` predicates on the terminal
@@ -97,9 +98,13 @@ unit query, so it uses the same row executor as direct `messages/actions/...`
 queries. For now the session stage accepts field/count/date predicates only;
 FTS, semantic, `exists`, lineage, and sequence stages are typed errors until
 they have dedicated unit-changing lowerers. Terminal pipeline stages currently
-support `limit N` and `offset N`; query-string limits narrow the surface limit
-instead of expanding caller/API caps, and query-string offsets are added to the
-caller offset.
+support `sort by time [asc|desc]`, `limit N`, and `offset N` for SQL-backed
+terminal rows (`messages`, `actions`, `blocks`, `assertions`). Query-string
+limits narrow the surface limit instead of expanding caller/API caps, and
+query-string offsets are added to the caller offset. Runtime-transform terminal
+rows (`runs`, `observed-events`, `context-snapshots`) reject sort stages until
+they have streaming lowerers; they must not collect every projected row in
+memory merely to sort a page.
 
 Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -238,6 +238,14 @@ class QueryExpressionAST:
 
 
 @dataclass(frozen=True)
+class QueryUnitSort:
+    """Terminal query-unit sort stage."""
+
+    field: Literal["time"]
+    direction: Literal["asc", "desc"] = "asc"
+
+
+@dataclass(frozen=True)
 class QueryUnitSource:
     """Explicit unit-changing source parsed from ``<unit>s where ...``."""
 
@@ -246,6 +254,7 @@ class QueryUnitSource:
     session_predicate: QueryPredicate | None = None
     limit: int | None = None
     offset: int | None = None
+    sort: QueryUnitSort | None = None
 
 
 ExplainClauseKind = Literal["field", "count", "count_range", "date", "date_range", "text", "json"]
@@ -1150,7 +1159,38 @@ def _parse_non_negative_int_stage(stage: str, keyword: str) -> int | None:
     return value
 
 
+def _parse_sort_stage(stage: str) -> QueryUnitSort | None:
+    lower = stage.lower()
+    if not lower.startswith("sort by "):
+        return None
+    parts = lower.removeprefix("sort by ").split()
+    if not parts:
+        raise ExpressionCompileError("pipeline `sort by` stage requires a field", field="sort")
+    if parts[0] != "time":
+        raise ExpressionCompileError(
+            "pipeline `sort by` currently supports only `time` for terminal rows",
+            field="sort",
+        )
+    if len(parts) == 1:
+        return QueryUnitSort(field="time")
+    if len(parts) == 2 and parts[1] in {"asc", "desc"}:
+        return QueryUnitSort(field="time", direction=cast(Literal["asc", "desc"], parts[1]))
+    raise ExpressionCompileError(
+        "pipeline `sort by time` accepts an optional `asc` or `desc` direction",
+        field="sort",
+    )
+
+
 def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSource:
+    sort = _parse_sort_stage(stage)
+    if sort is not None:
+        if source.unit not in {"message", "action", "block", "assertion"}:
+            raise ExpressionCompileError(
+                "pipeline `sort by time` currently supports message/action/block/assertion rows; "
+                "runtime-transform units need a streaming lowerer first",
+                field="sort",
+            )
+        return replace(source, sort=sort)
     limit = _parse_non_negative_int_stage(stage, "limit")
     if limit is not None:
         if limit == 0:
@@ -1160,7 +1200,8 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
     if offset is not None:
         return replace(source, offset=offset)
     raise ExpressionCompileError(
-        f"unsupported pipeline stage {stage!r}; supported terminal stages are `limit N` and `offset N`",
+        f"unsupported pipeline stage {stage!r}; supported terminal stages are "
+        "`sort by time [asc|desc]`, `limit N`, and `offset N`",
         field=None,
     )
 
@@ -1188,6 +1229,7 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
         session_predicate=session_predicate,
         limit=terminal_source.limit,
         offset=terminal_source.offset,
+        sort=terminal_source.sort,
     )
     for stage in tail_stages:
         source = _apply_pipeline_stage(source, stage)
@@ -1476,6 +1518,11 @@ def _ast_payload(
             unit_payload["limit"] = unit_source.limit
         if unit_source.offset is not None:
             unit_payload["offset"] = unit_source.offset
+        if unit_source.sort is not None:
+            unit_payload["sort"] = {
+                "field": unit_source.sort.field,
+                "direction": unit_source.sort.direction,
+            }
         payload["unit_source"] = unit_payload
     return payload
 
@@ -2094,6 +2141,7 @@ __all__ = [
     "QueryExpressionExplainClause",
     "QueryExpressionExplanation",
     "QueryExpressionAST",
+    "QueryUnitSort",
     "QueryUnitSource",
     "_HAS_BOOL_MAP",
     "parse_unit_source_expression",

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -621,6 +621,8 @@ def query_unit_rows(
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
+            sort=source.sort.field if source.sort is not None else None,
+            sort_direction=source.sort.direction if source.sort is not None else "asc",
         )
         return build_query_unit_envelope(
             tuple(MessageQueryRowPayload.from_row(row) for row in message_rows[:limit]),
@@ -636,6 +638,8 @@ def query_unit_rows(
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
+            sort=source.sort.field if source.sort is not None else None,
+            sort_direction=source.sort.direction if source.sort is not None else "asc",
         )
         return build_query_unit_envelope(
             tuple(ActionQueryRowPayload.from_row(row) for row in action_rows[:limit]),
@@ -651,6 +655,8 @@ def query_unit_rows(
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
+            sort=source.sort.field if source.sort is not None else None,
+            sort_direction=source.sort.direction if source.sort is not None else "asc",
         )
         return build_query_unit_envelope(
             tuple(AssertionQueryRowPayload.from_row(row) for row in assertion_rows[:limit]),
@@ -665,6 +671,8 @@ def query_unit_rows(
         limit=fetch_limit,
         offset=offset,
         session_filters=session_filters,
+        sort=source.sort.field if source.sort is not None else None,
+        sort_direction=source.sort.direction if source.sort is not None else "asc",
     )
     return build_query_unit_envelope(
         tuple(BlockQueryRowPayload.from_row(row) for row in block_rows[:limit]),

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -252,6 +252,12 @@ class ArchiveAssertionQueryRow:
     updated_at_ms: int
 
 
+def _query_unit_order_direction(direction: Literal["asc", "desc"]) -> Literal["ASC", "DESC"]:
+    """Return a closed SQL direction token for terminal row ordering."""
+
+    return "DESC" if direction == "desc" else "ASC"
+
+
 class ArchiveStore:
     """Minimal archive-root façade for archive source/index/user tiers."""
 
@@ -3260,11 +3266,18 @@ class ArchiveStore:
         limit: int = 50,
         offset: int = 0,
         session_filters: Mapping[str, object] | None = None,
+        sort: Literal["time"] | None = None,
+        sort_direction: Literal["asc", "desc"] = "asc",
     ) -> list[ArchiveMessageQueryRow]:
         """Return message rows matching a unit-scoped query predicate."""
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
+        order_direction = _query_unit_order_direction(sort_direction)
+        if sort == "time":
+            order_by = f"COALESCE(m.occurred_at_ms, s.sort_key_ms, 0) {order_direction}, m.message_id {order_direction}"
+        else:
+            order_by = "COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), m.message_id"
         clause, params = _structural_predicate_clause("message", "m", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
@@ -3295,7 +3308,7 @@ class ArchiveStore:
             JOIN sessions s ON s.session_id = m.session_id
             WHERE {clause}
             {session_clause}
-            ORDER BY COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), m.message_id
+            ORDER BY {order_by}
             LIMIT ? OFFSET ?
             """,
             [*params, *session_params, normalized_limit, normalized_offset],
@@ -3322,11 +3335,20 @@ class ArchiveStore:
         limit: int = 50,
         offset: int = 0,
         session_filters: Mapping[str, object] | None = None,
+        sort: Literal["time"] | None = None,
+        sort_direction: Literal["asc", "desc"] = "asc",
     ) -> list[ArchiveActionQueryRow]:
         """Return action rows matching a unit-scoped query predicate."""
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
+        order_direction = _query_unit_order_direction(sort_direction)
+        if sort == "time":
+            order_by = (
+                f"COALESCE(m.occurred_at_ms, s.sort_key_ms, 0) {order_direction}, a.tool_use_block_id {order_direction}"
+            )
+        else:
+            order_by = "COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), a.tool_use_block_id"
         clause, params = _structural_predicate_clause("action", "a", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
@@ -3351,7 +3373,7 @@ class ArchiveStore:
             JOIN messages m ON m.message_id = a.message_id
             WHERE {clause}
             {session_clause}
-            ORDER BY COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), a.tool_use_block_id
+            ORDER BY {order_by}
             LIMIT ? OFFSET ?
             """,
             [*params, *session_params, normalized_limit, normalized_offset],
@@ -3382,11 +3404,18 @@ class ArchiveStore:
         limit: int = 50,
         offset: int = 0,
         session_filters: Mapping[str, object] | None = None,
+        sort: Literal["time"] | None = None,
+        sort_direction: Literal["asc", "desc"] = "asc",
     ) -> list[ArchiveBlockQueryRow]:
         """Return content-block rows matching a unit-scoped query predicate."""
 
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
+        order_direction = _query_unit_order_direction(sort_direction)
+        if sort == "time":
+            order_by = f"COALESCE(m.occurred_at_ms, s.sort_key_ms, 0) {order_direction}, b.block_id {order_direction}"
+        else:
+            order_by = "COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), b.block_id"
         clause, params = _structural_predicate_clause("block", "b", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
@@ -3412,7 +3441,7 @@ class ArchiveStore:
             JOIN messages m ON m.message_id = b.message_id
             WHERE {clause}
             {session_clause}
-            ORDER BY COALESCE(m.occurred_at_ms, s.sort_key_ms, 0), b.block_id
+            ORDER BY {order_by}
             LIMIT ? OFFSET ?
             """,
             [*params, *session_params, normalized_limit, normalized_offset],
@@ -3442,6 +3471,8 @@ class ArchiveStore:
         limit: int = 50,
         offset: int = 0,
         session_filters: Mapping[str, object] | None = None,
+        sort: Literal["time"] | None = None,
+        sort_direction: Literal["asc", "desc"] = "asc",
     ) -> list[ArchiveAssertionQueryRow]:
         """Return user-tier assertion rows matching a unit-scoped predicate."""
 
@@ -3450,6 +3481,13 @@ class ArchiveStore:
         self._attach_user_tier_if_present()
         normalized_limit = max(int(limit), 0)
         normalized_offset = max(int(offset), 0)
+        order_direction = _query_unit_order_direction(sort_direction)
+        if sort == "time":
+            order_by = (
+                f"COALESCE(a.updated_at_ms, a.created_at_ms, 0) {order_direction}, a.assertion_id {order_direction}"
+            )
+        else:
+            order_by = "a.updated_at_ms DESC, a.assertion_id"
         clause, params = _structural_predicate_clause("assertion", "a", predicate, session_alias="s")
         session_clause = ""
         session_params: list[object] = []
@@ -3478,7 +3516,7 @@ class ArchiveStore:
             LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id
             WHERE {clause}
             {session_clause}
-            ORDER BY a.updated_at_ms DESC, a.assertion_id
+            ORDER BY {order_by}
             LIMIT ? OFFSET ?
             """,
             [*params, *session_params, normalized_limit, normalized_offset],

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -474,10 +474,26 @@ class TestBooleanQueryExpression:
         assert source.limit == 2
         assert source.offset == 3
 
+    def test_pipeline_sort_stage_is_parsed(self) -> None:
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue | messages where role:assistant | sort by time desc"
+        )
+
+        assert source is not None
+        assert source.sort is not None
+        assert source.sort.field == "time"
+        assert source.sort.direction == "desc"
+
     def test_pipeline_rejects_unknown_terminal_stage(self) -> None:
         with pytest.raises(ExpressionCompileError, match="unsupported pipeline stage"):
             parse_unit_source_expression(
                 "sessions where repo:polylogue | messages where role:assistant | group by role"
+            )
+
+    def test_pipeline_rejects_sort_on_runtime_transform_units(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="runtime-transform units need a streaming lowerer"):
+            parse_unit_source_expression(
+                "sessions where repo:polylogue | runs where status:completed | sort by time desc"
             )
 
     def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
@@ -1046,6 +1062,42 @@ class TestBooleanQueryExpression:
         assert isinstance(next_row, MessageQueryRowPayload)
         assert next_row.message_id == "claude-code-session:ext-hit:m-3"
         assert next_row.text == "third"
+
+    def test_session_to_message_pipeline_sort_desc_executes_before_limit(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("pipeline sorted")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .add_message("m-new", role="assistant", text="new", timestamp="2026-01-02T00:00:00+00:00")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue | messages where role:assistant | sort by time desc | limit 1"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="pipeline-sort", limit=20)
+
+        assert envelope.limit == 1
+        assert envelope.next_offset == 1
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        from polylogue.surfaces.payloads import MessageQueryRowPayload
+
+        assert isinstance(row, MessageQueryRowPayload)
+        assert row.message_id == "claude-code-session:ext-hit:m-new"
+        assert row.text == "new"
 
     def test_exists_action_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -56,14 +56,14 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # ``table_name`` is a closed insight table name; ``any_terms`` is built
     # immediately above from closed ``(column, path)`` fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2605): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2611): (
         "readiness fallback reason counts: closed insight-table + _INSIGHT_FALLBACK_PAYLOAD column/path; values bound"
     ),
     # #1743 readiness fallback reason breakdown:
     #   rows = self._conn.execute(f"... FROM {table_name} ... json_each(... '{path}') ...{clause}")
     # ``table_name``/``column``/``path`` are closed fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2614): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2620): (
         "readiness fallback reason breakdown: closed insight-table + fallback payload column/path; values bound"
     ),
     # Terminal unit row readers:
@@ -71,17 +71,19 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # ``clause`` comes from the structural predicate lowerer, which returns SQL
     # fragments plus bound params from closed field metadata; ``session_clause``
     # comes from the shared session filter lowerer; pagination values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3273): (
-        "message query rows: structural predicate/session filter fragments from lowerers; values bound"
+    # ``order_by`` is a closed literal fragment selected from the parsed
+    # pipeline sort stage and bounded ASC/DESC tokens.
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3286): (
+        "message query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3335): (
-        "action query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3357): (
+        "action query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3395): (
-        "block query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3424): (
+        "block query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3458): (
-        "assertion query rows: structural predicate/session filter fragments from lowerers; values bound"
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3496): (
+        "assertion query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
     # Assertion readers:
     #   rows = conn.execute(f"SELECT {_ASSERTION_COLUMNS} FROM assertions ...", ...)


### PR DESCRIPTION
## Summary

Adds a typed `sort by time` pipeline stage for terminal query-unit rows. SQL-backed terminal units (`messages`, `actions`, `blocks`, and `assertions`) now carry the parsed sort stage into archive row execution so users can request ascending or descending time order directly in the DSL.

## Problem

#2006 defines the query DSL as the product selection language, including pipeline stages. Terminal row queries already existed, but their ordering was fixed per row source; the parser accepted pipeline stage syntax without a storage-backed row-ordering path for this useful base case.

## Solution

- Extended pipeline parsing/formatting for `sort by time [asc|desc]`.
- Threaded the parsed sort stage through terminal row execution into archive storage readers.
- Added bounded SQL order fragments for message/action/block/assertion rows, with runtime-transform units rejecting sort stages until they have a durable lowerer.
- Updated query docs and the SQL interpolation audit metadata for the new closed `ORDER BY` fragments.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_no_string_interpolated_sql.py tests/unit/cli/test_query_expression.py -k 'pipeline or string_interpolated_sql'` → 12 passed.
- `nix develop --command devtools test tests/unit/cli/test_help_snapshots.py::test_root_help_snapshot tests/unit/storage/test_no_string_interpolated_sql.py tests/unit/cli/test_query_expression.py -k 'root_help_snapshot or pipeline or string_interpolated_sql'` → 13 passed after rebasing onto current master.
- `nix develop --command devtools verify --quick` → exit_code 0.
- `nix develop --command devtools verify` before rebase → 6060 passed, 1 stale root-help snapshot failure caused by master moving underneath the branch; the focused root-help snapshot passed after rebase.