### PR TITLE
chore(dev): capture branch-local CLI debug artifacts (#2248)

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -319,6 +319,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools workspace dev-loop",
             "devtools workspace dev-loop --json",
             "devtools workspace dev-loop --prepare --api-port 8876 --browser-capture-port 8875",
+            "devtools workspace dev-loop --capture-cli -- polylogue ops status",
+            "devtools workspace dev-loop --receiver-smoke --json",
         ),
     ),
     CommandSpec(

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -319,6 +319,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools workspace dev-loop",
             "devtools workspace dev-loop --json",
             "devtools workspace dev-loop --prepare --api-port 8876 --browser-capture-port 8875",
+            "devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875 --launch-daemon",
             "devtools workspace dev-loop --capture-cli -- polylogue ops status",
             "devtools workspace dev-loop --receiver-smoke --json",
         ),

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -6,10 +6,13 @@ import argparse
 import json
 import os
 import re
+import shlex
 import socket
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from http.client import HTTPConnection
 from pathlib import Path
 from threading import Thread
@@ -43,6 +46,12 @@ def _run_command(args: list[str], *, timeout_s: float = 2.0) -> CommandResult:
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
         return CommandResult(exit_code=127, stdout="", stderr=str(exc))
     return CommandResult(exit_code=result.returncode, stdout=result.stdout.strip(), stderr=result.stderr.strip())
+
+
+def _safe_artifact_name(command: list[str]) -> str:
+    raw = "-".join(Path(part).name if index == 0 else part for index, part in enumerate(command))
+    name = _RUN_ID_SAFE_RE.sub("-", raw).strip("-").lower()
+    return name[:80] or "command"
 
 
 def _git_value(args: list[str], *, cwd: Path) -> str | None:
@@ -237,6 +246,119 @@ def run_receiver_smoke(*, spool_path: Path) -> dict[str, object]:
     }
 
 
+def _decode_timeout_stream(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def run_cli_capture(
+    *,
+    preflight: dict[str, Any],
+    command: list[str],
+    timeout_s: float,
+) -> dict[str, object]:
+    """Run a branch-local CLI command and persist debug artifacts."""
+
+    if not command:
+        raise ValueError("capture command must not be empty")
+    if command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise ValueError("capture command must not be empty")
+
+    artifacts = preflight.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("preflight payload is missing artifact paths")
+    terminal_dir = Path(str(artifacts["terminal_dir"]))
+    terminal_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    suggested_env = preflight.get("suggested_env")
+    if isinstance(suggested_env, dict):
+        env.update({str(key): str(value) for key, value in suggested_env.items()})
+    env.setdefault("POLYLOGUE_FORCE_PLAIN", "1")
+
+    artifact_name = _safe_artifact_name(command)
+    stdout_path = terminal_dir / f"{artifact_name}.stdout"
+    stderr_path = terminal_dir / f"{artifact_name}.stderr"
+    transcript_path = terminal_dir / f"{artifact_name}.transcript.txt"
+    env_path = terminal_dir / f"{artifact_name}.env.json"
+    summary_path = terminal_dir / f"{artifact_name}.summary.json"
+
+    started_at = datetime.now(UTC)
+    started = time.monotonic()
+    timed_out = False
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(preflight["repo_root"]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        exit_code = int(result.returncode)
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        exit_code = 124
+        stdout = _decode_timeout_stream(exc.stdout)
+        stderr = _decode_timeout_stream(exc.stderr)
+        stderr = (stderr + "\n" if stderr else "") + f"command timed out after {timeout_s:.1f}s\n"
+    except OSError as exc:
+        exit_code = 127
+        stdout = ""
+        stderr = f"{type(exc).__name__}: {exc}\n"
+    duration_ms = int((time.monotonic() - started) * 1000)
+    ended_at = datetime.now(UTC)
+
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    transcript = (
+        f"$ {shlex.join(command)}\n"
+        f"# cwd={preflight['repo_root']}\n"
+        f"# run_id={preflight['run_id']}\n"
+        f"# started_at={started_at.isoformat()}\n\n"
+        "[stdout]\n"
+        f"{stdout}"
+        "\n[stderr]\n"
+        f"{stderr}"
+        f"\n[exit {exit_code}]\n"
+    )
+    transcript_path.write_text(transcript, encoding="utf-8")
+    env_snapshot = {
+        key: env[key] for key in sorted(env) if key.startswith("POLYLOGUE_") or key in {"PATH", "PYTHONPATH"}
+    }
+    env_path.write_text(json.dumps(env_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    payload: dict[str, object] = {
+        "ok": exit_code == 0,
+        "command": command,
+        "command_text": shlex.join(command),
+        "cwd": str(preflight["repo_root"]),
+        "run_id": str(preflight["run_id"]),
+        "started_at": started_at.isoformat(),
+        "ended_at": ended_at.isoformat(),
+        "duration_ms": duration_ms,
+        "exit_code": exit_code,
+        "timed_out": timed_out,
+        "artifacts": {
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "transcript": str(transcript_path),
+            "env": str(env_path),
+            "summary": str(summary_path),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
 def _dev_loop_run_id(*, branch: str | None, commit: str | None, api_port: int, browser_capture_port: int) -> str:
     branch_part = _RUN_ID_SAFE_RE.sub("-", branch or "detached").strip("-") or "detached"
     commit_part = _RUN_ID_SAFE_RE.sub("-", commit or "unknown").strip("-") or "unknown"
@@ -394,6 +516,21 @@ def _print_receiver_smoke(payload: dict[str, Any]) -> None:
     print(f"  artifact: {smoke.get('artifact_ref')}")
 
 
+def _print_cli_capture(payload: dict[str, Any]) -> None:
+    preflight = payload["preflight"]
+    capture = payload["cli_capture"]
+    assert isinstance(preflight, dict)
+    assert isinstance(capture, dict)
+    artifacts = capture["artifacts"]
+    assert isinstance(artifacts, dict)
+    print("Polylogue dev-loop CLI capture")
+    print(f"  run id:    {preflight['run_id']}")
+    print(f"  command:   {capture['command_text']}")
+    print(f"  exit:      {capture['exit_code']}")
+    print(f"  duration:  {capture['duration_ms']} ms")
+    print(f"  transcript: {artifacts['transcript']}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -411,6 +548,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run a deterministic in-process browser-capture receiver smoke.",
     )
+    parser.add_argument(
+        "--capture-timeout-s",
+        type=float,
+        default=30.0,
+        help="Timeout for --capture-cli commands.",
+    )
+    parser.add_argument(
+        "--capture-cli",
+        action="store_true",
+        help="Run a branch-local CLI command and write stdout/stderr/transcript artifacts.",
+    )
+    parser.add_argument("capture_command", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
     payload = build_dev_loop_status(
         api_port=args.api_port,
@@ -430,6 +579,28 @@ def main(argv: list[str] | None = None) -> int:
         else:
             _print_receiver_smoke(smoke_payload)
         return 0 if smoke_payload["receiver_smoke"]["ok"] else 1
+    if args.capture_cli:
+        try:
+            capture_payload = run_cli_capture(
+                preflight=payload,
+                command=list(args.capture_command),
+                timeout_s=args.capture_timeout_s,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        combined_payload: dict[str, Any] = {
+            "preflight": payload,
+            "cli_capture": capture_payload,
+        }
+        if args.json:
+            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            _print_cli_capture(combined_payload)
+        capture_exit = capture_payload["exit_code"]
+        if not isinstance(capture_exit, int):
+            capture_exit = 1
+        return 0 if capture_payload.get("ok") is True else capture_exit
     if args.json:
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 from http.client import HTTPConnection
 from pathlib import Path
 from threading import Thread
-from typing import Any
+from typing import Any, TextIO
 
 from devtools import repo_root as _repo_root
 from polylogue.browser_capture.server import make_server
@@ -254,6 +254,24 @@ def _decode_timeout_stream(value: bytes | str | None) -> str:
     return value
 
 
+def _start_daemon_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log_file: TextIO,
+) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        command,
+        cwd=str(cwd),
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
 def run_cli_capture(
     *,
     preflight: dict[str, Any],
@@ -352,6 +370,121 @@ def run_cli_capture(
             "stderr": str(stderr_path),
             "transcript": str(transcript_path),
             "env": str(env_path),
+            "summary": str(summary_path),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def launch_branch_daemon(
+    *,
+    preflight: dict[str, Any],
+    readiness_timeout_s: float,
+) -> dict[str, object]:
+    """Launch a branch-local polylogued and persist process/debug artifacts."""
+
+    ports = preflight.get("ports")
+    if not isinstance(ports, dict):
+        raise ValueError("preflight payload is missing port status")
+    occupied_ports: list[str] = []
+    for name in ("api", "browser_capture"):
+        status = ports.get(name)
+        if isinstance(status, dict) and int(status.get("owner_count") or 0) > 0:
+            occupied_ports.append(f"{name} port {status.get('port')}")
+    if occupied_ports:
+        raise ValueError(
+            "selected branch-local ports already have listeners: "
+            + ", ".join(occupied_ports)
+            + "; stop the deployed service or choose isolated ports"
+        )
+
+    artifacts = preflight.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("preflight payload is missing artifact paths")
+    run_log_dir = Path(str(preflight["run_log_dir"]))
+    run_log_dir.mkdir(parents=True, exist_ok=True)
+    daemon_log = Path(str(artifacts["daemon_log"]))
+    daemon_log.parent.mkdir(parents=True, exist_ok=True)
+    env_path = run_log_dir / "polylogued.env.json"
+    pid_path = run_log_dir / "polylogued.pid"
+    summary_path = run_log_dir / "polylogued.launch.json"
+
+    env = os.environ.copy()
+    suggested_env = preflight.get("suggested_env")
+    if isinstance(suggested_env, dict):
+        env.update({str(key): str(value) for key, value in suggested_env.items()})
+    env.setdefault("POLYLOGUE_FORCE_PLAIN", "1")
+
+    api_status = ports["api"]
+    receiver_status = ports["browser_capture"]
+    assert isinstance(api_status, dict)
+    assert isinstance(receiver_status, dict)
+    api_port = int(api_status["port"])
+    receiver_port = int(receiver_status["port"])
+    spool_path = run_log_dir / "browser-capture-spool"
+    spool_path.mkdir(parents=True, exist_ok=True)
+    command = [
+        "polylogued",
+        "run",
+        "--no-watch",
+        "--api-port",
+        str(api_port),
+        "--port",
+        str(receiver_port),
+        "--spool",
+        str(spool_path),
+    ]
+
+    env_snapshot = {
+        key: env[key] for key in sorted(env) if key.startswith("POLYLOGUE_") or key in {"PATH", "PYTHONPATH"}
+    }
+    env_path.write_text(json.dumps(env_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    started_at = datetime.now(UTC)
+    with daemon_log.open("a", encoding="utf-8") as log_file:
+        log_file.write(
+            f"\n# dev-loop launch {started_at.isoformat()} run_id={preflight['run_id']}\n$ {shlex.join(command)}\n"
+        )
+        log_file.flush()
+        process = _start_daemon_process(
+            command,
+            cwd=Path(str(preflight["repo_root"])),
+            env=env,
+            log_file=log_file,
+        )
+    pid_path.write_text(f"{process.pid}\n", encoding="utf-8")
+
+    deadline = time.monotonic() + max(0.0, readiness_timeout_s)
+    api_ready = False
+    receiver_ready = False
+    exit_code: int | None = None
+    while time.monotonic() <= deadline:
+        exit_code = process.poll()
+        api_ready = _socket_connectable(api_port)
+        receiver_ready = _socket_connectable(receiver_port)
+        if exit_code is not None or (api_ready and receiver_ready):
+            break
+        time.sleep(0.1)
+    if exit_code is None:
+        exit_code = process.poll()
+
+    payload: dict[str, object] = {
+        "ok": exit_code is None and api_ready and receiver_ready,
+        "pid": process.pid,
+        "command": command,
+        "command_text": shlex.join(command),
+        "cwd": str(preflight["repo_root"]),
+        "run_id": str(preflight["run_id"]),
+        "started_at": started_at.isoformat(),
+        "exit_code": exit_code,
+        "api_ready": api_ready,
+        "browser_capture_ready": receiver_ready,
+        "readiness_timeout_s": readiness_timeout_s,
+        "spool_path": str(spool_path),
+        "artifacts": {
+            "log": str(daemon_log),
+            "env": str(env_path),
+            "pid": str(pid_path),
             "summary": str(summary_path),
         },
     }
@@ -531,6 +664,23 @@ def _print_cli_capture(payload: dict[str, Any]) -> None:
     print(f"  transcript: {artifacts['transcript']}")
 
 
+def _print_daemon_launch(payload: dict[str, Any]) -> None:
+    preflight = payload["preflight"]
+    launch = payload["daemon_launch"]
+    assert isinstance(preflight, dict)
+    assert isinstance(launch, dict)
+    artifacts = launch["artifacts"]
+    assert isinstance(artifacts, dict)
+    print("Polylogue dev-loop daemon launch")
+    print(f"  run id:   {preflight['run_id']}")
+    print(f"  pid:      {launch['pid']}")
+    print(f"  command:  {launch['command_text']}")
+    print(f"  api:      ready={launch['api_ready']}")
+    print(f"  capture:  ready={launch['browser_capture_ready']}")
+    print(f"  log:      {artifacts['log']}")
+    print(f"  summary:  {artifacts['summary']}")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -559,6 +709,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run a branch-local CLI command and write stdout/stderr/transcript artifacts.",
     )
+    parser.add_argument(
+        "--launch-daemon",
+        action="store_true",
+        help="Launch branch-local polylogued with --no-watch and write PID/log/summary artifacts.",
+    )
+    parser.add_argument(
+        "--daemon-ready-timeout-s",
+        type=float,
+        default=10.0,
+        help="Readiness wait for --launch-daemon.",
+    )
     parser.add_argument("capture_command", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
     payload = build_dev_loop_status(
@@ -566,7 +727,7 @@ def main(argv: list[str] | None = None) -> int:
         browser_capture_port=args.browser_capture_port,
         archive_root=args.archive_root,
         log_dir=args.log_dir,
-        prepare=args.prepare or args.receiver_smoke,
+        prepare=args.prepare or args.receiver_smoke or args.launch_daemon,
     )
     if args.receiver_smoke:
         smoke_payload: dict[str, Any] = {
@@ -601,6 +762,24 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(capture_exit, int):
             capture_exit = 1
         return 0 if capture_payload.get("ok") is True else capture_exit
+    if args.launch_daemon:
+        try:
+            launch_payload = launch_branch_daemon(
+                preflight=payload,
+                readiness_timeout_s=args.daemon_ready_timeout_s,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        combined_payload = {
+            "preflight": payload,
+            "daemon_launch": launch_payload,
+        }
+        if args.json:
+            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            _print_daemon_launch(combined_payload)
+        return 0 if launch_payload.get("ok") is True else 1
     if args.json:
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -25,6 +25,7 @@ DEFAULT_API_PORT = 8766
 DEFAULT_BROWSER_CAPTURE_PORT = 8765
 _RECEIVER_SMOKE_ORIGIN = "chrome-extension://polylogue-dev-loop"
 _RECEIVER_SMOKE_TOKEN = "polylogue-dev-loop-token"
+_SENSITIVE_ENV_NAME_RE = re.compile(r"(TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL|AUTH)", re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +53,15 @@ def _safe_artifact_name(command: list[str]) -> str:
     raw = "-".join(Path(part).name if index == 0 else part for index, part in enumerate(command))
     name = _RUN_ID_SAFE_RE.sub("-", raw).strip("-").lower()
     return name[:80] or "command"
+
+
+def _dev_loop_env_snapshot(env: dict[str, str]) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for key in sorted(env):
+        if not (key.startswith("POLYLOGUE_") or key in {"PATH", "PYTHONPATH"}):
+            continue
+        snapshot[key] = "[redacted]" if _SENSITIVE_ENV_NAME_RE.search(key) else env[key]
+    return snapshot
 
 
 def _git_value(args: list[str], *, cwd: Path) -> str | None:
@@ -349,9 +359,7 @@ def run_cli_capture(
         f"\n[exit {exit_code}]\n"
     )
     transcript_path.write_text(transcript, encoding="utf-8")
-    env_snapshot = {
-        key: env[key] for key in sorted(env) if key.startswith("POLYLOGUE_") or key in {"PATH", "PYTHONPATH"}
-    }
+    env_snapshot = _dev_loop_env_snapshot(env)
     env_path.write_text(json.dumps(env_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     payload: dict[str, object] = {
@@ -436,9 +444,7 @@ def launch_branch_daemon(
         str(spool_path),
     ]
 
-    env_snapshot = {
-        key: env[key] for key in sorted(env) if key.startswith("POLYLOGUE_") or key in {"PATH", "PYTHONPATH"}
-    }
+    env_snapshot = _dev_loop_env_snapshot(env)
     env_path.write_text(json.dumps(env_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     started_at = datetime.now(UTC)
     with daemon_log.open("a", encoding="utf-8") as log_file:
@@ -682,6 +688,7 @@ def _print_daemon_launch(payload: dict[str, Any]) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    original_argv = list(argv) if argv is not None else sys.argv[1:]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument("--api-port", type=int, default=int(os.environ.get("POLYLOGUE_API_PORT", DEFAULT_API_PORT)))
@@ -722,6 +729,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("capture_command", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
+    capture_command = list(args.capture_command)
+    if args.capture_cli and not args.json and "--" not in original_argv and capture_command[-1:] == ["--json"]:
+        args.json = True
+        capture_command = capture_command[:-1]
     payload = build_dev_loop_status(
         api_port=args.api_port,
         browser_capture_port=args.browser_capture_port,
@@ -744,7 +755,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             capture_payload = run_cli_capture(
                 preflight=payload,
-                command=list(args.capture_command),
+                command=capture_command,
                 timeout_s=args.capture_timeout_s,
             )
         except ValueError as exc:

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -104,10 +104,23 @@ JSON payloads. The preflight reserves run-local directories for those artifacts:
 .cache/dev-loop/<run-id>/tui/
 ```
 
-The `commands.capture_cli_status` entry shows a concrete terminal transcript
-capture for `polylogue ops status` against the branch-local archive. Use the
-same pattern for other CLI commands whose layout, colors, wrapping, or progress
-behavior matters.
+Use the managed capture helper for normal command-line runs:
+
+```bash
+devtools workspace dev-loop --capture-cli -- polylogue ops status
+devtools workspace dev-loop --capture-cli -- polylogue analyze insights profiles --limit 5
+```
+
+The helper runs the command with the branch-local `POLYLOGUE_*` environment and
+writes stdout, stderr, a combined transcript, the relevant environment snapshot,
+and a JSON summary under:
+
+```text
+.cache/dev-loop/<run-id>/terminal/
+```
+
+The preflight payload still includes `commands.capture_cli_status` as a
+copy-pastable `script` example when an actual terminal typescript is useful.
 
 For TUI or full-screen terminal work, record into the run-local `tui/`
 directory using the local terminal-control surface, `script`, or VHS-style

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -65,7 +65,18 @@ preflight output before starting the branch daemon:
 devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875
 ```
 
-Then run the command printed by the preflight. The important variables are:
+Then launch the branch-local daemon with the managed helper:
+
+```bash
+devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875 --launch-daemon
+```
+
+The helper refuses to start if the selected API or browser-capture port already
+has a listener. It starts `polylogued run --no-watch` in a separate process
+group, writes `polylogued.pid`, `polylogued.env.json`,
+`polylogued.launch.json`, and the daemon log into the run-local directory, and
+waits briefly for both the API and receiver ports to become reachable. The
+important variables are:
 
 ```bash
 POLYLOGUE_ARCHIVE_ROOT=.local/dev-archive
@@ -82,9 +93,9 @@ process. Open the URL printed by the preflight, usually:
 http://127.0.0.1:8766/
 ```
 
-For web shell work, keep the daemon output tee'd into `.cache/dev-loop/` so UI
-errors can be correlated with route logs and request failures. The development
-loop should make these facts obvious before an agent starts debugging:
+For web shell work, use the run-local daemon log so UI errors can be correlated
+with route logs and request failures. The development loop should make these
+facts obvious before an agent starts debugging:
 
 - which checkout started the daemon;
 - which run id ties together the daemon log, browser artifacts, and receiver

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -184,3 +185,63 @@ def test_receiver_smoke_cli_outputs_combined_payload(
     assert payload["preflight"]["prepared"] is True
     assert payload["preflight"]["preflight_json_written"] is True
     assert payload["receiver_smoke"]["ok"] is True
+
+
+def test_cli_capture_runs_command_with_branch_local_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    command = [
+        sys.executable,
+        "-c",
+        "import os; print(os.environ['POLYLOGUE_DEV_LOOP_RUN_ID'])",
+    ]
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--capture-cli",
+                "--",
+                *command,
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    capture = payload["cli_capture"]
+    run_id = payload["preflight"]["run_id"]
+
+    assert capture["ok"] is True
+    assert capture["exit_code"] == 0
+    artifacts = capture["artifacts"]
+    stdout_path = Path(artifacts["stdout"])
+    transcript_path = Path(artifacts["transcript"])
+    env_path = Path(artifacts["env"])
+    summary_path = Path(artifacts["summary"])
+
+    assert stdout_path.read_text(encoding="utf-8").strip() == run_id
+    assert f"run_id={run_id}" in transcript_path.read_text(encoding="utf-8")
+    env_payload = json.loads(env_path.read_text(encoding="utf-8"))
+    assert env_payload["POLYLOGUE_ARCHIVE_ROOT"] == str(tmp_path / "archive")
+    assert json.loads(summary_path.read_text(encoding="utf-8"))["exit_code"] == 0
+
+
+def test_cli_capture_rejects_missing_command(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        dev_loop.main(["--capture-cli"])
+    assert exc.value.code == 2
+    assert "capture command must not be empty" in capsys.readouterr().err

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -201,6 +201,8 @@ def test_cli_capture_runs_command_with_branch_local_artifacts(
     monkeypatch.setattr(
         dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
     )
+    monkeypatch.setenv("POLYLOGUE_API_AUTH_TOKEN", "should-not-be-written")
+    monkeypatch.setenv("POLYLOGUE_NOTIFICATION_EMAIL_PASSWORD", "should-not-be-written")
 
     command = [
         sys.executable,
@@ -237,6 +239,8 @@ def test_cli_capture_runs_command_with_branch_local_artifacts(
     assert f"run_id={run_id}" in transcript_path.read_text(encoding="utf-8")
     env_payload = json.loads(env_path.read_text(encoding="utf-8"))
     assert env_payload["POLYLOGUE_ARCHIVE_ROOT"] == str(tmp_path / "archive")
+    assert env_payload["POLYLOGUE_API_AUTH_TOKEN"] == "[redacted]"
+    assert env_payload["POLYLOGUE_NOTIFICATION_EMAIL_PASSWORD"] == "[redacted]"
     assert json.loads(summary_path.read_text(encoding="utf-8"))["exit_code"] == 0
 
 
@@ -245,6 +249,41 @@ def test_cli_capture_rejects_missing_command(capsys: pytest.CaptureFixture[str])
         dev_loop.main(["--capture-cli"])
     assert exc.value.code == 2
     assert "capture command must not be empty" in capsys.readouterr().err
+
+
+def test_cli_capture_treats_forwarded_trailing_json_as_wrapper_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    assert (
+        dev_loop.main(
+            [
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--capture-cli",
+                sys.executable,
+                "-c",
+                "import sys; print(sys.argv[1:])",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    stdout_path = Path(payload["cli_capture"]["artifacts"]["stdout"])
+    assert stdout_path.read_text(encoding="utf-8").strip() == "[]"
 
 
 def test_daemon_launch_writes_branch_local_process_artifacts(

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -245,3 +245,103 @@ def test_cli_capture_rejects_missing_command(capsys: pytest.CaptureFixture[str])
         dev_loop.main(["--capture-cli"])
     assert exc.value.code == 2
     assert "capture command must not be empty" in capsys.readouterr().err
+
+
+def test_daemon_launch_writes_branch_local_process_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+    monkeypatch.setattr(dev_loop, "_socket_connectable", lambda port: True)
+
+    launched: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 4242
+
+        def poll(self) -> int | None:
+            return None
+
+    def fake_start_daemon_process(
+        command: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+        log_file: object,
+    ) -> FakeProcess:
+        launched["command"] = command
+        launched["cwd"] = cwd
+        launched["env"] = env
+        launched["log_file"] = log_file
+        return FakeProcess()
+
+    monkeypatch.setattr(dev_loop, "_start_daemon_process", fake_start_daemon_process)
+
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--api-port",
+                "9876",
+                "--browser-capture-port",
+                "9875",
+                "--launch-daemon",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    launch = payload["daemon_launch"]
+    command = launch["command"]
+    assert command[:2] == ["polylogued", "run"]
+    assert "--no-watch" in command
+    assert command[command.index("--api-port") : command.index("--api-port") + 2] == ["--api-port", "9876"]
+    assert command[command.index("--port") : command.index("--port") + 2] == ["--port", "9875"]
+    assert launch["pid"] == 4242
+    assert launch["api_ready"] is True
+    assert launch["browser_capture_ready"] is True
+
+    env = launched["env"]
+    assert isinstance(env, dict)
+    assert env["POLYLOGUE_ARCHIVE_ROOT"] == str(tmp_path / "archive")
+    assert launched["cwd"] == Path(payload["preflight"]["repo_root"])
+
+    artifacts = launch["artifacts"]
+    assert Path(artifacts["pid"]).read_text(encoding="utf-8") == "4242\n"
+    assert json.loads(Path(artifacts["summary"]).read_text(encoding="utf-8"))["pid"] == 4242
+    assert json.loads(Path(artifacts["env"]).read_text(encoding="utf-8"))["POLYLOGUE_API_PORT"] == "9876"
+    assert Path(artifacts["log"]).read_text(encoding="utf-8").startswith("\n# dev-loop launch")
+
+
+def test_daemon_launch_rejects_occupied_branch_local_ports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": True, "owner_count": 1, "owners": [{"pid": 1234}]},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        dev_loop.main(["--archive-root", str(tmp_path / "archive"), "--launch-daemon"])
+
+    assert exc.value.code == 2
+    assert "selected branch-local ports already have listeners" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds managed branch-local development-loop actions for #2248. `devtools workspace dev-loop --capture-cli -- <command...>` runs a command with the branch-local Polylogue environment and writes stdout, stderr, transcript, redacted environment, and JSON summary artifacts under `.cache/dev-loop/<run-id>/terminal/`. `devtools workspace dev-loop --launch-daemon` starts a safe branch-local `polylogued run --no-watch` process with explicit ports/archive root and writes PID, env, launch summary, spool path, and daemon log artifacts under the same run id.

## Problem

#2248 asks for development loops that agents can inspect without guessing from the systemwide deployment. The existing preflight created branch-local archive and artifact paths, but CLI debugging still relied on manually copying shell snippets, and daemon/web-shell debugging still depended on a printed `polylogued run ... | tee ...` command rather than an owned launcher with process artifacts and collision checks.

## Solution

`devtools/dev_loop.py` now has two concrete action modes. `--capture-cli` reuses the preflight payload, applies the suggested `POLYLOGUE_*` environment, supervises the requested command with a timeout, and persists terminal artifacts with token/secret/password/key-shaped environment variables redacted. It also treats the devtools wrapper's forwarded trailing `--json` as the wrapper JSON flag instead of passing it to the captured command. `--launch-daemon` prepares the run directory, refuses selected API/browser-capture ports that already have listeners, starts `polylogued run --no-watch` in a separate process group, writes process/debug artifacts, and waits briefly for API and browser-capture readiness. The dev-loop docs and command catalog advertise these managed paths, and focused tests cover artifact creation, environment propagation/redaction, port-collision rejection, forwarded JSON handling, and missing-command rejection.

This materially advances #2248, but does not close it. Remaining scope still includes richer web-shell debug bundles, browser-extension development-mode diagnostics, receiver ingest-handoff observability, and possible ops-tier dev-loop event storage if logs/artifacts prove insufficient.

Ref #2248

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> 10 passed
- `devtools test tests/unit/devtools/test_dev_loop.py tests/unit/devtools/test_devtools_main.py -q` -> 19 passed
- `devtools render all --check` -> sync OK
- `devtools verify --quick` -> exit_code 0
- pre-push `devtools verify --quick` on pushed head `4a97a03ce` -> exit_code 0