### PR TITLE
fix(query): route unit execution by descriptor lowerer (#2006)

### DIFF
--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from polylogue.archive.query.archive_execution import _session_to_session
 from polylogue.archive.query.expression import QueryUnitSource
+from polylogue.archive.query.metadata import query_unit_descriptor
 from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate, QueryNotPredicate, QueryPredicate
 from polylogue.archive.query.spec import (
     normalize_action_sequence,
@@ -550,23 +551,16 @@ def _query_observed_events(
     return tuple(rows)
 
 
-def query_unit_rows(
+def _build_runtime_transform_envelope(
     archive: ArchiveStore,
     source: QueryUnitSource,
     *,
     query: str,
     limit: int,
-    offset: int = 0,
-    session_filters: Mapping[str, object] | None = None,
+    offset: int,
+    caller_offset: int,
+    session_filters: Mapping[str, object] | None,
 ) -> QueryUnitEnvelope:
-    """Execute an explicit unit-source query."""
-
-    caller_offset = offset
-    if source.limit is not None:
-        limit = min(limit, source.limit)
-    if source.offset is not None:
-        offset += source.offset
-    fetch_limit = limit + 1
     if source.unit == "observed-event":
         event_rows = _query_observed_events(
             archive,
@@ -615,14 +609,30 @@ def query_unit_rows(
             offset=caller_offset,
             has_next=len(snapshot_rows) > limit,
         )
+    raise ValueError(f"Query unit {source.unit!r} is not wired to a runtime-transform executor")
+
+
+def _build_sql_envelope(
+    archive: ArchiveStore,
+    source: QueryUnitSource,
+    *,
+    query: str,
+    limit: int,
+    offset: int,
+    caller_offset: int,
+    fetch_limit: int,
+    session_filters: Mapping[str, object] | None,
+) -> QueryUnitEnvelope:
+    sort = source.sort.field if source.sort is not None else None
+    sort_direction = source.sort.direction if source.sort is not None else "asc"
     if source.unit == "message":
         message_rows = archive.query_messages(
             source.predicate,
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
-            sort=source.sort.field if source.sort is not None else None,
-            sort_direction=source.sort.direction if source.sort is not None else "asc",
+            sort=sort,
+            sort_direction=sort_direction,
         )
         return build_query_unit_envelope(
             tuple(MessageQueryRowPayload.from_row(row) for row in message_rows[:limit]),
@@ -638,8 +648,8 @@ def query_unit_rows(
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
-            sort=source.sort.field if source.sort is not None else None,
-            sort_direction=source.sort.direction if source.sort is not None else "asc",
+            sort=sort,
+            sort_direction=sort_direction,
         )
         return build_query_unit_envelope(
             tuple(ActionQueryRowPayload.from_row(row) for row in action_rows[:limit]),
@@ -655,8 +665,8 @@ def query_unit_rows(
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,
-            sort=source.sort.field if source.sort is not None else None,
-            sort_direction=source.sort.direction if source.sort is not None else "asc",
+            sort=sort,
+            sort_direction=sort_direction,
         )
         return build_query_unit_envelope(
             tuple(AssertionQueryRowPayload.from_row(row) for row in assertion_rows[:limit]),
@@ -666,21 +676,65 @@ def query_unit_rows(
             offset=caller_offset,
             has_next=len(assertion_rows) > limit,
         )
-    block_rows = archive.query_blocks(
-        source.predicate,
-        limit=fetch_limit,
-        offset=offset,
-        session_filters=session_filters,
-        sort=source.sort.field if source.sort is not None else None,
-        sort_direction=source.sort.direction if source.sort is not None else "asc",
-    )
-    return build_query_unit_envelope(
-        tuple(BlockQueryRowPayload.from_row(row) for row in block_rows[:limit]),
-        unit=source.unit,
+    if source.unit == "block":
+        block_rows = archive.query_blocks(
+            source.predicate,
+            limit=fetch_limit,
+            offset=offset,
+            session_filters=session_filters,
+            sort=sort,
+            sort_direction=sort_direction,
+        )
+        return build_query_unit_envelope(
+            tuple(BlockQueryRowPayload.from_row(row) for row in block_rows[:limit]),
+            unit=source.unit,
+            query=query,
+            limit=limit,
+            offset=caller_offset,
+            has_next=len(block_rows) > limit,
+        )
+    raise ValueError(f"Query unit {source.unit!r} is not wired to a SQL executor")
+
+
+def query_unit_rows(
+    archive: ArchiveStore,
+    source: QueryUnitSource,
+    *,
+    query: str,
+    limit: int,
+    offset: int = 0,
+    session_filters: Mapping[str, object] | None = None,
+) -> QueryUnitEnvelope:
+    """Execute an explicit unit-source query."""
+
+    caller_offset = offset
+    if source.limit is not None:
+        limit = min(limit, source.limit)
+    if source.offset is not None:
+        offset += source.offset
+    fetch_limit = limit + 1
+    descriptor = query_unit_descriptor(source.unit)
+    if descriptor is None or not descriptor.terminal_supported:
+        raise ValueError(f"Unsupported terminal query unit: {source.unit}")
+    if descriptor.lowerer_kind == "runtime_transform":
+        return _build_runtime_transform_envelope(
+            archive,
+            source,
+            query=query,
+            limit=limit,
+            offset=offset,
+            caller_offset=caller_offset,
+            session_filters=session_filters,
+        )
+    return _build_sql_envelope(
+        archive,
+        source,
         query=query,
         limit=limit,
-        offset=caller_offset,
-        has_next=len(block_rows) > limit,
+        offset=offset,
+        caller_offset=caller_offset,
+        fetch_limit=fetch_limit,
+        session_filters=session_filters,
     )
 
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -20,13 +20,14 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from polylogue.archive.query.expression import (
     EXPRESSION_FIELD_REGISTRY,
     ExpressionCompileError,
+    QueryUnitSource,
     _CountRangeToken,
     _CountToken,
     _DateComparisonToken,
@@ -1082,6 +1083,18 @@ class TestBooleanQueryExpression:
         assert isinstance(next_row, MessageQueryRowPayload)
         assert next_row.message_id == "claude-code-session:ext-hit:m-3"
         assert next_row.text == "third"
+
+    def test_unknown_terminal_unit_does_not_fall_through_to_block_rows(self) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        source = QueryUnitSource(
+            unit=cast(Any, "bundle"),
+            predicate=QueryFieldPredicate(field="text", values=("needle",)),
+        )
+
+        with pytest.raises(ValueError, match="Unsupported terminal query unit: bundle"):
+            query_unit_rows(cast(ArchiveStore, object()), source, query="bundles where text:needle", limit=10)
 
     def test_terminal_source_pipeline_sort_desc_executes_before_limit(
         self,


### PR DESCRIPTION
## Summary

Route terminal query-unit execution through the shared `QueryUnitDescriptor.lowerer_kind` before dispatching to SQL-backed or runtime-transform executors. Unknown or unwired units now fail typed instead of falling through to the block query path.

## Problem

`QueryUnitDescriptor` already owns terminal support, lowerer kind, payload model, aliases, fields, and renderer metadata, but `query_unit_rows()` still used a local branch chain with a dangerous final fallback: anything not matched by the earlier branches executed through `archive.query_blocks()`. That is the opposite of #2006's contract for future units: unsupported or not-yet-lowered vocabulary must fail narrow, never broaden or execute as another unit.

## Solution

- Resolve the query-unit descriptor at the start of `query_unit_rows()`.
- Dispatch runtime-transform units through a dedicated helper for runs, observed events, and context snapshots.
- Dispatch SQL-backed units through a dedicated helper for messages, actions, assertions, and blocks.
- Raise `ValueError` for unsupported terminal units or units not wired to the selected lowerer kind.
- Add a regression proving an unwired `bundle` unit does not call the block-row executor.

This keeps the existing row payloads and lowerers intact; it just makes descriptor metadata the execution selector and removes the implicit block fallback.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k "unknown_terminal_unit or pipeline_sort or pipeline_limit_offset" -q` -> 6 passed
- `devtools verify --quick` -> exit_code 0

Ref #2006