### PR TITLE
fix(cli): reject read options for unrelated views

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -76,6 +76,48 @@ _READ_VIEW_HELP = "What to render (" + ", ".join(_READ_VIEWS) + ")."
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
 _READ_FORMATS = tuple(sorted({fmt for profile in READ_VIEW_PROFILES for fmt in profile.formats}))
 _RECOVERY_REPORT_PRESETS = ("continue", "blame", "work-packet")
+_READ_VIEW_SPECIFIC_OPTION_NAMES = frozenset(
+    {
+        "confidence_threshold",
+        "github_api",
+        "limit",
+        "max_messages",
+        "max_sessions",
+        "message_role",
+        "message_type",
+        "no_code_blocks",
+        "no_file_reads",
+        "no_redact",
+        "no_tool_calls",
+        "no_tool_outputs",
+        "offset",
+        "otlp",
+        "pack_origin",
+        "pack_query",
+        "project_path",
+        "project_repo",
+        "prose_only",
+        "recovery_report",
+        "related_limit",
+        "repo_path",
+        "since",
+        "since_hours",
+        "until",
+        "window_hours",
+    }
+)
+
+
+def _explicit_read_view_options(ctx: click.Context) -> frozenset[str]:
+    """Return view-specific read options supplied on the command line."""
+
+    return frozenset(
+        name
+        for name in _READ_VIEW_SPECIFIC_OPTION_NAMES
+        if (source := ctx.get_parameter_source(name)) is not None and source.name == "COMMANDLINE"
+    )
+
+
 _CONTINUE_CANDIDATE_DEFAULT_LIMIT = 10
 
 
@@ -436,6 +478,7 @@ def read_verb(
     if view == "recovery" and effective_format is None:
         root_format = request.params.get("output_format")
         effective_format = root_format if isinstance(root_format, str) else None
+    explicit_options = _explicit_read_view_options(ctx)
     if destination == "browser":
         run_read_view(
             env,
@@ -446,6 +489,7 @@ def read_verb(
                 output_format=effective_format,
                 destination=destination,
                 out_path=out_path,
+                explicit_options=explicit_options,
             ),
         )
         return
@@ -491,6 +535,7 @@ def read_verb(
                 github_api=github_api,
                 otlp=otlp,
             ),
+            explicit_options=explicit_options,
         ),
     )
 

--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -30,16 +30,69 @@ if TYPE_CHECKING:
     from polylogue.cli.root_request import RootModeRequest
 
 
+_MESSAGE_OPTIONS = frozenset(
+    {
+        "limit",
+        "message_role",
+        "message_type",
+        "no_code_blocks",
+        "no_file_reads",
+        "no_tool_calls",
+        "no_tool_outputs",
+        "offset",
+        "prose_only",
+    }
+)
+_CONTEXT_PACK_OPTIONS = frozenset(
+    {
+        "max_messages",
+        "max_sessions",
+        "no_redact",
+        "pack_origin",
+        "pack_query",
+        "project_path",
+        "project_repo",
+        "since",
+        "until",
+    }
+)
+_CORRELATION_OPTIONS = frozenset({"confidence_threshold", "github_api", "otlp", "repo_path", "since_hours"})
+
+
 READ_VIEW_HANDLERS: dict[str, ReadViewHandler] = {
     "summary": ReadViewHandler("summary", "optional", run_read_summary_or_transcript, default_format="markdown"),
     "transcript": ReadViewHandler("transcript", "optional", run_read_summary_or_transcript, default_format="markdown"),
-    "messages": ReadViewHandler("messages", "required", run_read_messages, default_format="text"),
-    "raw": ReadViewHandler("raw", "required", run_read_raw, default_format="json"),
-    "context": ReadViewHandler("context", "required", run_read_context, default_format="json"),
-    "context-pack": ReadViewHandler("context-pack", "none", run_read_context_pack, default_format="markdown"),
-    "recovery": ReadViewHandler("recovery", "required", run_read_recovery, default_format="markdown"),
-    "neighbors": ReadViewHandler("neighbors", "query_or_session", run_read_neighbors, default_format="text"),
-    "correlation": ReadViewHandler("correlation", "required", run_read_correlation, default_format="text"),
+    "messages": ReadViewHandler(
+        "messages", "required", run_read_messages, default_format="text", accepted_options=_MESSAGE_OPTIONS
+    ),
+    "raw": ReadViewHandler("raw", "required", run_read_raw, default_format="json", accepted_options=_MESSAGE_OPTIONS),
+    "context": ReadViewHandler(
+        "context", "required", run_read_context, default_format="json", accepted_options=frozenset({"related_limit"})
+    ),
+    "context-pack": ReadViewHandler(
+        "context-pack",
+        "none",
+        run_read_context_pack,
+        default_format="markdown",
+        accepted_options=_CONTEXT_PACK_OPTIONS,
+    ),
+    "recovery": ReadViewHandler(
+        "recovery",
+        "required",
+        run_read_recovery,
+        default_format="markdown",
+        accepted_options=frozenset({"recovery_report"}),
+    ),
+    "neighbors": ReadViewHandler(
+        "neighbors",
+        "query_or_session",
+        run_read_neighbors,
+        default_format="text",
+        accepted_options=frozenset({"limit", "window_hours"}),
+    ),
+    "correlation": ReadViewHandler(
+        "correlation", "required", run_read_correlation, default_format="text", accepted_options=_CORRELATION_OPTIONS
+    ),
 }
 
 

--- a/polylogue/cli/read_views/base.py
+++ b/polylogue/cli/read_views/base.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 
 ReadViewSessionPolicy = Literal["optional", "required", "query_or_session", "none"]
+ReadViewOptionName = str
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,6 +98,7 @@ class ReadViewInvocation:
     recovery: ReadViewRecoveryOptions = ReadViewRecoveryOptions()
     neighbors: ReadViewNeighborOptions = ReadViewNeighborOptions()
     correlation: ReadViewCorrelationOptions = ReadViewCorrelationOptions()
+    explicit_options: frozenset[ReadViewOptionName] = frozenset()
 
 
 ReadViewHandlerFunc = Callable[[AppEnv, "RootModeRequest", ReadViewInvocation], None]
@@ -110,6 +112,7 @@ class ReadViewHandler:
     session_policy: ReadViewSessionPolicy
     handler: ReadViewHandlerFunc
     default_format: str | None = None
+    accepted_options: frozenset[ReadViewOptionName] = frozenset()
 
     def validate(self, invocation: ReadViewInvocation, request: RootModeRequest) -> None:
         """Validate cross-view selection rules before executing the handler."""
@@ -132,6 +135,10 @@ class ReadViewHandler:
                     f"read --view {self.view_id} does not support --format {invocation.output_format}. "
                     f"Supported formats: {supported}."
                 )
+        unsupported_options = sorted(invocation.explicit_options - self.accepted_options)
+        if unsupported_options:
+            options = ", ".join(f"--{option.replace('_', '-')}" for option in unsupported_options)
+            raise click.UsageError(f"read --view {self.view_id} does not use {options}.")
 
 
 def deliver_content(env: AppEnv, content: str, *, destination: str, out_path: str | None) -> None:
@@ -165,6 +172,7 @@ __all__ = [
     "ReadViewHandler",
     "ReadViewHandlerFunc",
     "ReadViewInvocation",
+    "ReadViewOptionName",
     "ReadViewMessageOptions",
     "ReadViewNeighborOptions",
     "ReadViewRecoveryOptions",

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -767,6 +767,47 @@ def test_read_view_rejects_format_outside_selected_profile() -> None:
         )
 
 
+def test_read_view_rejects_explicit_options_for_other_views() -> None:
+    env = SimpleNamespace(polylogue=SimpleNamespace())
+
+    with pytest.raises(click.UsageError, match="read --view recovery does not use --message-role"):
+        read_view_handlers.run_read_view(
+            cast(AppEnv, env),
+            RootModeRequest.from_params({}),
+            ReadViewInvocation(
+                view="recovery",
+                session_id="s1",
+                output_format=None,
+                destination="terminal",
+                out_path=None,
+                explicit_options=frozenset({"message_role"}),
+            ),
+        )
+
+
+def test_read_view_accepts_explicit_options_owned_by_selected_view() -> None:
+    read_view_handlers.READ_VIEW_HANDLERS["recovery"].validate(
+        ReadViewInvocation(
+            view="recovery",
+            session_id="s1",
+            output_format=None,
+            destination="terminal",
+            out_path=None,
+            recovery=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
+            explicit_options=frozenset({"recovery_report"}),
+        ),
+        RootModeRequest.from_params({}),
+    )
+
+
+def test_explicit_read_view_options_reports_command_line_values_only() -> None:
+    ctx = click.Context(query_verbs.read_verb)
+    ctx.set_parameter_source("message_role", click.core.ParameterSource.COMMANDLINE)
+    ctx.set_parameter_source("related_limit", click.core.ParameterSource.DEFAULT)
+
+    assert query_verbs._explicit_read_view_options(ctx) == frozenset({"message_role"})
+
+
 def test_resolve_target_session_id_uses_explicit_conv_id() -> None:
     request = RootModeRequest.from_params({"conv_id": "claude-code:abc123"})
     assert query_verbs._resolve_target_session_id(request) == "claude-code:abc123"


### PR DESCRIPTION
## Summary

Makes read-view option ownership executable: `read --view ...` now rejects explicitly supplied options that belong to another read view instead of silently ignoring them.

## Problem

The query-first `read` command exposes options for several read views at the same root command. Help text says which view owns each option, and handlers already had per-view option dataclasses, but the selected handler did not validate that command-line-supplied flags were relevant to that view. For example, a messages-only filter could be supplied to `--view recovery` and disappear without effect.

## Solution

`ReadViewInvocation` now carries the view-specific option names that Click reports as command-line-supplied. Each `ReadViewHandler` declares the option names it consumes. Handler validation rejects unsupported explicit options before executing the view, while defaulted options and common delivery flags stay common. This makes the existing read-view registry own a real behavior boundary instead of leaving the root `read` command as an option sink.

Ref #2177.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py -k 'read_view_rejects_explicit_options or read_view_accepts_explicit_options or explicit_read_view_options' -q` -> `3 passed, 34 deselected`
- `devtools test tests/unit/cli/test_query_verbs_runtime.py -q` -> `37 passed`
- `devtools verify --quick` -> exit 0; ruff, mypy, render all, topology, layering, manifests, doc commands, and quick gates passed