### PR TITLE
feat(query): expose pipeline stages on query-unit results (#2006)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1428,6 +1428,29 @@ components:
             - $ref: '#/components/schemas/ContextSnapshotQueryRowPayload'
           title: Items
           type: array
+        pipeline_stages:
+          default: []
+          items:
+            additionalProperties: true
+            properties:
+              kind:
+                enum:
+                - session_scope
+                - sort
+                - limit
+                - offset
+                type: string
+              predicate:
+                type: object
+              sort:
+                type: object
+              value:
+                type: integer
+            required:
+            - kind
+            type: object
+          title: Pipeline Stages
+          type: array
         total:
           title: Total
           type: integer

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -832,6 +832,38 @@
       "title": "Offset",
       "type": "integer"
     },
+    "pipeline_stages": {
+      "default": [],
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "kind": {
+            "enum": [
+              "session_scope",
+              "sort",
+              "limit",
+              "offset"
+            ],
+            "type": "string"
+          },
+          "predicate": {
+            "type": "object"
+          },
+          "sort": {
+            "type": "object"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "type": "object"
+      },
+      "title": "Pipeline Stages",
+      "type": "array"
+    },
     "query": {
       "title": "Query",
       "type": "string"

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -658,6 +658,7 @@ def _build_runtime_transform_envelope(
         limit=limit,
         offset=caller_offset,
         has_next=len(rows) > limit,
+        pipeline_stages=tuple(stage.to_payload() for stage in source.pipeline_stages),
     )
 
 
@@ -698,6 +699,7 @@ def _build_sql_envelope(
         limit=limit,
         offset=caller_offset,
         has_next=len(rows) > limit,
+        pipeline_stages=tuple(stage.to_payload() for stage in source.pipeline_stages),
     )
 
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1566,6 +1566,26 @@ class QueryUnitEnvelope(SurfacePayloadModel):
     unit: QueryUnitKind
     query: str
     items: tuple[QueryUnitRowPayload, ...]
+    pipeline_stages: tuple[dict[str, object], ...] = Field(
+        default=(),
+        json_schema_extra={
+            "items": {
+                "additionalProperties": True,
+                "properties": {
+                    "kind": {
+                        "enum": ["session_scope", "sort", "limit", "offset"],
+                        "type": "string",
+                    },
+                    "predicate": {"type": "object"},
+                    "sort": {"type": "object"},
+                    "value": {"type": "integer"},
+                },
+                "required": ["kind"],
+                "type": "object",
+            }
+        },
+    )
+    """Ordered terminal pipeline stages that shaped this page, if any."""
     total: int
     """Number of terminal rows returned in this page."""
     limit: int
@@ -1644,6 +1664,7 @@ def build_query_unit_envelope(
     limit: int,
     offset: int,
     has_next: bool,
+    pipeline_stages: Sequence[Mapping[str, object]] = (),
 ) -> QueryUnitEnvelope:
     """Construct the canonical terminal query-unit response envelope."""
 
@@ -1652,6 +1673,7 @@ def build_query_unit_envelope(
         unit=unit,
         query=query,
         items=items_tuple,
+        pipeline_stages=tuple(dict(stage) for stage in pipeline_stages),
         total=len(items_tuple),
         limit=limit,
         offset=offset,

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1495,6 +1495,51 @@ async def test_query_units_applies_session_scope_filters(tmp_path: Path) -> None
         await archive.close()
 
 
+async def test_query_units_reports_pipeline_stages(tmp_path: Path) -> None:
+    """``query_units()`` exposes the terminal pipeline that shaped returned rows."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="unit-pipeline-codex",
+                    title="Unit pipeline Codex",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.ASSISTANT,
+                            text="first terminal pipeline row",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first terminal pipeline row")],
+                        ),
+                        ParsedMessage(
+                            provider_message_id="m2",
+                            role=Role.ASSISTANT,
+                            text="second terminal pipeline row",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="second terminal pipeline row")],
+                        ),
+                    ],
+                )
+            )
+
+        envelope = await archive.query_units(
+            "sessions where origin:codex-session | messages where role:assistant | limit 1 | offset 1"
+        )
+
+        assert envelope.pipeline_stages == (
+            {
+                "kind": "session_scope",
+                "predicate": {"field": "origin", "kind": "field", "op": "=", "values": ["codex-session"]},
+            },
+            {"kind": "limit", "value": 1},
+            {"kind": "offset", "value": 1},
+        )
+        assert envelope.limit == 1
+        assert [cast(Any, item).message_id for item in envelope.items] == ["codex-session:unit-pipeline-codex:m2"]
+    finally:
+        await archive.close()
+
+
 async def test_query_units_accepts_inline_session_scope(tmp_path: Path) -> None:
     """``query_units()`` accepts owning-session scope inside the shared DSL."""
     archive = _archive(tmp_path)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -19,10 +19,12 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from click.testing import CliRunner
 
 from polylogue.archive.query.expression import (
     EXPRESSION_FIELD_REGISTRY,
@@ -1128,6 +1130,14 @@ class TestBooleanQueryExpression:
         assert envelope.limit == 1
         assert envelope.offset == 0
         assert envelope.next_offset == 1
+        assert envelope.pipeline_stages == (
+            {
+                "kind": "session_scope",
+                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
+            },
+            {"kind": "limit", "value": 1},
+            {"kind": "offset", "value": 1},
+        )
         assert len(envelope.items) == 1
         row = envelope.items[0]
         from polylogue.surfaces.payloads import MessageQueryRowPayload
@@ -1146,6 +1156,47 @@ class TestBooleanQueryExpression:
         assert isinstance(next_row, MessageQueryRowPayload)
         assert next_row.message_id == "claude-code-session:ext-hit:m-3"
         assert next_row.text == "third"
+
+    def test_cli_json_reports_terminal_pipeline_stages(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.cli import cli
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("pipeline cli")
+            .add_message("m-1", role="assistant", text="first")
+            .add_message("m-2", role="assistant", text="second")
+            .save()
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "--plain",
+                "--format",
+                "json",
+                "find",
+                "sessions where repo:polylogue | messages where role:assistant | limit 1 | offset 1",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["pipeline_stages"] == [
+            {
+                "kind": "session_scope",
+                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
+            },
+            {"kind": "limit", "value": 1},
+            {"kind": "offset", "value": 1},
+        ]
+        assert [item["text"] for item in payload["items"]] == ["second"]
 
     def test_unknown_terminal_unit_does_not_fall_through_to_block_rows(self) -> None:
         from polylogue.archive.query.unit_results import query_unit_rows


### PR DESCRIPTION
## Summary

Expose terminal query pipeline stages on the shared `QueryUnitEnvelope`, so result-producing query-unit surfaces report the same shaping metadata that `--explain` already shows. The field is populated from the canonical `QueryUnitSource.pipeline_stages` for both SQL-backed units and runtime-transform units, and the CLI/OpenAPI output schemas now advertise the shape.

## Problem

PR #2231 made terminal pipeline stages explainable, but actual result envelopes still returned only rows, limits, offsets, and pagination. That left CLI/API/MCP/daemon consumers unable to tell whether a page was shaped by a session-scoped pipeline, `sort`, `limit`, or `offset` without separately re-parsing the query.

## Solution

- Added `pipeline_stages` to `QueryUnitEnvelope` in `polylogue/surfaces/payloads.py`, with explicit schema metadata for `session_scope`, `sort`, `limit`, and `offset` stage payloads.
- Threaded `QueryUnitSource.pipeline_stages` through `polylogue/archive/query/unit_results.py` for both SQL and runtime-transform result envelopes.
- Added executor, CLI JSON, and Python facade coverage proving pipeline metadata appears on real query-unit results, not only explain payloads.
- Regenerated CLI output schema and OpenAPI surfaces.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k "pipeline_stages or session_to_message_pipeline_limit_offset" -q` -> `3 passed, 270 deselected`.
- `devtools test tests/unit/api/test_facade_contracts.py -k query_units_reports_pipeline_stages -q` -> `1 passed, 224 deselected`.
- `mypy polylogue/surfaces/payloads.py polylogue/archive/query/unit_results.py tests/unit/api/test_facade_contracts.py tests/unit/cli/test_query_expression.py` -> `Success: no issues found in 4 source files`.
- `devtools render cli-output-schemas --check` -> `sync OK`.
- `devtools verify --quick` -> `exit_code: 0`.
- `devtools verify --seed-testmon --skip-slow` -> `11682 passed`; peak pytest tree RSS `3169.0 MiB`; diagnosis `pytest_passed`.
- `devtools verify` -> `7 passed`; peak pytest tree RSS `583.3 MiB`; diagnosis `pytest_passed`.
- Pre-push `devtools verify --quick` on `09a930d` -> `exit_code: 0`.

Ref #2006