### PR TITLE
fix(schema): scope action result joins by session

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ over the `CREATE TABLE` statement.
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 1` |
-| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 3` |
+| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 4` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 1` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 1` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from polylogue.core.enums import BlockType, BranchType, LinkType, MessageType, Origin, PasteBoundary, Role
 from polylogue.storage.sqlite.archive_tiers.common import CONTENT_HASH_CHECK, check, nullable_check
 
-INDEX_SCHEMA_VERSION = 3
+INDEX_SCHEMA_VERSION = 4
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -183,6 +183,7 @@ SELECT
 FROM blocks u
 LEFT JOIN blocks r
     ON r.tool_id = u.tool_id
+   AND r.session_id = u.session_id
    AND r.block_type = 'tool_result'
 WHERE u.block_type = 'tool_use';
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -18,6 +18,7 @@ from polylogue.daemon.convergence import ConvergenceStage
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from tests.infra.frozen_clock import FrozenClock
@@ -119,7 +120,7 @@ def test_polylogued_status_json_reports_archive_storage(tmp_path: Path) -> None:
     tiers = cast(list[dict[str, object]], storage["tiers"])
     assert {tier["name"]: tier["user_version"] for tier in tiers} == {
         "source": 1,
-        "index": 3,
+        "index": INDEX_SCHEMA_VERSION,
         "embeddings": 1,
         "user": USER_SCHEMA_VERSION,
         "ops": 1,

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -21,6 +21,7 @@ from polylogue.sources.live.batch_support import (
     _parse_path_as_session_artifact,
 )
 from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 
 
@@ -189,7 +190,10 @@ def test_full_ingest_writes_archive_with_route_observability(
         "archive_bootstrapped": False,
         "archive_present_tiers": "source,index,ops",
         "archive_missing_tiers": "embeddings,user",
-        "archive_tier_user_versions_json": ('{"embeddings": null, "index": 3, "ops": 1, "source": 1, "user": null}'),
+        "archive_tier_user_versions_json": json.dumps(
+            {"embeddings": None, "index": INDEX_SCHEMA_VERSION, "ops": 1, "source": 1, "user": None},
+            sort_keys=True,
+        ),
     }
     write_event = next(payload for phase, payload in stage_events if phase == "full_archive_write")
     assert write_event == {
@@ -278,7 +282,10 @@ def test_streaming_full_ingest_writes_archive_from_blob(
         "archive_bootstrapped": False,
         "archive_present_tiers": "source,index,ops",
         "archive_missing_tiers": "embeddings,user",
-        "archive_tier_user_versions_json": ('{"embeddings": null, "index": 3, "ops": 1, "source": 1, "user": null}'),
+        "archive_tier_user_versions_json": json.dumps(
+            {"embeddings": None, "index": INDEX_SCHEMA_VERSION, "ops": 1, "source": 1, "user": None},
+            sort_keys=True,
+        ),
     }
     write_event = next(payload for phase, payload in stage_events if phase == "full_archive_write")
     assert write_event == {
@@ -352,7 +359,7 @@ def test_full_ingest_bootstraps_archive_root(
         "archive_present_tiers": "source,index,embeddings,user,ops",
         "archive_missing_tiers": "",
         "archive_tier_user_versions_json": json.dumps(
-            {"embeddings": 1, "index": 3, "ops": 1, "source": 1, "user": USER_SCHEMA_VERSION},
+            {"embeddings": 1, "index": INDEX_SCHEMA_VERSION, "ops": 1, "source": 1, "user": USER_SCHEMA_VERSION},
             sort_keys=True,
         ),
     }

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -145,8 +145,41 @@ def test_archive_tiers_index_generates_ids_and_actions_view(tmp_path: Path) -> N
         """,
         (messages[0]["message_id"], session["session_id"], 2, "tool_result", "passed", "tool-1"),
     )
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            native_id, origin, title, content_hash, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("other-native-session", "codex-session", "Other schema work", _HASH, 1_767_225_602_000, 1_767_225_603_000),
+    )
+    other_session = conn.execute(
+        "SELECT session_id FROM sessions WHERE native_id = ?", ("other-native-session",)
+    ).fetchone()
+    conn.execute(
+        """
+        INSERT INTO messages (
+            session_id, native_id, position, role, message_type, content_hash, occurred_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (other_session["session_id"], "other-native-message", 0, "assistant", "message", _HASH, 1_767_225_603_000),
+    )
+    other_message = conn.execute(
+        "SELECT message_id FROM messages WHERE session_id = ?", (other_session["session_id"],)
+    ).fetchone()
+    conn.execute(
+        """
+        INSERT INTO blocks (
+            message_id, session_id, position, block_type, text, tool_id
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (other_message["message_id"], other_session["session_id"], 0, "tool_result", "wrong session", "tool-1"),
+    )
 
-    blocks = conn.execute("SELECT block_id, tool_command, tool_path FROM blocks ORDER BY position").fetchall()
+    blocks = conn.execute(
+        "SELECT block_id, tool_command, tool_path FROM blocks WHERE session_id = ? ORDER BY position",
+        (session["session_id"],),
+    ).fetchall()
     assert [row["block_id"] for row in blocks] == [
         "codex-session:native-session:native-message:0",
         "codex-session:native-session:native-message:1",
@@ -155,8 +188,16 @@ def test_archive_tiers_index_generates_ids_and_actions_view(tmp_path: Path) -> N
     assert blocks[1]["tool_command"] == "pytest -q"
     assert blocks[1]["tool_path"] == "tests"
 
-    action = conn.execute("SELECT tool_command, output_text FROM actions").fetchone()
-    assert dict(action) == {"tool_command": "pytest -q", "output_text": "passed"}
+    actions = conn.execute(
+        """
+        SELECT tool_command, output_text
+        FROM actions
+        WHERE session_id = ?
+        ORDER BY output_text
+        """,
+        (session["session_id"],),
+    ).fetchall()
+    assert [dict(row) for row in actions] == [{"tool_command": "pytest -q", "output_text": "passed"}]
 
     fts_row = conn.execute(
         """


### PR DESCRIPTION
## Summary

Fixes the `actions` view so tool-result rows are matched to tool-use rows within the same session, then bumps the index-tier schema version so fresh-first archives rebuild the corrected view. This is the first concrete schema hygiene slice from #2246.

## Problem

`polylogue/storage/sqlite/archive_tiers/index.py` joined tool-use blocks to tool-result blocks by `tool_id` only. Provider call ids can be session-local, so forensic consumers of the `actions` view could attach output from a different session when two sessions reuse the same id.

## Solution

The index DDL now joins result blocks with both `tool_id` and `session_id`. `INDEX_SCHEMA_VERSION` is bumped from 3 to 4, `docs/schema.md` reflects the current tier version, and the DDL regression seeds two sessions with the same `tool_id` to prove the first session only sees its own result. Archive status/live-batch tests now use `INDEX_SCHEMA_VERSION` directly instead of repeating the literal.

Schema impact: this is a canonical view change, not an in-place migration. Existing `index.db` files at v3 are rejected by the fresh-first schema policy and should be rebuilt from source using the normal reset/re-ingest path.

Ref #2246

## Verification

- `nix develop --command devtools test tests/unit/storage/test_archive_tiers_ddl.py tests/unit/daemon/test_daemon_cli.py::test_polylogued_status_json_reports_archive_storage tests/unit/sources/test_live_batch_support.py::test_full_ingest_writes_archive_with_route_observability tests/unit/sources/test_live_batch_support.py::test_streaming_full_ingest_writes_archive_from_blob tests/unit/sources/test_live_batch_support.py::test_full_ingest_bootstraps_archive_root -q` -> 24 passed in 17.11s
- `nix develop --command devtools verify --quick` -> exit_code 0
- `nix develop --command devtools verify` -> 441 passed in 150.63s, exit_code 0