### PR TITLE
feat(query): bind predicates to field refs

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -129,6 +129,7 @@ from polylogue.archive.query.predicate import (
     QueryCompareOp,
     QueryExistsPredicate,
     QueryFieldPredicate,
+    QueryFieldRef,
     QueryLineagePredicate,
     QueryNotPredicate,
     QueryPredicate,
@@ -985,6 +986,53 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         return
 
 
+def _field_ref_for_predicate(
+    predicate: QueryFieldPredicate,
+    *,
+    unit: Literal["session"] | QueryUnitName,
+) -> QueryFieldRef:
+    session_field = _scoped_session_field(predicate.field)
+    if unit == "session":
+        return QueryFieldRef(scope="session", name=predicate.field, source_name=predicate.field)
+    if session_field is not None:
+        return QueryFieldRef(
+            scope="session",
+            name=session_field,
+            source_name=predicate.field,
+            unit=unit,
+        )
+    return QueryFieldRef(scope="unit", name=predicate.field, source_name=predicate.field, unit=unit)
+
+
+def _bind_predicate_context(
+    predicate: QueryPredicate,
+    *,
+    unit: Literal["session"] | QueryUnitName,
+) -> QueryPredicate:
+    """Validate a predicate tree and attach closed field identity to leaves."""
+
+    _validate_predicate_context(predicate, unit=unit)
+    if isinstance(predicate, QueryFieldPredicate):
+        return predicate.with_field_ref(_field_ref_for_predicate(predicate, unit=unit))
+    if isinstance(predicate, QueryNotPredicate):
+        return QueryNotPredicate(_bind_predicate_context(predicate.child, unit=unit))
+    if isinstance(predicate, QueryBoolPredicate):
+        return QueryBoolPredicate(
+            predicate.op,
+            tuple(_bind_predicate_context(child, unit=unit) for child in predicate.children),
+        )
+    if isinstance(predicate, QueryExistsPredicate):
+        return QueryExistsPredicate(
+            predicate.unit,
+            _bind_predicate_context(predicate.child, unit=predicate.unit),
+        )
+    if isinstance(predicate, QuerySequencePredicate):
+        return QuerySequencePredicate(
+            steps=tuple(_bind_predicate_context(step, unit="action") for step in predicate.steps)
+        )
+    return predicate
+
+
 @v_args(inline=True)
 class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
     def boolean_query(self, *items: object) -> QueryPredicate:
@@ -1174,8 +1222,7 @@ def _transform_boolean_predicate(expression: str) -> QueryPredicate:
 
 def _parse_boolean_predicate(expression: str) -> QueryPredicate:
     transformed = _transform_boolean_predicate(expression)
-    _validate_predicate_context(transformed, unit="session")
-    return transformed
+    return _bind_predicate_context(transformed, unit="session")
 
 
 def _split_pipeline_stages(expression: str) -> tuple[str, ...]:
@@ -1461,8 +1508,8 @@ def _parse_plain_unit_source_expression(expression: str) -> QueryUnitSource | No
     if not inner:
         raise ExpressionCompileError(f"{unit}s where requires a predicate", field=None)
     transformed = _transform_boolean_predicate(inner)
-    _validate_predicate_context(transformed, unit=unit)
-    return QueryUnitSource(unit=unit, predicate=transformed)
+    bound = _bind_predicate_context(transformed, unit=unit)
+    return QueryUnitSource(unit=unit, predicate=bound)
 
 
 def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
@@ -1484,10 +1531,10 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
             )
         scoped_session_predicate = _scope_session_predicate(session_predicate)
         combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
-        _validate_predicate_context(combined, unit=terminal_source.unit)
+        bound = _bind_predicate_context(combined, unit=terminal_source.unit)
         source = QueryUnitSource(
             unit=terminal_source.unit,
-            predicate=combined,
+            predicate=bound,
             session_predicate=session_predicate,
             limit=terminal_source.limit,
             offset=terminal_source.offset,

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Literal, TypeAlias
 
 QueryBoolOp: TypeAlias = Literal["and", "or"]
 QueryCompareOp: TypeAlias = Literal["=", ">=", "<="]
+QueryFieldScope: TypeAlias = Literal["session", "unit"]
+
+
+@dataclass(frozen=True)
+class QueryFieldRef:
+    """Validated field identity carried by executable field predicates."""
+
+    scope: QueryFieldScope
+    name: str
+    source_name: str
+    unit: str | None = None
 
 
 @dataclass(frozen=True)
@@ -16,6 +28,17 @@ class QueryFieldPredicate:
     field: str
     values: tuple[str, ...] = ()
     op: QueryCompareOp = "="
+    field_ref: QueryFieldRef | None = dataclass_field(default=None, compare=False, repr=False)
+
+    def with_field_ref(self, field_ref: QueryFieldRef) -> QueryFieldPredicate:
+        """Return this predicate annotated with validated field identity."""
+
+        return QueryFieldPredicate(
+            field=self.field,
+            values=self.values,
+            op=self.op,
+            field_ref=field_ref,
+        )
 
     def to_payload(self) -> dict[str, object]:
         return {"kind": "field", "field": self.field, "op": self.op, "values": list(self.values)}
@@ -143,7 +166,9 @@ __all__ = [
     "QueryBoolPredicate",
     "QueryCompareOp",
     "QueryExistsPredicate",
+    "QueryFieldRef",
     "QueryFieldPredicate",
+    "QueryFieldScope",
     "QueryLineagePredicate",
     "QueryNotPredicate",
     "QueryPredicate",

--- a/polylogue/archive/query/runtime_matching.py
+++ b/polylogue/archive/query/runtime_matching.py
@@ -115,18 +115,19 @@ def _matches_action_field(predicate: QueryFieldPredicate, action: Action) -> boo
     values = tuple(value.strip().lower() for value in predicate.values if value.strip())
     if not values:
         return False
-    if predicate.field in {"action", "type"}:
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    if field in {"action", "type"}:
         return _matches_exact_values(action.kind.value, values)
-    if predicate.field == "tool":
+    if field == "tool":
         return _matches_exact_values(action.normalized_tool_name, values)
-    if predicate.field == "command":
+    if field == "command":
         return _matches_text(action.command, values)
-    if predicate.field == "path":
+    if field == "path":
         normalized_paths = tuple(path.lower().replace("\\", "/") for path in action.affected_paths)
         return any(value.replace("\\", "/") in path for value in values for path in normalized_paths)
-    if predicate.field == "output":
+    if field == "output":
         return _matches_text(action.output_text, values)
-    if predicate.field == "text":
+    if field == "text":
         return _matches_text(action.search_text, values)
     return False
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -250,7 +250,11 @@ def _summary_timestamp_matches(summary: ArchiveSessionSummary, field: str, predi
 
 
 def _summary_field_matches(summary: ArchiveSessionSummary, predicate: QueryFieldPredicate) -> bool:
-    field = predicate.field.removeprefix("session.")
+    field = (
+        predicate.field_ref.name
+        if predicate.field_ref is not None and predicate.field_ref.scope == "session"
+        else predicate.field.removeprefix("session.")
+    )
     values = predicate.values
     if field == "id":
         return _exact_or_contains(str(summary.session_id), values)
@@ -299,7 +303,9 @@ def _observed_event_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
+        return _summary_field_matches(summary, predicate)
     if field.startswith("session."):
         return _summary_field_matches(summary, predicate)
     if field == "kind":
@@ -367,7 +373,9 @@ def _context_snapshot_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
+        return _summary_field_matches(summary, predicate)
     if field.startswith("session."):
         return _summary_field_matches(summary, predicate)
     if field == "boundary":
@@ -419,7 +427,9 @@ def _run_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
+        return _summary_field_matches(summary, predicate)
     if field.startswith("session."):
         return _summary_field_matches(summary, predicate)
     if field in {"run", "run_ref"}:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4691,7 +4691,7 @@ def _field_predicate_clause(
     *,
     tags_relation: str,
 ) -> tuple[str, list[object]]:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
     values = predicate.values
     kwargs: dict[str, Any] = {}
     if field == "id":
@@ -4759,6 +4759,12 @@ def _scoped_session_field(field: str) -> str | None:
         return None
     scoped = field[len(prefix) :]
     return scoped or None
+
+
+def _predicate_session_field(predicate: QueryFieldPredicate) -> str | None:
+    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
+        return predicate.field_ref.name
+    return _scoped_session_field(predicate.field)
 
 
 def _in_or_equals_clause(column: str, values: tuple[str, ...], *, lower: bool = False) -> tuple[str, list[object]]:
@@ -4843,7 +4849,7 @@ def _like_clause(
 
 
 def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
     if field == "role":
         return _in_or_equals_clause(f"{message_alias}.role", predicate.values, lower=True)
     if field == "type":
@@ -4910,7 +4916,7 @@ def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPre
 
 
 def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
     if field == "tool":
         return _in_or_equals_clause(f"{action_alias}.tool_name", predicate.values, lower=True)
     if field in {"action", "type"}:
@@ -4939,7 +4945,7 @@ def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredi
 
 
 def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
     if field == "type":
         return _in_or_equals_clause(f"{block_alias}.block_type", predicate.values, lower=True)
     if field == "time":
@@ -4961,7 +4967,7 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
 
 
 def _assertion_field_predicate_clause(assertion_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field
+    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
     if field == "time":
         return _time_predicate_clause(_query_unit_time_expression("assertion", assertion_alias), predicate)
     if field == "status":
@@ -5007,7 +5013,7 @@ def _structural_predicate_clause(
     session_alias: str | None = None,
 ) -> tuple[str, list[object]]:
     if isinstance(predicate, QueryFieldPredicate):
-        session_field = _scoped_session_field(predicate.field)
+        session_field = _predicate_session_field(predicate)
         if session_field is not None:
             if session_alias is None:
                 raise ValueError(f"session-scoped {unit} predicate requires a session alias")

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -580,13 +580,20 @@ class TestBooleanQueryExpression:
         assert isinstance(scoped_session, QueryBoolPredicate)
         assert isinstance(role, QueryFieldPredicate)
         scoped_repo = scoped_session.children[0]
+        scoped_origin = scoped_session.children[1]
         assert isinstance(scoped_repo, QueryFieldPredicate)
+        assert isinstance(scoped_origin, QueryFieldPredicate)
 
         assert scoped_repo.field_ref is not None
         assert scoped_repo.field_ref.scope == "session"
         assert scoped_repo.field_ref.name == "repo"
         assert scoped_repo.field_ref.source_name == "session.repo"
         assert scoped_repo.field_ref.unit == "message"
+        assert scoped_origin.field_ref is not None
+        assert scoped_origin.field_ref.scope == "session"
+        assert scoped_origin.field_ref.name == "origin"
+        assert scoped_origin.field_ref.source_name == "session.origin"
+        assert scoped_origin.field_ref.unit == "message"
         assert role.field_ref is not None
         assert role.field_ref.scope == "unit"
         assert role.field_ref.name == "role"
@@ -943,8 +950,10 @@ class TestBooleanQueryExpression:
         sequence = ast.boolean_predicate
         first_step = sequence.steps[0]
         second_step = sequence.steps[1]
+        third_step = sequence.steps[2]
         assert isinstance(first_step, QueryFieldPredicate)
         assert isinstance(second_step, QueryBoolPredicate)
+        assert isinstance(third_step, QueryFieldPredicate)
         second_action = second_step.children[0]
         second_output = second_step.children[1]
         assert isinstance(second_action, QueryFieldPredicate)
@@ -957,6 +966,10 @@ class TestBooleanQueryExpression:
         assert second_action.field_ref.name == "action"
         assert second_output.field_ref is not None
         assert second_output.field_ref.name == "output"
+        assert third_step.field_ref is not None
+        assert third_step.field_ref.scope == "unit"
+        assert third_step.field_ref.unit == "action"
+        assert third_step.field_ref.name == "action"
 
     def test_sequence_step_rejects_session_fields(self) -> None:
         with pytest.raises(ExpressionCompileError, match="not supported for action predicates"):

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -535,6 +535,18 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="not supported for session predicates"):
             parse_expression_ast("sessions where time >= 2026-01-02T00:00:00+00:00")
 
+    def test_session_predicate_carries_validated_field_ref(self) -> None:
+        ast = parse_expression_ast("sessions where repo:polylogue")
+
+        predicate = cast(QueryFieldPredicate, ast.boolean_predicate)
+
+        assert predicate.field == "repo"
+        assert predicate.field_ref is not None
+        assert predicate.field_ref.scope == "session"
+        assert predicate.field_ref.name == "repo"
+        assert predicate.field_ref.source_name == "repo"
+        assert predicate.field_ref.unit is None
+
     def test_pipeline_session_source_scopes_terminal_unit_query(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"
@@ -562,6 +574,23 @@ class TestBooleanQueryExpression:
                 QueryFieldPredicate(field="role", values=("assistant",)),
             ),
         )
+        assert isinstance(source.predicate, QueryBoolPredicate)
+        scoped_session = source.predicate.children[0]
+        role = source.predicate.children[1]
+        assert isinstance(scoped_session, QueryBoolPredicate)
+        assert isinstance(role, QueryFieldPredicate)
+        scoped_repo = scoped_session.children[0]
+        assert isinstance(scoped_repo, QueryFieldPredicate)
+
+        assert scoped_repo.field_ref is not None
+        assert scoped_repo.field_ref.scope == "session"
+        assert scoped_repo.field_ref.name == "repo"
+        assert scoped_repo.field_ref.source_name == "session.repo"
+        assert scoped_repo.field_ref.unit == "message"
+        assert role.field_ref is not None
+        assert role.field_ref.scope == "unit"
+        assert role.field_ref.name == "role"
+        assert role.field_ref.unit == "message"
 
     def test_pipeline_split_ignores_field_alternation_pipe(self) -> None:
         source = parse_unit_source_expression(
@@ -910,6 +939,24 @@ class TestBooleanQueryExpression:
                 QueryFieldPredicate(field="action", values=("file_edit",)),
             ),
         )
+        assert isinstance(ast.boolean_predicate, QuerySequencePredicate)
+        sequence = ast.boolean_predicate
+        first_step = sequence.steps[0]
+        second_step = sequence.steps[1]
+        assert isinstance(first_step, QueryFieldPredicate)
+        assert isinstance(second_step, QueryBoolPredicate)
+        second_action = second_step.children[0]
+        second_output = second_step.children[1]
+        assert isinstance(second_action, QueryFieldPredicate)
+        assert isinstance(second_output, QueryFieldPredicate)
+
+        assert first_step.field_ref is not None
+        assert first_step.field_ref.scope == "unit"
+        assert first_step.field_ref.unit == "action"
+        assert second_action.field_ref is not None
+        assert second_action.field_ref.name == "action"
+        assert second_output.field_ref is not None
+        assert second_output.field_ref.name == "output"
 
     def test_sequence_step_rejects_session_fields(self) -> None:
         with pytest.raises(ExpressionCompileError, match="not supported for action predicates"):


### PR DESCRIPTION
## Summary

Bind parsed query field predicates to validated field references so executable query predicates carry their session/unit field identity past parser validation.

## Problem

The query DSL validates field names at parse time, but the executable predicate tree still reached SQL lowerers and runtime matchers as raw strings. That left lowerers reinterpreting `session.*` and terminal-unit fields after validation, which is exactly the kind of stringly boundary #2006 is supposed to remove.

## Solution

`QueryFieldPredicate` now carries an optional `QueryFieldRef` with the validated scope, normalized field name, original source spelling, and terminal unit when applicable. The expression parser binds those refs after validating session predicates, terminal unit predicates, pipeline-scoped session predicates, and action sequences. SQL lowerers and runtime-transform matchers consume the bound field identity while keeping a fallback for manually constructed predicates in tests and internal callers.

This is an internal #2006 substrate step, not the full DSL closure.

## Verification

- `mypy polylogue/archive/query/predicate.py polylogue/archive/query/expression.py polylogue/archive/query/runtime_matching.py polylogue/archive/query/unit_results.py polylogue/storage/sqlite/archive_tiers/archive.py tests/unit/cli/test_query_expression.py`
- `devtools test tests/unit/cli/test_query_expression.py -k 'field_ref or pipeline_session_source_scopes_terminal_unit_query or sequence_ast_exposes_step_predicates' -q`
- `devtools test tests/unit/cli/test_query_expression.py -q`
- `devtools verify --quick`
- `devtools verify --seed-testmon --skip-slow`
- `devtools verify`

Ref #2006

Note: the first default `devtools verify` selected `tests/benchmarks/test_fts_trigger_amplification.py::test_messages_fts_trigger_growth_is_subquadratic` because this branch touches `archive.py`; that timing assertion failed once on scratch storage. The exact node passed under `POLYLOGUE_PYTEST_TMPFS=1`, and the default affected baseline then passed under the same tmpfs setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced query field predicate validation and binding mechanisms to carry resolved field reference metadata throughout query execution, improving consistency of field matching across different query contexts and source types.

* **Tests**
  * Added comprehensive test coverage for field reference resolution in session-scoped and unit-scoped query predicates to ensure proper metadata propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->