### PR TITLE
feat(context): compile message read-view segments (#2193)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1534,7 +1534,12 @@ class PolylogueArchiveMixin:
         reuses existing recovery/read primitives and records unsupported or
         missing inputs as omissions instead of creating a parallel memory store.
         """
-        from polylogue.context.compiler import ContextImage, ContextOmission, ContextSegment
+        from polylogue.context.compiler import (
+            ContextImage,
+            ContextOmission,
+            ContextSegment,
+            compile_messages_context_segment,
+        )
 
         segments: list[ContextSegment] = []
         omitted: list[ContextOmission] = []
@@ -1586,14 +1591,52 @@ class PolylogueArchiveMixin:
                     )
                 )
                 continue
+            session = await self.get_session(session_id)
             for view in requested_views:
+                if view == "messages":
+                    if session is None:
+                        omitted.append(
+                            ContextOmission(
+                                ref=f"session:{session_id}",
+                                view=view,
+                                reason="not_found",
+                                detail="session seed did not resolve to messages",
+                            )
+                        )
+                        continue
+                    segment = compile_messages_context_segment(
+                        session_id=digest.session_id,
+                        title=digest.title,
+                        messages=tuple(
+                            (
+                                str(getattr(message.role, "value", message.role)),
+                                message.text or "",
+                            )
+                            for message in session.messages
+                            if message.text
+                        ),
+                        evidence_refs=tuple(ref.to_evidence_ref() for ref in digest.raw_refs),
+                    )
+                    if token_budget is not None and token_total + segment.token_estimate > token_budget:
+                        omitted.append(
+                            ContextOmission(
+                                ref=f"session:{session_id}",
+                                view=view,
+                                reason="budget",
+                                detail="segment exceeded the requested context token budget",
+                            )
+                        )
+                        continue
+                    token_total += segment.token_estimate
+                    segments.append(segment)
+                    continue
                 if view not in {"recovery", "work-packet"}:
                     omitted.append(
                         ContextOmission(
                             ref=f"session:{session_id}",
                             view=view,
                             reason="unsupported",
-                            detail="compile_context currently supports recovery and work-packet views",
+                            detail="compile_context currently supports recovery, work-packet, and messages views",
                         )
                     )
                     continue

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -244,6 +244,33 @@ def context_image_from_recovery(compilation: RecoveryContextCompilation) -> Cont
     )
 
 
+def compile_messages_context_segment(
+    *,
+    session_id: str,
+    title: str | None,
+    messages: Sequence[tuple[str, str]],
+    evidence_refs: Sequence[EvidenceRef],
+) -> ContextSegment:
+    """Compile a normalized message transcript into a context segment."""
+
+    lines = [f"# Messages: {title or session_id}", ""]
+    for role, text in messages:
+        lines.append(f"{role}: {text}")
+        lines.append("")
+    markdown = "\n".join(lines).rstrip() + "\n"
+    return ContextSegment(
+        segment_id=f"read-view:{session_id}:messages",
+        kind="read_view",
+        title="Messages",
+        markdown=markdown,
+        payload_kind="messages",
+        object_refs=(ObjectRef(kind="session", object_id=session_id),),
+        evidence_refs=tuple(evidence_refs),
+        token_estimate=_estimate_tokens(markdown),
+        lossiness="normalized_message_text",
+    )
+
+
 def context_snapshot_record_from_image(
     image: ContextImage,
     *,
@@ -364,6 +391,7 @@ __all__ = [
     "ContextSpec",
     "RecoveryContextCompilation",
     "RecoveryContextKind",
+    "compile_messages_context_segment",
     "compile_recovery_context",
     "context_image_from_recovery",
     "context_snapshot_record_from_image",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -994,8 +994,10 @@ async def test_compile_context_builds_recovery_segments_from_refs_and_query(tmp_
         assert [segment.payload_kind for segment in image.segments] == [
             "recovery_digest",
             "work_packet",
+            "messages",
             "recovery_digest",
             "work_packet",
+            "messages",
         ]
         assert {ref.object_id for ref in image.object_refs if ref.kind == "session"} == {
             "claude-ai-export:conv-alpha",
@@ -1007,9 +1009,12 @@ async def test_compile_context_builds_recovery_segments_from_refs_and_query(tmp_
         }
         assert image.token_estimate > 0
         unsupported = [item for item in image.omitted if item.reason == "unsupported"]
-        assert len(unsupported) == 3
+        assert len(unsupported) == 1
         assert unsupported[0].ref == "assertion:claim-1"
-        assert {item.view for item in unsupported[1:]} == {"messages"}
+        message_segments = [segment for segment in image.segments if segment.payload_kind == "messages"]
+        assert len(message_segments) == 2
+        assert "user: alpha body" in (message_segments[0].markdown or "")
+        assert "user: beta body" in (message_segments[1].markdown or "")
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Adds the first non-recovery read-view segment to the general context compiler: `ContextSpec(read_views=("messages", ...))` now emits a bounded `read_view` context segment instead of recording `messages` as unsupported.

## Problem

#2193’s current compiler could seed from refs/query and produce recovery/work-packet segments, but the general ContextSpec shape still treated normal read views as unsupported. That kept the compiler recovery-specific even though `messages` is already a stable archive read view.

## Solution

`polylogue.context.compiler` now exposes `compile_messages_context_segment()`, which turns normalized session messages into a `ContextSegment` with session object refs, evidence refs, token estimate, and explicit lossiness metadata. `PolylogueArchiveMixin.compile_context()` routes requested `messages` views through that segment builder while keeping unsupported views fail-closed as omissions. The API test now proves a mixed ref/query context spec returns recovery, work-packet, and messages segments for both selected sessions.

## Verification

- `python -m py_compile polylogue/context/compiler.py polylogue/api/archive.py tests/unit/api/test_facade_contracts.py` -> passed.
- `nix develop --command devtools test tests/unit/context/test_compiler.py tests/unit/api/test_facade_contracts.py -k "compile_context or context"` -> 16 passed, 218 deselected.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- `nix develop --command devtools verify --seed-testmon --skip-slow` -> 11694 passed, peak tree RSS 3265.2 MiB.
- `nix develop --command devtools verify` -> 7 passed, peak tree RSS 577.9 MiB.