### PR TITLE
refactor(devtools): bind generated surfaces to contract owners (#2177)

### DIFF
--- a/devtools/generated_surfaces.py
+++ b/devtools/generated_surfaces.py
@@ -56,6 +56,9 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         main=render_cli_reference.main,
         inputs=(
             "polylogue/cli/",
+            "polylogue/archive/query/metadata.py",
+            "polylogue/archive/viewport/profiles.py",
+            "polylogue/operations/action_contracts.py",
             "polylogue/surfaces/payloads.py",
             "polylogue/sources/provider_completeness.py",
             "devtools/render_cli_reference.py",
@@ -70,7 +73,11 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         description="Render JSON Schema artifacts for stable CLI output payloads (#1272).",
         command=control_plane_argv("render cli-output-schemas"),
         main=render_cli_output_schemas.main,
-        inputs=("polylogue/surfaces/payloads.py", "devtools/render_cli_output_schemas.py"),
+        inputs=(
+            "polylogue/archive/query/metadata.py",
+            "polylogue/surfaces/payloads.py",
+            "devtools/render_cli_output_schemas.py",
+        ),
     ),
     GeneratedSurface(
         name="openapi",
@@ -79,6 +86,9 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
         command=control_plane_argv("render openapi"),
         main=render_openapi.main,
         inputs=(
+            "polylogue/archive/query/metadata.py",
+            "polylogue/archive/viewport/profiles.py",
+            "polylogue/daemon/route_contracts.py",
             "polylogue/surfaces/payloads.py",
             "polylogue/sources/provider_completeness.py",
             "devtools/render_openapi.py",

--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 from devtools.command_catalog import control_plane_command
 from devtools.render_support import write_if_changed
 from polylogue.archive.query.metadata import terminal_query_source_list
+from polylogue.daemon.route_contracts import ROUTE_CONTRACTS, RouteContract
 from polylogue.surfaces.payloads import (
     RANKING_POLICY_MIXED,
     RANKING_POLICY_VERSION,
@@ -57,6 +58,21 @@ _PUBLISHED_MODELS: tuple[type[BaseModel], ...] = (
     SessionSearchHitPayload,
     SessionListRowPayload,
 )
+
+
+def _route_contract_payload(contract: RouteContract) -> dict[str, str]:
+    """Return the OpenAPI vendor-extension shape for one daemon route contract."""
+    payload = {
+        "method": contract.method,
+        "pattern": contract.pattern,
+        "kind": contract.kind,
+        "stability": contract.stability,
+        "auth_policy": contract.auth_policy,
+        "response_contract": contract.response_contract,
+    }
+    if contract.notes:
+        payload["notes"] = contract.notes
+    return payload
 
 
 def _collect_component_schemas() -> dict[str, Any]:
@@ -658,6 +674,7 @@ def _build_openapi_document() -> dict[str, Any]:
                 ),
             },
         },
+        "x-polylogue-route-contracts": [_route_contract_payload(contract) for contract in ROUTE_CONTRACTS],
     }
 
 

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1776,3 +1776,414 @@ components:
     version: '1'
     description: The ``ranking_policy`` and ``ranking_policy_version`` fields on ``SearchEnvelope`` declare the ordering semantics
       in use. Consumers should pin a known version and treat any change as a contract event.
+x-polylogue-route-contracts:
+- method: GET
+  pattern: /
+  kind: browser_shell
+  stability: shell_supported
+  auth_policy: unauthenticated_loopback
+  response_contract: text/html web shell
+  notes: HTML bootstrap only; shell JavaScript calls authenticated /api routes.
+- method: GET
+  pattern: /s/:session_id
+  kind: browser_shell
+  stability: shell_supported
+  auth_policy: unauthenticated_loopback
+  response_contract: text/html web shell
+  notes: Session deep-link bootstrap.
+- method: GET
+  pattern: /w/:mode
+  kind: browser_shell
+  stability: shell_supported
+  auth_policy: unauthenticated_loopback
+  response_contract: text/html web shell
+  notes: Workspace shell bootstrap for registered workspace modes.
+- method: GET
+  pattern: /p
+  kind: browser_shell
+  stability: shell_supported
+  auth_policy: unauthenticated_loopback
+  response_contract: text/html paste browser
+  notes: Standalone reader page; archive API calls remain authenticated.
+- method: GET
+  pattern: /a
+  kind: browser_shell
+  stability: shell_supported
+  auth_policy: unauthenticated_loopback
+  response_contract: text/html attachment library
+  notes: Standalone reader page; archive API calls remain authenticated.
+- method: GET
+  pattern: /healthz/live
+  kind: operational
+  stability: operational
+  auth_policy: unauthenticated_loopback
+  response_contract: health liveness JSON
+  notes: Unauthenticated for systemd/docker/kubernetes probes.
+- method: GET
+  pattern: /healthz/ready
+  kind: operational
+  stability: operational
+  auth_policy: unauthenticated_loopback
+  response_contract: health readiness JSON
+  notes: Unauthenticated for systemd/docker/kubernetes probes.
+- method: GET
+  pattern: /metrics
+  kind: operational
+  stability: operational
+  auth_policy: unauthenticated_loopback
+  response_contract: Prometheus text exposition
+  notes: Unauthenticated for Prometheus scrapers; no raw archive content.
+- method: POST
+  pattern: /v1/traces
+  kind: observability
+  stability: private
+  auth_policy: observability_flag_then_loopback_or_bearer
+  response_contract: OTLP protobuf response
+- method: POST
+  pattern: /v1/metrics
+  kind: observability
+  stability: private
+  auth_policy: observability_flag_then_loopback_or_bearer
+  response_contract: OTLP protobuf response
+- method: POST
+  pattern: /v1/logs
+  kind: observability
+  stability: private
+  auth_policy: observability_flag_then_loopback_or_bearer
+  response_contract: OTLP protobuf response
+- method: GET
+  pattern: /api/health/check
+  kind: operational
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: JSON
+- method: GET
+  pattern: /api/health
+  kind: operational
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: JSON
+- method: GET
+  pattern: /api/status
+  kind: operational
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: Daemon status JSON
+- method: GET
+  pattern: /api/events
+  kind: operational
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: SSE or JSON event poll
+- method: GET
+  pattern: /api/sessions
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: SearchEnvelope
+- method: GET
+  pattern: /api/facets
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: Facets envelope
+- method: GET
+  pattern: /api/query-units
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: QueryUnitEnvelope
+- method: GET
+  pattern: /api/refs/resolve
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: PublicRefResolutionPayload
+- method: GET
+  pattern: /api/query-completions
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: query completion metadata
+- method: GET
+  pattern: /api/read-view-profiles
+  kind: read_query
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: read-view profile metadata
+- method: GET
+  pattern: /api/assertions
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: AssertionClaimListPayload
+  notes: Read-only assertion-backed overlay claims shared by the web workbench and API clients.
+- method: GET
+  pattern: /api/sources
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: source list JSON
+- method: GET
+  pattern: /api/sessions/:id
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: Session detail JSON
+- method: GET
+  pattern: /api/sessions/:id/messages
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: session messages JSON
+- method: GET
+  pattern: /api/sessions/:id/recovery
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: RecoveryReadPayload
+  notes: Consumes shared recovery digest/work-packet DTOs for the local workbench and API clients.
+- method: GET
+  pattern: /api/sessions/:id/read
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: SessionReadViewEnvelope
+  notes: Executes supported single-session read profiles over shared DTO/facade payload helpers.
+- method: GET
+  pattern: /api/sessions/:id/raw
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: raw session payload JSON
+  notes: Raw preview is opt-in and authenticated.
+- method: GET
+  pattern: /api/sessions/:id/cost
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: cost JSON
+- method: GET
+  pattern: /api/sessions/:id/provenance
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: provenance envelope
+  notes: Raw bytes require the include_raw query parameter.
+- method: GET
+  pattern: /api/sessions/:id/topology
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: topology envelope
+- method: GET
+  pattern: /api/sessions/:id/topology/parent-chain
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: parent-chain topology envelope
+- method: GET
+  pattern: /api/sessions/:id/similar
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: similar-session envelope
+- method: GET
+  pattern: /api/sessions/:id/attachments
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: session attachment envelope
+- method: GET
+  pattern: /api/insights/sessions/:id
+  kind: read_detail
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: session insights envelope
+- method: GET
+  pattern: /api/raw_artifacts/:id
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: raw artifact preview
+  notes: Authenticated raw preview helper for the local shell.
+- method: GET
+  pattern: /api/thread-continue-templates
+  kind: read_detail
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: thread continuation templates
+- method: GET
+  pattern: /api/paste-browser
+  kind: read_query
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: paste browser JSON
+- method: GET
+  pattern: /api/attachments
+  kind: read_query
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: attachment library JSON
+- method: GET
+  pattern: /api/stack
+  kind: workspace
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: stack workspace JSON
+- method: GET
+  pattern: /api/compare
+  kind: workspace
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: compare workspace JSON
+- method: GET
+  pattern: /api/user/marks
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: marks JSON
+- method: GET
+  pattern: /api/user/annotations
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: annotations JSON
+- method: GET
+  pattern: /api/user/annotations/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: annotation JSON
+- method: GET
+  pattern: /api/user/saved-views
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: saved views JSON
+- method: GET
+  pattern: /api/user/saved-views/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: saved view JSON
+- method: GET
+  pattern: /api/user/recall-packs
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: recall packs JSON
+- method: GET
+  pattern: /api/user/recall-packs/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: recall pack JSON
+- method: GET
+  pattern: /api/user/workspaces
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: workspaces JSON
+- method: GET
+  pattern: /api/user/workspaces/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: workspace JSON
+- method: GET
+  pattern: /api/maintenance/operations
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: maintenance operations JSON
+- method: GET
+  pattern: /api/maintenance/status/:id
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_if_configured
+  response_contract: maintenance operation status JSON
+- method: POST
+  pattern: /api/reset
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: reset result JSON
+- method: POST
+  pattern: /api/ingest
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: ingest result JSON
+- method: POST
+  pattern: /api/maintenance/plan
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: maintenance operation preview
+- method: POST
+  pattern: /api/maintenance/run
+  kind: maintenance
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: maintenance operation result
+- method: POST
+  pattern: /api/user/marks
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: POST
+  pattern: /api/user/annotations
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: POST
+  pattern: /api/user/saved-views
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: POST
+  pattern: /api/user/recall-packs
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: POST
+  pattern: /api/user/workspaces
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: DELETE
+  pattern: /api/user/marks
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: DELETE
+  pattern: /api/user/annotations/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: DELETE
+  pattern: /api/user/saved-views/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: DELETE
+  pattern: /api/user/recall-packs/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope
+- method: DELETE
+  pattern: /api/user/workspaces/:id
+  kind: user_overlay
+  stability: stable
+  auth_policy: bearer_and_same_origin
+  response_contract: mutation envelope

--- a/tests/unit/devtools/test_generated_surfaces.py
+++ b/tests/unit/devtools/test_generated_surfaces.py
@@ -5,6 +5,13 @@ from pathlib import Path
 from devtools.generated_surfaces import GENERATED_SURFACES
 
 
+def _surface_inputs(name: str) -> set[str]:
+    for surface in GENERATED_SURFACES:
+        if surface.name == name:
+            return set(surface.inputs)
+    raise AssertionError(f"unknown generated surface: {name}")
+
+
 def test_generated_surfaces_use_public_devtools_commands() -> None:
     assert GENERATED_SURFACES
     for surface in GENERATED_SURFACES:
@@ -24,3 +31,25 @@ def test_generated_surface_cache_inputs_include_renderer_module() -> None:
     for surface in GENERATED_SURFACES:
         renderer_path = Path(*surface.main.__module__.split(".")).with_suffix(".py").as_posix()
         assert renderer_path in surface.inputs, surface.name
+
+
+def test_generated_surface_cache_inputs_include_contract_owners() -> None:
+    """Contract-owner edits must invalidate generated surfaces that publish them."""
+    assert {
+        "polylogue/archive/query/metadata.py",
+        "polylogue/archive/viewport/profiles.py",
+        "polylogue/operations/action_contracts.py",
+        "polylogue/surfaces/payloads.py",
+    }.issubset(_surface_inputs("cli-reference"))
+
+    assert {
+        "polylogue/archive/query/metadata.py",
+        "polylogue/surfaces/payloads.py",
+    }.issubset(_surface_inputs("cli-output-schemas"))
+
+    assert {
+        "polylogue/archive/query/metadata.py",
+        "polylogue/archive/viewport/profiles.py",
+        "polylogue/daemon/route_contracts.py",
+        "polylogue/surfaces/payloads.py",
+    }.issubset(_surface_inputs("openapi"))

--- a/tests/unit/devtools/test_render_openapi.py
+++ b/tests/unit/devtools/test_render_openapi.py
@@ -21,3 +21,19 @@ def test_openapi_publishes_stable_evidence_routes() -> None:
     }
     assert "RecoveryReadPayload" in schemas
     assert "AssertionClaimListPayload" in schemas
+
+
+def test_openapi_publishes_route_contract_extension() -> None:
+    document = _build_openapi_document()
+    contracts = document["x-polylogue-route-contracts"]
+
+    contract_by_pattern = {(contract["method"], contract["pattern"]): contract for contract in contracts}
+    query_units = contract_by_pattern[("GET", "/api/query-units")]
+    recovery = contract_by_pattern[("GET", "/api/sessions/:id/recovery")]
+
+    assert query_units["kind"] == "read_query"
+    assert query_units["stability"] == "stable"
+    assert query_units["response_contract"] == "QueryUnitEnvelope"
+    assert recovery["kind"] == "read_detail"
+    assert recovery["auth_policy"] == "bearer_if_configured"
+    assert recovery["response_contract"] == "RecoveryReadPayload"


### PR DESCRIPTION
## Summary

Binds generated-surface cache invalidation and OpenAPI output to the contract files that actually shape the published surfaces. Route contracts are now rendered into OpenAPI as a `x-polylogue-route-contracts` extension, and render-all input stamps include query metadata, read-view profiles, action contracts, route contracts, and payload schemas where those surfaces publish them.

## Problem

#2177 tracks cleanup where contracts should own behavior instead of parallel hand-written surfaces. The generated-surface registry still missed several contract owners, so changes to query units, read-view profiles, action contracts, or daemon route contracts could fail to invalidate the corresponding generated artifact. OpenAPI also described itself as route-backed without carrying the route-contract metadata.

## Solution

- Add `x-polylogue-route-contracts` to the generated OpenAPI document from `polylogue.daemon.route_contracts.ROUTE_CONTRACTS`.
- Add route/query/read-view/action contract owner files to the relevant `GeneratedSurface.inputs` entries.
- Add devtools tests proving generated-surface inputs include those owners.
- Extend the OpenAPI renderer test to assert route-contract metadata is published for representative query/read routes.

This is one #2177 slice; it does not attempt the larger read-view handler or daemon dispatcher refactors.

## Verification

- `devtools test tests/unit/devtools/test_generated_surfaces.py tests/unit/devtools/test_render_openapi.py -q` -> 6 passed.
- `devtools verify --quick` -> exit_code 0.

Ref #2177