### PR TITLE
refactor(query): share terminal unit request wiring (#2177)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1743,18 +1743,13 @@ class PolylogueArchiveMixin:
         message_type: str | None = None,
     ) -> QueryUnitEnvelope:
         """Execute a terminal unit-source query."""
-        from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
-        from polylogue.archive.query.metadata import terminal_query_source_list
-        from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
+        from polylogue.archive.query.unit_results import query_unit_envelope, query_unit_request
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
-        source = parse_unit_source_expression(expression)
-        if source is None:
-            raise ExpressionCompileError(
-                f"query_units requires an explicit {terminal_query_source_list()} where expression",
-                field=None,
-            )
-        session_filters = query_unit_session_filters(
+        request = query_unit_request(
+            expression=expression,
+            limit=limit,
+            offset=offset,
             origin=origin,
             origins=origins,
             tags=(tag,) if tag else tags,
@@ -1785,9 +1780,7 @@ class PolylogueArchiveMixin:
             message_type=message_type,
         )
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
-            return query_unit_rows(
-                archive, source, query=expression, limit=limit, offset=offset, session_filters=session_filters
-            )
+            return query_unit_envelope(archive, request)
 
     async def export_otel(
         self,

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
 from polylogue.archive.query.archive_execution import _session_to_session
@@ -36,6 +37,17 @@ from polylogue.surfaces.payloads import (
 )
 
 _SUMMARY_SCAN_BATCH_SIZE = 500
+
+
+@dataclass(frozen=True)
+class QueryUnitRequest:
+    """Compiled terminal query-unit request shared by daemon, MCP, and API callers."""
+
+    expression: str
+    source: QueryUnitSource
+    limit: int
+    offset: int = 0
+    session_filters: Mapping[str, object] | None = None
 
 
 class _RowPayloadModel(Protocol):
@@ -142,6 +154,35 @@ def query_unit_session_filters(**params: object) -> dict[str, object]:
         "since_ms": int(since_ms) if isinstance(since_ms, int) else _epoch_ms("since", params.get("since")),
         "until_ms": int(until_ms) if isinstance(until_ms, int) else _epoch_ms("until", params.get("until")),
     }
+
+
+def query_unit_request(
+    *,
+    expression: str,
+    limit: int,
+    offset: int = 0,
+    session_filters: Mapping[str, object] | None = None,
+    **filter_params: object,
+) -> QueryUnitRequest:
+    """Build a terminal query-unit request from surface parameters."""
+
+    from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
+    from polylogue.archive.query.metadata import terminal_query_source_list
+
+    source = parse_unit_source_expression(expression)
+    if source is None:
+        raise ExpressionCompileError(
+            f"query_units requires an explicit {terminal_query_source_list()} where expression",
+            field=None,
+        )
+    filters = session_filters if session_filters is not None else query_unit_session_filters(**filter_params)
+    return QueryUnitRequest(
+        expression=expression,
+        source=source,
+        limit=limit,
+        offset=offset,
+        session_filters=filters,
+    )
 
 
 def _object_ref_text(ref: ObjectRef | None) -> str | None:
@@ -703,4 +744,23 @@ def query_unit_rows(
     )
 
 
-__all__ = ["query_unit_rows", "query_unit_session_filters"]
+def query_unit_envelope(archive: ArchiveStore, request: QueryUnitRequest) -> QueryUnitEnvelope:
+    """Execute a compiled terminal query-unit request."""
+
+    return query_unit_rows(
+        archive,
+        request.source,
+        query=request.expression,
+        limit=request.limit,
+        offset=request.offset,
+        session_filters=request.session_filters,
+    )
+
+
+__all__ = [
+    "QueryUnitRequest",
+    "query_unit_envelope",
+    "query_unit_request",
+    "query_unit_rows",
+    "query_unit_session_filters",
+]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2463,68 +2463,57 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _handle_query_units(self, params: dict[str, list[str]]) -> None:
         """``GET /api/query-units`` returns terminal query-unit rows."""
 
-        from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
-        from polylogue.archive.query.metadata import terminal_query_source_list
+        from polylogue.archive.query.expression import ExpressionCompileError
         from polylogue.archive.query.spec import clamp_query_limit
-        from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
+        from polylogue.archive.query.unit_results import query_unit_envelope, query_unit_request
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         expression = self._get_param(params, "expression") or ""
+        limit = clamp_query_limit(self._get_int(params, "limit", 50), default=50)
+        offset = max(0, self._get_int(params, "offset", 0))
         try:
-            source = parse_unit_source_expression(expression)
+            request = query_unit_request(
+                expression=expression,
+                limit=limit,
+                offset=offset,
+                origin=self._get_param(params, "origin"),
+                origins=_csv_values(params, "origins"),
+                exclude_origin=self._get_param(params, "exclude_origin"),
+                tag=self._get_param(params, "tag"),
+                exclude_tag=self._get_param(params, "exclude_tag"),
+                repo=self._get_param(params, "repo"),
+                has_type=self._get_param(params, "has_type"),
+                referenced_path=self._get_param(params, "referenced_path"),
+                cwd_prefix=self._get_param(params, "cwd_prefix"),
+                action=self._get_param(params, "action"),
+                exclude_action=self._get_param(params, "exclude_action"),
+                action_sequence=self._get_param(params, "action_sequence"),
+                action_text=self._get_param(params, "action_text"),
+                tool=self._get_param(params, "tool"),
+                exclude_tool=self._get_param(params, "exclude_tool"),
+                title=self._get_param(params, "title"),
+                since=self._get_param(params, "since"),
+                until=self._get_param(params, "until"),
+                has_tool_use=self._get_bool(params, "has_tool_use"),
+                has_thinking=self._get_bool(params, "has_thinking"),
+                has_paste=self._get_bool(params, "has_paste"),
+                typed_only=self._get_bool(params, "typed_only"),
+                min_messages=self._get_param(params, "min_messages"),
+                max_messages=self._get_param(params, "max_messages"),
+                min_words=self._get_param(params, "min_words"),
+                max_words=self._get_param(params, "max_words"),
+                message_type=self._get_param(params, "message_type"),
+            )
         except ExpressionCompileError as exc:
             self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_query", "message": str(exc)})
             return
-        if source is None:
-            self._send_json(
-                HTTPStatus.BAD_REQUEST,
-                {
-                    "error": "invalid_query",
-                    "message": (f"query-units requires a {terminal_query_source_list()} where expression"),
-                },
-            )
-            return
-
-        limit = clamp_query_limit(self._get_int(params, "limit", 50), default=50)
-        offset = max(0, self._get_int(params, "offset", 0))
-        session_filters = query_unit_session_filters(
-            origin=self._get_param(params, "origin"),
-            origins=_csv_values(params, "origins"),
-            exclude_origin=self._get_param(params, "exclude_origin"),
-            tag=self._get_param(params, "tag"),
-            exclude_tag=self._get_param(params, "exclude_tag"),
-            repo=self._get_param(params, "repo"),
-            has_type=self._get_param(params, "has_type"),
-            referenced_path=self._get_param(params, "referenced_path"),
-            cwd_prefix=self._get_param(params, "cwd_prefix"),
-            action=self._get_param(params, "action"),
-            exclude_action=self._get_param(params, "exclude_action"),
-            action_sequence=self._get_param(params, "action_sequence"),
-            action_text=self._get_param(params, "action_text"),
-            tool=self._get_param(params, "tool"),
-            exclude_tool=self._get_param(params, "exclude_tool"),
-            title=self._get_param(params, "title"),
-            since=self._get_param(params, "since"),
-            until=self._get_param(params, "until"),
-            has_tool_use=self._get_bool(params, "has_tool_use"),
-            has_thinking=self._get_bool(params, "has_thinking"),
-            has_paste=self._get_bool(params, "has_paste"),
-            typed_only=self._get_bool(params, "typed_only"),
-            min_messages=self._get_param(params, "min_messages"),
-            max_messages=self._get_param(params, "max_messages"),
-            min_words=self._get_param(params, "min_words"),
-            max_words=self._get_param(params, "max_words"),
-            message_type=self._get_param(params, "message_type"),
-        )
         archive_root = _web_reader_archive_root()
         if archive_root is None:
             self._send_error(HTTPStatus.SERVICE_UNAVAILABLE, "archive_unavailable")
             return
 
         with ArchiveStore.open_existing(archive_root) as archive:
-            payload = query_unit_rows(
-                archive, source, query=expression, limit=limit, offset=offset, session_filters=session_filters
-            )
+            payload = query_unit_envelope(archive, request)
 
         self._send_json(HTTPStatus.OK, payload.model_dump(mode="json"))
 

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -397,21 +397,19 @@ def archive_query_unit_payload(
     limit: int,
     offset: int,
     session_filters: Mapping[str, object] | None = None,
+    **filter_params: object,
 ) -> QueryUnitEnvelope:
     """Build the shared terminal query-unit envelope from an archive."""
-    from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
-    from polylogue.archive.query.metadata import terminal_query_source_list
-    from polylogue.archive.query.unit_results import query_unit_rows
+    from polylogue.archive.query.unit_results import query_unit_envelope, query_unit_request
 
-    source = parse_unit_source_expression(expression)
-    if source is None:
-        raise ExpressionCompileError(
-            f"query_units requires an explicit {terminal_query_source_list()} where expression",
-            field=None,
-        )
-    return query_unit_rows(
-        archive, source, query=expression, limit=limit, offset=offset, session_filters=session_filters
+    request = query_unit_request(
+        expression=expression,
+        limit=limit,
+        offset=offset,
+        session_filters=session_filters,
+        **filter_params,
     )
+    return query_unit_envelope(archive, request)
 
 
 def archive_messages_payload(

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -197,37 +197,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         async def run() -> str:
             from polylogue.archive.query.expression import ExpressionCompileError
-            from polylogue.archive.query.unit_results import query_unit_session_filters
 
             config = hooks.get_config()
-            session_filters = query_unit_session_filters(
-                origin=origin,
-                exclude_origin=exclude_origin,
-                tag=tag,
-                exclude_tag=exclude_tag,
-                repo=repo,
-                has_type=has_type,
-                referenced_path=referenced_path,
-                cwd_prefix=cwd_prefix,
-                action=action,
-                exclude_action=exclude_action,
-                action_sequence=action_sequence,
-                action_text=action_text,
-                tool=tool,
-                exclude_tool=exclude_tool,
-                title=title,
-                since=since,
-                until=until,
-                has_tool_use=has_tool_use,
-                has_thinking=has_thinking,
-                has_paste=has_paste,
-                typed_only=typed_only,
-                min_messages=min_messages,
-                max_messages=max_messages,
-                min_words=min_words,
-                max_words=max_words,
-                message_type=message_type,
-            )
             with ArchiveStore.open_existing(active_archive_root(config) or config.archive_root) as archive:
                 try:
                     return hooks.json_payload(
@@ -236,7 +207,32 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                             expression=expression,
                             limit=hooks.clamp_limit(limit),
                             offset=max(0, offset),
-                            session_filters=session_filters,
+                            origin=origin,
+                            exclude_origin=exclude_origin,
+                            tag=tag,
+                            exclude_tag=exclude_tag,
+                            repo=repo,
+                            has_type=has_type,
+                            referenced_path=referenced_path,
+                            cwd_prefix=cwd_prefix,
+                            action=action,
+                            exclude_action=exclude_action,
+                            action_sequence=action_sequence,
+                            action_text=action_text,
+                            tool=tool,
+                            exclude_tool=exclude_tool,
+                            title=title,
+                            since=since,
+                            until=until,
+                            has_tool_use=has_tool_use,
+                            has_thinking=has_thinking,
+                            has_paste=has_paste,
+                            typed_only=typed_only,
+                            min_messages=min_messages,
+                            max_messages=max_messages,
+                            min_words=min_words,
+                            max_words=max_words,
+                            message_type=message_type,
                         )
                     )
                 except ExpressionCompileError as exc:

--- a/tests/unit/core/test_query_unit_request.py
+++ b/tests/unit/core/test_query_unit_request.py
@@ -46,3 +46,24 @@ def test_query_unit_request_preserves_prebuilt_session_filters() -> None:
     )
 
     assert request.session_filters is filters
+
+
+def test_query_unit_request_accepts_api_style_tuple_filters() -> None:
+    request = query_unit_request(
+        expression="messages where text:timeout",
+        limit=10,
+        origins=("codex-session",),
+        tags=("important", "follow-up"),
+        repo_names=("polylogue",),
+        tool_terms=("bash",),
+        action_terms=("file_edit",),
+        referenced_paths=("polylogue/archive/query",),
+    )
+
+    assert request.session_filters is not None
+    assert request.session_filters["origins"] == ("codex-session",)
+    assert request.session_filters["tags"] == ("important", "follow-up")
+    assert request.session_filters["repo_names"] == ("polylogue",)
+    assert request.session_filters["tool_terms"] == ("bash",)
+    assert request.session_filters["action_terms"] == ("file_edit",)
+    assert request.session_filters["referenced_paths"] == ("polylogue/archive/query",)

--- a/tests/unit/core/test_query_unit_request.py
+++ b/tests/unit/core/test_query_unit_request.py
@@ -24,7 +24,7 @@ def test_query_unit_request_compiles_source_and_session_filters() -> None:
     assert request.limit == 25
     assert request.offset == 3
     assert request.session_filters is not None
-    assert request.session_filters["origins"] == ("claude-code-session",)
+    assert request.session_filters["origin"] == "claude-code-session"
     assert request.session_filters["repo_names"] == ("polylogue", "sinex")
     assert request.session_filters["has_tool_use"] is True
     assert request.session_filters["min_messages"] == 2

--- a/tests/unit/core/test_query_unit_request.py
+++ b/tests/unit/core/test_query_unit_request.py
@@ -1,0 +1,48 @@
+"""Shared terminal query-unit request normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.archive.query.expression import ExpressionCompileError
+from polylogue.archive.query.unit_results import query_unit_request
+
+
+def test_query_unit_request_compiles_source_and_session_filters() -> None:
+    request = query_unit_request(
+        expression="messages where text:timeout",
+        limit=25,
+        offset=3,
+        origin="claude-code-session",
+        repo="polylogue, sinex",
+        has_tool_use=True,
+        min_messages="2",
+    )
+
+    assert request.expression == "messages where text:timeout"
+    assert request.source.unit == "message"
+    assert request.limit == 25
+    assert request.offset == 3
+    assert request.session_filters is not None
+    assert request.session_filters["origins"] == ("claude-code-session",)
+    assert request.session_filters["repo_names"] == ("polylogue", "sinex")
+    assert request.session_filters["has_tool_use"] is True
+    assert request.session_filters["min_messages"] == 2
+
+
+def test_query_unit_request_rejects_session_expressions() -> None:
+    with pytest.raises(ExpressionCompileError, match="requires an explicit"):
+        query_unit_request(expression="timeout", limit=10)
+
+
+def test_query_unit_request_preserves_prebuilt_session_filters() -> None:
+    filters = {"origin": "chatgpt-export"}
+
+    request = query_unit_request(
+        expression="messages where text:timeout",
+        limit=10,
+        session_filters=filters,
+        origin="claude-code-session",
+    )
+
+    assert request.session_filters is filters


### PR DESCRIPTION
## Summary

Adds a shared terminal query-unit request boundary in the archive query layer and routes the Python API, daemon, and MCP query-unit surfaces through it. Public parameters and payloads are unchanged; expression parsing, terminal-source rejection, session-scope normalization, and envelope execution now converge through `QueryUnitRequest`.

## Problem

`Polylogue.query_units(...)`, `/api/query-units`, and the MCP `query_units` tool all exposed the same terminal unit-query behavior, but each surface assembled the request independently before calling archive execution. That kept expression parsing, session-scope filter normalization, and envelope execution split across surface code instead of owned by the query substrate.

## Solution

- Added `QueryUnitRequest`, `query_unit_request()`, and `query_unit_envelope()` in `polylogue/archive/query/unit_results.py`.
- Kept `polylogue/mcp/archive_support.py::archive_query_unit_payload()` as the MCP helper, but made it delegate to the shared archive request boundary.
- Simplified `polylogue/api/archive.py::query_units`, `polylogue/mcp/server_tools.py::query_units`, and `polylogue/daemon/http.py::_handle_query_units` so they pass surface parameters into the shared request builder.
- Added focused request-normalization coverage in `tests/unit/core/test_query_unit_request.py`; existing API, daemon, and MCP query-unit tests continue to prove cross-surface behavior.

## Verification

- `nix develop --command devtools test tests/unit/core/test_query_unit_request.py tests/unit/api/test_facade_contracts.py -k 'query_units' tests/unit/daemon/test_web_reader.py -k 'query_units_endpoint' tests/unit/mcp/test_server_surfaces.py -k 'query_units_tool' -q` → `7 passed, 420 deselected`
- `nix develop --command devtools verify --quick` → `exit_code: 0`
- Push hook reran `devtools verify --quick` → `exit_code: 0`

Ref #2177