### PR TITLE
feat(query): add row-time predicates for query units (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -40,6 +40,7 @@ and explicit Boolean session predicates:
     messages where role:assistant AND text:timeout
     actions where action:file_edit AND path:polylogue/archive
     blocks where type:code AND text:timeout
+    messages where time >= 2026-01-01T00:00:00+00:00
     sessions where repo:polylogue | messages where role:assistant | group by role | count
 
 Unit-scoped ``messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`` predicates are executable
@@ -49,6 +50,9 @@ predicates, while terminal query-unit surfaces preserve the selected unit and
 return raw message/action/block/assertion/observed-event/context-snapshot rows from the same predicate semantics.
 SQL-backed terminal units also support exact ``group by FIELD | count``
 aggregate pipelines for the closed aggregate fields declared in this module.
+They also support ``time >= VALUE``, ``time <= VALUE``, and
+``time between A and B`` predicates over the same row timestamp used by
+``sort by time``.
 
 Unknown fields and unsupported structured forms fail loudly. The Lark grammar
 in this module is the query grammar. Compact field/text clauses and explicit
@@ -410,6 +414,8 @@ _QUERY_GRAMMAR = r"""
         | COUNT_FIELD COMP_OP INT          -> count_compare_leaf
         | DATE_FIELD BETWEEN DATE_VALUE AND DATE_VALUE -> date_between_leaf
         | DATE_FIELD DATE_COMP_OP DATE_VALUE -> date_compare_leaf
+        | TIME_FIELD BETWEEN DATE_VALUE AND DATE_VALUE -> time_between_leaf
+        | TIME_FIELD DATE_COMP_OP DATE_VALUE -> time_compare_leaf
         | FIELD_CLAUSE                     -> field_leaf
         | "(" expr ")"
     sequence_step: FIELD_CLAUSE
@@ -426,6 +432,7 @@ _QUERY_GRAMMAR = r"""
     BETWEEN.6: /between/i
     COUNT_FIELD.6: /(messages|words)/i
     DATE_FIELD.6: /date/i
+    TIME_FIELD.6: /time/i
     DATE_COMP_OP: ">=" | "<=" | "=" | ">" | "<"
     COMP_OP: ">=" | "<=" | "=" | ">" | "<"
     DATE_VALUE: /[^\s"()]+/
@@ -557,6 +564,24 @@ def _normalize_date_comparison(op_text: str, value_text: str) -> _DateComparison
 
 def _normalize_date_range(min_text: str, max_text: str) -> _DateRangeToken:
     return _DateRangeToken(min_value=_parse_relative_date(min_text), max_value=_parse_relative_date(max_text))
+
+
+def _normalize_time_comparison(op_text: str, value_text: str) -> QueryFieldPredicate:
+    if op_text in {">=", ">"}:
+        return QueryFieldPredicate(field="time", values=(_parse_relative_date(value_text),), op=">=")
+    if op_text in {"<=", "<"}:
+        return QueryFieldPredicate(field="time", values=(_parse_relative_date(value_text),), op="<=")
+    raise ExpressionCompileError("time equality is not supported; use time between A and B", field="time")
+
+
+def _normalize_time_range(min_text: str, max_text: str) -> QueryPredicate:
+    return QueryBoolPredicate(
+        op="and",
+        children=(
+            QueryFieldPredicate(field="time", values=(_parse_relative_date(min_text),), op=">="),
+            QueryFieldPredicate(field="time", values=(_parse_relative_date(max_text),), op="<="),
+        ),
+    )
 
 
 @v_args(inline=True)
@@ -870,6 +895,15 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 raise ExpressionCompileError("field 'date' requires a value", field="date")
             if predicate.op not in {">=", "<="}:
                 raise ExpressionCompileError("field 'date' supports only >=, <=, >, <, and between", field="date")
+        if effective_field == "time":
+            if unit == "session":
+                raise ExpressionCompileError(
+                    "field 'time' is supported only for terminal unit predicates", field="time"
+                )
+            if not predicate.values:
+                raise ExpressionCompileError("field 'time' requires a value", field="time")
+            if predicate.op not in {">=", "<="}:
+                raise ExpressionCompileError("field 'time' supports only >=, <=, >, <, and between", field="time")
         if effective_field == "words":
             if not predicate.values:
                 raise ExpressionCompileError("field 'words' requires a numeric value", field="words")
@@ -967,6 +1001,19 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
         max_value: Token,
     ) -> QueryPredicate:
         return _date_range_token_to_predicate(_normalize_date_range(str(min_value), str(max_value)))
+
+    def time_compare_leaf(self, _field_name: Token, op: Token, value: Token) -> QueryPredicate:
+        return _normalize_time_comparison(str(op), str(value))
+
+    def time_between_leaf(
+        self,
+        _field_name: Token,
+        _between: Token,
+        min_value: Token,
+        _and: Token,
+        max_value: Token,
+    ) -> QueryPredicate:
+        return _normalize_time_range(str(min_value), str(max_value))
 
     def field_leaf(self, token: Token) -> QueryPredicate:
         return _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -178,10 +178,11 @@ _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
     "path",
     "output",
     "words",
+    "time",
 }
-_MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command", "path", "output", "words"}
-_ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text"}
-_BLOCK_STRUCTURAL_FIELDS = {"type", "text", "tool", "action", "command", "path"}
+_MESSAGE_STRUCTURAL_FIELDS = {"role", "type", "text", "tool", "action", "command", "path", "output", "words", "time"}
+_ACTION_STRUCTURAL_FIELDS = {"tool", "action", "type", "command", "path", "output", "text", "time"}
+_BLOCK_STRUCTURAL_FIELDS = {"type", "text", "tool", "action", "command", "path", "time"}
 _ASSERTION_STRUCTURAL_FIELDS = {
     "kind",
     "status",
@@ -199,6 +200,7 @@ _ASSERTION_STRUCTURAL_FIELDS = {
     "value",
     "evidence",
     "context",
+    "time",
 }
 _OBSERVED_EVENT_STRUCTURAL_FIELDS = {
     "kind",
@@ -305,6 +307,7 @@ _COMMON_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "path": _field_info("path", "Referenced file or artifact path substring.", "path:polylogue/archive"),
     "role": _field_info("role", "Message role.", "role:assistant"),
     "text": _field_info("text", "Text/content substring for the selected unit.", "text:timeout"),
+    "time": _field_info("time", "Row timestamp predicate for the selected unit.", "time >= 2026-01-01"),
     "tool": _field_info("tool", "Normalized tool name.", "tool:bash"),
     "type": _field_info("type", "Unit-specific type token.", "type:code"),
     "words": _field_info("words", "Word-count predicate for the selected unit.", "words:>=200"),
@@ -325,6 +328,7 @@ _ASSERTION_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "target": _field_info("target", "Assertion target string.", "target:session"),
     "target_ref": _field_info("target_ref", "Assertion target ObjectRef.", "target_ref:session:abc"),
     "text": _field_info("text", "Assertion body/value/evidence text substring.", "text:query"),
+    "time": _field_info("time", "Assertion update/create timestamp predicate.", "time >= 2026-01-01"),
     "value": _field_info("value", "Assertion value JSON/text substring.", "value:priority"),
     "visibility": _field_info("visibility", "Assertion visibility.", "visibility:private"),
 }

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4766,6 +4766,37 @@ def _count_predicate_clause(column: str, predicate: QueryFieldPredicate) -> tupl
     return f"{column} = ?", [value]
 
 
+def _time_predicate_clause(expression: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
+    if not predicate.values:
+        return "", []
+    value_ms = _date_ms(predicate.values[-1], field="time")
+    if predicate.op == ">=":
+        return f"{expression} >= ?", [value_ms]
+    if predicate.op == "<=":
+        return f"{expression} <= ?", [value_ms]
+    raise ValueError("unsupported Boolean query operator for time")
+
+
+def _query_unit_time_expression(unit: str, row_alias: str) -> str:
+    if unit == "message":
+        return (
+            f"COALESCE({row_alias}.occurred_at_ms, "
+            f"(SELECT time_sessions.sort_key_ms FROM sessions time_sessions "
+            f"WHERE time_sessions.session_id = {row_alias}.session_id), 0)"
+        )
+    if unit in {"action", "block"}:
+        return (
+            f"(SELECT COALESCE(time_messages.occurred_at_ms, time_sessions.sort_key_ms, 0) "
+            f"FROM messages time_messages "
+            f"JOIN sessions time_sessions ON time_sessions.session_id = time_messages.session_id "
+            f"WHERE time_messages.message_id = {row_alias}.message_id "
+            f"LIMIT 1)"
+        )
+    if unit == "assertion":
+        return f"COALESCE({row_alias}.updated_at_ms, {row_alias}.created_at_ms, 0)"
+    raise ValueError(f"unsupported time predicate unit: {unit}")
+
+
 def _like_clause(
     expression: str,
     values: tuple[str, ...],
@@ -4788,6 +4819,8 @@ def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPre
         return _in_or_equals_clause(f"{message_alias}.message_type", predicate.values, lower=True)
     if field == "words":
         return _count_predicate_clause(f"{message_alias}.word_count", predicate)
+    if field == "time":
+        return _time_predicate_clause(_query_unit_time_expression("message", message_alias), predicate)
     if field in {"text", "command", "path", "output", "tool", "action"}:
         action_clause = ""
         params: list[object] = []
@@ -4846,6 +4879,8 @@ def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredi
         return _in_or_equals_clause(f"{action_alias}.tool_name", predicate.values, lower=True)
     if field in {"action", "type"}:
         return _in_or_equals_clause(f"{action_alias}.semantic_type", predicate.values, lower=True)
+    if field == "time":
+        return _time_predicate_clause(_query_unit_time_expression("action", action_alias), predicate)
     if field == "command":
         return _like_clause(f"COALESCE({action_alias}.tool_command, '')", predicate.values)
     if field == "path":
@@ -4871,6 +4906,8 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
     field = predicate.field
     if field == "type":
         return _in_or_equals_clause(f"{block_alias}.block_type", predicate.values, lower=True)
+    if field == "time":
+        return _time_predicate_clause(_query_unit_time_expression("block", block_alias), predicate)
     if field == "text":
         return _like_clause(f"COALESCE({block_alias}.search_text, '')", predicate.values)
     if field == "tool":
@@ -4889,6 +4926,8 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
 
 def _assertion_field_predicate_clause(assertion_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
     field = predicate.field
+    if field == "time":
+        return _time_predicate_clause(_query_unit_time_expression("assertion", assertion_alias), predicate)
     if field == "status":
         clause, params = _in_or_equals_clause(f"COALESCE({assertion_alias}.status, ?)", predicate.values, lower=True)
         return clause, [ASSERTION_DEFAULT_STATUS, *params]

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -475,6 +475,36 @@ class TestBooleanQueryExpression:
             ),
         )
 
+    def test_terminal_source_time_comparison_is_parsed(self) -> None:
+        source = parse_unit_source_expression("messages where time >= 2026-01-02T00:00:00+00:00")
+
+        assert source is not None
+        assert source.unit == "message"
+        assert source.predicate == QueryFieldPredicate(
+            field="time",
+            values=("2026-01-02T00:00:00+00:00",),
+            op=">=",
+        )
+
+    def test_terminal_source_time_range_is_parsed(self) -> None:
+        source = parse_unit_source_expression(
+            "messages where time between 2026-01-01T00:00:00+00:00 and 2026-01-02T00:00:00+00:00"
+        )
+
+        assert source is not None
+        assert source.unit == "message"
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="time", values=("2026-01-01T00:00:00+00:00",), op=">="),
+                QueryFieldPredicate(field="time", values=("2026-01-02T00:00:00+00:00",), op="<="),
+            ),
+        )
+
+    def test_time_predicate_is_rejected_on_sessions(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="not supported for session predicates"):
+            parse_expression_ast("sessions where time >= 2026-01-02T00:00:00+00:00")
+
     def test_pipeline_session_source_scopes_terminal_unit_query(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"
@@ -1005,6 +1035,55 @@ class TestBooleanQueryExpression:
             )
         ]
 
+    def test_terminal_message_source_filters_by_row_time(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("message time hit")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .add_message("m-new", role="assistant", text="new", timestamp="2026-01-02T00:00:00+00:00")
+            .save()
+        )
+
+        source = parse_unit_source_expression("messages where time >= 2026-01-02T00:00:00+00:00")
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.message_id, row.text) for row in rows] == [("chatgpt-export:ext-hit:m-new", "new")]
+
+    def test_exists_message_predicate_filters_by_row_time(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("message time hit")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .add_message("m-new", role="assistant", text="new", timestamp="2026-01-02T00:00:00+00:00")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("message time miss")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .save()
+        )
+
+        spec = compile_expression("exists message(time >= 2026-01-02T00:00:00+00:00)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["chatgpt-export:ext-hit"]
+
     def test_session_scoped_message_predicate_executes_against_archive(
         self,
         workspace_env: dict[str, Path],
@@ -1489,6 +1568,57 @@ class TestBooleanQueryExpression:
                 "file_edit",
                 "polylogue/archive/query/expression.py",
             )
+        ]
+
+    def test_terminal_action_source_filters_by_row_time(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("action time hit")
+            .add_message(
+                "m-old",
+                role="assistant",
+                text="old edit",
+                timestamp="2026-01-01T00:00:00+00:00",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-old",
+                        "input": {"file_path": "polylogue/archive/old.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
+                "m-new",
+                role="assistant",
+                text="new edit",
+                timestamp="2026-01-02T00:00:00+00:00",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-new",
+                        "input": {"file_path": "polylogue/archive/new.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        source = parse_unit_source_expression("actions where time >= 2026-01-02T00:00:00+00:00")
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_actions(source.predicate, limit=100)
+
+        assert [(row.message_id, row.tool_path) for row in rows] == [
+            ("claude-code-session:ext-hit:m-new", "polylogue/archive/new.py")
         ]
 
     def test_terminal_action_source_accepts_session_scoped_predicate(


### PR DESCRIPTION
## Summary

Adds executable row-time predicates to SQL-backed terminal query units: `time >= VALUE`, `time <= VALUE`, and `time between A and B` now work for message/action/block/assertion predicates.

## Problem

#2006 already had terminal row queries and `sort by time`, but the same row timestamp was not queryable as a predicate. That left users able to order terminal rows by time, but unable to select terminal rows by time without falling back to owning-session date filters.

## Solution

The Lark boolean grammar now recognizes readable `time` comparisons/ranges and validates them only inside terminal unit predicates. Storage lowers `time` to the same row timestamp semantics used by `sort by time`: message rows use `occurred_at_ms` with session fallback, action/block rows resolve their owning message timestamp, and assertion rows use update/create timestamps. Metadata/completion descriptors expose `time` for SQL-backed unit fields only.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k "time"` -> 11 passed
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k "terminal_source or exists_message or action_source or pipeline"` -> 27 passed
- `nix develop --command devtools test tests/benchmarks/test_daemon_convergence.py::test_convergence_scale_tier -- -k xs-tiny-files` -> 1 passed
- `nix develop --command devtools test tests/benchmarks/test_daemon_convergence.py -n 4` -> 11 passed
- `nix develop --command devtools verify --quick` -> exit_code 0
- `nix develop --command devtools verify --seed-testmon --skip-slow` -> 11694 passed, diagnosis `pytest_passed`, peak pytest tree RSS 3338.5 MiB
- `nix develop --command devtools verify` -> 7 passed, diagnosis `pytest_passed`, peak pytest tree RSS 585.2 MiB

One earlier seed-testmon attempt produced only convergence benchmark `succeeded_files == 0` failures; the exact failing node and full convergence file both passed immediately afterward, and the rerun seed baseline passed completely.

Ref #2006