### PR TITLE
feat(api): expose import explain payloads (#2178)

### DIFF
--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -292,6 +292,10 @@ async def main():
         # Parse files
         result = await archive.parse_file("chatgpt_export.json")
 
+        # Explain import decisions without writing archive rows
+        explain = await archive.explain_import("chatgpt_export.json", source_name="chatgpt")
+        print(explain.produced.sessions, explain.entries[0].provider)
+
         # Fluent filter (terminals are async)
         convs = await archive.filter().origin("claude-ai-export").contains("error").limit(10).list()
 
@@ -311,6 +315,7 @@ asyncio.run(main())
 | `search(query, limit, source, since)` | Search returning evidence snippets; text matches report message evidence and Drive/Gemini `provider_id` / `id` / `fileId` / `driveId` attachment-id matches report attachment evidence |
 | `parse_file(path, source_name)` | Parse a single export file |
 | `parse_sources(sources, download_assets)` | Parse from configured sources |
+| `explain_import(path, source_name, limit)` | Explain provider detection, artifact classification, parser mode, produced row counts, skips, and caveats without writing archive rows |
 | `rebuild_index()` | Rebuild FTS5 search index |
 | `stats()` | Archive statistics (returns `ArchiveStats`) |
 | `filter()` | Fluent filter builder (sync, reuses `SessionFilter`) |

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
         BulkTagMutationResult,
         DeleteSessionResult,
         FacetsResponse,
+        ImportExplainPayload,
         MetadataMutationResult,
         PublicRefResolutionPayload,
         QueryUnitEnvelope,
@@ -1240,6 +1241,18 @@ class PolylogueArchiveMixin:
             if content_projection is None or not content_projection.filters_content():
                 return session
             return session.with_content_projection(content_projection)
+
+    async def explain_import(
+        self,
+        path: str | Path,
+        *,
+        source_name: str = "unknown",
+        limit: int = 100,
+    ) -> ImportExplainPayload:
+        """Explain detector/parser decisions for a local import path without writing archive rows."""
+        from polylogue.sources.import_explain import explain_import_path
+
+        return explain_import_path(Path(path), source_name=source_name, limit=limit)
 
     async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:
         """Compile one resolved session and its child links into a recovery digest."""

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import shutil
 import sqlite3
 from collections.abc import Iterable
 from pathlib import Path
@@ -227,6 +228,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "list_blackboard_notes",
         "post_blackboard_note",
         # Shared web/MCP payload DTO helpers covered by daemon/MCP surface tests.
+        "explain_import",
         "list_assertion_claim_payloads",
         "neighbor_candidate_payloads",
         "recovery_read_payload",
@@ -804,6 +806,46 @@ async def test_explain_query_expression_exposes_runtime_transform_unit_payload(t
         lowering_plan = cast(dict[str, object], payload["lowering_plan"])
         assert "compatibility_selector" not in lowering_plan
         assert payload["predicate"]
+    finally:
+        await archive.close()
+
+
+async def test_explain_import_exposes_shared_import_payload(tmp_path: Path) -> None:
+    """``explain_import`` exposes the same bounded payload as ``polylogue import --explain``."""
+    source = Path("tests/data/codex_event_stream/text_only_stream.jsonl")
+    target = tmp_path / "session.jsonl"
+    shutil.copy2(source, target)
+
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_import(target, source_name="codex")
+
+        assert payload.mode == "import-explain"
+        assert payload.produced.sessions == 1
+        assert payload.produced.messages >= 1
+        assert payload.entries[0].detected_provider == "codex"
+        assert payload.entries[0].detected_origin == "codex-session"
+        assert payload.entries[0].parser_mode == "grouped_records"
+        assert payload.entries[0].produced.session_refs
+    finally:
+        await archive.close()
+
+
+async def test_explain_import_reports_bounded_decode_failure(tmp_path: Path) -> None:
+    """``explain_import`` reports malformed local input without exposing raw bytes."""
+    target = tmp_path / "broken.json"
+    target.write_text("{not json", encoding="utf-8")
+
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_import(target)
+
+        assert payload.produced.sessions == 0
+        assert payload.skipped
+        assert payload.skipped[0].reason.startswith("decode failure:")
+        rendered = payload.to_json(exclude_none=True)
+        assert "{not json" not in rendered
+        assert "raw_bytes" not in rendered
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Adds `Polylogue.explain_import(...)` as the Python API counterpart to the existing `polylogue import PATH --explain` CLI path. The method returns the shared `ImportExplainPayload` without writing archive rows, so library callers can inspect provider detection, parser mode, produced counts, skips, and caveats directly.

## Problem

#2178 already has a CLI vertical for ImportExplain, but the explanation surface was not reusable from the async facade. That left Python/API consumers either shelling out to the CLI or reimplementing the local-path explanation helper, while the issue's next slices need shared API/MCP/daemon/web reuse.

## Solution

- Add `PolylogueArchiveMixin.explain_import(path, source_name="unknown", limit=100)` and delegate to the existing `polylogue.sources.import_explain.explain_import_path` helper.
- Categorize the method in the facade contract tests as a bespoke payload helper.
- Add focused tests for a successful Codex JSONL explanation and for malformed input staying bounded/no-raw-bytes.
- Document the method in `docs/library-api.md`.

This does not close #2178. Raw/source-ref lookup plus daemon/MCP/web reuse remain owned by the issue.

## Verification

- `devtools test tests/unit/api/test_facade_contracts.py -k "explain_import or undiscovered_async_methods or public_async_methods_have_return_annotations" -q` -> 4 passed, 213 deselected.
- `devtools verify --quick` -> exit_code 0.

Ref #2178