### PR TITLE
fix(query): bind runtime unit fields to descriptors (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -234,13 +234,16 @@ one child row matching the nested predicate.
 | `assertion` | `author`, `author_kind`, `author_ref`, `body`, `context`, `evidence`, `key`, `kind`, `scope`, `scope_ref`, `status`, `target`, `target_ref`, `text`, `value`, `visibility` |
 
 Structural units also accept `session.<field>` predicates for the owning
-session fields, such as `session.repo`, `session.origin`,
-`session.tag`, `session.title`, `session.date`, `session.since`, and
-`session.until`. Count and date session fields accept compact comparison
-prefixes such as `session.messages:>=2`, `session.words:<=500`, and
-`session.date:>=2026-01-02`. This lets a unit query carry its session scope
-inline instead of splitting selection between the query string and parallel
-parameters.
+session fields that their lowerer can evaluate. SQL-backed units can use the
+full session filter surface, including action/tool/path/feature predicates.
+Runtime-transform units (`runs`, `observed-events`, `context-snapshots`) can
+only use fields present on the session-summary projection, such as
+`session.repo`, `session.origin`, `session.tag`, `session.title`,
+`session.date`, `session.since`, and `session.until`. Count and date session
+fields accept compact comparison prefixes such as `session.messages:>=2`,
+`session.words:<=500`, and `session.date:>=2026-01-02`. This lets a unit query
+carry its session scope inline instead of splitting selection between the
+query string and parallel parameters.
 
 Examples:
 
@@ -313,7 +316,10 @@ polylogue context-snapshots where session.messages:>=2 AND session.date:>=2026-0
 sources. They return projected evidence from existing recovery/run-projection
 transforms, not durable SQL table rows, so they are terminal unit sources only;
 they do not act as `exists run(...)`, `exists observed-event(...)`, or
-`exists context-snapshot(...)` session selectors.
+`exists context-snapshot(...)` session selectors. Their inline `session.*`
+predicates are limited to summary-backed fields; SQL-backed session predicates
+such as `session.action`, `session.tool`, `session.path`, and `session.has` are
+typed errors for these runtime sources rather than empty or broadened matches.
 
 Session filters such as `--origin`, `--tag`, `--repo`, `--since`, and `--until`
 still narrow the owning sessions before rows are returned. Session-only actions

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -95,14 +95,7 @@ from lark import Lark, Token, Transformer, v_args
 from lark.exceptions import UnexpectedInput, VisitError
 
 from polylogue.archive.query.metadata import (
-    _ACTION_STRUCTURAL_FIELDS,
-    _ASSERTION_STRUCTURAL_FIELDS,
-    _BLOCK_STRUCTURAL_FIELDS,
     _BOOLEAN_SUPPORTED_FIELDS,
-    _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS,
-    _MESSAGE_STRUCTURAL_FIELDS,
-    _OBSERVED_EVENT_STRUCTURAL_FIELDS,
-    _RUN_STRUCTURAL_FIELDS,
     _STRUCTURAL_BOOLEAN_SUPPORTED_FIELDS,
     COUNT_QUERY_FIELD_REGISTRY,
     DATE_QUERY_FIELD_REGISTRY,
@@ -119,6 +112,7 @@ from polylogue.archive.query.metadata import (
     date_query_fields,
     date_query_operators,
     query_unit_descriptor,
+    query_unit_field_names,
     structural_query_fields,
     structural_query_units,
     terminal_query_source_pairs,
@@ -830,37 +824,19 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         session_field = _scoped_session_field(predicate.field)
         if unit == "session":
             supported = _BOOLEAN_SUPPORTED_FIELDS
-            effective_field = predicate.field
-        elif unit == "message":
-            supported = _MESSAGE_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        elif unit == "action":
-            supported = _ACTION_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        elif unit == "block":
-            supported = _BLOCK_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        elif unit == "assertion":
-            supported = _ASSERTION_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        elif unit == "observed-event":
-            supported = _OBSERVED_EVENT_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        elif unit == "context-snapshot":
-            supported = _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
+            supported_field = predicate.field
+            validation_field = predicate.field
         else:
-            supported = _RUN_STRUCTURAL_FIELDS
-            effective_field = session_field or predicate.field
-        if session_field is not None and unit != "session":
-            supported = _BOOLEAN_SUPPORTED_FIELDS
-        if effective_field not in supported:
+            supported = set(query_unit_field_names(unit))
+            supported_field = predicate.field
+            validation_field = session_field or predicate.field
+        if supported_field not in supported:
             raise ExpressionCompileError(
                 f"field {predicate.field!r} is not supported for {unit} predicates",
                 field=predicate.field,
             )
         if (
-            effective_field
+            validation_field
             in {
                 "role",
                 "type",
@@ -916,12 +892,12 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
             and not predicate.values
         ):
             raise ExpressionCompileError(f"field {predicate.field!r} requires a value", field=predicate.field)
-        if effective_field == "date":
+        if validation_field == "date":
             if not predicate.values:
                 raise ExpressionCompileError("field 'date' requires a value", field="date")
             if predicate.op not in {">=", "<="}:
                 raise ExpressionCompileError("field 'date' supports only >=, <=, >, <, and between", field="date")
-        if effective_field == "time":
+        if validation_field == "time":
             if unit == "session":
                 raise ExpressionCompileError(
                     "field 'time' is supported only for terminal unit predicates", field="time"
@@ -930,16 +906,16 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 raise ExpressionCompileError("field 'time' requires a value", field="time")
             if predicate.op not in {">=", "<="}:
                 raise ExpressionCompileError("field 'time' supports only >=, <=, >, <, and between", field="time")
-        if effective_field in COUNT_QUERY_FIELD_REGISTRY or effective_field in NUMERIC_QUERY_FIELD_REGISTRY:
+        if validation_field in COUNT_QUERY_FIELD_REGISTRY or validation_field in NUMERIC_QUERY_FIELD_REGISTRY:
             if not predicate.values:
                 raise ExpressionCompileError(
-                    f"field {effective_field!r} requires a numeric value", field=effective_field
+                    f"field {validation_field!r} requires a numeric value", field=validation_field
                 )
             try:
                 int(predicate.values[-1])
             except ValueError as exc:
                 raise ExpressionCompileError(
-                    f"field {effective_field!r} requires a numeric value", field=effective_field
+                    f"field {validation_field!r} requires a numeric value", field=validation_field
                 ) from exc
         return
     if isinstance(predicate, QueryNotPredicate):

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -547,25 +547,61 @@ _RUN_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
 
 _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "action": "session.action:file_edit",
+    "assistant_messages": "session.assistant_messages:>=2",
+    "assistant_words": "session.assistant_words:>=500",
     "cwd": "session.cwd:/realm/project",
+    "date": "session.date:>=2026-01-02",
     "duration_ms": "session.duration_ms:>=60000",
     "has": "session.has:tools",
     "id": "session.id:abc123",
     "messages": "session.messages:>=10",
     "origin": "session.origin:claude-code-session",
+    "paste_messages": "session.paste_messages:=0",
     "repo": "session.repo:polylogue",
     "since": "session.since:7d",
+    "system_messages": "session.system_messages:=0",
     "tag": "session.tag:review",
+    "thinking_messages": "session.thinking_messages:>=1",
     "title": "session.title:refactor",
     "tool": "session.tool:bash",
+    "tool_messages": "session.tool_messages:=0",
+    "tool_use_messages": "session.tool_use_messages:>=1",
     "until": "session.until:2024-01-15",
+    "user_messages": "session.user_messages:>=2",
+    "user_words": "session.user_words:>=100",
     "words": "session.words:<=200",
 }
 
+_RUNTIME_SESSION_SCOPED_STRUCTURAL_FIELDS = {
+    "assistant_messages",
+    "assistant_words",
+    "cwd",
+    "date",
+    "duration_ms",
+    "id",
+    "messages",
+    "origin",
+    "paste_messages",
+    "repo",
+    "since",
+    "system_messages",
+    "tag",
+    "thinking_messages",
+    "title",
+    "tool_messages",
+    "tool_use_messages",
+    "until",
+    "user_messages",
+    "user_words",
+    "words",
+}
 
-def _session_scoped_field_info() -> tuple[StructuralQueryFieldInfo, ...]:
+
+def _session_scoped_field_info(*, runtime_transform: bool = False) -> tuple[StructuralQueryFieldInfo, ...]:
     fields: list[StructuralQueryFieldInfo] = []
     for field, example in sorted(_SESSION_SCOPED_STRUCTURAL_EXAMPLES.items()):
+        if runtime_transform and field not in _RUNTIME_SESSION_SCOPED_STRUCTURAL_FIELDS:
+            continue
         info = EXPRESSION_FIELD_REGISTRY.get(field)
         description = info["description"] if info is not None else f"Owning session {field} predicate."
         fields.append(
@@ -579,6 +615,7 @@ def _session_scoped_field_info() -> tuple[StructuralQueryFieldInfo, ...]:
 
 
 _SCOPED_SESSION_STRUCTURAL_FIELD_INFO = _session_scoped_field_info()
+_RUNTIME_SCOPED_SESSION_STRUCTURAL_FIELD_INFO = _session_scoped_field_info(runtime_transform=True)
 _SCOPED_SESSION_STRUCTURAL_FIELDS = tuple(field.name for field in _SCOPED_SESSION_STRUCTURAL_FIELD_INFO)
 
 
@@ -604,7 +641,14 @@ def _context_snapshot_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
 
 def _run_field_infos() -> tuple[StructuralQueryFieldInfo, ...]:
     infos = [_RUN_STRUCTURAL_FIELD_INFO[name] for name in sorted(_RUN_STRUCTURAL_FIELDS)]
-    return tuple(sorted((*infos, *_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+    return tuple(sorted((*infos, *_RUNTIME_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
+
+
+def _runtime_field_infos(
+    infos: dict[str, StructuralQueryFieldInfo], names: set[str]
+) -> tuple[StructuralQueryFieldInfo, ...]:
+    own_infos = [infos[name] for name in sorted(names)]
+    return tuple(sorted((*own_infos, *_RUNTIME_SCOPED_SESSION_STRUCTURAL_FIELD_INFO), key=lambda field: field.name))
 
 
 STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
@@ -635,12 +679,12 @@ STRUCTURAL_QUERY_UNIT_REGISTRY: dict[str, StructuralQueryUnitInfo] = {
     ),
     "observed-event": StructuralQueryUnitInfo(
         description="Return runtime-transform observed events satisfying the child predicate.",
-        fields=_observed_event_field_infos(),
+        fields=_runtime_field_infos(_OBSERVED_EVENT_STRUCTURAL_FIELD_INFO, _OBSERVED_EVENT_STRUCTURAL_FIELDS),
         example="observed-events where session.repo:polylogue AND delivery_state:acted_on",
     ),
     "context-snapshot": StructuralQueryUnitInfo(
         description="Return runtime-transform context snapshots satisfying the child predicate.",
-        fields=_context_snapshot_field_infos(),
+        fields=_runtime_field_infos(_CONTEXT_SNAPSHOT_STRUCTURAL_FIELD_INFO, _CONTEXT_SNAPSHOT_STRUCTURAL_FIELDS),
         example="context-snapshots where session.repo:polylogue AND boundary:session_start",
     ),
 }
@@ -1003,6 +1047,15 @@ def terminal_query_fields(source: str) -> tuple[str, ...]:
 
     descriptor = query_unit_descriptor(source)
     if descriptor is None or not descriptor.terminal_supported:
+        return ()
+    return tuple(field.name for field in descriptor.fields)
+
+
+def query_unit_field_names(unit_or_source: str) -> tuple[str, ...]:
+    """Return descriptor-owned field names accepted for a query unit/source."""
+
+    descriptor = query_unit_descriptor(unit_or_source)
+    if descriptor is None:
         return ()
     return tuple(field.name for field in descriptor.fields)
 

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -557,6 +557,7 @@ _SESSION_SCOPED_STRUCTURAL_EXAMPLES: dict[str, str] = {
     "messages": "session.messages:>=10",
     "origin": "session.origin:claude-code-session",
     "paste_messages": "session.paste_messages:=0",
+    "path": "session.path:polylogue/archive",
     "repo": "session.repo:polylogue",
     "since": "session.since:7d",
     "system_messages": "session.system_messages:=0",

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -20,6 +20,16 @@ class QueryFieldRef:
     source_name: str
     unit: str | None = None
 
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "scope": self.scope,
+            "name": self.name,
+            "source_name": self.source_name,
+        }
+        if self.unit is not None:
+            payload["unit"] = self.unit
+        return payload
+
 
 @dataclass(frozen=True)
 class QueryFieldPredicate:
@@ -41,7 +51,10 @@ class QueryFieldPredicate:
         )
 
     def to_payload(self) -> dict[str, object]:
-        return {"kind": "field", "field": self.field, "op": self.op, "values": list(self.values)}
+        payload: dict[str, object] = {"kind": "field", "field": self.field, "op": self.op, "values": list(self.values)}
+        if self.field_ref is not None:
+            payload["field_ref"] = self.field_ref.to_payload()
+        return payload
 
 
 @dataclass(frozen=True)

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -105,6 +105,20 @@ def test_query_unit_descriptors_own_terminal_aliases() -> None:
     assert "runs where session.repo:polylogue AND role:main" in terminal_query_examples()
 
 
+def test_runtime_terminal_units_expose_only_summary_available_session_scope() -> None:
+    from polylogue.archive.query.metadata import terminal_query_fields
+
+    message_fields = set(terminal_query_fields("messages"))
+    context_fields = set(terminal_query_fields("context-snapshots"))
+    observed_fields = set(terminal_query_fields("observed-events"))
+
+    assert {"session.action", "session.tool", "session.has"}.issubset(message_fields)
+    assert {"session.repo", "session.origin", "session.messages", "session.date"}.issubset(context_fields)
+    assert {"session.repo", "session.origin", "session.messages", "session.date"}.issubset(observed_fields)
+    assert context_fields.isdisjoint({"session.action", "session.tool", "session.path", "session.has"})
+    assert observed_fields.isdisjoint({"session.action", "session.tool", "session.path", "session.has"})
+
+
 def test_query_unit_schema_surfaces_are_descriptor_derived() -> None:
     from devtools.render_cli_output_schemas import SCHEMAS
     from polylogue.archive.query.metadata import terminal_query_cli_surfaces

--- a/tests/unit/archive/test_query_metadata.py
+++ b/tests/unit/archive/test_query_metadata.py
@@ -112,7 +112,7 @@ def test_runtime_terminal_units_expose_only_summary_available_session_scope() ->
     context_fields = set(terminal_query_fields("context-snapshots"))
     observed_fields = set(terminal_query_fields("observed-events"))
 
-    assert {"session.action", "session.tool", "session.has"}.issubset(message_fields)
+    assert {"session.action", "session.tool", "session.path", "session.has"}.issubset(message_fields)
     assert {"session.repo", "session.origin", "session.messages", "session.date"}.issubset(context_fields)
     assert {"session.repo", "session.origin", "session.messages", "session.date"}.issubset(observed_fields)
     assert context_fields.isdisjoint({"session.action", "session.tool", "session.path", "session.has"})

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -611,6 +611,19 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="field 'session.action' is not supported"):
             parse_unit_source_expression("context-snapshots where session.action:file_edit")
 
+    def test_sql_terminal_unit_accepts_session_path_scope(self) -> None:
+        source = parse_unit_source_expression("messages where session.path:polylogue/archive AND role:assistant")
+
+        assert source is not None
+        predicate = cast(QueryBoolPredicate, source.predicate)
+        scoped_path = cast(QueryFieldPredicate, predicate.children[0])
+
+        assert scoped_path.field_ref is not None
+        assert scoped_path.field_ref.scope == "session"
+        assert scoped_path.field_ref.name == "path"
+        assert scoped_path.field_ref.source_name == "session.path"
+        assert scoped_path.field_ref.unit == "message"
+
     def test_pipeline_session_source_scopes_terminal_unit_query(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -547,6 +547,31 @@ class TestBooleanQueryExpression:
         assert predicate.field_ref.source_name == "repo"
         assert predicate.field_ref.unit is None
 
+    def test_runtime_terminal_unit_accepts_descriptor_backed_session_scope(self) -> None:
+        source = parse_unit_source_expression(
+            "context-snapshots where session.repo:polylogue AND boundary:session_start"
+        )
+
+        assert source is not None
+        assert source.unit == "context-snapshot"
+        predicate = cast(QueryBoolPredicate, source.predicate)
+        scoped_repo = cast(QueryFieldPredicate, predicate.children[0])
+        boundary = cast(QueryFieldPredicate, predicate.children[1])
+
+        assert scoped_repo.field_ref is not None
+        assert scoped_repo.field_ref.scope == "session"
+        assert scoped_repo.field_ref.name == "repo"
+        assert scoped_repo.field_ref.source_name == "session.repo"
+        assert scoped_repo.field_ref.unit == "context-snapshot"
+        assert boundary.field_ref is not None
+        assert boundary.field_ref.scope == "unit"
+        assert boundary.field_ref.name == "boundary"
+        assert boundary.field_ref.unit == "context-snapshot"
+
+    def test_runtime_terminal_unit_rejects_session_scope_not_in_summary_projection(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="field 'session.action' is not supported"):
+            parse_unit_source_expression("context-snapshots where session.action:file_edit")
+
     def test_pipeline_session_source_scopes_terminal_unit_query(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant"
@@ -2534,33 +2559,11 @@ class TestBooleanQueryExpression:
         )
         assert review_row.metadata["delivery_state"] == "injected_context"
 
-        unsupported_summary_source = parse_unit_source_expression(
-            "context-snapshots where session.tool:bash AND boundary:session_start"
-        )
-        assert unsupported_summary_source is not None
-        with ArchiveStore.open_existing(archive_root) as archive:
-            unsupported_summary_envelope = query_unit_rows(
-                archive,
-                unsupported_summary_source,
-                query="context-snapshots where session.tool:bash AND boundary:session_start",
-                limit=10,
-            )
+        with pytest.raises(ExpressionCompileError, match="field 'session.tool' is not supported"):
+            parse_unit_source_expression("context-snapshots where session.tool:bash AND boundary:session_start")
 
-        assert unsupported_summary_envelope.items == ()
-
-        path_source = parse_unit_source_expression(
-            "context-snapshots where session.path:polylogue AND boundary:session_start"
-        )
-        assert path_source is not None
-        with ArchiveStore.open_existing(archive_root) as archive:
-            path_envelope = query_unit_rows(
-                archive,
-                path_source,
-                query="context-snapshots where session.path:polylogue AND boundary:session_start",
-                limit=10,
-            )
-
-        assert path_envelope.items == ()
+        with pytest.raises(ExpressionCompileError, match="field 'session.path' is not supported"):
+            parse_unit_source_expression("context-snapshots where session.path:polylogue AND boundary:session_start")
 
     def test_context_snapshot_session_since_uses_created_at_fallback(self, workspace_env: dict[str, Path]) -> None:
         """Runtime-transform session date filters match normal session timestamp semantics."""

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -71,6 +71,45 @@ def _clauses(expression: str) -> list[object]:
     return list(parse_expression_ast(expression).clauses)
 
 
+def _field_payload(
+    field: str,
+    *values: str,
+    op: str = "=",
+    field_ref: dict[str, object] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {"kind": "field", "field": field, "op": op, "values": list(values)}
+    if field_ref is not None:
+        payload["field_ref"] = field_ref
+    return payload
+
+
+def _session_field_ref(name: str, *, source_name: str | None = None, unit: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "scope": "session",
+        "name": name,
+        "source_name": source_name or name,
+    }
+    if unit is not None:
+        payload["unit"] = unit
+    return payload
+
+
+def _unit_field_ref(name: str, unit: str, *, source_name: str | None = None) -> dict[str, object]:
+    return {
+        "scope": "unit",
+        "name": name,
+        "source_name": source_name or name,
+        "unit": unit,
+    }
+
+
+def _session_scope_stage(field: str, *values: str) -> dict[str, object]:
+    return {
+        "kind": "session_scope",
+        "predicate": _field_payload(field, *values, field_ref=_session_field_ref(field)),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Lexer tests
 # ---------------------------------------------------------------------------
@@ -214,7 +253,7 @@ class TestExplainExpression:
             "predicate": {
                 "children": [
                     {
-                        "child": {"field": "type", "kind": "field", "op": "=", "values": ["code"]},
+                        "child": _field_payload("type", "code", field_ref=_unit_field_ref("type", "block")),
                         "kind": "exists",
                         "unit": "block",
                     },
@@ -254,12 +293,12 @@ class TestExplainExpression:
             "kind": "sequence",
             "unit": "action",
             "steps": [
-                {"kind": "field", "field": "action", "op": "=", "values": ["file_edit"]},
+                _field_payload("action", "file_edit", field_ref=_unit_field_ref("action", "action")),
                 {
                     "kind": "and",
                     "children": [
-                        {"kind": "field", "field": "action", "op": "=", "values": ["shell"]},
-                        {"kind": "field", "field": "output", "op": "=", "values": ["failed"]},
+                        _field_payload("action", "shell", field_ref=_unit_field_ref("action", "action")),
+                        _field_payload("output", "failed", field_ref=_unit_field_ref("output", "action")),
                     ],
                 },
             ],
@@ -280,8 +319,8 @@ class TestExplainExpression:
             "entry": "unit_source",
             "predicate": {
                 "children": [
-                    {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
-                    {"field": "text", "kind": "field", "op": "=", "values": ["timeout"]},
+                    _field_payload("role", "assistant", field_ref=_unit_field_ref("role", "message")),
+                    _field_payload("text", "timeout", field_ref=_unit_field_ref("text", "message")),
                 ],
                 "kind": "and",
             },
@@ -289,8 +328,8 @@ class TestExplainExpression:
                 "unit": "message",
                 "predicate": {
                     "children": [
-                        {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
-                        {"field": "text", "kind": "field", "op": "=", "values": ["timeout"]},
+                        _field_payload("role", "assistant", field_ref=_unit_field_ref("role", "message")),
+                        _field_payload("text", "timeout", field_ref=_unit_field_ref("text", "message")),
                     ],
                     "kind": "and",
                 },
@@ -321,10 +360,10 @@ class TestExplainExpression:
         payload = explanation.to_payload()
         assert payload["ast"] == {
             "entry": "unit_source",
-            "predicate": {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+            "predicate": _field_payload("role", "assistant", field_ref=_unit_field_ref("role", "message")),
             "unit_source": {
                 "unit": "message",
-                "predicate": {"field": "role", "kind": "field", "op": "=", "values": ["assistant"]},
+                "predicate": _field_payload("role", "assistant", field_ref=_unit_field_ref("role", "message")),
                 "limit": 2,
                 "offset": 3,
                 "sort": {"field": "time", "direction": "desc"},
@@ -348,17 +387,11 @@ class TestExplainExpression:
         payload = explanation.to_payload()
         ast_payload = cast(dict[str, Any], payload["ast"])
         unit_source = cast(dict[str, Any], ast_payload["unit_source"])
-        assert unit_source["session_predicate"] == {
-            "field": "repo",
-            "kind": "field",
-            "op": "=",
-            "values": ["polylogue"],
-        }
+        assert unit_source["session_predicate"] == _field_payload(
+            "repo", "polylogue", field_ref=_session_field_ref("repo")
+        )
         assert unit_source["pipeline_stages"] == [
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 5},
         ]
         lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
@@ -567,6 +600,12 @@ class TestBooleanQueryExpression:
         assert boundary.field_ref.scope == "unit"
         assert boundary.field_ref.name == "boundary"
         assert boundary.field_ref.unit == "context-snapshot"
+        assert scoped_repo.to_payload()["field_ref"] == {
+            "scope": "session",
+            "name": "repo",
+            "source_name": "session.repo",
+            "unit": "context-snapshot",
+        }
 
     def test_runtime_terminal_unit_rejects_session_scope_not_in_summary_projection(self) -> None:
         with pytest.raises(ExpressionCompileError, match="field 'session.action' is not supported"):
@@ -648,10 +687,7 @@ class TestBooleanQueryExpression:
         assert source.limit == 2
         assert source.offset == 3
         assert [stage.to_payload() for stage in source.pipeline_stages] == [
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 2},
             {"kind": "offset", "value": 3},
         ]
@@ -696,10 +732,7 @@ class TestBooleanQueryExpression:
         assert source.sort.field == "count"
         assert source.sort.direction == "asc"
         assert [stage.to_payload() for stage in source.pipeline_stages] == [
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
             {"kind": "sort", "sort": {"field": "count", "direction": "asc"}},
@@ -1585,10 +1618,7 @@ class TestBooleanQueryExpression:
         assert envelope.offset == 0
         assert envelope.next_offset == 1
         assert envelope.pipeline_stages == (
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},
         )
@@ -1643,10 +1673,7 @@ class TestBooleanQueryExpression:
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert payload["pipeline_stages"] == [
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},
         ]
@@ -1691,10 +1718,7 @@ class TestBooleanQueryExpression:
         assert isinstance(envelope, QueryUnitAggregateEnvelope)
         assert envelope.mode == "query-unit-aggregate"
         assert envelope.pipeline_stages == (
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
         )
@@ -1778,10 +1802,7 @@ class TestBooleanQueryExpression:
         payload = json.loads(result.output)
         assert payload["mode"] == "query-unit-aggregate"
         assert payload["pipeline_stages"] == [
-            {
-                "kind": "session_scope",
-                "predicate": {"field": "repo", "kind": "field", "op": "=", "values": ["polylogue"]},
-            },
+            _session_scope_stage("repo", "polylogue"),
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
         ]


### PR DESCRIPTION
## Summary

Runtime-transform terminal query units now expose and validate only the session-scoped fields their summary projection can actually evaluate. The parser validates terminal-unit fields through `QueryUnitDescriptor` metadata instead of maintaining a parallel branch of hard-coded unit field sets. Bound field predicates also serialize their validated `field_ref` identity into machine-readable AST/explain payloads.

## Problem

#2006's descriptor work had landed, but parser validation still duplicated unit field truth in `expression.py`. That left runtime-transform units (`runs`, `observed-events`, `context-snapshots`) advertising SQL-backed session predicates that their in-memory recovery/run projection cannot evaluate. The old behavior was narrower than broad FTS fallback, but still misleading: some unsupported inline session predicates parsed and then produced empty results. Also, validated field identity existed only as an internal Python attribute, so explain/query-builder consumers could not see the descriptor-backed field binding execution uses.

## Solution

- Split terminal unit metadata between SQL-backed session-scoped fields and runtime-summary-backed session-scoped fields.
- Added `query_unit_field_names()` so parser validation uses the same descriptor field list as completions/docs/schema surfaces.
- Kept summary-backed counters/date fields available for runtime units while rejecting SQL-only fields such as `session.action`, `session.tool`, `session.path`, and `session.has`.
- Retained SQL-backed `session.path` inline scoping for messages/actions/blocks/assertions.
- Included `field_ref` in `QueryFieldPredicate.to_payload()` when parser binding has resolved the field scope/unit.
- Updated query docs to describe the runtime-transform boundary explicitly.
- Updated parser/metadata tests to cover descriptor-backed field refs, explain payloads, SQL `session.path`, and typed runtime rejection.

## Verification

- `devtools test tests/unit/archive/test_query_metadata.py tests/unit/cli/test_query_expression.py -q` → `338 passed in 88.58s (0:01:28)`
- `devtools verify --quick` → exit 0
- Push hook reran `devtools verify --quick` at `1fc3e5c8cfc3cf85a9fce14f9f87e9bc99b4997b` → exit 0

Ref #2006