### PR TITLE
refactor(cli): move read-view option building into handlers (#2177)

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -24,15 +24,9 @@ from polylogue.archive.viewport import (
 )
 from polylogue.cli.click_option_groups import _LazyChoice
 from polylogue.cli.read_view_handlers import (
-    ReadViewContextOptions,
-    ReadViewContextPackOptions,
-    ReadViewCorrelationOptions,
     ReadViewInvocation,
-    ReadViewMessageOptions,
-    ReadViewNeighborOptions,
-    ReadViewOptions,
-    ReadViewRecoveryOptions,
     read_view_option_names,
+    read_view_options_for_view,
     run_bulk_export_view,
     run_read_view,
 )
@@ -90,8 +84,7 @@ def _explicit_read_view_options(ctx: click.Context) -> frozenset[str]:
     )
 
 
-def _read_view_options_for_view(
-    view: str,
+def _read_view_option_values(
     *,
     limit: int | None,
     offset: int,
@@ -119,46 +112,37 @@ def _read_view_options_for_view(
     confidence_threshold: float,
     github_api: bool,
     otlp: bool,
-) -> ReadViewOptions | None:
-    if view in {"messages", "raw"}:
-        return ReadViewMessageOptions(
-            limit=limit,
-            offset=offset,
-            role=message_role,
-            message_type=message_type,
-            no_code_blocks=no_code_blocks,
-            no_tool_calls=no_tool_calls,
-            no_tool_outputs=no_tool_outputs,
-            no_file_reads=no_file_reads,
-            prose_only=prose_only,
-        )
-    if view == "context":
-        return ReadViewContextOptions(related_limit=related_limit)
-    if view == "context-pack":
-        return ReadViewContextPackOptions(
-            project_path=project_path,
-            project_repo=project_repo,
-            since=since,
-            until=until,
-            origin=pack_origin,
-            query=pack_query,
-            max_sessions=max_sessions,
-            max_messages=max_messages,
-            no_redact=no_redact,
-        )
-    if view == "recovery":
-        return ReadViewRecoveryOptions(report=recovery_report)
-    if view == "neighbors":
-        return ReadViewNeighborOptions(limit=limit, window_hours=window_hours)
-    if view == "correlation":
-        return ReadViewCorrelationOptions(
-            repo_path=repo_path,
-            since_hours=since_hours,
-            confidence_threshold=confidence_threshold,
-            github_api=github_api,
-            otlp=otlp,
-        )
-    return None
+) -> dict[str, object]:
+    """Collect raw Click option values for read-view handler builders."""
+
+    return {
+        "limit": limit,
+        "offset": offset,
+        "message_role": message_role,
+        "message_type": message_type,
+        "no_code_blocks": no_code_blocks,
+        "no_tool_calls": no_tool_calls,
+        "no_tool_outputs": no_tool_outputs,
+        "no_file_reads": no_file_reads,
+        "prose_only": prose_only,
+        "related_limit": related_limit,
+        "project_path": project_path,
+        "project_repo": project_repo,
+        "since": since,
+        "until": until,
+        "pack_origin": pack_origin,
+        "pack_query": pack_query,
+        "max_sessions": max_sessions,
+        "max_messages": max_messages,
+        "no_redact": no_redact,
+        "recovery_report": recovery_report,
+        "window_hours": window_hours,
+        "repo_path": repo_path,
+        "since_hours": since_hours,
+        "confidence_threshold": confidence_threshold,
+        "github_api": github_api,
+        "otlp": otlp,
+    }
 
 
 _CONTINUE_CANDIDATE_DEFAULT_LIMIT = 10
@@ -546,34 +530,36 @@ def read_verb(
             output_format=effective_format,
             destination=destination,
             out_path=out_path,
-            options=_read_view_options_for_view(
+            options=read_view_options_for_view(
                 view,
-                limit=limit,
-                offset=offset,
-                message_role=message_role,
-                message_type=message_type,
-                no_code_blocks=no_code_blocks,
-                no_tool_calls=no_tool_calls,
-                no_tool_outputs=no_tool_outputs,
-                no_file_reads=no_file_reads,
-                prose_only=prose_only,
-                related_limit=related_limit,
-                project_path=project_path,
-                project_repo=project_repo,
-                since=since,
-                until=until,
-                pack_origin=pack_origin,
-                pack_query=pack_query,
-                max_sessions=max_sessions,
-                max_messages=max_messages,
-                no_redact=no_redact,
-                recovery_report=recovery_report,
-                window_hours=window_hours,
-                repo_path=repo_path,
-                since_hours=since_hours,
-                confidence_threshold=confidence_threshold,
-                github_api=github_api,
-                otlp=otlp,
+                _read_view_option_values(
+                    limit=limit,
+                    offset=offset,
+                    message_role=message_role,
+                    message_type=message_type,
+                    no_code_blocks=no_code_blocks,
+                    no_tool_calls=no_tool_calls,
+                    no_tool_outputs=no_tool_outputs,
+                    no_file_reads=no_file_reads,
+                    prose_only=prose_only,
+                    related_limit=related_limit,
+                    project_path=project_path,
+                    project_repo=project_repo,
+                    since=since,
+                    until=until,
+                    pack_origin=pack_origin,
+                    pack_query=pack_query,
+                    max_sessions=max_sessions,
+                    max_messages=max_messages,
+                    no_redact=no_redact,
+                    recovery_report=recovery_report,
+                    window_hours=window_hours,
+                    repo_path=repo_path,
+                    since_hours=since_hours,
+                    confidence_threshold=confidence_threshold,
+                    github_api=github_api,
+                    otlp=otlp,
+                ),
             ),
             explicit_options=explicit_options,
         ),
@@ -700,7 +686,7 @@ def continue_verb(
             output_format=effective_format,
             destination=destination,
             out_path=out_path,
-            options=ReadViewRecoveryOptions(report="continue"),
+            options=read_view_options_for_view("recovery", {"recovery_report": "continue"}),
         ),
     )
 

--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -19,11 +19,31 @@ from polylogue.cli.read_views.base import (
     ReadViewRecoveryOptions,
 )
 from polylogue.cli.read_views.bulk import run_bulk_export_view
-from polylogue.cli.read_views.context import run_read_context, run_read_context_pack
-from polylogue.cli.read_views.correlation import run_read_correlation
-from polylogue.cli.read_views.messages import run_read_messages, run_read_raw
-from polylogue.cli.read_views.neighbors import run_read_neighbors
-from polylogue.cli.read_views.recovery import run_read_recovery
+from polylogue.cli.read_views.context import (
+    CONTEXT_PACK_READ_VIEW_OPTION_NAMES,
+    CONTEXT_READ_VIEW_OPTION_NAMES,
+    build_context_options,
+    build_context_pack_options,
+    run_read_context,
+    run_read_context_pack,
+)
+from polylogue.cli.read_views.correlation import (
+    CORRELATION_READ_VIEW_OPTION_NAMES,
+    build_correlation_options,
+    run_read_correlation,
+)
+from polylogue.cli.read_views.messages import (
+    MESSAGE_READ_VIEW_OPTION_NAMES,
+    build_message_options,
+    run_read_messages,
+    run_read_raw,
+)
+from polylogue.cli.read_views.neighbors import (
+    NEIGHBOR_READ_VIEW_OPTION_NAMES,
+    build_neighbor_options,
+    run_read_neighbors,
+)
+from polylogue.cli.read_views.recovery import RECOVERY_READ_VIEW_OPTION_NAMES, build_recovery_options, run_read_recovery
 from polylogue.cli.read_views.standard import run_read_summary_or_transcript
 from polylogue.cli.shared.types import AppEnv
 
@@ -31,68 +51,64 @@ if TYPE_CHECKING:
     from polylogue.cli.root_request import RootModeRequest
 
 
-_MESSAGE_OPTIONS = frozenset(
-    {
-        "limit",
-        "message_role",
-        "message_type",
-        "no_code_blocks",
-        "no_file_reads",
-        "no_tool_calls",
-        "no_tool_outputs",
-        "offset",
-        "prose_only",
-    }
-)
-_CONTEXT_PACK_OPTIONS = frozenset(
-    {
-        "max_messages",
-        "max_sessions",
-        "no_redact",
-        "pack_origin",
-        "pack_query",
-        "project_path",
-        "project_repo",
-        "since",
-        "until",
-    }
-)
-_CORRELATION_OPTIONS = frozenset({"confidence_threshold", "github_api", "otlp", "repo_path", "since_hours"})
-
-
 READ_VIEW_HANDLERS: dict[str, ReadViewHandler] = {
     "summary": ReadViewHandler("summary", "optional", run_read_summary_or_transcript, default_format="markdown"),
     "transcript": ReadViewHandler("transcript", "optional", run_read_summary_or_transcript, default_format="markdown"),
     "messages": ReadViewHandler(
-        "messages", "required", run_read_messages, default_format="text", accepted_options=_MESSAGE_OPTIONS
+        "messages",
+        "required",
+        run_read_messages,
+        default_format="text",
+        accepted_options=MESSAGE_READ_VIEW_OPTION_NAMES,
+        option_builder=build_message_options,
     ),
-    "raw": ReadViewHandler("raw", "required", run_read_raw, default_format="json", accepted_options=_MESSAGE_OPTIONS),
+    "raw": ReadViewHandler(
+        "raw",
+        "required",
+        run_read_raw,
+        default_format="json",
+        accepted_options=MESSAGE_READ_VIEW_OPTION_NAMES,
+        option_builder=build_message_options,
+    ),
     "context": ReadViewHandler(
-        "context", "required", run_read_context, default_format="json", accepted_options=frozenset({"related_limit"})
+        "context",
+        "required",
+        run_read_context,
+        default_format="json",
+        accepted_options=CONTEXT_READ_VIEW_OPTION_NAMES,
+        option_builder=build_context_options,
     ),
     "context-pack": ReadViewHandler(
         "context-pack",
         "none",
         run_read_context_pack,
         default_format="markdown",
-        accepted_options=_CONTEXT_PACK_OPTIONS,
+        accepted_options=CONTEXT_PACK_READ_VIEW_OPTION_NAMES,
+        option_builder=build_context_pack_options,
     ),
     "recovery": ReadViewHandler(
         "recovery",
         "required",
         run_read_recovery,
         default_format="markdown",
-        accepted_options=frozenset({"recovery_report"}),
+        accepted_options=RECOVERY_READ_VIEW_OPTION_NAMES,
+        option_builder=build_recovery_options,
     ),
     "neighbors": ReadViewHandler(
         "neighbors",
         "query_or_session",
         run_read_neighbors,
         default_format="text",
-        accepted_options=frozenset({"limit", "window_hours"}),
+        accepted_options=NEIGHBOR_READ_VIEW_OPTION_NAMES,
+        option_builder=build_neighbor_options,
     ),
     "correlation": ReadViewHandler(
-        "correlation", "required", run_read_correlation, default_format="text", accepted_options=_CORRELATION_OPTIONS
+        "correlation",
+        "required",
+        run_read_correlation,
+        default_format="text",
+        accepted_options=CORRELATION_READ_VIEW_OPTION_NAMES,
+        option_builder=build_correlation_options,
     ),
 }
 
@@ -118,6 +134,16 @@ def read_view_option_names() -> frozenset[str]:
     """Return every view-specific option name owned by read-view handlers."""
 
     return frozenset(option_name for handler in READ_VIEW_HANDLERS.values() for option_name in handler.accepted_options)
+
+
+def read_view_options_for_view(view: str, values: dict[str, object]) -> ReadViewOptions | None:
+    """Build typed options for one read view."""
+
+    try:
+        handler = READ_VIEW_HANDLERS[view]
+    except KeyError as exc:  # pragma: no cover - Click choice prevents this.
+        raise click.UsageError(f"Unknown read view: {view}") from exc
+    return handler.build_options(values)
 
 
 def validate_read_view_handler_registry() -> None:
@@ -151,6 +177,7 @@ __all__ = [
     "ReadViewRecoveryOptions",
     "read_view_handler_ids",
     "read_view_option_names",
+    "read_view_options_for_view",
     "run_bulk_export_view",
     "run_read_view",
     "validate_read_view_handler_registry",

--- a/polylogue/cli/read_views/base.py
+++ b/polylogue/cli/read_views/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -91,6 +91,8 @@ ReadViewOptions = (
     | ReadViewNeighborOptions
     | ReadViewCorrelationOptions
 )
+ReadViewOptionValues = Mapping[str, object]
+ReadViewOptionBuilder = Callable[[ReadViewOptionValues], ReadViewOptions | None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,6 +120,7 @@ class ReadViewHandler:
     handler: ReadViewHandlerFunc
     default_format: str | None = None
     accepted_options: frozenset[ReadViewOptionName] = frozenset()
+    option_builder: ReadViewOptionBuilder | None = None
 
     def validate(self, invocation: ReadViewInvocation, request: RootModeRequest) -> None:
         """Validate cross-view selection rules before executing the handler."""
@@ -144,6 +147,13 @@ class ReadViewHandler:
         if unsupported_options:
             options = ", ".join(f"--{option.replace('_', '-')}" for option in unsupported_options)
             raise click.UsageError(f"read --view {self.view_id} does not use {options}.")
+
+    def build_options(self, values: ReadViewOptionValues) -> ReadViewOptions | None:
+        """Build typed view options from raw Click option values."""
+
+        if self.option_builder is None:
+            return None
+        return self.option_builder(values)
 
 
 def deliver_content(env: AppEnv, content: str, *, destination: str, out_path: str | None) -> None:
@@ -180,7 +190,9 @@ __all__ = [
     "ReadViewOptionName",
     "ReadViewMessageOptions",
     "ReadViewNeighborOptions",
+    "ReadViewOptionBuilder",
     "ReadViewOptions",
+    "ReadViewOptionValues",
     "ReadViewRecoveryOptions",
     "ReadViewSessionPolicy",
     "deliver_content",

--- a/polylogue/cli/read_views/context.py
+++ b/polylogue/cli/read_views/context.py
@@ -8,10 +8,48 @@ from polylogue.cli.read_views.base import (
     ReadViewContextOptions,
     ReadViewContextPackOptions,
     ReadViewInvocation,
+    ReadViewOptionValues,
     deliver_content,
 )
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+
+CONTEXT_READ_VIEW_OPTION_NAMES = frozenset({"related_limit"})
+CONTEXT_PACK_READ_VIEW_OPTION_NAMES = frozenset(
+    {
+        "max_messages",
+        "max_sessions",
+        "no_redact",
+        "pack_origin",
+        "pack_query",
+        "project_path",
+        "project_repo",
+        "since",
+        "until",
+    }
+)
+
+
+def build_context_options(values: ReadViewOptionValues) -> ReadViewContextOptions:
+    """Build options owned by the context preamble read view."""
+
+    return ReadViewContextOptions(related_limit=cast(int, values.get("related_limit", 5)))
+
+
+def build_context_pack_options(values: ReadViewOptionValues) -> ReadViewContextPackOptions:
+    """Build options owned by the context-pack read view."""
+
+    return ReadViewContextPackOptions(
+        project_path=cast(str | None, values.get("project_path")),
+        project_repo=cast(str | None, values.get("project_repo")),
+        since=cast(str | None, values.get("since")),
+        until=cast(str | None, values.get("until")),
+        origin=cast(str | None, values.get("pack_origin")),
+        query=cast(str | None, values.get("pack_query")),
+        max_sessions=cast(int, values.get("max_sessions", 5)),
+        max_messages=cast(int, values.get("max_messages", 20)),
+        no_redact=cast(bool, values.get("no_redact", False)),
+    )
 
 
 def run_read_context(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
@@ -51,4 +89,11 @@ def run_read_context_pack(env: AppEnv, request: RootModeRequest, invocation: Rea
     )
 
 
-__all__ = ["run_read_context", "run_read_context_pack"]
+__all__ = [
+    "CONTEXT_PACK_READ_VIEW_OPTION_NAMES",
+    "CONTEXT_READ_VIEW_OPTION_NAMES",
+    "build_context_options",
+    "build_context_pack_options",
+    "run_read_context",
+    "run_read_context_pack",
+]

--- a/polylogue/cli/read_views/correlation.py
+++ b/polylogue/cli/read_views/correlation.py
@@ -4,9 +4,25 @@ from __future__ import annotations
 
 from typing import cast
 
-from polylogue.cli.read_views.base import ReadViewCorrelationOptions, ReadViewInvocation
+from polylogue.cli.read_views.base import ReadViewCorrelationOptions, ReadViewInvocation, ReadViewOptionValues
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+
+CORRELATION_READ_VIEW_OPTION_NAMES = frozenset(
+    {"confidence_threshold", "github_api", "otlp", "repo_path", "since_hours"}
+)
+
+
+def build_correlation_options(values: ReadViewOptionValues) -> ReadViewCorrelationOptions:
+    """Build options owned by the correlation read view."""
+
+    return ReadViewCorrelationOptions(
+        repo_path=cast(str | None, values.get("repo_path")),
+        since_hours=cast(int, values.get("since_hours", 2)),
+        confidence_threshold=cast(float, values.get("confidence_threshold", 0.3)),
+        github_api=cast(bool, values.get("github_api", True)),
+        otlp=cast(bool, values.get("otlp", False)),
+    )
 
 
 def run_read_correlation(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
@@ -29,4 +45,4 @@ def run_read_correlation(env: AppEnv, request: RootModeRequest, invocation: Read
     )
 
 
-__all__ = ["run_read_correlation"]
+__all__ = ["CORRELATION_READ_VIEW_OPTION_NAMES", "build_correlation_options", "run_read_correlation"]

--- a/polylogue/cli/read_views/messages.py
+++ b/polylogue/cli/read_views/messages.py
@@ -7,9 +7,44 @@ from typing import cast
 
 import click
 
-from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewMessageOptions, deliver_content
+from polylogue.cli.read_views.base import (
+    ReadViewInvocation,
+    ReadViewMessageOptions,
+    ReadViewOptionValues,
+    deliver_content,
+)
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+
+MESSAGE_READ_VIEW_OPTION_NAMES = frozenset(
+    {
+        "limit",
+        "message_role",
+        "message_type",
+        "no_code_blocks",
+        "no_file_reads",
+        "no_tool_calls",
+        "no_tool_outputs",
+        "offset",
+        "prose_only",
+    }
+)
+
+
+def build_message_options(values: ReadViewOptionValues) -> ReadViewMessageOptions:
+    """Build options shared by the messages and raw read views."""
+
+    return ReadViewMessageOptions(
+        limit=cast(int | None, values.get("limit")),
+        offset=cast(int, values.get("offset", 0)),
+        role=cast(tuple[str, ...], values.get("message_role", ())),
+        message_type=cast(str | None, values.get("message_type")),
+        no_code_blocks=cast(bool, values.get("no_code_blocks", False)),
+        no_tool_calls=cast(bool, values.get("no_tool_calls", False)),
+        no_tool_outputs=cast(bool, values.get("no_tool_outputs", False)),
+        no_file_reads=cast(bool, values.get("no_file_reads", False)),
+        prose_only=cast(bool, values.get("prose_only", False)),
+    )
 
 
 def run_read_messages(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
@@ -109,4 +144,4 @@ def run_read_raw(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvo
     )
 
 
-__all__ = ["run_read_messages", "run_read_raw"]
+__all__ = ["MESSAGE_READ_VIEW_OPTION_NAMES", "build_message_options", "run_read_messages", "run_read_raw"]

--- a/polylogue/cli/read_views/neighbors.py
+++ b/polylogue/cli/read_views/neighbors.py
@@ -5,9 +5,25 @@ from __future__ import annotations
 from typing import cast
 
 from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
-from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewNeighborOptions, deliver_content
+from polylogue.cli.read_views.base import (
+    ReadViewInvocation,
+    ReadViewNeighborOptions,
+    ReadViewOptionValues,
+    deliver_content,
+)
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+
+NEIGHBOR_READ_VIEW_OPTION_NAMES = frozenset({"limit", "window_hours"})
+
+
+def build_neighbor_options(values: ReadViewOptionValues) -> ReadViewNeighborOptions:
+    """Build options owned by the neighbor-discovery read view."""
+
+    return ReadViewNeighborOptions(
+        limit=cast(int | None, values.get("limit")),
+        window_hours=cast(int, values.get("window_hours", 24)),
+    )
 
 
 def _neighbor_score_label(score: float) -> str:
@@ -87,4 +103,4 @@ def run_read_neighbors(env: AppEnv, request: RootModeRequest, invocation: ReadVi
     )
 
 
-__all__ = ["run_read_neighbors"]
+__all__ = ["NEIGHBOR_READ_VIEW_OPTION_NAMES", "build_neighbor_options", "run_read_neighbors"]

--- a/polylogue/cli/read_views/recovery.py
+++ b/polylogue/cli/read_views/recovery.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 from typing import cast
 
-from polylogue.cli.read_views.base import ReadViewInvocation, ReadViewRecoveryOptions, deliver_content
+from polylogue.cli.read_views.base import (
+    ReadViewInvocation,
+    ReadViewOptionValues,
+    ReadViewRecoveryOptions,
+    deliver_content,
+)
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+
+RECOVERY_READ_VIEW_OPTION_NAMES = frozenset({"recovery_report"})
+
+
+def build_recovery_options(values: ReadViewOptionValues) -> ReadViewRecoveryOptions:
+    """Build options owned by the recovery read view."""
+
+    return ReadViewRecoveryOptions(report=cast(str | None, values.get("recovery_report")))
 
 
 def run_read_recovery(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
@@ -49,4 +62,4 @@ def run_read_recovery(env: AppEnv, request: RootModeRequest, invocation: ReadVie
     deliver_content(env, digest.resume_markdown, destination=invocation.destination, out_path=invocation.out_path)
 
 
-__all__ = ["run_read_recovery"]
+__all__ = ["RECOVERY_READ_VIEW_OPTION_NAMES", "build_recovery_options", "run_read_recovery"]

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -800,6 +800,28 @@ def test_read_view_accepts_explicit_options_owned_by_selected_view() -> None:
     )
 
 
+def test_read_view_registry_builds_typed_view_options() -> None:
+    options = read_view_handlers.read_view_options_for_view(
+        "context-pack",
+        {
+            "project_path": "/workspace/polylogue",
+            "project_repo": "github.com/Sinity/polylogue",
+            "pack_query": "route contracts",
+            "max_sessions": 3,
+            "max_messages": 8,
+            "no_redact": True,
+        },
+    )
+
+    assert isinstance(options, read_view_handlers.ReadViewContextPackOptions)
+    assert options.project_path == "/workspace/polylogue"
+    assert options.project_repo == "github.com/Sinity/polylogue"
+    assert options.query == "route contracts"
+    assert options.max_sessions == 3
+    assert options.max_messages == 8
+    assert options.no_redact is True
+
+
 def test_explicit_read_view_options_reports_command_line_values_only() -> None:
     ctx = click.Context(query_verbs.read_verb)
     ctx.set_parameter_source("message_role", click.core.ParameterSource.COMMANDLINE)


### PR DESCRIPTION
## Summary

Moves read-view-specific option construction out of `query_verbs.py` and into the read-view handler modules that consume those options. The CLI callback now collects raw Click values and asks the read-view registry to build the selected view's typed option object.

## Problem

#2177 calls out that `ReadViewInvocation` had improved the read-view dispatch path, but option ownership still leaked back into the query verb: `query_verbs.py` knew how to instantiate every messages/raw/context/context-pack/recovery/neighbors/correlation option dataclass, while `read_view_handlers.py` separately listed accepted option names. That kept per-view truth split between the CLI boundary and the executable handlers.

## Solution

Each read-view module now exports the option names and builder for the view it owns. `ReadViewHandler` carries an optional `option_builder`, and `read_view_options_for_view()` builds typed options through the registry. `query_verbs.py` no longer branches by view to construct option dataclasses; it only forwards the raw Click option values. The continuation action also uses the registry to build its recovery options.

The behavior test added in `test_query_verbs_runtime.py` verifies that the registry builds typed context-pack options directly, and the existing read-view runtime tests continue to cover CLI invocation behavior.

Closes part of #2177.

## Verification

- `ruff check tests/unit/cli/test_query_verbs_runtime.py polylogue/cli/query_verbs.py polylogue/cli/read_view_handlers.py polylogue/cli/read_views`
  - `All checks passed!`
- `devtools test tests/unit/cli/test_query_verbs_runtime.py tests/unit/cli/test_neighbors_command.py tests/unit/cli/test_messages.py -q`
  - `48 passed in 4.80s`
- `devtools verify --quick` via pre-push on `bee37bef11b84ad6f74bd346153f1f54d23834a4`
  - `exit_code: 0`