### PR TITLE
feat(refs): resolve public archive refs (#2181)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -210,7 +210,7 @@ Options:
 ## Read Verb
 
 ```text
-Usage: polylogue read [OPTIONS]
+Usage: polylogue read [OPTIONS] [REF]
 
   Read matched sessions.
 
@@ -233,6 +233,7 @@ Usage: polylogue read [OPTIONS]
       polylogue --latest read --view neighbors --format json
       polylogue find id:abc then read --view correlation --since-hours 4
       polylogue --latest read --view correlation --otlp --format json
+      polylogue read session:abc123 --format json
 
   Deferred views (not yet implemented; note in PR body):
       timeline, tools, files, metadata, continuation

--- a/docs/search.md
+++ b/docs/search.md
@@ -249,6 +249,28 @@ and result-shaping modes that do not have row semantics yet, such as
 `delete`, `open`, `stats`, `count`, `--cursor`, and custom sort/reverse modes,
 are rejected instead of silently coercing row queries back to session queries.
 
+## Public Ref Resolution
+
+Query/read payloads carry public object and evidence refs so agents and the web
+shell can jump from a row, work packet, or assertion back to the exact archive
+object it cites. Resolve refs through the shared resolver rather than turning
+them into broad text search:
+
+```bash
+polylogue read session:codex-session:abc123 --format json
+polylogue read message:codex-session:abc123:m1 --format json
+polylogue read block:codex-session:abc123:m1:0 --format json
+polylogue read assertion:assertion-id --format json
+```
+
+The same `PublicRefResolutionPayload` is exposed by
+`Polylogue.resolve_ref()`, MCP `resolve_ref`, and daemon
+`GET /api/refs/resolve?ref=...`. The resolver supports session, message,
+block, assertion, and runtime projection refs (`run`, `observed-event`,
+`context-snapshot`) when the addressed object exists. Unsupported or missing
+refs return a bounded unresolved payload with caveats; they never widen into a
+session search.
+
 ## Filters
 
 ### Identity and content

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -25,6 +25,7 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument
+from polylogue.core.refs import EvidenceRef, ObjectRef, parse_public_ref
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.core.user_state_targets import TARGET_MESSAGE, TARGET_SESSION
 from polylogue.errors import PolylogueError
@@ -86,6 +87,7 @@ if TYPE_CHECKING:
         DeleteSessionResult,
         FacetsResponse,
         MetadataMutationResult,
+        PublicRefResolutionPayload,
         QueryUnitEnvelope,
         RecoveryReadPayload,
         RecoveryReportFormat,
@@ -117,6 +119,26 @@ def _archive_message_type(value: str | None) -> str | None:
 
 def _archive_action_terms(field: str, values: Sequence[str]) -> tuple[str, ...]:
     return normalize_action_terms(field, tuple(values))
+
+
+def _resolution_action(label: str, command: str | None = None, href: str | None = None) -> Any:
+    from polylogue.surfaces.payloads import RefResolutionActionPayload
+
+    return RefResolutionActionPayload(label=label, command=command, href=href)
+
+
+def _unresolved_ref_payload(
+    ref: str, message: str, *, normalized_ref: str | None = None, kind: str | None = None
+) -> Any:
+    from polylogue.surfaces.payloads import PublicRefResolutionPayload
+
+    return PublicRefResolutionPayload(
+        ref=ref,
+        normalized_ref=normalized_ref,
+        kind=kind,
+        resolved=False,
+        caveats=(message,),
+    )
 
 
 def _archive_action_sequence(values: Sequence[str]) -> tuple[str, ...]:
@@ -1521,6 +1543,396 @@ class PolylogueArchiveMixin:
             return query_unit_rows(
                 archive, source, query=expression, limit=limit, offset=offset, session_filters=session_filters
             )
+
+    async def resolve_ref(self, ref: str) -> PublicRefResolutionPayload:
+        """Resolve one public object/evidence ref into a bounded read payload."""
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import PublicRefResolutionPayload
+
+        try:
+            parsed = parse_public_ref(ref)
+        except ValueError as exc:
+            return cast(PublicRefResolutionPayload, _unresolved_ref_payload(ref, str(exc)))
+
+        if isinstance(parsed, EvidenceRef):
+            evidence_ref: EvidenceRef | None = parsed
+            object_ref = parsed.to_object_ref()
+        else:
+            evidence_ref = None
+            object_ref = parsed
+        normalized_ref = parsed.format()
+        archive_root = _active_archive_root(self.config)
+        with ArchiveStore.open_existing(archive_root) as archive:
+            if object_ref.kind == "session":
+                return self._resolve_session_object_ref(archive, ref, normalized_ref, object_ref, evidence_ref)
+            if object_ref.kind == "message":
+                return self._resolve_message_object_ref(archive, ref, normalized_ref, object_ref, evidence_ref)
+            if object_ref.kind == "block":
+                return self._resolve_block_object_ref(archive, ref, normalized_ref, object_ref, evidence_ref)
+            if object_ref.kind == "assertion":
+                return self._resolve_assertion_object_ref(archive_root, ref, normalized_ref, object_ref)
+            if object_ref.kind in {"run", "observed-event", "context-snapshot"}:
+                return self._resolve_runtime_object_ref(archive, ref, normalized_ref, object_ref)
+        return cast(
+            PublicRefResolutionPayload,
+            _unresolved_ref_payload(
+                ref,
+                f"unsupported public ref kind for resolution: {object_ref.kind}",
+                normalized_ref=normalized_ref,
+                kind=object_ref.kind,
+            ),
+        )
+
+    def _resolve_session_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+        evidence_ref: EvidenceRef | None,
+    ) -> PublicRefResolutionPayload:
+        from polylogue.surfaces.payloads import PublicRefResolutionPayload, SessionSummaryPayload, model_json_document
+
+        try:
+            session_id = archive.resolve_session_id(object_ref.object_id)
+        except KeyError:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "session not found", normalized_ref=normalized_ref, kind="session"),
+            )
+        summaries = archive.list_summaries(session_id=session_id, limit=1)
+        if not summaries:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "session not found", normalized_ref=normalized_ref, kind="session"),
+            )
+        summary_payload = SessionSummaryPayload.from_summary(_archive_summary_to_domain(summaries[0]))
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="session",
+            resolved=True,
+            payload_kind="session-summary",
+            payload=model_json_document(summary_payload),
+            title=summary_payload.title,
+            summary=f"{summary_payload.message_count} messages",
+            object_refs=(f"session:{session_id}",),
+            evidence_refs=() if evidence_ref is None else (evidence_ref.format(),),
+            actions=(_resolution_action("read", f"polylogue find id:{session_id} then read --format json"),),
+        )
+
+    def _resolve_message_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+        evidence_ref: EvidenceRef | None,
+    ) -> PublicRefResolutionPayload:
+        from polylogue.surfaces.payloads import PublicRefResolutionPayload, SessionMessagePayload, model_json_document
+
+        row = archive._conn.execute(
+            """
+            SELECT m.session_id, m.message_id
+            FROM messages m
+            WHERE m.message_id = ?
+               OR ('message:' || m.session_id || ':' || m.message_id) = ?
+            LIMIT 1
+            """,
+            (object_ref.object_id, normalized_ref),
+        ).fetchone()
+        if row is None:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "message not found", normalized_ref=normalized_ref, kind="message"),
+            )
+        session_id = str(row["session_id"])
+        message_id = str(row["message_id"])
+        session = _archive_session_to_session(archive.read_session(session_id))
+        message = next((item for item in session.messages if str(item.id) == message_id), None)
+        if message is None:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "message not found", normalized_ref=normalized_ref, kind="message"),
+            )
+        payload = SessionMessagePayload.from_message(message, session_id=session_id)
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="message",
+            resolved=True,
+            payload_kind="message",
+            payload=model_json_document(payload),
+            title=session.display_title,
+            summary=(message.text or "")[:240],
+            object_refs=(f"session:{session_id}", f"message:{message_id}"),
+            evidence_refs=() if evidence_ref is None else (evidence_ref.format(),),
+            actions=(_resolution_action("read session", f"polylogue find id:{session_id} then read --view messages"),),
+        )
+
+    def _resolve_block_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+        evidence_ref: EvidenceRef | None,
+    ) -> PublicRefResolutionPayload:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveBlockQueryRow
+        from polylogue.surfaces.payloads import BlockQueryRowPayload, PublicRefResolutionPayload, model_json_document
+
+        block_index: int | None = None
+        if object_ref.qualifiers:
+            try:
+                block_index = int(object_ref.qualifiers[0])
+            except ValueError:
+                return cast(
+                    PublicRefResolutionPayload,
+                    _unresolved_ref_payload(
+                        ref,
+                        "block ref qualifier must be an integer",
+                        normalized_ref=normalized_ref,
+                        kind="block",
+                    ),
+                )
+        row = archive._conn.execute(
+            """
+            SELECT b.block_id, b.message_id, b.session_id, s.origin, s.title,
+                   b.block_type, b.position, b.text, b.tool_name, b.semantic_type,
+                   b.tool_command, b.tool_path
+            FROM blocks b
+            JOIN sessions s ON s.session_id = b.session_id
+            WHERE b.block_id = ?
+               OR (b.message_id = ? AND (? IS NOT NULL AND b.position = ?))
+               OR ('block:' || b.block_id) = ?
+            LIMIT 1
+            """,
+            (object_ref.object_id, object_ref.object_id, block_index, block_index, normalized_ref),
+        ).fetchone()
+        if row is None:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "block not found", normalized_ref=normalized_ref, kind="block"),
+            )
+        payload = BlockQueryRowPayload.from_row(
+            ArchiveBlockQueryRow(
+                block_id=str(row["block_id"]),
+                message_id=str(row["message_id"]),
+                session_id=str(row["session_id"]),
+                origin=str(row["origin"]),
+                title=str(row["title"]) if row["title"] is not None else None,
+                block_type=str(row["block_type"]),
+                position=int(row["position"]),
+                text=str(row["text"]) if row["text"] is not None else None,
+                tool_name=str(row["tool_name"]) if row["tool_name"] is not None else None,
+                semantic_type=str(row["semantic_type"]) if row["semantic_type"] is not None else None,
+                tool_command=str(row["tool_command"]) if row["tool_command"] is not None else None,
+                tool_path=str(row["tool_path"]) if row["tool_path"] is not None else None,
+            )
+        )
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="block",
+            resolved=True,
+            payload_kind="block",
+            payload=model_json_document(payload),
+            title=payload.title,
+            summary=(payload.text or payload.tool_command or payload.tool_name or "")[:240],
+            object_refs=(f"session:{payload.session_id}", f"message:{payload.message_id}", f"block:{payload.block_id}"),
+            evidence_refs=() if evidence_ref is None else (evidence_ref.format(),),
+            actions=(
+                _resolution_action("read message", f"polylogue find id:{payload.session_id} then read --view messages"),
+            ),
+        )
+
+    def _resolve_assertion_object_ref(
+        self,
+        archive_root: Path,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+    ) -> PublicRefResolutionPayload:
+        from polylogue.storage.sqlite.archive_tiers.user_write import read_assertion_envelope
+        from polylogue.surfaces.payloads import AssertionClaimPayload, PublicRefResolutionPayload, model_json_document
+
+        user_db = archive_root / "user.db"
+        if not user_db.exists():
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "assertion not found", normalized_ref=normalized_ref, kind="assertion"),
+            )
+        with sqlite3.connect(user_db) as conn:
+            conn.row_factory = sqlite3.Row
+            envelope = read_assertion_envelope(conn, object_ref.object_id)
+        if envelope is None:
+            return cast(
+                PublicRefResolutionPayload,
+                _unresolved_ref_payload(ref, "assertion not found", normalized_ref=normalized_ref, kind="assertion"),
+            )
+        payload = AssertionClaimPayload.from_envelope(envelope)
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="assertion",
+            resolved=True,
+            payload_kind="assertion-claim",
+            payload=model_json_document(payload),
+            title=payload.key or payload.kind,
+            summary=payload.body_text,
+            object_refs=(normalized_ref, payload.target_ref),
+            evidence_refs=payload.evidence_refs,
+            actions=(_resolution_action("list assertion target", f"polylogue find {payload.target_ref} then read"),),
+        )
+
+    def _resolve_runtime_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+    ) -> PublicRefResolutionPayload:
+        from polylogue.surfaces.payloads import PublicRefResolutionPayload
+
+        summary_offset = 0
+        while True:
+            summaries = archive.list_summaries(limit=200, offset=summary_offset)
+            if not summaries:
+                break
+            summary_offset += len(summaries)
+            for summary in summaries:
+                resolved = self._resolve_runtime_object_ref_for_summary(
+                    archive, ref, normalized_ref, object_ref, summary
+                )
+                if resolved is not None:
+                    return resolved
+            if len(summaries) < 200:
+                break
+        return cast(
+            PublicRefResolutionPayload,
+            _unresolved_ref_payload(
+                ref, f"{object_ref.kind} not found", normalized_ref=normalized_ref, kind=object_ref.kind
+            ),
+        )
+
+    def _resolve_runtime_object_ref_for_summary(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+        summary: Any,
+    ) -> PublicRefResolutionPayload | None:
+        from polylogue.insights.transforms import compile_recovery_digest
+        from polylogue.surfaces.payloads import (
+            ContextSnapshotQueryRowPayload,
+            ObservedEventQueryRowPayload,
+            PublicRefResolutionPayload,
+            RunQueryRowPayload,
+            model_json_document,
+        )
+
+        session = _archive_session_to_session(archive.read_session(str(summary.session_id)))
+        digest = compile_recovery_digest(session)
+        if object_ref.kind == "run":
+            for run in digest.run_projection.runs:
+                if run.run_ref.format() != normalized_ref:
+                    continue
+                run_payload = RunQueryRowPayload(
+                    run_ref=run.run_ref.format(),
+                    session_id=str(summary.session_id),
+                    origin=str(summary.origin),
+                    title=summary.title,
+                    native_session_id=run.native_session_id,
+                    native_parent_session_id=run.native_parent_session_id,
+                    parent_run_ref=run.parent_run_ref.format() if run.parent_run_ref else None,
+                    agent_ref=run.agent_ref.format() if run.agent_ref else None,
+                    lineage_refs=tuple(lineage.format() for lineage in run.lineage_refs),
+                    provider_origin=run.provider_origin,
+                    harness=run.harness,
+                    role=run.role,
+                    cwd=run.cwd,
+                    git_branch=run.git_branch,
+                    status=run.status,
+                    confidence=run.confidence,
+                    transcript_ref=run.transcript_ref.format() if run.transcript_ref else None,
+                    evidence_refs=tuple(evidence.format() for evidence in run.evidence_refs),
+                    context_snapshot_ref=run.context_snapshot_ref.format() if run.context_snapshot_ref else None,
+                )
+                return PublicRefResolutionPayload(
+                    ref=ref,
+                    normalized_ref=normalized_ref,
+                    kind="run",
+                    resolved=True,
+                    payload_kind="run",
+                    payload=model_json_document(run_payload),
+                    title=summary.title,
+                    summary=f"{run_payload.role} {run_payload.status}",
+                    object_refs=(f"session:{summary.session_id}", normalized_ref),
+                    evidence_refs=run_payload.evidence_refs,
+                )
+        if object_ref.kind == "observed-event":
+            for event in digest.run_projection.events:
+                if event.event_ref.format() != normalized_ref:
+                    continue
+                event_payload = ObservedEventQueryRowPayload(
+                    event_ref=event.event_ref.format(),
+                    session_id=str(summary.session_id),
+                    origin=str(summary.origin),
+                    title=summary.title,
+                    kind=event.kind,
+                    summary=event.summary,
+                    delivery_state=event.delivery_state,
+                    subject_ref=event.subject_ref.format() if event.subject_ref else None,
+                    object_refs=tuple(item.format() for item in event.object_refs),
+                    evidence_refs=tuple(item.format() for item in event.evidence_refs),
+                )
+                return PublicRefResolutionPayload(
+                    ref=ref,
+                    normalized_ref=normalized_ref,
+                    kind="observed-event",
+                    resolved=True,
+                    payload_kind="observed-event",
+                    payload=model_json_document(event_payload),
+                    title=summary.title,
+                    summary=event_payload.summary,
+                    object_refs=(f"session:{summary.session_id}", normalized_ref, *event_payload.object_refs),
+                    evidence_refs=event_payload.evidence_refs,
+                )
+        if object_ref.kind == "context-snapshot":
+            for snapshot in digest.run_projection.context_snapshots:
+                if snapshot.snapshot_ref.format() != normalized_ref:
+                    continue
+                snapshot_payload = ContextSnapshotQueryRowPayload(
+                    snapshot_ref=snapshot.snapshot_ref.format(),
+                    session_id=str(summary.session_id),
+                    origin=str(summary.origin),
+                    title=summary.title,
+                    run_ref=snapshot.run_ref.format(),
+                    boundary=snapshot.boundary,
+                    inheritance_mode=snapshot.inheritance_mode,
+                    segment_refs=tuple(item.format() for item in snapshot.segment_refs),
+                    evidence_refs=tuple(item.format() for item in snapshot.evidence_refs),
+                    metadata=dict(snapshot.metadata),
+                )
+                return PublicRefResolutionPayload(
+                    ref=ref,
+                    normalized_ref=normalized_ref,
+                    kind="context-snapshot",
+                    resolved=True,
+                    payload_kind="context-snapshot",
+                    payload=model_json_document(snapshot_payload),
+                    title=summary.title,
+                    summary=f"{snapshot_payload.boundary} ({snapshot_payload.inheritance_mode})",
+                    object_refs=(
+                        f"session:{summary.session_id}",
+                        normalized_ref,
+                        snapshot_payload.run_ref,
+                        *snapshot_payload.segment_refs,
+                    ),
+                    evidence_refs=snapshot_payload.evidence_refs,
+                )
+        return None
 
     async def query_completions(
         self,

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -269,6 +269,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "query_sessions": ("archive_routed", "index", "queries summaries from index.db"),
     "rebuild_index": ("archive_routed", "index", "rebuilds messages_fts from index.db"),
     "rebuild_insights": ("archive_routed", "index", "rebuilds insight tables"),
+    "resolve_ref": ("archive_routed", "index", "resolves public refs through bounded archive read payloads"),
     "record_correction": ("archive_routed", "user", "writes corrections through user.db"),
     "context_pack_payload": ("archive_routed", "index", "builds context-pack DTOs from archive-routed reads"),
     "context_preamble_payload": ("archive_routed", "index", "builds context preamble DTOs from archive-routed reads"),

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from polylogue.cli.root_request import RootModeRequest
     from polylogue.cli.select import SelectPrintField
 
+from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.viewport import (
     READ_VIEW_PROFILE_BY_ID,
     READ_VIEW_PROFILES,
@@ -25,6 +26,7 @@ from polylogue.cli.click_option_groups import _LazyChoice
 from polylogue.cli.read_view_handlers import ReadViewInvocation, run_bulk_export_view, run_read_view
 from polylogue.cli.shared.types import AppEnv
 from polylogue.cli.verb_names import VERB_NAMES
+from polylogue.surfaces.payloads import serialize_surface_payload
 
 
 # Deferred imports: RootModeRequest triggers the archive.query.spec →
@@ -271,6 +273,7 @@ def select_verb(ctx: click.Context, limit: int, print_field: str, json_output: b
 @click.option("--prose-only", is_flag=True, help="Show only prose text (--view messages).")
 @click.option("--fields", help="Fields for JSON/YAML outputs (--all).")
 @click.option("--views", "show_views", is_flag=True, help="List executable read-view profiles and exit.")
+@click.argument("ref", required=False)
 @click.pass_context
 def read_verb(
     ctx: click.Context,
@@ -307,6 +310,7 @@ def read_verb(
     prose_only: bool,
     fields: str | None,
     show_views: bool = False,
+    ref: str | None = None,
 ) -> None:
     """Read matched sessions.
 
@@ -331,6 +335,7 @@ def read_verb(
         polylogue --latest read --view neighbors --format json
         polylogue find id:abc then read --view correlation --since-hours 4
         polylogue --latest read --view correlation --otlp --format json
+        polylogue read session:abc123 --format json
 
     \b
     Deferred views (not yet implemented; note in PR body):
@@ -341,6 +346,14 @@ def read_verb(
         _emit_read_view_profiles(output_format)
         return
     request = _parent_request(ctx)
+    if ref is not None:
+        if output_format not in (None, "json"):
+            raise click.UsageError("Direct ref reads currently support --format json only.")
+        if destination not in ("terminal", "stdout"):
+            raise click.UsageError("Direct ref reads write JSON to terminal/stdout only.")
+        payload = run_coroutine_sync(env.polylogue.resolve_ref(ref))
+        click.echo(serialize_surface_payload(payload, exclude_none=True))
+        return
 
     # Summary all-mode is the command-floor replacement for the old list verb:
     # it preserves the summary-list envelope and fields/limit behavior instead

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -105,6 +105,7 @@ def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
         _StaticGetRoute("/api/sessions", ("api", "sessions"), "_handle_list_sessions", passes_params=True),
         _StaticGetRoute("/api/facets", ("api", "facets"), "_handle_facets", passes_params=True),
         _StaticGetRoute("/api/query-units", ("api", "query-units"), "_handle_query_units", passes_params=True),
+        _StaticGetRoute("/api/refs/resolve", ("api", "refs", "resolve"), "_handle_ref_resolve", passes_params=True),
         _StaticGetRoute(
             "/api/query-completions", ("api", "query-completions"), "_handle_query_completions", passes_params=True
         ),
@@ -2473,6 +2474,28 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             )
 
         self._send_json(HTTPStatus.OK, payload.model_dump(mode="json"))
+
+    @daemon_safe_handler
+    def _handle_ref_resolve(self, params: dict[str, list[str]]) -> None:
+        """``GET /api/refs/resolve`` resolves public object/evidence refs."""
+
+        from polylogue import Polylogue
+        from polylogue.api.sync.bridge import run_coroutine_sync
+
+        ref = self._get_param(params, "ref")
+        if not ref:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST, {"error": "missing_ref", "message": "ref query parameter is required"}
+            )
+            return
+        archive_root = _web_reader_archive_root()
+        if archive_root is None:
+            self._send_error(HTTPStatus.SERVICE_UNAVAILABLE, "archive_unavailable")
+            return
+        payload = run_coroutine_sync(
+            Polylogue(archive_root=archive_root, db_path=archive_root / "index.db").resolve_ref(ref)
+        )
+        self._send_json(HTTPStatus.OK, payload.model_dump(mode="json", exclude_none=True))
 
     @daemon_safe_handler
     def _handle_query_completions(self, params: dict[str, list[str]]) -> None:

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -150,6 +150,9 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
     RouteContract("GET", "/api/facets", "read_query", "stable", "bearer_if_configured", "Facets envelope"),
     RouteContract("GET", "/api/query-units", "read_query", "stable", "bearer_if_configured", "QueryUnitEnvelope"),
     RouteContract(
+        "GET", "/api/refs/resolve", "read_query", "stable", "bearer_if_configured", "PublicRefResolutionPayload"
+    ),
+    RouteContract(
         "GET",
         "/api/query-completions",
         "read_query",

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -42,6 +42,7 @@ from polylogue.surfaces.payloads import (
     AssertionClaimListPayload,
     AssertionClaimPayload,
     MutationResultPayload,
+    PublicRefResolutionPayload,
     SearchCursor,
     SearchEnvelope,
     SurfacePayloadModel,
@@ -86,6 +87,7 @@ if TYPE_CHECKING:
 
 MCPAssertionClaimPayload = AssertionClaimPayload
 MCPAssertionClaimListPayload = AssertionClaimListPayload
+MCPPublicRefResolutionPayload = PublicRefResolutionPayload
 
 TRoot = TypeVar("TRoot")
 
@@ -953,6 +955,7 @@ __all__ = [
     "MCPArchiveSessionSummaryPayload",
     "MCPAssertionClaimPayload",
     "MCPAssertionClaimListPayload",
+    "MCPPublicRefResolutionPayload",
     "MCPSessionTreePayload",
     "MCPStatsByPayload",
     "MCPTagCountsPayload",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -208,6 +208,17 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("query_units", run)
 
+    @mcp.tool()
+    async def resolve_ref(ref: str) -> str:
+        """Resolve a public object/evidence ref into a bounded payload."""
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            payload = await poly.resolve_ref(ref)
+            return hooks.json_payload(payload)
+
+        return await hooks.async_safe_call("resolve_ref", run)
+
     async def _list_sessions(**kwargs: object) -> str:
         request = build_session_query_request(**kwargs)
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1243,6 +1243,48 @@ class RecoveryReadPayload(SurfacePayloadModel):
         return cls(session_id=str(session_id), report="work-packet", format="markdown", markdown=markdown)
 
 
+class RefResolutionActionPayload(SurfacePayloadModel):
+    """One affordance a client can offer after resolving a public ref."""
+
+    label: str
+    command: str | None = None
+    href: str | None = None
+    enabled: bool = True
+
+
+class PublicRefResolutionPayload(SurfacePayloadModel):
+    """Bounded shared payload for resolving public object/evidence refs."""
+
+    mode: Literal["ref-resolution"] = "ref-resolution"
+    ref: str
+    normalized_ref: str | None = None
+    kind: str | None = None
+    resolved: bool
+    payload_kind: str | None = None
+    payload: dict[str, Any] | None = None
+    title: str | None = None
+    summary: str | None = None
+    object_refs: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    caveats: tuple[str, ...] = ()
+    actions: tuple[RefResolutionActionPayload, ...] = ()
+
+    @field_validator("normalized_ref")
+    @classmethod
+    def _validate_normalized_ref(cls, value: str | None) -> str | None:
+        return normalize_public_ref_text(value) if value is not None else None
+
+    @field_validator("object_refs")
+    @classmethod
+    def _validate_resolution_object_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_object_ref_text(ref) for ref in value)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_resolution_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
+
+
 class SessionReadViewEnvelope(SurfacePayloadModel):
     """Stable daemon envelope for one executed session read-view."""
 
@@ -2031,6 +2073,7 @@ __all__ = [
     "ProviderPackageCompletenessPayload",
     "ProviderPackageCompletenessRowPayload",
     "ProviderPackageCompletenessTotalsPayload",
+    "PublicRefResolutionPayload",
     "MachineErrorPayload",
     "MachineErrorEnvelope",
     "MachineSuccessEnvelope",
@@ -2054,6 +2097,7 @@ __all__ = [
     "RecoveryReadPayload",
     "RecoveryReportFormat",
     "RecoveryReportKind",
+    "RefResolutionActionPayload",
     "RANKING_POLICY_MIXED",
     "RANKING_POLICY_VERSION",
     "ReaderActionAvailabilityPayload",

--- a/tests/baselines/showcase/help-read.txt
+++ b/tests/baselines/showcase/help-read.txt
@@ -1,4 +1,4 @@
-Usage: polylogue read [OPTIONS]
+Usage: polylogue read [OPTIONS] [REF]
 
   Read matched sessions.
 
@@ -21,6 +21,7 @@ Usage: polylogue read [OPTIONS]
       polylogue --latest read --view neighbors --format json
       polylogue find id:abc then read --view correlation --since-hours 4
       polylogue --latest read --view correlation --otlp --format json
+      polylogue read session:abc123 --format json
 
   Deferred views (not yet implemented; note in PR body):
       timeline, tools, files, metadata, continuation

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -15,6 +15,7 @@ from tests.infra.builders import make_conv, make_msg
 EXPECTED_TOOL_NAMES = {
     "search",
     "query_units",
+    "resolve_ref",
     "list_sessions",
     "build_context_pack",
     "blackboard_list",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -229,6 +229,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "list_assertion_claim_payloads",
         "neighbor_candidate_payloads",
         "recovery_read_payload",
+        "resolve_ref",
         "session_correlation_payload",
     }
 )
@@ -1475,6 +1476,106 @@ async def test_query_units_returns_context_snapshot_rows(tmp_path: Path) -> None
         assert item.session_id == "codex-session:facade-context-snapshot-v1"
         assert item.boundary == "session_start"
         assert item.evidence_refs == ("codex-session:facade-context-snapshot-v1",)
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_bounded_session_message_block_and_runtime_payloads(tmp_path: Path) -> None:
+    """``resolve_ref()`` makes public refs actionable without broad search."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            session_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="ref-resolution-v1",
+                    title="Ref resolution fixture",
+                    working_directories=["/realm/project/polylogue"],
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            text="resolve this public ref",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="resolve this public ref")],
+                        )
+                    ],
+                )
+            )
+
+        session_payload = await archive.resolve_ref(f"session:{session_id}")
+        assert session_payload.resolved is True
+        assert session_payload.payload_kind == "session-summary"
+        assert session_payload.payload is not None
+        assert session_payload.payload["id"] == session_id
+
+        message_id = f"{session_id}:m1"
+        message_payload = await archive.resolve_ref(f"message:{session_id}:{message_id}")
+        assert message_payload.resolved is True
+        assert message_payload.payload_kind == "message"
+        assert message_payload.payload is not None
+        assert message_payload.payload["id"] == message_id
+
+        evidence_message_payload = await archive.resolve_ref(f"{session_id}::{message_id}")
+        assert evidence_message_payload.resolved is True
+        assert evidence_message_payload.payload_kind == "message"
+        assert evidence_message_payload.evidence_refs == (f"{session_id}::{message_id}",)
+
+        block_payload = await archive.resolve_ref(f"block:{message_id}:0")
+        assert block_payload.resolved is True
+        assert block_payload.payload_kind == "block"
+        assert block_payload.payload is not None
+        assert block_payload.payload["block_id"] == f"{message_id}:0"
+
+        evidence_block_payload = await archive.resolve_ref(f"{session_id}::{message_id}::0")
+        assert evidence_block_payload.resolved is True
+        assert evidence_block_payload.payload_kind == "block"
+        assert evidence_block_payload.evidence_refs == (f"{session_id}::{message_id}::0",)
+
+        runtime_payload = await archive.resolve_ref(f"context-snapshot:{session_id}:session_start")
+        assert runtime_payload.resolved is True
+        assert runtime_payload.payload_kind == "context-snapshot"
+        assert runtime_payload.payload is not None
+        assert runtime_payload.payload["session_id"] == session_id
+
+        unsupported_payload = await archive.resolve_ref("commit:abc123")
+        assert unsupported_payload.resolved is False
+        assert unsupported_payload.kind == "commit"
+        assert unsupported_payload.payload is None
+
+        missing_payload = await archive.resolve_ref("session:missing")
+        assert missing_payload.resolved is False
+        assert missing_payload.payload is None
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_assertion_payload(tmp_path: Path) -> None:
+    """Assertion refs resolve through the shared assertion claim DTO."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
+    archive = _archive(tmp_path)
+    try:
+        user_db = archive.config.archive_root / "user.db"
+        initialize_archive_database(user_db, ArchiveTier.USER)
+        with sqlite3.connect(user_db) as conn:
+            upsert_assertion(
+                conn,
+                assertion_id="assertion-ref-resolution",
+                target_ref="session:codex-session:ref-resolution-v1",
+                kind=AssertionKind.DECISION,
+                body_text="Resolve assertion refs through shared payloads.",
+                evidence_refs=["codex-session:ref-resolution-v1"],
+            )
+
+        payload = await archive.resolve_ref("assertion:assertion-ref-resolution")
+
+        assert payload.resolved is True
+        assert payload.payload_kind == "assertion-claim"
+        assert payload.payload is not None
+        assert payload.payload["assertion_id"] == "assertion-ref-resolution"
+        assert payload.evidence_refs == ("codex-session:ref-resolution-v1",)
     finally:
         await archive.close()
 

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -388,17 +388,17 @@
     "archive_facade_routes": {
       "checked": true,
       "source": "static_facade_route_catalog",
-      "total_method_count": 117,
-      "archive_ready_method_count": 116,
+      "total_method_count": 118,
+      "archive_ready_method_count": 117,
       "unsupported_method_count": 0,
       "route_counts": {
-        "archive_routed": 102,
+        "archive_routed": 103,
         "archive_direct": 14,
         "not_archive_runtime": 1
       },
       "tier_counts": {
         "user": 36,
-        "index": 77,
+        "index": 78,
         "none": 1,
         "source": 3
       },
@@ -924,6 +924,11 @@
           "tier": "user",
           "detail": "writes user tags through user.db"
         },
+        "resolve_ref": {
+          "route": "archive_routed",
+          "tier": "index",
+          "detail": "resolves public refs through bounded archive read payloads"
+        },
         "resume_brief": {
           "route": "archive_routed",
           "tier": "index",
@@ -1052,7 +1057,7 @@
       ],
       "facade_tier_route_counts": {
         "user": 36,
-        "index": 77,
+        "index": 78,
         "none": 1,
         "source": 3
       },

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -13,6 +14,7 @@ from polylogue.cli import query_verbs, read_view_handlers
 from polylogue.cli.read_view_handlers import ReadViewInvocation
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+from polylogue.surfaces.payloads import PublicRefResolutionPayload
 
 
 def _context_pair(
@@ -161,6 +163,66 @@ def test_read_all_and_analyze_count_update_parent_request() -> None:
 
     with pytest.raises(click.UsageError, match="does not support --limit"):
         wrapped_analyze(child, True, None, False, False, None, 5)
+
+
+def test_read_direct_ref_emits_shared_resolution_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    _, child = _context_pair()
+    child.obj = SimpleNamespace(polylogue=SimpleNamespace(resolve_ref=lambda ref: f"resolve:{ref}"))
+    wrapped_read = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped_read)
+    payload = PublicRefResolutionPayload(
+        ref="session:abc",
+        normalized_ref="session:abc",
+        kind="session",
+        resolved=True,
+        payload_kind="session-summary",
+        payload={"id": "abc", "title": "Resolved"},
+    )
+
+    with patch("polylogue.cli.query_verbs.run_coroutine_sync", return_value=payload) as run_sync:
+        wrapped_read(
+            ctx=child,
+            view="summary",
+            destination="terminal",
+            output_format="json",
+            out_path=None,
+            export_all=False,
+            message_role=(),
+            message_type=None,
+            limit=None,
+            offset=0,
+            window_hours=24,
+            repo_path=None,
+            since_hours=2,
+            confidence_threshold=0.3,
+            github_api=True,
+            otlp=False,
+            related_limit=5,
+            recovery_report=None,
+            project_path=None,
+            project_repo=None,
+            since=None,
+            until=None,
+            pack_origin=None,
+            pack_query=None,
+            max_sessions=5,
+            max_messages=20,
+            no_redact=False,
+            no_code_blocks=False,
+            no_tool_calls=False,
+            no_tool_outputs=False,
+            no_file_reads=False,
+            prose_only=False,
+            fields=None,
+            show_views=False,
+            ref="session:abc",
+        )
+
+    run_sync.assert_called_once()
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["mode"] == "ref-resolution"
+    assert emitted["normalized_ref"] == "session:abc"
+    assert emitted["payload"]["id"] == "abc"
 
 
 def test_analyze_verb_toggles_stats_only_and_updates_grouping() -> None:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -604,6 +604,18 @@ class TestReaderSessionState:
         assert message["actions"]["annotate"]["enabled"] is True
         assert message["actions"]["annotate"]["state"] == "enabled"
 
+    def test_ref_resolve_route_returns_shared_payload(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, f"/api/refs/resolve?ref={quote('session:claude-code-session:c1')}")
+
+        result = cast(dict[str, object], payload)
+        assert result["mode"] == "ref-resolution"
+        assert result["resolved"] is True
+        assert result["normalized_ref"] == "session:claude-code-session:c1"
+        assert result["payload_kind"] == "session-summary"
+        resolved_payload = cast(dict[str, object], result["payload"])
+        assert resolved_payload["id"] == "claude-code-session:c1"
+
     def test_session_messages_apply_content_projection_flags(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.archive.message.roles import Role
         from polylogue.core.enums import BlockType, Provider

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -65,6 +65,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "list_assertion_claims": ("envelope", frozenset({"items", "total", "limit"})),
     "explain_query_expression": "single_object",
     "query_completions": "single_object",
+    "resolve_ref": "single_object",
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     "archive_list_sessions": ("envelope", frozenset({"items", "total", "limit", "offset"})),
     "archive_search_sessions": ("envelope", frozenset({"items", "total", "limit", "query"})),
@@ -216,11 +217,12 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         MCPSessionTopologyPayload,
         MCPSessionTreePayload,
     )
-    from polylogue.surfaces.payloads import QueryUnitEnvelope, SearchEnvelope
+    from polylogue.surfaces.payloads import PublicRefResolutionPayload, QueryUnitEnvelope, SearchEnvelope
 
     return {
         "search": SearchEnvelope,
         "query_units": QueryUnitEnvelope,
+        "resolve_ref": PublicRefResolutionPayload,
         "list_sessions": MCPPaginatedQueryResultPayload,
         "neighbor_candidates": MCPNeighborCandidatesPayload,
         "get_session_tree": MCPSessionTreePayload,

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -21,7 +21,7 @@ from polylogue.insights.transforms import RecoveryWorkPacket, RecoveryWorkPacket
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
-from polylogue.surfaces.payloads import AssertionClaimPayload
+from polylogue.surfaces.payloads import AssertionClaimPayload, PublicRefResolutionPayload
 from polylogue.types import SessionId
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
@@ -1036,6 +1036,33 @@ class TestArchiveGenericToolSurfaces:
             context_inject=True,
             limit=5,
         )
+
+    @pytest.mark.asyncio
+    async def test_resolve_ref_reads_shared_facade_payload(self: object, mcp_server: MCPServerUnderTest) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.resolve_ref = AsyncMock(
+            return_value=PublicRefResolutionPayload(
+                ref="session:session-1",
+                normalized_ref="session:session-1",
+                kind="session",
+                resolved=True,
+                payload_kind="session-summary",
+                payload={"id": "session-1"},
+            )
+        )
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["resolve_ref"].fn,
+                ref="session:session-1",
+            )
+
+        payload = json.loads(result)
+        assert payload["mode"] == "ref-resolution"
+        assert payload["resolved"] is True
+        assert payload["payload_kind"] == "session-summary"
+        assert payload["payload"]["id"] == "session-1"
+        mock_poly.resolve_ref.assert_awaited_once_with("session:session-1")
 
 
 class TestPromptSurfaces:

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -28,6 +28,7 @@ _SYNTHETIC_CONV_ID = "test:conv-discovery-nonexistent"
 _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "search": {"query": "hello", "limit": 1},
     "query_units": {"expression": "messages where text:hello", "limit": 1},
+    "resolve_ref": {"ref": f"session:{_SYNTHETIC_CONV_ID}"},
     "blackboard_list": {},
     "get_session": {"id": _SYNTHETIC_CONV_ID},
     "get_session_summary": {"id": _SYNTHETIC_CONV_ID},


### PR DESCRIPTION
## Summary

Adds a shared public-ref resolver so ObjectRef/EvidenceRef strings in archive payloads become actionable across CLI, Python API, MCP, and daemon HTTP. The resolver returns a bounded `PublicRefResolutionPayload` instead of widening unsupported refs into search.

## Problem

Polylogue already emits refs from recovery, work-packet, assertion, and runtime projection surfaces, but users and agents could not ask the product to dereference those refs consistently. That made evidence links less useful and encouraged each surface to invent local lookup behavior.

## Solution

- Added `PublicRefResolutionPayload` and `RefResolutionActionPayload` in `polylogue.surfaces.payloads`.
- Implemented `Polylogue.resolve_ref(...)` for session, message, block, assertion, run, observed-event, and context-snapshot refs, including EvidenceRef projection to the nearest object payload.
- Exposed the resolver through:
  - `polylogue read REF --format json`,
  - MCP `resolve_ref`,
  - daemon `GET /api/refs/resolve?ref=...`,
  - Python API `Polylogue.resolve_ref(...)`.
- Updated daemon route contracts, MCP envelope/tool discovery contracts, status route catalogs, CLI reference, and search docs.
- Added behavior coverage for object refs, EvidenceRefs, unsupported refs, CLI JSON output, daemon route output, MCP payload reuse, and status snapshot/catalog drift.

Closes #2181

## Verification

- `devtools test tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade tests/unit/cli/commands/test_status.py tests/unit/api/test_facade_contracts.py::test_resolve_ref_returns_bounded_session_message_block_and_runtime_payloads tests/unit/api/test_facade_contracts.py::test_resolve_ref_returns_assertion_payload` → 89 passed.
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade tests/unit/api/test_facade_contracts.py::test_resolve_ref_returns_bounded_session_message_block_and_runtime_payloads` → 3 passed.
- `devtools verify --quick` → exit 0.
- `devtools verify --seed-testmon --skip-slow` → 11,556 passed, 9 warnings; peak pytest RSS 3,374 MB.
- `devtools verify` → 7 affected tests passed; exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public reference resolution across CLI (`polylogue read [REF]`), HTTP API, Python API, and MCP interfaces
  * Enables resolution of references to sessions, messages, blocks, assertions, and runtime objects with standardized bounded payloads

* **Documentation**
  * Updated CLI command documentation with optional reference argument and usage examples
  * Added reference resolution guide documenting available resolver entry points and supported reference types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->