### PR TITLE
chore(dev): record dev-loop daemon lifecycle events (#2248)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -282,6 +282,33 @@ def _start_daemon_process(
     )
 
 
+def _write_dev_loop_event(
+    path: Path,
+    *,
+    preflight: dict[str, Any],
+    surface: str,
+    event_type: str,
+    status: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    event: dict[str, object] = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "run_id": str(preflight["run_id"]),
+        "surface": surface,
+        "event_type": event_type,
+        "status": status,
+        "repo_root": str(preflight["repo_root"]),
+        "branch": preflight.get("branch"),
+        "commit": preflight.get("commit"),
+        "archive_root": str(preflight["dev_archive_root"]),
+        "payload": payload or {},
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+    return event
+
+
 def run_cli_capture(
     *,
     preflight: dict[str, Any],
@@ -392,6 +419,18 @@ def launch_branch_daemon(
 ) -> dict[str, object]:
     """Launch a branch-local polylogued and persist process/debug artifacts."""
 
+    artifacts = preflight.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("preflight payload is missing artifact paths")
+    run_log_dir = Path(str(preflight["run_log_dir"]))
+    run_log_dir.mkdir(parents=True, exist_ok=True)
+    daemon_log = Path(str(artifacts["daemon_log"]))
+    daemon_log.parent.mkdir(parents=True, exist_ok=True)
+    event_path = Path(str(artifacts.get("dev_events", run_log_dir / "dev-loop.events.jsonl")))
+    env_path = run_log_dir / "polylogued.env.json"
+    pid_path = run_log_dir / "polylogued.pid"
+    summary_path = run_log_dir / "polylogued.launch.json"
+
     ports = preflight.get("ports")
     if not isinstance(ports, dict):
         raise ValueError("preflight payload is missing port status")
@@ -401,22 +440,19 @@ def launch_branch_daemon(
         if isinstance(status, dict) and int(status.get("owner_count") or 0) > 0:
             occupied_ports.append(f"{name} port {status.get('port')}")
     if occupied_ports:
+        _write_dev_loop_event(
+            event_path,
+            preflight=preflight,
+            surface="daemon",
+            event_type="launch_rejected",
+            status="blocked",
+            payload={"occupied_ports": occupied_ports, "ports": ports},
+        )
         raise ValueError(
             "selected branch-local ports already have listeners: "
             + ", ".join(occupied_ports)
             + "; stop the deployed service or choose isolated ports"
         )
-
-    artifacts = preflight.get("artifacts")
-    if not isinstance(artifacts, dict):
-        raise ValueError("preflight payload is missing artifact paths")
-    run_log_dir = Path(str(preflight["run_log_dir"]))
-    run_log_dir.mkdir(parents=True, exist_ok=True)
-    daemon_log = Path(str(artifacts["daemon_log"]))
-    daemon_log.parent.mkdir(parents=True, exist_ok=True)
-    env_path = run_log_dir / "polylogued.env.json"
-    pid_path = run_log_dir / "polylogued.pid"
-    summary_path = run_log_dir / "polylogued.launch.json"
 
     env = os.environ.copy()
     suggested_env = preflight.get("suggested_env")
@@ -447,6 +483,22 @@ def launch_branch_daemon(
     env_snapshot = _dev_loop_env_snapshot(env)
     env_path.write_text(json.dumps(env_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     started_at = datetime.now(UTC)
+    started = time.monotonic()
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="daemon",
+        event_type="launch_requested",
+        status="starting",
+        payload={
+            "command": command,
+            "cwd": str(preflight["repo_root"]),
+            "api_port": api_port,
+            "browser_capture_port": receiver_port,
+            "spool_path": str(spool_path),
+            "log_path": str(daemon_log),
+        },
+    )
     with daemon_log.open("a", encoding="utf-8") as log_file:
         log_file.write(
             f"\n# dev-loop launch {started_at.isoformat()} run_id={preflight['run_id']}\n$ {shlex.join(command)}\n"
@@ -459,6 +511,14 @@ def launch_branch_daemon(
             log_file=log_file,
         )
     pid_path.write_text(f"{process.pid}\n", encoding="utf-8")
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="daemon",
+        event_type="process_spawned",
+        status="running",
+        payload={"pid": process.pid},
+    )
 
     deadline = time.monotonic() + max(0.0, readiness_timeout_s)
     api_ready = False
@@ -473,15 +533,35 @@ def launch_branch_daemon(
         time.sleep(0.1)
     if exit_code is None:
         exit_code = process.poll()
+    duration_ms = int((time.monotonic() - started) * 1000)
+    ended_at = datetime.now(UTC)
+    launch_ok = exit_code is None and api_ready and receiver_ready
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="daemon",
+        event_type="readiness_succeeded" if launch_ok else "readiness_failed",
+        status="ok" if launch_ok else "failed",
+        payload={
+            "pid": process.pid,
+            "exit_code": exit_code,
+            "api_ready": api_ready,
+            "browser_capture_ready": receiver_ready,
+            "duration_ms": duration_ms,
+            "readiness_timeout_s": readiness_timeout_s,
+        },
+    )
 
     payload: dict[str, object] = {
-        "ok": exit_code is None and api_ready and receiver_ready,
+        "ok": launch_ok,
         "pid": process.pid,
         "command": command,
         "command_text": shlex.join(command),
         "cwd": str(preflight["repo_root"]),
         "run_id": str(preflight["run_id"]),
         "started_at": started_at.isoformat(),
+        "ended_at": ended_at.isoformat(),
+        "duration_ms": duration_ms,
         "exit_code": exit_code,
         "api_ready": api_ready,
         "browser_capture_ready": receiver_ready,
@@ -492,6 +572,7 @@ def launch_branch_daemon(
             "env": str(env_path),
             "pid": str(pid_path),
             "summary": str(summary_path),
+            "events": str(event_path),
         },
     }
     summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -534,6 +615,7 @@ def build_dev_loop_status(
     terminal_artifact_dir = run_log_dir / "terminal"
     tui_artifact_dir = run_log_dir / "tui"
     preflight_json = run_log_dir / "preflight.json"
+    dev_events = run_log_dir / "dev-loop.events.jsonl"
     if prepare:
         archive.mkdir(parents=True, exist_ok=True)
         browser_artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -564,6 +646,7 @@ def build_dev_loop_status(
             "terminal_dir": str(terminal_artifact_dir),
             "tui_dir": str(tui_artifact_dir),
             "preflight_json": str(preflight_json),
+            "dev_events": str(dev_events),
         },
         "system_service": service,
         "ports": {

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -74,9 +74,9 @@ devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875 --launch
 The helper refuses to start if the selected API or browser-capture port already
 has a listener. It starts `polylogued run --no-watch` in a separate process
 group, writes `polylogued.pid`, `polylogued.env.json`,
-`polylogued.launch.json`, and the daemon log into the run-local directory, and
-waits briefly for both the API and receiver ports to become reachable. The
-important variables are:
+`polylogued.launch.json`, `dev-loop.events.jsonl`, and the daemon log into the
+run-local directory, and waits briefly for both the API and receiver ports to
+become reachable. The important variables are:
 
 ```bash
 POLYLOGUE_ARCHIVE_ROOT=.local/dev-archive
@@ -85,6 +85,21 @@ POLYLOGUE_BROWSER_CAPTURE_PORT=8875
 POLYLOGUE_DEV_LOOP_RUN_ID=<run-id>
 POLYLOGUE_DEV_LOOP_LOG_DIR=.cache/dev-loop/<run-id>
 ```
+
+The JSONL event stream records the launcher-side lifecycle in order:
+
+```text
+launch_requested
+process_spawned
+readiness_succeeded | readiness_failed
+```
+
+If the selected ports are already occupied, the helper writes a
+`launch_rejected` event before exiting. Each event carries the run id, checkout
+path, branch, commit, archive root, status, timestamp, and a small event
+payload. Use this file together with `polylogued.launch.json` and
+`polylogued.log` when diagnosing whether a branch-local failure happened before
+process spawn, during API/receiver readiness, or inside the daemon itself.
 
 ## Web Shell Debugging
 
@@ -119,6 +134,11 @@ facts obvious before an agent starts debugging:
 - which API port the browser should open;
 - where daemon logs are written;
 - whether the deployed service is still active.
+
+The web shell `dev:` chip and `/api/dev-loop` endpoint expose the run id and log
+directory from the daemon process. The launcher-side `dev-loop.events.jsonl`
+then gives agents a stable local artifact to correlate that UI-visible run id
+with the process spawn and readiness state that created it.
 
 ## CLI and TUI Capture
 

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -97,9 +97,12 @@ readiness_succeeded | readiness_failed
 If the selected ports are already occupied, the helper writes a
 `launch_rejected` event before exiting. Each event carries the run id, checkout
 path, branch, commit, archive root, status, timestamp, and a small event
-payload. Use this file together with `polylogued.launch.json` and
-`polylogued.log` when diagnosing whether a branch-local failure happened before
-process spawn, during API/receiver readiness, or inside the daemon itself.
+payload. For a port-blocked launch, this event stream is the primary artifact:
+the daemon process is never spawned, so `polylogued.launch.json` and
+`polylogued.log` are not expected to exist. When the process does spawn, use the
+event stream together with `polylogued.launch.json` and `polylogued.log` to
+diagnose whether a branch-local failure happened during API/receiver readiness
+or inside the daemon itself.
 
 ## Web Shell Debugging
 

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -111,6 +111,9 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert payload["artifacts"]["daemon_log"].endswith(
         ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/polylogued.log"
     )
+    assert payload["artifacts"]["dev_events"].endswith(
+        ".cache/dev-loop/feature-dev-loop-abc1234-api9999-capture9998/dev-loop.events.jsonl"
+    )
     assert "polylogued run --api-port 9999 --port 9998" in payload["commands"]["run_daemon"]
     assert "polylogue ops status" in payload["commands"]["capture_cli_status"]
     assert payload["commands"]["capture_cli_status"].endswith("terminal/polylogue-ops-status.typescript")
@@ -291,6 +294,9 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(dev_loop, "_repo_root", lambda: repo)
     monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
     monkeypatch.setattr(
         dev_loop,
@@ -362,6 +368,20 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
     assert json.loads(Path(artifacts["summary"]).read_text(encoding="utf-8"))["pid"] == 4242
     assert json.loads(Path(artifacts["env"]).read_text(encoding="utf-8"))["POLYLOGUE_API_PORT"] == "9876"
     assert Path(artifacts["log"]).read_text(encoding="utf-8").startswith("\n# dev-loop launch")
+    event_rows = [
+        json.loads(line) for line in Path(artifacts["events"]).read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert [row["event_type"] for row in event_rows] == [
+        "launch_requested",
+        "process_spawned",
+        "readiness_succeeded",
+    ]
+    assert event_rows[0]["run_id"] == payload["preflight"]["run_id"]
+    assert event_rows[0]["archive_root"] == str(tmp_path / "archive")
+    assert event_rows[0]["payload"]["api_port"] == 9876
+    assert event_rows[1]["payload"]["pid"] == 4242
+    assert event_rows[2]["status"] == "ok"
+    assert event_rows[2]["payload"]["api_ready"] is True
 
 
 def test_daemon_launch_rejects_occupied_branch_local_ports(
@@ -369,6 +389,9 @@ def test_daemon_launch_rejects_occupied_branch_local_ports(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(dev_loop, "_repo_root", lambda: repo)
     monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
     monkeypatch.setattr(
         dev_loop,
@@ -384,3 +407,9 @@ def test_daemon_launch_rejects_occupied_branch_local_ports(
 
     assert exc.value.code == 2
     assert "selected branch-local ports already have listeners" in capsys.readouterr().err
+    run_log_dir = tmp_path / "repo" / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api8766-capture8765"
+    event_path = run_log_dir / "dev-loop.events.jsonl"
+    event_rows = [json.loads(line) for line in event_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["event_type"] for row in event_rows] == ["launch_rejected"]
+    assert event_rows[0]["status"] == "blocked"
+    assert event_rows[0]["payload"]["occupied_ports"] == ["api port 8766", "browser_capture port 8765"]

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -70,7 +70,7 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = tmp_path / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
 
     monkeypatch.setattr(
         dev_loop,
@@ -290,12 +290,13 @@ def test_cli_capture_treats_forwarded_trailing_json_as_wrapper_flag(
 
 
 def test_daemon_launch_writes_branch_local_process_artifacts(
-    tmp_path: Path,
+    workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    repo = workspace_env["state_dir"] / "repo"
+    repo.mkdir(parents=True)
+    archive_root = workspace_env["archive_root"]
     monkeypatch.setattr(dev_loop, "_repo_root", lambda: repo)
     monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
     monkeypatch.setattr(
@@ -336,7 +337,7 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
             [
                 "--json",
                 "--archive-root",
-                str(tmp_path / "archive"),
+                str(archive_root),
                 "--api-port",
                 "9876",
                 "--browser-capture-port",
@@ -360,7 +361,7 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
 
     env = launched["env"]
     assert isinstance(env, dict)
-    assert env["POLYLOGUE_ARCHIVE_ROOT"] == str(tmp_path / "archive")
+    assert env["POLYLOGUE_ARCHIVE_ROOT"] == str(archive_root)
     assert launched["cwd"] == Path(payload["preflight"]["repo_root"])
 
     artifacts = launch["artifacts"]
@@ -377,7 +378,7 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
         "readiness_succeeded",
     ]
     assert event_rows[0]["run_id"] == payload["preflight"]["run_id"]
-    assert event_rows[0]["archive_root"] == str(tmp_path / "archive")
+    assert event_rows[0]["archive_root"] == str(archive_root)
     assert event_rows[0]["payload"]["api_port"] == 9876
     assert event_rows[1]["payload"]["pid"] == 4242
     assert event_rows[2]["status"] == "ok"
@@ -385,12 +386,13 @@ def test_daemon_launch_writes_branch_local_process_artifacts(
 
 
 def test_daemon_launch_rejects_occupied_branch_local_ports(
-    tmp_path: Path,
+    workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    repo = workspace_env["state_dir"] / "repo"
+    repo.mkdir(parents=True)
+    archive_root = workspace_env["archive_root"]
     monkeypatch.setattr(dev_loop, "_repo_root", lambda: repo)
     monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
     monkeypatch.setattr(
@@ -403,11 +405,11 @@ def test_daemon_launch_rejects_occupied_branch_local_ports(
     )
 
     with pytest.raises(SystemExit) as exc:
-        dev_loop.main(["--archive-root", str(tmp_path / "archive"), "--launch-daemon"])
+        dev_loop.main(["--archive-root", str(archive_root), "--launch-daemon"])
 
     assert exc.value.code == 2
     assert "selected branch-local ports already have listeners" in capsys.readouterr().err
-    run_log_dir = tmp_path / "repo" / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api8766-capture8765"
+    run_log_dir = repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api8766-capture8765"
     event_path = run_log_dir / "dev-loop.events.jsonl"
     event_rows = [json.loads(line) for line in event_path.read_text(encoding="utf-8").splitlines()]
     assert [row["event_type"] for row in event_rows] == ["launch_rejected"]


### PR DESCRIPTION
## Summary

Adds a structured launcher-side event stream for branch-local daemon runs under `devtools workspace dev-loop --launch-daemon`. The run directory now contains `dev-loop.events.jsonl` beside `polylogued.launch.json`, `polylogued.env.json`, `polylogued.pid`, and `polylogued.log`.

## Problem

#2248 is about making branch-local daemon/web/browser-capture work debuggable without guessing or leaning on the deployed service. The managed launcher already wrote a PID, env snapshot, launch summary, and daemon log, but it did not preserve a structured lifecycle timeline. When a launch failed, agents still had to infer whether it was blocked before spawn, failed during readiness, or reached the daemon and failed later.

## Solution

- Add `dev-loop.events.jsonl` to the dev-loop artifact inventory.
- Record launcher lifecycle events:
  - `launch_requested`
  - `process_spawned`
  - `readiness_succeeded` / `readiness_failed`
  - `launch_rejected` when selected ports are already occupied
- Include run id, checkout path, branch, commit, archive root, status, timestamp, and compact event payloads in each event row.
- Point the daemon launch summary at the event stream.
- Update `docs/dev-loop.md` to explain how to use the event stream with `polylogued.launch.json` and `polylogued.log`.

This deliberately stays in local artifacts instead of adding an ops-tier table: the current debugging query is per-run launcher correlation, and structured JSONL answers it without creating persistent schema.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> 11 passed
- `devtools render all --check` -> sync OK
- `devtools verify --quick` -> exit_code 0

Ref #2248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added structured event logging for daemon launches, capturing lifecycle events (launch request, process spawn, readiness status) for improved diagnostics and troubleshooting.
  * Event logs are now available as a dedicated artifact file for correlation with UI diagnostics.

* **Documentation**
  * Updated documentation to describe daemon launcher lifecycle events and their sequence.

* **Tests**
  * Enhanced test coverage for new event logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->