### PR TITLE
research(storage): deepen pyturso runtime probe (#2257)

### DIFF
--- a/devtools/turso_probe.py
+++ b/devtools/turso_probe.py
@@ -385,48 +385,49 @@ def run_probe(*, tursodb: str | None = None, scratch_dir: Path | None = None) ->
     else:
         tmp_context = None
         scratch_root = scratch_dir
-    results = [
-        _python_binding_probe(),
-        _python_runtime_api_probe(),
-        _python_readonly_uri_probe(scratch_dir=scratch_root),
-        _python_multiprocess_probe(scratch_dir=scratch_root),
-    ]
-    if resolved_tursodb is None:
-        results.append(
-            ProbeResult(
-                name="tursodb_binary",
-                status="skip",
-                expected_status="skip",
-                summary="`tursodb` is not on PATH; CLI feature probes were not run.",
-                command=["tursodb", "--version"],
-            )
-        )
-    else:
-        with tempfile.TemporaryDirectory(dir=scratch_root) as tmp:
-            root = Path(tmp)
-            for name, flags, sql, expected_status, summary in SQL_PROBES:
-                results.append(
-                    _run_tursodb_sql(
-                        tursodb=resolved_tursodb,
-                        scratch_dir=root,
-                        name=name,
-                        flags=flags,
-                        sql=sql,
-                        expected_status=expected_status,
-                        summary=summary,
-                    )
+    try:
+        results = [
+            _python_binding_probe(),
+            _python_runtime_api_probe(),
+            _python_readonly_uri_probe(scratch_dir=scratch_root),
+            _python_multiprocess_probe(scratch_dir=scratch_root),
+        ]
+        if resolved_tursodb is None:
+            results.append(
+                ProbeResult(
+                    name="tursodb_binary",
+                    status="skip",
+                    expected_status="skip",
+                    summary="`tursodb` is not on PATH; CLI feature probes were not run.",
+                    command=["tursodb", "--version"],
                 )
-            results.append(_attach_probe(tursodb=resolved_tursodb, scratch_dir=root))
-    if tmp_context is not None:
-        tmp_context.cleanup()
+            )
+        else:
+            with tempfile.TemporaryDirectory(dir=scratch_root) as tmp:
+                root = Path(tmp)
+                for name, flags, sql, expected_status, summary in SQL_PROBES:
+                    results.append(
+                        _run_tursodb_sql(
+                            tursodb=resolved_tursodb,
+                            scratch_dir=root,
+                            name=name,
+                            flags=flags,
+                            sql=sql,
+                            expected_status=expected_status,
+                            summary=summary,
+                        )
+                    )
+                results.append(_attach_probe(tursodb=resolved_tursodb, scratch_dir=root))
+    finally:
+        if tmp_context is not None:
+            tmp_context.cleanup()
     blockers = [
         result.name
         for result in results
         if (
             (result.name == "python_binding" and result.status != "pass")
             or (result.name == "python_readonly_uri" and result.status == "fail")
-            or result.name in {"stored_generated_columns", "fts5_virtual_table"}
-            and result.status != "pass"
+            or (result.name in {"stored_generated_columns", "fts5_virtual_table"} and result.status != "pass")
         )
     ]
     unexpected = [result.name for result in results if not result.expected]

--- a/devtools/turso_probe.py
+++ b/devtools/turso_probe.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import importlib.util
 import json
 import shutil
 import subprocess
 import sys
 import tempfile
+from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 ProbeStatus = Literal["pass", "fail", "skip"]
 
@@ -104,6 +106,10 @@ def _find_python_turso() -> object | None:
     return importlib.util.find_spec("turso")
 
 
+def _import_python_turso() -> Any:
+    return importlib.import_module("turso")
+
+
 def _find_tursodb() -> str | None:
     return shutil.which("tursodb")
 
@@ -112,38 +118,203 @@ def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, capture_output=True, text=True, check=False, timeout=20)
 
 
+def _python_unavailable_result(name: str, summary: str) -> ProbeResult:
+    return ProbeResult(
+        name=name,
+        status="skip",
+        expected_status="skip",
+        summary=summary,
+        command=[sys.executable, "-c", "import turso"],
+    )
+
+
 def _python_binding_probe() -> ProbeResult:
     spec = _find_python_turso()
     if spec is None:
-        return ProbeResult(
-            name="python_binding",
-            status="skip",
-            expected_status="skip",
-            summary="Python package `turso` is not importable in this environment.",
-            command=[sys.executable, "-c", "import turso"],
+        return _python_unavailable_result(
+            "python_binding",
+            "Python package `turso` is not importable in this environment.",
         )
     try:
-        import turso
+        turso = _import_python_turso()
 
         conn = turso.connect(":memory:")
-        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT)")
-        conn.execute("INSERT INTO t(name) VALUES (?)", ("polylogue",))
-        conn.commit()
-        rows = list(conn.execute("SELECT name FROM t"))
     except Exception as exc:  # pragma: no cover - depends on optional external package
         return ProbeResult(
             name="python_binding",
             status="fail",
             expected_status="pass",
-            summary=f"Python package `turso` imported but sqlite3-style smoke failed: {type(exc).__name__}: {exc}",
+            summary=f"Python package `turso` imported but connect(':memory:') failed: {type(exc).__name__}: {exc}",
             command=[sys.executable, "-c", "import turso; turso.connect(':memory:')"],
         )
+    with suppress(Exception):
+        conn.close()
     return ProbeResult(
         name="python_binding",
         status="pass",
         expected_status="pass",
-        summary=f"Python package `turso` imported and returned {len(rows)} smoke row(s).",
+        summary="Python package `turso` imported and opened an in-memory connection.",
         command=[sys.executable, "-c", "import turso; turso.connect(':memory:')"],
+    )
+
+
+def _python_runtime_api_probe() -> ProbeResult:
+    if _find_python_turso() is None:
+        return _python_unavailable_result(
+            "python_runtime_api",
+            "Skipped because Python package `turso` is not importable.",
+        )
+    command = [
+        sys.executable,
+        "-c",
+        "import turso; c=turso.connect(':memory:'); c.execute('select 1')",
+    ]
+    conn: Any | None = None
+    try:
+        turso = _import_python_turso()
+        conn = turso.connect(":memory:")
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT) STRICT")
+        cursor = conn.execute("INSERT INTO t(name) VALUES (?)", ("polylogue",))
+        rowcount = cursor.rowcount
+        lastrowid = cursor.lastrowid
+        conn.commit()
+        conn.row_factory = turso.Row
+        row = conn.execute("SELECT id, name FROM t WHERE name = ?", ("polylogue",)).fetchone()
+        if row is None:
+            raise RuntimeError("row_factory query returned no row")
+        if row["name"] != "polylogue":
+            raise RuntimeError("row_factory did not support name lookup")
+        if rowcount != 1:
+            raise RuntimeError(f"unexpected rowcount {rowcount!r}")
+        if lastrowid is None:
+            raise RuntimeError("lastrowid was not populated")
+        conn.executescript("CREATE TABLE aux(id INTEGER PRIMARY KEY) STRICT; INSERT INTO aux VALUES (1);")
+        aux_row = conn.execute("SELECT count(*) FROM aux").fetchone()
+        if aux_row is None or aux_row[0] != 1:
+            raise RuntimeError(f"executescript did not create aux row: {aux_row!r}")
+        conn.execute("INSERT INTO t(name) VALUES ('rollback-target')")
+        conn.rollback()
+        names = [record[0] for record in conn.execute("SELECT name FROM t ORDER BY id")]
+        if names != ["polylogue"]:
+            raise RuntimeError(f"rollback did not restore expected rows: {names!r}")
+        conn.execute("PRAGMA user_version=42")
+        version_row = conn.execute("PRAGMA user_version").fetchone()
+        if version_row is None or version_row[0] != 42:
+            raise RuntimeError(f"PRAGMA user_version roundtrip failed: {version_row!r}")
+    except Exception as exc:  # pragma: no cover - depends on optional external package
+        return ProbeResult(
+            name="python_runtime_api",
+            status="fail",
+            expected_status="pass",
+            summary=f"Python runtime API smoke failed: {type(exc).__name__}: {exc}",
+            command=command,
+        )
+    finally:
+        if conn is not None:
+            with suppress(Exception):
+                conn.close()
+    return ProbeResult(
+        name="python_runtime_api",
+        status="pass",
+        expected_status="pass",
+        summary="Parameter binding, row_factory, executescript, rollback, cursor metadata, and PRAGMA user_version work.",
+        command=command,
+    )
+
+
+def _python_readonly_uri_probe(*, scratch_dir: Path) -> ProbeResult:
+    if _find_python_turso() is None:
+        return _python_unavailable_result(
+            "python_readonly_uri",
+            "Skipped because Python package `turso` is not importable.",
+        )
+    db_path = scratch_dir / "python-readonly-uri.db"
+    command = [
+        sys.executable,
+        "-c",
+        "import turso; turso.connect('file:archive.db?mode=ro')",
+    ]
+    writer: Any | None = None
+    reader: Any | None = None
+    try:
+        turso = _import_python_turso()
+        db_path.unlink(missing_ok=True)
+        writer = turso.connect(str(db_path))
+        writer.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT) STRICT")
+        writer.execute("INSERT INTO t(name) VALUES ('seed')")
+        writer.commit()
+        writer.close()
+        reader = turso.connect(f"file:{db_path}?mode=ro")
+        count_row = reader.execute("SELECT count(*) FROM t").fetchone()
+        if count_row is None or count_row[0] != 1:
+            raise RuntimeError(f"read-only URI did not read seeded row: {count_row!r}")
+        try:
+            reader.execute("INSERT INTO t(name) VALUES ('should-fail')")
+            reader.commit()
+        except Exception:
+            pass
+        else:
+            raise RuntimeError("read-only URI allowed a write")
+    except Exception as exc:  # pragma: no cover - depends on optional external package
+        return ProbeResult(
+            name="python_readonly_uri",
+            status="fail",
+            expected_status="fail",
+            summary=f"sqlite3-style file:...?mode=ro URI is not usable as Polylogue's readonly connection pattern: {type(exc).__name__}: {exc}",
+            command=command,
+        )
+    finally:
+        if writer is not None:
+            with suppress(Exception):
+                writer.close()
+        if reader is not None:
+            with suppress(Exception):
+                reader.close()
+    return ProbeResult(
+        name="python_readonly_uri",
+        status="pass",
+        expected_status="fail",
+        summary="sqlite3-style file:...?mode=ro URI opened and rejected writes.",
+        command=command,
+    )
+
+
+def _python_multiprocess_probe(*, scratch_dir: Path) -> ProbeResult:
+    if _find_python_turso() is None:
+        return _python_unavailable_result(
+            "python_multiprocess_wal",
+            "Skipped because Python package `turso` is not importable.",
+        )
+    command = [
+        sys.executable,
+        "-c",
+        "import turso; turso.connect('archive.db', experimental_features='multiprocess_wal')",
+    ]
+    conn: Any | None = None
+    try:
+        turso = _import_python_turso()
+        db_path = scratch_dir / "python-multiprocess-wal.db"
+        db_path.unlink(missing_ok=True)
+        conn = turso.connect(str(db_path), experimental_features="multiprocess_wal")
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY) STRICT")
+    except Exception as exc:  # pragma: no cover - depends on optional external package
+        return ProbeResult(
+            name="python_multiprocess_wal",
+            status="fail",
+            expected_status="pass",
+            summary=f"Python multiprocess_wal connection failed: {type(exc).__name__}: {exc}",
+            command=command,
+        )
+    finally:
+        if conn is not None:
+            with suppress(Exception):
+                conn.close()
+    return ProbeResult(
+        name="python_multiprocess_wal",
+        status="pass",
+        expected_status="pass",
+        summary="Python binding accepts experimental_features='multiprocess_wal'.",
+        command=command,
     )
 
 
@@ -207,9 +378,19 @@ def _attach_probe(*, tursodb: str, scratch_dir: Path) -> ProbeResult:
 
 
 def run_probe(*, tursodb: str | None = None, scratch_dir: Path | None = None) -> dict[str, object]:
-    python_result = _python_binding_probe()
     resolved_tursodb = tursodb or _find_tursodb()
-    results = [python_result]
+    if scratch_dir is None:
+        tmp_context = tempfile.TemporaryDirectory()
+        scratch_root = Path(tmp_context.name)
+    else:
+        tmp_context = None
+        scratch_root = scratch_dir
+    results = [
+        _python_binding_probe(),
+        _python_runtime_api_probe(),
+        _python_readonly_uri_probe(scratch_dir=scratch_root),
+        _python_multiprocess_probe(scratch_dir=scratch_root),
+    ]
     if resolved_tursodb is None:
         results.append(
             ProbeResult(
@@ -221,7 +402,7 @@ def run_probe(*, tursodb: str | None = None, scratch_dir: Path | None = None) ->
             )
         )
     else:
-        with tempfile.TemporaryDirectory(dir=scratch_dir) as tmp:
+        with tempfile.TemporaryDirectory(dir=scratch_root) as tmp:
             root = Path(tmp)
             for name, flags, sql, expected_status, summary in SQL_PROBES:
                 results.append(
@@ -236,11 +417,17 @@ def run_probe(*, tursodb: str | None = None, scratch_dir: Path | None = None) ->
                     )
                 )
             results.append(_attach_probe(tursodb=resolved_tursodb, scratch_dir=root))
+    if tmp_context is not None:
+        tmp_context.cleanup()
     blockers = [
         result.name
         for result in results
-        if result.status != "pass"
-        and result.name in {"python_binding", "stored_generated_columns", "fts5_virtual_table"}
+        if (
+            (result.name == "python_binding" and result.status != "pass")
+            or (result.name == "python_readonly_uri" and result.status == "fail")
+            or result.name in {"stored_generated_columns", "fts5_virtual_table"}
+            and result.status != "pass"
+        )
     ]
     unexpected = [result.name for result in results if not result.expected]
     return {

--- a/tests/unit/devtools/test_turso_probe.py
+++ b/tests/unit/devtools/test_turso_probe.py
@@ -24,6 +24,9 @@ def test_probe_reports_missing_python_binding_and_binary(
     rows = cast(list[dict[str, object]], payload["results"])
     results = {row["name"]: row for row in rows}
     assert results["python_binding"]["status"] == "skip"
+    assert results["python_runtime_api"]["status"] == "skip"
+    assert results["python_readonly_uri"]["status"] == "skip"
+    assert results["python_multiprocess_wal"]["status"] == "skip"
     assert results["tursodb_binary"]["status"] == "skip"
 
 
@@ -62,6 +65,63 @@ def test_probe_classifies_polylogue_sql_compatibility(
     assert results["fts5_virtual_table"]["status"] == "fail"
     assert results["wal_journal_size_limit"]["status"] == "fail"
     assert results["attach_experimental"]["status"] == "pass"
+
+
+def test_python_readonly_uri_failure_is_a_compatibility_blocker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        turso_probe,
+        "_python_binding_probe",
+        lambda: turso_probe.ProbeResult(
+            name="python_binding",
+            status="pass",
+            expected_status="pass",
+            summary="available",
+            command=["python", "-c", "import turso"],
+        ),
+    )
+    monkeypatch.setattr(
+        turso_probe,
+        "_python_runtime_api_probe",
+        lambda: turso_probe.ProbeResult(
+            name="python_runtime_api",
+            status="pass",
+            expected_status="pass",
+            summary="runtime ok",
+            command=["python", "-c", "import turso"],
+        ),
+    )
+    monkeypatch.setattr(
+        turso_probe,
+        "_python_readonly_uri_probe",
+        lambda *, scratch_dir: turso_probe.ProbeResult(
+            name="python_readonly_uri",
+            status="fail",
+            expected_status="fail",
+            summary=f"readonly incompatible in {scratch_dir}",
+            command=["python", "-c", "import turso"],
+        ),
+    )
+    monkeypatch.setattr(
+        turso_probe,
+        "_python_multiprocess_probe",
+        lambda *, scratch_dir: turso_probe.ProbeResult(
+            name="python_multiprocess_wal",
+            status="pass",
+            expected_status="pass",
+            summary=f"multiprocess ok in {scratch_dir}",
+            command=["python", "-c", "import turso"],
+        ),
+    )
+    monkeypatch.setattr(turso_probe, "_find_tursodb", lambda: None)
+
+    payload = turso_probe.run_probe(scratch_dir=tmp_path)
+
+    assert payload["ok"] is True
+    assert payload["unexpected"] == []
+    assert payload["compatibility_blockers"] == ["python_readonly_uri"]
 
 
 def test_main_json_emits_probe_payload(


### PR DESCRIPTION
## Summary

Extends `devtools lab probe turso` so the Python side is measured as first-class compatibility evidence, not just an import check. The probe now reports separate rows for the `turso` Python binding, ordinary DB-API-like runtime behavior, sqlite3-style read-only URI opens, and file-backed `multiprocess_wal`.

## Problem

#2257 needs measured evidence for whether Turso Database can replace or augment Polylogue's SQLite tiers. PR #2269 proved the CLI/storage-engine side and showed that `pyturso` was absent from the devshell, but it did not answer whether the actual Python API behaves enough like `sqlite3` for Polylogue's connection layer.

## Solution

`devtools/turso_probe.py` now records Python capability rows:

- `python_binding`: import and in-memory connection open.
- `python_runtime_api`: parameter binding, `row_factory`, `executescript`, rollback, cursor metadata, and `PRAGMA user_version`.
- `python_readonly_uri`: current sqlite3-style `file:...?mode=ro` read-only open pattern.
- `python_multiprocess_wal`: file-backed `experimental_features=\"multiprocess_wal\"` connection.

The blocker classification distinguishes a missing optional binding from dependent skipped rows, and treats `python_readonly_uri` as a compatibility blocker only once the Python binding is present and the probe actually fails.

Measured result with `uv run --with pyturso`:

```text
ok: true
blockers: python_readonly_uri, stored_generated_columns, fts5_virtual_table
python_binding: pass
python_runtime_api: pass
python_readonly_uri: fail (expected) - IoError: open: NotFound
python_multiprocess_wal: pass
```

So the Python binding is materially useful, but not a drop-in replacement for Polylogue's current read-only URI connection pattern.

## Verification

```text
devtools test tests/unit/devtools/test_turso_probe.py -q
# 4 passed

devtools lab probe turso --json --scratch-dir /realm/tmp/polylogue-turso-probe-no-py
# ok: true; blockers: python_binding, stored_generated_columns, fts5_virtual_table

uv run --with pyturso devtools lab probe turso --json --scratch-dir /realm/tmp/polylogue-turso-probe-py
# ok: true; blockers: python_readonly_uri, stored_generated_columns, fts5_virtual_table

devtools verify --quick
# exit_code: 0
```

I also ran:

```text
devtools verify --seed-testmon --skip-slow
```

Static/generated checks passed, then the broad seed test run failed in 13 unrelated existing CLI/scenario/verification-lab nodes:

```text
tests/unit/devtools/test_quality_registry.py::test_build_quality_registry_exposes_live_catalogs
tests/unit/cli/test_insights.py::test_analyze_rejects_aggregate_options_before_insights_subcommand
tests/unit/devtools/test_scenario_projections.py::test_render_scenario_projections_text_lists_authored_sources
tests/unit/scenarios/test_insight_surfaces.py::test_build_insight_contract_surfaces_compiles_canonical_json_contract_entries
tests/unit/scenarios/test_insight_surfaces.py::test_build_live_insight_surface_lanes_compiles_live_variants
tests/unit/devtools/test_command_catalog.py::test_verification_lab_surface_is_explicit_and_implemented
tests/unit/devtools/test_artifact_graph.py::test_render_artifact_graph_json_is_machine_readable
tests/unit/devtools/test_artifact_graph.py::test_render_artifact_graph_text_mentions_the_current_runtime_paths
tests/unit/devtools/test_scenario_coverage.py::test_build_runtime_scenario_coverage_tracks_the_current_authored_map
tests/unit/cli/test_plain_cli_snapshots.py::test_plain_analyze_snapshot
tests/unit/cli/test_plain_output_contract.py::TestPlainEmptyArchiveMessages::test_plain_stats_empty_archive_message
tests/unit/cli/test_plain_output_contract.py::TestPlainEmptyArchiveMessages::test_plain_stats_missing_archive_files_reports_empty
tests/unit/cli/test_help_snapshots.py::test_root_help_snapshot
```

Those failures are outside this two-file probe change and match the broader command/scenario-surface drift already being handled separately.

Ref #2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Python binding compatibility detection with new probes for readonly URI mode, multiprocess WAL support, and extended runtime API validation.

* **Tests**
  * Added test coverage for readonly mode incompatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->