### PR TITLE
refactor(query): let unit descriptors own executor metadata (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1211,17 +1211,6 @@ def _parse_sort_stage(stage: str) -> QueryUnitSort | None:
     )
 
 
-_AGGREGATE_GROUP_FIELDS: dict[QueryUnitName, frozenset[str]] = {
-    "message": frozenset({"role", "type", "session.origin", "session.repo"}),
-    "action": frozenset({"tool", "action", "type", "session.origin", "session.repo"}),
-    "block": frozenset({"type", "tool", "action", "session.origin", "session.repo"}),
-    "assertion": frozenset({"kind", "status", "visibility", "author_kind", "session.origin", "session.repo"}),
-    "run": frozenset(),
-    "observed-event": frozenset(),
-    "context-snapshot": frozenset(),
-}
-
-
 def _parse_group_stage(stage: str) -> str | None:
     normalized = " ".join(stage.split()).lower()
     if not normalized.startswith("group by "):
@@ -1239,8 +1228,10 @@ def _parse_count_stage(stage: str) -> bool:
 
 
 def _validate_aggregate_group_field(unit: QueryUnitName, field: str) -> None:
-    if field not in _AGGREGATE_GROUP_FIELDS[unit]:
-        supported = ", ".join(sorted(_AGGREGATE_GROUP_FIELDS[unit]))
+    descriptor = query_unit_descriptor(unit)
+    supported_fields = frozenset(descriptor.aggregate_group_fields) if descriptor is not None else frozenset()
+    if field not in supported_fields:
+        supported = ", ".join(sorted(supported_fields))
         if not supported:
             raise ExpressionCompileError(
                 f"pipeline `group by` is not supported for {unit} rows yet",

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -20,7 +20,9 @@ class QueryUnitDescriptor:
     terminal_supported: bool = True
     exists_supported: bool = False
     lowerer_kind: QueryUnitLowererKind = "sql"
+    sql_query_method: str | None = None
     cli_plain_renderer: str | None = None
+    aggregate_group_fields: tuple[str, ...] = ()
     fields: tuple[StructuralQueryFieldInfo, ...] = ()
     description: str = ""
     example: str = ""
@@ -521,7 +523,9 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "messages",
         exists_supported=True,
         payload_model="MessageQueryRowPayload",
+        sql_query_method="query_messages",
         cli_plain_renderer="message",
+        aggregate_group_fields=("role", "type", "session.origin", "session.repo"),
         fields=_unit_info("message").fields,
         description=_unit_info("message").description,
         example=_unit_info("message").example,
@@ -532,7 +536,9 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "actions",
         exists_supported=True,
         payload_model="ActionQueryRowPayload",
+        sql_query_method="query_actions",
         cli_plain_renderer="action",
+        aggregate_group_fields=("tool", "action", "type", "session.origin", "session.repo"),
         fields=_unit_info("action").fields,
         description=_unit_info("action").description,
         example=_unit_info("action").example,
@@ -543,7 +549,9 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "blocks",
         exists_supported=True,
         payload_model="BlockQueryRowPayload",
+        sql_query_method="query_blocks",
         cli_plain_renderer="block",
+        aggregate_group_fields=("type", "tool", "action", "session.origin", "session.repo"),
         fields=_unit_info("block").fields,
         description=_unit_info("block").description,
         example=_unit_info("block").example,
@@ -554,7 +562,9 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         "assertions",
         exists_supported=True,
         payload_model="AssertionQueryRowPayload",
+        sql_query_method="query_assertions",
         cli_plain_renderer="assertion",
+        aggregate_group_fields=("kind", "status", "visibility", "author_kind", "session.origin", "session.repo"),
         fields=_unit_info("assertion").fields,
         description=_unit_info("assertion").description,
         example=_unit_info("assertion").example,

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -76,13 +76,6 @@ _ROW_PAYLOAD_MODELS: dict[str, _RowPayloadModel] = {
     "MessageQueryRowPayload": MessageQueryRowPayload,
 }
 
-_SQL_QUERY_METHODS: dict[str, str] = {
-    "action": "query_actions",
-    "assertion": "query_assertions",
-    "block": "query_blocks",
-    "message": "query_messages",
-}
-
 
 def _bool_param(value: object) -> bool:
     if isinstance(value, bool):
@@ -698,7 +691,7 @@ def _build_sql_envelope(
         )
     sort = source.sort.field if source.sort is not None else None
     sort_direction = source.sort.direction if source.sort is not None else "asc"
-    method_name = _SQL_QUERY_METHODS.get(source.unit)
+    method_name = descriptor.sql_query_method
     payload_model = _ROW_PAYLOAD_MODELS.get(descriptor.payload_model)
     if method_name is None or payload_model is None:
         raise ValueError(f"Query unit {source.unit!r} is not wired to a SQL executor")

--- a/tests/unit/cli/test_query_unit_renderer_metadata.py
+++ b/tests/unit/cli/test_query_unit_renderer_metadata.py
@@ -6,8 +6,9 @@ import click
 import pytest
 
 from polylogue.archive.query.metadata import QueryUnitDescriptor, query_unit_descriptors
-from polylogue.archive.query.unit_results import _ROW_PAYLOAD_MODELS, _RUNTIME_TRANSFORM_QUERIES, _SQL_QUERY_METHODS
+from polylogue.archive.query.unit_results import _ROW_PAYLOAD_MODELS, _RUNTIME_TRANSFORM_QUERIES
 from polylogue.cli.archive_query import _query_unit_text_line
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 
 @pytest.mark.parametrize(
@@ -35,7 +36,11 @@ def test_terminal_query_unit_descriptors_resolve_executors(descriptor: object) -
     unit = descriptor.unit
     if descriptor.lowerer_kind == "runtime_transform":
         assert unit in _RUNTIME_TRANSFORM_QUERIES
+        assert descriptor.sql_query_method is None
+        assert descriptor.aggregate_group_fields == ()
         return
     assert descriptor.lowerer_kind == "sql"
-    assert unit in _SQL_QUERY_METHODS
+    assert descriptor.sql_query_method is not None
+    assert hasattr(ArchiveStore, descriptor.sql_query_method)
+    assert descriptor.aggregate_group_fields
     assert descriptor.payload_model in _ROW_PAYLOAD_MODELS


### PR DESCRIPTION
## Summary

Moves query-unit executor method names and aggregate grouping fields into `QueryUnitDescriptor`, so parser validation and result execution read from the same unit registry.

## Problem

The aggregate pipeline work left two small but important parallel truths: `expression.py` owned aggregate group-field support, while `unit_results.py` owned SQL executor method names. That made each new terminal unit require another scattered wiring edit, which is exactly the #2006 descriptor-drift problem.

## Solution

`QueryUnitDescriptor` now carries `sql_query_method` and `aggregate_group_fields`. The pipeline parser validates `group by` against the descriptor, and SQL unit-result execution dispatches through `descriptor.sql_query_method`. The descriptor metadata test now checks the live `ArchiveStore` method instead of a separate `_SQL_QUERY_METHODS` map.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_unit_renderer_metadata.py tests/unit/cli/test_query_expression.py -k "pipeline_group_by_count or aggregate_on_runtime"` -> 3 passed
- `nix develop --command devtools verify --quick` -> exit_code 0
- `nix develop --command devtools verify --seed-testmon --skip-slow` -> 11688 passed, diagnosis `pytest_passed`, peak pytest tree RSS 3212.5 MiB
- `nix develop --command devtools verify` -> 7 passed, diagnosis `pytest_passed`, peak pytest tree RSS 581.5 MiB

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized query unit configuration by consolidating internal mappings into unit descriptor definitions, improving maintainability and reducing code duplication.
  * Restructured validation logic to derive supported fields from unit metadata rather than hardcoded allowlists, making the system more flexible for future extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->