### PR TITLE
chore(dev): add branch-local dev-loop preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1728,6 +1728,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools workspace dev-loop` | Preflight branch-local daemon, web-shell, and browser-capture development loops. |
 | `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools workspace tasks` | Record and query local agent task execution history. |
 | `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Start with the generated command and architecture references; use [docs/README.m
 | [Provider Package Completeness](docs/provider-completeness.md) | Readiness report for provider/importer package modes by origin and capture mode. |
 | [Archive Backup](docs/archive-backup.md) | Archive-tier backup profiles, restore boundaries, and blob-GC safety rules. |
 | [Developer Tools](docs/devtools.md) | `devtools` guide for generated surfaces, validation, and repo hygiene. |
+| [Branch-Local Development Loop](docs/dev-loop.md) | Branch-local daemon, web-shell, browser-capture, and extension debugging workflow. |
 | [Providers](docs/providers/README.md) | Provider-specific parsing and export-format notes. |
 
 <!-- END GENERATED: docs-surface -->

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -303,6 +303,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace dev-loop",
+        "workspace",
+        "Preflight branch-local daemon, web-shell, and browser-capture development loops.",
+        "devtools.dev_loop",
+        use_when=(
+            "Before running a branch-local polylogued/web-shell/browser-capture loop, "
+            "check whether the deployed user service is active, which ports are occupied, "
+            "and which isolated archive/log paths this checkout should use."
+        ),
+        examples=(
+            "devtools workspace dev-loop",
+            "devtools workspace dev-loop --json",
+            "devtools workspace dev-loop --prepare --api-port 8876 --browser-capture-port 8875",
+        ),
+    ),
+    CommandSpec(
         "lab projections",
         "verification lab",
         "Render the authored scenario-bearing verification projections.",

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -164,9 +164,6 @@ def build_dev_loop_status(
     root = repo_root or _repo_root()
     archive = archive_root or root / ".local" / "dev-archive"
     logs = log_dir or root / ".cache" / "dev-loop"
-    if prepare:
-        archive.mkdir(parents=True, exist_ok=True)
-        logs.mkdir(parents=True, exist_ok=True)
 
     service = system_service_status()
     api = port_status(api_port)
@@ -182,6 +179,9 @@ def build_dev_loop_status(
     run_log_dir = logs / run_id
     daemon_log = run_log_dir / "polylogued.log"
     browser_artifact_dir = run_log_dir / "browser"
+    if prepare:
+        archive.mkdir(parents=True, exist_ok=True)
+        browser_artifact_dir.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
     if service.get("active"):
         warnings.append(

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -1,0 +1,270 @@
+"""Branch-local daemon/web/browser-capture development preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from devtools import repo_root as _repo_root
+
+DEFAULT_API_PORT = 8766
+DEFAULT_BROWSER_CAPTURE_PORT = 8765
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def _run_command(args: list[str], *, timeout_s: float = 2.0) -> CommandResult:
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return CommandResult(exit_code=127, stdout="", stderr=str(exc))
+    return CommandResult(exit_code=result.returncode, stdout=result.stdout.strip(), stderr=result.stderr.strip())
+
+
+def _git_value(args: list[str], *, cwd: Path) -> str | None:
+    result = _run_command(["git", "-C", str(cwd), *args], timeout_s=2.0)
+    if result.exit_code != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _read_environ(pid: int) -> dict[str, str]:
+    path = Path("/proc") / str(pid) / "environ"
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return {}
+    env: dict[str, str] = {}
+    for item in raw.split(b"\0"):
+        if not item or b"=" not in item:
+            continue
+        key, _, value = item.partition(b"=")
+        try:
+            env[key.decode()] = value.decode(errors="replace")
+        except UnicodeDecodeError:
+            continue
+    return env
+
+
+def _socket_connectable(port: int, *, host: str = "127.0.0.1", timeout_s: float = 0.2) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return True
+    except OSError:
+        return False
+
+
+def system_service_status(unit: str = "polylogued.service") -> dict[str, Any]:
+    result = _run_command(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            unit,
+            "--property=ActiveState,SubState,MainPID,FragmentPath",
+            "--no-pager",
+        ]
+    )
+    if result.exit_code != 0:
+        return {
+            "unit": unit,
+            "available": False,
+            "active": False,
+            "error": result.stderr or result.stdout or "systemctl query failed",
+        }
+    fields: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, _, value = line.partition("=")
+        if key:
+            fields[key] = value
+    pid = int(fields.get("MainPID") or 0)
+    env = _read_environ(pid) if pid else {}
+    return {
+        "unit": unit,
+        "available": True,
+        "active": fields.get("ActiveState") == "active",
+        "active_state": fields.get("ActiveState") or "unknown",
+        "sub_state": fields.get("SubState") or "unknown",
+        "main_pid": pid,
+        "archive_root": env.get("POLYLOGUE_ARCHIVE_ROOT"),
+        "fragment_path": fields.get("FragmentPath") or None,
+    }
+
+
+_PID_RE = re.compile(r"pid=(?P<pid>\d+)")
+
+
+def _parse_ss_port_owners(stdout: str, port: int) -> list[dict[str, Any]]:
+    owners: list[dict[str, Any]] = []
+    port_token = f":{port}"
+    for line in stdout.splitlines():
+        if port_token not in line:
+            continue
+        match = _PID_RE.search(line)
+        pid = int(match.group("pid")) if match else None
+        env = _read_environ(pid) if pid is not None else {}
+        owners.append(
+            {
+                "pid": pid,
+                "line": line.strip(),
+                "archive_root": env.get("POLYLOGUE_ARCHIVE_ROOT"),
+            }
+        )
+    return owners
+
+
+def port_status(port: int) -> dict[str, Any]:
+    result = _run_command(["ss", "-H", "-ltnp"])
+    owners = _parse_ss_port_owners(result.stdout, port) if result.exit_code == 0 else []
+    return {
+        "port": port,
+        "connectable": _socket_connectable(port),
+        "owner_count": len(owners),
+        "owners": owners,
+        "probe_error": None if result.exit_code == 0 else (result.stderr or result.stdout or "ss query failed"),
+    }
+
+
+def build_dev_loop_status(
+    *,
+    repo_root: Path | None = None,
+    api_port: int = DEFAULT_API_PORT,
+    browser_capture_port: int = DEFAULT_BROWSER_CAPTURE_PORT,
+    archive_root: Path | None = None,
+    log_dir: Path | None = None,
+    prepare: bool = False,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    archive = archive_root or root / ".local" / "dev-archive"
+    logs = log_dir or root / ".cache" / "dev-loop"
+    if prepare:
+        archive.mkdir(parents=True, exist_ok=True)
+        logs.mkdir(parents=True, exist_ok=True)
+
+    service = system_service_status()
+    api = port_status(api_port)
+    receiver = port_status(browser_capture_port)
+    branch = _git_value(["branch", "--show-current"], cwd=root)
+    commit = _git_value(["rev-parse", "--short", "HEAD"], cwd=root)
+    warnings: list[str] = []
+    if service.get("active"):
+        warnings.append(
+            "systemwide polylogued.service is active; stop it or use isolated ports before branch-local runs"
+        )
+    for name, status in (("api", api), ("browser_capture", receiver)):
+        if int(status.get("owner_count") or 0) > 0:
+            warnings.append(f"{name} port {status['port']} already has a listener")
+
+    return {
+        "repo_root": str(root),
+        "branch": branch,
+        "commit": commit,
+        "prepared": prepare,
+        "dev_archive_root": str(archive),
+        "log_dir": str(logs),
+        "system_service": service,
+        "ports": {
+            "api": api,
+            "browser_capture": receiver,
+        },
+        "suggested_env": {
+            "POLYLOGUE_ARCHIVE_ROOT": str(archive),
+            "POLYLOGUE_API_PORT": str(api_port),
+            "POLYLOGUE_BROWSER_CAPTURE_PORT": str(browser_capture_port),
+        },
+        "commands": {
+            "stop_system_service": "systemctl --user stop polylogued.service",
+            "prepare": "devtools workspace dev-loop --prepare",
+            "run_daemon": (
+                f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
+                f"POLYLOGUE_API_PORT={api_port} "
+                f"POLYLOGUE_BROWSER_CAPTURE_PORT={browser_capture_port} "
+                f"polylogued run 2>&1 | tee {logs / 'polylogued.log'}"
+            ),
+            "open_web_shell": f"http://127.0.0.1:{api_port}/",
+            "receiver_status": f"curl -sf http://127.0.0.1:{browser_capture_port}/v1/status",
+        },
+        "warnings": warnings,
+    }
+
+
+def _print_human(payload: dict[str, Any]) -> None:
+    print("Polylogue dev loop")
+    print(f"  repo:    {payload['repo_root']}")
+    print(f"  branch:  {payload.get('branch') or 'unknown'} @ {payload.get('commit') or 'unknown'}")
+    print(f"  archive: {payload['dev_archive_root']}")
+    print(f"  logs:    {payload['log_dir']}")
+    service = payload["system_service"]
+    assert isinstance(service, dict)
+    print(
+        f"  service: {service.get('unit')} {service.get('active_state', 'unavailable')} pid={service.get('main_pid') or '-'}"
+    )
+    ports = payload["ports"]
+    assert isinstance(ports, dict)
+    for name in ("api", "browser_capture"):
+        status = ports[name]
+        assert isinstance(status, dict)
+        print(f"  port {name}: {status['port']} listeners={status['owner_count']} connectable={status['connectable']}")
+    warnings = payload["warnings"]
+    assert isinstance(warnings, list)
+    if warnings:
+        print("  warnings:")
+        for warning in warnings:
+            print(f"    - {warning}")
+    commands = payload["commands"]
+    assert isinstance(commands, dict)
+    print("\nCommands:")
+    for name, command in commands.items():
+        print(f"  {name}: {command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument("--api-port", type=int, default=int(os.environ.get("POLYLOGUE_API_PORT", DEFAULT_API_PORT)))
+    parser.add_argument(
+        "--browser-capture-port",
+        type=int,
+        default=int(os.environ.get("POLYLOGUE_BROWSER_CAPTURE_PORT", DEFAULT_BROWSER_CAPTURE_PORT)),
+    )
+    parser.add_argument("--archive-root", type=Path, help="Branch-local archive root to report/use.")
+    parser.add_argument("--log-dir", type=Path, help="Branch-local dev-loop log directory to report/use.")
+    parser.add_argument("--prepare", action="store_true", help="Create the reported archive/log directories.")
+    args = parser.parse_args(argv)
+    payload = build_dev_loop_status(
+        api_port=args.api_port,
+        browser_capture_port=args.browser_capture_port,
+        archive_root=args.archive_root,
+        log_dir=args.log_dir,
+        prepare=args.prepare,
+    )
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        _print_human(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -270,10 +270,14 @@ def build_dev_loop_status(
     run_log_dir = logs / run_id
     daemon_log = run_log_dir / "polylogued.log"
     browser_artifact_dir = run_log_dir / "browser"
+    terminal_artifact_dir = run_log_dir / "terminal"
+    tui_artifact_dir = run_log_dir / "tui"
     preflight_json = run_log_dir / "preflight.json"
     if prepare:
         archive.mkdir(parents=True, exist_ok=True)
         browser_artifact_dir.mkdir(parents=True, exist_ok=True)
+        terminal_artifact_dir.mkdir(parents=True, exist_ok=True)
+        tui_artifact_dir.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
     if service.get("active"):
         warnings.append(
@@ -296,6 +300,8 @@ def build_dev_loop_status(
         "artifacts": {
             "daemon_log": str(daemon_log),
             "browser_dir": str(browser_artifact_dir),
+            "terminal_dir": str(terminal_artifact_dir),
+            "tui_dir": str(tui_artifact_dir),
             "preflight_json": str(preflight_json),
         },
         "system_service": service,
@@ -325,6 +331,15 @@ def build_dev_loop_status(
             ),
             "open_web_shell": f"http://127.0.0.1:{api_port}/",
             "receiver_status": f"curl -sf http://127.0.0.1:{browser_capture_port}/v1/status",
+            "capture_cli_status": (
+                "script -q -c "
+                f"'env POLYLOGUE_ARCHIVE_ROOT={archive} polylogue ops status' "
+                f"{terminal_artifact_dir / 'polylogue-ops-status.typescript'}"
+            ),
+            "capture_tui_placeholder": (
+                "Record branch-local TUI/terminal runs into "
+                f"{tui_artifact_dir}; use the local terminal-control surface or VHS when visual playback is needed"
+            ),
         },
         "warnings": warnings,
     }

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -112,6 +112,7 @@ def system_service_status(unit: str = "polylogued.service") -> dict[str, Any]:
 
 
 _PID_RE = re.compile(r"pid=(?P<pid>\d+)")
+_RUN_ID_SAFE_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
 
 
 def _parse_ss_port_owners(stdout: str, port: int) -> list[dict[str, Any]]:
@@ -145,6 +146,12 @@ def port_status(port: int) -> dict[str, Any]:
     }
 
 
+def _dev_loop_run_id(*, branch: str | None, commit: str | None, api_port: int, browser_capture_port: int) -> str:
+    branch_part = _RUN_ID_SAFE_RE.sub("-", branch or "detached").strip("-") or "detached"
+    commit_part = _RUN_ID_SAFE_RE.sub("-", commit or "unknown").strip("-") or "unknown"
+    return f"{branch_part}-{commit_part}-api{api_port}-capture{browser_capture_port}"
+
+
 def build_dev_loop_status(
     *,
     repo_root: Path | None = None,
@@ -166,6 +173,15 @@ def build_dev_loop_status(
     receiver = port_status(browser_capture_port)
     branch = _git_value(["branch", "--show-current"], cwd=root)
     commit = _git_value(["rev-parse", "--short", "HEAD"], cwd=root)
+    run_id = _dev_loop_run_id(
+        branch=branch,
+        commit=commit,
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+    )
+    run_log_dir = logs / run_id
+    daemon_log = run_log_dir / "polylogued.log"
+    browser_artifact_dir = run_log_dir / "browser"
     warnings: list[str] = []
     if service.get("active"):
         warnings.append(
@@ -179,9 +195,16 @@ def build_dev_loop_status(
         "repo_root": str(root),
         "branch": branch,
         "commit": commit,
+        "run_id": run_id,
         "prepared": prepare,
         "dev_archive_root": str(archive),
         "log_dir": str(logs),
+        "run_log_dir": str(run_log_dir),
+        "artifacts": {
+            "daemon_log": str(daemon_log),
+            "browser_dir": str(browser_artifact_dir),
+            "preflight_json": str(run_log_dir / "preflight.json"),
+        },
         "system_service": service,
         "ports": {
             "api": api,
@@ -191,15 +214,20 @@ def build_dev_loop_status(
             "POLYLOGUE_ARCHIVE_ROOT": str(archive),
             "POLYLOGUE_API_PORT": str(api_port),
             "POLYLOGUE_BROWSER_CAPTURE_PORT": str(browser_capture_port),
+            "POLYLOGUE_DEV_LOOP_RUN_ID": run_id,
+            "POLYLOGUE_DEV_LOOP_LOG_DIR": str(run_log_dir),
         },
         "commands": {
             "stop_system_service": "systemctl --user stop polylogued.service",
             "prepare": "devtools workspace dev-loop --prepare",
+            "save_preflight": f"mkdir -p {run_log_dir} && devtools workspace dev-loop --json > {run_log_dir / 'preflight.json'}",
             "run_daemon": (
                 f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
                 f"POLYLOGUE_API_PORT={api_port} "
                 f"POLYLOGUE_BROWSER_CAPTURE_PORT={browser_capture_port} "
-                f"polylogued run 2>&1 | tee {logs / 'polylogued.log'}"
+                f"POLYLOGUE_DEV_LOOP_RUN_ID={run_id} "
+                f"POLYLOGUE_DEV_LOOP_LOG_DIR={run_log_dir} "
+                f"polylogued run 2>&1 | tee {daemon_log}"
             ),
             "open_web_shell": f"http://127.0.0.1:{api_port}/",
             "receiver_status": f"curl -sf http://127.0.0.1:{browser_capture_port}/v1/status",
@@ -212,8 +240,10 @@ def _print_human(payload: dict[str, Any]) -> None:
     print("Polylogue dev loop")
     print(f"  repo:    {payload['repo_root']}")
     print(f"  branch:  {payload.get('branch') or 'unknown'} @ {payload.get('commit') or 'unknown'}")
+    print(f"  run id:  {payload['run_id']}")
     print(f"  archive: {payload['dev_archive_root']}")
     print(f"  logs:    {payload['log_dir']}")
+    print(f"  run log: {payload['run_log_dir']}")
     service = payload["system_service"]
     assert isinstance(service, dict)
     print(

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -179,6 +179,7 @@ def build_dev_loop_status(
     run_log_dir = logs / run_id
     daemon_log = run_log_dir / "polylogued.log"
     browser_artifact_dir = run_log_dir / "browser"
+    preflight_json = run_log_dir / "preflight.json"
     if prepare:
         archive.mkdir(parents=True, exist_ok=True)
         browser_artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -191,19 +192,20 @@ def build_dev_loop_status(
         if int(status.get("owner_count") or 0) > 0:
             warnings.append(f"{name} port {status['port']} already has a listener")
 
-    return {
+    payload = {
         "repo_root": str(root),
         "branch": branch,
         "commit": commit,
         "run_id": run_id,
         "prepared": prepare,
+        "preflight_json_written": False,
         "dev_archive_root": str(archive),
         "log_dir": str(logs),
         "run_log_dir": str(run_log_dir),
         "artifacts": {
             "daemon_log": str(daemon_log),
             "browser_dir": str(browser_artifact_dir),
-            "preflight_json": str(run_log_dir / "preflight.json"),
+            "preflight_json": str(preflight_json),
         },
         "system_service": service,
         "ports": {
@@ -220,7 +222,7 @@ def build_dev_loop_status(
         "commands": {
             "stop_system_service": "systemctl --user stop polylogued.service",
             "prepare": "devtools workspace dev-loop --prepare",
-            "save_preflight": f"mkdir -p {run_log_dir} && devtools workspace dev-loop --json > {run_log_dir / 'preflight.json'}",
+            "save_preflight": f"mkdir -p {run_log_dir} && devtools workspace dev-loop --json > {preflight_json}",
             "run_daemon": (
                 f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
                 f"POLYLOGUE_API_PORT={api_port} "
@@ -234,6 +236,10 @@ def build_dev_loop_status(
         },
         "warnings": warnings,
     }
+    if prepare:
+        payload["preflight_json_written"] = True
+        preflight_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
 
 
 def _print_human(payload: dict[str, Any]) -> None:

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -327,7 +327,7 @@ def build_dev_loop_status(
                 f"POLYLOGUE_BROWSER_CAPTURE_PORT={browser_capture_port} "
                 f"POLYLOGUE_DEV_LOOP_RUN_ID={run_id} "
                 f"POLYLOGUE_DEV_LOOP_LOG_DIR={run_log_dir} "
-                f"polylogued run 2>&1 | tee {daemon_log}"
+                f"polylogued run --api-port {api_port} --port {browser_capture_port} 2>&1 | tee {daemon_log}"
             ),
             "open_web_shell": f"http://127.0.0.1:{api_port}/",
             "receiver_status": f"curl -sf http://127.0.0.1:{browser_capture_port}/v1/status",

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -10,13 +10,18 @@ import socket
 import subprocess
 import sys
 from dataclasses import dataclass
+from http.client import HTTPConnection
 from pathlib import Path
+from threading import Thread
 from typing import Any
 
 from devtools import repo_root as _repo_root
+from polylogue.browser_capture.server import make_server
 
 DEFAULT_API_PORT = 8766
 DEFAULT_BROWSER_CAPTURE_PORT = 8765
+_RECEIVER_SMOKE_ORIGIN = "chrome-extension://polylogue-dev-loop"
+_RECEIVER_SMOKE_TOKEN = "polylogue-dev-loop-token"
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,6 +151,92 @@ def port_status(port: int) -> dict[str, Any]:
     }
 
 
+def _browser_capture_smoke_payload() -> dict[str, object]:
+    return {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "provenance": {
+            "source_url": "https://chatgpt.com/c/dev-loop-smoke",
+            "page_title": "Polylogue dev-loop smoke",
+            "captured_at": "2026-06-20T00:00:00+00:00",
+            "adapter_name": "dev-loop-smoke",
+        },
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": "dev-loop-smoke",
+            "title": "Polylogue dev-loop smoke",
+            "turns": [{"provider_turn_id": "turn-1", "role": "user", "text": "smoke"}],
+        },
+    }
+
+
+def _receiver_post(
+    *,
+    host: str,
+    port: int,
+    body: object,
+    auth_token: str | None,
+) -> tuple[int, dict[str, object]]:
+    headers = {
+        "Content-Type": "application/json",
+        "Origin": _RECEIVER_SMOKE_ORIGIN,
+    }
+    if auth_token is not None:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    conn = HTTPConnection(host, port, timeout=5)
+    try:
+        conn.request("POST", "/v1/browser-captures", body=json.dumps(body), headers=headers)
+        response = conn.getresponse()
+        response_body = json.loads(response.read().decode("utf-8"))
+        return response.status, dict(response_body)
+    finally:
+        conn.close()
+
+
+def run_receiver_smoke(*, spool_path: Path) -> dict[str, object]:
+    spool_path.mkdir(parents=True, exist_ok=True)
+    server = make_server(
+        "127.0.0.1",
+        0,
+        spool_path=spool_path,
+        auth_token=_RECEIVER_SMOKE_TOKEN,
+        extra_origins=(_RECEIVER_SMOKE_ORIGIN,),
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        payload = _browser_capture_smoke_payload()
+        rejected_status, rejected_body = _receiver_post(host=str(host), port=int(port), body=payload, auth_token=None)
+        accepted_status, accepted_body = _receiver_post(
+            host=str(host),
+            port=int(port),
+            body=payload,
+            auth_token=_RECEIVER_SMOKE_TOKEN,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    artifact_ref = accepted_body.get("artifact_ref")
+    artifact_path = spool_path / str(artifact_ref) if isinstance(artifact_ref, str) else None
+    return {
+        "ok": rejected_status == 401
+        and accepted_status == 202
+        and artifact_path is not None
+        and artifact_path.exists(),
+        "host": str(host),
+        "port": int(port),
+        "spool_path": str(spool_path),
+        "unauthenticated_status": rejected_status,
+        "unauthenticated_error": rejected_body.get("error"),
+        "authenticated_status": accepted_status,
+        "artifact_ref": artifact_ref,
+        "artifact_path": str(artifact_path) if artifact_path is not None else None,
+        "bytes_written": accepted_body.get("bytes_written"),
+    }
+
+
 def _dev_loop_run_id(*, branch: str | None, commit: str | None, api_port: int, browser_capture_port: int) -> str:
     branch_part = _RUN_ID_SAFE_RE.sub("-", branch or "detached").strip("-") or "detached"
     commit_part = _RUN_ID_SAFE_RE.sub("-", commit or "unknown").strip("-") or "unknown"
@@ -223,6 +314,7 @@ def build_dev_loop_status(
             "stop_system_service": "systemctl --user stop polylogued.service",
             "prepare": "devtools workspace dev-loop --prepare",
             "save_preflight": f"mkdir -p {run_log_dir} && devtools workspace dev-loop --json > {preflight_json}",
+            "receiver_smoke": "devtools workspace dev-loop --receiver-smoke --json",
             "run_daemon": (
                 f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
                 f"POLYLOGUE_API_PORT={api_port} "
@@ -274,6 +366,19 @@ def _print_human(payload: dict[str, Any]) -> None:
         print(f"  {name}: {command}")
 
 
+def _print_receiver_smoke(payload: dict[str, Any]) -> None:
+    preflight = payload["preflight"]
+    smoke = payload["receiver_smoke"]
+    assert isinstance(preflight, dict)
+    assert isinstance(smoke, dict)
+    print("Polylogue dev-loop receiver smoke")
+    print(f"  run id:  {preflight['run_id']}")
+    print(f"  ok:      {smoke['ok']}")
+    print(f"  reject:  {smoke['unauthenticated_status']} {smoke.get('unauthenticated_error')}")
+    print(f"  accept:  {smoke['authenticated_status']}")
+    print(f"  artifact: {smoke.get('artifact_ref')}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -286,14 +391,30 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--archive-root", type=Path, help="Branch-local archive root to report/use.")
     parser.add_argument("--log-dir", type=Path, help="Branch-local dev-loop log directory to report/use.")
     parser.add_argument("--prepare", action="store_true", help="Create the reported archive/log directories.")
+    parser.add_argument(
+        "--receiver-smoke",
+        action="store_true",
+        help="Run a deterministic in-process browser-capture receiver smoke.",
+    )
     args = parser.parse_args(argv)
     payload = build_dev_loop_status(
         api_port=args.api_port,
         browser_capture_port=args.browser_capture_port,
         archive_root=args.archive_root,
         log_dir=args.log_dir,
-        prepare=args.prepare,
+        prepare=args.prepare or args.receiver_smoke,
     )
+    if args.receiver_smoke:
+        smoke_payload: dict[str, Any] = {
+            "preflight": payload,
+            "receiver_smoke": run_receiver_smoke(spool_path=Path(str(payload["run_log_dir"])) / "receiver-smoke-spool"),
+        }
+        if args.json:
+            json.dump(smoke_payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            _print_receiver_smoke(smoke_payload)
+        return 0 if smoke_payload["receiver_smoke"]["ok"] else 1
     if args.json:
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -26,6 +26,11 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
         "docs/devtools.md",
         "`devtools` guide for generated surfaces, validation, and repo hygiene.",
     ),
+    DocsEntry(
+        "Branch-Local Development Loop",
+        "docs/dev-loop.md",
+        "Branch-local daemon, web-shell, browser-capture, and extension debugging workflow.",
+    ),
     DocsEntry("Library API", "docs/library-api.md", "Async archive API, filters, and query patterns."),
     DocsEntry("Data Model", "docs/data-model.md", "Archive entities, storage shape, and metadata rules."),
     DocsEntry(
@@ -117,6 +122,7 @@ README_DOC_TITLES: tuple[str, ...] = (
     "Provider Package Completeness",
     "Archive Backup",
     "Developer Tools",
+    "Branch-Local Development Loop",
     "Providers",
 )
 

--- a/devtools/task_history.py
+++ b/devtools/task_history.py
@@ -142,6 +142,7 @@ _CLASS_PREFIXES: tuple[tuple[str, str], ...] = (
     ("workspace tasks", "query"),
     ("workspace failure-context", "query"),
     ("workspace worktree-gc", "query"),
+    ("workspace dev-loop", "query"),
     ("status", "query"),
 )
 

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -1,0 +1,115 @@
+# Branch-Local Development Loop
+
+Use this workflow when working on the daemon web shell, daemon HTTP routes,
+browser-capture receiver, or browser extension from a feature branch. The goal
+is to debug the branch you are editing without deploying it systemwide or
+pointing it at the production archive by accident.
+
+## Preflight
+
+Run the workspace preflight first:
+
+```bash
+devtools workspace dev-loop
+devtools workspace dev-loop --json
+```
+
+It reports:
+
+- the current checkout path, branch, and commit;
+- whether the user `polylogued.service` is active;
+- listeners on the daemon API port and browser-capture receiver port;
+- the branch-local archive root and log directory to use;
+- a concrete `polylogued run` command with branch-local environment variables.
+
+The default branch-local paths are:
+
+```text
+.local/dev-archive/
+.cache/dev-loop/
+```
+
+Create them explicitly when needed:
+
+```bash
+devtools workspace dev-loop --prepare
+```
+
+These paths are local development state. Do not commit archive data, logs,
+browser profiles, cookies, screenshots, or receiver payloads from them.
+
+## Service Separation
+
+The simplest safe posture is to stop the deployed user service while running a
+branch-local daemon:
+
+```bash
+systemctl --user stop polylogued.service
+```
+
+If you keep the deployed service running, use different ports and verify the
+preflight output before starting the branch daemon:
+
+```bash
+devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875
+```
+
+Then run the command printed by the preflight. The important variables are:
+
+```bash
+POLYLOGUE_ARCHIVE_ROOT=.local/dev-archive
+POLYLOGUE_API_PORT=8876
+POLYLOGUE_BROWSER_CAPTURE_PORT=8875
+```
+
+## Web Shell Debugging
+
+The branch-local web shell is served by the branch-local `polylogued run`
+process. Open the URL printed by the preflight, usually:
+
+```text
+http://127.0.0.1:8766/
+```
+
+For web shell work, keep the daemon output tee'd into `.cache/dev-loop/` so UI
+errors can be correlated with route logs and request failures. The development
+loop should make these facts obvious before an agent starts debugging:
+
+- which checkout started the daemon;
+- which archive root the daemon serves;
+- which API port the browser should open;
+- where daemon logs are written;
+- whether the deployed service is still active.
+
+## Browser-Capture Extension Development
+
+Load `browser-extension/` unpacked into a development Chrome profile and point
+the extension at the receiver URL printed by the preflight. For ordinary local
+development, use an empty agent-private profile. For authenticated ChatGPT or
+Claude.ai adapter work, an operator-approved copy of the real browser profile
+may be used on this workstation only.
+
+Copied-profile rules:
+
+- copy the profile into `.local/browser-profiles/` or another ignored local
+  path;
+- restrict permissions to the local user;
+- never use copied profiles in CI or cloud agents;
+- delete the copy after the debugging session if it is no longer needed;
+- do not commit profile data, cookies, screenshots, or raw captured content.
+
+The extension loop should verify both failure and success cases:
+
+- receiver unavailable;
+- missing or invalid auth token when auth is configured;
+- valid capture POST accepted by the branch-local receiver;
+- service-worker logs show the receiver URL, status, and last error;
+- content adapters expose diagnostic state without dumping raw conversation
+  text by default.
+
+## Current Boundary
+
+`devtools workspace dev-loop` is a preflight and directory-preparation command.
+It does not start or stop services for you. That keeps destructive/runtime acts
+explicit while still giving agents a single place to discover the active ports,
+service state, and branch-local paths before they start a daemon/browser loop.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -22,7 +22,8 @@ It reports:
 - whether the user `polylogued.service` is active;
 - listeners on the daemon API port and browser-capture receiver port;
 - the branch-local archive root, run log directory, daemon log, browser
-  artifact directory, and preflight JSON path to use;
+  artifact directory, terminal/TUI artifact directories, and preflight JSON
+  path to use;
 - a concrete `polylogued run` command with branch-local environment variables.
 
 The default branch-local paths are:
@@ -93,13 +94,36 @@ loop should make these facts obvious before an agent starts debugging:
 - where daemon logs are written;
 - whether the deployed service is still active.
 
+## CLI and TUI Capture
+
+Human-facing CLI/TUI behavior should be debuggable as rendered, not only as
+JSON payloads. The preflight reserves run-local directories for those artifacts:
+
+```text
+.cache/dev-loop/<run-id>/terminal/
+.cache/dev-loop/<run-id>/tui/
+```
+
+The `commands.capture_cli_status` entry shows a concrete terminal transcript
+capture for `polylogue ops status` against the branch-local archive. Use the
+same pattern for other CLI commands whose layout, colors, wrapping, or progress
+behavior matters.
+
+For TUI or full-screen terminal work, record into the run-local `tui/`
+directory using the local terminal-control surface, `script`, or VHS-style
+recording when visual playback is needed. Polylogue only provides the
+branch-local environment and artifact locations; visual inspection and terminal
+control remain local agent/operator capabilities.
+
 ## Browser-Capture Extension Development
 
 Load `browser-extension/` unpacked into a development Chrome profile and point
-the extension at the receiver URL printed by the preflight. For ordinary local
-development, use an empty agent-private profile. For authenticated ChatGPT or
-Claude.ai adapter work, an operator-approved copy of the real browser profile
-may be used on this workstation only.
+the extension at the receiver URL printed by the preflight. Polylogue does not
+provide or verify the browser-control substrate itself; local agents/operators
+use their existing browser tooling to open the branch-local web shell, inspect
+DOM/network state, and load the unpacked extension. For authenticated ChatGPT
+or Claude.ai adapter work, an operator-approved copy of the real browser
+profile may be used on this workstation only.
 
 Copied-profile rules:
 

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -119,6 +119,19 @@ The extension loop should verify both failure and success cases:
 - content adapters expose diagnostic state without dumping raw conversation
   text by default.
 
+Before involving a real browser, run the deterministic receiver smoke:
+
+```bash
+devtools workspace dev-loop --receiver-smoke
+devtools workspace dev-loop --receiver-smoke --json
+```
+
+The smoke starts an in-process loopback receiver on an ephemeral port, configures
+auth, verifies that an unauthenticated capture is rejected, verifies that an
+authenticated synthetic capture is accepted, and reports the written spool
+artifact. It uses the branch-local run directory and does not talk to the
+deployed `polylogued.service`.
+
 ## Current Boundary
 
 `devtools workspace dev-loop` is a preflight and directory-preparation command.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -38,14 +38,12 @@ Create them explicitly when needed:
 devtools workspace dev-loop --prepare
 ```
 
-For a reproducible debugging bundle, save the exact preflight before starting
-the daemon:
+`--prepare` creates the branch-local archive root, the run-specific browser
+artifact directory, and writes the preflight payload to:
 
-```bash
-devtools workspace dev-loop --json > .cache/dev-loop/<run-id>/preflight.json
+```text
+.cache/dev-loop/<run-id>/preflight.json
 ```
-
-The printed `save_preflight` command expands the current run id for you.
 
 These paths are local development state. Do not commit archive data, logs,
 browser profiles, cookies, screenshots, or receiver payloads from them.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -17,9 +17,12 @@ devtools workspace dev-loop --json
 It reports:
 
 - the current checkout path, branch, and commit;
+- a deterministic branch-local run id for correlating daemon, browser, and
+  receiver artifacts;
 - whether the user `polylogued.service` is active;
 - listeners on the daemon API port and browser-capture receiver port;
-- the branch-local archive root and log directory to use;
+- the branch-local archive root, run log directory, daemon log, browser
+  artifact directory, and preflight JSON path to use;
 - a concrete `polylogued run` command with branch-local environment variables.
 
 The default branch-local paths are:
@@ -34,6 +37,15 @@ Create them explicitly when needed:
 ```bash
 devtools workspace dev-loop --prepare
 ```
+
+For a reproducible debugging bundle, save the exact preflight before starting
+the daemon:
+
+```bash
+devtools workspace dev-loop --json > .cache/dev-loop/<run-id>/preflight.json
+```
+
+The printed `save_preflight` command expands the current run id for you.
 
 These paths are local development state. Do not commit archive data, logs,
 browser profiles, cookies, screenshots, or receiver payloads from them.
@@ -76,6 +88,8 @@ errors can be correlated with route logs and request failures. The development
 loop should make these facts obvious before an agent starts debugging:
 
 - which checkout started the daemon;
+- which run id ties together the daemon log, browser artifacts, and receiver
+  observations;
 - which archive root the daemon serves;
 - which API port the browser should open;
 - where daemon logs are written;

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -155,6 +155,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools workspace dev-loop` | Preflight branch-local daemon, web-shell, and browser-capture development loops. |
 | `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools workspace tasks` | Record and query local agent task execution history. |
 | `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged or abandoned git worktrees. |

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -98,11 +98,13 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert payload["commit"] == "abc1234"
     assert payload["run_id"] == "feature-dev-loop-abc1234-api9999-capture9998"
     assert payload["prepared"] is True
+    assert payload["preflight_json_written"] is True
     assert Path(str(payload["dev_archive_root"])).is_dir()
     assert Path(str(payload["log_dir"])).is_dir()
     assert payload["run_log_dir"] == str(repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api9999-capture9998")
     assert Path(str(payload["run_log_dir"])).is_dir()
     assert Path(str(payload["artifacts"]["browser_dir"])).is_dir()
+    assert Path(str(payload["artifacts"]["preflight_json"])).is_file()
     assert payload["artifacts"]["daemon_log"].endswith(
         ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
     )
@@ -126,6 +128,7 @@ def test_main_json_outputs_machine_payload(
             "commit": "abc1234",
             "run_id": "feature-dev-loop-abc1234-api8766-capture8765",
             "prepared": kwargs["prepare"],
+            "preflight_json_written": kwargs["prepare"],
             "dev_archive_root": str(tmp_path / "archive"),
             "log_dir": str(tmp_path / "logs"),
             "run_log_dir": str(tmp_path / "logs" / "run"),

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -104,9 +104,16 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert payload["run_log_dir"] == str(repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api9999-capture9998")
     assert Path(str(payload["run_log_dir"])).is_dir()
     assert Path(str(payload["artifacts"]["browser_dir"])).is_dir()
+    assert Path(str(payload["artifacts"]["terminal_dir"])).is_dir()
+    assert Path(str(payload["artifacts"]["tui_dir"])).is_dir()
     assert Path(str(payload["artifacts"]["preflight_json"])).is_file()
     assert payload["artifacts"]["daemon_log"].endswith(
         ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
+    )
+    assert "polylogue ops status" in payload["commands"]["capture_cli_status"]
+    assert payload["commands"]["capture_cli_status"].endswith("terminal/polylogue-ops-status.typescript")
+    assert payload["commands"]["capture_tui_placeholder"].endswith(
+        "tui; use the local terminal-control surface or VHS when visual playback is needed"
     )
     assert payload["suggested_env"]["POLYLOGUE_ARCHIVE_ROOT"] == str(repo / ".local" / "dev-archive")
     assert payload["suggested_env"]["POLYLOGUE_DEV_LOOP_RUN_ID"] == payload["run_id"]

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -145,3 +145,34 @@ def test_main_json_outputs_machine_payload(
     payload = json.loads(capsys.readouterr().out)
     assert payload["prepared"] is True
     assert payload["branch"] == "feature/dev-loop"
+
+
+def test_receiver_smoke_proves_auth_rejection_and_acceptance(tmp_path: Path) -> None:
+    payload = dev_loop.run_receiver_smoke(spool_path=tmp_path / "spool")
+
+    assert payload["ok"] is True
+    assert payload["unauthenticated_status"] == 401
+    assert payload["unauthenticated_error"] == "unauthorized"
+    assert payload["authenticated_status"] == 202
+    assert payload["artifact_ref"] == "chatgpt/dev-loop-smoke-e368c8af2a6b.json"
+    assert Path(str(payload["artifact_path"])).is_file()
+
+
+def test_receiver_smoke_cli_outputs_combined_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    assert dev_loop.main(["--json", "--receiver-smoke", "--archive-root", str(tmp_path / "archive")]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["preflight"]["prepared"] is True
+    assert payload["preflight"]["preflight_json_written"] is True
+    assert payload["receiver_smoke"]["ok"] is True

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools import dev_loop
+
+
+def test_system_service_status_reports_active_unit_archive_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(args: list[str], *, timeout_s: float = 2.0) -> dev_loop.CommandResult:
+        assert args[:3] == ["systemctl", "--user", "show"]
+        return dev_loop.CommandResult(
+            exit_code=0,
+            stdout="\n".join(
+                [
+                    "ActiveState=active",
+                    "SubState=running",
+                    "MainPID=1234",
+                    "FragmentPath=/home/sinity/.config/systemd/user/polylogued.service",
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(dev_loop, "_run_command", fake_run)
+    monkeypatch.setattr(
+        dev_loop, "_read_environ", lambda pid: {"POLYLOGUE_ARCHIVE_ROOT": "/archive"} if pid == 1234 else {}
+    )
+
+    payload = dev_loop.system_service_status()
+
+    assert payload["available"] is True
+    assert payload["active"] is True
+    assert payload["main_pid"] == 1234
+    assert payload["archive_root"] == "/archive"
+
+
+def test_port_status_reports_owner_and_archive_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    ss_output = (
+        'LISTEN 0 4096 127.0.0.1:8766 0.0.0.0:* users:(("python",pid=2222,fd=8))\n'
+        'LISTEN 0 4096 127.0.0.1:8765 0.0.0.0:* users:(("python",pid=3333,fd=9))'
+    )
+
+    def fake_run(args: list[str], *, timeout_s: float = 2.0) -> dev_loop.CommandResult:
+        assert args == ["ss", "-H", "-ltnp"]
+        return dev_loop.CommandResult(exit_code=0, stdout=ss_output, stderr="")
+
+    monkeypatch.setattr(dev_loop, "_run_command", fake_run)
+    monkeypatch.setattr(dev_loop, "_socket_connectable", lambda port: port == 8766)
+    monkeypatch.setattr(
+        dev_loop,
+        "_read_environ",
+        lambda pid: {"POLYLOGUE_ARCHIVE_ROOT": f"/archive/{pid}"},
+    )
+
+    payload = dev_loop.port_status(8766)
+
+    assert payload["connectable"] is True
+    assert payload["owner_count"] == 1
+    owner = payload["owners"][0]
+    assert owner["pid"] == 2222
+    assert owner["archive_root"] == "/archive/2222"
+
+
+def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    monkeypatch.setattr(
+        dev_loop,
+        "system_service_status",
+        lambda: {
+            "unit": "polylogued.service",
+            "available": True,
+            "active": True,
+            "active_state": "active",
+            "main_pid": 123,
+            "archive_root": "/prod",
+        },
+    )
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 1 if port == 9999 else 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    payload = dev_loop.build_dev_loop_status(repo_root=repo, api_port=9999, browser_capture_port=9998, prepare=True)
+
+    assert payload["branch"] == "feature/dev-loop"
+    assert payload["commit"] == "abc1234"
+    assert payload["prepared"] is True
+    assert Path(str(payload["dev_archive_root"])).is_dir()
+    assert Path(str(payload["log_dir"])).is_dir()
+    assert payload["suggested_env"]["POLYLOGUE_ARCHIVE_ROOT"] == str(repo / ".local" / "dev-archive")
+    assert payload["warnings"] == [
+        "systemwide polylogued.service is active; stop it or use isolated ports before branch-local runs",
+        "api port 9999 already has a listener",
+    ]
+
+
+def test_main_json_outputs_machine_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        dev_loop,
+        "build_dev_loop_status",
+        lambda **kwargs: {
+            "repo_root": str(tmp_path),
+            "branch": "feature/dev-loop",
+            "commit": "abc1234",
+            "prepared": kwargs["prepare"],
+            "dev_archive_root": str(tmp_path / "archive"),
+            "log_dir": str(tmp_path / "logs"),
+            "system_service": {"active": False},
+            "ports": {},
+            "suggested_env": {},
+            "commands": {},
+            "warnings": [],
+        },
+    )
+
+    assert dev_loop.main(["--json", "--prepare"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["prepared"] is True
+    assert payload["branch"] == "feature/dev-loop"

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -96,10 +96,16 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
 
     assert payload["branch"] == "feature/dev-loop"
     assert payload["commit"] == "abc1234"
+    assert payload["run_id"] == "feature-dev-loop-abc1234-api9999-capture9998"
     assert payload["prepared"] is True
     assert Path(str(payload["dev_archive_root"])).is_dir()
     assert Path(str(payload["log_dir"])).is_dir()
+    assert payload["run_log_dir"] == str(repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api9999-capture9998")
+    assert payload["artifacts"]["daemon_log"].endswith(
+        ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
+    )
     assert payload["suggested_env"]["POLYLOGUE_ARCHIVE_ROOT"] == str(repo / ".local" / "dev-archive")
+    assert payload["suggested_env"]["POLYLOGUE_DEV_LOOP_RUN_ID"] == payload["run_id"]
     assert payload["warnings"] == [
         "systemwide polylogued.service is active; stop it or use isolated ports before branch-local runs",
         "api port 9999 already has a listener",
@@ -116,9 +122,12 @@ def test_main_json_outputs_machine_payload(
             "repo_root": str(tmp_path),
             "branch": "feature/dev-loop",
             "commit": "abc1234",
+            "run_id": "feature-dev-loop-abc1234-api8766-capture8765",
             "prepared": kwargs["prepare"],
             "dev_archive_root": str(tmp_path / "archive"),
             "log_dir": str(tmp_path / "logs"),
+            "run_log_dir": str(tmp_path / "logs" / "run"),
+            "artifacts": {},
             "system_service": {"active": False},
             "ports": {},
             "suggested_env": {},

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -101,6 +101,8 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert Path(str(payload["dev_archive_root"])).is_dir()
     assert Path(str(payload["log_dir"])).is_dir()
     assert payload["run_log_dir"] == str(repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api9999-capture9998")
+    assert Path(str(payload["run_log_dir"])).is_dir()
+    assert Path(str(payload["artifacts"]["browser_dir"])).is_dir()
     assert payload["artifacts"]["daemon_log"].endswith(
         ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
     )

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -110,6 +110,7 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert payload["artifacts"]["daemon_log"].endswith(
         ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
     )
+    assert "polylogued run --api-port 9999 --port 9998" in payload["commands"]["run_daemon"]
     assert "polylogue ops status" in payload["commands"]["capture_cli_status"]
     assert payload["commands"]["capture_cli_status"].endswith("terminal/polylogue-ops-status.typescript")
     assert payload["commands"]["capture_tui_placeholder"].endswith(

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -83,7 +83,6 @@ def test_fresh_user_tier_creates_assertions_table(tmp_path: Path) -> None:
     try:
         assert _table_exists(conn, "assertions")
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
-        assert USER_SCHEMA_VERSION == 2
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Adds `devtools workspace dev-loop` as the branch-local preflight and artifact-preparation surface for daemon, web shell, browser-capture receiver, extension, CLI, and TUI debugging. The command reports deployed-service/port collisions, branch/archive/log metadata, run-local artifact directories, concrete launch/capture commands, and can run a deterministic browser receiver auth/spool smoke without touching the production archive.

## Problem

Daemon/web/extension work was too easy to test accidentally against the deployed `polylogued.service` or the production archive. Agents also lacked one obvious run id, log directory, and artifact tree for correlating branch-local daemon output, web-shell inspection, receiver logs, CLI transcripts, and future TUI recordings. That made debugging loops slower and encouraged guessing from live system state instead of inspecting branch-local evidence.

## Solution

`devtools/dev_loop.py` now owns a repo-local dev-loop report. It derives a deterministic run id from branch/commit/ports, checks `polylogued.service`, inspects listeners on the daemon API and browser-capture ports, reports archive roots from `/proc/<pid>/environ` when discoverable, prepares `.local/dev-archive` plus `.cache/dev-loop/<run-id>/` subdirectories, and writes preflight JSON on `--prepare`.

The report prints environment-scoped launch commands for branch-local `polylogued`, web-shell URLs, receiver status, a concrete `script` transcript command for `polylogue ops status`, and TUI artifact guidance that keeps terminal control/VHS/visual inspection in the local agent/operator control plane rather than inside the repo. `--receiver-smoke` starts an in-process receiver on an ephemeral loopback port, proves missing auth is rejected, proves an authenticated synthetic capture is accepted, and reports the spool artifact.

Docs add `docs/dev-loop.md`, wire it into generated surfaces, and clarify the browser-control boundary: Polylogue provides branch-local URLs, receiver settings, logs, and extension configuration; the local agent/operator environment owns browser/terminal control, copied-profile handling, screenshots, and visual inspection.

Closes #2248.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py tests/unit/storage/test_archive_tiers_assertions.py::test_fresh_user_tier_creates_assertions_table -q` -> `7 passed`.
- `devtools workspace dev-loop --json --prepare --receiver-smoke > /tmp/polylogue-dev-loop-smoke.json` -> receiver smoke `ok: true`, unauthenticated POST `401`, authenticated POST `202`, and run-local preflight/spool artifacts written.
- `devtools render all --check` -> clean.
- `devtools verify --quick` -> exit 0.
- `devtools verify --seed-testmon --skip-slow` -> `11772 passed`, peak pytest tree RSS `3403.2 MiB`, diagnosis `pytest_passed`.
- `devtools verify` -> `7 passed`, peak pytest tree RSS `579.9 MiB`, diagnosis `pytest_passed`.
