### PR TITLE
refactor(daemon): enrich read-view envelopes (#2177)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1465,6 +1465,43 @@ components:
         format:
           title: Format
           type: string
+        target_refs:
+          items:
+            type: string
+          title: Target Refs
+          type: array
+        object_refs:
+          default: []
+          items:
+            type: string
+          title: Object Refs
+          type: array
+        evidence_refs:
+          default: []
+          items:
+            type: string
+          title: Evidence Refs
+          type: array
+        caveats:
+          default: []
+          items:
+            type: string
+          title: Caveats
+          type: array
+        lossiness:
+          title: Lossiness
+          type: string
+        evidence_policy:
+          title: Evidence Policy
+          type: string
+        privacy_policy:
+          title: Privacy Policy
+          type: string
+        actions:
+          additionalProperties:
+            $ref: '#/components/schemas/ReaderActionAvailabilityPayload'
+          title: Actions
+          type: object
         payload:
           description: Profile-specific JSON payload for the selected read view.
           title: Payload
@@ -1472,6 +1509,10 @@ components:
       - session_id
       - view
       - format
+      - target_refs
+      - lossiness
+      - evidence_policy
+      - privacy_policy
       - payload
       title: SessionReadViewEnvelope
       type: object

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -7,7 +7,7 @@ import contextlib
 import functools
 import json
 import os
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
 from http import HTTPStatus
@@ -145,6 +145,39 @@ def _read_view_http_capability_payloads() -> dict[str, JSONDocument]:
     """Return daemon execution capabilities keyed by read-view id."""
 
     return {view_id: capability.to_payload() for view_id, capability in _SESSION_READ_VIEW_HTTP_CAPABILITIES.items()}
+
+
+def _read_view_payload_field_values(payload: object, field_name: str, *, max_depth: int = 4) -> tuple[str, ...]:
+    """Collect common read-view metadata fields from a profile-specific payload."""
+
+    seen: set[str] = set()
+    values: list[str] = []
+
+    def add(value: object) -> None:
+        if isinstance(value, str) and value not in seen:
+            seen.add(value)
+            values.append(value)
+
+    def walk(value: object, depth: int) -> None:
+        if depth < 0:
+            return
+        if hasattr(value, "model_dump"):
+            value = cast(Any, value).model_dump(mode="python", exclude_none=True)
+        if isinstance(value, Mapping):
+            field_value = value.get(field_name)
+            if isinstance(field_value, str):
+                add(field_value)
+            elif isinstance(field_value, Sequence) and not isinstance(field_value, str):
+                for item in field_value:
+                    add(item)
+            for child in value.values():
+                walk(child, depth - 1)
+        elif isinstance(value, Sequence) and not isinstance(value, str):
+            for child in value:
+                walk(child, depth - 1)
+
+    walk(payload, max_depth)
+    return tuple(values)
 
 
 def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
@@ -2848,10 +2881,20 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if payload is None:
             self._send_error(HTTPStatus.NOT_FOUND, "not_found")
             return
+        from polylogue.archive.viewport import get_read_view_profile
+
+        profile = get_read_view_profile(view)
         envelope = SessionReadViewEnvelope(
             session_id=conv_id,
             view=view,
             format=output_format,
+            target_refs=(f"session:{conv_id}",),
+            object_refs=_read_view_payload_field_values(payload, "object_refs"),
+            evidence_refs=_read_view_payload_field_values(payload, "evidence_refs"),
+            caveats=_read_view_payload_field_values(payload, "caveats"),
+            lossiness=profile.lossiness,
+            evidence_policy=profile.evidence_policy,
+            privacy_policy=profile.privacy_policy,
             payload=payload,
         )
         self._send_json(HTTPStatus.OK, model_json_document(envelope, exclude_none=True))

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1414,7 +1414,25 @@ class SessionReadViewEnvelope(SurfacePayloadModel):
     session_id: str
     view: str
     format: str
+    target_refs: tuple[str, ...]
+    object_refs: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    caveats: tuple[str, ...] = ()
+    lossiness: str
+    evidence_policy: str
+    privacy_policy: str
+    actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_session_actions)
     payload: Any = Field(description="Profile-specific JSON payload for the selected read view.")
+
+    @field_validator("target_refs", "object_refs")
+    @classmethod
+    def _validate_session_read_object_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_object_ref_text(ref) for ref in value)
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def _validate_session_read_evidence_refs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(normalize_public_ref_text(ref) for ref in value)
 
 
 class ObservedEventQueryRowPayload(SurfacePayloadModel):

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1580,12 +1580,23 @@ class TestReaderViewProfiles:
             )
 
         assert messages["view"] == "messages"
+        assert messages["target_refs"] == [f"session:{C1}"]
+        assert messages["lossiness"] == "filtered"
+        assert messages["evidence_policy"] == "optional"
+        assert "projection flags" in cast(str, messages["privacy_policy"])
+        message_actions = cast(dict[str, dict[str, object]], messages["actions"])
+        assert message_actions["open"]["enabled"] is True
         message_payload = cast(dict[str, object], messages["payload"])
         assert message_payload["total"] == 1
         assert recovery["view"] == "recovery"
+        assert recovery["lossiness"] == "derived"
+        assert recovery["evidence_policy"] == "required"
         recovery_payload = cast(dict[str, object], recovery["payload"])
         assert recovery_payload["report"] == "work-packet"
         assert raw["view"] == "raw"
+        assert raw["target_refs"] == [f"session:{C1}"]
+        assert raw["lossiness"] == "raw"
+        assert "raw provider data" in cast(str, raw["privacy_policy"])
         raw_payload = cast(dict[str, object], raw["payload"])
         assert raw_payload["id"] == C1
         assert context["view"] == "context"


### PR DESCRIPTION
## Summary

Extends `SessionReadViewEnvelope` so executed daemon read views carry the same contract metadata that `/api/read-view-profiles` already exposes: target refs, extracted refs/caveats, lossiness, evidence policy, privacy policy, and session actions.

## Problem

`GET /api/sessions/:id/read` used a typed envelope, but that envelope only contained `session_id`, `view`, `format`, and the profile-specific payload. Clients had to separately join profile metadata to understand lossiness, evidence posture, privacy/raw-material posture, or affordances for an executed view.

## Solution

- Added metadata fields to `SessionReadViewEnvelope` in `polylogue/surfaces/payloads.py`.
- Populated the daemon read route from the existing read-view profile registry rather than introducing a second read-view registry.
- Added bounded extraction for common `object_refs`, `evidence_refs`, and `caveats` fields from profile-specific payloads.
- Updated daemon route coverage and regenerated `docs/openapi/search.yaml`.

## Verification

- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k 'read_view_execution or read_view_profiles' tests/unit/daemon/test_route_contracts.py -k 'read_view' -q` → `4 passed, 206 deselected`
- `nix develop --command devtools verify --quick` → `exit_code: 0`
- Push hook reran `devtools verify --quick` → `exit_code: 0`

Ref #2177