### PR TITLE
fix(cli): render run query-unit rows (#2006)

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -1552,6 +1552,8 @@ def _emit_unit_source_rows(
         text_line = _block_query_line
     elif source.unit == "assertion":
         text_line = _assertion_query_line
+    elif source.unit == "run":
+        text_line = _run_query_line
     elif source.unit == "observed-event":
         text_line = _observed_event_query_line
     elif source.unit == "context-snapshot":
@@ -1610,6 +1612,12 @@ def _block_query_line(item: dict[str, object]) -> str:
 def _assertion_query_line(item: dict[str, object]) -> str:
     detail = item.get("body_text") or item.get("key") or item.get("value") or item.get("target_ref") or ""
     return f"{item['assertion_id']} [{item['kind']}/{item['status']}] {_snippet(detail)}"
+
+
+def _run_query_line(item: dict[str, object]) -> str:
+    detail_parts = [str(part) for part in (item.get("agent_ref"), item.get("title")) if part]
+    detail = " ".join(detail_parts) or item.get("run_ref") or ""
+    return f"{item['run_ref']} [{item['role']}/{item['status']}] {_snippet(detail)}"
 
 
 def _observed_event_query_line(item: dict[str, object]) -> str:

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -95,6 +95,41 @@ def search_workspace(cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyP
         .add_message("m6", role="assistant", text="Rust ownership ensures memory safety without garbage collection.")
         .save()
     )
+    (
+        SessionBuilder(index_db, "run-hit")
+        .provider("codex")
+        .git_repository_url("polylogue")
+        .git_branch("feature/query-runs")
+        .working_directories(["/realm/project/polylogue"])
+        .title("Run query rendering")
+        .created_at((now - timedelta(minutes=30)).isoformat())
+        .updated_at((now - timedelta(minutes=30)).isoformat())
+        .add_message("m7", role="user", text="Wire run query unit rendering.")
+        .add_message(
+            "m8",
+            role="assistant",
+            text="Delegating the run query rendering check.",
+            blocks=[
+                {
+                    "type": "tool_use",
+                    "id": "tool-run",
+                    "name": "Task",
+                    "tool_input": {
+                        "subagent_type": "Explore",
+                        "taskId": "task-run",
+                        "child_session_id": "codex-session:child-run",
+                        "prompt": "Map run query unit CLI rendering.",
+                    },
+                },
+                {
+                    "type": "tool_result",
+                    "tool_id": "tool-run",
+                    "text": "Subagent done: run query unit rendered.\n2 passed in 0.12s",
+                },
+            ],
+        )
+        .save()
+    )
 
     with sqlite3.connect(cli_workspace["archive_root"] / "user.db") as conn:
         conn.row_factory = sqlite3.Row
@@ -2578,7 +2613,7 @@ class TestSearchQueryContracts:
             ],
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert payload["mode"] == "query-unit"
         assert payload["unit"] == "assertion"
@@ -2604,8 +2639,34 @@ class TestSearchQueryContracts:
             ],
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "assertion-cli-decision [decision/active] Python terminal assertion" in result.output
+
+    def test_run_unit_source_renders_plain_rows(self, search_workspace: SearchWorkspace) -> None:
+        """Run terminal rows render through the CLI instead of failing after query execution."""
+        from polylogue.cli import cli
+
+        del search_workspace
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--plain",
+                "find",
+                "runs",
+                "where",
+                "session.repo:polylogue",
+                "AND",
+                "role:subagent",
+                "AND",
+                "agent:Explore",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "run:codex-session:child-run [subagent/completed]" in result.output
+        assert "agent:codex/Explore" in result.output
 
     def test_context_snapshot_unit_source_routes_to_query_units(self, search_workspace: SearchWorkspace) -> None:
         """Context snapshot expressions stay on terminal query-unit routing, not stats."""


### PR DESCRIPTION
## Summary

Adds the missing CLI renderer for explicit `runs where ...` terminal query-unit rows so the query DSL no longer executes successfully and then fails at presentation time.

## Problem

`runs where ...` was already part of the query-unit substrate: the parser, query metadata, API facade, and row payloads all support runtime run rows. The CLI terminal row emitter handled messages, actions, blocks, assertions, observed events, and context snapshots, but not runs, so a valid run query reached `_emit_unit_source_rows` and raised `Unsupported query unit: run`.

## Solution

- Added `_run_query_line(...)` in `polylogue/cli/archive_query.py` and routed `source.unit == "run"` through it.
- Extended the query execution fixture with a Codex subagent run projection.
- Added a CLI smoke test proving `polylogue --plain find runs where ...` renders the run row and agent ref instead of failing after execution.

## Verification

```bash
devtools test tests/unit/cli/test_query_exec_laws.py::TestSearchQueryContracts::test_run_unit_source_renders_plain_rows tests/unit/cli/test_query_expression.py::TestBooleanQueryExpression::test_terminal_run_source_returns_runtime_rows tests/unit/api/test_facade_contracts.py::test_query_units_returns_run_rows -q
# 3 passed in 28.21s

devtools verify --seed-testmon --skip-slow
# 11634 passed, 9 warnings in 273.13s; peak pytest tree RSS 3280.3 MiB

devtools verify
# 7 passed in 17.85s; exit_code 0

devtools verify --quick
# exit_code 0 after rebasing onto current master
```