### PR TITLE
chore(daemon): emit lifecycle events for dev-loop runs (#2248)

### DIFF
--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -104,6 +104,16 @@ event stream together with `polylogued.launch.json` and `polylogued.log` to
 diagnose whether a branch-local failure happened during API/receiver readiness
 or inside the daemon itself.
 
+Once the daemon passes its schema preflight, it also writes durable
+`daemon.lifecycle` rows to the existing `ops.db` daemon event ledger. These
+rows carry the same dev-loop run id when `POLYLOGUE_DEV_LOOP_RUN_ID` is set and
+record startup, API/browser-capture binding, FTS readiness, converger/watcher
+start, skipped watcher state, and shutdown. Use the launcher JSONL stream for
+process-spawn/readiness questions and `/api/events?kind=daemon.lifecycle` or
+the ops event reader for daemon-internal lifecycle questions. Schema-blocked
+startup intentionally does not write these rows, because that path must remain
+observable without opening archive databases.
+
 ## Web Shell Debugging
 
 The branch-local web shell is served by the branch-local `polylogued run`

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -593,6 +593,40 @@ def _emit_live_batch_event(kind: str, payload: dict[str, object]) -> None:
     )
 
 
+def _emit_daemon_lifecycle_event(
+    phase: str,
+    *,
+    archive_root_path: Path,
+    status: str = "ok",
+    component: str | None = None,
+    payload: dict[str, object] | None = None,
+) -> None:
+    """Persist a daemon lifecycle event without making observability fatal."""
+    from polylogue.daemon.events import emit_daemon_event
+
+    run_id = os.environ.get("POLYLOGUE_DEV_LOOP_RUN_ID")
+    event_payload: dict[str, object] = {
+        "phase": phase,
+        "status": status,
+        "pid": os.getpid(),
+        "cwd": os.getcwd(),
+        "archive_root": str(archive_root_path),
+    }
+    if component is not None:
+        event_payload["component"] = component
+    log_dir = os.environ.get("POLYLOGUE_DEV_LOOP_LOG_DIR")
+    if run_id:
+        event_payload["dev_loop_run_id"] = run_id
+    if log_dir:
+        event_payload["dev_loop_log_dir"] = log_dir
+    if payload:
+        event_payload.update(payload)
+    try:
+        emit_daemon_event("daemon.lifecycle", operation_id=run_id, payload=event_payload)
+    except Exception:
+        logger.warning("daemon: failed to emit lifecycle event %s", phase, exc_info=True)
+
+
 async def run_live_watcher(
     *,
     sources: tuple[WatchSource, ...],
@@ -629,6 +663,7 @@ async def run_daemon_services(
 
     global _pidfile_path
     _process_start.started_at_wall()
+    archive_root_path = Path(archive_root())
 
     # Non-localhost API binding requires explicit opt-in AND an auth token.
     if enable_api and not is_loopback_host(api_host):
@@ -650,6 +685,7 @@ async def run_daemon_services(
     # heartbeat queries — that is the IO cost #1003 is meant to avoid.
     schema_alert = _check_schema_version_fast()
     watcher_blocked = enable_watch and schema_alert.severity == HealthSeverity.CRITICAL
+    lifecycle_events_enabled = not watcher_blocked
     if watcher_blocked:
         logger.error(
             "daemon: schema preflight CRITICAL — %s. Refusing to start the live watcher; "
@@ -664,7 +700,7 @@ async def run_daemon_services(
             )
         )
 
-    pidfile = Path(archive_root()) / "daemon.pid"
+    pidfile = archive_root_path / "daemon.pid"
     pidfile_fd: int | None = None
 
     # Prevent concurrent daemon instances: verify existing pidfile, then
@@ -686,6 +722,23 @@ async def run_daemon_services(
     # never-yet-used sources (e.g. hooks sidecar dir) as missing.
     for src in sources:
         src.root.mkdir(parents=True, exist_ok=True)
+
+    if lifecycle_events_enabled:
+        _emit_daemon_lifecycle_event(
+            "startup",
+            archive_root_path=archive_root_path,
+            status="starting",
+            payload={
+                "api_enabled": enable_api,
+                "api_host": api_host,
+                "api_port": api_port,
+                "browser_capture_enabled": enable_browser_capture,
+                "browser_capture_host": browser_capture_host,
+                "browser_capture_port": browser_capture_port,
+                "watch_enabled": enable_watch,
+                "source_roots": [str(src.root) for src in sources],
+            },
+        )
 
     # Periodic maintenance tasks. If schema preflight blocks the watcher, do
     # not start any background loop that opens the archive: a mismatched
@@ -719,6 +772,19 @@ async def run_daemon_services(
             )
             server_task = asyncio.create_task(asyncio.to_thread(server.serve_forever, 0.5))
             tasks.append(server_task)
+            if lifecycle_events_enabled:
+                _emit_daemon_lifecycle_event(
+                    "component_started",
+                    archive_root_path=archive_root_path,
+                    component="browser_capture",
+                    payload={
+                        "host": browser_capture_host,
+                        "port": browser_capture_port,
+                        "spool_path": str(browser_capture_spool_path)
+                        if browser_capture_spool_path is not None
+                        else None,
+                    },
+                )
 
         if enable_api:
             from polylogue.daemon.http import (
@@ -734,6 +800,13 @@ async def run_daemon_services(
             )
             api_server_task = asyncio.create_task(asyncio.to_thread(api_server.serve_forever, 0.5))
             tasks.append(api_server_task)
+            if lifecycle_events_enabled:
+                _emit_daemon_lifecycle_event(
+                    "component_started",
+                    archive_root_path=archive_root_path,
+                    component="api",
+                    payload={"host": api_host, "port": api_port, "auth_enabled": bool(api_auth_token)},
+                )
 
         # Ensure FTS structure after HTTP surfaces are bound and before live
         # catch-up starts. Startup FTS maintenance and catch-up ingestion are
@@ -745,6 +818,12 @@ async def run_daemon_services(
             from polylogue.daemon.embedding_backlog import periodic_embedding_backlog_check
 
             await _ensure_fts_startup_readiness()
+            if lifecycle_events_enabled:
+                _emit_daemon_lifecycle_event(
+                    "component_ready",
+                    archive_root_path=archive_root_path,
+                    component="fts_startup",
+                )
             # Disable per-write FTS5 automerge so each small ingest batch does
             # not trigger a merge of the full (hundreds-of-MB) existing
             # segments (#1851).  A periodic merge pass amortises the cost.
@@ -776,6 +855,12 @@ async def run_daemon_services(
                 max_workers=2,
             )
             await converger.start()
+            if lifecycle_events_enabled:
+                _emit_daemon_lifecycle_event(
+                    "component_started",
+                    archive_root_path=archive_root_path,
+                    component="converger",
+                )
 
         # Preflight already ran at the top of run_daemon_services (see
         # ``watcher_blocked`` above); reuse that result.
@@ -799,19 +884,52 @@ async def run_daemon_services(
                     )
                     watcher_task = asyncio.create_task(watcher.run())
                     tasks.append(watcher_task)
+                    if lifecycle_events_enabled:
+                        _emit_daemon_lifecycle_event(
+                            "component_started",
+                            archive_root_path=archive_root_path,
+                            component="watcher",
+                            payload={"source_count": len(sources), "debounce_s": debounce_s},
+                        )
                     all_tasks = tasks + maintenance_tasks
                     await asyncio.gather(*all_tasks)
             elif tasks:
                 # Watcher disabled or preflight-blocked: keep HTTP/health and
                 # other components serving so operators see the degraded state.
+                if lifecycle_events_enabled:
+                    _emit_daemon_lifecycle_event(
+                        "component_skipped",
+                        archive_root_path=archive_root_path,
+                        component="watcher",
+                        payload={
+                            "reason": "schema_blocked" if watcher_blocked else "disabled",
+                            "watch_enabled": enable_watch,
+                        },
+                    )
                 all_tasks = tasks + maintenance_tasks
                 await asyncio.gather(*all_tasks)
             else:
+                if lifecycle_events_enabled:
+                    _emit_daemon_lifecycle_event(
+                        "component_skipped",
+                        archive_root_path=archive_root_path,
+                        component="watcher",
+                        payload={
+                            "reason": "schema_blocked" if watcher_blocked else "disabled",
+                            "watch_enabled": enable_watch,
+                        },
+                    )
                 await asyncio.gather(*maintenance_tasks)
         except BaseException:
             _log_completed_daemon_tasks(tasks + maintenance_tasks)
             raise
     finally:
+        if lifecycle_events_enabled:
+            _emit_daemon_lifecycle_event(
+                "shutdown_started",
+                archive_root_path=archive_root_path,
+                status="stopping",
+            )
         if watcher is not None:
             watcher.stop()
         if converger is not None:
@@ -852,6 +970,12 @@ async def run_daemon_services(
             with contextlib.suppress(OSError):
                 os.close(pidfile_fd)
         _cleanup_pidfile()
+        if lifecycle_events_enabled:
+            _emit_daemon_lifecycle_event(
+                "shutdown_complete",
+                archive_root_path=archive_root_path,
+                status="stopped",
+            )
 
     logger.info("daemon stopped")
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1193,10 +1193,46 @@ def test_run_daemon_services_stops_live_watcher_on_failure() -> None:
     assert stopped == [True]
 
 
+def test_emit_daemon_lifecycle_event_carries_dev_loop_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_emit(kind: str, **kwargs: object) -> None:
+        calls.append((kind, kwargs))
+
+    monkeypatch.setenv("POLYLOGUE_DEV_LOOP_RUN_ID", "dev-loop-run")
+    monkeypatch.setenv("POLYLOGUE_DEV_LOOP_LOG_DIR", str(tmp_path / "logs"))
+
+    with patch("polylogue.daemon.events.emit_daemon_event", side_effect=fake_emit):
+        daemon_cli._emit_daemon_lifecycle_event(
+            "component_started",
+            archive_root_path=tmp_path / "archive",
+            component="api",
+            payload={"port": 8766},
+        )
+
+    assert len(calls) == 1
+    kind, kwargs = calls[0]
+    assert kind == "daemon.lifecycle"
+    assert kwargs["operation_id"] == "dev-loop-run"
+    payload = cast(dict[str, object], kwargs["payload"])
+    assert payload["phase"] == "component_started"
+    assert payload["component"] == "api"
+    assert payload["port"] == 8766
+    assert payload["archive_root"] == str(tmp_path / "archive")
+    assert payload["dev_loop_run_id"] == "dev-loop-run"
+    assert payload["dev_loop_log_dir"] == str(tmp_path / "logs")
+
+
 def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     from polylogue.daemon import cli as daemon_cli
 
     events: list[str] = []
+    lifecycle_payloads: list[dict[str, object]] = []
 
     class FakePolylogue:
         async def __aenter__(self) -> object:
@@ -1241,6 +1277,10 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         async def stop(self) -> None:
             events.append("converger-stop")
 
+    def fake_emit_daemon_event(kind: str, **kwargs: object) -> None:
+        assert kind == "daemon.lifecycle"
+        lifecycle_payloads.append(cast(dict[str, object], kwargs["payload"]))
+
     with (
         patch.object(daemon_cli, "Polylogue", FakePolylogue),
         patch.object(daemon_cli, "LiveWatcher", FakeWatcher),
@@ -1257,6 +1297,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         patch("polylogue.daemon.embedding_backlog.periodic_embedding_backlog_check", lambda: fake_loop("embedding")),
         patch("polylogue.daemon.convergence.DaemonConverger", FakeConverger),
         patch("polylogue.daemon.convergence_stages.make_default_convergence_stages", return_value=()),
+        patch("polylogue.daemon.events.emit_daemon_event", side_effect=fake_emit_daemon_event),
         pytest.raises(RuntimeError, match="watch stopped"),
     ):
         asyncio.run(
@@ -1277,6 +1318,12 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     assert events.index("fts") < events.index("convergence")
     assert events.index("fts") < events.index("drive")
     assert events.index("fts") < events.index("converger")
+    lifecycle_phases = [str(payload["phase"]) for payload in lifecycle_payloads]
+    assert lifecycle_phases[0] == "startup"
+    assert "component_ready" in lifecycle_phases
+    assert lifecycle_phases[-2:] == ["shutdown_started", "shutdown_complete"]
+    lifecycle_components = {payload.get("component") for payload in lifecycle_payloads}
+    assert {"fts_startup", "converger", "watcher"}.issubset(lifecycle_components)
 
 
 def test_run_daemon_services_closes_browser_capture_server_on_failure() -> None:


### PR DESCRIPTION
## Summary

Adds daemon-side lifecycle events to the existing `ops.db` daemon event ledger so branch-local dev-loop runs can correlate process startup, component readiness, watcher state, and shutdown from the daemon itself.

## Problem

`devtools workspace dev-loop --launch-daemon` recorded launcher-side spawn/readiness events, but once the daemon process was running the only durable runtime evidence was logs. That made it harder to answer whether a branch-local failure happened before binding, during FTS/converger/watcher startup, or during shutdown.

## Solution

`run_daemon_services()` now emits `daemon.lifecycle` rows through the existing `polylogue.daemon.events` ledger after schema preflight succeeds. Rows include pid, cwd, archive root, component/phase/status, dev-loop run id/log dir when present, API/browser-capture binding details, watcher source counts, and shutdown phases. Schema-blocked startup intentionally skips these writes so the mismatch path does not open archive databases.

`docs/dev-loop.md` now explains the split: launcher JSONL for process spawn/readiness, `/api/events?kind=daemon.lifecycle` or the ops event reader for daemon-internal lifecycle state.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py -q` → 38 passed.
- `devtools render all --check` → generated surfaces sync OK.
- `devtools verify --quick` → exit_code 0.

Ref #2248