### PR TITLE
feat(query): expose terminal pipeline stages in explain (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -34,6 +34,8 @@ through the same typed AST and query planner:
 compact-query      ::= compact-clause*
 boolean-query      ::= ["sessions" "where"] predicate
 unit-query         ::= ("messages" | "actions" | "blocks" | "assertions" | "runs" | "observed-events" | "context-snapshots") "where" predicate
+pipeline-query     ::= unit-query ("|" pipeline-stage)+
+                     | "sessions" "where" predicate "|" unit-query ("|" pipeline-stage)*
 
 compact-clause     ::= field-clause
                      | quoted-text | bare-text
@@ -53,6 +55,9 @@ predicate          ::= predicate "OR" predicate
                      | "seq" "(" sequence-step "->" sequence-step+ ")"
 
 structural-unit    ::= "message" | "action" | "block" | "assertion"
+pipeline-stage     ::= "sort" "by" "time" ["asc" | "desc"]
+                     | "limit" integer
+                     | "offset" integer
 ```
 
 Compact queries select sessions:
@@ -107,6 +112,13 @@ of expanding caller/API caps, and query-string offsets are added to the caller
 offset. Runtime-transform terminal rows (`runs`, `observed-events`,
 `context-snapshots`) reject sort stages until they have streaming lowerers;
 they must not collect every projected row in memory merely to sort a page.
+
+`--explain --format json` reports terminal pipelines as a `unit_source` AST with
+ordered `pipeline_stages`. Session-scoped pipelines include a `session_scope`
+stage carrying the original session predicate, followed by any terminal
+`sort`/`limit`/`offset` stages. Consumers should use that stage list rather than
+inferring pipeline behavior from incidental `limit`, `offset`, or `sort`
+fields.
 
 Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -247,6 +247,32 @@ class QueryUnitSort:
     direction: Literal["asc", "desc"] = "asc"
 
 
+QueryUnitPipelineStageKind = Literal["session_scope", "sort", "limit", "offset"]
+
+
+@dataclass(frozen=True)
+class QueryUnitPipelineStage:
+    """Typed terminal query pipeline stage for explain and future lowerers."""
+
+    kind: QueryUnitPipelineStageKind
+    predicate: QueryPredicate | None = None
+    sort: QueryUnitSort | None = None
+    value: int | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": self.kind}
+        if self.predicate is not None:
+            payload["predicate"] = self.predicate.to_payload()
+        if self.sort is not None:
+            payload["sort"] = {
+                "field": self.sort.field,
+                "direction": self.sort.direction,
+            }
+        if self.value is not None:
+            payload["value"] = self.value
+        return payload
+
+
 @dataclass(frozen=True)
 class QueryUnitSource:
     """Explicit unit-changing source parsed from ``<unit>s where ...``."""
@@ -257,6 +283,7 @@ class QueryUnitSource:
     limit: int | None = None
     offset: int | None = None
     sort: QueryUnitSort | None = None
+    pipeline_stages: tuple[QueryUnitPipelineStage, ...] = ()
 
 
 ExplainClauseKind = Literal["field", "count", "count_range", "date", "date_range", "text", "json"]
@@ -1182,15 +1209,36 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
                 "runtime-transform units need a streaming lowerer first",
                 field="sort",
             )
-        return replace(source, sort=sort)
+        return replace(
+            source,
+            sort=sort,
+            pipeline_stages=(
+                *source.pipeline_stages,
+                QueryUnitPipelineStage(kind="sort", sort=sort),
+            ),
+        )
     limit = _parse_non_negative_int_stage(stage, "limit")
     if limit is not None:
         if limit == 0:
             raise ExpressionCompileError("pipeline `limit` stage must be greater than zero", field="limit")
-        return replace(source, limit=limit)
+        return replace(
+            source,
+            limit=limit,
+            pipeline_stages=(
+                *source.pipeline_stages,
+                QueryUnitPipelineStage(kind="limit", value=limit),
+            ),
+        )
     offset = _parse_non_negative_int_stage(stage, "offset")
     if offset is not None:
-        return replace(source, offset=offset)
+        return replace(
+            source,
+            offset=offset,
+            pipeline_stages=(
+                *source.pipeline_stages,
+                QueryUnitPipelineStage(kind="offset", value=offset),
+            ),
+        )
     raise ExpressionCompileError(
         f"unsupported pipeline stage {stage!r}; supported terminal stages are "
         "`sort by time [asc|desc]`, `limit N`, and `offset N`",
@@ -1246,6 +1294,10 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
             limit=terminal_source.limit,
             offset=terminal_source.offset,
             sort=terminal_source.sort,
+            pipeline_stages=(
+                QueryUnitPipelineStage(kind="session_scope", predicate=session_predicate),
+                *terminal_source.pipeline_stages,
+            ),
         )
         tail_stages = tuple(remaining_stages)
     else:
@@ -1547,6 +1599,8 @@ def _ast_payload(
                 "field": unit_source.sort.field,
                 "direction": unit_source.sort.direction,
             }
+        if unit_source.pipeline_stages:
+            unit_payload["pipeline_stages"] = [stage.to_payload() for stage in unit_source.pipeline_stages]
         payload["unit_source"] = unit_payload
     return payload
 
@@ -1558,6 +1612,7 @@ def _lowering_plan_payload(
     execution_legs: tuple[str, ...],
     plan_description: tuple[str, ...],
     compatibility_selector: str | None = None,
+    pipeline_stages: tuple[QueryUnitPipelineStage, ...] = (),
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "lowerer": lowerer,
@@ -1567,6 +1622,8 @@ def _lowering_plan_payload(
     }
     if compatibility_selector is not None:
         payload["compatibility_selector"] = compatibility_selector
+    if pipeline_stages:
+        payload["pipeline_stages"] = [stage.to_payload() for stage in pipeline_stages]
     return payload
 
 
@@ -1634,6 +1691,7 @@ def explain_expression(expression: str) -> QueryExpressionExplanation:
                 execution_legs=execution_legs,
                 plan_description=plan_description,
                 compatibility_selector=compatibility_selector,
+                pipeline_stages=unit_source.pipeline_stages,
             ),
         )
     ast = parse_expression_ast(stripped)
@@ -2165,6 +2223,7 @@ __all__ = [
     "QueryExpressionExplainClause",
     "QueryExpressionExplanation",
     "QueryExpressionAST",
+    "QueryUnitPipelineStage",
     "QueryUnitSort",
     "QueryUnitSource",
     "_HAS_BOOL_MAP",

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -270,6 +271,33 @@ def test_root_query_explain_json_outputs_terminal_unit_payload(cli_runner: CliRu
     assert payload["ast"]["unit_source"]["unit"] == "message"
     assert payload["lowering_plan"]["compatibility_selector"] == "exists message(...)"
     assert payload["predicate"]["kind"] == "and"
+
+
+def test_root_query_explain_json_outputs_terminal_pipeline_stages(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "find",
+            "messages where role:assistant | sort by time desc | limit 2 | offset 3",
+            "--explain",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = cast(dict[str, Any], json.loads(result.output))
+    ast_payload = cast(dict[str, Any], payload["ast"])
+    unit_source = cast(dict[str, Any], ast_payload["unit_source"])
+    expected_stages = [
+        {"kind": "sort", "sort": {"field": "time", "direction": "desc"}},
+        {"kind": "limit", "value": 2},
+        {"kind": "offset", "value": 3},
+    ]
+    assert unit_source["pipeline_stages"] == expected_stages
+    lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
+    assert lowering_plan["pipeline_stages"] == expected_stages
 
 
 def test_root_query_explain_json_marks_runtime_transform_unit_payload(cli_runner: CliRunner) -> None:

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -295,6 +295,56 @@ class TestExplainExpression:
             ),
         )
 
+    def test_explain_expression_reports_terminal_pipeline_stages(self) -> None:
+        explanation = explain_expression("messages where role:assistant | sort by time desc | limit 2 | offset 3")
+
+        assert explanation.selected_units == ("message",)
+        payload = explanation.to_payload()
+        assert payload["ast"] == {
+            "entry": "unit_source",
+            "predicate": {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+            "unit_source": {
+                "unit": "message",
+                "predicate": {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+                "limit": 2,
+                "offset": 3,
+                "sort": {"field": "time", "direction": "desc"},
+                "pipeline_stages": [
+                    {"kind": "sort", "sort": {"field": "time", "direction": "desc"}},
+                    {"kind": "limit", "value": 2},
+                    {"kind": "offset", "value": 3},
+                ],
+            },
+        }
+        lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
+        assert lowering_plan["pipeline_stages"] == [
+            {"kind": "sort", "sort": {"field": "time", "direction": "desc"}},
+            {"kind": "limit", "value": 2},
+            {"kind": "offset", "value": 3},
+        ]
+
+    def test_explain_expression_reports_session_scoped_pipeline_stage(self) -> None:
+        explanation = explain_expression("sessions where repo:polylogue | messages where role:assistant | limit 5")
+
+        payload = explanation.to_payload()
+        ast_payload = cast(dict[str, Any], payload["ast"])
+        unit_source = cast(dict[str, Any], ast_payload["unit_source"])
+        assert unit_source["session_predicate"] == {
+            "field": "repo",
+            "kind": "field",
+            "op": "=",
+            "values": ["polylogue"],
+        }
+        assert unit_source["pipeline_stages"] == [
+            {
+                "kind": "session_scope",
+                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
+            },
+            {"kind": "limit", "value": 5},
+        ]
+        lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
+        assert lowering_plan["pipeline_stages"] == unit_source["pipeline_stages"]
+
 
 class TestBooleanQueryExpression:
     def test_boolean_ast_exposes_predicate_tree(self) -> None:
@@ -474,6 +524,14 @@ class TestBooleanQueryExpression:
         assert source is not None
         assert source.limit == 2
         assert source.offset == 3
+        assert [stage.to_payload() for stage in source.pipeline_stages] == [
+            {
+                "kind": "session_scope",
+                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
+            },
+            {"kind": "limit", "value": 2},
+            {"kind": "offset", "value": 3},
+        ]
 
     def test_terminal_source_pipeline_limit_offset_and_sort_are_parsed(self) -> None:
         source = parse_unit_source_expression("messages where role:assistant | sort by time desc | limit 2 | offset 3")
@@ -487,6 +545,11 @@ class TestBooleanQueryExpression:
         assert source.sort.field == "time"
         assert source.sort.direction == "desc"
         assert source.predicate == QueryFieldPredicate(field="role", values=("assistant",))
+        assert [stage.to_payload() for stage in source.pipeline_stages] == [
+            {"kind": "sort", "sort": {"field": "time", "direction": "desc"}},
+            {"kind": "limit", "value": 2},
+            {"kind": "offset", "value": 3},
+        ]
 
     def test_pipeline_sort_stage_is_parsed(self) -> None:
         source = parse_unit_source_expression(


### PR DESCRIPTION
## Summary

Adds a typed terminal pipeline-stage model to the shared query DSL explain surface. Terminal `messages/actions/... where ... | sort/limit/offset` pipelines now expose ordered `pipeline_stages` in both the parsed `unit_source` AST payload and the lowering plan, so CLI/API/MCP/query-builder consumers can inspect the executable pipeline instead of reverse-engineering incidental scalar fields.

## Problem

#2006 already has executable terminal pipelines for direct unit rows and `sessions where ... | <unit>s where ...` scoped pipelines. The execution path honored `sort by time`, `limit`, and `offset`, but `--explain` only reported a generic terminal unit source plus optional `limit`/`offset`/`sort` fields. That made the shipped pipeline behavior harder to debug and left no typed stage spine for the next traversal/aggregation/terminal-action work.

## Solution

- Added `QueryUnitPipelineStage` and threaded ordered stages through `QueryUnitSource` in `polylogue/archive/query/expression.py`.
- Recorded `sort`, `limit`, `offset`, and session-scope stages as typed payloads in both AST and lowering-plan explain output.
- Covered the shared parser/explain API and the real Click `find ... --explain --format json` path.
- Updated `docs/search.md` so the public grammar documents shipped terminal pipeline syntax and the new explain payload contract.
- Updated #1807 while verification was running so its child graph reflects that #2006 is now the only open child implementation issue after the #2177-#2193 closure wave.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -q` -> `272 passed`.
- `devtools test tests/unit/cli/test_click_app.py -k 'query_explain_json_outputs_terminal' -q` -> `2 passed, 66 deselected`.
- `devtools test tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py -k 'pipeline_stages or query_explain_json_outputs_terminal' -q` -> `3 passed, 337 deselected`.
- `mypy polylogue/archive/query/expression.py tests/unit/cli/test_query_expression.py tests/unit/cli/test_click_app.py` -> `Success: no issues found in 3 source files`.
- `devtools verify --quick` -> `exit_code: 0`.
- `devtools verify --seed-testmon --skip-slow` -> `11680 passed`, diagnosis `pytest_passed`, peak pytest tree RSS `3199.2 MiB`.
- `devtools verify` -> `7 passed`, diagnosis `pytest_passed`.
- Pre-push `devtools verify --quick` on `bcbdf591f` -> `exit_code: 0`.

## Changelog

Skipped: this is an internal explain-payload/query-substrate improvement under the active #2006 DSL work, not a released command addition.

## Risks and Follow-ups

This does not add new pipeline vocabulary or aggregation/traversal behavior. It gives the shipped terminal pipeline stages a typed explain spine that later #2006 work can extend when adding real traversal, aggregation, and terminal action lowerers.

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline stages (`sort by time`, `limit`, `offset`) are now explicitly modeled and reported in `--explain --format json` output, enabling clearer visibility into query execution structure.

* **Documentation**
  * Updated Search & Query Reference to document pipeline-query grammar and stage productions.

* **Tests**
  * Added comprehensive test coverage for pipeline stage serialization in query explain output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->