### PR TITLE
feat(query): sort terminal aggregate pipelines (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -56,6 +56,9 @@ predicate          ::= predicate "OR" predicate
 
 structural-unit    ::= "message" | "action" | "block" | "assertion"
 pipeline-stage     ::= "sort" "by" "time" ["asc" | "desc"]
+                     | "group" "by" field
+                     | "count"
+                     | "sort" "by" ("count" | "key") ["asc" | "desc"]
                      | "limit" integer
                      | "offset" integer
 ```
@@ -106,11 +109,12 @@ executor as direct `messages/actions/...` pipelines. For now the session stage
 accepts field/count/date predicates only; FTS, semantic, `exists`, lineage, and
 sequence stages are typed errors until they have dedicated unit-changing
 lowerers. Terminal pipeline stages currently support `sort by time [asc|desc]`,
-`limit N`, and `offset N` for SQL-backed terminal rows (`messages`, `actions`,
-`blocks`, `assertions`). Query-string limits narrow the surface limit instead
-of expanding caller/API caps, and query-string offsets are added to the caller
-offset. Runtime-transform terminal rows (`runs`, `observed-events`,
-`context-snapshots`) reject sort stages until they have streaming lowerers;
+`group by FIELD | count`, aggregate `sort by count|key [asc|desc]`, `limit N`,
+and `offset N` for SQL-backed terminal rows (`messages`, `actions`, `blocks`,
+`assertions`). Query-string limits narrow the surface limit instead of expanding
+caller/API caps, and query-string offsets are added to the caller offset.
+Runtime-transform terminal rows (`runs`, `observed-events`, `context-snapshots`)
+reject sort/aggregate stages until they have streaming or aggregate lowerers;
 they must not collect every projected row in memory merely to sort a page.
 
 `--explain --format json` reports terminal pipelines as a `unit_source` AST with
@@ -239,6 +243,9 @@ Aggregate pipelines over SQL-backed terminal rows use the sibling
 `QueryUnitAggregateEnvelope` and currently support `group by FIELD | count`
 over closed unit fields such as message role, action tool/action, block type,
 assertion kind/status, and owning-session origin/repo.
+Aggregate rows can be ordered with `sort by count [asc|desc]` or
+`sort by key [asc|desc]` before `limit`/`offset`; the default order is count
+descending, then key.
 Those surfaces share the same session-scoping filters for the row source
 where applicable, such as origin, tag, repo, title, date bounds, message-type
 and tool/paste/thinking feature filters.

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1338,6 +1338,8 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
     if group_by is not None:
         if source.aggregate is not None:
             raise ExpressionCompileError("pipeline `group by` must appear before `count`", field="group")
+        if source.sort is not None:
+            raise ExpressionCompileError("pipeline `sort by time` cannot feed aggregate stages", field="group")
         if source.limit is not None or source.offset is not None:
             raise ExpressionCompileError("pipeline `group by` must appear before `limit` and `offset`", field="group")
         if source.unit not in {"message", "action", "block", "assertion"}:

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -41,7 +41,7 @@ and explicit Boolean session predicates:
     actions where action:file_edit AND path:polylogue/archive
     blocks where type:code AND text:timeout
     messages where time >= 2026-01-01T00:00:00+00:00
-    sessions where repo:polylogue | messages where role:assistant | group by role | count
+    sessions where repo:polylogue | messages where role:assistant | group by role | count | sort by count desc
 
 Unit-scoped ``messages/actions/blocks/assertions/runs/observed-events/context-snapshots where ...`` predicates are executable
 in two shared paths: ``compile_expression`` keeps the compatibility session
@@ -49,7 +49,8 @@ selector behavior by lowering them to correlated ``exists <unit>(...)``
 predicates, while terminal query-unit surfaces preserve the selected unit and
 return raw message/action/block/assertion/observed-event/context-snapshot rows from the same predicate semantics.
 SQL-backed terminal units also support exact ``group by FIELD | count``
-aggregate pipelines for the closed aggregate fields declared in this module.
+aggregate pipelines for the closed aggregate fields declared in this module,
+plus aggregate ``sort by count|key [asc|desc]`` before ``limit``/``offset``.
 They also support ``time >= VALUE``, ``time <= VALUE``, and
 ``time between A and B`` predicates over the same row timestamp used by
 ``sort by time``.
@@ -250,7 +251,7 @@ class QueryExpressionAST:
 class QueryUnitSort:
     """Terminal query-unit sort stage."""
 
-    field: Literal["time"]
+    field: Literal["time", "count", "key"]
     direction: Literal["asc", "desc"] = "asc"
 
 
@@ -1243,17 +1244,20 @@ def _parse_sort_stage(stage: str) -> QueryUnitSort | None:
     parts = lower.removeprefix("sort by ").split()
     if not parts:
         raise ExpressionCompileError("pipeline `sort by` stage requires a field", field="sort")
-    if parts[0] != "time":
+    if parts[0] not in {"time", "count", "key"}:
         raise ExpressionCompileError(
-            "pipeline `sort by` currently supports only `time` for terminal rows",
+            "pipeline `sort by` supports `time` for rows and `count` or `key` for aggregate rows",
             field="sort",
         )
     if len(parts) == 1:
-        return QueryUnitSort(field="time")
+        return QueryUnitSort(field=cast(Literal["time", "count", "key"], parts[0]))
     if len(parts) == 2 and parts[1] in {"asc", "desc"}:
-        return QueryUnitSort(field="time", direction=cast(Literal["asc", "desc"], parts[1]))
+        return QueryUnitSort(
+            field=cast(Literal["time", "count", "key"], parts[0]),
+            direction=cast(Literal["asc", "desc"], parts[1]),
+        )
     raise ExpressionCompileError(
-        "pipeline `sort by time` accepts an optional `asc` or `desc` direction",
+        "pipeline `sort by` accepts an optional `asc` or `desc` direction",
         field="sort",
     )
 
@@ -1293,14 +1297,33 @@ def _validate_aggregate_group_field(unit: QueryUnitName, field: str) -> None:
 def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSource:
     sort = _parse_sort_stage(stage)
     if sort is not None:
-        if source.aggregate is not None:
-            raise ExpressionCompileError("pipeline `sort by` must appear before aggregate stages", field="sort")
-        if source.group_by is not None:
-            raise ExpressionCompileError("pipeline `sort by` must appear before `group by`", field="sort")
+        if sort.field == "time":
+            if source.aggregate is not None:
+                raise ExpressionCompileError(
+                    "pipeline `sort by time` must appear before aggregate stages", field="sort"
+                )
+            if source.group_by is not None:
+                raise ExpressionCompileError("pipeline `sort by time` must appear before `group by`", field="sort")
+            if source.unit not in {"message", "action", "block", "assertion"}:
+                raise ExpressionCompileError(
+                    "pipeline `sort by time` currently supports message/action/block/assertion rows; "
+                    "runtime-transform units need a streaming lowerer first",
+                    field="sort",
+                )
+        elif source.aggregate != "count":
+            raise ExpressionCompileError(
+                "pipeline `sort by count` and `sort by key` require an aggregate `count` stage",
+                field="sort",
+            )
+        elif source.limit is not None or source.offset is not None:
+            raise ExpressionCompileError(
+                "pipeline aggregate `sort by` must appear before `limit` and `offset`",
+                field="sort",
+            )
         if source.unit not in {"message", "action", "block", "assertion"}:
             raise ExpressionCompileError(
-                "pipeline `sort by time` currently supports message/action/block/assertion rows; "
-                "runtime-transform units need a streaming lowerer first",
+                "pipeline aggregate sorting currently supports message/action/block/assertion rows; "
+                "runtime-transform units need an aggregate lowerer first",
                 field="sort",
             )
         return replace(
@@ -1373,7 +1396,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
         )
     raise ExpressionCompileError(
         f"unsupported pipeline stage {stage!r}; supported terminal stages are "
-        "`sort by time [asc|desc]`, `group by FIELD`, `count`, `limit N`, and `offset N`",
+        "`sort by time|count|key [asc|desc]`, `group by FIELD`, `count`, `limit N`, and `offset N`",
         field=None,
     )
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -681,7 +681,9 @@ def _build_sql_envelope(
             if source.sort is not None and source.sort.field in {"count", "key"}
             else None
         )
-        aggregate_sort_direction = source.sort.direction if source.sort is not None else "desc"
+        aggregate_sort_direction: Literal["asc", "desc"] = (
+            source.sort.direction if aggregate_sort is not None and source.sort is not None else "desc"
+        )
         aggregate_rows = archive.query_unit_counts(
             source.unit,
             source.predicate,

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 from polylogue.archive.query.archive_execution import _session_to_session
 from polylogue.archive.query.expression import QueryUnitSource
@@ -676,10 +676,18 @@ def _build_sql_envelope(
     session_filters: Mapping[str, object] | None,
 ) -> QueryUnitResultEnvelope:
     if source.aggregate == "count":
+        aggregate_sort = (
+            cast(Literal["count", "key"], source.sort.field)
+            if source.sort is not None and source.sort.field in {"count", "key"}
+            else None
+        )
+        aggregate_sort_direction = source.sort.direction if source.sort is not None else "desc"
         aggregate_rows = archive.query_unit_counts(
             source.unit,
             source.predicate,
             group_by=source.group_by,
+            sort=aggregate_sort,
+            sort_direction=aggregate_sort_direction,
             limit=fetch_limit,
             offset=offset,
             session_filters=session_filters,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -269,6 +269,18 @@ def _query_unit_order_direction(direction: Literal["asc", "desc"]) -> Literal["A
     return "DESC" if direction == "desc" else "ASC"
 
 
+def _query_unit_aggregate_order(
+    sort: Literal["count", "key"] | None,
+    direction: Literal["asc", "desc"],
+) -> str:
+    """Return a closed SQL order clause for terminal aggregate rows."""
+
+    sql_direction = _query_unit_order_direction(direction)
+    if sort == "key":
+        return f"group_key {sql_direction}, count DESC"
+    return f"count {sql_direction}, group_key"
+
+
 def _query_unit_group_expression(unit: str, row_alias: str, group_by: str | None) -> str:
     """Return the SQL expression for a supported terminal aggregate group."""
 
@@ -3415,6 +3427,8 @@ class ArchiveStore:
         predicate: QueryPredicate,
         *,
         group_by: str | None = None,
+        sort: Literal["count", "key"] | None = None,
+        sort_direction: Literal["asc", "desc"] = "desc",
         limit: int = 50,
         offset: int = 0,
         session_filters: Mapping[str, object] | None = None,
@@ -3449,6 +3463,7 @@ class ArchiveStore:
             "block": "blocks b JOIN sessions s ON s.session_id = b.session_id",
             "assertion": "user_tier.assertions a LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id",
         }[unit]
+        order_clause = _query_unit_aggregate_order(sort, sort_direction)
         rows = self._conn.execute(
             f"""
             SELECT {group_expr} AS group_key, COUNT(*) AS count
@@ -3456,7 +3471,7 @@ class ArchiveStore:
             WHERE {where_clause}
             {session_clause}
             GROUP BY group_key
-            ORDER BY count DESC, group_key
+            ORDER BY {order_clause}
             LIMIT ? OFFSET ?
             """,
             [*params, *session_params, normalized_limit, normalized_offset],

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -595,12 +595,15 @@ class TestBooleanQueryExpression:
 
     def test_pipeline_group_by_count_stages_are_parsed(self) -> None:
         source = parse_unit_source_expression(
-            "sessions where repo:polylogue | messages where role:assistant | group by role | count"
+            "sessions where repo:polylogue | messages where role:assistant | group by role | count | sort by count asc"
         )
 
         assert source is not None
         assert source.group_by == "role"
         assert source.aggregate == "count"
+        assert source.sort is not None
+        assert source.sort.field == "count"
+        assert source.sort.direction == "asc"
         assert [stage.to_payload() for stage in source.pipeline_stages] == [
             {
                 "kind": "session_scope",
@@ -608,6 +611,7 @@ class TestBooleanQueryExpression:
             },
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
+            {"kind": "sort", "sort": {"field": "count", "direction": "asc"}},
         ]
 
     def test_pipeline_rejects_unknown_terminal_stage(self) -> None:
@@ -624,6 +628,16 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="runtime-transform units need an aggregate lowerer"):
             parse_unit_source_expression(
                 "sessions where repo:polylogue | context-snapshots where boundary:session_start | count"
+            )
+
+    def test_pipeline_rejects_aggregate_sort_before_count(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="require an aggregate `count` stage"):
+            parse_unit_source_expression("messages where role:assistant | group by role | sort by count desc")
+
+    def test_pipeline_rejects_aggregate_sort_after_limit(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="must appear before `limit` and `offset`"):
+            parse_unit_source_expression(
+                "messages where role:assistant | group by role | count | limit 5 | sort by count"
             )
 
     def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
@@ -1348,6 +1362,48 @@ class TestBooleanQueryExpression:
             ("role", "assistant", 2),
             ("role", "user", 1),
         ]
+
+    def test_terminal_aggregate_sort_count_asc_executes_before_limit(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import QueryUnitAggregateEnvelope
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("aggregate sort")
+            .add_message("m-user", role="user", text="aggregate sort")
+            .add_message("m-system", role="system", text="aggregate sort")
+            .add_message("m-assistant-1", role="assistant", text="aggregate sort")
+            .add_message("m-assistant-2", role="assistant", text="aggregate sort")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "messages where text:aggregate | group by role | count | sort by count asc | limit 2"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="pipeline-aggregate-sort", limit=20)
+
+        assert isinstance(envelope, QueryUnitAggregateEnvelope)
+        assert envelope.pipeline_stages == (
+            {"kind": "group", "field": "role"},
+            {"kind": "count", "metric": "count"},
+            {"kind": "sort", "sort": {"field": "count", "direction": "asc"}},
+            {"kind": "limit", "value": 2},
+        )
+        assert [(row.group_key, row.count) for row in envelope.items] == [
+            ("system", 1),
+            ("user", 1),
+        ]
+        assert envelope.next_offset == 2
 
     def test_cli_json_reports_terminal_aggregate_counts(
         self,

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -640,6 +640,10 @@ class TestBooleanQueryExpression:
                 "messages where role:assistant | group by role | count | limit 5 | sort by count"
             )
 
+    def test_pipeline_rejects_row_sort_before_aggregate(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="cannot feed aggregate stages"):
+            parse_unit_source_expression("messages where role:assistant | sort by time asc | group by role | count")
+
     def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
         with pytest.raises(ExpressionCompileError, match="FTS, semantic, exists, lineage, and sequence"):
             parse_unit_source_expression('sessions where ~"timeout" | messages where role:assistant')

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -56,14 +56,14 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # ``table_name`` is a closed insight table name; ``any_terms`` is built
     # immediately above from closed ``(column, path)`` fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2692): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2704): (
         "readiness fallback reason counts: closed insight-table + _INSIGHT_FALLBACK_PAYLOAD column/path; values bound"
     ),
     # #1743 readiness fallback reason breakdown:
     #   rows = self._conn.execute(f"... FROM {table_name} ... json_each(... '{path}') ...{clause}")
     # ``table_name``/``column``/``path`` are closed fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2701): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2713): (
         "readiness fallback reason breakdown: closed insight-table + fallback payload column/path; values bound"
     ),
     # Terminal unit row readers:
@@ -73,19 +73,19 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # comes from the shared session filter lowerer; pagination values are bound.
     # ``order_by`` is a closed literal fragment selected from the parsed
     # pipeline sort stage and bounded ASC/DESC tokens.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3367): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3379): (
         "message query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3452): (
-        "query-unit aggregate counts: closed unit/group/session fragments from lowerers; values bound"
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3467): (
+        "query-unit aggregate counts: closed unit/group/order/session fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3500): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3515): (
         "action query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3567): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3582): (
         "block query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3639): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3654): (
         "assertion query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
     # Assertion readers:


### PR DESCRIPTION
## Summary

Adds explicit aggregate ordering to SQL-backed terminal query pipelines. Queries such as `messages where text:aggregate | group by role | count | sort by count asc | limit 2` now parse, execute, and report their aggregate sort stage through the shared `QueryUnitAggregateEnvelope` pipeline metadata.

## Problem

#2006 already had executable `group by FIELD | count` aggregate pipelines, but ordering was hidden inside storage as a fixed `ORDER BY count DESC, group_key`. Users and query-builder surfaces could not request ascending counts or key ordering, and the stage list could not explain the aggregate order that shaped a page.

## Solution

`QueryUnitSort` now covers row-time sorting and aggregate `count`/`key` sorting. The parser accepts aggregate sort stages only after `count` and before `limit`/`offset`, while row `sort by time` remains pre-aggregate only. `ArchiveStore.query_unit_counts()` takes a closed sort selector and direction and builds the SQL order clause from trusted literals. The aggregate envelope builder passes the parsed sort through, and the search docs describe the shipped syntax.

The SQL interpolation audit line numbers were updated because the storage edit shifted existing audited f-string execute sites; the aggregate rationale now also names the closed aggregate order fragment.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k "pipeline_group_by_count or aggregate_sort or terminal_aggregate"` -> `6 passed, 280 deselected`
- `devtools test tests/unit/storage/test_no_string_interpolated_sql.py` -> `2 passed`
- `devtools verify --quick` -> `exit_code: 0`
- `devtools verify --seed-testmon --skip-slow` -> `11697 passed`, peak tree RSS `3587.2 MiB`
- `devtools verify` -> `7 passed`, peak tree RSS `584.8 MiB`

Closes no issue; advances #2006.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sorting for aggregated results: now supports sorting by count or key (ascending/descending) in addition to timestamp-based sorting.

* **Documentation**
  * Updated query and search reference documentation with extended sorting and aggregation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->