### PR TITLE
chore(dev): add CLI capture events to dev-loop timeline (#2248)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -329,6 +329,7 @@ def run_cli_capture(
         raise ValueError("preflight payload is missing artifact paths")
     terminal_dir = Path(str(artifacts["terminal_dir"]))
     terminal_dir.mkdir(parents=True, exist_ok=True)
+    event_path = Path(str(artifacts.get("dev_events", Path(str(preflight["run_log_dir"])) / "dev-loop.events.jsonl")))
 
     env = os.environ.copy()
     suggested_env = preflight.get("suggested_env")
@@ -344,6 +345,19 @@ def run_cli_capture(
     summary_path = terminal_dir / f"{artifact_name}.summary.json"
 
     started_at = datetime.now(UTC)
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="cli",
+        event_type="cli_capture_requested",
+        status="starting",
+        payload={
+            "command": command,
+            "command_text": shlex.join(command),
+            "artifact_name": artifact_name,
+            "timeout_s": timeout_s,
+        },
+    )
     started = time.monotonic()
     timed_out = False
     try:
@@ -409,6 +423,21 @@ def run_cli_capture(
         },
     }
     summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="cli",
+        event_type="cli_capture_finished",
+        status="ok" if exit_code == 0 else "failed",
+        payload={
+            "command": command,
+            "command_text": shlex.join(command),
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "duration_ms": duration_ms,
+            "artifacts": payload["artifacts"],
+        },
+    )
     return payload
 
 

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -177,6 +177,12 @@ and a JSON summary under:
 .cache/dev-loop/<run-id>/terminal/
 ```
 
+It also appends `cli_capture_requested` and `cli_capture_finished` rows to the
+same `dev-loop.events.jsonl` stream used by daemon launches. Those rows carry
+the command, timeout, exit code, duration, timeout flag, and artifact paths, so
+a run directory has one timeline covering the branch-local daemon and any CLI
+captures performed against it.
+
 The preflight payload still includes `commands.capture_cli_status` as a
 copy-pastable `script` example when an actual terminal typescript is useful.
 

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -216,6 +216,8 @@ def test_cli_capture_runs_command_with_branch_local_artifacts(
         dev_loop.main(
             [
                 "--json",
+                "--log-dir",
+                str(tmp_path / "dev-loop-logs"),
                 "--archive-root",
                 str(tmp_path / "archive"),
                 "--capture-cli",
@@ -245,6 +247,15 @@ def test_cli_capture_runs_command_with_branch_local_artifacts(
     assert env_payload["POLYLOGUE_API_AUTH_TOKEN"] == "[redacted]"
     assert env_payload["POLYLOGUE_NOTIFICATION_EMAIL_PASSWORD"] == "[redacted]"
     assert json.loads(summary_path.read_text(encoding="utf-8"))["exit_code"] == 0
+    event_path = Path(payload["preflight"]["artifacts"]["dev_events"])
+    event_rows = [json.loads(line) for line in event_path.read_text(encoding="utf-8").splitlines()]
+    capture_events = event_rows[-2:]
+    assert [row["event_type"] for row in capture_events] == ["cli_capture_requested", "cli_capture_finished"]
+    assert capture_events[0]["surface"] == "cli"
+    assert capture_events[0]["payload"]["command"] == command
+    assert capture_events[1]["status"] == "ok"
+    assert capture_events[1]["payload"]["exit_code"] == 0
+    assert capture_events[1]["payload"]["artifacts"]["transcript"] == str(transcript_path)
 
 
 def test_cli_capture_rejects_missing_command(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

Adds CLI capture events to the same `dev-loop.events.jsonl` stream used by branch-local daemon launch events. `devtools workspace dev-loop --capture-cli` now records command start and finish metadata alongside its stdout/stderr/transcript/env/summary artifacts.

## Problem

#2248 is about making one branch-local run diagnosable from local artifacts. The daemon launcher now writes lifecycle events, and CLI capture writes good per-command artifacts, but the CLI captures were not represented in the shared run timeline. That left a gap when trying to answer which CLI commands were run against the branch-local archive during the same debugging session.

## Solution

- Emit `cli_capture_requested` before running the captured command.
- Emit `cli_capture_finished` after artifacts are written.
- Include command, timeout, exit code, timeout flag, duration, and artifact paths in the event payload.
- Extend the existing CLI capture test to assert the event stream.
- Document that daemon and CLI capture events share one run timeline.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> 11 passed
- `devtools render all --check` -> sync OK
- `devtools verify --quick` -> exit_code 0

Ref #2248