### PR TITLE
refactor(daemon): expose read-view route capabilities (#2177)

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -31,6 +31,7 @@ from polylogue.cli.read_view_handlers import (
     ReadViewMessageOptions,
     ReadViewNeighborOptions,
     ReadViewRecoveryOptions,
+    read_view_option_names,
     run_bulk_export_view,
     run_read_view,
 )
@@ -76,36 +77,6 @@ _READ_VIEW_HELP = "What to render (" + ", ".join(_READ_VIEWS) + ")."
 _READ_DESTINATIONS = ("terminal", "stdout", "browser", "clipboard", "file")
 _READ_FORMATS = tuple(sorted({fmt for profile in READ_VIEW_PROFILES for fmt in profile.formats}))
 _RECOVERY_REPORT_PRESETS = ("continue", "blame", "work-packet")
-_READ_VIEW_SPECIFIC_OPTION_NAMES = frozenset(
-    {
-        "confidence_threshold",
-        "github_api",
-        "limit",
-        "max_messages",
-        "max_sessions",
-        "message_role",
-        "message_type",
-        "no_code_blocks",
-        "no_file_reads",
-        "no_redact",
-        "no_tool_calls",
-        "no_tool_outputs",
-        "offset",
-        "otlp",
-        "pack_origin",
-        "pack_query",
-        "project_path",
-        "project_repo",
-        "prose_only",
-        "recovery_report",
-        "related_limit",
-        "repo_path",
-        "since",
-        "since_hours",
-        "until",
-        "window_hours",
-    }
-)
 
 
 def _explicit_read_view_options(ctx: click.Context) -> frozenset[str]:
@@ -113,7 +84,7 @@ def _explicit_read_view_options(ctx: click.Context) -> frozenset[str]:
 
     return frozenset(
         name
-        for name in _READ_VIEW_SPECIFIC_OPTION_NAMES
+        for name in read_view_option_names()
         if (source := ctx.get_parameter_source(name)) is not None and source.name == "COMMANDLINE"
     )
 

--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -113,6 +113,12 @@ def read_view_handler_ids() -> tuple[str, ...]:
     return tuple(READ_VIEW_HANDLERS)
 
 
+def read_view_option_names() -> frozenset[str]:
+    """Return every view-specific option name owned by read-view handlers."""
+
+    return frozenset(option_name for handler in READ_VIEW_HANDLERS.values() for option_name in handler.accepted_options)
+
+
 def validate_read_view_handler_registry() -> None:
     """Fail fast if profile metadata and executable handlers drift."""
 
@@ -142,6 +148,7 @@ __all__ = [
     "ReadViewNeighborOptions",
     "ReadViewRecoveryOptions",
     "read_view_handler_ids",
+    "read_view_option_names",
     "run_bulk_export_view",
     "run_read_view",
     "validate_read_view_handler_registry",

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -16,6 +16,7 @@ from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import parse_qs, urlparse
 
+from polylogue.core.json import JSONDocument
 from polylogue.core.loopback import is_loopback_host, is_loopback_origin
 from polylogue.core.sources import source_name_to_origin
 from polylogue.daemon import user_state_http, workspace_routes
@@ -94,6 +95,56 @@ class _StaticPostRoute:
     segments: tuple[str, ...]
     handler_name: str
     passes_path: bool = False
+
+
+@dataclass(frozen=True)
+class _ReadViewHttpCapability:
+    view_id: str
+    formats: tuple[str, ...]
+    query_params: tuple[str, ...] = ()
+
+    def to_payload(self) -> JSONDocument:
+        return {
+            "supported": True,
+            "route": "/api/sessions/{session_id}/read",
+            "formats": list(self.formats),
+            "query_params": list(self.query_params),
+        }
+
+
+_SESSION_READ_VIEW_HTTP_CAPABILITIES: dict[str, _ReadViewHttpCapability] = {
+    "messages": _ReadViewHttpCapability(
+        "messages",
+        ("json",),
+        (
+            "limit",
+            "offset",
+            "message_role",
+            "message_type",
+            "no_code_blocks",
+            "no_file_reads",
+            "no_tool_calls",
+            "no_tool_outputs",
+            "prose_only",
+        ),
+    ),
+    "recovery": _ReadViewHttpCapability("recovery", ("json", "markdown"), ("report",)),
+    "raw": _ReadViewHttpCapability("raw", ("json",)),
+    "context": _ReadViewHttpCapability("context", ("json",), ("related_limit",)),
+    "context-pack": _ReadViewHttpCapability(
+        "context-pack", ("json",), ("include_messages", "max_messages", "max_text", "no_redact")
+    ),
+    "neighbors": _ReadViewHttpCapability("neighbors", ("json",), ("limit", "window_hours")),
+    "correlation": _ReadViewHttpCapability(
+        "correlation", ("json",), ("confidence_threshold", "repo_path", "since_hours")
+    ),
+}
+
+
+def _read_view_http_capability_payloads() -> dict[str, JSONDocument]:
+    """Return daemon execution capabilities keyed by read-view id."""
+
+    return {view_id: capability.to_payload() for view_id, capability in _SESSION_READ_VIEW_HTTP_CAPABILITIES.items()}
 
 
 def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
@@ -2543,7 +2594,14 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         from polylogue.archive.viewport import read_view_profile_payloads
 
-        profiles = read_view_profile_payloads()
+        capabilities = _read_view_http_capability_payloads()
+        profiles = []
+        for profile in read_view_profile_payloads():
+            view_id = profile.get("view_id")
+            capability = capabilities.get(view_id) if isinstance(view_id, str) else None
+            if capability is not None:
+                profile = {**profile, "http": capability}
+            profiles.append(profile)
         self._send_json(HTTPStatus.OK, {"read_views": profiles, "total": len(profiles)})
 
     @daemon_safe_handler
@@ -2676,10 +2734,11 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         view = (self._get_param(params, "view", "messages") or "messages").strip().lower()
         output_format = (self._get_param(params, "format", "json") or "json").strip().lower()
-        if view not in {"messages", "recovery", "raw", "context", "context-pack", "neighbors", "correlation"}:
+        capability = _SESSION_READ_VIEW_HTTP_CAPABILITIES.get(view)
+        if capability is None:
             self._send_error(HTTPStatus.BAD_REQUEST, "unsupported_read_view")
             return
-        if output_format != "json" and not (view == "recovery" and output_format == "markdown"):
+        if output_format not in capability.formats:
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_format")
             return
 

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -778,8 +778,6 @@ function renderFacets() {
 function renderReadViewSelector(c) {
   if (!c) return '';
   var profiles = state.readViewProfiles || [];
-  var supported = {messages: true, recovery: true, raw: true, context: true, 'context-pack': true, neighbors: true, correlation: true};
-  var labels = {messages: 'Messages', recovery: 'Recovery', raw: 'Raw', context: 'Context', 'context-pack': 'Context Pack', neighbors: 'Neighbors', correlation: 'Correlation'};
   if (!profiles.length) {
     var fallback = state.readViewProfileError || 'Read profiles loading';
     return '<div id="read-profile-selector" class="read-profile-selector muted">' + esc(fallback) + '</div>';
@@ -789,12 +787,14 @@ function renderReadViewSelector(c) {
   profiles.forEach(function(profile) {
     var id = profile.view_id || profile.id;
     if (!id) return;
-    var disabled = supported[id] ? '' : ' disabled';
-    var suffix = supported[id] ? '' : ' (pending HTTP route)';
+    var http = profile.http || {};
+    var supported = http.supported === true;
+    var disabled = supported ? '' : ' disabled';
+    var suffix = supported ? '' : ' (pending HTTP route)';
     var selected = (state.selectedReadView === id) ? ' selected' : '';
-    var title = profile.description || profile.summary || '';
+    var title = profile.purpose || profile.description || profile.summary || '';
     html += '<option value="' + escAttr(id) + '"' + selected + disabled + ' title="' + escAttr(title) + '">'
-      + esc(labels[id] || id) + esc(suffix) + '</option>';
+      + esc(profile.label || id) + esc(suffix) + '</option>';
   });
   html += '</select><span class="profile-hint">from /api/read-view-profiles</span></div>';
   return html;

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1539,8 +1539,17 @@ class TestReaderViewProfiles:
         profiles = {profile["view_id"]: profile for profile in read_views}
         assert profiles["raw"]["lossiness"] == "raw"
         assert profiles["raw"]["evidence_policy"] == "required"
+        raw_http = cast(dict[str, object], profiles["raw"]["http"])
+        assert raw_http["supported"] is True
+        assert raw_http["route"] == "/api/sessions/{session_id}/read"
+        assert raw_http["formats"] == ["json"]
         assert profiles["recovery"]["successor_handoff"] is True
         assert "markdown" in profiles["recovery"]["formats"]
+        recovery_http = cast(dict[str, object], profiles["recovery"]["http"])
+        assert recovery_http["formats"] == ["json", "markdown"]
+        assert "report" in cast(list[str], recovery_http["query_params"])
+        context_pack_http = cast(dict[str, object], profiles["context-pack"]["http"])
+        assert "max_messages" in cast(list[str], context_pack_http["query_params"])
 
     def test_read_view_execution_route_returns_messages_recovery_raw_context_and_context_pack(
         self,


### PR DESCRIPTION
## Summary

Expose daemon read-view execution capability metadata through `/api/read-view-profiles` and make the web shell consume that metadata instead of keeping a duplicate supported-view map. The CLI read command also now derives explicit view-option names from `READ_VIEW_HANDLERS`, removing a second literal option list.

## Problem

The read-view surface had several parallel truths after the recent route work: handler metadata owned executable CLI options, `query_verbs.py` separately listed those option names to detect explicit wrong-view flags, and `web_shell.py` separately listed which read views `/api/sessions/{id}/read` could execute. That is exactly the #2177 failure mode: surfaces drift because contract metadata exists but adapters still carry their own local ledgers.

## Solution

- Added a daemon-owned `_ReadViewHttpCapability` map beside the `/api/sessions/{id}/read` handler.
- Joined those capabilities into `/api/read-view-profiles` as `profile.http` so clients can see route support, formats, and accepted query params.
- Updated the web shell read-view selector to use `profile.http.supported`, profile labels, and profile purpose text.
- Replaced the CLI `_READ_VIEW_SPECIFIC_OPTION_NAMES` literal with `read_view_option_names()` derived from `READ_VIEW_HANDLERS`.

This deliberately keeps archive read-view profiles semantic: daemon HTTP capabilities are joined at the daemon surface rather than imported into the archive profile registry.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py -k "read_view_rejects_explicit_options or read_view_accepts_explicit_options or explicit_read_view_options" -q` -> 3 passed
- `devtools test tests/unit/daemon/test_web_reader.py -k ReaderViewProfiles -q` -> 3 passed
- `devtools verify --quick` -> exit_code 0

Ref #2177