### PR TITLE
feat(query): execute role-count predicates through DSL

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -169,6 +169,19 @@ polylogue 'words between 100 and 500'
 polylogue 'date between 2026-06-01 and 2026-06-17'
 ```
 
+Explicit Boolean queries can also compare the role-split session aggregate
+columns already maintained by the archive:
+
+```bash
+polylogue 'sessions where user_messages >= 2 AND assistant_words between 500 and 2000'
+polylogue 'sessions where system_messages = 0 AND tool_messages = 0'
+```
+
+Supported role-split count fields are `user_messages`,
+`assistant_messages`, `system_messages`, `tool_messages`, `user_words`, and
+`assistant_words`. These fields are SQL-backed session predicates; use them in
+`sessions where ...` Boolean queries.
+
 Compact count syntax is equivalent where available:
 
 ```bash

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -256,9 +256,15 @@ def _archive_list_summaries_for_spec(
     spec: SessionQuerySpec,
     *,
     default_limit: int,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[ArchiveSessionSummary]:
     query_text = _archive_text_query(spec)
     query_kwargs = _archive_query_kwargs(spec, default_limit=default_limit)
+    if limit is not None:
+        query_kwargs["limit"] = limit
+    if offset is not None:
+        query_kwargs["offset"] = offset
     if query_text is not None:
         return [archive.read_summary(hit.session_id) for hit in archive.search_summaries(query_text, **query_kwargs)]
     return cast(list[ArchiveSessionSummary], archive.list_summaries(**query_kwargs))
@@ -2511,13 +2517,19 @@ class PolylogueArchiveMixin:
                     _archive_search_hit_to_payload(hit, archive.read_summary(hit.session_id)) for hit in hits
                 )
             elif query.strip():
-                summaries = _archive_list_summaries_for_spec(archive, spec, default_limit=display_limit)
+                summaries = _archive_list_summaries_for_spec(
+                    archive,
+                    spec,
+                    default_limit=display_limit,
+                    limit=fetch_limit,
+                    offset=fetch_offset,
+                )
                 total = _archive_count_sessions_for_spec(archive, spec)
                 hit_payloads = tuple(
                     SessionSearchHitPayload.from_search_hit(
                         session_search_hit_from_summary(
                             _archive_summary_to_domain(summary),
-                            rank=display_offset + index,
+                            rank=fetch_offset + index,
                             retrieval_lane=spec.retrieval_lane,
                             match_surface="session",
                             message_id=None,

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -266,6 +266,7 @@ def _archive_list_summaries_for_spec(
     if offset is not None:
         query_kwargs["offset"] = offset
     if query_text is not None:
+        query_kwargs.pop("sample", None)
         return [archive.read_summary(hit.session_id) for hit in archive.search_summaries(query_text, **query_kwargs)]
     return cast(list[ArchiveSessionSummary], archive.list_summaries(**query_kwargs))
 
@@ -279,6 +280,7 @@ def _archive_search_hits_for_spec(
     offset: int,
 ) -> list[Any]:
     query_kwargs = _archive_query_kwargs(spec, default_limit=None)
+    query_kwargs.pop("sample", None)
     query_kwargs["limit"] = limit
     query_kwargs["offset"] = offset
     return cast(list[Any], archive.search_summaries(query_text, **query_kwargs))

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -231,6 +231,7 @@ def _archive_query_kwargs(spec: SessionQuerySpec, *, default_limit: int | None) 
         "since_ms": _archive_query_date_ms("since", spec.since),
         "until_ms": _archive_query_date_ms("until", spec.until),
         "since_session_id": spec.since_session_id,
+        "boolean_predicate": spec.boolean_predicate,
     }
     if limit is not None:
         kwargs["limit"] = limit
@@ -261,6 +262,20 @@ def _archive_list_summaries_for_spec(
     if query_text is not None:
         return [archive.read_summary(hit.session_id) for hit in archive.search_summaries(query_text, **query_kwargs)]
     return cast(list[ArchiveSessionSummary], archive.list_summaries(**query_kwargs))
+
+
+def _archive_search_hits_for_spec(
+    archive: Any,
+    spec: SessionQuerySpec,
+    query_text: str,
+    *,
+    limit: int,
+    offset: int,
+) -> list[Any]:
+    query_kwargs = _archive_query_kwargs(spec, default_limit=None)
+    query_kwargs["limit"] = limit
+    query_kwargs["offset"] = offset
+    return cast(list[Any], archive.search_summaries(query_text, **query_kwargs))
 
 
 def _archive_count_sessions_for_spec(archive: Any, spec: SessionQuerySpec) -> int:
@@ -2441,18 +2456,21 @@ class PolylogueArchiveMixin:
         without losing or duplicating hits even when the archive grew
         between requests (#1268).
         """
+        from polylogue.archive.query.expression import compile_expression_into
+        from polylogue.archive.query.search_hits import session_search_hit_from_summary
         from polylogue.archive.query.spec import SessionQuerySpec
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import (
             InvalidSearchCursorError,
+            SessionSearchHitPayload,
             build_search_envelope,
             decode_search_cursor,
             search_cursor_lane_matches_request,
         )
 
-        spec = SessionQuerySpec.from_params(
+        base_spec = SessionQuerySpec.from_params(
             {
-                "query": query,
+                "query": "",
                 "origin": origin,
                 "since": since,
                 "until": until,
@@ -2464,6 +2482,7 @@ class PolylogueArchiveMixin:
             },
             strict=True,
         )
+        spec = compile_expression_into(query, base_spec) if query.strip() else base_spec
         decoded_cursor = decode_search_cursor(spec.cursor) if spec.cursor else None
         if decoded_cursor is not None and not search_cursor_lane_matches_request(
             decoded_cursor.lane,
@@ -2477,45 +2496,47 @@ class PolylogueArchiveMixin:
         display_offset = spec.offset
         fetch_offset = decoded_cursor.r if decoded_cursor is not None else display_offset
         fetch_limit = display_limit * 2 if decoded_cursor is not None else display_limit
-        origins = spec.origins
-        excluded_origins = spec.excluded_origins
+        query_text = _archive_text_query(spec)
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
-            if query.strip():
-                hits = archive.search_summaries(
-                    query,
+            if query_text is not None:
+                hits = _archive_search_hits_for_spec(
+                    archive,
+                    spec,
+                    query_text,
                     limit=fetch_limit,
                     offset=fetch_offset,
-                    sort=spec.sort,
-                    origins=origins,
-                    excluded_origins=excluded_origins,
-                    since_ms=_archive_query_date_ms("since", since),
-                    until_ms=_archive_query_date_ms("until", until),
                 )
-                total = archive.count_search_sessions(
-                    query,
-                    origins=origins,
-                    excluded_origins=excluded_origins,
-                    since_ms=_archive_query_date_ms("since", since),
-                    until_ms=_archive_query_date_ms("until", until),
-                )
+                total = _archive_count_sessions_for_spec(archive, spec)
                 hit_payloads = tuple(
                     _archive_search_hit_to_payload(hit, archive.read_summary(hit.session_id)) for hit in hits
                 )
+            elif query.strip():
+                summaries = _archive_list_summaries_for_spec(archive, spec, default_limit=display_limit)
+                total = _archive_count_sessions_for_spec(archive, spec)
+                hit_payloads = tuple(
+                    SessionSearchHitPayload.from_search_hit(
+                        session_search_hit_from_summary(
+                            _archive_summary_to_domain(summary),
+                            rank=display_offset + index,
+                            retrieval_lane=spec.retrieval_lane,
+                            match_surface="session",
+                            message_id=None,
+                            snippet=None,
+                        ),
+                        message_count=summary.message_count,
+                    )
+                    for index, summary in enumerate(summaries, start=1)
+                )
             else:
                 hit_payloads = ()
-                total = archive.count_sessions(
-                    origins=origins,
-                    excluded_origins=excluded_origins,
-                    since_ms=_archive_query_date_ms("since", since),
-                    until_ms=_archive_query_date_ms("until", until),
-                )
+                total = _archive_count_sessions_for_spec(archive, spec)
         return build_search_envelope(
             hit_payloads,
             total=total,
             limit=display_limit,
             offset=display_offset,
             query=query,
-            retrieval_lane="dialogue" if query.strip() else spec.retrieval_lane,
+            retrieval_lane="dialogue" if query_text is not None else spec.retrieval_lane,
             sort=spec.sort,
             cursor=decoded_cursor,
         )

--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -99,6 +99,9 @@ def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
         if current and not field_name.startswith(current):
             continue
         count_info = COUNT_QUERY_FIELD_REGISTRY.get(field_name)
+        # The compact grammar keeps messages:/words: for compatibility.
+        # Role-split count fields are Boolean-only and complete with an
+        # operator-ready space, e.g. "user_messages >= 2".
         insert = (
             f"{field_name} " if count_info is not None and field_name not in {"messages", "words"} else f"{field_name}:"
         )

--- a/polylogue/archive/query/completions.py
+++ b/polylogue/archive/query/completions.py
@@ -98,13 +98,15 @@ def query_field_candidates(incomplete: str) -> list[QueryCompletionCandidate]:
     for field_name, info in sorted(EXPRESSION_FIELD_REGISTRY.items()):
         if current and not field_name.startswith(current):
             continue
-        insert = f"{field_name}:"
+        count_info = COUNT_QUERY_FIELD_REGISTRY.get(field_name)
+        insert = (
+            f"{field_name} " if count_info is not None and field_name not in {"messages", "words"} else f"{field_name}:"
+        )
         description = info.get("description", "")
         example = info.get("example")
         if example:
             description = f"{description} Example: {example}" if description else f"Example: {example}"
         source = "EXPRESSION_FIELD_REGISTRY"
-        count_info = COUNT_QUERY_FIELD_REGISTRY.get(field_name)
         if count_info is not None:
             operators = ", ".join((*count_info.operators, count_info.range_keyword))
             description = (

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -431,7 +431,7 @@ _QUERY_GRAMMAR = r"""
     AND: /and/i
     NOT: /not/i
     BETWEEN.6: /between/i
-    COUNT_FIELD.6: /(messages|words)/i
+    COUNT_FIELD.6: /(messages|words|user_messages|assistant_messages|system_messages|tool_messages|user_words|assistant_words)/i
     DATE_FIELD.6: /date/i
     TIME_FIELD.6: /time/i
     DATE_COMP_OP: ">=" | "<=" | "=" | ">" | "<"
@@ -441,7 +441,7 @@ _QUERY_GRAMMAR = r"""
     SEMANTIC_BARE_TEXT.6: /(?:semantic|near:text):[^\s"()]+/i
     FTS_QUOTED_TEXT.6: /~"(\\.|[^"\\])*"/
     FTS_BARE_TEXT.5: /~[^\s"()]+/
-    COUNT_CLAUSE.8: /(messages|words):(>=|<=|=)\d+(?!\S)/
+    COUNT_CLAUSE.8: /(messages|words|user_messages|assistant_messages|system_messages|tool_messages|user_words|assistant_words):(>=|<=|=)\d+(?!\S)/
     FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_.]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{}]+)/
     NEG_QUOTED_TEXT.3: /-"(\\.|[^"\\])*"/
     QUOTED_TEXT.2: /"(\\.|[^"\\])*"/
@@ -461,7 +461,9 @@ _QUERY_PARSER = Lark(
     maybe_placeholders=False,
 )
 
-_COUNT_CLAUSE_RE = re.compile(r"^(messages|words):(>=|<=|=)(\d+)$")
+_COUNT_CLAUSE_RE = re.compile(
+    r"^(messages|words|user_messages|assistant_messages|system_messages|tool_messages|user_words|assistant_words):(>=|<=|=)(\d+)$"
+)
 _FIELD_CLAUSE_RE = re.compile(
     r"""
     ^(-?)
@@ -905,13 +907,17 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 raise ExpressionCompileError("field 'time' requires a value", field="time")
             if predicate.op not in {">=", "<="}:
                 raise ExpressionCompileError("field 'time' supports only >=, <=, >, <, and between", field="time")
-        if effective_field == "words":
+        if effective_field in COUNT_QUERY_FIELD_REGISTRY:
             if not predicate.values:
-                raise ExpressionCompileError("field 'words' requires a numeric value", field="words")
+                raise ExpressionCompileError(
+                    f"field {effective_field!r} requires a numeric value", field=effective_field
+                )
             try:
                 int(predicate.values[-1])
             except ValueError as exc:
-                raise ExpressionCompileError("field 'words' requires a numeric value", field="words") from exc
+                raise ExpressionCompileError(
+                    f"field {effective_field!r} requires a numeric value", field=effective_field
+                ) from exc
         return
     if isinstance(predicate, QueryNotPredicate):
         _validate_predicate_context(predicate.child, unit=unit)
@@ -1984,6 +1990,11 @@ class _SpecAccumulator:
                 else:  # "="
                     self.min_words = tok.number
                     self.max_words = tok.number
+            else:
+                raise ExpressionCompileError(
+                    f"field {tok.field!r} is supported only inside `sessions where` Boolean queries",
+                    field=tok.field,
+                )
             return
 
         if isinstance(tok, _CountRangeToken):
@@ -1993,6 +2004,11 @@ class _SpecAccumulator:
             elif tok.field == "words":
                 self.min_words = tok.min_number
                 self.max_words = tok.max_number
+            else:
+                raise ExpressionCompileError(
+                    f"field {tok.field!r} is supported only inside `sessions where` Boolean queries",
+                    field=tok.field,
+                )
             return
 
         if isinstance(tok, _DateComparisonToken):

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -110,6 +110,7 @@ from polylogue.archive.query.metadata import (
     STRUCTURAL_QUERY_UNIT_REGISTRY,
     CountQueryFieldInfo,
     DateQueryFieldInfo,
+    QueryUnitLowererKind,
     QueryUnitName,
     StructuralQueryUnitInfo,
     count_query_fields,
@@ -1300,6 +1301,31 @@ def _validate_aggregate_group_field(unit: QueryUnitName, field: str) -> None:
         )
 
 
+def _query_unit_lowerer_kind(unit: QueryUnitName) -> QueryUnitLowererKind:
+    descriptor = query_unit_descriptor(unit)
+    if descriptor is None or not descriptor.terminal_supported:
+        raise ExpressionCompileError(f"unsupported terminal query unit {unit!r}", field=None)
+    return descriptor.lowerer_kind
+
+
+def _ensure_sql_row_pipeline_lowerer(unit: QueryUnitName, *, stage: str) -> None:
+    if _query_unit_lowerer_kind(unit) != "sql":
+        raise ExpressionCompileError(
+            f"pipeline `{stage}` currently supports SQL-backed terminal rows; "
+            "runtime-transform units need a streaming lowerer first",
+            field=stage.partition(" ")[0],
+        )
+
+
+def _ensure_sql_aggregate_pipeline_lowerer(unit: QueryUnitName, *, stage: str) -> None:
+    if _query_unit_lowerer_kind(unit) != "sql":
+        raise ExpressionCompileError(
+            f"pipeline `{stage}` currently supports SQL-backed terminal rows; "
+            "runtime-transform units need an aggregate lowerer first",
+            field=stage.partition(" ")[0],
+        )
+
+
 def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSource:
     sort = _parse_sort_stage(stage)
     if sort is not None:
@@ -1310,12 +1336,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
                 )
             if source.group_by is not None:
                 raise ExpressionCompileError("pipeline `sort by time` must appear before `group by`", field="sort")
-            if source.unit not in {"message", "action", "block", "assertion"}:
-                raise ExpressionCompileError(
-                    "pipeline `sort by time` currently supports message/action/block/assertion rows; "
-                    "runtime-transform units need a streaming lowerer first",
-                    field="sort",
-                )
+            _ensure_sql_row_pipeline_lowerer(source.unit, stage="sort by time")
         elif source.aggregate != "count":
             raise ExpressionCompileError(
                 "pipeline `sort by count` and `sort by key` require an aggregate `count` stage",
@@ -1326,12 +1347,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
                 "pipeline aggregate `sort by` must appear before `limit` and `offset`",
                 field="sort",
             )
-        if source.unit not in {"message", "action", "block", "assertion"}:
-            raise ExpressionCompileError(
-                "pipeline aggregate sorting currently supports message/action/block/assertion rows; "
-                "runtime-transform units need an aggregate lowerer first",
-                field="sort",
-            )
+        _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage=f"sort by {sort.field}")
         return replace(
             source,
             sort=sort,
@@ -1348,12 +1364,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
             raise ExpressionCompileError("pipeline `sort by time` cannot feed aggregate stages", field="group")
         if source.limit is not None or source.offset is not None:
             raise ExpressionCompileError("pipeline `group by` must appear before `limit` and `offset`", field="group")
-        if source.unit not in {"message", "action", "block", "assertion"}:
-            raise ExpressionCompileError(
-                "pipeline `group by` currently supports message/action/block/assertion rows; "
-                "runtime-transform units need an aggregate lowerer first",
-                field="group",
-            )
+        _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage="group by")
         _validate_aggregate_group_field(source.unit, group_by)
         return replace(
             source,
@@ -1366,12 +1377,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
     if _parse_count_stage(stage):
         if source.limit is not None or source.offset is not None:
             raise ExpressionCompileError("pipeline `count` must appear before `limit` and `offset`", field="count")
-        if source.unit not in {"message", "action", "block", "assertion"}:
-            raise ExpressionCompileError(
-                "pipeline `count` currently supports message/action/block/assertion rows; "
-                "runtime-transform units need an aggregate lowerer first",
-                field="count",
-            )
+        _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage="count")
         return replace(
             source,
             aggregate="count",

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -148,6 +148,42 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
         "negatable": "no",
         "example": "words:>=200",
     },
+    "user_messages": {
+        "description": "Count comparison for user messages",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where user_messages >= 2",
+    },
+    "assistant_messages": {
+        "description": "Count comparison for assistant messages",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where assistant_messages >= 2",
+    },
+    "system_messages": {
+        "description": "Count comparison for system messages",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where system_messages = 0",
+    },
+    "tool_messages": {
+        "description": "Count comparison for tool messages",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where tool_messages = 0",
+    },
+    "user_words": {
+        "description": "Count comparison for user words",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where user_words >= 100",
+    },
+    "assistant_words": {
+        "description": "Count comparison for assistant words",
+        "spec_field": "boolean_predicate",
+        "negatable": "no",
+        "example": "sessions where assistant_words >= 500",
+    },
     "lane": {
         "description": "Force retrieval lane (auto, dialogue, hybrid)",
         "spec_field": "retrieval_lane",
@@ -178,6 +214,12 @@ _BOOLEAN_SUPPORTED_FIELDS = {
     "until",
     "messages",
     "words",
+    "user_messages",
+    "assistant_messages",
+    "system_messages",
+    "tool_messages",
+    "user_words",
+    "assistant_words",
     "lineage",
 }
 _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS = {
@@ -296,6 +338,7 @@ class CountQueryFieldInfo:
     operators: tuple[str, ...]
     range_keyword: str
     example: str
+    session_column: str
 
 
 @dataclass(frozen=True)
@@ -662,12 +705,56 @@ COUNT_QUERY_FIELD_REGISTRY: dict[str, CountQueryFieldInfo] = {
         operators=(">=", "<=", "=", ">", "<"),
         range_keyword="between",
         example="messages between 5 and 20",
+        session_column="message_count",
     ),
     "words": CountQueryFieldInfo(
         description="Word-count predicate over normalized session text.",
         operators=(">=", "<=", "=", ">", "<"),
         range_keyword="between",
         example="words between 100 and 500",
+        session_column="word_count",
+    ),
+    "user_messages": CountQueryFieldInfo(
+        description="User-message-count predicate over normalized session messages.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="user_messages >= 2",
+        session_column="user_message_count",
+    ),
+    "assistant_messages": CountQueryFieldInfo(
+        description="Assistant-message-count predicate over normalized session messages.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="assistant_messages >= 2",
+        session_column="assistant_message_count",
+    ),
+    "system_messages": CountQueryFieldInfo(
+        description="System-message-count predicate over normalized session messages.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="system_messages = 0",
+        session_column="system_message_count",
+    ),
+    "tool_messages": CountQueryFieldInfo(
+        description="Tool-message-count predicate over normalized session messages.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="tool_messages = 0",
+        session_column="tool_message_count",
+    ),
+    "user_words": CountQueryFieldInfo(
+        description="User-word-count predicate over normalized session text.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="user_words between 100 and 500",
+        session_column="user_word_count",
+    ),
+    "assistant_words": CountQueryFieldInfo(
+        description="Assistant-word-count predicate over normalized session text.",
+        operators=(">=", "<=", "=", ">", "<"),
+        range_keyword="between",
+        example="assistant_words >= 500",
+        session_column="assistant_word_count",
     ),
 }
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Literal, TypedDict, cast
 
+from polylogue.archive.query.metadata import COUNT_QUERY_FIELD_REGISTRY
 from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
@@ -4723,28 +4724,8 @@ def _field_predicate_clause(
     elif field == "until":
         if values:
             kwargs["until_ms"] = _date_ms(values[-1], field="until")
-    elif field == "messages":
-        if not values:
-            return "", []
-        count_value = int(values[-1])
-        if predicate.op == ">=":
-            kwargs["min_messages"] = count_value
-        elif predicate.op == "<=":
-            kwargs["max_messages"] = count_value
-        else:
-            kwargs["min_messages"] = count_value
-            kwargs["max_messages"] = count_value
-    elif field == "words":
-        if not values:
-            return "", []
-        count_value = int(values[-1])
-        if predicate.op == ">=":
-            kwargs["min_words"] = count_value
-        elif predicate.op == "<=":
-            kwargs["max_words"] = count_value
-        else:
-            kwargs["min_words"] = count_value
-            kwargs["max_words"] = count_value
+    elif count_info := COUNT_QUERY_FIELD_REGISTRY.get(field):
+        return _count_predicate_clause(f"{table_alias}.{count_info.session_column}", predicate)
     else:
         raise ValueError(f"unsupported Boolean query field: {field}")
     where, params = _session_filter_clause(table_alias, tags_relation=tags_relation, prefix="WHERE", **kwargs)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1517,6 +1517,48 @@ async def test_search_envelope_executes_role_count_boolean_predicate(tmp_path: P
         await archive.close()
 
 
+async def test_search_envelope_paginates_filter_only_boolean_predicates(tmp_path: Path) -> None:
+    """Filter-only DSL envelopes honor cursor offsets when fetching the next page."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            for index in range(3):
+                archive_db.write_parsed(
+                    ParsedSession(
+                        source_name=Provider.CODEX,
+                        provider_session_id=f"role-count-page-{index}",
+                        title=f"Role Count Page {index}",
+                        messages=[
+                            ParsedMessage(
+                                provider_message_id=f"u{index}",
+                                role=Role.USER,
+                                text=f"page {index} question",
+                                blocks=[
+                                    ParsedContentBlock(
+                                        type=BlockType.TEXT,
+                                        text=f"page {index} question",
+                                    )
+                                ],
+                            )
+                        ],
+                    )
+                )
+
+        query = "sessions where user_messages >= 1"
+        first = await archive.search_envelope(query, limit=1)
+        assert first.total == 3
+        assert len(first.hits) == 1
+        assert first.next_cursor is not None
+
+        second = await archive.search_envelope(query, limit=1, cursor=first.next_cursor)
+
+        assert second.total == 3
+        assert len(second.hits) == 1
+        assert second.hits[0].session.id != first.hits[0].session.id
+    finally:
+        await archive.close()
+
+
 async def test_query_units_returns_typed_envelope_on_empty_archive(tmp_path: Path) -> None:
     """``query_units()`` returns a typed terminal-unit envelope even with no rows."""
     from polylogue.surfaces.payloads import QueryUnitEnvelope

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1559,6 +1559,34 @@ async def test_search_envelope_paginates_filter_only_boolean_predicates(tmp_path
         await archive.close()
 
 
+async def test_query_sessions_sampled_text_query_uses_search_kwargs(tmp_path: Path) -> None:
+    """Sampled specs with text queries do not leak list-only kwargs into FTS search."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="sampled-text-query",
+                    title="Sampled Text Query",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="u1",
+                            role=Role.USER,
+                            text="sampled needle",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="sampled needle")],
+                        )
+                    ],
+                )
+            )
+
+        rows = await archive.query_sessions(query="sampled needle", sample=1, limit=5)
+
+        assert [row["id"] for row in rows] == ["codex-session:sampled-text-query"]
+    finally:
+        await archive.close()
+
+
 async def test_query_units_returns_typed_envelope_on_empty_archive(tmp_path: Path) -> None:
     """``query_units()`` returns a typed terminal-unit envelope even with no rows."""
     from polylogue.surfaces.payloads import QueryUnitEnvelope

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1454,6 +1454,69 @@ async def test_search_envelope_returns_typed_envelope_on_empty_archive(
         await archive.close()
 
 
+async def test_search_envelope_executes_role_count_boolean_predicate(tmp_path: Path) -> None:
+    """``search_envelope()`` executes role-split count predicates through the shared DSL."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="role-count-hit",
+                    title="Role Count Hit",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="u1",
+                            role=Role.USER,
+                            text="one question",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="one question")],
+                        ),
+                        ParsedMessage(
+                            provider_message_id="u2",
+                            role=Role.USER,
+                            text="second question",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="second question")],
+                        ),
+                        ParsedMessage(
+                            provider_message_id="a1",
+                            role=Role.ASSISTANT,
+                            text="one two three four five",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="one two three four five")],
+                        ),
+                    ],
+                )
+            )
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="role-count-miss",
+                    title="Role Count Miss",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="u1",
+                            role=Role.USER,
+                            text="one question",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="one question")],
+                        ),
+                        ParsedMessage(
+                            provider_message_id="a1",
+                            role=Role.ASSISTANT,
+                            text="one two three four five",
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="one two three four five")],
+                        ),
+                    ],
+                )
+            )
+
+        envelope = await archive.search_envelope(
+            "sessions where user_messages >= 2 AND assistant_words between 5 and 6"
+        )
+
+        assert [hit.session.id for hit in envelope.hits] == ["codex-session:role-count-hit"]
+    finally:
+        await archive.close()
+
+
 async def test_query_units_returns_typed_envelope_on_empty_archive(tmp_path: Path) -> None:
     """``query_units()`` returns a typed terminal-unit envelope even with no rows."""
     from polylogue.surfaces.payloads import QueryUnitEnvelope

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -149,6 +149,14 @@ def test_query_field_candidates_include_readable_operator_fields() -> None:
     assert message_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
     assert "messages between 5 and 20" in message_candidate.description
 
+    role_count_candidates = shell_completion_values.query_field_candidates("user_m")
+    user_messages_candidate = next(
+        candidate for candidate in role_count_candidates if candidate.value == "user_messages"
+    )
+    assert user_messages_candidate.insert == "user_messages "
+    assert user_messages_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
+    assert "sessions where user_messages >= 2" in user_messages_candidate.description
+
 
 def test_query_field_candidates_disappear_with_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:
     from polylogue.archive.query.expression import EXPRESSION_FIELD_REGISTRY

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -2441,6 +2441,36 @@ class TestBooleanQueryExpression:
 
         assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
 
+    def test_role_count_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "role-count-hit")
+            .provider("claude-code")
+            .title("role count hit")
+            .add_message("m-hit-user-1", role="user", text="please inspect the query")
+            .add_message("m-hit-user-2", role="user", text="and add coverage")
+            .add_message("m-hit-assistant", role="assistant", text="I added focused aggregate count coverage")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "role-count-control")
+            .provider("claude-code")
+            .title("role count control")
+            .add_message("m-control-user", role="user", text="please inspect")
+            .add_message("m-control-assistant", role="assistant", text="short reply")
+            .save()
+        )
+
+        spec = compile_expression("sessions where user_messages >= 2 AND assistant_words between 5 and 8")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-role-count-hit"]
+
     def test_sequence_predicate_executes_in_order_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from tests.infra.storage_records import SessionBuilder
@@ -2850,6 +2880,22 @@ class TestLowererFieldMapping:
         assert spec.max_messages == 20
         assert spec.min_words == 100
         assert spec.max_words == 500
+
+    def test_role_count_comparison_requires_boolean_query(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="supported only inside `sessions where`"):
+            compile_expression("user_messages >= 2")
+
+    def test_boolean_ast_exposes_role_count_comparisons(self) -> None:
+        ast = parse_expression_ast("sessions where user_messages >= 2 AND assistant_words between 5 and 20")
+
+        assert ast.boolean_predicate == QueryBoolPredicate(
+            "and",
+            (
+                QueryFieldPredicate(field="user_messages", values=("2",), op=">="),
+                QueryFieldPredicate(field="assistant_words", values=("5",), op=">="),
+                QueryFieldPredicate(field="assistant_words", values=("20",), op="<="),
+            ),
+        )
 
     def test_readable_count_range_rejects_inverted_bounds(self) -> None:
         with pytest.raises(ExpressionCompileError, match="lower bound 20 is greater than upper bound 5"):

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -3217,6 +3217,36 @@ class TestFieldRegistry:
         "contains": ("contains:foo", "contains_terms", ("foo",)),
         "messages": ("messages:>=10", "min_messages", 10),
         "words": ("words:>=200", "min_words", 200),
+        "user_messages": (
+            "sessions where user_messages >= 2",
+            "boolean_predicate",
+            QueryFieldPredicate(field="user_messages", values=("2",), op=">="),
+        ),
+        "assistant_messages": (
+            "sessions where assistant_messages >= 2",
+            "boolean_predicate",
+            QueryFieldPredicate(field="assistant_messages", values=("2",), op=">="),
+        ),
+        "system_messages": (
+            "sessions where system_messages = 0",
+            "boolean_predicate",
+            QueryFieldPredicate(field="system_messages", values=("0",), op="="),
+        ),
+        "tool_messages": (
+            "sessions where tool_messages = 0",
+            "boolean_predicate",
+            QueryFieldPredicate(field="tool_messages", values=("0",), op="="),
+        ),
+        "user_words": (
+            "sessions where user_words >= 100",
+            "boolean_predicate",
+            QueryFieldPredicate(field="user_words", values=("100",), op=">="),
+        ),
+        "assistant_words": (
+            "sessions where assistant_words >= 500",
+            "boolean_predicate",
+            QueryFieldPredicate(field="assistant_words", values=("500",), op=">="),
+        ),
         "lane": ("lane:dialogue", "retrieval_lane", "dialogue"),
         "lineage": (
             "lineage:id:chatgpt-export:ext-root",

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -42,6 +42,7 @@ from polylogue.archive.query.expression import (
     parse_expression_ast,
     parse_unit_source_expression,
 )
+from polylogue.archive.query.metadata import query_unit_descriptors
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
     QueryExistsPredicate,
@@ -629,6 +630,47 @@ class TestBooleanQueryExpression:
             parse_unit_source_expression(
                 "sessions where repo:polylogue | context-snapshots where boundary:session_start | count"
             )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            descriptor.plural_source
+            for descriptor in query_unit_descriptors(lowerer_kind="sql")
+            if descriptor.aggregate_group_fields
+        ],
+    )
+    def test_descriptor_sql_units_accept_advertised_aggregate_pipeline(self, source: str) -> None:
+        descriptor = next(
+            descriptor
+            for descriptor in query_unit_descriptors(lowerer_kind="sql")
+            if descriptor.plural_source == source
+        )
+        group_field = descriptor.aggregate_group_fields[0]
+
+        parsed = parse_unit_source_expression(
+            f"{source} where {descriptor.fields[0].example} | group by {group_field} | count | sort by count desc"
+        )
+
+        assert parsed is not None
+        assert parsed.unit == descriptor.unit
+        assert parsed.group_by == group_field
+        assert parsed.aggregate == "count"
+        assert parsed.sort is not None
+        assert parsed.sort.field == "count"
+
+    @pytest.mark.parametrize(
+        "source",
+        [descriptor.plural_source for descriptor in query_unit_descriptors(lowerer_kind="runtime_transform")],
+    )
+    def test_descriptor_runtime_transform_units_reject_aggregate_pipeline(self, source: str) -> None:
+        descriptor = next(
+            descriptor
+            for descriptor in query_unit_descriptors(lowerer_kind="runtime_transform")
+            if descriptor.plural_source == source
+        )
+
+        with pytest.raises(ExpressionCompileError, match="runtime-transform units need an aggregate lowerer"):
+            parse_unit_source_expression(f"{source} where {descriptor.fields[0].example} | count")
 
     def test_pipeline_rejects_aggregate_sort_before_count(self) -> None:
         with pytest.raises(ExpressionCompileError, match="require an aggregate `count` stage"):

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -56,14 +56,14 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # ``table_name`` is a closed insight table name; ``any_terms`` is built
     # immediately above from closed ``(column, path)`` fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2704): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2705): (
         "readiness fallback reason counts: closed insight-table + _INSIGHT_FALLBACK_PAYLOAD column/path; values bound"
     ),
     # #1743 readiness fallback reason breakdown:
     #   rows = self._conn.execute(f"... FROM {table_name} ... json_each(... '{path}') ...{clause}")
     # ``table_name``/``column``/``path`` are closed fallback specs; ``clause``
     # values are bound.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2713): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 2714): (
         "readiness fallback reason breakdown: closed insight-table + fallback payload column/path; values bound"
     ),
     # Terminal unit row readers:
@@ -73,19 +73,19 @@ _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     # comes from the shared session filter lowerer; pagination values are bound.
     # ``order_by`` is a closed literal fragment selected from the parsed
     # pipeline sort stage and bounded ASC/DESC tokens.
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3379): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3380): (
         "message query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3467): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3468): (
         "query-unit aggregate counts: closed unit/group/order/session fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3515): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3516): (
         "action query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3582): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3583): (
         "block query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
-    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3654): (
+    ("polylogue/storage/sqlite/archive_tiers/archive.py", 3655): (
         "assertion query rows: structural predicate/session filter/order fragments from lowerers; values bound"
     ),
     # Assertion readers:


### PR DESCRIPTION
## Summary

Adds an executable #2006 query phase for role-split session counts and tightens the terminal pipeline metadata path so descriptor state, parser validation, completions, docs, API envelopes, and storage lowering all agree.

Ref #2006

## Problem

The DSL already supported generic `messages` / `words` comparisons, but common agent-work questions need role-aware counts such as `user_messages >= 2` or `assistant_words between 500 and 2000`. Those fields were not executable through the shared Boolean predicate lowerer. While wiring that, the parser still carried a local hard-coded list of SQL-backed terminal units for pipeline stages even though `QueryUnitDescriptor` already owns lowerer kind and aggregate fields. The Python `search_envelope()` facade also treated its `query` parameter as raw FTS text, so filter-only DSL expressions could compile in parser tests but return no facade hits.

## Solution

- Extends the query metadata/count registry with SQL-backed role-count fields: `user_messages`, `assistant_messages`, `system_messages`, `tool_messages`, `user_words`, and `assistant_words`.
- Extends the Lark-backed Boolean/count grammar and validation so role-count comparisons and ranges execute only inside explicit `sessions where ...` predicates, with compact non-Boolean forms rejected rather than broadened.
- Lowers count predicates in archive SQL through `COUNT_QUERY_FIELD_REGISTRY` instead of bespoke `messages`/`words` branches.
- Makes terminal pipeline validation consult `QueryUnitDescriptor.lowerer_kind` / aggregate metadata instead of maintaining parser-local SQL unit sets.
- Routes `Polylogue.search_envelope()` query strings through the shared DSL compiler, preserving raw text search behavior while allowing filter-only DSL predicates to return session-target search envelopes.
- Updates completions and `docs/search.md` for role-count examples and supported fields.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k "role_count or readable_count or count_range"` -> 9 passed, 293 deselected.
- `nix develop --command devtools test tests/unit/cli/test_command_aux_runtime.py -k "readable_operator_fields or count_operator"` -> 2 passed, 316 deselected.
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k "FieldRegistry or role_count"` -> 56 passed, 246 deselected.
- `nix develop --command devtools test tests/unit/storage/test_no_string_interpolated_sql.py tests/unit/cli/test_query_expression.py -k "audited_sites_are_real_violations or no_unaudited_string_interpolated_sql or FieldRegistry or role_count"` -> 58 passed, 246 deselected.
- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py -k "search_envelope" tests/unit/cli/test_query_expression.py -k "descriptor_sql_units or descriptor_runtime_transform or role_count"` -> 11 passed, 525 deselected.
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py` -> 309 passed.
- `nix develop --command devtools verify --quick` -> exit_code 0.
- `nix develop --command devtools verify` -> 2172 passed, diagnosis `pytest_passed`, exit_code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries now support role-specific message and word count filters (`user_messages`, `assistant_messages`, `system_messages`, `tool_messages`, `user_words`, `assistant_words`) in `sessions where` Boolean queries for advanced filtering.

* **Documentation**
  * Added documentation with example queries demonstrating role-based count comparisons and supported count field predicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->