### PR TITLE
chore(web): surface API request diagnostics in the shell (#2248)

### DIFF
--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -143,6 +143,15 @@ directory from the daemon process. The launcher-side `dev-loop.events.jsonl`
 then gives agents a stable local artifact to correlate that UI-visible run id
 with the process spawn and readiness state that created it.
 
+The shell also records the latest API request it made. Every request sent by
+the shell carries an `X-Request-ID` header, measures client-side duration, and
+updates the `api:` status chip with success latency or failure status. Hover the
+chip to see the route, request id, status, duration, any echoed response request
+id, and a bounded response-body summary. This is intentionally a local UI-debug
+aid: use it with browser network logs and daemon logs to identify which route
+handled the visible action, without storing raw archive payloads in a separate
+ledger.
+
 ## CLI and TUI Capture
 
 Human-facing CLI/TUI behavior should be debuggable as rendered, not only as

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -267,6 +267,7 @@ __ATTACHMENT_CSS__
     <span class="chip" id="status-ingest" style="display:none">live</span>
     <span class="chip" id="status-browser-capture" title="Browser capture readiness" style="display:none">capture: --</span>
     <span class="chip" id="status-dev-loop" title="Branch-local dev loop" style="display:none">dev: --</span>
+    <span class="chip" id="status-api-debug" title="Latest API request" style="display:none">api: --</span>
     <span class="chip" id="status-live" title="Realtime channel">live: --</span>
   </div>
   <div id="sidebar">
@@ -384,23 +385,104 @@ var state = {
   // session_id; populated on demand when the Similar inspector
   // tab is opened. ``undefined`` means "not loaded yet"; the envelope
   // carries the explicit pipeline state under ``status``.
-  similarPanels: {}
+  similarPanels: {},
+  // Latest web-shell API request metadata. This is a UI/debug aid only: it
+  // records route, status, duration, request id, and a bounded response summary
+  // without storing raw archive payloads.
+  apiDebug: {counter: 0, last: null}
 };
 
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 function escAttr(s) { return String(s).replace(/'/g,"\\'").replace(/"/g,'&quot;'); }
 
+function nowMs() {
+  return (window.performance && performance.now) ? performance.now() : Date.now();
+}
+
+function nextApiRequestId() {
+  state.apiDebug.counter += 1;
+  return 'web-' + Date.now().toString(36) + '-' + state.apiDebug.counter;
+}
+
+function summarizeApiBody(text) {
+  if (!text) return '';
+  var compact = String(text).replace(/\s+/g, ' ').trim();
+  return compact.length > 240 ? compact.slice(0, 237) + '...' : compact;
+}
+
+function rememberApiDebug(entry) {
+  state.apiDebug.last = entry;
+  renderApiDebugChip();
+}
+
+async function requestJSON(url, opts) {
+  opts = opts || {};
+  var method = opts.method || 'GET';
+  var requestId = nextApiRequestId();
+  var headers = Object.assign({'X-Request-ID': requestId}, opts.headers || {});
+  var requestOpts = Object.assign({}, opts, {method: method, headers: headers});
+  var started = nowMs();
+  var response;
+  try {
+    response = await fetch(API + url, requestOpts);
+  } catch(e) {
+    var networkDuration = Math.round(nowMs() - started);
+    rememberApiDebug({
+      ok: false, method: method, url: url, request_id: requestId,
+      status: 'network_error', duration_ms: networkDuration,
+      response_summary: String(e && e.message ? e.message : e)
+    });
+    throw e;
+  }
+  var text = await response.text();
+  var duration = Math.round(nowMs() - started);
+  var responseRequestId = response.headers && response.headers.get ? response.headers.get('X-Request-ID') : '';
+  var summary = summarizeApiBody(text);
+  rememberApiDebug({
+    ok: response.ok,
+    method: method,
+    url: url,
+    request_id: requestId,
+    response_request_id: responseRequestId || '',
+    status: response.status,
+    duration_ms: duration,
+    response_summary: summary
+  });
+  if (!response.ok) {
+    var error = new Error(String(response.status));
+    error.status = response.status;
+    error.request_id = requestId;
+    error.response_summary = summary;
+    throw error;
+  }
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch(e) {
+    rememberApiDebug({
+      ok: false,
+      method: method,
+      url: url,
+      request_id: requestId,
+      response_request_id: responseRequestId || '',
+      status: 'invalid_json',
+      duration_ms: duration,
+      response_summary: summary
+    });
+    var parseError = new Error('invalid_json');
+    parseError.request_id = requestId;
+    parseError.response_summary = summary;
+    throw parseError;
+  }
+}
+
 async function fetchJSON(url) {
-  var r = await fetch(API + url);
-  if (!r.ok) throw new Error(r.status);
-  return r.json();
+  return requestJSON(url, {method: 'GET'});
 }
 async function sendJSON(url, method, body) {
   var opts = {method: method, headers: {'Content-Type': 'application/json'}};
   if (body !== undefined) opts.body = JSON.stringify(body);
-  var r = await fetch(API + url, opts);
-  if (!r.ok) throw new Error(r.status);
-  return r.json();
+  return requestJSON(url, opts);
 }
 
 function markSetFor(sessionId) {
@@ -695,6 +777,31 @@ function renderDevLoopChip(payload) {
   el.title = 'Branch-local dev loop'
     + (payload.run_id ? ' ' + payload.run_id : '')
     + (details.length ? '; ' + details.join('; ') : '');
+}
+
+function renderApiDebugChip() {
+  var el = document.getElementById('status-api-debug');
+  if (!el) return;
+  var entry = state.apiDebug && state.apiDebug.last;
+  if (!entry) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  var status = entry.status || 'unknown';
+  if (entry.ok) {
+    el.textContent = 'api: ' + entry.duration_ms + 'ms';
+    setChipQuality(el, 'canonical');
+  } else {
+    el.textContent = 'api: ' + status;
+    setChipQuality(el, 'stale');
+  }
+  var title = [
+    entry.method + ' ' + entry.url,
+    'status ' + status,
+    'duration ' + entry.duration_ms + 'ms',
+    'request ' + entry.request_id
+  ];
+  if (entry.response_request_id) title.push('response ' + entry.response_request_id);
+  if (entry.response_summary) title.push('body ' + entry.response_summary);
+  el.title = title.join('; ');
 }
 
 function renderSidebarState(kind, msg) {

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -2432,6 +2432,19 @@ class TestReaderInformability:
         assert "function renderDevLoopChip(" in body
         assert "/api/dev-loop" in body
 
+    def test_web_shell_surfaces_latest_api_request_diagnostics(self, workspace_env: dict[str, Path]) -> None:
+        """The web shell has local request diagnostics for UI/API failures."""
+
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert 'id="status-api-debug"' in body
+        assert "function nextApiRequestId(" in body
+        assert "'X-Request-ID': requestId" in body
+        assert "function renderApiDebugChip(" in body
+        assert "response_summary" in body
+        assert "invalid_json" in body
+
     def test_insight_freshness_chip_keeps_legacy_fallback(self, workspace_env: dict[str, Path]) -> None:
         """Session insight freshness gets its own status-strip chip. It now
         prefers ``component_readiness.session_profiles`` and keeps the


### PR DESCRIPTION
## Summary

Adds browser-side request diagnostics to the daemon web shell. Every JSON request from the shell now carries an `X-Request-ID`, records client-side duration, status, and a bounded response/error summary, and exposes the latest request in a compact `api:` status chip.

## Problem

#2248 asks for enough branch-local web UI observability to correlate a UI/browser action to the daemon/API event that handled it. The web shell already showed branch-local run metadata, but route failures still collapsed into generic fetch errors. An agent could see that a panel failed without knowing the route, request id, status, timing, or response summary needed to line it up with browser network logs and daemon logs.

## Solution

- Route all shell JSON fetch/send calls through one request wrapper.
- Add `X-Request-ID` to every request generated by the shell.
- Measure client-side duration and capture status plus a bounded response-body summary.
- Render the latest request as an `api:` chip with a hover title containing route, request id, status, duration, echoed response id when present, and response summary.
- Document how to use the chip with browser network logs and daemon logs.

This remains a local UI-debug surface. It does not persist raw archive payloads or add a backend ledger.

## Verification

- `devtools test tests/unit/daemon/test_web_reader.py::TestReaderInformability -q` -> 11 passed
- `devtools render all --check` -> sync OK
- `devtools verify --quick` -> exit_code 0

Ref #2248