### PR TITLE
refactor(cli): carry selected read-view options (#2177)

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -30,6 +30,7 @@ from polylogue.cli.read_view_handlers import (
     ReadViewInvocation,
     ReadViewMessageOptions,
     ReadViewNeighborOptions,
+    ReadViewOptions,
     ReadViewRecoveryOptions,
     read_view_option_names,
     run_bulk_export_view,
@@ -87,6 +88,77 @@ def _explicit_read_view_options(ctx: click.Context) -> frozenset[str]:
         for name in read_view_option_names()
         if (source := ctx.get_parameter_source(name)) is not None and source.name == "COMMANDLINE"
     )
+
+
+def _read_view_options_for_view(
+    view: str,
+    *,
+    limit: int | None,
+    offset: int,
+    message_role: tuple[str, ...],
+    message_type: str | None,
+    no_code_blocks: bool,
+    no_tool_calls: bool,
+    no_tool_outputs: bool,
+    no_file_reads: bool,
+    prose_only: bool,
+    related_limit: int,
+    project_path: str | None,
+    project_repo: str | None,
+    since: str | None,
+    until: str | None,
+    pack_origin: str | None,
+    pack_query: str | None,
+    max_sessions: int,
+    max_messages: int,
+    no_redact: bool,
+    recovery_report: str | None,
+    window_hours: int,
+    repo_path: str | None,
+    since_hours: int,
+    confidence_threshold: float,
+    github_api: bool,
+    otlp: bool,
+) -> ReadViewOptions | None:
+    if view in {"messages", "raw"}:
+        return ReadViewMessageOptions(
+            limit=limit,
+            offset=offset,
+            role=message_role,
+            message_type=message_type,
+            no_code_blocks=no_code_blocks,
+            no_tool_calls=no_tool_calls,
+            no_tool_outputs=no_tool_outputs,
+            no_file_reads=no_file_reads,
+            prose_only=prose_only,
+        )
+    if view == "context":
+        return ReadViewContextOptions(related_limit=related_limit)
+    if view == "context-pack":
+        return ReadViewContextPackOptions(
+            project_path=project_path,
+            project_repo=project_repo,
+            since=since,
+            until=until,
+            origin=pack_origin,
+            query=pack_query,
+            max_sessions=max_sessions,
+            max_messages=max_messages,
+            no_redact=no_redact,
+        )
+    if view == "recovery":
+        return ReadViewRecoveryOptions(report=recovery_report)
+    if view == "neighbors":
+        return ReadViewNeighborOptions(limit=limit, window_hours=window_hours)
+    if view == "correlation":
+        return ReadViewCorrelationOptions(
+            repo_path=repo_path,
+            since_hours=since_hours,
+            confidence_threshold=confidence_threshold,
+            github_api=github_api,
+            otlp=otlp,
+        )
+    return None
 
 
 _CONTINUE_CANDIDATE_DEFAULT_LIMIT = 10
@@ -474,32 +546,29 @@ def read_verb(
             output_format=effective_format,
             destination=destination,
             out_path=out_path,
-            messages=ReadViewMessageOptions(
+            options=_read_view_options_for_view(
+                view,
                 limit=limit,
                 offset=offset,
-                role=message_role,
+                message_role=message_role,
                 message_type=message_type,
                 no_code_blocks=no_code_blocks,
                 no_tool_calls=no_tool_calls,
                 no_tool_outputs=no_tool_outputs,
                 no_file_reads=no_file_reads,
                 prose_only=prose_only,
-            ),
-            context=ReadViewContextOptions(related_limit=related_limit),
-            context_pack=ReadViewContextPackOptions(
+                related_limit=related_limit,
                 project_path=project_path,
                 project_repo=project_repo,
                 since=since,
                 until=until,
-                origin=pack_origin,
-                query=pack_query,
+                pack_origin=pack_origin,
+                pack_query=pack_query,
                 max_sessions=max_sessions,
                 max_messages=max_messages,
                 no_redact=no_redact,
-            ),
-            recovery=ReadViewRecoveryOptions(report=recovery_report),
-            neighbors=ReadViewNeighborOptions(limit=limit, window_hours=window_hours),
-            correlation=ReadViewCorrelationOptions(
+                recovery_report=recovery_report,
+                window_hours=window_hours,
                 repo_path=repo_path,
                 since_hours=since_hours,
                 confidence_threshold=confidence_threshold,
@@ -631,7 +700,7 @@ def continue_verb(
             output_format=effective_format,
             destination=destination,
             out_path=out_path,
-            recovery=ReadViewRecoveryOptions(report="continue"),
+            options=ReadViewRecoveryOptions(report="continue"),
         ),
     )
 

--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -15,6 +15,7 @@ from polylogue.cli.read_views.base import (
     ReadViewInvocation,
     ReadViewMessageOptions,
     ReadViewNeighborOptions,
+    ReadViewOptions,
     ReadViewRecoveryOptions,
 )
 from polylogue.cli.read_views.bulk import run_bulk_export_view
@@ -146,6 +147,7 @@ __all__ = [
     "ReadViewInvocation",
     "ReadViewMessageOptions",
     "ReadViewNeighborOptions",
+    "ReadViewOptions",
     "ReadViewRecoveryOptions",
     "read_view_handler_ids",
     "read_view_option_names",

--- a/polylogue/cli/read_views/base.py
+++ b/polylogue/cli/read_views/base.py
@@ -83,6 +83,16 @@ class ReadViewCorrelationOptions:
     otlp: bool = False
 
 
+ReadViewOptions = (
+    ReadViewMessageOptions
+    | ReadViewContextOptions
+    | ReadViewContextPackOptions
+    | ReadViewRecoveryOptions
+    | ReadViewNeighborOptions
+    | ReadViewCorrelationOptions
+)
+
+
 @dataclass(frozen=True, slots=True)
 class ReadViewInvocation:
     """Common transport and selection fields for one read-view execution."""
@@ -92,12 +102,7 @@ class ReadViewInvocation:
     output_format: str | None
     destination: str
     out_path: str | None
-    messages: ReadViewMessageOptions = ReadViewMessageOptions()
-    context: ReadViewContextOptions = ReadViewContextOptions()
-    context_pack: ReadViewContextPackOptions = ReadViewContextPackOptions()
-    recovery: ReadViewRecoveryOptions = ReadViewRecoveryOptions()
-    neighbors: ReadViewNeighborOptions = ReadViewNeighborOptions()
-    correlation: ReadViewCorrelationOptions = ReadViewCorrelationOptions()
+    options: ReadViewOptions | None = None
     explicit_options: frozenset[ReadViewOptionName] = frozenset()
 
 
@@ -175,6 +180,7 @@ __all__ = [
     "ReadViewOptionName",
     "ReadViewMessageOptions",
     "ReadViewNeighborOptions",
+    "ReadViewOptions",
     "ReadViewRecoveryOptions",
     "ReadViewSessionPolicy",
     "deliver_content",

--- a/polylogue/cli/read_views/context.py
+++ b/polylogue/cli/read_views/context.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from polylogue.cli.read_views.base import ReadViewInvocation, deliver_content
+from typing import cast
+
+from polylogue.cli.read_views.base import (
+    ReadViewContextOptions,
+    ReadViewContextPackOptions,
+    ReadViewInvocation,
+    deliver_content,
+)
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
@@ -14,10 +21,11 @@ def run_read_context(env: AppEnv, request: RootModeRequest, invocation: ReadView
 
     del request
     assert invocation.session_id is not None
+    options = cast(ReadViewContextOptions, invocation.options or ReadViewContextOptions())
     preamble = compose_context_preamble(
         env,
         session_id=invocation.session_id,
-        related_limit=max(1, invocation.context.related_limit),
+        related_limit=max(1, options.related_limit),
     )
     deliver_content(env, preamble + "\n", destination=invocation.destination, out_path=invocation.out_path)
 
@@ -28,7 +36,7 @@ def run_read_context_pack(env: AppEnv, request: RootModeRequest, invocation: Rea
     from polylogue.context.pack import run_context_pack_view
 
     del request
-    options = invocation.context_pack
+    options = cast(ReadViewContextPackOptions, invocation.options or ReadViewContextPackOptions())
     run_context_pack_view(
         env,
         project_path=options.project_path,

--- a/polylogue/cli/read_views/correlation.py
+++ b/polylogue/cli/read_views/correlation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from polylogue.cli.read_views.base import ReadViewInvocation
+from typing import cast
+
+from polylogue.cli.read_views.base import ReadViewCorrelationOptions, ReadViewInvocation
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
@@ -14,7 +16,7 @@ def run_read_correlation(env: AppEnv, request: RootModeRequest, invocation: Read
 
     del request
     assert invocation.session_id is not None
-    options = invocation.correlation
+    options = cast(ReadViewCorrelationOptions, invocation.options or ReadViewCorrelationOptions())
     run_correlation_view(
         env,
         session_id=invocation.session_id,

--- a/polylogue/cli/read_views/messages.py
+++ b/polylogue/cli/read_views/messages.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import io
+from typing import cast
 
 import click
 
-from polylogue.cli.read_views.base import ReadViewInvocation, deliver_content
+from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewMessageOptions, deliver_content
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
@@ -17,7 +18,7 @@ def run_read_messages(env: AppEnv, request: RootModeRequest, invocation: ReadVie
     from polylogue.cli.messages import run_messages
 
     assert invocation.session_id is not None
-    options = invocation.messages
+    options = cast(ReadViewMessageOptions, invocation.options or ReadViewMessageOptions())
     limit = options.limit if options.limit is not None else 50
 
     if invocation.destination in ("file", "clipboard"):
@@ -72,7 +73,7 @@ def run_read_raw(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvo
     from polylogue.cli.messages import run_raw
 
     assert invocation.session_id is not None
-    options = invocation.messages
+    options = cast(ReadViewMessageOptions, invocation.options or ReadViewMessageOptions())
     limit = options.limit if options.limit is not None else 50
     output_format = invocation.output_format or "json"
 

--- a/polylogue/cli/read_views/neighbors.py
+++ b/polylogue/cli/read_views/neighbors.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
-from polylogue.cli.read_views.base import ReadViewInvocation, deliver_content
+from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewNeighborOptions, deliver_content
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
@@ -48,7 +50,7 @@ def run_read_neighbors(env: AppEnv, request: RootModeRequest, invocation: ReadVi
     query_seed = " ".join(request.query_terms).strip() or None
     if not invocation.session_id and not query_seed:
         fail("read", "read --view neighbors requires a seed (use --id, id:prefix, --latest, or a query).")
-    options = invocation.neighbors
+    options = cast(ReadViewNeighborOptions, invocation.options or ReadViewNeighborOptions())
 
     origin = request.params.get("origin")
     provider = provider_from_origin(Origin(str(origin))).value if origin else None

--- a/polylogue/cli/read_views/recovery.py
+++ b/polylogue/cli/read_views/recovery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import cast
 
-from polylogue.cli.read_views.base import ReadViewInvocation, deliver_content
+from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewRecoveryOptions, deliver_content
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
@@ -20,7 +20,7 @@ def run_read_recovery(env: AppEnv, request: RootModeRequest, invocation: ReadVie
 
     del request
     assert invocation.session_id is not None
-    options = invocation.recovery
+    options = cast(ReadViewRecoveryOptions, invocation.options or ReadViewRecoveryOptions())
     if options.report is not None:
         if options.report == "work-packet" and invocation.output_format == "json":
             packet = run_coroutine_sync(env.polylogue.recovery_work_packet(invocation.session_id))

--- a/tests/unit/cli/test_neighbors_command.py
+++ b/tests/unit/cli/test_neighbors_command.py
@@ -60,7 +60,7 @@ def test_read_view_neighbors_emits_json_payload(capsys: pytest.CaptureFixture[st
             output_format="json",
             destination="stdout",
             out_path=None,
-            neighbors=ReadViewNeighborOptions(limit=10, window_hours=24),
+            options=ReadViewNeighborOptions(limit=10, window_hours=24),
         ),
     )
 
@@ -91,7 +91,7 @@ def test_read_view_neighbors_plain_renders_reasons(capsys: pytest.CaptureFixture
             output_format=None,
             destination="stdout",
             out_path=None,
-            neighbors=ReadViewNeighborOptions(limit=10, window_hours=24),
+            options=ReadViewNeighborOptions(limit=10, window_hours=24),
         ),
     )
 
@@ -119,7 +119,7 @@ def test_read_view_neighbors_surfaces_discovery_error(capsys: pytest.CaptureFixt
                 output_format=None,
                 destination="stdout",
                 out_path=None,
-                neighbors=ReadViewNeighborOptions(limit=10, window_hours=24),
+                options=ReadViewNeighborOptions(limit=10, window_hours=24),
             ),
         )
 
@@ -140,7 +140,7 @@ def test_read_view_neighbors_empty_renders_message(capsys: pytest.CaptureFixture
             output_format=None,
             destination="stdout",
             out_path=None,
-            neighbors=ReadViewNeighborOptions(limit=10, window_hours=24),
+            options=ReadViewNeighborOptions(limit=10, window_hours=24),
         ),
     )
 
@@ -161,7 +161,7 @@ def test_read_view_neighbors_requires_a_seed(capsys: pytest.CaptureFixture[str])
                 output_format=None,
                 destination="stdout",
                 out_path=None,
-                neighbors=ReadViewNeighborOptions(limit=10, window_hours=24),
+                options=ReadViewNeighborOptions(limit=10, window_hours=24),
             ),
         )
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -534,7 +534,7 @@ def test_continue_verb_renders_recovery_continue_report() -> None:
         output_format=None,
         destination="clipboard",
         out_path=None,
-        recovery=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
+        options=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
     )
 
 
@@ -700,7 +700,7 @@ def test_read_view_recovery_work_packet_json_uses_success_envelope(capsys: pytes
                 output_format="json",
                 destination="terminal",
                 out_path=None,
-                recovery=read_view_handlers.ReadViewRecoveryOptions(report="work-packet"),
+                options=read_view_handlers.ReadViewRecoveryOptions(report="work-packet"),
             ),
         )
 
@@ -793,7 +793,7 @@ def test_read_view_accepts_explicit_options_owned_by_selected_view() -> None:
             output_format=None,
             destination="terminal",
             out_path=None,
-            recovery=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
+            options=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
             explicit_options=frozenset({"recovery_report"}),
         ),
         RootModeRequest.from_params({}),


### PR DESCRIPTION
## Summary

Refactors read-view invocation so each read execution carries only the option bundle for the selected view, instead of every view-specific option dataclass at once.

## Problem

`ReadViewInvocation` still mirrored the old dispatcher shape: it held message, context, context-pack, recovery, neighbor, and correlation option objects simultaneously. That kept unrelated view options attached to every read path and made handler ownership less explicit than the registry/API shape introduced by #2177.

## Solution

- Add a `ReadViewOptions` union and replace the six per-view fields on `ReadViewInvocation` with one `options` field.
- Make `query_verbs.read_verb` construct the selected view's option object through `_read_view_options_for_view()`.
- Update `continue` and the read-view handlers to consume the selected option object, falling back to view defaults only for direct tests/callers that omit options.
- Update invocation tests to assert the selected option object rather than unused parallel fields.

No compatibility aliases or absence-only tests were added.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py tests/unit/cli/test_neighbors_command.py -q` -> `42 passed`
- `devtools verify --quick` -> `exit_code: 0`