### PR TITLE
chore(extension): show receiver request diagnostics (#2248)

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -64,6 +64,13 @@ polylogued browser-capture status
 Then navigate to `chatgpt.com` or `claude.ai`. The extension badge should
 turn green. Start a conversation — each exchange is captured as you type.
 
+For branch-local development, point **Local receiver URL** in the popup at the
+URL printed by `devtools workspace dev-loop`, usually
+`http://127.0.0.1:8875` when the production receiver is still running on the
+default port. Each status/archive/capture request sends `X-Request-ID` and the
+popup shows the receiver's echoed request id. Use that value to correlate the
+popup/service-worker result with browser network traces and receiver logs.
+
 ## Supported Sites
 
 | Site | Provider | Notes |

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -26,34 +26,52 @@ async function setState(state) {
   await chrome.action.setBadgeBackgroundColor({ color: state.captured ? "#1f7a4d" : state.online ? "#805ad5" : "#9b2c2c" });
 }
 
-async function requestHeaders({ hasBody = false } = {}) {
+function buildReceiverRequestId() {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `polylogue-ext-${Date.now().toString(36)}-${random}`;
+}
+
+async function requestHeaders({ hasBody = false, requestId = "" } = {}) {
   const settings = await receiverSettings();
   const headers = {};
   if (hasBody) headers["Content-Type"] = "application/json";
   if (settings.authToken) headers.Authorization = `Bearer ${settings.authToken}`;
+  if (requestId) headers["X-Request-ID"] = requestId;
   return headers;
 }
 
 async function postJson(path, payload) {
   const settings = await receiverSettings();
+  const requestId = buildReceiverRequestId();
   const response = await fetch(`${settings.baseUrl}${path}`, {
     method: "POST",
-    headers: await requestHeaders({ hasBody: true }),
+    headers: await requestHeaders({ hasBody: true, requestId }),
     body: JSON.stringify(payload)
   });
+  const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
   const body = await response.json().catch(() => ({}));
-  if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
-  return body;
+  if (!response.ok) {
+    const error = new Error(body.error || `HTTP ${response.status}`);
+    error.receiverRequestId = receiverRequestId;
+    throw error;
+  }
+  return { ...body, receiver_request_id: receiverRequestId };
 }
 
 async function getJson(path) {
   const settings = await receiverSettings();
+  const requestId = buildReceiverRequestId();
   const response = await fetch(`${settings.baseUrl}${path}`, {
-    headers: await requestHeaders(),
+    headers: await requestHeaders({ requestId }),
   });
+  const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
   const body = await response.json().catch(() => ({}));
-  if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
-  return body;
+  if (!response.ok) {
+    const error = new Error(body.error || `HTTP ${response.status}`);
+    error.receiverRequestId = receiverRequestId;
+    throw error;
+  }
+  return { ...body, receiver_request_id: receiverRequestId };
 }
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -65,7 +83,12 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
     if (message.type === "polylogue.capture") {
       const result = await postJson("/v1/browser-captures", message.envelope);
-      await setState({ online: true, captured: true, last_capture: result });
+      await setState({
+        online: true,
+        captured: true,
+        last_capture: result,
+        last_receiver_request_id: result.receiver_request_id || null
+      });
       sendResponse(result);
       return;
     }
@@ -75,19 +98,38 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         provider_session_id: message.provider_session_id
       });
       const state = await getJson(`/v1/archive-state?${query.toString()}`);
-      await setState({ online: true, captured: Boolean(state.captured), archive_state: state });
+      await setState({
+        online: true,
+        captured: Boolean(state.captured),
+        archive_state: state,
+        last_receiver_request_id: state.receiver_request_id || null
+      });
       sendResponse(state);
       return;
     }
     if (message.type === "polylogue.status") {
       const status = await getJson("/v1/status");
-      await setState({ online: true, captured: false, status });
+      await setState({
+        online: true,
+        captured: false,
+        status,
+        last_receiver_request_id: status.receiver_request_id || null
+      });
       sendResponse(status);
       return;
     }
   })().catch(async (error) => {
-    await setState({ online: false, captured: false, error: String(error.message || error) });
-    sendResponse({ ok: false, error: String(error.message || error) });
+    await setState({
+      online: false,
+      captured: false,
+      error: String(error.message || error),
+      last_receiver_request_id: error.receiverRequestId || null
+    });
+    sendResponse({
+      ok: false,
+      error: String(error.message || error),
+      receiver_request_id: error.receiverRequestId || null
+    });
   });
   return true;
 });

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -138,6 +138,7 @@
         <div class="row"><span class="label">Page</span><span id="page" class="value">Unknown</span></div>
         <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
         <div class="row"><span class="label">Archive</span><span id="archive" class="value">Not checked</span></div>
+        <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
       </section>
 
       <section>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -35,11 +35,14 @@ async function render() {
   const tab = await activeTab();
   document.getElementById("page").textContent = hostLabel(tab?.url || "");
   const state = stored.polylogueState;
+  const requestNode = document.getElementById("receiver-request");
   if (!state) {
     stateNode.textContent = "No capture state yet.";
+    requestNode.textContent = "--";
     setBadge("warn", "idle");
     return;
   }
+  requestNode.textContent = state.last_receiver_request_id || "--";
   if (!state.online) {
     stateNode.textContent = `Receiver offline. Start: polylogue browser-capture serve\n${state.error || ""}`.trim();
     document.getElementById("archive").textContent = "Offline";

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let messageListener;
+let stored;
+let fetchCalls;
+
+function installChromeMock() {
+  stored = {
+    receiverAuthToken: "token-1",
+    receiverBaseUrl: "http://127.0.0.1:8875",
+  };
+  messageListener = null;
+  fetchCalls = [];
+  globalThis.chrome = {
+    action: {
+      setBadgeBackgroundColor: vi.fn(async () => undefined),
+      setBadgeText: vi.fn(async () => undefined),
+    },
+    runtime: {
+      onMessage: {
+        addListener: vi.fn((fn) => {
+          messageListener = fn;
+        }),
+      },
+    },
+    storage: {
+      local: {
+        get: vi.fn(async (defaults) => ({ ...defaults, ...stored })),
+        set: vi.fn(async (patch) => {
+          stored = { ...stored, ...patch };
+        }),
+      },
+    },
+  };
+}
+
+async function loadBackground() {
+  vi.resetModules();
+  installChromeMock();
+  await import("../src/background.js");
+  expect(messageListener).toBeTypeOf("function");
+}
+
+async function sendRuntimeMessage(message) {
+  let response;
+  const keepAlive = messageListener(message, {}, (payload) => {
+    response = payload;
+  });
+  await vi.waitFor(() => expect(response).toBeDefined());
+  expect(keepAlive).toBe(true);
+  return response;
+}
+
+function responseJson(body, { ok = true, status = 200, requestId = "receiver-request-1" } = {}) {
+  return {
+    headers: {
+      get: vi.fn((name) => (name === "X-Request-ID" ? requestId : null)),
+    },
+    json: vi.fn(async () => body),
+    ok,
+    status,
+  };
+}
+
+describe("background receiver diagnostics", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await loadBackground();
+  });
+
+  it("sends a request id to the receiver and stores the echoed id", async () => {
+    globalThis.fetch = vi.fn(async (url, options) => {
+      fetchCalls.push({ url, options });
+      return responseJson({
+        ok: true,
+        provider: "chatgpt",
+        provider_session_id: "conv-123",
+        artifact_ref: "chatgpt/conv-123.json",
+      });
+    });
+
+    const response = await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { polylogue_capture_kind: "browser_llm_session" },
+    });
+
+    expect(response.receiver_request_id).toBe("receiver-request-1");
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:8875/v1/browser-captures");
+    expect(fetchCalls[0].options.headers.Authorization).toBe("Bearer token-1");
+    expect(fetchCalls[0].options.headers["Content-Type"]).toBe("application/json");
+    expect(fetchCalls[0].options.headers["X-Request-ID"]).toMatch(/^polylogue-ext-/);
+    expect(stored.polylogueState.last_receiver_request_id).toBe("receiver-request-1");
+    expect(stored.polylogueState.last_capture.receiver_request_id).toBe("receiver-request-1");
+  });
+
+  it("keeps receiver request id on error state", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      responseJson({ error: "unauthorized" }, { ok: false, status: 401, requestId: "reject-42" }),
+    );
+
+    const response = await sendRuntimeMessage({ type: "polylogue.status" });
+
+    expect(response).toEqual({
+      ok: false,
+      error: "unauthorized",
+      receiver_request_id: "reject-42",
+    });
+    expect(stored.polylogueState.online).toBe(false);
+    expect(stored.polylogueState.last_receiver_request_id).toBe("reject-42");
+  });
+});


### PR DESCRIPTION
## Summary

Extends the browser-capture extension development loop by carrying receiver request IDs from the service worker into popup state, so extension-side failures can be correlated with receiver logs and network traces.

## Problem

#2248 calls out extension development mode as still weak: popup/options state, service-worker POST result, receiver URL, and last error were not easy to connect to the branch-local receiver. After receiver-side request IDs landed, the extension still needed to send and surface those ids.

## Solution

- The background service worker now sends `X-Request-ID` on status, archive-state, and capture requests.
- Successful and failed receiver responses preserve the echoed request id in extension state and message responses.
- The popup shows the latest receiver request id in a dedicated row for direct copy into receiver logs.
- Added Vitest coverage for service-worker request headers, success state, and error state.
- Documented branch-local receiver URL and request-id debugging in `browser-extension/README.md`.

## Verification

- `npm test -- --run` in `browser-extension/` -> 5 files / 48 tests passed.
- `npm run lint` in `browser-extension/` -> passed.
- `npm run validate` in `browser-extension/` -> `manifest ok`.
- `devtools render all --check` -> sync OK.
- `devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.

Ref #2248