### PR TITLE
feat(context): compile bounded context images (#2193)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -383,6 +383,7 @@ Usage: polylogue continue [OPTIONS]
 
   Examples:
       polylogue find id:abc then continue
+      polylogue find id:abc then continue --format json
       polylogue --latest continue --to clipboard
       polylogue find 'repo:polylogue near:id:abc' then continue --to file --out handoff.md
 
@@ -390,6 +391,8 @@ Options:
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
   --out PATH                      File path for --to file.
+  -f, --format [json]             Output format. JSON emits the shared
+                                  ContextImage payload.
   --help                          Show this message and exit.
 ```
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -6,7 +6,7 @@ import builtins
 import json
 import sqlite3
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Iterable, Sequence
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
     from polylogue.archive.stats import ArchiveStats as StorageArchiveStats
     from polylogue.config import Config
-    from polylogue.context.compiler import RecoveryContextCompilation
+    from polylogue.context.compiler import ContextImage, ContextSpec, RecoveryContextCompilation
     from polylogue.insights.audit import InsightRigorAuditQuery, InsightRigorAuditReport
     from polylogue.insights.export_bundles import InsightExportBundleRequest, InsightExportBundleResult
     from polylogue.insights.readiness import InsightReadinessQuery, InsightReadinessReport
@@ -164,6 +164,30 @@ def _provider_for_archive_origin(origin: str) -> Provider:
         return provider_from_origin(Origin(origin))
     except ValueError:
         return Provider.UNKNOWN
+
+
+def _dedupe_object_refs(refs: Iterable[ObjectRef]) -> tuple[ObjectRef, ...]:
+    deduped: list[ObjectRef] = []
+    seen: set[tuple[str, str]] = set()
+    for ref in refs:
+        key = (ref.kind, ref.object_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ref)
+    return tuple(deduped)
+
+
+def _dedupe_evidence_refs(refs: Iterable[EvidenceRef]) -> tuple[EvidenceRef, ...]:
+    deduped: list[EvidenceRef] = []
+    seen: set[tuple[str, str | None, int | None]] = set()
+    for ref in refs:
+        key = (ref.session_id, ref.message_id, ref.block_index)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ref)
+    return tuple(deduped)
 
 
 def _parse_archive_datetime(value: str | None) -> datetime | None:
@@ -1263,6 +1287,7 @@ class PolylogueArchiveMixin:
         digest: RecoveryDigest,
         *,
         report: RecoveryReportPreset | None = None,
+        include_assertions: bool = True,
     ) -> RecoveryContextCompilation:
         """Compile one recovery-context view without making callers branch on bundle shape."""
         from polylogue.context.compiler import compile_recovery_context
@@ -1270,7 +1295,12 @@ class PolylogueArchiveMixin:
 
         packet: RecoveryWorkPacket | None = None
         target_ref = f"session:{digest.session_id}"
-        if report == "work-packet":
+        claims: Sequence[ArchiveAssertionEnvelope]
+        if not include_assertions:
+            claims = ()
+            if report == "work-packet":
+                packet = await self._recovery_work_packet_from_digest(digest, claims=claims)
+        elif report == "work-packet":
             claims = await self.list_assertion_claims(target_ref=target_ref, limit=20)
             packet = await self._recovery_work_packet_from_digest(digest, claims=claims)
         else:
@@ -1397,6 +1427,121 @@ class PolylogueArchiveMixin:
                 )
             return RecoveryReadPayload.from_work_packet_json(packet)
         raise ValueError(f"unsupported recovery report: {report}")
+
+    async def compile_context(self, spec: ContextSpec) -> ContextImage:
+        """Compile a bounded context image from query/ref seeds and read views.
+
+        This is the executable API boundary for ``ContextSpec``. It deliberately
+        reuses existing recovery/read primitives and records unsupported or
+        missing inputs as omissions instead of creating a parallel memory store.
+        """
+        from polylogue.context.compiler import ContextImage, ContextOmission, ContextSegment
+
+        segments: list[ContextSegment] = []
+        omitted: list[ContextOmission] = []
+        requested_views = tuple(dict.fromkeys(spec.read_views or ("recovery",)))
+        session_ids: list[str] = []
+        seen_sessions: set[str] = set()
+
+        for seed_ref in spec.seed_refs:
+            if not seed_ref.startswith("session:"):
+                omitted.append(
+                    ContextOmission(
+                        ref=seed_ref,
+                        reason="unsupported",
+                        detail="compile_context currently accepts session: refs as direct seeds",
+                    )
+                )
+                continue
+            session_id = seed_ref.removeprefix("session:")
+            if session_id not in seen_sessions:
+                seen_sessions.add(session_id)
+                session_ids.append(session_id)
+
+        if spec.seed_query is not None:
+            result = await self.search(spec.seed_query, limit=1)
+            if not result.hits:
+                omitted.append(
+                    ContextOmission(
+                        query=spec.seed_query,
+                        reason="not_found",
+                        detail="seed query matched no sessions",
+                    )
+                )
+            else:
+                session_id = result.hits[0].session_id
+                if session_id not in seen_sessions:
+                    seen_sessions.add(session_id)
+                    session_ids.append(session_id)
+
+        token_budget = spec.max_tokens
+        token_total = 0
+        for session_id in session_ids:
+            digest = await self.recovery_digest(session_id)
+            if digest is None:
+                omitted.append(
+                    ContextOmission(
+                        ref=f"session:{session_id}",
+                        reason="not_found",
+                        detail="session seed did not resolve to a recovery digest",
+                    )
+                )
+                continue
+            for view in requested_views:
+                if view not in {"recovery", "work-packet"}:
+                    omitted.append(
+                        ContextOmission(
+                            ref=f"session:{session_id}",
+                            view=view,
+                            reason="unsupported",
+                            detail="compile_context currently supports recovery and work-packet views",
+                        )
+                    )
+                    continue
+                compilation = await self._compile_recovery_context_from_digest(
+                    digest,
+                    report="work-packet" if view == "work-packet" else None,
+                    include_assertions=spec.include_assertions,
+                )
+                if compilation.context_image is None:
+                    omitted.append(
+                        ContextOmission(
+                            ref=f"session:{session_id}",
+                            view=view,
+                            reason="not_found",
+                            detail="recovery compiler did not produce a context image",
+                        )
+                    )
+                    continue
+                segment = compilation.context_image.segments[0]
+                if token_budget is not None and token_total + segment.token_estimate > token_budget:
+                    omitted.append(
+                        ContextOmission(
+                            ref=f"session:{session_id}",
+                            view=view,
+                            reason="budget",
+                            detail="segment exceeded the requested context token budget",
+                        )
+                    )
+                    continue
+                token_total += segment.token_estimate
+                segments.append(segment)
+
+        object_refs = _dedupe_object_refs(ref for segment in segments for ref in segment.object_refs)
+        evidence_refs = _dedupe_evidence_refs(ref for segment in segments for ref in segment.evidence_refs)
+        assertion_refs = tuple(dict.fromkeys(ref for segment in segments for ref in segment.assertion_refs))
+        caveats = tuple(dict.fromkeys(caveat for segment in segments for caveat in segment.caveats))
+
+        return ContextImage(
+            spec=spec,
+            segments=tuple(segments),
+            object_refs=object_refs,
+            evidence_refs=evidence_refs,
+            assertion_refs=assertion_refs,
+            omitted=tuple(omitted),
+            caveats=caveats,
+            token_estimate=token_total,
+        )
 
     async def list_read_view_profiles(self) -> list[JSONDocument]:
         """List executable read-view profile metadata."""

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -271,6 +271,7 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "rebuild_insights": ("archive_routed", "index", "rebuilds insight tables"),
     "resolve_ref": ("archive_routed", "index", "resolves public refs through bounded archive read payloads"),
     "record_correction": ("archive_routed", "user", "writes corrections through user.db"),
+    "compile_context": ("archive_routed", "index", "compiles bounded context images from archive reads"),
     "context_pack_payload": ("archive_routed", "index", "builds context-pack DTOs from archive-routed reads"),
     "context_preamble_payload": ("archive_routed", "index", "builds context preamble DTOs from archive-routed reads"),
     "recovery_digest": ("archive_routed", "index", "builds recovery digests from archive-routed session reads"),

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -445,13 +445,22 @@ def read_verb(
     help="Output destination.",
 )
 @click.option("--out", "out_path", type=click.Path(), default=None, help="File path for --to file.")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["json"]),
+    default=None,
+    help="Output format. JSON emits the shared ContextImage payload.",
+)
 @click.pass_context
-def continue_verb(ctx: click.Context, destination: str, out_path: str | None) -> None:
+def continue_verb(ctx: click.Context, destination: str, out_path: str | None, output_format: str | None) -> None:
     """Compile a successor-agent continuation report for one matched session.
 
     \b
     Examples:
         polylogue find id:abc then continue
+        polylogue find id:abc then continue --format json
         polylogue --latest continue --to clipboard
         polylogue find 'repo:polylogue near:id:abc' then continue --to file --out handoff.md
     """
@@ -460,6 +469,31 @@ def continue_verb(ctx: click.Context, destination: str, out_path: str | None) ->
     session_id = _resolve_target_session_id(request)
     if session_id is None:
         raise click.UsageError("continue requires one matched session (use --id, --latest, or a narrowing query).")
+    if output_format == "json":
+        if destination not in ("terminal", "stdout", "file"):
+            raise click.UsageError("continue --format json supports terminal, stdout, or file destinations only.")
+        if destination == "file" and not out_path:
+            raise click.UsageError("continue --format json --to file requires --out.")
+        from pathlib import Path
+
+        from polylogue.context.compiler import ContextSpec
+
+        image = run_coroutine_sync(
+            env.polylogue.compile_context(
+                ContextSpec(
+                    purpose="continue",
+                    seed_refs=(f"session:{session_id}",),
+                    read_views=("recovery",),
+                )
+            )
+        )
+        rendered = serialize_surface_payload(image, exclude_none=True)
+        if destination == "file":
+            assert out_path is not None
+            Path(out_path).write_text(rendered + "\n", encoding="utf-8")
+        else:
+            click.echo(rendered)
+        return
     run_read_view(
         env,
         request,

--- a/polylogue/context/__init__.py
+++ b/polylogue/context/__init__.py
@@ -3,17 +3,31 @@
 from __future__ import annotations
 
 __all__ = [
+    "ContextImage",
+    "ContextOmission",
+    "ContextSegment",
+    "ContextSnapshotRecord",
+    "ContextSpec",
     "compile_recovery_context",
     "compose_context_preamble",
+    "context_image_from_recovery",
     "run_context_pack_view",
 ]
 
 
 def __getattr__(name: str) -> object:
+    if name in {"ContextImage", "ContextOmission", "ContextSegment", "ContextSnapshotRecord", "ContextSpec"}:
+        from polylogue.context import compiler as compiler_module
+
+        return getattr(compiler_module, name)
     if name == "compile_recovery_context":
         from polylogue.context.compiler import compile_recovery_context
 
         return compile_recovery_context
+    if name == "context_image_from_recovery":
+        from polylogue.context.compiler import context_image_from_recovery
+
+        return context_image_from_recovery
     if name == "compose_context_preamble":
         from polylogue.context.preamble import compose_context_preamble
 

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Literal, cast
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from polylogue.context.assertion_claims import context_claim_text
 from polylogue.core.refs import EvidenceRef, ObjectRef
@@ -20,8 +20,85 @@ from polylogue.insights.transforms import RecoveryDigest, RecoveryReportPreset, 
 from polylogue.surfaces.payloads import AssertionClaimPayload
 
 RecoveryContextKind = Literal["recovery_digest", "recovery_report", "work_packet"]
+ContextPurpose = Literal["continue", "review", "handoff", "debug", "export"]
+ContextSegmentKind = Literal["recovery", "read_view", "assertion", "caveat"]
+ContextOmissionReason = Literal["budget", "unsupported", "not_found", "policy", "redacted"]
 
 _SUPPORTED_REPORTS: frozenset[str] = frozenset({"continue", "blame", "work-packet"})
+
+
+class ContextSegment(ArchiveInsightModel):
+    """One bounded section of a compiled context image."""
+
+    segment_id: str
+    kind: ContextSegmentKind
+    title: str
+    markdown: str | None = None
+    payload_kind: str | None = None
+    object_refs: tuple[ObjectRef, ...] = ()
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+    assertion_refs: tuple[str, ...] = ()
+    caveats: tuple[str, ...] = ()
+    token_estimate: int = 0
+    lossiness: str | None = None
+
+
+class ContextOmission(ArchiveInsightModel):
+    """A requested context input that was omitted deliberately."""
+
+    ref: str | None = None
+    query: str | None = None
+    view: str | None = None
+    reason: ContextOmissionReason
+    detail: str
+
+
+class ContextSpec(ArchiveInsightModel):
+    """Declarative request for a compiled context image.
+
+    The spec is pure input. It does not imply delivery, durable recording, or
+    automatic context injection.
+    """
+
+    purpose: ContextPurpose = "continue"
+    seed_query: str | None = None
+    seed_refs: tuple[str, ...] = ()
+    read_views: tuple[str, ...] = ("recovery",)
+    max_tokens: int | None = Field(default=None, ge=1)
+    include_assertions: bool = True
+    include_candidates: bool = False
+    redaction_policy: Literal["default", "raw-opt-in"] = "default"
+
+    @model_validator(mode="after")
+    def _requires_seed(self) -> ContextSpec:
+        if self.seed_query is None and not self.seed_refs:
+            raise ValueError("ContextSpec requires seed_query or seed_refs")
+        return self
+
+
+class ContextImage(ArchiveInsightModel):
+    """Compiled, storage-free context payload over archive refs and views."""
+
+    spec: ContextSpec
+    segments: tuple[ContextSegment, ...]
+    object_refs: tuple[ObjectRef, ...] = ()
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+    assertion_refs: tuple[str, ...] = ()
+    omitted: tuple[ContextOmission, ...] = ()
+    caveats: tuple[str, ...] = ()
+    token_estimate: int = 0
+
+
+class ContextSnapshotRecord(ArchiveInsightModel):
+    """Evidence record for context that was actually delivered."""
+
+    snapshot_ref: str
+    run_ref: str | None = None
+    boundary: str
+    inheritance_mode: str = "explicit"
+    segment_refs: tuple[str, ...] = ()
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+    metadata: dict[str, object] = Field(default_factory=dict)
 
 
 class RecoveryContextCompilation(ArchiveInsightModel):
@@ -45,6 +122,7 @@ class RecoveryContextCompilation(ArchiveInsightModel):
     object_refs: tuple[ObjectRef, ...] = ()
     caveats: tuple[str, ...] = ()
     assertion_claims: tuple[AssertionClaimPayload, ...] = ()
+    context_image: ContextImage | None = None
 
     @model_validator(mode="after")
     def _validate_requested_shape(self) -> RecoveryContextCompilation:
@@ -54,6 +132,8 @@ class RecoveryContextCompilation(ArchiveInsightModel):
             raise ValueError("work_packet compilation requires work_packet")
         if self.kind in {"recovery_report", "work_packet"} and not self.markdown:
             raise ValueError(f"{self.kind} compilation requires markdown")
+        if self.context_image is not None and self.context_image.segments == ():
+            raise ValueError("context_image requires at least one segment")
         return self
 
 
@@ -80,7 +160,7 @@ def compile_recovery_context(
     if report is None:
         if work_packet is not None:
             raise ValueError("work_packet may only be supplied when report='work-packet'")
-        return RecoveryContextCompilation(
+        compiled = RecoveryContextCompilation(
             kind="recovery_digest",
             session_id=digest.session_id,
             digest=digest,
@@ -90,13 +170,14 @@ def compile_recovery_context(
             caveats=_digest_caveats(digest),
             assertion_claims=claims,
         )
+        return _attach_context_image(compiled)
 
     if report not in _SUPPORTED_REPORTS:
         raise ValueError(f"unsupported recovery report preset: {report}")
     preset = cast(RecoveryReportPreset, report)
     if preset == "work-packet":
         packet = work_packet or digest.work_packet()
-        return RecoveryContextCompilation(
+        compiled = RecoveryContextCompilation(
             kind="work_packet",
             session_id=digest.session_id,
             report=preset,
@@ -108,10 +189,11 @@ def compile_recovery_context(
             caveats=_packet_caveats(packet),
             assertion_claims=claims,
         )
+        return _attach_context_image(compiled)
 
     if work_packet is not None:
         raise ValueError("work_packet may only be supplied when report='work-packet'")
-    return RecoveryContextCompilation(
+    compiled = RecoveryContextCompilation(
         kind="recovery_report",
         session_id=digest.session_id,
         report=preset,
@@ -122,6 +204,60 @@ def compile_recovery_context(
         caveats=_digest_caveats(digest),
         assertion_claims=claims,
     )
+    return _attach_context_image(compiled)
+
+
+def context_image_from_recovery(compilation: RecoveryContextCompilation) -> ContextImage:
+    """Promote a recovery compilation into the general context-image shape."""
+
+    segment = ContextSegment(
+        segment_id=f"recovery:{compilation.session_id}:{compilation.report or compilation.kind}",
+        kind="recovery",
+        title=_recovery_segment_title(compilation),
+        markdown=compilation.markdown,
+        payload_kind=compilation.kind,
+        object_refs=compilation.object_refs,
+        evidence_refs=compilation.evidence_refs,
+        assertion_refs=tuple(claim.assertion_id for claim in compilation.assertion_claims),
+        caveats=compilation.caveats,
+        token_estimate=_estimate_tokens(compilation.markdown),
+        lossiness="bounded_recovery_transform",
+    )
+    spec = ContextSpec(
+        purpose="handoff" if compilation.report == "work-packet" else "continue",
+        seed_refs=(f"session:{compilation.session_id}",),
+        read_views=("work-packet",) if compilation.report == "work-packet" else ("recovery",),
+        include_assertions=bool(compilation.assertion_claims),
+        include_candidates=False,
+    )
+    assertion_refs = tuple(claim.assertion_id for claim in compilation.assertion_claims)
+    return ContextImage(
+        spec=spec,
+        segments=(segment,),
+        object_refs=compilation.object_refs,
+        evidence_refs=compilation.evidence_refs,
+        assertion_refs=assertion_refs,
+        caveats=compilation.caveats,
+        token_estimate=segment.token_estimate,
+    )
+
+
+def _attach_context_image(compilation: RecoveryContextCompilation) -> RecoveryContextCompilation:
+    return compilation.model_copy(update={"context_image": context_image_from_recovery(compilation)})
+
+
+def _recovery_segment_title(compilation: RecoveryContextCompilation) -> str:
+    if compilation.report == "work-packet":
+        return "Recovery work packet"
+    if compilation.report is not None:
+        return f"Recovery {compilation.report} report"
+    return "Recovery digest"
+
+
+def _estimate_tokens(text: str | None) -> int:
+    if not text:
+        return 0
+    return max(1, len(text.split()))
 
 
 def _digest_evidence_refs(digest: RecoveryDigest) -> tuple[EvidenceRef, ...]:
@@ -162,7 +298,16 @@ def _append_assertion_claims_markdown(markdown: str, claims: Sequence[AssertionC
 
 
 __all__ = [
+    "ContextImage",
+    "ContextOmission",
+    "ContextOmissionReason",
+    "ContextPurpose",
+    "ContextSegment",
+    "ContextSegmentKind",
+    "ContextSnapshotRecord",
+    "ContextSpec",
     "RecoveryContextCompilation",
     "RecoveryContextKind",
     "compile_recovery_context",
+    "context_image_from_recovery",
 ]

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 from pydantic import RootModel
 from typing_extensions import TypedDict
 
+from polylogue.context.compiler import ContextImage
 from polylogue.core.json import JSONDocument
 from polylogue.core.user_state_targets import TARGET_SESSION
 from polylogue.mcp.context_pack import (
@@ -88,6 +89,7 @@ if TYPE_CHECKING:
 MCPAssertionClaimPayload = AssertionClaimPayload
 MCPAssertionClaimListPayload = AssertionClaimListPayload
 MCPPublicRefResolutionPayload = PublicRefResolutionPayload
+MCPContextImagePayload = ContextImage
 
 TRoot = TypeVar("TRoot")
 
@@ -915,6 +917,7 @@ __all__ = [
     "MCPContextPackDateRange",
     "MCPContextPackMessage",
     "MCPContextPackPayload",
+    "MCPContextImagePayload",
     "MCPContextPackProject",
     "MCPContextPackProvenance",
     "MCPContextPackQueryContext",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -26,6 +26,7 @@ from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPAssertionClaimListPayload,
     MCPBlackboardNoteListPayload,
+    MCPContextImagePayload,
     MCPEmbeddingPreflightPayload,
     MCPEmbeddingStatusPayload,
     MCPRawArtifactPayload,
@@ -241,6 +242,45 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         "List sessions matching the supplied filters. Filter parameters mirror ``MCPSessionQueryRequest`` fields."
     )
     mcp.tool()(_list_sessions)
+
+    @mcp.tool()
+    async def compile_context(
+        seed_ref: str | None = None,
+        seed_query: str | None = None,
+        read_views: str = "recovery",
+        max_tokens: int | None = None,
+        include_assertions: bool = True,
+        include_candidates: bool = False,
+    ) -> str:
+        """Compile a bounded context image from query/ref seeds and read views."""
+
+        async def run() -> str:
+            from pydantic import ValidationError
+
+            from polylogue.context.compiler import ContextSpec
+
+            seed_refs = _split_archive_csv(seed_ref)
+            if seed_query is None and not seed_refs:
+                return hooks.error_json(
+                    "compile_context requires seed_ref or seed_query",
+                    code="invalid_request",
+                    tool="compile_context",
+                )
+            try:
+                spec = ContextSpec(
+                    seed_query=seed_query,
+                    seed_refs=seed_refs,
+                    read_views=_split_archive_csv(read_views) or ("recovery",),
+                    max_tokens=max_tokens,
+                    include_assertions=include_assertions,
+                    include_candidates=include_candidates,
+                )
+            except ValidationError as exc:
+                return hooks.error_json(str(exc), code="invalid_request", tool="compile_context")
+            image = await hooks.get_polylogue().compile_context(spec)
+            return hooks.json_payload(MCPContextImagePayload.model_validate(image), exclude_none=True)
+
+        return await hooks.async_safe_call("compile_context", run)
 
     @mcp.tool()
     async def get_session(

--- a/tests/baselines/showcase/help-continue.txt
+++ b/tests/baselines/showcase/help-continue.txt
@@ -4,6 +4,7 @@ Usage: polylogue continue [OPTIONS]
 
   Examples:
       polylogue find id:abc then continue
+      polylogue find id:abc then continue --format json
       polylogue --latest continue --to clipboard
       polylogue find 'repo:polylogue near:id:abc' then continue --to file --out handoff.md
 
@@ -11,4 +12,6 @@ Options:
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
   --out PATH                      File path for --to file.
+  -f, --format [json]             Output format. JSON emits the shared
+                                  ContextImage payload.
   --help                          Show this message and exit.

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -17,6 +17,7 @@ EXPECTED_TOOL_NAMES = {
     "query_units",
     "resolve_ref",
     "list_sessions",
+    "compile_context",
     "build_context_pack",
     "blackboard_list",
     "blackboard_post",
@@ -205,6 +206,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.list_assertion_claim_payloads = AsyncMock(return_value=[])
     poly.recovery_report = AsyncMock(return_value=None)
     poly.recovery_work_packet = AsyncMock(return_value=None)
+    poly.compile_context = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -205,6 +205,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "neighbor_candidates",
         "context_pack_payload",
         "context_preamble_payload",
+        "compile_context",
         "recovery_report",
         "find_resume_candidates",
         "export_insight_bundle",
@@ -904,6 +905,126 @@ async def test_recovery_report_renders_seeded_session_presets(tmp_path: Path) ->
         assert "## Evidence" in work_packet_report
         assert await archive.recovery_report("nonexistent", "continue") is None
         assert await archive.recovery_work_packet("nonexistent") is None
+    finally:
+        await archive.close()
+
+
+async def test_compile_context_builds_recovery_segments_from_refs_and_query(tmp_path: Path) -> None:
+    """``compile_context`` executes ContextSpec over existing recovery views."""
+    from polylogue.context.compiler import ContextSpec
+
+    archive = _archive(tmp_path)
+    await _seed_two_sessions(archive.config.db_path)
+
+    try:
+        image = await archive.compile_context(
+            ContextSpec(
+                seed_refs=("session:claude-ai-export:conv-alpha", "assertion:claim-1"),
+                seed_query="beta body",
+                read_views=("recovery", "work-packet", "messages"),
+                max_tokens=20_000,
+            )
+        )
+
+        assert image.spec.seed_query == "beta body"
+        assert [segment.payload_kind for segment in image.segments] == [
+            "recovery_digest",
+            "work_packet",
+            "recovery_digest",
+            "work_packet",
+        ]
+        assert {ref.object_id for ref in image.object_refs if ref.kind == "session"} == {
+            "claude-ai-export:conv-alpha",
+            "chatgpt-export:conv-beta",
+        }
+        assert {ref.session_id for ref in image.evidence_refs} == {
+            "claude-ai-export:conv-alpha",
+            "chatgpt-export:conv-beta",
+        }
+        assert image.token_estimate > 0
+        unsupported = [item for item in image.omitted if item.reason == "unsupported"]
+        assert len(unsupported) == 3
+        assert unsupported[0].ref == "assertion:claim-1"
+        assert {item.view for item in unsupported[1:]} == {"messages"}
+    finally:
+        await archive.close()
+
+
+async def test_compile_context_honors_assertion_opt_out(tmp_path: Path) -> None:
+    """``ContextSpec(include_assertions=False)`` suppresses injectable claims."""
+    from polylogue.context.compiler import ContextSpec
+    from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+
+    archive = _archive(tmp_path)
+    await _seed_two_sessions(archive.config.db_path)
+    with sqlite3.connect(archive.config.archive_root / "user.db") as conn:
+        upsert_assertion(
+            conn,
+            assertion_id="context-opt-out-decision",
+            target_ref="session:claude-ai-export:conv-alpha",
+            kind=AssertionKind.DECISION,
+            body_text="This assertion must not enter opted-out context images.",
+            author_ref="user:test",
+            author_kind="user",
+            evidence_refs=["claude-ai-export:conv-alpha"],
+            status="active",
+            visibility="private",
+            context_policy={"inject": True},
+            now_ms=1_700_000_000_000,
+        )
+
+    try:
+        included = await archive.compile_context(
+            ContextSpec(seed_refs=("session:claude-ai-export:conv-alpha",), include_assertions=True)
+        )
+        omitted = await archive.compile_context(
+            ContextSpec(seed_refs=("session:claude-ai-export:conv-alpha",), include_assertions=False)
+        )
+
+        assert included.assertion_refs == ("context-opt-out-decision",)
+        included_markdown = included.segments[0].markdown
+        omitted_markdown = omitted.segments[0].markdown
+        assert included_markdown is not None
+        assert omitted_markdown is not None
+        assert "This assertion must not enter opted-out context images." in included_markdown
+        assert omitted.assertion_refs == ()
+        assert omitted.segments[0].assertion_refs == ()
+        assert "This assertion must not enter opted-out context images." not in omitted_markdown
+    finally:
+        await archive.close()
+
+
+async def test_compile_context_records_missing_and_budget_omissions(tmp_path: Path) -> None:
+    """``compile_context`` fails closed when seeds or budget do not resolve."""
+    from polylogue.context.compiler import ContextSpec
+
+    archive = _archive(tmp_path)
+    await _seed_two_sessions(archive.config.db_path)
+
+    try:
+        image = await archive.compile_context(
+            ContextSpec(
+                seed_refs=("session:missing",),
+                seed_query="no such query",
+                max_tokens=1,
+            )
+        )
+
+        assert image.segments == ()
+        assert image.token_estimate == 0
+        assert {(item.ref, item.query, item.reason) for item in image.omitted} == {
+            ("session:missing", None, "not_found"),
+            (None, "no such query", "not_found"),
+        }
+
+        budgeted = await archive.compile_context(
+            ContextSpec(
+                seed_refs=("session:claude-ai-export:conv-alpha",),
+                max_tokens=1,
+            )
+        )
+        assert budgeted.segments == ()
+        assert [(item.view, item.reason) for item in budgeted.omitted] == [("recovery", "budget")]
     finally:
         await archive.close()
 

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -388,17 +388,17 @@
     "archive_facade_routes": {
       "checked": true,
       "source": "static_facade_route_catalog",
-      "total_method_count": 118,
-      "archive_ready_method_count": 117,
+      "total_method_count": 119,
+      "archive_ready_method_count": 118,
       "unsupported_method_count": 0,
       "route_counts": {
-        "archive_routed": 103,
+        "archive_routed": 104,
         "archive_direct": 14,
         "not_archive_runtime": 1
       },
       "tier_counts": {
         "user": 36,
-        "index": 78,
+        "index": 79,
         "none": 1,
         "source": 3
       },
@@ -453,6 +453,11 @@
           "route": "not_archive_runtime",
           "tier": "none",
           "detail": "resource lifecycle method"
+        },
+        "compile_context": {
+          "route": "archive_routed",
+          "tier": "index",
+          "detail": "compiles bounded context images from archive reads"
         },
         "context_pack_payload": {
           "route": "archive_routed",
@@ -1057,7 +1062,7 @@
       ],
       "facade_tier_route_counts": {
         "user": 36,
-        "index": 78,
+        "index": 79,
         "none": 1,
         "source": 3
       },

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -14,6 +14,7 @@ from polylogue.cli import query_verbs, read_view_handlers
 from polylogue.cli.read_view_handlers import ReadViewInvocation
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec
 from polylogue.surfaces.payloads import PublicRefResolutionPayload
 
 
@@ -523,7 +524,7 @@ def test_continue_verb_renders_recovery_continue_report() -> None:
         patch("polylogue.cli.query_verbs._resolve_target_session_id", return_value="codex-session:abc123"),
         patch("polylogue.cli.query_verbs.run_read_view") as run_read_view,
     ):
-        wrapped(child, "clipboard", None)
+        wrapped(child, "clipboard", None, None)
 
     invocation = run_read_view.call_args.args[2]
     assert invocation == ReadViewInvocation(
@@ -534,6 +535,50 @@ def test_continue_verb_renders_recovery_continue_report() -> None:
         out_path=None,
         recovery_report="continue",
     )
+
+
+def test_continue_verb_json_emits_context_image(capsys: pytest.CaptureFixture[str]) -> None:
+    """``continue --format json`` exposes the shared ContextImage payload."""
+    _, child = _context_pair(query_terms=("id:codex-session:abc123",))
+    spec = ContextSpec(
+        purpose="continue",
+        seed_refs=("session:codex-session:abc123",),
+        read_views=("recovery",),
+    )
+    image = ContextImage(
+        spec=spec,
+        segments=(
+            ContextSegment(
+                segment_id="recovery:codex-session:abc123",
+                kind="recovery",
+                title="Recovery",
+                markdown="Continue from here.",
+                token_estimate=3,
+            ),
+        ),
+        token_estimate=3,
+    )
+    seen: dict[str, ContextSpec] = {}
+
+    async def compile_context(spec: ContextSpec) -> ContextImage:
+        seen["spec"] = spec
+        return image
+
+    child.obj = SimpleNamespace(polylogue=SimpleNamespace(compile_context=compile_context))
+    wrapped = getattr(query_verbs.continue_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._resolve_target_session_id", return_value="codex-session:abc123"):
+        wrapped(child, "terminal", None, "json")
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["spec"]["purpose"] == "continue"
+    assert emitted["spec"]["seed_refs"] == ["session:codex-session:abc123"]
+    assert emitted["segments"][0]["markdown"] == "Continue from here."
+    spec = seen["spec"]
+    assert spec.purpose == "continue"
+    assert spec.seed_refs == ("session:codex-session:abc123",)
+    assert spec.read_views == ("recovery",)
 
 
 def test_resolve_target_session_id_uses_query_terms(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/context/test_compiler.py
+++ b/tests/unit/context/test_compiler.py
@@ -6,7 +6,7 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.domain_models import Session
-from polylogue.context.compiler import compile_recovery_context
+from polylogue.context.compiler import ContextSpec, compile_recovery_context, context_image_from_recovery
 from polylogue.core.enums import Origin
 from polylogue.core.refs import EvidenceRef, ObjectRef
 from polylogue.insights.transforms import RecoveryWorkPacketEntry, compile_recovery_digest
@@ -70,6 +70,13 @@ def test_compiler_treats_digest_as_the_default_recovery_bundle() -> None:
         ObjectRef(kind="session", object_id="codex-session:compiler"),
         ObjectRef(kind="branch", object_id="feature/context-compiler"),
     )
+    assert compiled.context_image is not None
+    assert compiled.context_image.spec.seed_refs == ("session:codex-session:compiler",)
+    assert compiled.context_image.spec.read_views == ("recovery",)
+    assert compiled.context_image.segments[0].kind == "recovery"
+    assert compiled.context_image.segments[0].payload_kind == "recovery_digest"
+    assert compiled.context_image.segments[0].evidence_refs == compiled.evidence_refs
+    assert compiled.context_image.token_estimate > 0
 
 
 def test_compiler_renders_continue_report_without_work_packet_side_channel() -> None:
@@ -86,6 +93,9 @@ def test_compiler_renders_continue_report_without_work_packet_side_channel() -> 
     assert "Goal: unify continuation reports" in compiled.markdown
     assert "work_packet" not in compiled.kind
     assert "subagent_reports_missing" in compiled.caveats
+    assert compiled.context_image is not None
+    assert compiled.context_image.segments[0].title == "Recovery continue report"
+    assert compiled.context_image.segments[0].lossiness == "bounded_recovery_transform"
 
 
 def test_compiler_uses_supplied_work_packet_bundle_for_work_packet_report() -> None:
@@ -112,6 +122,11 @@ def test_compiler_uses_supplied_work_packet_bundle_for_work_packet_report() -> N
     assert compiled.object_refs == enriched_packet.target_refs
     assert "caveat" in compiled.caveats
     assert "subagents" in compiled.caveats
+    assert compiled.context_image is not None
+    assert compiled.context_image.spec.purpose == "handoff"
+    assert compiled.context_image.spec.read_views == ("work-packet",)
+    assert compiled.context_image.segments[0].payload_kind == "work_packet"
+    assert compiled.context_image.evidence_refs == enriched_packet.evidence_refs
 
 
 def test_compiler_rejects_parallel_packet_shape_for_non_packet_report() -> None:
@@ -122,3 +137,38 @@ def test_compiler_rejects_parallel_packet_shape_for_non_packet_report() -> None:
 
     with pytest.raises(ValueError, match="unsupported recovery report preset"):
         compile_recovery_context(digest, report="incident")
+
+
+def test_context_image_from_recovery_preserves_assertion_refs() -> None:
+    from polylogue.surfaces.payloads import AssertionClaimPayload
+
+    digest = compile_recovery_digest(_session())
+    claim = AssertionClaimPayload(
+        assertion_id="claim-1",
+        target_ref="session:codex-session:compiler",
+        kind="decision",
+        body_text="Keep context compilation evidence-backed.",
+        evidence_refs=("codex-session:compiler",),
+        status="active",
+        visibility="private",
+        context_policy={"inject": True},
+        created_at_ms=1,
+        updated_at_ms=1,
+    )
+    compiled = compile_recovery_context(digest, assertion_claims=(claim,))
+
+    image = context_image_from_recovery(compiled)
+
+    assert image.assertion_refs == ("claim-1",)
+    assert image.segments[0].assertion_refs == ("claim-1",)
+    assert image.segments[0].markdown is not None
+    assert "Assertion Claims" in image.segments[0].markdown
+
+
+def test_context_spec_requires_an_explicit_seed() -> None:
+    with pytest.raises(ValueError, match="requires seed_query or seed_refs"):
+        ContextSpec()
+
+    spec = ContextSpec(seed_query="sessions where repo:polylogue", max_tokens=1200)
+    assert spec.seed_query == "sessions where repo:polylogue"
+    assert spec.include_candidates is False

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -87,6 +87,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "get_session_summary": "single_object",
     "get_recovery_report": "single_object",
     "get_recovery_work_packet": "single_object",
+    "compile_context": "single_object",
     "archive_get_session": "single_object",
     "get_metadata": "single_object",
     "session_profile": "single_object",

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -985,6 +985,47 @@ class TestArchiveGenericToolSurfaces:
         mock_poly.recovery_work_packet.assert_awaited_once_with("missing")
 
     @pytest.mark.asyncio
+    async def test_compile_context_reads_shared_context_image(self: object, mcp_server: MCPServerUnderTest) -> None:
+        from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec
+
+        image = ContextImage(
+            spec=ContextSpec(seed_refs=("session:session-1",), read_views=("recovery", "work-packet")),
+            segments=(
+                ContextSegment(
+                    segment_id="recovery:session-1:recovery_digest",
+                    kind="recovery",
+                    title="Recovery digest",
+                    markdown="Resume with explicit evidence.",
+                    payload_kind="recovery_digest",
+                    evidence_refs=(EvidenceRef(session_id="session-1"),),
+                    token_estimate=4,
+                ),
+            ),
+            evidence_refs=(EvidenceRef(session_id="session-1"),),
+            token_estimate=4,
+        )
+        mock_poly = make_polylogue_mock()
+        mock_poly.compile_context.return_value = image
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["compile_context"].fn,
+                seed_ref="session:session-1",
+                read_views="recovery,work-packet",
+                max_tokens=1000,
+            )
+
+        payload = json.loads(result)
+        assert payload["spec"]["seed_refs"] == ["session:session-1"]
+        assert payload["spec"]["read_views"] == ["recovery", "work-packet"]
+        assert payload["segments"][0]["payload_kind"] == "recovery_digest"
+        assert payload["evidence_refs"][0]["session_id"] == "session-1"
+        called_spec = mock_poly.compile_context.await_args.args[0]
+        assert called_spec.seed_refs == ("session:session-1",)
+        assert called_spec.read_views == ("recovery", "work-packet")
+        assert called_spec.max_tokens == 1000
+
+    @pytest.mark.asyncio
     async def test_list_assertion_claims_reads_shared_facade_claims(
         self: object, mcp_server: MCPServerUnderTest
     ) -> None:

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -29,6 +29,7 @@ _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "search": {"query": "hello", "limit": 1},
     "query_units": {"expression": "messages where text:hello", "limit": 1},
     "resolve_ref": {"ref": f"session:{_SYNTHETIC_CONV_ID}"},
+    "compile_context": {"seed_ref": f"session:{_SYNTHETIC_CONV_ID}", "read_views": "recovery"},
     "blackboard_list": {},
     "get_session": {"id": _SYNTHETIC_CONV_ID},
     "get_session_summary": {"id": _SYNTHETIC_CONV_ID},


### PR DESCRIPTION
## Summary

Adds a generic `ContextSpec -> ContextImage` compiler for bounded successor-agent context, exposes it through the Python API, MCP, and `polylogue continue --format json`, and keeps the existing recovery/work-packet Markdown flows intact.

## Problem

Polylogue had recovery reports and work packets, but no shared machine payload for compiling a bounded continuation context from query/ref/read-view inputs. That left API/MCP/CLI continuation surfaces at risk of growing separate JSON shapes.

## Solution

- Adds typed context compiler models in `polylogue/context/compiler.py`: `ContextSpec`, `ContextImage`, `ContextSegment`, `ContextOmission`, and `ContextSnapshotRecord`.
- Implements `Polylogue.compile_context(...)` over seed session refs or a seed query, with recovery/work-packet read-view segments, budget omissions, caveats, and aggregate refs.
- Adds MCP `compile_context` plus envelope/tool-discovery coverage.
- Wires `polylogue continue --format json` to emit the shared `ContextImage` payload instead of a separate continuation JSON format.
- Updates CLI reference/help baselines and route catalog status text.

## Verification

- `devtools verify --seed-testmon --skip-slow` -> `11563 passed`, peak pytest tree RSS `3540.4 MB`.
- `devtools verify` -> `106 passed`, run `20260619T213412Z-testmon-3202253-c28a30f9`, peak pytest tree RSS `712.9 MB`.
- Pre-push `devtools verify --quick` -> all static/generated gates passed, run `20260619T213514Z-quick-3203565-97707b41`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format json` option to the `continue` command for JSON-formatted context output
  * New context compilation capability available via API and MCP interface

* **Documentation**
  * Updated CLI help text with examples demonstrating the `--format json` option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->