### PR TITLE
feat(import): expose archive-backed import explain (#2178)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -2096,6 +2096,13 @@ x-polylogue-route-contracts:
   response_contract: ArchiveDebtListPayload
   notes: Unified archive debt rows shared by CLI, Python API, MCP, and daemon clients.
 - method: GET
+  pattern: /api/import/explain
+  kind: operational
+  stability: shell_supported
+  auth_policy: bearer_if_configured
+  response_contract: ImportExplainPayload
+  notes: Local import/source evidence explanation; paths are redacted unless explicitly requested.
+- method: GET
   pattern: /api/refs/resolve
   kind: read_query
   stability: stable

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1310,14 +1310,27 @@ class PolylogueArchiveMixin:
 
     async def explain_import(
         self,
-        path: str | Path,
+        path: str | Path | None = None,
         *,
+        raw_ref: str | None = None,
+        source_path: str | None = None,
         source_name: str = "unknown",
         limit: int = 100,
+        redact_paths: bool = True,
     ) -> ImportExplainPayload:
-        """Explain detector/parser decisions for a local import path without writing archive rows."""
-        from polylogue.sources.import_explain import explain_import_path
+        """Explain detector/parser decisions for local or archived import evidence."""
+        from polylogue.sources.import_explain import explain_import_archive, explain_import_path
 
+        if raw_ref is not None or source_path is not None:
+            return explain_import_archive(
+                _active_archive_root(self.config),
+                raw_ref=raw_ref,
+                source_path=source_path,
+                limit=limit,
+                redact_paths=redact_paths,
+            )
+        if path is None:
+            raise ValueError("path is required unless raw_ref or source_path is provided")
         return explain_import_path(Path(path), source_name=source_name, limit=limit)
 
     async def recovery_digest(self, session_id: str) -> RecoveryDigest | None:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -231,6 +231,7 @@ def _static_get_routes() -> tuple[_StaticGetRoute, ...]:
         _static_get_route("/api/facets", "_handle_facets", passes_params=True),
         _static_get_route("/api/query-units", "_handle_query_units", passes_params=True),
         _static_get_route("/api/archive-debt", "_handle_archive_debt", passes_params=True),
+        _static_get_route("/api/import/explain", "_handle_import_explain", passes_params=True),
         _static_get_route("/api/refs/resolve", "_handle_ref_resolve", passes_params=True),
         _static_get_route("/api/query-completions", "_handle_query_completions", passes_params=True),
         _static_get_route("/api/read-view-profiles", "_handle_read_view_profiles"),
@@ -2554,6 +2555,40 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 only_actionable=self._get_bool(params, "only_actionable"),
                 limit=limit,
                 exact_fts=self._get_bool(params, "exact_fts"),
+            )
+        )
+        self._send_json(HTTPStatus.OK, payload.model_dump(mode="json", exclude_none=True))
+
+    @daemon_safe_handler
+    def _handle_import_explain(self, params: dict[str, list[str]]) -> None:
+        """``GET /api/import/explain`` explains archived import/source evidence."""
+
+        from polylogue import Polylogue
+        from polylogue.api.sync.bridge import run_coroutine_sync
+
+        path = self._get_param(params, "path")
+        raw_ref = self._get_param(params, "raw_ref")
+        source_path = self._get_param(params, "source_path")
+        if not path and not raw_ref and not source_path:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {
+                    "error": "missing_import_explain_target",
+                    "message": "path, raw_ref, or source_path query parameter is required",
+                },
+            )
+            return
+        archive_root = _web_reader_archive_root()
+        if archive_root is None:
+            self._send_error(HTTPStatus.SERVICE_UNAVAILABLE, "archive_unavailable")
+            return
+        payload = run_coroutine_sync(
+            Polylogue(archive_root=archive_root, db_path=archive_root / "index.db").explain_import(
+                path,
+                raw_ref=raw_ref,
+                source_path=source_path,
+                limit=self._get_int(params, "limit", 100),
+                redact_paths=not self._get_bool(params, "no_redact"),
             )
         )
         self._send_json(HTTPStatus.OK, payload.model_dump(mode="json", exclude_none=True))

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -159,6 +159,15 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "Unified archive debt rows shared by CLI, Python API, MCP, and daemon clients.",
     ),
     RouteContract(
+        "GET",
+        "/api/import/explain",
+        "operational",
+        "shell_supported",
+        "bearer_if_configured",
+        "ImportExplainPayload",
+        "Local import/source evidence explanation; paths are redacted unless explicitly requested.",
+    ),
+    RouteContract(
         "GET", "/api/refs/resolve", "read_query", "stable", "bearer_if_configured", "PublicRefResolutionPayload"
     ),
     RouteContract(

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -909,6 +909,36 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("archive_debt", run)
 
+    @mcp.tool()
+    async def explain_import(
+        path: str | None = None,
+        raw_ref: str | None = None,
+        source_path: str | None = None,
+        source_name: str = "unknown",
+        limit: MCPToolLimit = 100,
+        redact_paths: bool = True,
+    ) -> str:
+        """Explain import detection/parsing from a local path or archived raw evidence."""
+
+        async def run() -> str:
+            if path is None and raw_ref is None and source_path is None:
+                return hooks.error_json(
+                    "explain_import requires path, raw_ref, or source_path",
+                    code="invalid_request",
+                    tool="explain_import",
+                )
+            payload = await hooks.get_polylogue().explain_import(
+                path,
+                raw_ref=raw_ref,
+                source_path=source_path,
+                source_name=source_name,
+                limit=hooks.clamp_limit(limit),
+                redact_paths=redact_paths,
+            )
+            return hooks.json_payload(payload, exclude_none=True)
+
+        return await hooks.async_safe_call("explain_import", run)
+
     async def list_read_view_profiles() -> str:
         async def run() -> str:
             profiles = await hooks.get_polylogue().list_read_view_profiles()

--- a/polylogue/sources/import_explain.py
+++ b/polylogue/sources/import_explain.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sqlite3
 import zipfile
 from collections.abc import Iterable
 from io import BytesIO
@@ -72,6 +74,68 @@ def explain_import_path(
     return _envelope(resolved, entries=entries, skipped=skipped, caveats=caveats)
 
 
+def explain_import_archive(
+    archive_root: Path,
+    *,
+    raw_ref: str | None = None,
+    source_path: str | None = None,
+    limit: int = 100,
+    redact_paths: bool = True,
+) -> ImportExplainPayload:
+    """Return an import explanation from already-archived source/index evidence."""
+
+    if raw_ref is None and source_path is None:
+        raise ValueError("raw_ref or source_path is required for archive import explain")
+
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    query_label = _archive_query_label(raw_ref=raw_ref, source_path=source_path, redact_paths=redact_paths)
+    entries: list[ImportExplainEntryPayload] = []
+    skipped: list[ImportSkippedRowPayload] = []
+    caveats: list[str] = ["archive-backed explanation; raw bytes are omitted."]
+
+    if not source_db.exists():
+        skipped.append(ImportSkippedRowPayload(reason="source tier is unavailable", raw_ref=raw_ref))
+        return _envelope(Path(query_label), entries=entries, skipped=skipped, caveats=caveats)
+
+    raw_id = _normalize_raw_ref(raw_ref) if raw_ref is not None else None
+    with _readonly_sqlite(source_db) as source_conn:
+        raw_rows = _select_raw_session_rows(source_conn, raw_id=raw_id, source_path=source_path, limit=limit)
+        if not raw_rows:
+            skipped.append(
+                ImportSkippedRowPayload(
+                    reason="no archived raw session matched",
+                    source_path=_display_source_path(source_path, redact=redact_paths),
+                    raw_ref=raw_ref,
+                )
+            )
+            return _envelope(Path(query_label), entries=entries, skipped=skipped, caveats=caveats)
+
+        index_conn: sqlite3.Connection | None = None
+        if index_db.exists():
+            index_conn = _readonly_sqlite(index_db)
+        else:
+            caveats.append("index tier is unavailable; produced archive row counts are incomplete")
+        try:
+            for row in raw_rows:
+                artifact_rows = _select_artifact_rows(source_conn, raw_id=str(row["raw_id"]))
+                entry = _archive_entry_from_rows(
+                    row,
+                    artifact_rows=artifact_rows,
+                    index_conn=index_conn,
+                    redact_paths=redact_paths,
+                )
+                entries.append(entry)
+                skipped.extend(entry.skipped)
+        finally:
+            if index_conn is not None:
+                index_conn.close()
+
+    if len(raw_rows) >= limit:
+        caveats.append(f"entry limit {limit} reached; remaining archived raw rows omitted")
+    return _envelope(Path(query_label), entries=entries, skipped=skipped, caveats=caveats)
+
+
 def _candidate_paths(path: Path, *, source_name: str) -> Iterable[Path]:
     if path.is_file():
         yield path
@@ -101,6 +165,235 @@ def _envelope(
         skipped=tuple(skipped),
         caveats=tuple(caveats),
     )
+
+
+def _archive_entry_from_rows(
+    row: sqlite3.Row,
+    *,
+    artifact_rows: tuple[sqlite3.Row, ...],
+    index_conn: sqlite3.Connection | None,
+    redact_paths: bool,
+) -> ImportExplainEntryPayload:
+    raw_id = str(row["raw_id"])
+    source_path = _display_source_path(str(row["source_path"]), redact=redact_paths)
+    parse_error = _optional_text(row["parse_error"])
+    validation_error = _optional_text(row["validation_error"])
+    detection_warnings = _loads_warning_tuple(_optional_text(row["detection_warnings_json"]))
+    artifact_kind = _archive_artifact_kind(artifact_rows)
+    produced = _archive_produced_rows(index_conn, raw_id)
+    skipped: list[ImportSkippedRowPayload] = []
+    caveats: list[str] = []
+
+    if parse_error is not None:
+        skipped.append(
+            ImportSkippedRowPayload(
+                reason=f"parse error: {parse_error}",
+                source_path=source_path,
+                raw_ref=f"raw:{raw_id}",
+            )
+        )
+    if validation_error is not None:
+        caveats.append(f"validation error: {validation_error}")
+    for artifact in artifact_rows:
+        decode_error = _optional_text(artifact["decode_error"])
+        if decode_error is not None:
+            skipped.append(
+                ImportSkippedRowPayload(
+                    reason=f"decode error: {decode_error}",
+                    source_path=source_path,
+                    raw_ref=f"raw:{raw_id}",
+                )
+            )
+    if redact_paths and source_path != str(row["source_path"]):
+        caveats.append("source path redacted for this surface")
+    if artifact_rows:
+        artifact_evidence = tuple(
+            _evidence(
+                f"source.raw_artifacts.{artifact['artifact_id']}",
+                matched=bool(artifact["parse_as_session"]),
+                reason=str(artifact["classification_reason"]),
+            )
+            for artifact in artifact_rows
+        )
+    else:
+        artifact_evidence = (_evidence("source.raw_artifacts", matched=False, reason="no artifact row recorded"),)
+
+    return ImportExplainEntryPayload(
+        raw_ref=f"raw:{raw_id}",
+        source_path=source_path,
+        artifact_kind=artifact_kind,
+        provider_hint=str(row["origin"]),
+        detected_origin=str(row["origin"]),
+        detected_provider=None,
+        detector="source.raw_sessions",
+        detector_evidence=(
+            _evidence("source.raw_sessions", matched=True, reason=f"raw_id={raw_id}"),
+            *artifact_evidence,
+        ),
+        parser="archive source/index evidence",
+        parser_mode="archived_raw_session",
+        schema_resolution=_schema_resolution(row),
+        produced=produced,
+        skipped=tuple(skipped),
+        caveats=tuple(caveats),
+        raw_evidence_refs=(f"raw:{raw_id}",)
+        + tuple(f"raw-artifact:{artifact['artifact_id']}" for artifact in artifact_rows),
+        normalization_warnings=detection_warnings,
+    )
+
+
+def _readonly_sqlite(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _select_raw_session_rows(
+    conn: sqlite3.Connection,
+    *,
+    raw_id: str | None,
+    source_path: str | None,
+    limit: int,
+) -> tuple[sqlite3.Row, ...]:
+    clauses: list[str] = []
+    params: list[object] = []
+    if raw_id is not None:
+        clauses.append("raw_id = ?")
+        params.append(raw_id)
+    if source_path is not None:
+        clauses.append("source_path = ?")
+        params.append(source_path)
+    where = " AND ".join(clauses) if clauses else "1 = 1"
+    return tuple(
+        conn.execute(
+            f"""
+            SELECT
+                raw_id, origin, native_id, source_path, source_index, blob_size,
+                acquired_at_ms, parsed_at_ms, parse_error, validated_at_ms,
+                validation_status, validation_error, detection_warnings_json
+            FROM raw_sessions
+            WHERE {where}
+            ORDER BY source_path, source_index, raw_id
+            LIMIT ?
+            """,
+            (*params, max(0, limit)),
+        ).fetchall()
+    )
+
+
+def _select_artifact_rows(conn: sqlite3.Connection, *, raw_id: str) -> tuple[sqlite3.Row, ...]:
+    return tuple(
+        conn.execute(
+            """
+            SELECT artifact_id, artifact_kind, classification_reason, parse_as_session,
+                   support_status, decode_error
+            FROM raw_artifacts
+            WHERE raw_id = ?
+            ORDER BY source_index, artifact_id
+            """,
+            (raw_id,),
+        ).fetchall()
+    )
+
+
+def _archive_produced_rows(conn: sqlite3.Connection | None, raw_id: str) -> ImportProducedRowsPayload:
+    if conn is None:
+        return ImportProducedRowsPayload(raw_records=1)
+    session_rows = tuple(
+        conn.execute(
+            """
+            SELECT session_id, message_count, tool_use_count
+            FROM sessions
+            WHERE raw_id = ?
+            ORDER BY session_id
+            """,
+            (raw_id,),
+        ).fetchall()
+    )
+    if not session_rows:
+        return ImportProducedRowsPayload(raw_records=1)
+    session_ids = tuple(str(row["session_id"]) for row in session_rows)
+    placeholders = ",".join("?" for _ in session_ids)
+    messages = int(
+        conn.execute(f"SELECT COUNT(*) FROM messages WHERE session_id IN ({placeholders})", session_ids).fetchone()[0]
+    )
+    blocks = int(
+        conn.execute(f"SELECT COUNT(*) FROM blocks WHERE session_id IN ({placeholders})", session_ids).fetchone()[0]
+    )
+    actions = int(
+        conn.execute(f"SELECT COUNT(*) FROM actions WHERE session_id IN ({placeholders})", session_ids).fetchone()[0]
+    )
+    return ImportProducedRowsPayload(
+        sessions=len(session_rows),
+        messages=messages,
+        blocks=blocks,
+        actions=actions,
+        raw_records=1,
+        session_refs=tuple(f"session:{session_id}" for session_id in session_ids),
+    )
+
+
+def _archive_artifact_kind(rows: tuple[sqlite3.Row, ...]) -> str:
+    kinds = tuple(dict.fromkeys(str(row["artifact_kind"]) for row in rows if row["artifact_kind"] is not None))
+    if not kinds:
+        return "raw_session"
+    if len(kinds) == 1:
+        return kinds[0]
+    return "mixed_raw_artifacts"
+
+
+def _schema_resolution(row: sqlite3.Row) -> str | None:
+    status = _optional_text(row["validation_status"])
+    if status is not None:
+        return status
+    if row["validated_at_ms"] is not None:
+        return "validated"
+    if row["parsed_at_ms"] is not None:
+        return "parsed"
+    return None
+
+
+def _normalize_raw_ref(raw_ref: str) -> str:
+    return raw_ref.removeprefix("raw:")
+
+
+def _archive_query_label(*, raw_ref: str | None, source_path: str | None, redact_paths: bool) -> str:
+    if raw_ref is not None:
+        return f"archive:{raw_ref}"
+    return _display_source_path(source_path or "archive:source-path", redact=redact_paths) or "archive:source-path"
+
+
+def _display_source_path(raw_path: str | None, *, redact: bool) -> str | None:
+    if raw_path is None:
+        return None
+    if not redact:
+        return raw_path
+    home = os.path.expanduser("~")
+    if home and home != "/" and (raw_path == home or raw_path.startswith(home + os.sep)):
+        return "~" + raw_path[len(home) :]
+    path = Path(raw_path)
+    if path.is_absolute():
+        return f".../{path.name}" if path.name else "<absolute-path>"
+    return raw_path
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _loads_warning_tuple(value: str | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return (value,)
+    if isinstance(parsed, list):
+        return tuple(str(item) for item in parsed)
+    return (str(parsed),)
 
 
 def _explain_file(path: Path, *, provider_hint: Provider) -> ImportExplainEntryPayload:
@@ -365,4 +658,4 @@ def _evidence(check: str, *, matched: bool, reason: str | None = None) -> Import
     return ImportDetectorEvidencePayload(check=check, matched=matched, reason=reason)
 
 
-__all__ = ["explain_import_path"]
+__all__ = ["explain_import_archive", "explain_import_path"]

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -16,6 +16,7 @@ EXPECTED_TOOL_NAMES = {
     "search",
     "query_units",
     "resolve_ref",
+    "explain_import",
     "list_sessions",
     "compile_context",
     "build_context_pack",
@@ -207,6 +208,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.recovery_report = AsyncMock(return_value=None)
     poly.recovery_work_packet = AsyncMock(return_value=None)
     poly.compile_context = AsyncMock(return_value=None)
+    poly.explain_import = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -281,6 +281,95 @@ def _archive(tmp_path: Path) -> Polylogue:
     return Polylogue(archive_root=tmp_path, db_path=tmp_path / "index.db")
 
 
+_HASH = b"x" * 32
+
+
+def _seed_import_explain_archive(tmp_path: Path, *, source_path: str | None = None) -> tuple[str, str]:
+    source_path = source_path or str(Path.home() / ".codex" / "sessions" / "session.jsonl")
+    raw_id = "raw-import-1"
+    source_conn = sqlite3.connect(tmp_path / "source.db")
+    index_conn = sqlite3.connect(tmp_path / "index.db")
+    try:
+        initialize_archive_tier(source_conn, ArchiveTier.SOURCE)
+        initialize_archive_tier(index_conn, ArchiveTier.INDEX)
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+                acquired_at_ms, parsed_at_ms, validated_at_ms, validation_status,
+                detection_warnings_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "codex-session",
+                "native-1",
+                source_path,
+                0,
+                _HASH,
+                42,
+                1_700_000_000_000,
+                1_700_000_000_100,
+                1_700_000_000_200,
+                "passed",
+                '["normalized path separators"]',
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, source_index, artifact_kind,
+                support_status, classification_reason, parse_as_session, schema_eligible,
+                first_observed_at_ms, last_observed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "artifact-1",
+                raw_id,
+                "codex-session",
+                source_path,
+                0,
+                "session_record_stream",
+                "supported_parseable",
+                "codex session stream",
+                1,
+                1,
+                1_700_000_000_000,
+                1_700_000_000_000,
+            ),
+        )
+        index_conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, title, content_hash, message_count, tool_use_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("native-1", "codex-session", raw_id, "Import explain", _HASH, 1, 1),
+        )
+        index_conn.execute(
+            """
+            INSERT INTO messages (
+                session_id, native_id, position, role, message_type, content_hash
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("codex-session:native-1", "msg-1", 0, "assistant", "message", _HASH),
+        )
+        index_conn.execute(
+            """
+            INSERT INTO blocks (
+                message_id, session_id, position, block_type, text, tool_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("codex-session:native-1:msg-1", "codex-session:native-1", 0, "tool_use", "pytest", "tool-1"),
+        )
+        source_conn.commit()
+        index_conn.commit()
+    finally:
+        source_conn.close()
+        index_conn.close()
+    return raw_id, source_path
+
+
 @pytest.mark.asyncio
 async def test_archive_tiers_facade_reads_active_db_override_root(tmp_path: Path) -> None:
     """Archive facade reads open the active index root, not just config.archive_root."""
@@ -868,6 +957,47 @@ async def test_explain_import_reports_bounded_decode_failure(tmp_path: Path) -> 
         rendered = payload.to_json(exclude_none=True)
         assert "{not json" not in rendered
         assert "raw_bytes" not in rendered
+    finally:
+        await archive.close()
+
+
+async def test_explain_import_reads_archived_raw_evidence(tmp_path: Path) -> None:
+    """``explain_import`` can explain already-archived source/index rows."""
+    raw_id, source_path = _seed_import_explain_archive(tmp_path)
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_import(raw_ref=f"raw:{raw_id}")
+
+        assert payload.mode == "import-explain"
+        assert payload.source_path == f"archive:raw:{raw_id}"
+        assert payload.produced.raw_records == 1
+        assert payload.produced.sessions == 1
+        assert payload.produced.messages == 1
+        assert payload.produced.blocks == 1
+        assert payload.produced.actions == 1
+        assert payload.entries[0].raw_ref == f"raw:{raw_id}"
+        assert payload.entries[0].detected_origin == "codex-session"
+        assert payload.entries[0].artifact_kind == "session_record_stream"
+        assert payload.entries[0].parser_mode == "archived_raw_session"
+        assert payload.entries[0].schema_resolution == "passed"
+        assert payload.entries[0].raw_evidence_refs == (f"raw:{raw_id}", "raw-artifact:artifact-1")
+        assert payload.entries[0].normalization_warnings == ("normalized path separators",)
+        rendered = payload.to_json(exclude_none=True)
+        assert source_path not in rendered
+        assert "raw_bytes" not in rendered
+    finally:
+        await archive.close()
+
+
+async def test_explain_import_redacts_non_home_absolute_archive_paths(tmp_path: Path) -> None:
+    """Archive-backed import explain does not expose arbitrary absolute paths by default."""
+    raw_id, source_path = _seed_import_explain_archive(tmp_path, source_path="/realm/private/imports/session.jsonl")
+    archive = _archive(tmp_path)
+    try:
+        payload = await archive.explain_import(raw_ref=f"raw:{raw_id}")
+
+        assert payload.entries[0].source_path == ".../session.jsonl"
+        assert source_path not in payload.to_json(exclude_none=True)
     finally:
         await archive.close()
 

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -128,6 +128,7 @@ def test_read_view_execution_route_is_published_as_stable_api() -> None:
         ("GET", "/api/sessions", "/api/sessions", "read_query", "bearer_if_configured"),
         ("GET", "/api/query-units", "/api/query-units", "read_query", "bearer_if_configured"),
         ("GET", "/api/archive-debt", "/api/archive-debt", "operational", "bearer_if_configured"),
+        ("GET", "/api/import/explain", "/api/import/explain", "operational", "bearer_if_configured"),
         ("GET", "/api/assertions", "/api/assertions", "user_overlay", "bearer_if_configured"),
         (
             "GET",

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -372,6 +372,98 @@ def _index_db_path(workspace: dict[str, Path]) -> Path:
     return workspace["data_root"] / "polylogue" / "index.db"
 
 
+def _seed_import_explain_archive(workspace: dict[str, Path]) -> tuple[str, str]:
+    import sqlite3
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    raw_id = "raw-import-route"
+    source_path = str(Path.home() / ".codex" / "sessions" / "route.jsonl")
+    digest = b"r" * 32
+    archive_root = workspace["archive_root"]
+    archive_root.mkdir(parents=True, exist_ok=True)
+    source_conn = sqlite3.connect(archive_root / "source.db")
+    index_conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        initialize_archive_tier(source_conn, ArchiveTier.SOURCE)
+        initialize_archive_tier(index_conn, ArchiveTier.INDEX)
+        source_conn.execute(
+            """
+            INSERT OR REPLACE INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+                acquired_at_ms, parsed_at_ms, validated_at_ms, validation_status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "codex-session",
+                "route-native",
+                source_path,
+                0,
+                digest,
+                128,
+                1_700_000_000_000,
+                1_700_000_000_100,
+                1_700_000_000_200,
+                "passed",
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT OR REPLACE INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, source_index, artifact_kind,
+                support_status, classification_reason, parse_as_session, schema_eligible,
+                first_observed_at_ms, last_observed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "route-artifact",
+                raw_id,
+                "codex-session",
+                source_path,
+                0,
+                "session_record_stream",
+                "supported_parseable",
+                "codex route fixture",
+                1,
+                1,
+                1_700_000_000_000,
+                1_700_000_000_000,
+            ),
+        )
+        index_conn.execute(
+            """
+            INSERT OR REPLACE INTO sessions (
+                native_id, origin, raw_id, title, content_hash, message_count, tool_use_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("route-native", "codex-session", raw_id, "Route import explain", digest, 1, 1),
+        )
+        index_conn.execute(
+            """
+            INSERT OR REPLACE INTO messages (
+                session_id, native_id, position, role, message_type, content_hash
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("codex-session:route-native", "m1", 0, "assistant", "message", digest),
+        )
+        index_conn.execute(
+            """
+            INSERT OR REPLACE INTO blocks (
+                message_id, session_id, position, block_type, text, tool_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("codex-session:route-native:m1", "codex-session:route-native", 0, "tool_use", "pytest", "tool-1"),
+        )
+        source_conn.commit()
+        index_conn.commit()
+    finally:
+        source_conn.close()
+        index_conn.close()
+    return raw_id, source_path
+
+
 def _get_json(base_url: str, path: str, *, headers: dict[str, str] | None = None) -> object:
     req = Request(f"{base_url}{path}", headers=headers or {})
     with urlopen(req, timeout=10) as resp:
@@ -646,6 +738,28 @@ class TestReaderSessionState:
         assert result["payload_kind"] == "session-summary"
         resolved_payload = cast(dict[str, object], result["payload"])
         assert resolved_payload["id"] == "claude-code-session:c1"
+
+    def test_import_explain_route_reads_archived_raw_evidence(self, workspace_env: dict[str, Path]) -> None:
+        raw_id, source_path = _seed_import_explain_archive(workspace_env)
+        with _running_server(workspace_env, seeded=False) as (_, base_url):
+            payload = cast(
+                dict[str, object],
+                _get_json(base_url, f"/api/import/explain?raw_ref={quote(f'raw:{raw_id}')}"),
+            )
+
+        assert payload["mode"] == "import-explain"
+        assert payload["source_path"] == f"archive:raw:{raw_id}"
+        produced = cast(dict[str, object], payload["produced"])
+        assert produced["sessions"] == 1
+        assert produced["messages"] == 1
+        assert produced["blocks"] == 1
+        assert produced["actions"] == 1
+        entries = cast(list[dict[str, object]], payload["entries"])
+        assert entries[0]["raw_ref"] == f"raw:{raw_id}"
+        assert entries[0]["source_path"] == "~/.codex/sessions/route.jsonl"
+        assert entries[0]["artifact_kind"] == "session_record_stream"
+        assert entries[0]["parser_mode"] == "archived_raw_session"
+        assert source_path not in json.dumps(payload)
 
     def test_session_messages_apply_content_projection_flags(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.archive.message.roles import Role

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -66,6 +66,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "explain_query_expression": "single_object",
     "query_completions": "single_object",
     "resolve_ref": "single_object",
+    "explain_import": "typed_envelope",
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     "archive_list_sessions": ("envelope", frozenset({"items", "total", "limit", "offset"})),
     "archive_search_sessions": ("envelope", frozenset({"items", "total", "limit", "query"})),
@@ -220,6 +221,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
     )
     from polylogue.surfaces.payloads import (
         ArchiveDebtListPayload,
+        ImportExplainPayload,
         PublicRefResolutionPayload,
         QueryUnitEnvelope,
         SearchEnvelope,
@@ -229,6 +231,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         "search": SearchEnvelope,
         "query_units": QueryUnitEnvelope,
         "archive_debt": ArchiveDebtListPayload,
+        "explain_import": ImportExplainPayload,
         "resolve_ref": PublicRefResolutionPayload,
         "list_sessions": MCPPaginatedQueryResultPayload,
         "neighbor_candidates": MCPNeighborCandidatesPayload,

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -25,6 +25,9 @@ from polylogue.surfaces.payloads import (
     ArchiveDebtListPayload,
     ArchiveDebtTotalsPayload,
     AssertionClaimPayload,
+    ImportExplainEntryPayload,
+    ImportExplainPayload,
+    ImportProducedRowsPayload,
     PublicRefResolutionPayload,
 )
 from polylogue.types import SessionId
@@ -978,6 +981,45 @@ class TestArchiveGenericToolSurfaces:
             only_actionable=True,
             limit=3,
             exact_fts=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_explain_import_reads_shared_facade_payload(self: object, mcp_server: MCPServerUnderTest) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.explain_import.return_value = ImportExplainPayload(
+            source_path="archive:raw:raw-1",
+            entries=(
+                ImportExplainEntryPayload(
+                    raw_ref="raw:raw-1",
+                    source_path="~/.codex/sessions/a.jsonl",
+                    artifact_kind="session_record_stream",
+                    detected_origin="codex-session",
+                    detector="source.raw_sessions",
+                    parser="archive source/index evidence",
+                    parser_mode="archived_raw_session",
+                    produced=ImportProducedRowsPayload(sessions=1, raw_records=1),
+                ),
+            ),
+            produced=ImportProducedRowsPayload(sessions=1, raw_records=1),
+        )
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["explain_import"].fn,
+                raw_ref="raw:raw-1",
+                limit=7,
+            )
+
+        payload = json.loads(result)
+        assert payload["mode"] == "import-explain"
+        assert payload["entries"][0]["raw_ref"] == "raw:raw-1"
+        mock_poly.explain_import.assert_awaited_once_with(
+            None,
+            raw_ref="raw:raw-1",
+            source_path=None,
+            source_name="unknown",
+            limit=7,
+            redact_paths=True,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes #2178 by making ImportExplain archive-backed and cross-surface: `Polylogue.explain_import(...)` can now explain already-observed raw evidence by `raw_ref` or `source_path`, MCP exposes the shared `ImportExplainPayload`, and the daemon exposes a shell-supported `/api/import/explain` route. The archive-backed path reads `source.db` raw/artifact evidence and `index.db` produced rows without re-reading raw payload bytes.

## Problem

The first #2178 implementation was useful but incomplete: it explained local paths before import, while the issue also required a raw-ref/source-path read path for prior import evidence and explicit Python API/MCP/daemon treatment. That left ImportExplain narrowly true for CLI/API preflight but not broadly useful as an evidence-cockpit surface.

## Solution

- Added `explain_import_archive(...)` in `polylogue/sources/import_explain.py` to build `ImportExplainPayload` from existing `source.db` and `index.db` rows.
- Extended `Polylogue.explain_import(...)` so callers can pass `raw_ref` or `source_path` for archive-backed explanations, while preserving the existing path preflight behavior.
- Added MCP `explain_import` and classified it in the MCP envelope contract matrix as a typed report payload.
- Added daemon route `GET /api/import/explain` with route-contract/OpenAPI metadata as `shell_supported` local import/source evidence inspection.
- Redacts archive source paths by default (`~/...` for home paths, `.../filename` for other absolute paths) and omits raw bytes from every exposed payload.

Closure matrix for #2178:

- Shared `ImportExplainPayload`: satisfied by the existing payloads and reused by CLI/API/MCP/daemon.
- Representative provider/path explanation: satisfied by existing Codex path tests.
- CLI JSON/NDJSON preflight: already landed and retained.
- Raw-ref/source-path retrieval from archive evidence: satisfied by archive-backed source/index tests.
- Python API/MCP/daemon surfaces: satisfied by `Polylogue.explain_import`, MCP `explain_import`, and `/api/import/explain`.
- Generated schemas/docs: OpenAPI route contract regenerated; CLI output schema unchanged.
- Failure/privacy coverage: existing malformed path/ZIP tests retained; archive-backed tests prove raw bytes are omitted and absolute paths are redacted.

## Verification

- `devtools test tests/unit/api/test_facade_contracts.py::test_explain_import_reads_archived_raw_evidence tests/unit/api/test_facade_contracts.py::test_explain_import_redacts_non_home_absolute_archive_paths tests/unit/mcp/test_server_surfaces.py::TestArchiveGenericToolSurfaces::test_explain_import_reads_shared_facade_payload tests/unit/mcp/test_envelope_contracts.py::TestRegistryWideClassification::test_every_registered_tool_is_classified tests/unit/mcp/test_envelope_contracts.py::test_envelope_class_carries_required_fields tests/unit/daemon/test_web_reader.py::TestReaderSessionState::test_import_explain_route_reads_archived_raw_evidence -q` — 16 passed.
- `devtools verify --quick` — exit 0.
- `devtools verify` — exit 0; 266 affected tests passed in 147.78s, peak pytest RSS 781.5 MiB.

Closes #2178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added import explanation API endpoint and tool that displays detailed information about import sources, including metadata about artifacts, parsing status, validation results, and produced data rows.
  * Supports explaining both local and archived import evidence with optional path redaction for privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->