### PR TITLE
feat(context): record delivered context snapshots (#2193)

### DIFF
--- a/polylogue/context/__init__.py
+++ b/polylogue/context/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "compile_recovery_context",
     "compose_context_preamble",
     "context_image_from_recovery",
+    "context_snapshot_record_from_image",
     "run_context_pack_view",
 ]
 
@@ -28,6 +29,10 @@ def __getattr__(name: str) -> object:
         from polylogue.context.compiler import context_image_from_recovery
 
         return context_image_from_recovery
+    if name == "context_snapshot_record_from_image":
+        from polylogue.context.compiler import context_snapshot_record_from_image
+
+        return context_snapshot_record_from_image
     if name == "compose_context_preamble":
         from polylogue.context.preamble import compose_context_preamble
 

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -100,7 +100,7 @@ class ContextSnapshotRecord(ArchiveInsightModel):
     inheritance_mode: str = "explicit"
     segment_refs: tuple[str, ...] = ()
     evidence_refs: tuple[EvidenceRef, ...] = ()
-    metadata: dict[str, object] = Field(default_factory=dict)
+    metadata: dict[str, str] = Field(default_factory=dict)
 
 
 class RecoveryContextCompilation(ArchiveInsightModel):
@@ -257,20 +257,20 @@ def context_snapshot_record_from_image(
     boundary, then persist or emit the returned record through the surface that
     actually performed the handoff.
     """
-    if not boundary:
+    if not boundary.strip():
         raise ValueError("ContextSnapshotRecord requires a delivery boundary")
     segment_refs = tuple(segment.segment_id for segment in image.segments)
-    metadata: dict[str, object] = {
-        "purpose": image.spec.purpose,
-        "read_views": image.spec.read_views,
-        "max_tokens": image.spec.max_tokens,
-        "token_estimate": image.token_estimate,
-        "include_assertions": image.spec.include_assertions,
-        "include_candidates": image.spec.include_candidates,
-        "redaction_policy": image.spec.redaction_policy,
-        "omitted_count": len(image.omitted),
-        "assertion_refs": image.assertion_refs,
-        "caveats": image.caveats,
+    metadata: dict[str, str] = {
+        "purpose": _metadata_value_to_text(image.spec.purpose),
+        "read_views": _metadata_value_to_text(image.spec.read_views),
+        "max_tokens": _metadata_value_to_text(image.spec.max_tokens),
+        "token_estimate": _metadata_value_to_text(image.token_estimate),
+        "include_assertions": _metadata_value_to_text(image.spec.include_assertions),
+        "include_candidates": _metadata_value_to_text(image.spec.include_candidates),
+        "redaction_policy": _metadata_value_to_text(image.spec.redaction_policy),
+        "omitted_count": _metadata_value_to_text(len(image.omitted)),
+        "assertion_refs": _metadata_value_to_text(image.assertion_refs),
+        "caveats": _metadata_value_to_text(image.caveats),
     }
     fingerprint_payload = {
         "boundary": boundary,
@@ -290,6 +290,12 @@ def context_snapshot_record_from_image(
         evidence_refs=image.evidence_refs,
         metadata=metadata,
     )
+
+
+def _metadata_value_to_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
 def _attach_context_image(compilation: RecoveryContextCompilation) -> RecoveryContextCompilation:

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -8,6 +8,8 @@ shape that CLI/API/MCP surfaces can share.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Sequence
 from typing import Literal, cast
 
@@ -242,6 +244,54 @@ def context_image_from_recovery(compilation: RecoveryContextCompilation) -> Cont
     )
 
 
+def context_snapshot_record_from_image(
+    image: ContextImage,
+    *,
+    boundary: str,
+    run_ref: str | None = None,
+    inheritance_mode: str = "explicit",
+) -> ContextSnapshotRecord:
+    """Build a storage-free evidence record for delivered context.
+
+    Compilation remains pure. Callers use this helper only at a delivery
+    boundary, then persist or emit the returned record through the surface that
+    actually performed the handoff.
+    """
+    if not boundary:
+        raise ValueError("ContextSnapshotRecord requires a delivery boundary")
+    segment_refs = tuple(segment.segment_id for segment in image.segments)
+    metadata: dict[str, object] = {
+        "purpose": image.spec.purpose,
+        "read_views": image.spec.read_views,
+        "max_tokens": image.spec.max_tokens,
+        "token_estimate": image.token_estimate,
+        "include_assertions": image.spec.include_assertions,
+        "include_candidates": image.spec.include_candidates,
+        "redaction_policy": image.spec.redaction_policy,
+        "omitted_count": len(image.omitted),
+        "assertion_refs": image.assertion_refs,
+        "caveats": image.caveats,
+    }
+    fingerprint_payload = {
+        "boundary": boundary,
+        "run_ref": run_ref,
+        "inheritance_mode": inheritance_mode,
+        "segment_refs": segment_refs,
+        "evidence_refs": tuple(ref.format() for ref in image.evidence_refs),
+        "metadata": metadata,
+    }
+    fingerprint = hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+    return ContextSnapshotRecord(
+        snapshot_ref=f"context-snapshot:{fingerprint}",
+        run_ref=run_ref,
+        boundary=boundary,
+        inheritance_mode=inheritance_mode,
+        segment_refs=segment_refs,
+        evidence_refs=image.evidence_refs,
+        metadata=metadata,
+    )
+
+
 def _attach_context_image(compilation: RecoveryContextCompilation) -> RecoveryContextCompilation:
     return compilation.model_copy(update={"context_image": context_image_from_recovery(compilation)})
 
@@ -310,4 +360,5 @@ __all__ = [
     "RecoveryContextKind",
     "compile_recovery_context",
     "context_image_from_recovery",
+    "context_snapshot_record_from_image",
 ]

--- a/tests/unit/context/test_compiler.py
+++ b/tests/unit/context/test_compiler.py
@@ -180,17 +180,29 @@ def test_context_snapshot_record_is_explicit_delivery_boundary() -> None:
         boundary="handoff",
         run_ref="run:local-review",
     )
+    record_again = context_snapshot_record_from_image(
+        compiled.context_image,
+        boundary="handoff",
+        run_ref="run:local-review",
+    )
+    different_boundary = context_snapshot_record_from_image(
+        compiled.context_image,
+        boundary="review",
+        run_ref="run:local-review",
+    )
 
     assert record.snapshot_ref.startswith("context-snapshot:")
+    assert record.snapshot_ref == record_again.snapshot_ref
+    assert record.snapshot_ref != different_boundary.snapshot_ref
     assert record.run_ref == "run:local-review"
     assert record.boundary == "handoff"
     assert record.inheritance_mode == "explicit"
     assert record.segment_refs == (compiled.context_image.segments[0].segment_id,)
     assert record.evidence_refs == compiled.context_image.evidence_refs
     assert record.metadata["purpose"] == "handoff"
-    assert record.metadata["read_views"] == ("work-packet",)
-    assert record.metadata["token_estimate"] == compiled.context_image.token_estimate
-    assert record.metadata["include_candidates"] is False
+    assert record.metadata["read_views"] == '["work-packet"]'
+    assert record.metadata["token_estimate"] == str(compiled.context_image.token_estimate)
+    assert record.metadata["include_candidates"] == "false"
 
 
 def test_context_snapshot_record_requires_delivery_boundary() -> None:
@@ -200,6 +212,8 @@ def test_context_snapshot_record_requires_delivery_boundary() -> None:
 
     with pytest.raises(ValueError, match="delivery boundary"):
         context_snapshot_record_from_image(compiled.context_image, boundary="")
+    with pytest.raises(ValueError, match="delivery boundary"):
+        context_snapshot_record_from_image(compiled.context_image, boundary="   ")
 
 
 def test_context_spec_requires_an_explicit_seed() -> None:

--- a/tests/unit/context/test_compiler.py
+++ b/tests/unit/context/test_compiler.py
@@ -6,7 +6,12 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.domain_models import Session
-from polylogue.context.compiler import ContextSpec, compile_recovery_context, context_image_from_recovery
+from polylogue.context.compiler import (
+    ContextSpec,
+    compile_recovery_context,
+    context_image_from_recovery,
+    context_snapshot_record_from_image,
+)
 from polylogue.core.enums import Origin
 from polylogue.core.refs import EvidenceRef, ObjectRef
 from polylogue.insights.transforms import RecoveryWorkPacketEntry, compile_recovery_digest
@@ -163,6 +168,38 @@ def test_context_image_from_recovery_preserves_assertion_refs() -> None:
     assert image.segments[0].assertion_refs == ("claim-1",)
     assert image.segments[0].markdown is not None
     assert "Assertion Claims" in image.segments[0].markdown
+
+
+def test_context_snapshot_record_is_explicit_delivery_boundary() -> None:
+    digest = compile_recovery_digest(_session())
+    compiled = compile_recovery_context(digest, report="work-packet")
+    assert compiled.context_image is not None
+
+    record = context_snapshot_record_from_image(
+        compiled.context_image,
+        boundary="handoff",
+        run_ref="run:local-review",
+    )
+
+    assert record.snapshot_ref.startswith("context-snapshot:")
+    assert record.run_ref == "run:local-review"
+    assert record.boundary == "handoff"
+    assert record.inheritance_mode == "explicit"
+    assert record.segment_refs == (compiled.context_image.segments[0].segment_id,)
+    assert record.evidence_refs == compiled.context_image.evidence_refs
+    assert record.metadata["purpose"] == "handoff"
+    assert record.metadata["read_views"] == ("work-packet",)
+    assert record.metadata["token_estimate"] == compiled.context_image.token_estimate
+    assert record.metadata["include_candidates"] is False
+
+
+def test_context_snapshot_record_requires_delivery_boundary() -> None:
+    digest = compile_recovery_digest(_session())
+    compiled = compile_recovery_context(digest)
+    assert compiled.context_image is not None
+
+    with pytest.raises(ValueError, match="delivery boundary"):
+        context_snapshot_record_from_image(compiled.context_image, boundary="")
 
 
 def test_context_spec_requires_an_explicit_seed() -> None:


### PR DESCRIPTION
## Summary

Closes #2193 by completing the last explicit ContextSpec compiler boundary: a compiled `ContextImage` can now be converted into a storage-free `ContextSnapshotRecord` only at a delivery boundary. The broader compiler surface already existed on master (`ContextSpec`, `ContextImage`, query/ref-driven `Polylogue.compile_context`, CLI `continue --format json`, and MCP `compile_context`); this PR adds the missing snapshot evidence record helper and tests it directly.

## Problem

#2193 asked for `ContextSpec -> ContextImage -> optional ContextSnapshot` without turning compilation into a memory store or hidden automatic injection. The code already compiled context images from query/ref seeds, assertions, recovery/work-packet views, and exposed the shared DTO through API/CLI/MCP, but `ContextSnapshotRecord` was only a DTO. There was no explicit boundary helper proving that snapshot recording is a separate delivery/evidence act rather than an implicit compiler side effect.

## Solution

- Added `context_snapshot_record_from_image(...)` in `polylogue/context/compiler.py`.
- The helper requires an explicit `boundary`, preserves segment refs and evidence refs, and records purpose, read views, token budget/estimate, assertion/candidate policy, redaction policy, omitted count, assertion refs, and caveats in metadata.
- Exported the helper lazily from `polylogue.context` so importing context primitives does not pull in heavier context-pack or API modules.
- Added focused tests proving delivery-boundary record creation and typed rejection of an empty boundary.

AC matrix for #2193:

- General `ContextSpec` / `ContextImage` compiler exists: satisfied on master, exercised by `Polylogue.compile_context`.
- Recovery compiler reused as segment builder: satisfied by `context_image_from_recovery` and API recovery segment compilation.
- Query-driven compilation: satisfied by `test_compile_context_builds_recovery_segments_from_refs_and_query`.
- Ref-driven compilation: satisfied by the same API test and missing/budget tests.
- Accepted assertions included by policy and candidates excluded by default: satisfied by `test_compile_context_honors_assertion_opt_out` plus `ContextSpec(include_candidates=False)` default.
- Evidence refs, object refs, caveats, omissions, token/budget metadata: satisfied by API/compiler tests and the new snapshot metadata assertions.
- Raw bytes/local paths not exposed by default: satisfied by recovery/read payload route using recovery DTOs, no raw path segment builder added here.
- ContextSnapshot recording separate from pure compilation: satisfied by `context_snapshot_record_from_image`; compilation remains side-effect free.
- Machine surface consumes shared payload: satisfied by API `compile_context`, CLI `continue --format json`, and MCP `compile_context` tests.

## Verification

```bash
devtools test tests/unit/context/test_compiler.py tests/unit/cli/test_query_verbs_runtime.py::test_read_verb_recovery_report_selector_renders_presets tests/unit/cli/test_query_verbs_runtime.py::test_read_view_recovery_work_packet_json_uses_success_envelope tests/unit/api/test_facade_contracts.py::test_recovery_report_renders_seeded_session_presets tests/unit/api/test_facade_contracts.py::test_compile_context_builds_recovery_segments_from_refs_and_query tests/unit/api/test_facade_contracts.py::test_compile_context_honors_assertion_opt_out tests/unit/api/test_facade_contracts.py::test_compile_context_records_missing_and_budget_omissions tests/unit/mcp/test_server_surfaces.py::TestArchiveGenericToolSurfaces::test_compile_context_reads_shared_context_image tests/unit/archive/test_view_profiles.py -q
# 18 passed

devtools verify --quick
# exit_code: 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new snapshot factory enabling efficient conversion of compiled context images to snapshot records with deterministic fingerprinting, comprehensive metadata preservation, and strict delivery boundary validation.

* **Tests**
  * Added unit tests validating snapshot record generation, metadata population, and delivery boundary enforcement with appropriate error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->