### PR TITLE
feat(query): support predicate-constrained action sequences (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -55,6 +55,9 @@ predicate          ::= predicate "OR" predicate
                      | "seq" "(" sequence-step "->" sequence-step+ ")"
 
 structural-unit    ::= "message" | "action" | "block" | "assertion"
+sequence-step      ::= action-field-clause ("AND" action-field-clause)*
+action-field-clause ::= "action:" value | "tool:" value | "command:" value
+                      | "path:" value | "output:" value | "text:" value
 pipeline-stage     ::= "sort" "by" "time" ["asc" | "desc"]
                      | "group" "by" field
                      | "count"
@@ -77,7 +80,22 @@ Explicit Boolean session queries also select sessions:
 polylogue sessions where '(repo:polylogue OR repo:sinex) AND NOT tag:stale'
 polylogue sessions where 'exists message(role:assistant AND text:timeout)'
 polylogue sessions where 'seq(action:file_edit -> action:shell)'
+polylogue sessions where 'seq(action:file_edit -> action:shell AND output:failed -> action:file_edit)'
 ```
+
+Sequence predicates match an ordered subsequence of action rows inside a
+session. Each step is an action-unit predicate, so the sequence can describe
+real coding workflows instead of only action categories:
+
+```bash
+polylogue sessions where 'seq(action:file_edit -> action:shell AND output:failed -> action:file_edit)'
+polylogue sessions where 'seq(tool:edit AND path:polylogue/archive -> tool:bash AND command:pytest)'
+```
+
+The SQL lowerer applies every step predicate to its own ordered action row and
+then enforces message/block order between steps. Unsupported fields in a
+sequence step fail typed as action-predicate errors; they do not broaden into a
+plain text search.
 
 Unit queries select terminal rows instead of sessions:
 

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -431,7 +431,8 @@ _QUERY_GRAMMAR = rf"""
         | TIME_FIELD DATE_COMP_OP DATE_VALUE -> time_compare_leaf
         | FIELD_CLAUSE                     -> field_leaf
         | "(" expr ")"
-    sequence_step: FIELD_CLAUSE
+    sequence_step: sequence_atom (AND sequence_atom)*
+    ?sequence_atom: FIELD_CLAUSE                     -> field_leaf
 
     SESSIONS: /sessions/i
     WHERE: /where/i
@@ -815,6 +816,14 @@ def _predicate_children(items: tuple[object, ...]) -> tuple[QueryPredicate, ...]
     )
 
 
+def _sequence_step_has_positive_match(predicate: QueryPredicate) -> bool:
+    if isinstance(predicate, QueryFieldPredicate):
+        return bool(predicate.values)
+    if isinstance(predicate, QueryBoolPredicate):
+        return any(_sequence_step_has_positive_match(child) for child in predicate.children)
+    return False
+
+
 def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["session"] | QueryUnitName) -> None:
     if isinstance(predicate, QueryFieldPredicate):
         session_field = _scoped_session_field(predicate.field)
@@ -953,6 +962,14 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
     if isinstance(predicate, QuerySequencePredicate):
         if unit != "session":
             raise ExpressionCompileError("seq predicates are only supported from sessions", field=None)
+        if len(predicate.steps) < 2:
+            raise ExpressionCompileError("seq() requires at least two action steps", field=None)
+        for step in predicate.steps:
+            _validate_predicate_context(step, unit="action")
+            if not _sequence_step_has_positive_match(step):
+                raise ExpressionCompileError(
+                    "seq() steps must include at least one positive action predicate", field=None
+                )
         return
     if isinstance(predicate, QueryTextPredicate):
         if unit != "session":
@@ -1068,19 +1085,19 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
             unit=cast(Literal["message", "action", "block", "assertion"], unit_value), child=child
         )
 
-    def sequence_step(self, token: Token) -> QueryPredicate:
-        predicate = _field_token_to_predicate(_QUERY_TRANSFORMER.field_clause(token))
-        if not isinstance(predicate, QueryFieldPredicate) or predicate.field != "action" or predicate.op != "=":
-            raise ExpressionCompileError("seq() currently supports action:<kind> steps", field=None)
-        if len(predicate.values) != 1:
-            raise ExpressionCompileError("seq() action steps must name exactly one action", field="action")
-        return predicate
+    def sequence_step(self, *items: object) -> QueryPredicate:
+        predicates = _predicate_children(items)
+        if not predicates:
+            raise ExpressionCompileError("seq() steps require at least one action predicate", field=None)
+        if len(predicates) == 1:
+            return predicates[0]
+        return QueryBoolPredicate(op="and", children=predicates)
 
     def sequence_leaf(self, _seq: Token, *items: object) -> QueryPredicate:
-        steps = [item for item in items if isinstance(item, QueryFieldPredicate)]
+        steps = _predicate_children(items)
         if len(steps) < 2:
             raise ExpressionCompileError("seq() requires at least two action steps", field=None)
-        return QuerySequencePredicate(action_terms=tuple(step.values[0] for step in steps))
+        return QuerySequencePredicate(steps=steps)
 
 
 _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -57,10 +57,43 @@ class QueryExistsPredicate:
 class QuerySequencePredicate:
     """Ordered action-sequence predicate over a session."""
 
-    action_terms: tuple[str, ...]
+    steps: tuple[QueryPredicate, ...] = ()
+    action_terms: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.steps and self.action_terms:
+            object.__setattr__(
+                self,
+                "steps",
+                tuple(QueryFieldPredicate(field="action", values=(term,), op="=") for term in self.action_terms),
+            )
+        elif self.steps and not self.action_terms:
+            object.__setattr__(self, "action_terms", _simple_sequence_action_terms(self.steps))
 
     def to_payload(self) -> dict[str, object]:
-        return {"kind": "sequence", "unit": "action", "actions": list(self.action_terms)}
+        payload: dict[str, object] = {
+            "kind": "sequence",
+            "unit": "action",
+            "steps": [step.to_payload() for step in self.steps],
+        }
+        if self.action_terms:
+            payload["actions"] = list(self.action_terms)
+        return payload
+
+
+def _simple_sequence_action_terms(steps: tuple[QueryPredicate, ...]) -> tuple[str, ...]:
+    terms: list[str] = []
+    for step in steps:
+        if (
+            isinstance(step, QueryFieldPredicate)
+            and step.field == "action"
+            and step.op == "="
+            and len(step.values) == 1
+        ):
+            terms.append(step.values[0])
+            continue
+        return ()
+    return tuple(terms)
 
 
 @dataclass(frozen=True)

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -61,14 +61,14 @@ class QuerySequencePredicate:
     action_terms: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if not self.steps and self.action_terms:
+        if self.steps:
+            object.__setattr__(self, "action_terms", _simple_sequence_action_terms(self.steps))
+        elif self.action_terms:
             object.__setattr__(
                 self,
                 "steps",
                 tuple(QueryFieldPredicate(field="action", values=(term,), op="=") for term in self.action_terms),
             )
-        elif self.steps and not self.action_terms:
-            object.__setattr__(self, "action_terms", _simple_sequence_action_terms(self.steps))
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {

--- a/polylogue/archive/query/runtime_matching.py
+++ b/polylogue/archive/query/runtime_matching.py
@@ -123,7 +123,7 @@ def _matches_action_field(predicate: QueryFieldPredicate, action: Action) -> boo
         return _matches_text(action.command, values)
     if predicate.field == "path":
         normalized_paths = tuple(path.lower().replace("\\", "/") for path in action.affected_paths)
-        return all(any(value.replace("\\", "/") in path for path in normalized_paths) for value in values)
+        return any(value.replace("\\", "/") in path for value in values for path in normalized_paths)
     if predicate.field == "output":
         return _matches_text(action.output_text, values)
     if predicate.field == "text":
@@ -138,7 +138,7 @@ def _matches_exact_values(value: str | None, expected: tuple[str, ...]) -> bool:
 
 def _matches_text(value: str | None, expected: tuple[str, ...]) -> bool:
     normalized = (value or "").lower().replace("\\", "/")
-    return all(term.replace("\\", "/") in normalized for term in expected)
+    return any(term.replace("\\", "/") in normalized for term in expected)
 
 
 def matches_action_text_terms(plan: SessionQueryPlan, session: Session) -> bool:

--- a/polylogue/archive/query/runtime_matching.py
+++ b/polylogue/archive/query/runtime_matching.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polylogue.archive.query.predicate import (
+    QueryBoolPredicate,
+    QueryFieldPredicate,
+    QueryNotPredicate,
+    QueryPredicate,
+)
+
 if TYPE_CHECKING:
     from polylogue.archive.actions.actions import Action
     from polylogue.archive.models import Session
@@ -74,6 +81,66 @@ def matches_action_sequence(plan: SessionQueryPlan, session: Session) -> bool:
     return False
 
 
+def matches_action_predicate_sequence(steps: tuple[QueryPredicate, ...], session: Session) -> bool:
+    if not steps:
+        return True
+    actions = _actions_for(session)
+    if not actions:
+        return False
+
+    index = 0
+    target_count = len(steps)
+    for action in actions:
+        if not _matches_action_predicate(steps[index], action):
+            continue
+        index += 1
+        if index >= target_count:
+            return True
+    return False
+
+
+def _matches_action_predicate(predicate: QueryPredicate, action: Action) -> bool:
+    if isinstance(predicate, QueryFieldPredicate):
+        return _matches_action_field(predicate, action)
+    if isinstance(predicate, QueryNotPredicate):
+        return not _matches_action_predicate(predicate.child, action)
+    if isinstance(predicate, QueryBoolPredicate):
+        if predicate.op == "or":
+            return any(_matches_action_predicate(child, action) for child in predicate.children)
+        return all(_matches_action_predicate(child, action) for child in predicate.children)
+    return False
+
+
+def _matches_action_field(predicate: QueryFieldPredicate, action: Action) -> bool:
+    values = tuple(value.strip().lower() for value in predicate.values if value.strip())
+    if not values:
+        return False
+    if predicate.field in {"action", "type"}:
+        return _matches_exact_values(action.kind.value, values)
+    if predicate.field == "tool":
+        return _matches_exact_values(action.normalized_tool_name, values)
+    if predicate.field == "command":
+        return _matches_text(action.command, values)
+    if predicate.field == "path":
+        normalized_paths = tuple(path.lower().replace("\\", "/") for path in action.affected_paths)
+        return all(any(value.replace("\\", "/") in path for path in normalized_paths) for value in values)
+    if predicate.field == "output":
+        return _matches_text(action.output_text, values)
+    if predicate.field == "text":
+        return _matches_text(action.search_text, values)
+    return False
+
+
+def _matches_exact_values(value: str | None, expected: tuple[str, ...]) -> bool:
+    normalized = (value or "").strip().lower()
+    return normalized in expected
+
+
+def _matches_text(value: str | None, expected: tuple[str, ...]) -> bool:
+    normalized = (value or "").lower().replace("\\", "/")
+    return all(term.replace("\\", "/") in normalized for term in expected)
+
+
 def matches_action_text_terms(plan: SessionQueryPlan, session: Session) -> bool:
     if not plan.action_text_terms:
         return True
@@ -84,6 +151,7 @@ def matches_action_text_terms(plan: SessionQueryPlan, session: Session) -> bool:
 
 
 __all__ = [
+    "matches_action_predicate_sequence",
     "matches_action_sequence",
     "matches_action_terms",
     "matches_action_text_terms",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5187,6 +5187,8 @@ def _boolean_predicate_clause(
     if isinstance(predicate, QueryExistsPredicate):
         return _exists_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QuerySequencePredicate):
+        if len(predicate.steps) < 2:
+            raise ValueError("action sequence predicates require at least two steps")
         return _action_sequence_steps_clause(table_alias, predicate.steps)
     if isinstance(predicate, QueryTextPredicate):
         return _fts_predicate_clause(table_alias, predicate)
@@ -5516,8 +5518,6 @@ def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate,
     joins: list[str] = []
     predicates: list[str] = []
     params: list[object] = []
-    if len(steps) < 2:
-        raise ValueError("action sequence predicates require at least two steps")
     for index, step in enumerate(steps):
         action_alias = f"seq_a{index}"
         message_alias = f"seq_m{index}"

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5187,7 +5187,7 @@ def _boolean_predicate_clause(
     if isinstance(predicate, QueryExistsPredicate):
         return _exists_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QuerySequencePredicate):
-        return _action_sequence_clause(table_alias, predicate.action_terms)
+        return _action_sequence_steps_clause(table_alias, predicate.steps)
     if isinstance(predicate, QueryTextPredicate):
         return _fts_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QueryLineagePredicate):
@@ -5506,10 +5506,19 @@ def _session_filter_clause(
 
 
 def _action_sequence_clause(table_alias: str, action_sequence: tuple[str, ...]) -> tuple[str, list[object]]:
+    steps = tuple(
+        QueryFieldPredicate(field="action", values=(term,), op="=") for term in action_sequence if term.strip()
+    )
+    return _action_sequence_steps_clause(table_alias, steps)
+
+
+def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate, ...]) -> tuple[str, list[object]]:
     joins: list[str] = []
     predicates: list[str] = []
     params: list[object] = []
-    for index, term in enumerate(action_sequence):
+    if len(steps) < 2:
+        raise ValueError("action sequence predicates require at least two steps")
+    for index, step in enumerate(steps):
         action_alias = f"seq_a{index}"
         message_alias = f"seq_m{index}"
         block_alias = f"seq_b{index}"
@@ -5523,8 +5532,10 @@ def _action_sequence_clause(table_alias: str, action_sequence: tuple[str, ...]) 
               ON {block_alias}.block_id = {action_alias}.tool_use_block_id
             """.strip()
         )
-        predicates.append(f"{action_alias}.semantic_type = ?")
-        params.append(term)
+        step_clause, step_params = _structural_predicate_clause("action", action_alias, step, session_alias=table_alias)
+        if step_clause:
+            predicates.append(f"({step_clause})")
+            params.extend(step_params)
         if index > 0:
             predicates.append(_action_after_predicate(index - 1, index))
     sql = (

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5532,7 +5532,7 @@ def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate,
               ON {block_alias}.block_id = {action_alias}.tool_use_block_id
             """.strip()
         )
-        step_clause, step_params = _structural_predicate_clause("action", action_alias, step, session_alias=table_alias)
+        step_clause, step_params = _structural_predicate_clause("action", action_alias, step)
         if step_clause:
             predicates.append(f"({step_clause})")
             params.extend(step_params)

--- a/tests/unit/archive/test_query_runtime_matching.py
+++ b/tests/unit/archive/test_query_runtime_matching.py
@@ -7,7 +7,9 @@ import pytest
 from polylogue.archive.actions.actions import Action
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.query.plan import SessionQueryPlan
+from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate
 from polylogue.archive.query.runtime_matching import (
+    matches_action_predicate_sequence,
     matches_action_sequence,
     matches_action_terms,
     matches_action_text_terms,
@@ -33,6 +35,8 @@ def _event(
     *,
     tool_name: str = "unknown",
     affected_paths: tuple[str, ...] = (),
+    command: str | None = None,
+    output_text: str | None = None,
     search_text: str = "",
     index: int = 0,
 ) -> Action:
@@ -48,11 +52,12 @@ def _event(
         affected_paths=affected_paths,
         cwd_path=None,
         branch_names=(),
-        command=None,
+        command=command,
         query=None,
         url=None,
-        output_text=None,
-        search_text=search_text,
+        output_text=output_text,
+        search_text=search_text
+        or " ".join(part for part in (kind.value, tool_name, command, output_text, *affected_paths) if part),
         raw={},
     )
 
@@ -118,3 +123,43 @@ def test_matches_action_sequence_and_search_text(monkeypatch: pytest.MonkeyPatch
     assert matches_action_sequence(SessionQueryPlan(action_sequence=("shell", "search")), session) is False
     assert matches_action_text_terms(SessionQueryPlan(action_text_terms=("schema", "pytest")), session) is True
     assert matches_action_text_terms(SessionQueryPlan(action_text_terms=("deployment",)), session) is False
+
+
+def test_matches_action_predicate_sequence_filters_step_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session()
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.FILE_EDIT, tool_name="Edit", affected_paths=("polylogue/archive/query/expression.py",)),
+            _event(
+                ToolCategory.SHELL, tool_name="Bash", command="pytest", output_text="FAILED test_query_expression.py"
+            ),
+            _event(ToolCategory.FILE_EDIT, tool_name="Edit", affected_paths=("polylogue/archive/query/expression.py",)),
+        ),
+    )
+    steps = (
+        QueryFieldPredicate(field="action", values=("file_edit",)),
+        QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="tool", values=("bash",)),
+                QueryFieldPredicate(field="output", values=("failed",)),
+            ),
+        ),
+        QueryFieldPredicate(field="path", values=("archive/query",)),
+    )
+
+    assert matches_action_predicate_sequence(steps, session) is True
+
+    missed_steps = (
+        QueryFieldPredicate(field="action", values=("file_edit",)),
+        QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="tool", values=("bash",)),
+                QueryFieldPredicate(field="output", values=("passed",)),
+            ),
+        ),
+        QueryFieldPredicate(field="path", values=("archive/query",)),
+    )
+    assert matches_action_predicate_sequence(missed_steps, session) is False

--- a/tests/unit/archive/test_query_runtime_matching.py
+++ b/tests/unit/archive/test_query_runtime_matching.py
@@ -163,3 +163,35 @@ def test_matches_action_predicate_sequence_filters_step_fields(monkeypatch: pyte
         QueryFieldPredicate(field="path", values=("archive/query",)),
     )
     assert matches_action_predicate_sequence(missed_steps, session) is False
+
+
+def test_matches_action_predicate_sequence_treats_field_values_as_alternatives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session()
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.FILE_EDIT, tool_name="Edit", affected_paths=("polylogue/archive/query/expression.py",)),
+            _event(
+                ToolCategory.SHELL,
+                tool_name="Bash",
+                command="pytest tests/unit/cli/test_query_expression.py",
+                output_text="FAILED test_query_expression.py",
+            ),
+            _event(ToolCategory.FILE_EDIT, tool_name="Edit", affected_paths=("polylogue/archive/query/expression.py",)),
+        ),
+    )
+    steps = (
+        QueryFieldPredicate(field="action", values=("file_edit",)),
+        QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryFieldPredicate(field="command", values=("ruff", "pytest")),
+                QueryFieldPredicate(field="output", values=("error", "failed")),
+            ),
+        ),
+        QueryFieldPredicate(field="path", values=("missing/path", "archive/query")),
+    )
+
+    assert matches_action_predicate_sequence(steps, session) is True

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -2819,6 +2819,57 @@ class TestBooleanQueryExpression:
 
         assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
 
+    def test_single_action_sequence_filter_still_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "shell-hit")
+            .provider("claude-code")
+            .title("shell action")
+            .add_message(
+                "m-shell",
+                role="assistant",
+                text="test",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "tool-shell",
+                        "input": {"command": "pytest tests/unit/cli/test_query_expression.py"},
+                        "semantic_type": "shell",
+                    }
+                ],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "edit-miss")
+            .provider("claude-code")
+            .title("edit action")
+            .add_message(
+                "m-edit",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-edit",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, action_sequence=("shell",))
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-shell-hit"]
+
     def test_sequence_predicate_filters_step_fields_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from tests.infra.storage_records import SessionBuilder

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -244,11 +244,26 @@ class TestExplainExpression:
 
     def test_explain_expression_reports_semantic_and_sequence_legs(self) -> None:
         semantic = explain_expression('sessions where semantic:"query compiler" AND title:hit')
-        sequence = explain_expression("sessions where seq(action:file_edit -> action:shell)")
+        sequence = explain_expression("sessions where seq(action:file_edit -> action:shell AND output:failed)")
 
         assert semantic.execution_legs == ("sql", "vector")
         assert sequence.selected_units == ("action", "session")
         assert sequence.execution_legs == ("sequence-action",)
+        assert sequence.predicate is not None
+        assert sequence.predicate.to_payload() == {
+            "kind": "sequence",
+            "unit": "action",
+            "steps": [
+                {"kind": "field", "field": "action", "op": "=", "values": ["file_edit"]},
+                {
+                    "kind": "and",
+                    "children": [
+                        {"kind": "field", "field": "action", "op": "=", "values": ["shell"]},
+                        {"kind": "field", "field": "output", "op": "=", "values": ["failed"]},
+                    ],
+                },
+            ],
+        }
 
     def test_explain_expression_reports_terminal_unit_source(self) -> None:
         explanation = explain_expression("messages where role:assistant AND text:timeout")
@@ -866,6 +881,27 @@ class TestBooleanQueryExpression:
         ast = parse_expression_ast("seq(action:file_edit -> action:shell -> action:file_edit)")
 
         assert ast.boolean_predicate == QuerySequencePredicate(action_terms=("file_edit", "shell", "file_edit"))
+
+    def test_sequence_ast_exposes_step_predicates(self) -> None:
+        ast = parse_expression_ast("seq(action:file_edit -> action:shell AND output:failed -> action:file_edit)")
+
+        assert ast.boolean_predicate == QuerySequencePredicate(
+            steps=(
+                QueryFieldPredicate(field="action", values=("file_edit",)),
+                QueryBoolPredicate(
+                    op="and",
+                    children=(
+                        QueryFieldPredicate(field="action", values=("shell",)),
+                        QueryFieldPredicate(field="output", values=("failed",)),
+                    ),
+                ),
+                QueryFieldPredicate(field="action", values=("file_edit",)),
+            ),
+        )
+
+    def test_sequence_step_rejects_session_fields(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="not supported for action predicates"):
+            compile_expression("seq(action:file_edit -> repo:polylogue)")
 
     def test_fts_ast_exposes_text_predicate(self) -> None:
         ast = parse_expression_ast('repo:polylogue AND ~"timeout failure"')
@@ -2782,6 +2818,121 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
+
+    def test_sequence_predicate_filters_step_fields_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "failed-cycle")
+            .provider("claude-code")
+            .title("failed test edit cycle")
+            .add_message(
+                "m-failed-1",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "edit-hit-1",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
+                "m-failed-2",
+                role="assistant",
+                text="test failed",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "bash-hit-1",
+                        "input": {"command": "pytest tests/unit/cli/test_query_expression.py"},
+                        "semantic_type": "shell",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": "bash-hit-1",
+                        "text": "FAILED tests/unit/cli/test_query_expression.py::test_sequence",
+                    },
+                ],
+            )
+            .add_message(
+                "m-failed-3",
+                role="assistant",
+                text="fix",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "edit-hit-2",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "passed-cycle")
+            .provider("claude-code")
+            .title("passed test edit cycle")
+            .add_message(
+                "m-passed-1",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "edit-miss-1",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
+                "m-passed-2",
+                role="assistant",
+                text="test passed",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "bash-miss-1",
+                        "input": {"command": "pytest tests/unit/cli/test_query_expression.py"},
+                        "semantic_type": "shell",
+                    },
+                    {"type": "tool_result", "tool_id": "bash-miss-1", "text": "1 passed"},
+                ],
+            )
+            .add_message(
+                "m-passed-3",
+                role="assistant",
+                text="fix",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "edit-miss-2",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        spec = compile_expression("seq(action:file_edit -> action:shell AND output:failed -> action:file_edit)")
+        assert spec.boolean_predicate is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["claude-code-session:ext-failed-cycle"]
 
     def test_fts_predicate_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -882,6 +882,18 @@ class TestBooleanQueryExpression:
 
         assert ast.boolean_predicate == QuerySequencePredicate(action_terms=("file_edit", "shell", "file_edit"))
 
+    def test_sequence_predicate_derives_action_terms_from_steps_when_both_are_supplied(self) -> None:
+        predicate = QuerySequencePredicate(
+            steps=(
+                QueryFieldPredicate(field="action", values=("file_edit",)),
+                QueryFieldPredicate(field="action", values=("shell",)),
+            ),
+            action_terms=("conflicting",),
+        )
+
+        assert predicate.action_terms == ("file_edit", "shell")
+        assert predicate.to_payload()["actions"] == ["file_edit", "shell"]
+
     def test_sequence_ast_exposes_step_predicates(self) -> None:
         ast = parse_expression_ast("seq(action:file_edit -> action:shell AND output:failed -> action:file_edit)")
 


### PR DESCRIPTION
## Summary

Adds executable predicate-constrained `seq(...)` steps for the shared query DSL. Sequence predicates can now express ordered coding workflows such as edit -> failing test -> edit by matching action fields per ordered step, rather than only matching bare action categories.

## Problem

#2006 already had `seq(action:file_edit -> action:shell)`, but each step was limited to a single `action:<kind>` token. That meant a query for a real workflow like a failed test cycle had to approximate the failure as a generic shell action, which made the sequence predicate too broad for evidence-cockpit use.

## Solution

- Extends `QuerySequencePredicate` with typed step predicates while preserving `action_terms` compatibility for existing `--action-sequence`/plan paths.
- Parses sequence steps as action-unit field predicates joined by `AND`, e.g. `action:shell AND output:failed`.
- Lowers each ordered step through the existing action structural predicate lowerer, then enforces message/block order between matched actions.
- Adds runtime matcher parity for predicate-constrained action sequences.
- Documents the executable sequence-step field surface in `docs/search.md`.
- Adds parser, explain-payload, archive execution, and runtime matching coverage.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/archive/test_query_runtime_matching.py -k 'sequence or explain_expression_reports_semantic' -q` -> `8 passed, 321 deselected`.
- `nix develop --command devtools test tests/unit/cli/test_query_expression.py tests/unit/archive/test_query_runtime_matching.py -q` -> `329 passed`.
- `nix develop --command devtools verify --quick` -> `exit_code: 0`.
- `nix develop --command devtools verify` -> `2054 passed`, diagnosis `pytest_passed`, peak pytest tree RSS `1858.5 MiB`.

Closes part of #2006.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sequence predicates now support multiple field constraints per step (e.g., `tool:`, `output:`, `path:`), enabling more precise action-sequence filtering.

* **Documentation**
  * Updated documentation with explicit grammar and examples demonstrating multi-field constraints in sequence predicates.

* **Tests**
  * Expanded test coverage for sequence predicate field matching and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->