### PR TITLE
refactor(query): centralize terminal unit descriptors (#2177)

### DIFF
--- a/devtools/render_cli_output_schemas.py
+++ b/devtools/render_cli_output_schemas.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from devtools.command_catalog import control_plane_command
 from devtools.render_support import write_if_changed
+from polylogue.archive.query.metadata import terminal_query_source_list
 from polylogue.surfaces.payloads import (
     ImportExplainPayload,
     MachineErrorPayload,
@@ -136,7 +137,7 @@ SCHEMAS: tuple[CliOutputSchema, ...] = (
         title="Query Unit Envelope",
         description=(
             "Terminal row envelope for explicit "
-            "`messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...` "
+            f"`{terminal_query_source_list()} where ...` "
             "query-unit expressions. "
             "Shared by CLI JSON output, Python API, MCP, and daemon HTTP."
         ),

--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel
 
 from devtools.command_catalog import control_plane_command
 from devtools.render_support import write_if_changed
+from polylogue.archive.query.metadata import terminal_query_source_list
 from polylogue.surfaces.payloads import (
     RANKING_POLICY_MIXED,
     RANKING_POLICY_VERSION,
@@ -205,7 +206,7 @@ def _build_openapi_document() -> dict[str, Any]:
                     "summary": "Terminal query-unit rows",
                     "description": (
                         "Returns terminal row results for explicit "
-                        "``messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`` expressions. "
+                        f"``{terminal_query_source_list()} where ...`` expressions. "
                         "This endpoint shares the ``QueryUnitEnvelope`` contract "
                         "with CLI JSON output, MCP ``query_units``, and "
                         "``Polylogue.query_units()``."

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -95,7 +95,6 @@ from polylogue.archive.query.metadata import (
     _MESSAGE_STRUCTURAL_FIELDS,
     _OBSERVED_EVENT_STRUCTURAL_FIELDS,
     _RUN_STRUCTURAL_FIELDS,
-    _SOURCE_WHERE_SOURCES,
     _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS,
     COUNT_QUERY_FIELD_REGISTRY,
     DATE_QUERY_FIELD_REGISTRY,
@@ -109,8 +108,11 @@ from polylogue.archive.query.metadata import (
     count_query_operators,
     date_query_fields,
     date_query_operators,
+    query_unit_descriptor,
     structural_query_fields,
     structural_query_units,
+    terminal_query_source_pairs,
+    terminal_query_unit,
 )
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
@@ -996,7 +998,7 @@ def _is_boolean_expression(expression: str) -> bool:
         or lower.startswith("lineage:")
     ):
         return True
-    for source, _unit in _SOURCE_WHERE_SOURCES:
+    for source, _unit in terminal_query_source_pairs():
         marker = f"{source} where"
         if lower == marker or (lower.startswith(marker) and lower[len(marker)].isspace()):
             return True
@@ -1014,19 +1016,9 @@ def _is_boolean_expression(expression: str) -> bool:
 
 
 def _source_where_unit(source: str) -> QueryUnitName:
-    normalized = source.strip().lower()
-    if normalized in {"message", "messages"}:
-        return "message"
-    if normalized in {"action", "actions"}:
-        return "action"
-    if normalized in {"block", "blocks"}:
-        return "block"
-    if normalized in {"assertion", "assertions"}:
-        return "assertion"
-    if normalized in {"observed-event", "observed-events"}:
-        return "observed-event"
-    if normalized in {"context-snapshot", "context-snapshots"}:
-        return "context-snapshot"
+    unit = terminal_query_unit(source.strip().lower())
+    if unit is not None:
+        return unit
     raise ExpressionCompileError(f"unsupported query source {source!r}", field=None)
 
 
@@ -1250,7 +1242,7 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
         return pipeline_source
     lower = stripped.lower()
     source_match: tuple[str, QueryUnitName, str] | None = None
-    for source, unit in _SOURCE_WHERE_SOURCES:
+    for source, unit in terminal_query_source_pairs():
         marker = f"{source} where"
         if lower == marker:
             source_match = (marker, unit, "")
@@ -1269,9 +1261,8 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
 
 
 def _terminal_only_unit_source_error(unit: QueryUnitName) -> ExpressionCompileError:
-    source = f"{unit}s" if unit != "context-snapshot" else "context-snapshots"
-    if unit == "observed-event":
-        source = "observed-events"
+    descriptor = query_unit_descriptor(unit)
+    source = descriptor.plural_source if descriptor is not None else f"{unit}s"
     return ExpressionCompileError(
         f"{source} where expressions return terminal {unit} rows; "
         "use query_units / /api/query-units or a CLI terminal-unit query instead of a session selector",

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -7,6 +7,21 @@ from typing import Literal
 
 QueryUnitName = Literal["message", "action", "block", "assertion", "run", "observed-event", "context-snapshot"]
 
+
+@dataclass(frozen=True)
+class QueryUnitDescriptor:
+    """Executable query-unit metadata shared by parser, completions, and surfaces."""
+
+    unit: QueryUnitName
+    singular_source: str
+    plural_source: str
+    terminal_supported: bool = True
+
+    @property
+    def source_aliases(self) -> tuple[str, str]:
+        return (self.singular_source, self.plural_source)
+
+
 #: Recognized DSL field tokens and a short human description.
 #: ``spec_field`` values correspond to :class:`~polylogue.archive.query.spec.SessionQuerySpec`
 #: attribute names or the special tokens ``"min_messages"``, ``"max_messages"`` etc.
@@ -125,21 +140,20 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
     },
 }
 
-_SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = (
-    ("message", "message"),
-    ("messages", "message"),
-    ("action", "action"),
-    ("actions", "action"),
-    ("block", "block"),
-    ("blocks", "block"),
-    ("assertion", "assertion"),
-    ("assertions", "assertion"),
-    ("run", "run"),
-    ("runs", "run"),
-    ("observed-event", "observed-event"),
-    ("observed-events", "observed-event"),
-    ("context-snapshot", "context-snapshot"),
-    ("context-snapshots", "context-snapshot"),
+QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
+    QueryUnitDescriptor("message", "message", "messages"),
+    QueryUnitDescriptor("action", "action", "actions"),
+    QueryUnitDescriptor("block", "block", "blocks"),
+    QueryUnitDescriptor("assertion", "assertion", "assertions"),
+    QueryUnitDescriptor("run", "run", "runs"),
+    QueryUnitDescriptor("observed-event", "observed-event", "observed-events"),
+    QueryUnitDescriptor("context-snapshot", "context-snapshot", "context-snapshots"),
+)
+_QUERY_UNIT_BY_UNIT: dict[QueryUnitName, QueryUnitDescriptor] = {
+    descriptor.unit: descriptor for descriptor in QUERY_UNIT_DESCRIPTORS
+}
+_SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = tuple(
+    (source, descriptor.unit) for descriptor in QUERY_UNIT_DESCRIPTORS for source in descriptor.source_aliases
 )
 _BOOLEAN_SUPPORTED_FIELDS = {
     "repo",
@@ -558,7 +572,13 @@ def structural_query_field_info(unit: str, field: str) -> StructuralQueryFieldIn
 def terminal_query_sources() -> tuple[str, ...]:
     """Return source tokens accepted by the ``<source> where ...`` grammar."""
 
-    return tuple(sorted(source for source, _unit in _SOURCE_WHERE_SOURCES))
+    return tuple(sorted(source for source, _unit in terminal_query_source_pairs()))
+
+
+def terminal_query_source_pairs() -> tuple[tuple[str, QueryUnitName], ...]:
+    """Return accepted ``<source> where`` aliases and their canonical units."""
+
+    return _SOURCE_WHERE_SOURCES
 
 
 def terminal_query_unit(source: str) -> QueryUnitName | None:
@@ -569,6 +589,27 @@ def terminal_query_unit(source: str) -> QueryUnitName | None:
         if source_name == normalized:
             return unit
     return None
+
+
+def query_unit_descriptor(unit_or_source: str) -> QueryUnitDescriptor | None:
+    """Return the descriptor for a canonical unit or accepted source alias."""
+
+    normalized = unit_or_source.lower()
+    for descriptor in QUERY_UNIT_DESCRIPTORS:
+        if descriptor.unit == normalized or normalized in descriptor.source_aliases:
+            return descriptor
+    return None
+
+
+def terminal_query_source_list(*, plural: bool = True, separator: str = "/") -> str:
+    """Return a user-facing terminal query-unit source list."""
+
+    labels = [
+        descriptor.plural_source if plural else descriptor.singular_source
+        for descriptor in QUERY_UNIT_DESCRIPTORS
+        if descriptor.terminal_supported
+    ]
+    return separator.join(labels)
 
 
 def terminal_query_fields(source: str) -> tuple[str, ...]:
@@ -625,6 +666,8 @@ __all__ = [
     "DATE_QUERY_FIELD_REGISTRY",
     "DateQueryFieldInfo",
     "EXPRESSION_FIELD_REGISTRY",
+    "QUERY_UNIT_DESCRIPTORS",
+    "QueryUnitDescriptor",
     "QueryUnitName",
     "STRUCTURAL_QUERY_UNIT_REGISTRY",
     "StructuralQueryFieldInfo",
@@ -646,8 +689,11 @@ __all__ = [
     "structural_query_field_info",
     "structural_query_fields",
     "structural_query_units",
+    "query_unit_descriptor",
     "terminal_query_field_info",
     "terminal_query_fields",
+    "terminal_query_source_list",
+    "terminal_query_source_pairs",
     "terminal_query_sources",
     "terminal_query_unit",
 ]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2412,6 +2412,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         """``GET /api/query-units`` returns terminal query-unit rows."""
 
         from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
+        from polylogue.archive.query.metadata import terminal_query_source_list
         from polylogue.archive.query.spec import clamp_query_limit
         from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2427,7 +2428,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 HTTPStatus.BAD_REQUEST,
                 {
                     "error": "invalid_query",
-                    "message": "query-units requires a messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
+                    "message": (f"query-units requires a {terminal_query_source_list()} where expression"),
                 },
             )
             return

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -400,12 +400,13 @@ def archive_query_unit_payload(
 ) -> QueryUnitEnvelope:
     """Build the shared terminal query-unit envelope from an archive."""
     from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
+    from polylogue.archive.query.metadata import terminal_query_source_list
     from polylogue.archive.query.unit_results import query_unit_rows
 
     source = parse_unit_source_expression(expression)
     if source is None:
         raise ExpressionCompileError(
-            "query_units requires an explicit messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
+            f"query_units requires an explicit {terminal_query_source_list()} where expression",
             field=None,
         )
     return query_unit_rows(

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -51,3 +51,23 @@ def test_terminal_query_completion_payloads_are_lightweight() -> None:
     field_candidate = field_candidates[0]
     assert field_candidate["insert"] == "boundary:"
     assert field_candidate["kind"] == "query-terminal-field"
+
+
+def test_query_unit_descriptors_own_terminal_aliases() -> None:
+    from polylogue.archive.query.metadata import (
+        query_unit_descriptor,
+        terminal_query_source_list,
+        terminal_query_source_pairs,
+        terminal_query_unit,
+    )
+
+    observed_descriptor = query_unit_descriptor("observed-events")
+    context_descriptor = query_unit_descriptor("context-snapshot")
+    assert observed_descriptor is not None
+    assert context_descriptor is not None
+    assert terminal_query_unit("messages") == "message"
+    assert terminal_query_unit("context-snapshots") == "context-snapshot"
+    assert observed_descriptor.plural_source == "observed-events"
+    assert context_descriptor.source_aliases == ("context-snapshot", "context-snapshots")
+    assert terminal_query_source_list() == "messages/actions/blocks/assertions/runs/observed-events/context-snapshots"
+    assert ("assertions", "assertion") in terminal_query_source_pairs()


### PR DESCRIPTION
## Summary

Centralizes terminal query-unit source aliases and user-facing unit lists in `QueryUnitDescriptor` metadata. The parser, daemon/MCP error messages, and generated schema/OpenAPI descriptions now derive from the same query metadata instead of restating `messages/actions/blocks/assertions/runs/observed-events/context-snapshots` in several places.

## Problem

#2177 calls for existing contracts to own surfaces instead of leaving parallel dispatch and documentation lists around them. Terminal query units already had lightweight metadata for completions, but parser source aliasing, terminal-only error labels, daemon/MCP invalid-query messages, and generated docs still carried hard-coded source lists. Adding or renaming a query unit would require several manual updates.

## Solution

- Added `QueryUnitDescriptor` and `QUERY_UNIT_DESCRIPTORS` in `polylogue/archive/query/metadata.py`.
- Derived accepted `<source> where ...` aliases, canonical units, and slash-separated public source lists from the descriptor registry.
- Updated `archive/query/expression.py` to use descriptor helpers for terminal query detection, source normalization, and terminal-only error labels.
- Updated daemon and MCP query-unit error messages to use `terminal_query_source_list()`.
- Updated CLI output schema and OpenAPI renderers to derive their query-unit descriptions from the same metadata.
- Added metadata tests for alias normalization, descriptor lookup, and the public unit list.

Ref #2177.

## Verification

- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_query_expression.py -q && mypy polylogue/archive/query/metadata.py polylogue/archive/query/expression.py polylogue/daemon/http.py polylogue/mcp/archive_support.py tests/unit/archive/test_query_metadata.py` -> 269 passed; mypy clean.
- `devtools render cli-output-schemas && devtools render openapi && devtools render all --check` -> generated surfaces synced.
- `devtools verify --quick` -> run `20260619T225827Z-quick-3794363-61745c45`, all static/generated checks passed.
- `devtools verify --seed-testmon --skip-slow` -> run `20260619T225926Z-seed-testmon-3796816-ecf56ab5`, 11563 passed.
- `devtools verify` -> run `20260619T230436Z-testmon-3841388-1ce73cd3`, 7 affected tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API documentation and CLI schemas to reflect supported query sources with consistent definitions.

* **Improvements**
  * Standardized error messages to provide consistent guidance on supported query sources during query operations.

* **Tests**
  * Added test coverage for query unit metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->