### PR TITLE
refactor(query): derive unit metadata from descriptors (#2006)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1742,13 +1742,14 @@ class PolylogueArchiveMixin:
     ) -> QueryUnitEnvelope:
         """Execute a terminal unit-source query."""
         from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
+        from polylogue.archive.query.metadata import terminal_query_source_list
         from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         source = parse_unit_source_expression(expression)
         if source is None:
             raise ExpressionCompileError(
-                "query_units requires an explicit messages/actions/blocks/assertions/runs/observed-events/context-snapshots where expression",
+                f"query_units requires an explicit {terminal_query_source_list()} where expression",
                 field=None,
             )
         session_filters = query_unit_session_filters(

--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -221,7 +221,7 @@ def query_terminal_source_candidates(incomplete: str) -> list[QueryCompletionCan
                 kind="query-terminal-source",
                 group="query terminal sources",
                 description=description,
-                source="_SOURCE_WHERE_SOURCES",
+                source="QUERY_UNIT_DESCRIPTORS",
             )
         )
     return candidates
@@ -251,7 +251,7 @@ def query_terminal_field_candidates(source: str, incomplete: str) -> list[QueryC
                 kind="query-terminal-field",
                 group=f"{source} terminal fields",
                 description=description,
-                source="_SOURCE_WHERE_SOURCES/STRUCTURAL_QUERY_UNIT_REGISTRY",
+                source="QUERY_UNIT_DESCRIPTORS",
             )
         )
     return candidates

--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -9,11 +9,11 @@ from polylogue.archive.query.metadata import (
     COUNT_QUERY_FIELD_REGISTRY,
     DATE_QUERY_FIELD_REGISTRY,
     EXPRESSION_FIELD_REGISTRY,
-    STRUCTURAL_QUERY_UNIT_REGISTRY,
     count_query_fields,
     count_query_operators,
     date_query_fields,
     date_query_operators,
+    query_unit_descriptor,
     structural_query_field_info,
     structural_query_fields,
     structural_query_units,
@@ -150,10 +150,14 @@ def query_structural_unit_candidates(incomplete: str) -> list[QueryCompletionCan
     for unit in structural_query_units():
         if current and not unit.startswith(current):
             continue
-        info = STRUCTURAL_QUERY_UNIT_REGISTRY[unit]
-        description = info.description
-        if info.example:
-            description = f"{description} Example: {info.example}" if description else f"Example: {info.example}"
+        descriptor = query_unit_descriptor(unit)
+        description = "Structural query unit."
+        if descriptor is not None:
+            description = descriptor.description
+            if descriptor.example:
+                description = (
+                    f"{description} Example: {descriptor.example}" if description else f"Example: {descriptor.example}"
+                )
         candidates.append(
             QueryCompletionCandidate(
                 value=unit,
@@ -207,12 +211,12 @@ def query_terminal_source_candidates(incomplete: str) -> list[QueryCompletionCan
         if current and not source.startswith(current):
             continue
         unit = terminal_query_unit(source)
-        info = STRUCTURAL_QUERY_UNIT_REGISTRY.get(unit or "")
+        descriptor = query_unit_descriptor(unit or "")
         description = "Terminal query row source."
-        if info is not None:
-            description = info.description
-            if info.example:
-                description = f"{description} Example: {info.example}"
+        if descriptor is not None:
+            description = descriptor.description
+            if descriptor.example:
+                description = f"{description} Example: {descriptor.example}"
         candidates.append(
             QueryCompletionCandidate(
                 value=source,

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -583,10 +583,31 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
 _QUERY_UNIT_BY_UNIT: dict[QueryUnitName, QueryUnitDescriptor] = {
     descriptor.unit: descriptor for descriptor in QUERY_UNIT_DESCRIPTORS
 }
+
+
+def query_unit_descriptors(
+    *,
+    terminal_supported: bool | None = None,
+    exists_supported: bool | None = None,
+    lowerer_kind: QueryUnitLowererKind | None = None,
+) -> tuple[QueryUnitDescriptor, ...]:
+    """Return query-unit descriptors matching the requested capabilities."""
+
+    descriptors = QUERY_UNIT_DESCRIPTORS
+    if terminal_supported is not None:
+        descriptors = tuple(
+            descriptor for descriptor in descriptors if descriptor.terminal_supported is terminal_supported
+        )
+    if exists_supported is not None:
+        descriptors = tuple(descriptor for descriptor in descriptors if descriptor.exists_supported is exists_supported)
+    if lowerer_kind is not None:
+        descriptors = tuple(descriptor for descriptor in descriptors if descriptor.lowerer_kind == lowerer_kind)
+    return descriptors
+
+
 _SOURCE_WHERE_SOURCES: tuple[tuple[str, QueryUnitName], ...] = tuple(
     (source, descriptor.unit)
-    for descriptor in QUERY_UNIT_DESCRIPTORS
-    if descriptor.terminal_supported
+    for descriptor in query_unit_descriptors(terminal_supported=True)
     for source in descriptor.source_aliases
 )
 
@@ -618,7 +639,7 @@ DATE_QUERY_FIELD_REGISTRY: dict[str, DateQueryFieldInfo] = {
 def structural_query_units() -> tuple[str, ...]:
     """Return the structural units accepted by the query grammar."""
 
-    return tuple(sorted(descriptor.unit for descriptor in QUERY_UNIT_DESCRIPTORS if descriptor.exists_supported))
+    return tuple(sorted(descriptor.unit for descriptor in query_unit_descriptors(exists_supported=True)))
 
 
 def structural_query_fields(unit: str) -> tuple[str, ...]:
@@ -680,8 +701,7 @@ def terminal_query_source_list(*, plural: bool = True, separator: str = "/") -> 
 
     labels = [
         descriptor.plural_source if plural else descriptor.singular_source
-        for descriptor in QUERY_UNIT_DESCRIPTORS
-        if descriptor.terminal_supported
+        for descriptor in query_unit_descriptors(terminal_supported=True)
     ]
     return separator.join(labels)
 
@@ -765,10 +785,11 @@ __all__ = [
     "count_query_operators",
     "date_query_fields",
     "date_query_operators",
+    "query_unit_descriptor",
+    "query_unit_descriptors",
     "structural_query_field_info",
     "structural_query_fields",
     "structural_query_units",
-    "query_unit_descriptor",
     "terminal_query_field_info",
     "terminal_query_fields",
     "terminal_query_source_list",

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -42,6 +42,7 @@ def test_terminal_query_completion_payloads_are_lightweight() -> None:
     source_candidate = next(candidate for candidate in source_candidates if candidate["value"] == "observed-events")
     assert source_candidate["insert"] == "observed-events where "
     assert source_candidate["kind"] == "query-terminal-source"
+    assert source_candidate["source"] == "QUERY_UNIT_DESCRIPTORS"
 
     field_payload = query_completion_payload("terminal-field", unit="context-snapshots", incomplete="bound")
     field_candidates = [
@@ -51,11 +52,13 @@ def test_terminal_query_completion_payloads_are_lightweight() -> None:
     field_candidate = field_candidates[0]
     assert field_candidate["insert"] == "boundary:"
     assert field_candidate["kind"] == "query-terminal-field"
+    assert field_candidate["source"] == "QUERY_UNIT_DESCRIPTORS"
 
 
 def test_query_unit_descriptors_own_terminal_aliases() -> None:
     from polylogue.archive.query.metadata import (
         query_unit_descriptor,
+        query_unit_descriptors,
         structural_query_fields,
         structural_query_units,
         terminal_query_fields,
@@ -81,5 +84,16 @@ def test_query_unit_descriptors_own_terminal_aliases() -> None:
     assert terminal_query_source_list() == "messages/actions/blocks/assertions/runs/observed-events/context-snapshots"
     assert ("assertions", "assertion") in terminal_query_source_pairs()
     assert structural_query_units() == ("action", "assertion", "block", "message")
+    assert tuple(descriptor.unit for descriptor in query_unit_descriptors(exists_supported=True)) == (
+        "message",
+        "action",
+        "block",
+        "assertion",
+    )
+    assert tuple(descriptor.unit for descriptor in query_unit_descriptors(lowerer_kind="runtime_transform")) == (
+        "run",
+        "observed-event",
+        "context-snapshot",
+    )
     assert structural_query_fields("context-snapshot") == ()
     assert "boundary" in terminal_query_fields("context-snapshots")

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1485,13 +1485,15 @@ class TestReaderQueryUnits:
         assert items[0]["boundary"] == "session_start"
 
     def test_query_units_endpoint_rejects_session_expression(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.archive.query.metadata import terminal_query_source_list
+
         expression = quote("repo:polylogue")
         with _running_server(workspace_env) as (_, base_url):
             status, payload = _get_json_ex(base_url, f"/api/query-units?expression={expression}")
 
         assert status == 400
         assert payload["error"] == "invalid_query"
-        assert "messages/actions/blocks/assertions/runs/observed-events/context-snapshots" in str(payload["message"])
+        assert terminal_query_source_list() in str(payload["message"])
 
 
 class TestReaderViewProfiles:


### PR DESCRIPTION
## Summary

Tightens the query-unit descriptor ownership introduced in #2207 by routing terminal/structural metadata helpers, completions, API error text, and daemon error assertions through `QueryUnitDescriptor` instead of older private unit lists or the structural registry.

## Problem

#2006 is trying to make the query DSL substrate easier to extend without updating scattered terminal-unit metadata by hand. After #2207, descriptors owned the unit fields and capabilities, but several helpers and tests still reached around them: terminal source lists used local loops, completion payloads cited private implementation structures, and one daemon test hard-coded the full terminal source list.

## Solution

- Added `query_unit_descriptors(...)` as a capability-filtered descriptor iterator.
- Derived structural unit lists, terminal source aliases, and terminal source labels through that iterator.
- Switched terminal-source and terminal-field completion candidates to report `QUERY_UNIT_DESCRIPTORS` as their source.
- Read structural/terminal completion descriptions from descriptors instead of `STRUCTURAL_QUERY_UNIT_REGISTRY`.
- Derived the Python API `query_units` invalid-expression message from `terminal_query_source_list()`.
- Updated focused tests so daemon and completion expectations consume the same metadata boundary.

## Verification

- `nix develop --command devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_command_aux_runtime.py -q` -> 18 passed
- `nix develop --command devtools test tests/unit/archive/test_query_metadata.py tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits::test_query_units_endpoint_rejects_session_expression -q` -> 4 passed
- `nix develop --command devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_command_aux_runtime.py tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits::test_query_units_endpoint_rejects_session_expression -q` -> 19 passed
- `nix develop --command devtools verify --quick` -> exit_code 0
- `nix develop --command devtools verify --seed-testmon --skip-slow` -> 11,615 passed, exit_code 0