### PR TITLE
refactor(query): drive unit rendering from descriptors (#2177)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1288,6 +1288,11 @@ def _terminal_only_unit_source_error(unit: QueryUnitName) -> ExpressionCompileEr
     )
 
 
+def _query_unit_uses_runtime_transform(unit: QueryUnitName) -> bool:
+    descriptor = query_unit_descriptor(unit)
+    return descriptor is not None and descriptor.lowerer_kind == "runtime_transform"
+
+
 def _parse_source_where_predicate(expression: str) -> QueryExistsPredicate | None:
     source = parse_unit_source_expression(expression)
     if source is None:
@@ -1302,7 +1307,7 @@ def _parse_source_where_predicate(expression: str) -> QueryExistsPredicate | Non
             "pipeline unit queries return terminal rows; use query_units / /api/query-units or a CLI terminal-unit query",
             field=None,
         )
-    if source.unit in {"run", "observed-event", "context-snapshot"}:
+    if _query_unit_uses_runtime_transform(source.unit):
         raise _terminal_only_unit_source_error(source.unit)
     return QueryExistsPredicate(unit=cast(Any, source.unit), child=source.predicate)
 
@@ -1507,7 +1512,7 @@ def _explain_execution_legs(spec: SessionQuerySpec) -> tuple[str, ...]:
 
 def _explain_unit_source_execution_legs(source: QueryUnitSource) -> tuple[str, ...]:
     legs = {f"terminal-{source.unit}-rows", *_predicate_execution_legs(source.predicate)}
-    if source.unit in {"run", "observed-event", "context-snapshot"}:
+    if _query_unit_uses_runtime_transform(source.unit):
         legs.add("runtime-transform")
     else:
         legs.add("sql")
@@ -1600,7 +1605,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
     if unit_source is not None:
         lowered = (
             SessionQuerySpec()
-            if unit_source.unit in {"run", "observed-event", "context-snapshot"}
+            if _query_unit_uses_runtime_transform(unit_source.unit)
             else SessionQuerySpec(
                 boolean_predicate=QueryExistsPredicate(unit=cast(Any, unit_source.unit), child=unit_source.predicate)
             )
@@ -1609,7 +1614,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
         execution_legs = _explain_unit_source_execution_legs(unit_source)
         plan_description = (f"terminal unit source: {unit_source.unit}",)
         compatibility_selector = None
-        if unit_source.unit not in {"run", "observed-event", "context-snapshot"}:
+        if not _query_unit_uses_runtime_transform(unit_source.unit):
             compatibility_selector = f"exists {unit_source.unit}(...)"
             plan_description = (*plan_description, f"compatibility session selector: {compatibility_selector}")
         lowerer = "lark-query-unit-source-to-terminal-unit"

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -19,6 +19,7 @@ class QueryUnitDescriptor:
     terminal_supported: bool = True
     exists_supported: bool = False
     lowerer_kind: QueryUnitLowererKind = "sql"
+    cli_plain_renderer: str | None = None
     fields: tuple[StructuralQueryFieldInfo, ...] = ()
     description: str = ""
     example: str = ""
@@ -518,6 +519,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "message",
         "messages",
         exists_supported=True,
+        cli_plain_renderer="message",
         fields=_unit_info("message").fields,
         description=_unit_info("message").description,
         example=_unit_info("message").example,
@@ -527,6 +529,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "action",
         "actions",
         exists_supported=True,
+        cli_plain_renderer="action",
         fields=_unit_info("action").fields,
         description=_unit_info("action").description,
         example=_unit_info("action").example,
@@ -536,6 +539,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "block",
         "blocks",
         exists_supported=True,
+        cli_plain_renderer="block",
         fields=_unit_info("block").fields,
         description=_unit_info("block").description,
         example=_unit_info("block").example,
@@ -545,6 +549,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "assertion",
         "assertions",
         exists_supported=True,
+        cli_plain_renderer="assertion",
         fields=_unit_info("assertion").fields,
         description=_unit_info("assertion").description,
         example=_unit_info("assertion").example,
@@ -555,6 +560,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "runs",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        cli_plain_renderer="run",
         fields=_unit_info("run").fields,
         description=_unit_info("run").description,
         example=_unit_info("run").example,
@@ -565,6 +571,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "observed-events",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        cli_plain_renderer="observed-event",
         fields=_unit_info("observed-event").fields,
         description=_unit_info("observed-event").description,
         example=_unit_info("observed-event").example,
@@ -575,6 +582,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "context-snapshots",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        cli_plain_renderer="context-snapshot",
         fields=_unit_info("context-snapshot").fields,
         description=_unit_info("context-snapshot").description,
         example=_unit_info("context-snapshot").example,

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -20,6 +20,7 @@ from typing_extensions import TypedDict
 from polylogue.archive.message.roles import MessageRoleFilter, Role, normalize_message_roles
 from polylogue.archive.message.types import validate_message_type_filter
 from polylogue.archive.query.expression import QueryUnitSource, parse_unit_source_expression
+from polylogue.archive.query.metadata import query_unit_descriptor
 from polylogue.archive.query.spec import (
     QuerySpecError,
     normalize_action_sequence,
@@ -66,6 +67,7 @@ from polylogue.surfaces.payloads import (
 _PageRow = TypeVar("_PageRow", ArchiveSessionSummary, ArchiveSessionSearchHit)
 
 _UNSUPPORTED_PARAM_MESSAGES: dict[str, str] = {}
+_QueryUnitTextLine = Callable[[dict[str, object]], str]
 
 
 class _ArchiveFilterKwargs(TypedDict):
@@ -1544,22 +1546,7 @@ def _emit_unit_source_rows(
     )
     envelope = envelope_model.model_dump(mode="json")
     items = [item.model_dump(mode="json") for item in envelope_model.items]
-    if source.unit == "message":
-        text_line = _message_query_line
-    elif source.unit == "action":
-        text_line = _action_query_line
-    elif source.unit == "block":
-        text_line = _block_query_line
-    elif source.unit == "assertion":
-        text_line = _assertion_query_line
-    elif source.unit == "run":
-        text_line = _run_query_line
-    elif source.unit == "observed-event":
-        text_line = _observed_event_query_line
-    elif source.unit == "context-snapshot":
-        text_line = _context_snapshot_query_line
-    else:
-        raise click.UsageError(f"Unsupported query unit: {source.unit}")
+    text_line = _query_unit_text_line(source.unit)
 
     if not items:
         _emit_unit_no_results(envelope, unit=source.unit, output_format=output_format)
@@ -1628,6 +1615,28 @@ def _observed_event_query_line(item: dict[str, object]) -> str:
 def _context_snapshot_query_line(item: dict[str, object]) -> str:
     detail = item.get("metadata") or item.get("segment_refs") or item.get("evidence_refs") or ""
     return f"{item['snapshot_ref']} [{item['boundary']}/{item['inheritance_mode']}] {_snippet(detail)}"
+
+
+_QUERY_UNIT_TEXT_LINES: dict[str, _QueryUnitTextLine] = {
+    "message": _message_query_line,
+    "action": _action_query_line,
+    "block": _block_query_line,
+    "assertion": _assertion_query_line,
+    "run": _run_query_line,
+    "observed-event": _observed_event_query_line,
+    "context-snapshot": _context_snapshot_query_line,
+}
+
+
+def _query_unit_text_line(unit: str) -> _QueryUnitTextLine:
+    descriptor = query_unit_descriptor(unit)
+    renderer = descriptor.cli_plain_renderer if descriptor else None
+    if renderer is None:
+        raise click.UsageError(f"Unsupported query unit: {unit}")
+    try:
+        return _QUERY_UNIT_TEXT_LINES[renderer]
+    except KeyError as exc:
+        raise click.UsageError(f"Unsupported query unit renderer: {renderer}") from exc
 
 
 def _project_payload(payload: dict[str, object], fields: str | None) -> dict[str, object]:

--- a/tests/unit/cli/test_query_unit_renderer_metadata.py
+++ b/tests/unit/cli/test_query_unit_renderer_metadata.py
@@ -1,0 +1,23 @@
+"""CLI renderer wiring for query-unit descriptors."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from polylogue.archive.query.metadata import query_unit_descriptors
+from polylogue.cli.archive_query import _query_unit_text_line
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [descriptor.unit for descriptor in query_unit_descriptors(terminal_supported=True)],
+)
+def test_terminal_query_unit_descriptors_resolve_plain_renderers(unit: str) -> None:
+    """Terminal query units render through descriptor-owned CLI metadata."""
+    assert callable(_query_unit_text_line(unit))
+
+
+def test_unknown_query_unit_renderer_fails_typed() -> None:
+    with pytest.raises(click.UsageError, match="Unsupported query unit: imaginary"):
+        _query_unit_text_line("imaginary")


### PR DESCRIPTION
## Summary

Moves two query-unit decisions into the existing `QueryUnitDescriptor`: CLI plain-row renderer selection and runtime-transform lowerer classification.

Ref #2177. Ref #2006.

## Problem

Polylogue already has a query-unit descriptor registry, but terminal-unit behavior still repeated unit truth in local string branches. The expression compiler hard-coded the runtime-transform units, and CLI terminal row rendering hard-coded a parallel `source.unit` branch. That makes each new terminal unit require another manual synchronization pass.

## Solution

- Added `cli_plain_renderer` metadata to `QueryUnitDescriptor` for every executable terminal unit.
- Changed CLI terminal row output to resolve its text renderer through descriptor metadata instead of branching on `source.unit`.
- Changed expression explanation/session-selector compatibility logic to use descriptor `lowerer_kind` instead of a hard-coded runtime-transform unit set.
- Added a focused invariant test that every terminal descriptor resolves to a callable CLI renderer and unknown units fail typed.

This does not add a new ledger. It expands the existing query-unit descriptor only where it replaces repeated behavior.

## Verification

- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_query_unit_renderer_metadata.py tests/unit/cli/test_query_expression.py -q` -> 280 passed.
- `devtools verify --quick` -> exit 0.
- `devtools verify --seed-testmon --skip-slow` -> 11660 passed, 9 warnings in 272.74s; peak pytest tree RSS 3160.4 MiB.
- `devtools verify` -> 7 passed in 18.55s, total gate exit 0.