### PR TITLE
test: surface slow pytest nodes in task stats

### DIFF
--- a/devtools/task_history.py
+++ b/devtools/task_history.py
@@ -315,10 +315,7 @@ def _phase_duration(value: object) -> float:
     return float(duration) if isinstance(duration, (int, float)) else 0.0
 
 
-def _latest_pytest_slow_tests(limit: int) -> list[dict[str, Any]]:
-    if limit <= 0:
-        return []
-    report_path = _get_root() / ".cache" / "verify" / "last-pytest.json"
+def _slow_test_rows_from_report(report_path: Path) -> list[dict[str, Any]]:
     try:
         payload = json.loads(report_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -348,8 +345,19 @@ def _latest_pytest_slow_tests(limit: int) -> list[dict[str, Any]]:
                 "call_s": round(call_s, 4),
                 "teardown_s": round(teardown_s, 4),
                 "outcome": item.get("outcome"),
+                "report": report_path.name,
             }
         )
+    return rows
+
+
+def _latest_pytest_slow_tests(limit: int) -> list[dict[str, Any]]:
+    if limit <= 0:
+        return []
+    rows: list[dict[str, Any]] = []
+    verify_dir = _get_root() / ".cache" / "verify"
+    for name in ("last-pytest.json", "last-pytest-isolated.json"):
+        rows.extend(_slow_test_rows_from_report(verify_dir / name))
     rows.sort(key=lambda row: float(row["total_s"]), reverse=True)
     return rows[:limit]
 
@@ -451,6 +459,7 @@ def _cmd_stats(args: argparse.Namespace) -> int:
                 f"setup={test['setup_s']:.2f}s "
                 f"call={test['call_s']:.2f}s "
                 f"teardown={test['teardown_s']:.2f}s "
+                f"report={test['report']} "
                 f"{test['nodeid']}"
             )
     if slowest:
@@ -654,7 +663,7 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=0,
         metavar="N",
-        help="Include the N slowest tests from .cache/verify/last-pytest.json.",
+        help="Include the N slowest tests from the latest pytest JSON reports.",
     )
 
     replay_parser = subparsers.add_parser("replay", help="Re-run the Nth most recent task (default 1).")

--- a/devtools/task_history.py
+++ b/devtools/task_history.py
@@ -308,6 +308,52 @@ def _class_distributions(tasks: list[TaskRecord]) -> dict[str, dict[str, float]]
     }
 
 
+def _phase_duration(value: object) -> float:
+    if not isinstance(value, dict):
+        return 0.0
+    duration = value.get("duration")
+    return float(duration) if isinstance(duration, (int, float)) else 0.0
+
+
+def _latest_pytest_slow_tests(limit: int) -> list[dict[str, Any]]:
+    if limit <= 0:
+        return []
+    report_path = _get_root() / ".cache" / "verify" / "last-pytest.json"
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    tests = payload.get("tests")
+    if not isinstance(tests, list):
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for item in tests:
+        if not isinstance(item, dict):
+            continue
+        nodeid = item.get("nodeid")
+        if not isinstance(nodeid, str):
+            continue
+        setup_s = _phase_duration(item.get("setup"))
+        call_s = _phase_duration(item.get("call"))
+        teardown_s = _phase_duration(item.get("teardown"))
+        total_s = setup_s + call_s + teardown_s
+        if total_s <= 0:
+            continue
+        rows.append(
+            {
+                "nodeid": nodeid,
+                "total_s": round(total_s, 4),
+                "setup_s": round(setup_s, 4),
+                "call_s": round(call_s, 4),
+                "teardown_s": round(teardown_s, 4),
+                "outcome": item.get("outcome"),
+            }
+        )
+    rows.sort(key=lambda row: float(row["total_s"]), reverse=True)
+    return rows[:limit]
+
+
 def _cmd_stats(args: argparse.Namespace) -> int:
     tasks = _read_tasks()
     if not tasks:
@@ -357,6 +403,9 @@ def _cmd_stats(args: argparse.Namespace) -> int:
             "peak_rss_mb_max": max(peaks),
             "peak_rss_mb_p95": _percentile(peaks, 95),
         }
+    slow_tests = _latest_pytest_slow_tests(args.slow_tests)
+    if slow_tests:
+        stats["slow_tests"] = slow_tests
 
     slowest: list[TaskRecord] = []
     if args.slowest and args.slowest > 0:
@@ -394,6 +443,16 @@ def _cmd_stats(args: argparse.Namespace) -> int:
             f"peak_rss_max={res['peak_rss_mb_max']:.1f}MiB "
             f"peak_rss_p95={res['peak_rss_mb_p95']:.1f}MiB"
         )
+    if slow_tests:
+        print(f"slow tests from latest pytest report ({len(slow_tests)}):")
+        for test in slow_tests:
+            print(
+                f"  {test['total_s']:.2f}s "
+                f"setup={test['setup_s']:.2f}s "
+                f"call={test['call_s']:.2f}s "
+                f"teardown={test['teardown_s']:.2f}s "
+                f"{test['nodeid']}"
+            )
     if slowest:
         print(f"slowest {len(slowest)}:")
         for task in slowest:
@@ -589,6 +648,13 @@ def main(argv: list[str] | None = None) -> int:
         "--resources",
         action="store_true",
         help="Add pytest resource distributions when verify/test records carry them.",
+    )
+    stats_parser.add_argument(
+        "--slow-tests",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Include the N slowest tests from .cache/verify/last-pytest.json.",
     )
 
     replay_parser = subparsers.add_parser("replay", help="Re-run the Nth most recent task (default 1).")

--- a/tests/unit/devtools/test_task_history.py
+++ b/tests/unit/devtools/test_task_history.py
@@ -197,6 +197,22 @@ def test_stats_slow_tests_reads_latest_pytest_report(
         ),
         encoding="utf-8",
     )
+    (verify_cache / "last-pytest-isolated.json").write_text(
+        json.dumps(
+            {
+                "tests": [
+                    {
+                        "nodeid": "tests/test_isolated.py::test_isolated",
+                        "outcome": "passed",
+                        "setup": {"duration": 0.5},
+                        "call": {"duration": 4.0},
+                        "teardown": {"duration": 0.25},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr("devtools.task_history._get_root", lambda: tmp_path)
     task_history.record_invocation(command="verify", args=[], duration_ms=100.0, exit_code=0)
 
@@ -205,12 +221,13 @@ def test_stats_slow_tests_reads_latest_pytest_report(
 
     assert payload["slow_tests"] == [
         {
-            "call_s": 2.0,
-            "nodeid": "tests/test_slow.py::test_slow",
+            "call_s": 4.0,
+            "nodeid": "tests/test_isolated.py::test_isolated",
             "outcome": "passed",
-            "setup_s": 1.0,
-            "teardown_s": 0.5,
-            "total_s": 3.5,
+            "report": "last-pytest-isolated.json",
+            "setup_s": 0.5,
+            "teardown_s": 0.25,
+            "total_s": 4.75,
         }
     ]
 

--- a/tests/unit/devtools/test_task_history.py
+++ b/tests/unit/devtools/test_task_history.py
@@ -166,6 +166,55 @@ def test_stats_resources_reports_peak_distribution(
     assert payload["resources"]["peak_rss_mb_max"] == 100.0
 
 
+def test_stats_slow_tests_reads_latest_pytest_report(
+    isolated_task_history_file: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    verify_cache = tmp_path / ".cache" / "verify"
+    verify_cache.mkdir(parents=True)
+    (verify_cache / "last-pytest.json").write_text(
+        json.dumps(
+            {
+                "tests": [
+                    {
+                        "nodeid": "tests/test_fast.py::test_fast",
+                        "outcome": "passed",
+                        "setup": {"duration": 0.1},
+                        "call": {"duration": 0.2},
+                        "teardown": {"duration": 0.1},
+                    },
+                    {
+                        "nodeid": "tests/test_slow.py::test_slow",
+                        "outcome": "passed",
+                        "setup": {"duration": 1.0},
+                        "call": {"duration": 2.0},
+                        "teardown": {"duration": 0.5},
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("devtools.task_history._get_root", lambda: tmp_path)
+    task_history.record_invocation(command="verify", args=[], duration_ms=100.0, exit_code=0)
+
+    assert task_history.main(["stats", "--slow-tests", "1", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["slow_tests"] == [
+        {
+            "call_s": 2.0,
+            "nodeid": "tests/test_slow.py::test_slow",
+            "outcome": "passed",
+            "setup_s": 1.0,
+            "teardown_s": 0.5,
+            "total_s": 3.5,
+        }
+    ]
+
+
 # ---------------------------------------------------------------------------
 # budget
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_tree_laws.py
+++ b/tests/unit/storage/test_tree_laws.py
@@ -39,6 +39,7 @@ from tests.infra.strategies.storage import (
 # keep that single-graph assumption true under archive semantics, every spec in a
 # generated graph is pinned to one provider before seeding.
 _GRAPH_PROVIDER = "claude-ai"
+_ARCHIVE_GRAPH_EXAMPLES = 8
 
 
 def _uniform_provider(specs: tuple[SessionSpec, ...]) -> tuple[SessionSpec, ...]:
@@ -85,7 +86,9 @@ async def _root_of(plg: Polylogue, session_id: str) -> Session:
 
 
 @given(session_graph_strategy(min_sessions=2, max_sessions=6))
-@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=_ARCHIVE_GRAPH_EXAMPLES, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
 async def test_get_root_returns_node_without_parent(tmp_path: Path, specs: tuple[SessionSpec, ...]) -> None:
     """The resolved root of each node is itself parentless."""
     archive_root = tmp_path / f"tree-{uuid.uuid4().hex}"
@@ -101,7 +104,9 @@ async def test_get_root_returns_node_without_parent(tmp_path: Path, specs: tuple
 
 
 @given(session_graph_strategy(min_sessions=2, max_sessions=6))
-@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=_ARCHIVE_GRAPH_EXAMPLES, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
 async def test_get_root_matches_expected(tmp_path: Path, specs: tuple[SessionSpec, ...]) -> None:
     """The resolved root for each node matches the strategy's expected root."""
     archive_root = tmp_path / f"tree-{uuid.uuid4().hex}"
@@ -120,7 +125,9 @@ async def test_get_root_matches_expected(tmp_path: Path, specs: tuple[SessionSpe
 
 
 @given(session_graph_strategy(min_sessions=2, max_sessions=6))
-@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=_ARCHIVE_GRAPH_EXAMPLES, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
 async def test_tree_ids_match_expected(tmp_path: Path, specs: tuple[SessionSpec, ...]) -> None:
     """The full tree reachable from each node matches expected_tree_ids."""
     archive_root = tmp_path / f"tree-{uuid.uuid4().hex}"
@@ -143,7 +150,9 @@ def _expected_indices(specs: tuple[SessionSpec, ...], index: int) -> set[int]:
 
 
 @given(session_graph_strategy(min_sessions=2, max_sessions=6))
-@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=_ARCHIVE_GRAPH_EXAMPLES, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture]
+)
 async def test_sorted_ids_match_expected(tmp_path: Path, specs: tuple[SessionSpec, ...]) -> None:
     """list_sessions returns sessions in expected sort order."""
     archive_root = tmp_path / f"tree-{uuid.uuid4().hex}"


### PR DESCRIPTION
## Summary

Adds a small operator-facing report for slow pytest nodes and trims repeated work from the archive tree-law property tests. `devtools workspace tasks stats --slow-tests N` now reads the latest pytest JSON report and prints the slowest node IDs with setup/call/teardown timing splits.

## Problem

The verify harness already records per-test timing and resource data, but the useful answer to “what am I waiting on?” still required hand-parsing `.cache/verify/last-pytest.json`. The latest broad #2006 verify also showed four archive tree-law property tests taking about a minute each, mostly from repeated archive seeding over the same graph-law shape.

## Solution

`devtools.task_history` now exposes slow-test rows in both text and JSON stats output when requested with `--slow-tests`. The tree-law tests keep their existing Hypothesis graph strategy and graph sizes, but the four expensive archive-backed laws run fewer repeated examples; the separate short-prefix property keeps its existing budget.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_tree_laws.py -q` -> `5 passed in 91.32s`
- `nix develop --command devtools test tests/unit/devtools/test_task_history.py -q` -> `35 passed in 1.12s`
- `nix develop --command devtools workspace tasks stats --resources --slow-tests 8`
- `nix develop --command devtools verify --quick` -> exit 0