### PR TITLE
chore(dev): smoke-test browser extension receiver loop (#2248)

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -71,6 +71,19 @@ default port. Each status/archive/capture request sends `X-Request-ID` and the
 popup shows the receiver's echoed request id. Use that value to correlate the
 popup/service-worker result with browser network traces and receiver logs.
 
+Before loading a GUI browser, run the branch-local background/receiver smoke:
+
+```bash
+devtools workspace dev-loop --extension-smoke
+```
+
+The smoke starts a temporary local receiver, imports the actual background
+worker with a Chrome API mock, proves unauthenticated rejection, configures the
+receiver token, checks receiver status, and posts a deterministic capture
+envelope. Artifacts are written under `.cache/dev-loop/<run-id>/browser/`.
+This proves the extension service-worker HTTP path without using real
+ChatGPT/Claude.ai profile data.
+
 ## Supported Sites
 
 | Site | Provider | Notes |
@@ -127,6 +140,7 @@ npm test              # vitest
 npm run test:watch    # watch mode
 npm run lint          # eslint
 npm run validate      # in-tree manifest validation
+npm run dev-loop-smoke # background worker -> local receiver smoke
 npm run build         # build Chrome .zip + Firefox .xpi under dist/
 npm run screenshots   # capture store-submission screenshots (Playwright)
 ```

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -9,6 +9,7 @@
     "test:watch": "vitest",
     "lint": "eslint src/ tests/",
     "validate": "node scripts/validate-manifest.mjs",
+    "dev-loop-smoke": "node scripts/dev-loop-smoke.mjs",
     "build": "node scripts/build.mjs",
     "screenshots": "node scripts/screenshots.mjs",
     "sync-version": "node scripts/build.mjs --sync-only"

--- a/browser-extension/scripts/dev-loop-smoke.mjs
+++ b/browser-extension/scripts/dev-loop-smoke.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Exercise the extension service-worker receiver path against a real local
+// Polylogue browser-capture receiver. This is intentionally runnable without a
+// GUI browser: it imports src/background.js with a small Chrome API mock and
+// sends the same runtime messages the popup/content scripts use.
+
+import { writeFileSync } from "node:fs";
+
+const receiverBaseUrl = (process.env.POLYLOGUE_EXTENSION_RECEIVER_URL || "http://127.0.0.1:8765").replace(/\/+$/, "");
+const receiverAuthToken = process.env.POLYLOGUE_EXTENSION_RECEIVER_TOKEN || "";
+const outputPath = process.env.POLYLOGUE_EXTENSION_SMOKE_OUT || "";
+
+let messageListener = null;
+let stored = {
+  receiverAuthToken: "",
+  receiverBaseUrl,
+};
+
+globalThis.chrome = {
+  action: {
+    setBadgeBackgroundColor: async () => undefined,
+    setBadgeText: async () => undefined,
+  },
+  runtime: {
+    onMessage: {
+      addListener: (fn) => {
+        messageListener = fn;
+      },
+    },
+  },
+  storage: {
+    local: {
+      get: async (defaults) => ({ ...defaults, ...stored }),
+      set: async (patch) => {
+        stored = { ...stored, ...patch };
+      },
+    },
+  },
+};
+
+await import(`../src/background.js?dev-loop-smoke=${Date.now()}`);
+if (typeof messageListener !== "function") {
+  throw new Error("background listener was not registered");
+}
+
+function fixtureEnvelope() {
+  return {
+    polylogue_capture_kind: "browser_llm_session",
+    schema_version: 1,
+    provenance: {
+      source_url: "https://chatgpt.com/c/dev-loop-extension-smoke",
+      page_title: "Polylogue extension dev-loop smoke",
+      captured_at: "2026-06-21T00:00:00+00:00",
+      adapter_name: "dev-loop-extension-smoke",
+    },
+    session: {
+      provider: "chatgpt",
+      provider_session_id: "dev-loop-extension-smoke",
+      title: "Polylogue extension dev-loop smoke",
+      turns: [{ provider_turn_id: "turn-1", role: "user", text: "extension smoke" }],
+    },
+  };
+}
+
+async function sendRuntimeMessage(message) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const keepAlive = messageListener(message, {}, (payload) => {
+      settled = true;
+      resolve(payload);
+    });
+    if (keepAlive !== true) {
+      reject(new Error(`runtime listener did not keep channel alive for ${message.type}`));
+      return;
+    }
+    setTimeout(() => {
+      if (!settled) reject(new Error(`runtime message timed out: ${message.type}`));
+    }, 5000);
+  });
+}
+
+const rejected = await sendRuntimeMessage({
+  type: "polylogue.capture",
+  envelope: fixtureEnvelope(),
+});
+if (rejected.ok !== false || !rejected.receiver_request_id) {
+  throw new Error(`expected unauthenticated rejection with receiver request id, got ${JSON.stringify(rejected)}`);
+}
+
+const configured = await sendRuntimeMessage({
+  type: "polylogue.configureReceiver",
+  receiverBaseUrl,
+  receiverAuthToken,
+});
+if (configured.ok !== true || configured.authConfigured !== Boolean(receiverAuthToken)) {
+  throw new Error(`receiver configuration failed: ${JSON.stringify(configured)}`);
+}
+
+const status = await sendRuntimeMessage({ type: "polylogue.status" });
+if (status.ok !== true || !status.receiver_request_id) {
+  throw new Error(`receiver status failed: ${JSON.stringify(status)}`);
+}
+
+const capture = await sendRuntimeMessage({
+  type: "polylogue.capture",
+  envelope: fixtureEnvelope(),
+});
+if (capture.ok !== true || capture.provider !== "chatgpt" || !capture.artifact_ref || !capture.receiver_request_id) {
+  throw new Error(`receiver capture failed: ${JSON.stringify(capture)}`);
+}
+
+const summary = {
+  ok: true,
+  receiver_base_url: receiverBaseUrl,
+  unauthenticated: {
+    ok: rejected.ok,
+    error: rejected.error,
+    receiver_request_id: rejected.receiver_request_id,
+  },
+  status: {
+    receiver_request_id: status.receiver_request_id,
+  },
+  capture: {
+    artifact_ref: capture.artifact_ref,
+    bytes_written: capture.bytes_written,
+    provider: capture.provider,
+    provider_session_id: capture.provider_session_id,
+    receiver_request_id: capture.receiver_request_id,
+  },
+  stored_state: stored.polylogueState || null,
+};
+
+if (outputPath) {
+  writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+}
+process.stdout.write(`${JSON.stringify(summary)}\n`);

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -322,6 +322,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875 --launch-daemon",
             "devtools workspace dev-loop --capture-cli -- polylogue ops status",
             "devtools workspace dev-loop --receiver-smoke --json",
+            "devtools workspace dev-loop --extension-smoke --json",
         ),
     ),
     CommandSpec(

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -256,6 +256,141 @@ def run_receiver_smoke(*, spool_path: Path) -> dict[str, object]:
     }
 
 
+def run_extension_smoke(*, preflight: dict[str, Any]) -> dict[str, object]:
+    """Run the browser-extension background worker against a real receiver."""
+
+    artifacts = preflight.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("preflight payload is missing artifact paths")
+    browser_dir = Path(str(artifacts["browser_dir"]))
+    browser_dir.mkdir(parents=True, exist_ok=True)
+    event_path = Path(str(artifacts.get("dev_events", Path(str(preflight["run_log_dir"])) / "dev-loop.events.jsonl")))
+    extension_root = Path(str(preflight["repo_root"])) / "browser-extension"
+    spool_path = browser_dir / "extension-smoke-spool"
+    summary_path = browser_dir / "extension-smoke.json"
+    result_path = browser_dir / "extension-smoke-result.json"
+    stdout_path = browser_dir / "extension-smoke.stdout"
+    stderr_path = browser_dir / "extension-smoke.stderr"
+    env_path = browser_dir / "extension-smoke.env.json"
+
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="browser_extension",
+        event_type="extension_smoke_requested",
+        status="starting",
+        payload={
+            "extension_root": str(extension_root),
+            "spool_path": str(spool_path),
+        },
+    )
+
+    spool_path.mkdir(parents=True, exist_ok=True)
+    server = make_server(
+        "127.0.0.1",
+        0,
+        spool_path=spool_path,
+        auth_token=_RECEIVER_SMOKE_TOKEN,
+        extra_origins=(_RECEIVER_SMOKE_ORIGIN,),
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    if isinstance(host, bytes):
+        host = host.decode("ascii")
+    receiver_url = f"http://{host}:{port}"
+    env = os.environ.copy()
+    env.update(
+        {
+            "POLYLOGUE_EXTENSION_RECEIVER_URL": receiver_url,
+            "POLYLOGUE_EXTENSION_RECEIVER_TOKEN": _RECEIVER_SMOKE_TOKEN,
+            "POLYLOGUE_EXTENSION_SMOKE_OUT": str(result_path),
+        }
+    )
+    env_path.write_text(json.dumps(_dev_loop_env_snapshot(env), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["npm", "run", "dev-loop-smoke", "--silent"],
+            cwd=str(extension_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _decode_timeout_stream(exc.stdout)
+        stderr = _decode_timeout_stream(exc.stderr)
+        result_payload: dict[str, object] | None = None
+        exit_code = 124
+        stderr = (stderr + "\n" if stderr else "") + "extension smoke timed out after 20s\n"
+    except OSError as exc:
+        stdout = ""
+        stderr = f"{type(exc).__name__}: {exc}\n"
+        result_payload = None
+        exit_code = 127
+    else:
+        stdout = result.stdout
+        stderr = result.stderr
+        exit_code = int(result.returncode)
+        result_payload = None
+        if result_path.exists():
+            result_payload = json.loads(result_path.read_text(encoding="utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    artifact_ref = None
+    artifact_path: Path | None = None
+    if isinstance(result_payload, dict):
+        capture = result_payload.get("capture")
+        if isinstance(capture, dict):
+            artifact_ref = capture.get("artifact_ref")
+            if isinstance(artifact_ref, str):
+                artifact_path = spool_path / artifact_ref
+    ok = exit_code == 0 and artifact_path is not None and artifact_path.exists()
+    payload: dict[str, object] = {
+        "ok": ok,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "extension_root": str(extension_root),
+        "receiver_url": receiver_url,
+        "spool_path": str(spool_path),
+        "artifact_ref": artifact_ref,
+        "artifact_path": str(artifact_path) if artifact_path is not None else None,
+        "result": result_payload,
+        "artifacts": {
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "summary": str(summary_path),
+            "result": str(result_path),
+            "env": str(env_path),
+            "spool": str(spool_path),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="browser_extension",
+        event_type="extension_smoke_finished",
+        status="ok" if ok else "failed",
+        payload={
+            "exit_code": exit_code,
+            "duration_ms": duration_ms,
+            "artifact_ref": artifact_ref,
+            "artifact_path": str(artifact_path) if artifact_path is not None else None,
+            "artifacts": payload["artifacts"],
+        },
+    )
+    return payload
+
+
 def _decode_timeout_stream(value: bytes | str | None) -> str:
     if value is None:
         return ""
@@ -799,6 +934,21 @@ def _print_daemon_launch(payload: dict[str, Any]) -> None:
     print(f"  summary:  {artifacts['summary']}")
 
 
+def _print_extension_smoke(payload: dict[str, Any]) -> None:
+    preflight = payload["preflight"]
+    smoke = payload["extension_smoke"]
+    assert isinstance(preflight, dict)
+    assert isinstance(smoke, dict)
+    artifacts = smoke["artifacts"]
+    assert isinstance(artifacts, dict)
+    print("Polylogue dev-loop browser extension smoke")
+    print(f"  run id:   {preflight['run_id']}")
+    print(f"  ok:       {smoke['ok']}")
+    print(f"  receiver: {smoke['receiver_url']}")
+    print(f"  artifact: {smoke.get('artifact_ref')}")
+    print(f"  summary:  {artifacts['summary']}")
+
+
 def main(argv: list[str] | None = None) -> int:
     original_argv = list(argv) if argv is not None else sys.argv[1:]
     parser = argparse.ArgumentParser(description=__doc__)
@@ -834,6 +984,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Launch branch-local polylogued with --no-watch and write PID/log/summary artifacts.",
     )
     parser.add_argument(
+        "--extension-smoke",
+        action="store_true",
+        help="Run the browser-extension background worker against a temporary local receiver.",
+    )
+    parser.add_argument(
         "--daemon-ready-timeout-s",
         type=float,
         default=10.0,
@@ -850,7 +1005,7 @@ def main(argv: list[str] | None = None) -> int:
         browser_capture_port=args.browser_capture_port,
         archive_root=args.archive_root,
         log_dir=args.log_dir,
-        prepare=args.prepare or args.receiver_smoke or args.launch_daemon,
+        prepare=args.prepare or args.receiver_smoke or args.launch_daemon or args.extension_smoke,
     )
     if args.receiver_smoke:
         smoke_payload: dict[str, Any] = {
@@ -903,6 +1058,18 @@ def main(argv: list[str] | None = None) -> int:
         else:
             _print_daemon_launch(combined_payload)
         return 0 if launch_payload.get("ok") is True else 1
+    if args.extension_smoke:
+        smoke_payload = run_extension_smoke(preflight=payload)
+        combined_payload = {
+            "preflight": payload,
+            "extension_smoke": smoke_payload,
+        }
+        if args.json:
+            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            _print_extension_smoke(combined_payload)
+        return 0 if smoke_payload.get("ok") is True else 1
     if args.json:
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -243,6 +243,32 @@ authenticated synthetic capture is accepted, and reports the written spool
 artifact. It uses the branch-local run directory and does not talk to the
 deployed `polylogued.service`.
 
+For service-worker-to-receiver coverage, run the extension smoke:
+
+```bash
+devtools workspace dev-loop --extension-smoke
+devtools workspace dev-loop --extension-smoke --json
+```
+
+This starts a temporary local browser-capture receiver, imports the actual
+extension background worker with a small Chrome API mock, sends the same
+runtime messages that popup/content scripts use, proves unauthenticated capture
+rejection, configures the branch-local receiver token, checks receiver status,
+and posts a deterministic capture envelope. It appends
+`extension_smoke_requested` / `extension_smoke_finished` rows to
+`dev-loop.events.jsonl` and writes stdout, stderr, a summary JSON, redacted
+environment snapshot, and the receiver spool artifact under:
+
+```text
+.cache/dev-loop/<run-id>/browser/
+```
+
+This is the CI-safe branch-local proof for the extension background HTTP path.
+It does not need authenticated ChatGPT/Claude.ai cookies and does not claim to
+prove GUI content-script injection. Use the same run id and receiver settings
+when you then load `browser-extension/` unpacked into an agent/private Chrome
+profile for real-page inspection.
+
 ## Current Boundary
 
 `devtools workspace dev-loop` is a preflight and directory-preparation command.

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -190,6 +190,56 @@ def test_receiver_smoke_cli_outputs_combined_payload(
     assert payload["receiver_smoke"]["ok"] is True
 
 
+def test_extension_smoke_runs_background_worker_against_receiver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--log-dir",
+                str(tmp_path / "dev-loop-logs"),
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--extension-smoke",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    smoke = payload["extension_smoke"]
+    assert smoke["ok"] is True
+    assert smoke["exit_code"] == 0
+    assert smoke["artifact_ref"] == "chatgpt/dev-loop-extension-smoke-17055bf60522.json"
+    assert Path(smoke["artifact_path"]).is_file()
+    artifacts = smoke["artifacts"]
+    assert Path(artifacts["summary"]).is_file()
+    assert Path(artifacts["stdout"]).read_text(encoding="utf-8").strip().startswith("{")
+    event_path = Path(payload["preflight"]["artifacts"]["dev_events"])
+    event_rows = [json.loads(line) for line in event_path.read_text(encoding="utf-8").splitlines()]
+    extension_events = event_rows[-2:]
+    assert [row["event_type"] for row in extension_events] == [
+        "extension_smoke_requested",
+        "extension_smoke_finished",
+    ]
+    assert extension_events[0]["surface"] == "browser_extension"
+    assert extension_events[1]["status"] == "ok"
+    assert extension_events[1]["payload"]["artifact_ref"] == smoke["artifact_ref"]
+
+
 def test_cli_capture_runs_command_with_branch_local_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Adds a branch-local browser-extension smoke path to `devtools workspace dev-loop`. The new `--extension-smoke` mode starts a temporary local browser-capture receiver, imports the actual extension background worker under a Chrome API mock, proves unauthenticated rejection, configures the receiver token, checks status, and posts a deterministic capture envelope.

## Problem

#2248 needs the development loop to verify browser-capture behavior without relying on the deployed `polylogued.service` or a manually prepared browser profile. The existing receiver smoke proved the HTTP receiver boundary, but it did not exercise the extension service-worker code that popup/content-script messages use.

## Solution

- Added `browser-extension/scripts/dev-loop-smoke.mjs` and an npm script that drive `src/background.js` directly with a minimal Chrome API mock.
- Added `devtools workspace dev-loop --extension-smoke`, which creates a temporary receiver on an ephemeral loopback port, captures stdout/stderr/env/result artifacts, verifies the written spool artifact, and records `extension_smoke_requested` / `extension_smoke_finished` rows in `dev-loop.events.jsonl`.
- Documented the smoke in `docs/dev-loop.md` and `browser-extension/README.md` as CI-safe service-worker-to-receiver coverage, explicitly separate from GUI/content-script inspection.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> 12 passed.
- `npm run validate && npm test -- --run && npm run lint` -> manifest ok; 48 Vitest tests passed; eslint passed.
- `devtools workspace dev-loop --json --log-dir /realm/tmp/polylogue-dev-loop-jsoncheck2 --archive-root /realm/tmp/polylogue-dev-loop-jsoncheck2-archive --extension-smoke` piped through `python -m json.tool` -> JSON parsed; artifact `chatgpt/dev-loop-extension-smoke-17055bf60522.json` written.
- `devtools render all --check` -> sync OK for generated surfaces.
- `devtools verify --quick` -> exit_code 0.
- `devtools verify --seed-testmon --skip-slow` -> static gates passed, then pytest seed selected 11,677 tests and failed 20 unrelated existing CLI/scenario/convergence nodes; `tests/unit/devtools/test_dev_loop.py::test_extension_smoke_runs_background_worker_against_receiver` passed in that run.

Ref #2248
