### PR TITLE
feat(query): let unit descriptors own terminal metadata (#2006)

### DIFF
--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -162,7 +162,7 @@ def query_structural_unit_candidates(incomplete: str) -> list[QueryCompletionCan
                 kind="query-structural-unit",
                 group="query structural units",
                 description=description,
-                source="STRUCTURAL_QUERY_UNIT_REGISTRY",
+                source="QUERY_UNIT_DESCRIPTORS",
             )
         )
     return candidates
@@ -192,7 +192,7 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
                 kind="query-structural-field",
                 group=f"{unit} structural fields",
                 description=description,
-                source="STRUCTURAL_QUERY_UNIT_REGISTRY",
+                source="QUERY_UNIT_DESCRIPTORS",
             )
         )
     return candidates

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 QueryUnitName = Literal["message", "action", "block", "assertion", "run", "observed-event", "context-snapshot"]
+QueryUnitLowererKind = Literal["sql", "runtime_transform"]
 
 
 @dataclass(frozen=True)
@@ -16,6 +17,11 @@ class QueryUnitDescriptor:
     singular_source: str
     plural_source: str
     terminal_supported: bool = True
+    exists_supported: bool = False
+    lowerer_kind: QueryUnitLowererKind = "sql"
+    fields: tuple[StructuralQueryFieldInfo, ...] = ()
+    description: str = ""
+    example: str = ""
 
     @property
     def source_aliases(self) -> tuple[str, str]:
@@ -140,21 +146,6 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
     },
 }
 
-QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
-    QueryUnitDescriptor("message", "message", "messages"),
-    QueryUnitDescriptor("action", "action", "actions"),
-    QueryUnitDescriptor("block", "block", "blocks"),
-    QueryUnitDescriptor("assertion", "assertion", "assertions"),
-    QueryUnitDescriptor("run", "run", "runs"),
-    QueryUnitDescriptor("observed-event", "observed-event", "observed-events"),
-    QueryUnitDescriptor("context-snapshot", "context-snapshot", "context-snapshots"),
-)
-_QUERY_UNIT_BY_UNIT: dict[QueryUnitName, QueryUnitDescriptor] = {
-    descriptor.unit: descriptor for descriptor in QUERY_UNIT_DESCRIPTORS
-}
-_SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = tuple(
-    (source, descriptor.unit) for descriptor in QUERY_UNIT_DESCRIPTORS for source in descriptor.source_aliases
-)
 _BOOLEAN_SUPPORTED_FIELDS = {
     "repo",
     "origin",
@@ -516,6 +507,89 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     ),
 }
 
+
+def _unit_info(unit: QueryUnitName) -> StructuralQueryUnitInfo:
+    return STRUCTURAL_QUERY_UNIT_REGISTRY[unit]
+
+
+QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
+    QueryUnitDescriptor(
+        "message",
+        "message",
+        "messages",
+        exists_supported=True,
+        fields=_unit_info("message").fields,
+        description=_unit_info("message").description,
+        example=_unit_info("message").example,
+    ),
+    QueryUnitDescriptor(
+        "action",
+        "action",
+        "actions",
+        exists_supported=True,
+        fields=_unit_info("action").fields,
+        description=_unit_info("action").description,
+        example=_unit_info("action").example,
+    ),
+    QueryUnitDescriptor(
+        "block",
+        "block",
+        "blocks",
+        exists_supported=True,
+        fields=_unit_info("block").fields,
+        description=_unit_info("block").description,
+        example=_unit_info("block").example,
+    ),
+    QueryUnitDescriptor(
+        "assertion",
+        "assertion",
+        "assertions",
+        exists_supported=True,
+        fields=_unit_info("assertion").fields,
+        description=_unit_info("assertion").description,
+        example=_unit_info("assertion").example,
+    ),
+    QueryUnitDescriptor(
+        "run",
+        "run",
+        "runs",
+        exists_supported=False,
+        lowerer_kind="runtime_transform",
+        fields=_unit_info("run").fields,
+        description=_unit_info("run").description,
+        example=_unit_info("run").example,
+    ),
+    QueryUnitDescriptor(
+        "observed-event",
+        "observed-event",
+        "observed-events",
+        exists_supported=False,
+        lowerer_kind="runtime_transform",
+        fields=_unit_info("observed-event").fields,
+        description=_unit_info("observed-event").description,
+        example=_unit_info("observed-event").example,
+    ),
+    QueryUnitDescriptor(
+        "context-snapshot",
+        "context-snapshot",
+        "context-snapshots",
+        exists_supported=False,
+        lowerer_kind="runtime_transform",
+        fields=_unit_info("context-snapshot").fields,
+        description=_unit_info("context-snapshot").description,
+        example=_unit_info("context-snapshot").example,
+    ),
+)
+_QUERY_UNIT_BY_UNIT: dict[QueryUnitName, QueryUnitDescriptor] = {
+    descriptor.unit: descriptor for descriptor in QUERY_UNIT_DESCRIPTORS
+}
+_SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = tuple(
+    (source, descriptor.unit)
+    for descriptor in QUERY_UNIT_DESCRIPTORS
+    if descriptor.terminal_supported
+    for source in descriptor.source_aliases
+)
+
 COUNT_QUERY_FIELD_REGISTRY: dict[str, CountQueryFieldInfo] = {
     "messages": CountQueryFieldInfo(
         description="Message-count predicate over normalized session messages.",
@@ -544,26 +618,26 @@ DATE_QUERY_FIELD_REGISTRY: dict[str, DateQueryFieldInfo] = {
 def structural_query_units() -> tuple[str, ...]:
     """Return the structural units accepted by the query grammar."""
 
-    return tuple(sorted(STRUCTURAL_QUERY_UNIT_REGISTRY))
+    return tuple(sorted(descriptor.unit for descriptor in QUERY_UNIT_DESCRIPTORS if descriptor.exists_supported))
 
 
 def structural_query_fields(unit: str) -> tuple[str, ...]:
     """Return structural field names accepted inside ``exists <unit>(...)``."""
 
-    info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit.lower())
-    if info is None:
+    descriptor = query_unit_descriptor(unit)
+    if descriptor is None or not descriptor.exists_supported:
         return ()
-    return tuple(field.name for field in info.fields)
+    return tuple(field.name for field in descriptor.fields)
 
 
 def structural_query_field_info(unit: str, field: str) -> StructuralQueryFieldInfo | None:
     """Return metadata for a structural field accepted by *unit*."""
 
-    info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit.lower())
-    if info is None:
+    descriptor = query_unit_descriptor(unit)
+    if descriptor is None or not descriptor.exists_supported:
         return None
     normalized = field.lower()
-    for field_info in info.fields:
+    for field_info in descriptor.fields:
         if field_info.name == normalized:
             return field_info
     return None
@@ -615,19 +689,23 @@ def terminal_query_source_list(*, plural: bool = True, separator: str = "/") -> 
 def terminal_query_fields(source: str) -> tuple[str, ...]:
     """Return field names accepted after ``<source> where``."""
 
-    unit = terminal_query_unit(source)
-    if unit is None:
+    descriptor = query_unit_descriptor(source)
+    if descriptor is None or not descriptor.terminal_supported:
         return ()
-    return structural_query_fields(unit)
+    return tuple(field.name for field in descriptor.fields)
 
 
 def terminal_query_field_info(source: str, field: str) -> StructuralQueryFieldInfo | None:
     """Return metadata for a field accepted after ``<source> where``."""
 
-    unit = terminal_query_unit(source)
-    if unit is None:
+    descriptor = query_unit_descriptor(source)
+    if descriptor is None or not descriptor.terminal_supported:
         return None
-    return structural_query_field_info(unit, field)
+    normalized = field.lower()
+    for field_info in descriptor.fields:
+        if field_info.name == normalized:
+            return field_info
+    return None
 
 
 def count_query_fields() -> tuple[str, ...]:
@@ -668,6 +746,7 @@ __all__ = [
     "EXPRESSION_FIELD_REGISTRY",
     "QUERY_UNIT_DESCRIPTORS",
     "QueryUnitDescriptor",
+    "QueryUnitLowererKind",
     "QueryUnitName",
     "STRUCTURAL_QUERY_UNIT_REGISTRY",
     "StructuralQueryFieldInfo",

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -56,6 +56,9 @@ def test_terminal_query_completion_payloads_are_lightweight() -> None:
 def test_query_unit_descriptors_own_terminal_aliases() -> None:
     from polylogue.archive.query.metadata import (
         query_unit_descriptor,
+        structural_query_fields,
+        structural_query_units,
+        terminal_query_fields,
         terminal_query_source_list,
         terminal_query_source_pairs,
         terminal_query_unit,
@@ -63,11 +66,20 @@ def test_query_unit_descriptors_own_terminal_aliases() -> None:
 
     observed_descriptor = query_unit_descriptor("observed-events")
     context_descriptor = query_unit_descriptor("context-snapshot")
+    message_descriptor = query_unit_descriptor("messages")
     assert observed_descriptor is not None
     assert context_descriptor is not None
+    assert message_descriptor is not None
     assert terminal_query_unit("messages") == "message"
     assert terminal_query_unit("context-snapshots") == "context-snapshot"
     assert observed_descriptor.plural_source == "observed-events"
+    assert observed_descriptor.exists_supported is False
+    assert observed_descriptor.lowerer_kind == "runtime_transform"
+    assert message_descriptor.exists_supported is True
+    assert message_descriptor.lowerer_kind == "sql"
     assert context_descriptor.source_aliases == ("context-snapshot", "context-snapshots")
     assert terminal_query_source_list() == "messages/actions/blocks/assertions/runs/observed-events/context-snapshots"
     assert ("assertions", "assertion") in terminal_query_source_pairs()
+    assert structural_query_units() == ("action", "assertion", "block", "message")
+    assert structural_query_fields("context-snapshot") == ()
+    assert "boundary" in terminal_query_fields("context-snapshots")

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -167,7 +167,7 @@ def test_query_structural_unit_candidates_come_from_expression_registry() -> Non
     block_candidate = candidates[0]
     assert block_candidate.insert == "block("
     assert block_candidate.kind == "query-structural-unit"
-    assert block_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
+    assert block_candidate.source == "QUERY_UNIT_DESCRIPTORS"
     assert block_candidate.description.startswith("Match sessions with at least one parsed message block")
 
 
@@ -179,7 +179,7 @@ def test_query_structural_field_candidates_come_from_expression_registry() -> No
     type_candidate = next(candidate for candidate in candidates if candidate.value == "type")
     assert type_candidate.insert == "type:"
     assert type_candidate.kind == "query-structural-field"
-    assert type_candidate.source == "STRUCTURAL_QUERY_UNIT_REGISTRY"
+    assert type_candidate.source == "QUERY_UNIT_DESCRIPTORS"
     assert "Unit-specific type token" in type_candidate.description
     assert "type:code" in type_candidate.description
 


### PR DESCRIPTION
## Summary

Moves query-unit terminal/structural metadata into `QueryUnitDescriptor` so the query substrate has one owner for terminal aliases, structural-exists availability, lowerer kind, and unit fields.

## Problem

#2006 needs query units to be executable metadata, not parser vocabulary plus several manually synchronized registries. The code already had a `QueryUnitDescriptor`, but it only described aliases. Structural completions still treated the separate `STRUCTURAL_QUERY_UNIT_REGISTRY` as the authority, which blurred a real semantic boundary: `messages/actions/blocks/assertions` can be structural `exists` predicates, while `runs/observed-events/context-snapshots` are terminal runtime-transform sources only.

## Solution

- Extended `QueryUnitDescriptor` with `exists_supported`, `lowerer_kind`, field metadata, descriptions, and examples.
- Builds terminal aliases and field completions from descriptors.
- Keeps runtime-transform units available for terminal `... where ...` queries and terminal-field completions.
- Restricts structural `exists` unit completions/field lookup to descriptor units with `exists_supported=True`.
- Updates completion metadata to identify `QUERY_UNIT_DESCRIPTORS` as the owner.
- Adds tests covering terminal aliases, runtime-transform lowerer kind, structural-vs-terminal field behavior, and completion source ownership.

## Verification

- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_completion_matrix.py tests/unit/cli/test_query_expression.py -q` -> `387 passed`
- `mypy polylogue/archive/query/metadata.py polylogue/archive/query/completions.py tests/unit/archive/test_query_metadata.py tests/unit/cli/test_command_aux_runtime.py` -> success
- `devtools verify --quick` -> exit_code 0

Ref #2006
