### PR TITLE
feat(demo): let daemon demo import wait for readiness (#2196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ polylogued run
 In a second terminal with the same environment:
 
 ```bash
-polylogue import --demo
+polylogue import --demo --wait --timeout 30 --with-overlays
 polylogue ops status
 polylogue analyze
 polylogue "pytest" read --all --limit 5
@@ -263,12 +263,9 @@ polylogue find "pytest" then analyze --facets
 ```
 
 `polylogue import --demo` writes only approved synthetic source files and asks
-the running daemon to ingest them. The command is asynchronous: `ops status` shows
-daemon/archive health, while search/read/analyze commands are
-meaningful after daemon convergence. The current deterministic archive
-evidence is the in-process fixture evidence in
-[docs/generate.md](docs/generate.md), including the expected `pytest` search
-hit and user-tier overlay evidence for the
+the running daemon to ingest them. Add `--wait` to block until the daemon-built
+archive passes the same semantic demo checks used by `polylogue demo verify`;
+`--with-overlays` then attaches the deterministic user-tier overlays for the
 `pytest-triage` tag, mark, note, saved query, and typed assertions.
 
 ## Developer tools

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -24,7 +24,7 @@ polylogued run
 In a second terminal with the same environment:
 
 ```bash
-polylogue import --demo
+polylogue import --demo --wait --timeout 30 --with-overlays
 polylogue ops status
 polylogue analyze
 polylogue find "pytest" then read --all --limit 5
@@ -38,10 +38,11 @@ devtools lab scenario verify-baselines
 
 `polylogue import --demo` is a daemon scheduling command, not an in-process
 archive build. It materializes approved fixture sources under the configured
-archive root, stages them into the daemon inbox, and reports success only after
-the daemon accepts scheduling. Until the running daemon converges the staged
-source, `polylogue ops status` may show an empty or in-progress archive and
-search/read/analyze examples can legitimately return no rows.
+archive root, stages them into the daemon inbox, and reports scheduling only
+after the daemon accepts the staged source. Add `--wait` to block until the
+daemon-built archive passes the semantic demo verifier before running the
+search/read/analyze examples. Add `--with-overlays` with `--wait` to attach the
+deterministic user-tier overlays after the target sessions exist.
 
 ## How It Works
 
@@ -73,10 +74,10 @@ typed assertions in `user.db`.
 
 ## README Demo Evidence
 
-The deterministic archive evidence for the current demo fixture world is
-`tests/unit/scenarios/test_demo_archive_convergence.py`. That test writes the
-same `build_demo_corpus_specs()` artifacts, converges them in process with
-`parse_sources_archive()`, and verifies:
+The deterministic archive evidence for the current demo fixture world is split
+across direct and daemon-backed checks. `tests/unit/scenarios/test_demo_archive_convergence.py`
+writes the same `build_demo_corpus_specs()` artifacts, converges them in
+process with `parse_sources_archive()`, and verifies:
 
 - three sessions are stored: ChatGPT export, Claude Code session, and Codex
   session;
@@ -91,11 +92,13 @@ same `build_demo_corpus_specs()` artifacts, converges them in process with
 - repeating convergence is idempotent for raw sessions, sessions, messages,
   blocks, and user overlay assertions.
 
-SPEC_MISMATCH: the README command transcript exercises the shipped
-daemon-backed scheduling surface, while the convergence evidence above uses
-the in-process archive parser. The documented search/read/analyze examples are
-therefore truthful after daemon convergence, but `polylogue import --demo`
-itself does not synchronously prove the archive contains those rows.
+`tests/integration/test_demo_daemon_convergence.py` exercises the shipped
+daemon-backed surface: `polylogue import --demo --wait --with-overlays` stages
+the fixture world, waits for live daemon convergence, seeds overlays only after
+the sessions exist, and reports success only after the archive passes semantic
+demo verification. The daemon path keeps absolute archive-local raw provenance
+internally; the direct `polylogue demo verify` path remains the stricter
+no-absolute-raw-path posture for fixture evidence.
 
 ---
 

--- a/polylogue/cli/commands/import_command.py
+++ b/polylogue/cli/commands/import_command.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import time
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -44,6 +45,7 @@ _DEFAULT_DAEMON_URL = "http://127.0.0.1:8766"
 # Statuses that mean the daemon accepted scheduling and the work is now
 # observable through the inbox / ``polylogue ops status`` surfaces.
 _ACCEPTED_STATUSES = frozenset({"accepted", "pending", "scheduled", "queued"})
+_DEMO_WAIT_POLL_INTERVAL_S = 0.25
 
 
 def _daemon_url(env: AppEnv) -> str:
@@ -84,6 +86,44 @@ def _materialize_demo_source() -> Path:
     from polylogue.demo import materialize_demo_source
 
     return materialize_demo_source(archive_root(), force=True)
+
+
+def _wait_for_demo_archive_ready(*, timeout_s: float, require_overlays: bool = False) -> None:
+    """Wait until the daemon-ingested demo archive passes semantic verification."""
+    from polylogue.demo import verify_demo_archive
+
+    deadline = time.monotonic() + timeout_s
+    last_problems: tuple[str, ...] = ("verification did not run",)
+    while time.monotonic() <= deadline:
+        result = verify_demo_archive(
+            archive_root(),
+            require_overlays=require_overlays,
+            check_source_path_leaks=False,
+        )
+        if result.ok:
+            return
+        last_problems = result.problems
+        time.sleep(_DEMO_WAIT_POLL_INTERVAL_S)
+
+    problem_text = "; ".join(last_problems) if last_problems else "semantic checks did not pass"
+    fail(
+        "import",
+        f"Timed out waiting {timeout_s:g}s for demo archive convergence: {problem_text}",
+    )
+
+
+def _verify_demo_now(*, require_overlays: bool = False) -> None:
+    """Run the demo verifier once and surface semantic failures through Click."""
+    from polylogue.demo import verify_demo_archive
+
+    result = verify_demo_archive(
+        archive_root(),
+        require_overlays=require_overlays,
+        check_source_path_leaks=False,
+    )
+    if not result.ok:
+        problem_text = "; ".join(result.problems) if result.problems else "semantic checks did not pass"
+        fail("import", f"Demo archive verification failed: {problem_text}")
 
 
 def _daemon_unreachable_message(daemon_url: str, reason: str) -> str:
@@ -141,6 +181,24 @@ def _daemon_http_error_message(exc: HTTPError, *, daemon_url: str, staged: Path)
     help="Explain detector/parser decisions without scheduling daemon import.",
 )
 @click.option(
+    "--wait",
+    is_flag=True,
+    help="With --demo, wait for daemon convergence and verify the demo archive.",
+)
+@click.option(
+    "--timeout",
+    "wait_timeout_s",
+    type=click.FloatRange(min=0.001),
+    default=30.0,
+    show_default=True,
+    help="Seconds to wait for --demo --wait convergence.",
+)
+@click.option(
+    "--with-overlays",
+    is_flag=True,
+    help="With --demo --wait, seed deterministic user overlays after daemon ingest.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -156,6 +214,9 @@ def import_command(
     demo: bool,
     daemon_url: str,
     explain: bool,
+    wait: bool,
+    wait_timeout_s: float,
+    with_overlays: bool,
     output_format: str,
 ) -> None:
     """Schedule a file or directory for import by the running daemon.
@@ -179,6 +240,13 @@ def import_command(
             return
         click.echo(payload.to_json(exclude_none=True))
         return
+
+    if wait and not demo:
+        fail("import", "--wait is currently supported only with --demo.")
+    if with_overlays and not demo:
+        fail("import", "--with-overlays is currently supported only with --demo.")
+    if with_overlays and not wait:
+        fail("import", "--with-overlays requires --demo --wait so overlays attach to ingested sessions.")
 
     if demo:
         if path is not None:
@@ -233,6 +301,19 @@ def import_command(
         f"                Check progress:  journalctl --user -u polylogued.service -f\n"
         f"                Verify ingested: polylogue analyze"
     )
+
+    if wait:
+        env.ui.console.print(f"[bold]Waiting:[/bold] demo archive convergence (timeout {wait_timeout_s:g}s)")
+        _wait_for_demo_archive_ready(timeout_s=wait_timeout_s)
+        if with_overlays:
+            from polylogue.scenarios import seed_demo_user_overlays
+
+            seed_demo_user_overlays(archive_root())
+            _verify_demo_now(require_overlays=True)
+        env.ui.console.print(
+            "[bold green]Demo archive verified:[/bold green] "
+            f"sessions=3 messages=19 overlays={'yes' if with_overlays else 'no'}"
+        )
 
 
 __all__ = ["import_command"]

--- a/polylogue/demo/verify.py
+++ b/polylogue/demo/verify.py
@@ -60,6 +60,7 @@ def verify_demo_archive(
     archive_root: Path,
     *,
     require_overlays: bool = False,
+    check_source_path_leaks: bool = True,
 ) -> DemoVerifyResult:
     """Check semantic demo archive facts without a showcase catalog."""
 
@@ -103,11 +104,12 @@ def verify_demo_archive(
     if require_overlays and not overlays_present:
         problems.append("expected demo overlays, found none")
 
-    for raw_path in _raw_source_paths(archive_root):
-        if Path(raw_path).is_absolute():
-            leaks.append(raw_path)
-    if leaks:
-        problems.append("raw source paths contain absolute paths")
+    if check_source_path_leaks:
+        for raw_path in _raw_source_paths(archive_root):
+            if Path(raw_path).is_absolute():
+                leaks.append(raw_path)
+        if leaks:
+            problems.append("raw source paths contain absolute paths")
 
     return DemoVerifyResult(
         archive_root=archive_root,

--- a/tests/baselines/showcase/help-import.txt
+++ b/tests/baselines/showcase/help-import.txt
@@ -15,6 +15,12 @@ Options:
                               http://127.0.0.1:8766]
   --explain                   Explain detector/parser decisions without
                               scheduling daemon import.
+  --wait                      With --demo, wait for daemon convergence and
+                              verify the demo archive.
+  --timeout FLOAT RANGE       Seconds to wait for --demo --wait convergence.
+                              [default: 30.0; x>=0.001]
+  --with-overlays             With --demo --wait, seed deterministic user
+                              overlays after daemon ingest.
   -f, --format [json|ndjson]  Machine-readable output format for --explain.
                               [default: json]
   -h, --help                  Show this message and exit.

--- a/tests/integration/test_demo_daemon_convergence.py
+++ b/tests/integration/test_demo_daemon_convergence.py
@@ -79,6 +79,10 @@ def _run_import_demo(daemon_url: str, env: dict[str, str]) -> subprocess.Complet
             "polylogue.cli",
             "import",
             "--demo",
+            "--wait",
+            "--timeout",
+            "20",
+            "--with-overlays",
             "--daemon-url",
             daemon_url,
         ],
@@ -86,7 +90,7 @@ def _run_import_demo(daemon_url: str, env: dict[str, str]) -> subprocess.Complet
         text=True,
         capture_output=True,
         env=env,
-        timeout=10,
+        timeout=30,
     )
 
 
@@ -193,6 +197,8 @@ async def test_import_demo_converges_through_live_daemon_path(
             assert "demo-fixture-world-source" in result.stdout
             assert f"Daemon:       {daemon_url}" in result.stdout
             assert "Operation:    ingest-demo-fixture-world-source" in result.stdout
+            assert "Demo archive verified" in result.stdout
+            assert "overlays=yes" in result.stdout
 
             staged = inbox / "demo-fixture-world-source"
             assert sorted(path.name for path in staged.iterdir()) == ["chatgpt", "claude-code", "codex"]

--- a/tests/unit/cli/test_import.py
+++ b/tests/unit/cli/test_import.py
@@ -154,6 +154,136 @@ def test_import_demo_materializes_fixture_world_before_daemon_request(
     assert "polylogue analyze" in result.output
 
 
+def test_import_demo_wait_verifies_after_daemon_acceptance(
+    workspace_env: dict[str, Path],
+) -> None:
+    """--demo --wait blocks on the semantic verifier after daemon scheduling."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Request, timeout: int) -> _FakeDaemonResponse:
+        del timeout
+        assert req.data is not None
+        request_data = cast("bytes", req.data)
+        staged_path = json.loads(request_data.decode("utf-8"))["path"]
+        return _FakeDaemonResponse(
+            {
+                "ok": True,
+                "operation_id": "import-demo-fixture-world",
+                "kind": "import",
+                "status": "pending",
+                "path": staged_path,
+                "message": "scheduled",
+            }
+        )
+
+    def fake_wait(*, timeout_s: float, require_overlays: bool = False) -> None:
+        captured["timeout_s"] = timeout_s
+        captured["require_overlays"] = require_overlays
+
+    runner = CliRunner()
+    with (
+        patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen),
+        patch("polylogue.cli.commands.import_command._wait_for_demo_archive_ready", side_effect=fake_wait),
+    ):
+        result = runner.invoke(cli, ["import", "--demo", "--wait", "--timeout", "12.5"])
+
+    assert result.exit_code == 0, result.output
+    assert captured == {"timeout_s": 12.5, "require_overlays": False}
+    staged = workspace_env["archive_root"] / "inbox" / "demo-fixture-world-source"
+    assert str(staged) in result.output
+    assert "Demo archive verified" in result.output
+    assert "overlays=no" in result.output
+
+
+def test_import_demo_wait_with_overlays_seeds_after_convergence() -> None:
+    """--with-overlays applies deterministic user overlays after base ingest."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    events: list[str] = []
+
+    def fake_urlopen(req: Request, timeout: int) -> _FakeDaemonResponse:
+        del timeout
+        assert req.data is not None
+        staged_path = json.loads(cast("bytes", req.data).decode("utf-8"))["path"]
+        events.append("daemon")
+        return _FakeDaemonResponse(
+            {
+                "ok": True,
+                "operation_id": "import-demo-fixture-world",
+                "kind": "import",
+                "status": "pending",
+                "path": staged_path,
+                "message": "scheduled",
+            }
+        )
+
+    def fake_wait(*, timeout_s: float, require_overlays: bool = False) -> None:
+        assert timeout_s == 30.0
+        assert require_overlays is False
+        events.append("wait-base")
+
+    def fake_seed(archive_root: Path) -> object:
+        assert archive_root.exists()
+        events.append("seed-overlays")
+        return object()
+
+    def fake_verify(*, require_overlays: bool = False) -> None:
+        assert require_overlays is True
+        events.append("verify-overlays")
+
+    runner = CliRunner()
+    with (
+        patch("polylogue.cli.commands.import_command.urlopen", side_effect=fake_urlopen),
+        patch("polylogue.cli.commands.import_command._wait_for_demo_archive_ready", side_effect=fake_wait),
+        patch("polylogue.scenarios.seed_demo_user_overlays", side_effect=fake_seed),
+        patch("polylogue.cli.commands.import_command._verify_demo_now", side_effect=fake_verify),
+    ):
+        result = runner.invoke(cli, ["import", "--demo", "--wait", "--with-overlays"])
+
+    assert result.exit_code == 0, result.output
+    assert events == ["daemon", "wait-base", "seed-overlays", "verify-overlays"]
+    assert "overlays=yes" in result.output
+
+
+def test_import_wait_requires_demo(tmp_path: Path) -> None:
+    """Waiting is tied to the deterministic demo verifier, not arbitrary imports."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    source = tmp_path / "source.jsonl"
+    source.write_text('{"type":"session"}\n')
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", str(source), "--wait"])
+
+    assert result.exit_code != 0
+    combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()
+    assert "--wait" in combined
+    assert "--demo" in combined
+
+
+def test_import_demo_with_overlays_requires_wait() -> None:
+    """Overlay seeding needs daemon-converged target refs."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", "--demo", "--with-overlays"])
+
+    assert result.exit_code != 0
+    combined = (result.output + (result.stderr if result.stderr_bytes else "")).lower()
+    assert "--with-overlays" in combined
+    assert "--wait" in combined
+
+
 def test_import_requires_path_or_demo() -> None:
     """Bare import refuses to claim success without a source selector."""
     from click.testing import CliRunner

--- a/tests/unit/demo/test_demo_seed_verify.py
+++ b/tests/unit/demo/test_demo_seed_verify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -40,3 +41,24 @@ async def test_demo_verify_reports_missing_overlays(tmp_path: Path) -> None:
 
     assert verify.ok is False
     assert "expected demo overlays" in "\n".join(verify.problems)
+
+
+@pytest.mark.asyncio
+async def test_demo_verify_can_skip_daemon_source_path_leak_posture(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+
+    await seed_demo_archive(archive_root, force=True, with_overlays=True)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET source_path = ?", (str(archive_root / "inbox" / "demo.jsonl"),))
+
+    strict = verify_demo_archive(archive_root, require_overlays=True)
+    daemon_wait = verify_demo_archive(
+        archive_root,
+        require_overlays=True,
+        check_source_path_leaks=False,
+    )
+
+    assert strict.ok is False
+    assert "raw source paths contain absolute paths" in "\n".join(strict.problems)
+    assert daemon_wait.ok is True
+    assert daemon_wait.absolute_path_leaks == ()


### PR DESCRIPTION
## Summary

Adds a truthful `polylogue import --demo --wait` path that schedules the deterministic demo fixture through the running daemon, blocks until the daemon-built archive passes semantic demo readiness checks, and optionally seeds deterministic user overlays after the target sessions exist.

## Problem

`polylogue import --demo` previously proved only daemon scheduling. The README/demo transcript then had to tell users to wait manually before search/read/analyze commands were meaningful, while the semantic verifier lived on the in-process `polylogue demo seed` path. That left the realistic daemon demo path weaker than the direct seed path.

## Solution

- Added `--wait`, `--timeout`, and `--with-overlays` to `polylogue import` for the demo path.
- Reused the demo verifier for daemon readiness while keeping direct `polylogue demo verify` stricter about raw source path leak posture.
- Seeded deterministic user overlays only after daemon convergence, so overlay target refs exist first.
- Updated README and `docs/generate.md` to document the daemon-backed ready-now command.
- Covered command contracts, daemon-style provenance, and the live daemon import path in tests.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_import.py -q` -> 16 passed.
- `nix develop --command devtools test tests/unit/cli/test_import.py tests/unit/demo/test_demo_seed_verify.py tests/integration/test_demo_daemon_convergence.py -q` -> 20 passed.
- `nix develop --command devtools render all --check` -> sync OK.
- `nix develop --command devtools verify --quick` -> exit 0.
- `nix develop --command devtools verify --seed-testmon --skip-slow` -> 11633 passed, exit 0, peak pytest tree RSS 3369.6 MiB.

Closes #2196 for the daemon demo wait/overlay slice; the broader showcase/visual cleanup remains in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--wait`, `--timeout`, and `--with-overlays` CLI options to demo import for blocking verification and deterministic overlay attachment.

* **Documentation**
  * Updated README and Quick Start guides to reflect new blocking demo import workflow with semantic verification.

* **Tests**
  * Added integration and unit tests validating demo import convergence, verification, and overlay seeding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->