### PR TITLE
feat(query): allow direct terminal pipeline stages (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -83,28 +83,30 @@ polylogue observed-events where 'delivery_state:acted_on AND text:#2100'
 polylogue context-snapshots where 'boundary:session_start AND session.repo:polylogue'
 ```
 
-The first executable pipeline form scopes a terminal row query through a
-session source stage:
+Pipeline stages can either decorate a direct terminal row query or scope one
+through a session source stage:
 
 ```bash
+polylogue 'messages where role:assistant | sort by time desc | limit 10'
+polylogue 'actions where action:file_edit | limit 20 | offset 40'
 polylogue 'sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant'
 polylogue 'sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit'
 polylogue 'sessions where repo:polylogue | messages where role:assistant | limit 10 | offset 20'
 polylogue 'sessions where repo:polylogue | messages where role:assistant | sort by time desc | limit 10'
 ```
 
-The left stage is lowered into `session.<field>` predicates on the terminal
-unit query, so it uses the same row executor as direct `messages/actions/...`
-queries. For now the session stage accepts field/count/date predicates only;
-FTS, semantic, `exists`, lineage, and sequence stages are typed errors until
-they have dedicated unit-changing lowerers. Terminal pipeline stages currently
-support `sort by time [asc|desc]`, `limit N`, and `offset N` for SQL-backed
-terminal rows (`messages`, `actions`, `blocks`, `assertions`). Query-string
-limits narrow the surface limit instead of expanding caller/API caps, and
-query-string offsets are added to the caller offset. Runtime-transform terminal
-rows (`runs`, `observed-events`, `context-snapshots`) reject sort stages until
-they have streaming lowerers; they must not collect every projected row in
-memory merely to sort a page.
+When a pipeline starts with `sessions where ...`, the left stage is lowered into
+`session.<field>` predicates on the terminal unit query, so it uses the same row
+executor as direct `messages/actions/...` pipelines. For now the session stage
+accepts field/count/date predicates only; FTS, semantic, `exists`, lineage, and
+sequence stages are typed errors until they have dedicated unit-changing
+lowerers. Terminal pipeline stages currently support `sort by time [asc|desc]`,
+`limit N`, and `offset N` for SQL-backed terminal rows (`messages`, `actions`,
+`blocks`, `assertions`). Query-string limits narrow the surface limit instead
+of expanding caller/API caps, and query-string offsets are added to the caller
+offset. Runtime-transform terminal rows (`runs`, `observed-events`,
+`context-snapshots`) reject sort stages until they have streaming lowerers;
+they must not collect every projected row in memory merely to sort a page.
 
 Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1198,31 +1198,66 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
     )
 
 
+def _parse_plain_unit_source_expression(expression: str) -> QueryUnitSource | None:
+    lower = expression.lower()
+    source_match: tuple[str, QueryUnitName, str] | None = None
+    for source, unit in terminal_query_source_pairs():
+        marker = f"{source} where"
+        if lower == marker:
+            source_match = (marker, unit, "")
+            break
+        if lower.startswith(marker) and lower[len(marker)].isspace():
+            source_match = (marker, unit, expression[len(marker) :].strip())
+            break
+    if source_match is None:
+        return None
+    _marker, unit, inner = source_match
+    if not inner:
+        raise ExpressionCompileError(f"{unit}s where requires a predicate", field=None)
+    transformed = _transform_boolean_predicate(inner)
+    _validate_predicate_context(transformed, unit=unit)
+    return QueryUnitSource(unit=unit, predicate=transformed)
+
+
 def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
     stages = _split_pipeline_stages(expression)
     if not stages:
         return None
     if len(stages) < 2:
         return None
-    session_stage, terminal_stage, *tail_stages = stages
-    session_predicate = _session_source_predicate(session_stage)
-    terminal_source = parse_unit_source_expression(terminal_stage)
-    if terminal_source is None:
-        raise ExpressionCompileError(
-            "pipeline terminal stage must be an executable `<unit>s where ...` query",
-            field=None,
+
+    first_stage, second_stage, *remaining_stages = stages
+    first_lower = first_stage.lower()
+    if first_lower.startswith("sessions where"):
+        session_predicate = _session_source_predicate(first_stage)
+        terminal_source = _parse_plain_unit_source_expression(second_stage)
+        if terminal_source is None:
+            raise ExpressionCompileError(
+                "pipeline terminal stage must be an executable `<unit>s where ...` query",
+                field=None,
+            )
+        scoped_session_predicate = _scope_session_predicate(session_predicate)
+        combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
+        _validate_predicate_context(combined, unit=terminal_source.unit)
+        source = QueryUnitSource(
+            unit=terminal_source.unit,
+            predicate=combined,
+            session_predicate=session_predicate,
+            limit=terminal_source.limit,
+            offset=terminal_source.offset,
+            sort=terminal_source.sort,
         )
-    scoped_session_predicate = _scope_session_predicate(session_predicate)
-    combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
-    _validate_predicate_context(combined, unit=terminal_source.unit)
-    source = QueryUnitSource(
-        unit=terminal_source.unit,
-        predicate=combined,
-        session_predicate=session_predicate,
-        limit=terminal_source.limit,
-        offset=terminal_source.offset,
-        sort=terminal_source.sort,
-    )
+        tail_stages = tuple(remaining_stages)
+    else:
+        direct_source = _parse_plain_unit_source_expression(first_stage)
+        if direct_source is None:
+            raise ExpressionCompileError(
+                "pipeline queries must start with `sessions where ...` or an executable `<unit>s where ...` query",
+                field=None,
+            )
+        source = direct_source
+        tail_stages = (second_stage, *remaining_stages)
+
     for stage in tail_stages:
         source = _apply_pipeline_stage(source, stage)
     return source
@@ -1240,24 +1275,7 @@ def parse_unit_source_expression(expression: str) -> QueryUnitSource | None:
     pipeline_source = _parse_pipeline_unit_source(stripped)
     if pipeline_source is not None:
         return pipeline_source
-    lower = stripped.lower()
-    source_match: tuple[str, QueryUnitName, str] | None = None
-    for source, unit in terminal_query_source_pairs():
-        marker = f"{source} where"
-        if lower == marker:
-            source_match = (marker, unit, "")
-            break
-        if lower.startswith(marker) and lower[len(marker)].isspace():
-            source_match = (marker, unit, stripped[len(marker) :].strip())
-            break
-    if source_match is None:
-        return None
-    _marker, unit, inner = source_match
-    if not inner:
-        raise ExpressionCompileError(f"{unit}s where requires a predicate", field=None)
-    transformed = _transform_boolean_predicate(inner)
-    _validate_predicate_context(transformed, unit=unit)
-    return QueryUnitSource(unit=unit, predicate=transformed)
+    return _parse_plain_unit_source_expression(stripped)
 
 
 def _terminal_only_unit_source_error(unit: QueryUnitName) -> ExpressionCompileError:
@@ -1274,6 +1292,16 @@ def _parse_source_where_predicate(expression: str) -> QueryExistsPredicate | Non
     source = parse_unit_source_expression(expression)
     if source is None:
         return None
+    if (
+        source.session_predicate is not None
+        or source.limit is not None
+        or source.offset is not None
+        or source.sort is not None
+    ):
+        raise ExpressionCompileError(
+            "pipeline unit queries return terminal rows; use query_units / /api/query-units or a CLI terminal-unit query",
+            field=None,
+        )
     if source.unit in {"run", "observed-event", "context-snapshot"}:
         raise _terminal_only_unit_source_error(source.unit)
     return QueryExistsPredicate(unit=cast(Any, source.unit), child=source.predicate)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -474,6 +474,19 @@ class TestBooleanQueryExpression:
         assert source.limit == 2
         assert source.offset == 3
 
+    def test_terminal_source_pipeline_limit_offset_and_sort_are_parsed(self) -> None:
+        source = parse_unit_source_expression("messages where role:assistant | sort by time desc | limit 2 | offset 3")
+
+        assert source is not None
+        assert source.unit == "message"
+        assert source.session_predicate is None
+        assert source.limit == 2
+        assert source.offset == 3
+        assert source.sort is not None
+        assert source.sort.field == "time"
+        assert source.sort.direction == "desc"
+        assert source.predicate == QueryFieldPredicate(field="role", values=("assistant",))
+
     def test_pipeline_sort_stage_is_parsed(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue | messages where role:assistant | sort by time desc"
@@ -499,6 +512,13 @@ class TestBooleanQueryExpression:
     def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
         with pytest.raises(ExpressionCompileError, match="FTS, semantic, exists, lineage, and sequence"):
             parse_unit_source_expression('sessions where ~"timeout" | messages where role:assistant')
+
+    def test_compile_expression_rejects_terminal_pipelines_as_session_selector(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="pipeline unit queries return terminal rows"):
+            compile_expression("messages where role:assistant | limit 10")
+
+        with pytest.raises(ExpressionCompileError, match="pipeline unit queries return terminal rows"):
+            compile_expression("sessions where repo:polylogue | messages where role:assistant")
 
     def test_assertion_source_where_lowers_to_structural_exists(self) -> None:
         ast = parse_expression_ast("assertions where kind:decision AND text:review")
@@ -1062,6 +1082,40 @@ class TestBooleanQueryExpression:
         assert isinstance(next_row, MessageQueryRowPayload)
         assert next_row.message_id == "claude-code-session:ext-hit:m-3"
         assert next_row.text == "third"
+
+    def test_terminal_source_pipeline_sort_desc_executes_before_limit(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("direct pipeline sorted")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .add_message("m-new", role="assistant", text="new", timestamp="2026-01-02T00:00:00+00:00")
+            .save()
+        )
+
+        source = parse_unit_source_expression("messages where role:assistant | sort by time desc | limit 1")
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="direct-pipeline-sort", limit=20)
+
+        assert envelope.limit == 1
+        assert envelope.next_offset == 1
+        assert len(envelope.items) == 1
+        row = envelope.items[0]
+        from polylogue.surfaces.payloads import MessageQueryRowPayload
+
+        assert isinstance(row, MessageQueryRowPayload)
+        assert row.message_id == "claude-code-session:ext-hit:m-new"
+        assert row.text == "new"
 
     def test_session_to_message_pipeline_sort_desc_executes_before_limit(
         self,


### PR DESCRIPTION
## Summary

Allows terminal query-unit expressions to use pipeline stages directly, without forcing an initial `sessions where ...` source stage. Queries such as `messages where role:assistant | sort by time desc | limit 10` now parse and execute as terminal row queries.

## Problem

The query DSL already supported scoped terminal pipelines like `sessions where repo:polylogue | messages where role:assistant | limit 10`, but direct terminal row queries could not be decorated with the same `sort by time`, `limit`, and `offset` stages. That made the terminal-unit path less complete than the documented query pipeline model and forced unnecessary session-source boilerplate.

## Solution

- Split plain terminal-unit parsing from pipeline parsing in `polylogue/archive/query/expression.py`.
- Accept either `sessions where ... | <unit>s where ...` or direct `<unit>s where ... | ...` pipeline starts.
- Keep pipeline terminal queries rejected from session-selector compilation so they cannot silently broaden into normal session search.
- Document direct terminal pipelines in `docs/search.md`.
- Add parser and execution coverage in `tests/unit/cli/test_query_expression.py`, including sort-before-limit behavior for direct message pipelines.

This was mined from `/realm/inbox/download/polylogue-turbo-closure.patch`, then ported onto the current descriptor-based query parser from #2198 rather than applied blindly.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -q` → `269 passed`.
- `mypy polylogue/archive/query/expression.py tests/unit/cli/test_query_expression.py` → `Success: no issues found in 2 source files`.
- `devtools verify --quick` → exit code 0 (`20260619T231817Z-quick-3934483-7529f7da`).
- Pre-push `devtools verify --quick` → exit code 0 (`20260619T231903Z-quick-3946039-50408390`).

Ref #2006