### PR TITLE
feat(query): expose unit payload models from descriptors

### DIFF
--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -59,6 +59,7 @@ class QueryCompletionCandidate:
     stale: bool = False
     danger: bool = False
     score: float = 1.0
+    payload_model: str | None = None
     unsupported_reason: str | None = None
     preview_command: str | None = None
 
@@ -78,6 +79,7 @@ class QueryCompletionCandidate:
             "source": self.source,
             "stale": self.stale,
             "danger": self.danger,
+            "payload_model": self.payload_model,
             "unsupported_reason": self.unsupported_reason,
             "preview_command": self.preview_command,
         }
@@ -167,6 +169,7 @@ def query_structural_unit_candidates(incomplete: str) -> list[QueryCompletionCan
                 group="query structural units",
                 description=description,
                 source="QUERY_UNIT_DESCRIPTORS",
+                payload_model=descriptor.payload_model if descriptor is not None else None,
             )
         )
     return candidates
@@ -178,6 +181,7 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
     current = incomplete.strip().lstrip("-").lower()
     if ":" in current:
         return []
+    descriptor = query_unit_descriptor(unit)
     candidates: list[QueryCompletionCandidate] = []
     for field_name in structural_query_fields(unit):
         if current and not field_name.startswith(current):
@@ -197,6 +201,7 @@ def query_structural_field_candidates(unit: str, incomplete: str) -> list[QueryC
                 group=f"{unit} structural fields",
                 description=description,
                 source="QUERY_UNIT_DESCRIPTORS",
+                payload_model=descriptor.payload_model if descriptor is not None else None,
             )
         )
     return candidates
@@ -226,6 +231,7 @@ def query_terminal_source_candidates(incomplete: str) -> list[QueryCompletionCan
                 group="query terminal sources",
                 description=description,
                 source="QUERY_UNIT_DESCRIPTORS",
+                payload_model=descriptor.payload_model if descriptor is not None else None,
             )
         )
     return candidates
@@ -237,6 +243,7 @@ def query_terminal_field_candidates(source: str, incomplete: str) -> list[QueryC
     current = incomplete.strip().lstrip("-").lower()
     if ":" in current:
         return []
+    descriptor = query_unit_descriptor(source)
     candidates: list[QueryCompletionCandidate] = []
     for field_name in terminal_query_fields(source):
         if current and not field_name.startswith(current):
@@ -256,6 +263,7 @@ def query_terminal_field_candidates(source: str, incomplete: str) -> list[QueryC
                 group=f"{source} terminal fields",
                 description=description,
                 source="QUERY_UNIT_DESCRIPTORS",
+                payload_model=descriptor.payload_model if descriptor is not None else None,
             )
         )
     return candidates

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -16,6 +16,7 @@ class QueryUnitDescriptor:
     unit: QueryUnitName
     singular_source: str
     plural_source: str
+    payload_model: str
     terminal_supported: bool = True
     exists_supported: bool = False
     lowerer_kind: QueryUnitLowererKind = "sql"
@@ -519,6 +520,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "message",
         "messages",
         exists_supported=True,
+        payload_model="MessageQueryRowPayload",
         cli_plain_renderer="message",
         fields=_unit_info("message").fields,
         description=_unit_info("message").description,
@@ -529,6 +531,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "action",
         "actions",
         exists_supported=True,
+        payload_model="ActionQueryRowPayload",
         cli_plain_renderer="action",
         fields=_unit_info("action").fields,
         description=_unit_info("action").description,
@@ -539,6 +542,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "block",
         "blocks",
         exists_supported=True,
+        payload_model="BlockQueryRowPayload",
         cli_plain_renderer="block",
         fields=_unit_info("block").fields,
         description=_unit_info("block").description,
@@ -549,6 +553,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "assertion",
         "assertions",
         exists_supported=True,
+        payload_model="AssertionQueryRowPayload",
         cli_plain_renderer="assertion",
         fields=_unit_info("assertion").fields,
         description=_unit_info("assertion").description,
@@ -560,6 +565,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "runs",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        payload_model="RunQueryRowPayload",
         cli_plain_renderer="run",
         fields=_unit_info("run").fields,
         description=_unit_info("run").description,
@@ -571,6 +577,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "observed-events",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        payload_model="ObservedEventQueryRowPayload",
         cli_plain_renderer="observed-event",
         fields=_unit_info("observed-event").fields,
         description=_unit_info("observed-event").description,
@@ -582,6 +589,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "context-snapshots",
         exists_supported=False,
         lowerer_kind="runtime_transform",
+        payload_model="ContextSnapshotQueryRowPayload",
         cli_plain_renderer="context-snapshot",
         fields=_unit_info("context-snapshot").fields,
         description=_unit_info("context-snapshot").description,

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -78,8 +78,10 @@ def test_query_unit_descriptors_own_terminal_aliases() -> None:
     assert observed_descriptor.plural_source == "observed-events"
     assert observed_descriptor.exists_supported is False
     assert observed_descriptor.lowerer_kind == "runtime_transform"
+    assert observed_descriptor.payload_model == "ObservedEventQueryRowPayload"
     assert message_descriptor.exists_supported is True
     assert message_descriptor.lowerer_kind == "sql"
+    assert message_descriptor.payload_model == "MessageQueryRowPayload"
     assert context_descriptor.source_aliases == ("context-snapshot", "context-snapshots")
     assert terminal_query_source_list() == "messages/actions/blocks/assertions/runs/observed-events/context-snapshots"
     assert ("assertions", "assertion") in terminal_query_source_pairs()
@@ -97,3 +99,21 @@ def test_query_unit_descriptors_own_terminal_aliases() -> None:
     )
     assert structural_query_fields("context-snapshot") == ()
     assert "boundary" in terminal_query_fields("context-snapshots")
+
+
+def test_terminal_query_completion_payloads_expose_payload_model() -> None:
+    from polylogue.archive.query.completions import query_completion_payload
+
+    source_payload = query_completion_payload("terminal-source", incomplete="runs")
+    source_candidates = [
+        cast(dict[str, object], candidate) for candidate in cast(list[object], source_payload["candidates"])
+    ]
+    run_candidate = next(candidate for candidate in source_candidates if candidate["value"] == "runs")
+    assert run_candidate["payload_model"] == "RunQueryRowPayload"
+
+    field_payload = query_completion_payload("terminal-field", unit="assertions", incomplete="kind")
+    field_candidates = [
+        cast(dict[str, object], candidate) for candidate in cast(list[object], field_payload["candidates"])
+    ]
+    field_candidate = next(candidate for candidate in field_candidates if candidate["value"] == "kind")
+    assert field_candidate["payload_model"] == "AssertionQueryRowPayload"


### PR DESCRIPTION
## Summary

Adds the terminal query-unit row payload model to `QueryUnitDescriptor` and exposes that metadata through query completion payloads.

## Problem

Query-unit descriptors already own aliases, lowerer kind, renderer name, examples, and field metadata, but machine-facing completion consumers still had to infer which typed row payload a terminal unit returns. That duplicated descriptor knowledge at API/MCP/shell boundaries and left #2006's query-unit substrate less self-describing than the code actually is.

## Solution

`QueryUnitDescriptor` now carries a `payload_model` for every supported query unit: messages, actions, blocks, assertions, runs, observed-events, and context-snapshots. Structural-unit, structural-field, terminal-source, and terminal-field completion candidates include the descriptor's payload model in their machine payloads, so callers can derive the row shape from the same registry that owns the query-unit vocabulary.

Ref #2006.

## Verification

- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_query_unit_renderer_metadata.py -q` -> `12 passed`
- `devtools verify --quick` -> exit 0; ruff format/check, mypy, render all, topology, layering, manifests, doc commands, and quick gates passed