### PR TITLE
feat(query): expose pipeline stage completions (#2006)

### DIFF
--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -19,6 +19,7 @@ from polylogue.archive.query.metadata import (
     structural_query_units,
     terminal_query_field_info,
     terminal_query_fields,
+    terminal_query_pipeline_stage_infos,
     terminal_query_sources,
     terminal_query_unit,
 )
@@ -33,6 +34,7 @@ QUERY_COMPLETION_KINDS: tuple[str, ...] = (
     "structural-field",
     "terminal-source",
     "terminal-field",
+    "pipeline-stage",
     "count-operator",
     "date-operator",
     "action",
@@ -269,6 +271,30 @@ def query_terminal_field_candidates(source: str, incomplete: str) -> list[QueryC
     return candidates
 
 
+def query_pipeline_stage_candidates(source: str, incomplete: str) -> list[QueryCompletionCandidate]:
+    """Return executable pipeline-stage candidates for a terminal query source."""
+
+    current = incomplete.strip().lower()
+    descriptor = query_unit_descriptor(source)
+    candidates: list[QueryCompletionCandidate] = []
+    for stage in terminal_query_pipeline_stage_infos(source):
+        if current and not stage.value.startswith(current):
+            continue
+        candidates.append(
+            QueryCompletionCandidate(
+                value=stage.value,
+                insert=stage.insert,
+                display=stage.insert,
+                kind="query-pipeline-stage",
+                group=f"{source} pipeline stages",
+                description=stage.description,
+                source="QUERY_UNIT_DESCRIPTORS",
+                payload_model=descriptor.payload_model if descriptor is not None else None,
+            )
+        )
+    return candidates
+
+
 def query_count_operator_candidates(field: str, incomplete: str) -> list[QueryCompletionCandidate]:
     """Return readable count operators accepted by the query grammar."""
 
@@ -385,6 +411,10 @@ def query_completion_candidates(
         if unit is None:
             raise QueryCompletionError("--unit is required for terminal-field completion")
         return query_terminal_field_candidates(unit, incomplete)
+    if kind == "pipeline-stage":
+        if unit is None:
+            raise QueryCompletionError("--unit is required for pipeline-stage completion")
+        return query_pipeline_stage_candidates(unit, incomplete)
     if kind == "count-operator":
         if field is None:
             raise QueryCompletionError("--field is required for count-operator completion")
@@ -427,6 +457,7 @@ __all__ = [
     "query_count_operator_candidates",
     "query_date_operator_candidates",
     "query_field_candidates",
+    "query_pipeline_stage_candidates",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",
     "query_terminal_field_candidates",

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -33,6 +33,17 @@ class QueryUnitDescriptor:
         return (self.singular_source, self.plural_source)
 
 
+@dataclass(frozen=True)
+class QueryPipelineStageInfo:
+    """Completion/query-builder metadata for executable terminal pipeline stages."""
+
+    value: str
+    insert: str
+    description: str
+    source_unit: QueryUnitName
+    lowerer_kind: QueryUnitLowererKind
+
+
 #: Recognized DSL field tokens and a short human description.
 #: ``spec_field`` values correspond to :class:`~polylogue.archive.query.spec.SessionQuerySpec`
 #: attribute names or the special tokens ``"min_messages"``, ``"max_messages"`` etc.
@@ -762,6 +773,82 @@ def terminal_query_field_info(source: str, field: str) -> StructuralQueryFieldIn
     return None
 
 
+def terminal_query_pipeline_stage_infos(source: str) -> tuple[QueryPipelineStageInfo, ...]:
+    """Return executable pipeline-stage candidates for a terminal query source."""
+
+    descriptor = query_unit_descriptor(source)
+    if descriptor is None or not descriptor.terminal_supported:
+        return ()
+    stages: list[QueryPipelineStageInfo] = []
+    if descriptor.lowerer_kind == "sql":
+        stages.append(
+            QueryPipelineStageInfo(
+                value="sort by time",
+                insert="sort by time desc",
+                description="Order SQL-backed terminal rows by row timestamp before pagination.",
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
+            )
+        )
+    for field_name in descriptor.aggregate_group_fields:
+        stages.append(
+            QueryPipelineStageInfo(
+                value=f"group by {field_name}",
+                insert=f"group by {field_name}",
+                description=f"Group {descriptor.plural_source} by {field_name} before an aggregate count stage.",
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
+            )
+        )
+    if descriptor.aggregate_group_fields:
+        stages.append(
+            QueryPipelineStageInfo(
+                value="count",
+                insert="count",
+                description="Count rows in each preceding group.",
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
+            )
+        )
+        stages.extend(
+            (
+                QueryPipelineStageInfo(
+                    value="sort by count",
+                    insert="sort by count desc",
+                    description="Order aggregate groups by count after a count stage.",
+                    source_unit=descriptor.unit,
+                    lowerer_kind=descriptor.lowerer_kind,
+                ),
+                QueryPipelineStageInfo(
+                    value="sort by key",
+                    insert="sort by key asc",
+                    description="Order aggregate groups by group key after a count stage.",
+                    source_unit=descriptor.unit,
+                    lowerer_kind=descriptor.lowerer_kind,
+                ),
+            )
+        )
+    stages.extend(
+        (
+            QueryPipelineStageInfo(
+                value="limit",
+                insert="limit ",
+                description="Limit terminal rows after filtering or aggregation.",
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
+            ),
+            QueryPipelineStageInfo(
+                value="offset",
+                insert="offset ",
+                description="Skip terminal rows after filtering or aggregation.",
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
+            ),
+        )
+    )
+    return tuple(stages)
+
+
 def count_query_fields() -> tuple[str, ...]:
     """Return count fields with readable comparison/range syntax."""
 
@@ -802,6 +889,7 @@ __all__ = [
     "QueryUnitDescriptor",
     "QueryUnitLowererKind",
     "QueryUnitName",
+    "QueryPipelineStageInfo",
     "STRUCTURAL_QUERY_UNIT_REGISTRY",
     "StructuralQueryFieldInfo",
     "StructuralQueryUnitInfo",
@@ -826,6 +914,7 @@ __all__ = [
     "structural_query_units",
     "terminal_query_field_info",
     "terminal_query_fields",
+    "terminal_query_pipeline_stage_infos",
     "terminal_query_source_list",
     "terminal_query_source_pairs",
     "terminal_query_sources",

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -23,6 +23,7 @@ from polylogue.archive.query.completions import (
     query_count_operator_candidates,
     query_date_operator_candidates,
     query_field_candidates,
+    query_pipeline_stage_candidates,
     query_structural_field_candidates,
     query_structural_unit_candidates,
     query_terminal_field_candidates,
@@ -285,6 +286,29 @@ def _complete_terminal_query_context(incomplete: str) -> list[CompletionItem] | 
     ]
 
 
+def _pipeline_completion_context(incomplete: str) -> tuple[str, str] | None:
+    stripped = incomplete.strip()
+    if "|" not in stripped:
+        return None
+    before_pipe, stage_prefix = stripped.rsplit("|", 1)
+    terminal_context = _terminal_completion_context(before_pipe.strip())
+    if terminal_context is None:
+        return None
+    source, _field_prefix = terminal_context
+    return source, stage_prefix.lstrip()
+
+
+def _complete_pipeline_query_context(incomplete: str) -> list[CompletionItem] | None:
+    context = _pipeline_completion_context(incomplete)
+    if context is None:
+        return None
+    source, prefix = context
+    return [
+        query_completion_candidate_to_click_item(candidate)
+        for candidate in query_pipeline_stage_candidates(source, prefix)
+    ]
+
+
 def complete_query_expression_context_fields(
     ctx: click.Context,
     param: click.Parameter | None,
@@ -294,6 +318,9 @@ def complete_query_expression_context_fields(
 
     if incomplete.startswith("--"):
         return None
+    pipeline_items = _complete_pipeline_query_context(incomplete)
+    if pipeline_items is not None:
+        return pipeline_items
     terminal_items = _complete_terminal_query_context(incomplete)
     if terminal_items is not None:
         return terminal_items
@@ -533,6 +560,7 @@ __all__ = [
     "query_date_operator_candidates",
     "query_field_candidates",
     "query_completion_candidate_to_click_item",
+    "query_pipeline_stage_candidates",
     "query_structural_field_candidates",
     "query_structural_unit_candidates",
     "query_terminal_field_candidates",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -897,6 +897,18 @@ async def test_query_completions_exposes_shared_completion_payload(tmp_path: Pat
         terminal_candidate_payloads = [cast(dict[str, object], candidate) for candidate in terminal_candidates]
         assert [candidate["value"] for candidate in terminal_candidate_payloads] == ["delivery_state"]
         assert terminal_candidate_payloads[0]["insert"] == "delivery_state:"
+
+        pipeline_payload = await archive.query_completions("pipeline-stage", unit="messages", incomplete="g")
+        assert pipeline_payload["kind"] == "pipeline-stage"
+        pipeline_candidates = pipeline_payload["candidates"]
+        assert isinstance(pipeline_candidates, list)
+        pipeline_candidate_payloads = [cast(dict[str, object], candidate) for candidate in pipeline_candidates]
+        assert "group by role" in {candidate["value"] for candidate in pipeline_candidate_payloads}
+        role_candidate = next(
+            candidate for candidate in pipeline_candidate_payloads if candidate["value"] == "group by role"
+        )
+        assert role_candidate["insert"] == "group by role"
+        assert role_candidate["payload_model"] == "MessageQueryRowPayload"
     finally:
         await archive.close()
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -211,6 +211,29 @@ def test_query_count_operator_candidates_come_from_expression_registry() -> None
     assert "messages between 5 and 20" in between_candidate.description
 
 
+def test_query_pipeline_stage_candidates_come_from_unit_descriptors() -> None:
+    candidates = shell_completion_values.query_pipeline_stage_candidates("messages", "g")
+    values = [candidate.value for candidate in candidates]
+
+    assert "group by role" in values
+    assert "group by session.repo" in values
+    role_candidate = next(candidate for candidate in candidates if candidate.value == "group by role")
+    assert role_candidate.insert == "group by role"
+    assert role_candidate.kind == "query-pipeline-stage"
+    assert role_candidate.source == "QUERY_UNIT_DESCRIPTORS"
+    assert role_candidate.payload_model == "MessageQueryRowPayload"
+
+    sort_candidates = shell_completion_values.query_pipeline_stage_candidates("messages", "sort")
+    sort_values = [candidate.value for candidate in sort_candidates]
+    assert "sort by count" in sort_values
+    assert "sort by key" in sort_values
+    count_sort_candidate = next(candidate for candidate in sort_candidates if candidate.value == "sort by count")
+    assert count_sort_candidate.insert == "sort by count desc"
+
+    runtime_candidates = shell_completion_values.query_pipeline_stage_candidates("context-snapshots", "")
+    assert [candidate.value for candidate in runtime_candidates] == ["limit", "offset"]
+
+
 def test_query_expression_value_completion_uses_field_completion_source() -> None:
     ctx, param = _ctx_param()
 
@@ -267,6 +290,14 @@ def test_query_expression_completion_handles_terminal_contexts() -> None:
         "context-snapshots where boundary:session_start AND sess",
     )
     assert "session.repo:" in {item.value for item in chained_snapshot_items}
+
+    pipeline_items = shell_completion_values.complete_query_expression_fields(
+        ctx,
+        param,
+        "messages where role:assistant | g",
+    )
+    pipeline_values = {item.value for item in pipeline_items}
+    assert {"group by role", "group by session.repo"}.issubset(pipeline_values)
 
 
 def test_query_action_candidates_come_from_action_contracts_with_danger_metadata() -> None:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1377,6 +1377,25 @@ class TestReaderQueryCompletions:
         assert [candidate["value"] for candidate in candidate_payloads] == ["boundary"]
         assert candidate_payloads[0]["insert"] == "boundary:"
 
+    def test_query_completions_endpoint_exposes_pipeline_stages(self) -> None:
+        with _running_server_without_seed() as (_server, base_url):
+            payload = _get_json(
+                base_url,
+                "/api/query-completions?kind=pipeline-stage&unit=messages&incomplete=sort",
+            )
+
+        payload_dict = cast(dict[str, object], payload)
+        envelope = payload_dict["query_completions"]
+        assert isinstance(envelope, dict)
+        envelope_payload = cast(dict[str, object], envelope)
+        assert envelope_payload["kind"] == "pipeline-stage"
+        candidates = envelope_payload["candidates"]
+        assert isinstance(candidates, list)
+        candidate_payloads = [cast(dict[str, object], candidate) for candidate in cast(list[object], candidates)]
+        assert {"sort by time", "sort by count", "sort by key"}.issubset(
+            {candidate["value"] for candidate in candidate_payloads}
+        )
+
 
 class TestReaderQueryUnits:
     def test_query_units_endpoint_returns_terminal_message_rows(self, workspace_env: dict[str, Path]) -> None:


### PR DESCRIPTION
## Summary

Expose executable terminal pipeline stages through the shared query-completion metadata path. CLI shell completion, Python API, MCP, and daemon completion consumers can now ask for `pipeline-stage` candidates backed by `QueryUnitDescriptor` metadata.

## Problem

#2006 requires completion/query-builder metadata to come from the same query unit and field registries as the parser/lowerers. Terminal pipeline syntax had executable support and docs, but completion consumers still knew only top-level fields, structural units, terminal sources, and terminal fields.

## Solution

- Added `QueryPipelineStageInfo` and `terminal_query_pipeline_stage_infos()` to `polylogue.archive.query.metadata`.
- Added shared `pipeline-stage` completion payloads in `polylogue.archive.query.completions`.
- Wired shell completion so `messages where ... | g` completes pipeline stages instead of returning predicate fields.
- Kept candidates execution-aware: SQL-backed units expose row sort, grouping, count, aggregate sort, limit, and offset; runtime-transform units expose only currently executable limit/offset.
- Added shell-helper, facade, and daemon HTTP tests proving the metadata and public payload behavior.

## Verification

- `devtools test tests/unit/cli/test_command_aux_runtime.py -k "query_pipeline_stage or terminal_contexts"` -> 2 passed.
- `devtools test tests/unit/api/test_facade_contracts.py -k query_completions_exposes_shared_completion_payload` -> 1 passed.
- `devtools test tests/unit/daemon/test_web_reader.py -k query_completions_endpoint_exposes_pipeline_stages` -> 1 passed.
- `devtools verify --quick` -> exit_code 0.
- `devtools verify --seed-testmon --skip-slow` -> 11699 passed, peak tree RSS 3126.6 MiB.
- `devtools verify` -> 126 passed, peak tree RSS 693.1 MiB.

Ref #2006