### PR TITLE
chore(capture): correlate browser receiver requests (#2248)

### DIFF
--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -30,6 +30,14 @@ observation of the same web session replaces the same source artifact. Receiver
 responses expose this artifact as an `artifact_ref` relative to the spool root;
 absolute filesystem paths stay inside the receiver process.
 
+Every receiver response carries `X-Request-ID`. If the extension or a local
+debug probe sends a safe `X-Request-ID` header, the receiver echoes its
+sanitized value; otherwise it generates one. Receiver logs use the same id for
+origin rejection, token rejection, malformed payloads, write failures, accepted
+captures, and request timing. During branch-local extension work, copy that id
+from the browser network panel or curl output into the run-local daemon log to
+connect UI action, receiver decision, artifact ref, and duration.
+
 The extension lives in `browser-extension/` and can be loaded unpacked in
 Chrome. It includes ChatGPT and Claude.ai DOM adapters, a popup control panel,
 receiver configuration, current-page capture controls, badge state, and

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import time
+from collections.abc import Callable
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 from pydantic import ValidationError
 
@@ -24,6 +27,9 @@ from polylogue.browser_capture.receiver import (
 )
 from polylogue.core.json import dumps_bytes
 from polylogue.core.loopback import is_loopback_host
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _json_bytes(payload: object) -> bytes:
@@ -74,14 +80,50 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
     """
 
     server: BrowserCaptureHTTPServer
+    _polylogue_request_id: str
+    _polylogue_status: int | None
 
     def log_message(self, format: str, *args: object) -> None:
         return
+
+    def _request_id(self) -> str:
+        existing = getattr(self, "_polylogue_request_id", None)
+        if isinstance(existing, str):
+            return existing
+        header = self.headers.get("X-Request-ID", "").strip()
+        request_id = "".join(ch for ch in header if ch.isalnum() or ch in "-_")[:80] if header else uuid4().hex[:16]
+        if not request_id:
+            request_id = uuid4().hex[:16]
+        self._polylogue_request_id = request_id
+        return request_id
+
+    def send_response(self, code: int, message: str | None = None) -> None:
+        self._polylogue_status = code
+        super().send_response(code, message)
+
+    def _finish_observed_request(self, method: str, started_at: float) -> None:
+        logger.info(
+            "browser_capture.request",
+            request_id=self._request_id(),
+            method=method,
+            path=urlparse(self.path).path,
+            status=getattr(self, "_polylogue_status", None),
+            duration_ms=round((time.perf_counter() - started_at) * 1000, 3),
+            origin=self.headers.get("Origin"),
+        )
+
+    def _observe_request(self, method: str, fn: Callable[[], None]) -> None:
+        started_at = time.perf_counter()
+        try:
+            fn()
+        finally:
+            self._finish_observed_request(method, started_at)
 
     def _send_json(self, status: HTTPStatus, payload: object) -> None:
         raw = _json_bytes(payload)
         origin = self.headers.get("Origin")
         self.send_response(status.value)
+        self.send_header("X-Request-ID", self._request_id())
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(raw)))
         if _origin_allowed(origin, self.server.config):
@@ -98,6 +140,7 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         origin = self.headers.get("Origin")
         if _origin_allowed(origin, self.server.config):
             return False
+        logger.warning("browser_capture.origin_rejected", request_id=self._request_id(), origin=origin)
         self._safe_error(HTTPStatus.FORBIDDEN, "origin_not_allowed")
         return True
 
@@ -108,16 +151,23 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             return False
         if _check_token(dict(self.headers), config):
             return False
+        logger.warning(
+            "browser_capture.token_rejected", request_id=self._request_id(), origin=self.headers.get("Origin")
+        )
         self._safe_error(HTTPStatus.UNAUTHORIZED, "unauthorized")
         return True
 
     def do_OPTIONS(self) -> None:
+        self._observe_request("OPTIONS", self._do_options)
+
+    def _do_options(self) -> None:
         # Browser CORS preflights cannot carry Authorization.  Guard origin here
         # and enforce the bearer token on the actual data request.
         if self._reject_origin():
             return
         origin = self.headers.get("Origin")
         self.send_response(HTTPStatus.NO_CONTENT.value)
+        self.send_header("X-Request-ID", self._request_id())
         self.send_header("Access-Control-Allow-Origin", origin or "null")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
@@ -125,6 +175,9 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self) -> None:
+        self._observe_request("GET", self._do_get)
+
+    def _do_get(self) -> None:
         if self._reject_origin() or self._reject_token():
             return
         parsed = urlparse(self.path)
@@ -146,6 +199,9 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
 
     def do_POST(self) -> None:
+        self._observe_request("POST", self._do_post)
+
+    def _do_post(self) -> None:
         if self._reject_origin() or self._reject_token():
             return
         if urlparse(self.path).path != "/v1/browser-captures":
@@ -162,18 +218,30 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         try:
             payload = json.loads(self.rfile.read(length))
         except json.JSONDecodeError:
+            logger.warning("browser_capture.invalid_json", request_id=self._request_id())
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_json")
             return
         try:
             envelope = BrowserCaptureEnvelope.model_validate(payload)
         except ValidationError:
+            logger.warning("browser_capture.invalid_payload", request_id=self._request_id())
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_payload")
             return
         try:
             result = write_capture_envelope(envelope, spool_path=self.server.config.spool_path)
-        except OSError:
+        except OSError as exc:
+            logger.warning("browser_capture.write_failed", request_id=self._request_id(), error=repr(exc))
             self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
             return
+        logger.info(
+            "browser_capture.capture_accepted",
+            request_id=self._request_id(),
+            provider=result.provider,
+            provider_session_id=result.provider_session_id,
+            artifact_ref=result.artifact_ref,
+            bytes_written=result.bytes_written,
+            replaced=result.replaced,
+        )
         self._send_json(
             HTTPStatus.ACCEPTED,
             BrowserCaptureAcceptedPayload(

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -168,6 +168,7 @@ def test_receiver_rejects_web_origins_by_default(tmp_path: Path) -> None:
         error = BrowserCaptureErrorPayload.model_validate(json.loads(response.read()))
 
     assert response.status == HTTPStatus.FORBIDDEN
+    assert response.getheader("X-Request-ID")
     assert error.error == "origin_not_allowed"
 
 
@@ -189,6 +190,7 @@ def test_receiver_accepts_extension_capture_and_reports_typed_dto(tmp_path: Path
         body = BrowserCaptureAcceptedPayload.model_validate(json.loads(response.read()))
 
     assert response.status == HTTPStatus.ACCEPTED
+    assert response.getheader("X-Request-ID")
     assert body.ok is True
     assert body.receiver == "polylogue-browser-capture"
     assert body.source == "browser-extension"
@@ -197,6 +199,25 @@ def test_receiver_accepts_extension_capture_and_reports_typed_dto(tmp_path: Path
     assert body.artifact_ref == capture_artifact_ref(BrowserCaptureEnvelope.model_validate(_payload()), tmp_path)
     assert Path(body.artifact_ref).is_absolute() is False
     assert (tmp_path / body.artifact_ref).exists()
+
+
+def test_receiver_echoes_safe_request_id_header(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        conn = HTTPConnection(host, port)
+        conn.request(
+            "GET",
+            "/v1/status",
+            headers={
+                "Origin": _EXTENSION_ORIGIN,
+                "X-Request-ID": "dev-loop/request 123",
+            },
+        )
+        response = conn.getresponse()
+        response.read()
+        conn.close()
+
+    assert response.status == HTTPStatus.OK
+    assert response.getheader("X-Request-ID") == "dev-looprequest123"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds request correlation to the local browser-capture receiver so extension and receiver debugging can connect browser network requests, receiver logs, accepted artifacts, and failures.

## Problem

The branch-local dev loop needs to answer where a browser-capture failure occurred. The receiver already had typed auth/CORS/payload behavior, but responses and logs did not carry a shared request id or timing signal, making popup/content-script/service-worker debugging harder than necessary.

## Solution

- Added `X-Request-ID` to receiver JSON and preflight responses, echoing a sanitized caller-provided id or generating one.
- Wrapped receiver GET/POST/OPTIONS handling with structured request timing logs.
- Logged key receiver decisions with the same id: origin rejection, token rejection, malformed JSON/payload, write failure, and accepted capture metadata.
- Documented the request-id workflow in `docs/browser-capture.md`.
- Extended receiver tests for request-id headers on success/rejection and sanitized echo behavior.

## Verification

- `devtools test tests/unit/browser_capture/test_receiver.py -q` -> 14 passed.
- `devtools render all --check` -> sync OK.
- `devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.

Ref #2248