### PR TITLE
fix(query): preserve exclusive comparison operators (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -245,6 +245,13 @@ fields accept compact comparison prefixes such as `session.messages:>=2`,
 carry its session scope inline instead of splitting selection between the
 query string and parallel parameters.
 
+Boolean and terminal predicates preserve comparison semantics: `>`, `>=`, `<`,
+`<=`, and `=` are distinct for count and numeric fields, while `date` and
+terminal `time` accept the four ordered comparisons plus `between`. The legacy
+flat root filters (`messages > 10`, `words < 500`) still compile into inclusive
+`SessionQuerySpec` min/max bounds because that older request object has no
+exclusive-bound fields.
+
 Examples:
 
 ```bash

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -196,7 +196,7 @@ class _CountToken:
     """Readable count comparison such as ``messages:>=10``."""
 
     field: str
-    op: Literal[">=", "<=", "="]
+    op: QueryCompareOp
     number: int
 
 
@@ -213,7 +213,7 @@ class _CountRangeToken:
 class _DateComparisonToken:
     """``date >= 2026-01-01`` or ``date < 7d``."""
 
-    op: Literal[">=", "<="]
+    op: Literal[">", ">=", "<", "<="]
     value: str
 
 
@@ -321,7 +321,7 @@ class QueryExpressionExplainClause:
     value: str | None = None
     negated: bool = False
     quoted: bool = False
-    op: Literal[">=", "<=", "="] | None = None
+    op: QueryCompareOp | None = None
     number: int | None = None
     min_number: int | None = None
     max_number: int | None = None
@@ -449,7 +449,7 @@ _QUERY_GRAMMAR = rf"""
     SEMANTIC_BARE_TEXT.6: /(?:semantic|near:text):[^\s"()]+/i
     FTS_QUOTED_TEXT.6: /~"(\\.|[^"\\])*"/
     FTS_BARE_TEXT.5: /~[^\s"()]+/
-    COUNT_CLAUSE.8: /({_COUNT_FIELD_REGEX}):(>=|<=|=)\d+(?!\S)/
+    COUNT_CLAUSE.8: /({_COUNT_FIELD_REGEX}):(>=|<=|=|>|<)\d+(?!\S)/
     FIELD_CLAUSE.4: /-?[a-zA-Z_][a-zA-Z0-9_.]*:(?:"(\\.|[^"\\])*"|\([^)]*\)|[^\s"()\[\]{{}}]+)/
     NEG_QUOTED_TEXT.3: /-"(\\.|[^"\\])*"/
     QUOTED_TEXT.2: /"(\\.|[^"\\])*"/
@@ -544,13 +544,7 @@ def _normalize_count_comparison(
 ) -> _CountToken:
     field = field_name.lower()
     number = int(number_text)
-    if op_text == ">":
-        return _CountToken(field=field, op=">=", number=number + 1)
-    if op_text == "<":
-        if number == 0:
-            raise ExpressionCompileError(f"{field} < 0 is not representable as a non-negative count bound", field=field)
-        return _CountToken(field=field, op="<=", number=number - 1)
-    op: Literal[">=", "<=", "="] = ">=" if op_text == ">=" else "<=" if op_text == "<=" else "="
+    op = cast(QueryCompareOp, op_text if op_text in {">", ">=", "<", "<=", "="} else "=")
     return _CountToken(field=field, op=op, number=number)
 
 
@@ -567,10 +561,10 @@ def _normalize_count_range(field_name: str, min_text: str, max_text: str) -> _Co
 
 
 def _normalize_date_comparison(op_text: str, value_text: str) -> _DateComparisonToken:
-    if op_text in {">=", ">"}:
-        return _DateComparisonToken(op=">=", value=_parse_relative_date(value_text))
-    if op_text in {"<=", "<"}:
-        return _DateComparisonToken(op="<=", value=_parse_relative_date(value_text))
+    if op_text in {">=", ">", "<=", "<"}:
+        return _DateComparisonToken(
+            op=cast(Literal[">", ">=", "<", "<="], op_text), value=_parse_relative_date(value_text)
+        )
     raise ExpressionCompileError("date equality is not supported; use date between A and B", field="date")
 
 
@@ -579,10 +573,10 @@ def _normalize_date_range(min_text: str, max_text: str) -> _DateRangeToken:
 
 
 def _normalize_time_comparison(op_text: str, value_text: str) -> QueryFieldPredicate:
-    if op_text in {">=", ">"}:
-        return QueryFieldPredicate(field="time", values=(_parse_relative_date(value_text),), op=">=")
-    if op_text in {"<=", "<"}:
-        return QueryFieldPredicate(field="time", values=(_parse_relative_date(value_text),), op="<=")
+    if op_text in {">=", ">", "<=", "<"}:
+        return QueryFieldPredicate(
+            field="time", values=(_parse_relative_date(value_text),), op=cast(QueryCompareOp, op_text)
+        )
     raise ExpressionCompileError("time equality is not supported; use time between A and B", field="time")
 
 
@@ -712,11 +706,11 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
     elif validation_field in COUNT_QUERY_FIELD_REGISTRY or validation_field in NUMERIC_QUERY_FIELD_REGISTRY:
         if not values:
             raise ExpressionCompileError(f"field {field_name!r} requires a numeric value", field=field_name)
-        match = re.fullmatch(r"(>=|<=|=)?(\d+)", values[-1].strip())
+        match = re.fullmatch(r"(>=|<=|=|>|<)?(\d+)", values[-1].strip())
         if match is None:
             raise ExpressionCompileError(f"field {field_name!r} requires a numeric value", field=field_name)
         raw_op = match.group(1) or "="
-        op_text: QueryCompareOp = ">=" if raw_op == ">=" else "<=" if raw_op == "<=" else "="
+        op_text = cast(QueryCompareOp, raw_op)
         values = (match.group(2),)
         count_predicate = QueryFieldPredicate(field=field_name, values=values, op=op_text)
         return QueryNotPredicate(count_predicate) if token.negated else count_predicate
@@ -725,7 +719,7 @@ def _field_token_to_predicate(token: _FieldToken) -> QueryPredicate:
         match = re.fullmatch(r"(>=|<=|>|<)?(.+)", raw_value)
         if match is not None:
             raw_op = match.group(1) or "="
-            normalized_op: QueryCompareOp = ">=" if raw_op in {">", ">="} else "<=" if raw_op in {"<", "<="} else "="
+            normalized_op = cast(QueryCompareOp, raw_op)
             values = (_parse_relative_date(match.group(2).strip()),)
             date_predicate = QueryFieldPredicate(field=field_name, values=values, op=normalized_op)
             return QueryNotPredicate(date_predicate) if token.negated else date_predicate
@@ -895,7 +889,7 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         if validation_field == "date":
             if not predicate.values:
                 raise ExpressionCompileError("field 'date' requires a value", field="date")
-            if predicate.op not in {">=", "<="}:
+            if predicate.op not in {">", ">=", "<", "<="}:
                 raise ExpressionCompileError("field 'date' supports only >=, <=, >, <, and between", field="date")
         if validation_field == "time":
             if unit == "session":
@@ -904,7 +898,7 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
                 )
             if not predicate.values:
                 raise ExpressionCompileError("field 'time' requires a value", field="time")
-            if predicate.op not in {">=", "<="}:
+            if predicate.op not in {">", ">=", "<", "<="}:
                 raise ExpressionCompileError("field 'time' supports only >=, <=, >, <, and between", field="time")
         if validation_field in COUNT_QUERY_FIELD_REGISTRY or validation_field in NUMERIC_QUERY_FIELD_REGISTRY:
             if not predicate.values:
@@ -2033,16 +2027,34 @@ class _SpecAccumulator:
 
         if isinstance(tok, _CountToken):
             if tok.field == "messages":
-                if tok.op == ">=":
+                if tok.op == ">":
+                    self.min_messages = tok.number + 1
+                elif tok.op == ">=":
                     self.min_messages = tok.number
+                elif tok.op == "<":
+                    if tok.number == 0:
+                        raise ExpressionCompileError(
+                            "messages < 0 is not representable as a non-negative count bound",
+                            field="messages",
+                        )
+                    self.max_messages = tok.number - 1
                 elif tok.op == "<=":
                     self.max_messages = tok.number
                 else:
                     self.min_messages = tok.number
                     self.max_messages = tok.number
             elif tok.field == "words":
-                if tok.op == ">=":
+                if tok.op == ">":
+                    self.min_words = tok.number + 1
+                elif tok.op == ">=":
                     self.min_words = tok.number
+                elif tok.op == "<":
+                    if tok.number == 0:
+                        raise ExpressionCompileError(
+                            "words < 0 is not representable as a non-negative count bound",
+                            field="words",
+                        )
+                    self.max_words = tok.number - 1
                 elif tok.op == "<=":
                     self.max_words = tok.number
                 else:  # "="
@@ -2070,7 +2082,7 @@ class _SpecAccumulator:
             return
 
         if isinstance(tok, _DateComparisonToken):
-            if tok.op == ">=":
+            if tok.op in {">", ">="}:
                 self.since = tok.value
             else:
                 self.until = tok.value

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -7,7 +7,7 @@ from dataclasses import field as dataclass_field
 from typing import Literal, TypeAlias
 
 QueryBoolOp: TypeAlias = Literal["and", "or"]
-QueryCompareOp: TypeAlias = Literal["=", ">=", "<="]
+QueryCompareOp: TypeAlias = Literal["=", ">", ">=", "<", "<="]
 QueryFieldScope: TypeAlias = Literal["session", "unit"]
 
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -228,8 +228,12 @@ def _numeric_field_matches(value: int | None, predicate: QueryFieldPredicate) ->
         target = int(predicate.values[-1])
     except ValueError:
         return False
+    if predicate.op == ">":
+        return value > target
     if predicate.op == ">=":
         return value >= target
+    if predicate.op == "<":
+        return value < target
     if predicate.op == "<=":
         return value <= target
     return value == target
@@ -242,8 +246,12 @@ def _summary_timestamp_matches(summary: ArchiveSessionSummary, field: str, predi
     target = _epoch_ms(field, predicate.values[-1])
     if timestamp is None or target is None:
         return False
+    if predicate.op == ">":
+        return timestamp > target
     if predicate.op == ">=":
         return timestamp >= target
+    if predicate.op == "<":
+        return timestamp < target
     if predicate.op == "<=":
         return timestamp <= target
     return timestamp == target

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4728,10 +4728,15 @@ def _field_predicate_clause(
         kwargs["title"] = " ".join(values)
     elif field == "date":
         if values:
+            session_time_expr = f"COALESCE({table_alias}.updated_at_ms, {table_alias}.created_at_ms)"
             if predicate.op == ">=":
                 kwargs["since_ms"] = _date_ms(values[-1], field="date")
+            elif predicate.op == ">":
+                return f"{session_time_expr} > ?", [_date_ms(values[-1], field="date")]
             elif predicate.op == "<=":
                 kwargs["until_ms"] = _date_ms(values[-1], field="date")
+            elif predicate.op == "<":
+                return f"{session_time_expr} < ?", [_date_ms(values[-1], field="date")]
             else:
                 raise ValueError("unsupported Boolean query operator for date")
     elif field == "since":
@@ -4782,8 +4787,12 @@ def _count_predicate_clause(column: str, predicate: QueryFieldPredicate) -> tupl
     if not predicate.values:
         return "", []
     value = int(predicate.values[-1])
+    if predicate.op == ">":
+        return f"{column} > ?", [value]
     if predicate.op == ">=":
         return f"{column} >= ?", [value]
+    if predicate.op == "<":
+        return f"{column} < ?", [value]
     if predicate.op == "<=":
         return f"{column} <= ?", [value]
     return f"{column} = ?", [value]
@@ -4796,8 +4805,12 @@ def _numeric_predicate_clause(
     if not predicate.values:
         return "", []
     value = int(predicate.values[-1])
+    if predicate.op == ">":
+        return f"{column} > ?", [value]
     if predicate.op == ">=":
         return f"{column} >= ?", [value]
+    if predicate.op == "<":
+        return f"{column} < ?", [value]
     if predicate.op == "<=":
         return f"{column} <= ?", [value]
     return f"{column} = ?", [value]
@@ -4807,8 +4820,12 @@ def _time_predicate_clause(expression: str, predicate: QueryFieldPredicate) -> t
     if not predicate.values:
         return "", []
     value_ms = _date_ms(predicate.values[-1], field="time")
+    if predicate.op == ">":
+        return f"{expression} > ?", [value_ms]
     if predicate.op == ">=":
         return f"{expression} >= ?", [value_ms]
+    if predicate.op == "<":
+        return f"{expression} < ?", [value_ms]
     if predicate.op == "<=":
         return f"{expression} <= ?", [value_ms]
     raise ValueError("unsupported Boolean query operator for time")

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -126,10 +126,10 @@ class TestLexer:
         )
 
     def test_parse_expression_ast_exposes_readable_count_clauses(self) -> None:
-        ast = parse_expression_ast("messages >= 10 words between 100 and 500 tool_use_messages:>=1")
+        ast = parse_expression_ast("messages > 10 words between 100 and 500 tool_use_messages:>=1")
 
         assert ast.clauses == (
-            _CountToken(field="messages", op=">=", number=10),
+            _CountToken(field="messages", op=">", number=10),
             _CountRangeToken(field="words", min_number=100, max_number=500),
             _CountToken(field="tool_use_messages", op=">=", number=1),
         )
@@ -444,7 +444,7 @@ class TestBooleanQueryExpression:
             op="and",
             children=(
                 QueryFieldPredicate(field="duration_ms", values=("60000",), op=">="),
-                QueryFieldPredicate(field="duration_ms", values=("119999",), op="<="),
+                QueryFieldPredicate(field="duration_ms", values=("120000",), op="<"),
             ),
         )
 
@@ -539,14 +539,14 @@ class TestBooleanQueryExpression:
         )
 
     def test_terminal_source_time_comparison_is_parsed(self) -> None:
-        source = parse_unit_source_expression("messages where time >= 2026-01-02T00:00:00+00:00")
+        source = parse_unit_source_expression("messages where time > 2026-01-02T00:00:00+00:00")
 
         assert source is not None
         assert source.unit == "message"
         assert source.predicate == QueryFieldPredicate(
             field="time",
             values=("2026-01-02T00:00:00+00:00",),
-            op=">=",
+            op=">",
         )
 
     def test_terminal_source_time_range_is_parsed(self) -> None:
@@ -1405,6 +1405,13 @@ class TestBooleanQueryExpression:
             .save()
         )
         (
+            SessionBuilder(index_db, "duration-boundary")
+            .provider("chatgpt")
+            .title("duration boundary")
+            .add_message("m-boundary", role="assistant", text="exact threshold")
+            .save()
+        )
+        (
             SessionBuilder(index_db, "duration-null")
             .provider("chatgpt")
             .title("duration null")
@@ -1420,6 +1427,10 @@ class TestBooleanQueryExpression:
                 "UPDATE sessions SET reported_duration_ms = ? WHERE session_id = ?",
                 (5_000, "chatgpt-export:ext-duration-miss"),
             )
+            conn.execute(
+                "UPDATE sessions SET reported_duration_ms = ? WHERE session_id = ?",
+                (60_000, "chatgpt-export:ext-duration-boundary"),
+            )
             conn.commit()
 
         with ArchiveStore.open_existing(index_db.parent) as archive:
@@ -1427,7 +1438,10 @@ class TestBooleanQueryExpression:
             assert spec.boolean_predicate is not None
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
-        assert [row.session_id for row in rows] == ["chatgpt-export:ext-duration-hit"]
+        assert [row.session_id for row in rows] == [
+            "chatgpt-export:ext-duration-boundary",
+            "chatgpt-export:ext-duration-hit",
+        ]
 
         with ArchiveStore.open_existing(index_db.parent) as archive:
             spec = compile_expression("sessions where NOT duration_ms >= 60000")
@@ -1435,6 +1449,13 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["chatgpt-export:ext-duration-miss"]
+
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            spec = compile_expression("sessions where duration_ms > 60000")
+            assert spec.boolean_predicate is not None
+            rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+
+        assert [row.session_id for row in rows] == ["chatgpt-export:ext-duration-hit"]
 
     def test_message_numeric_comparisons_execute_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.archive.query.unit_results import query_unit_rows
@@ -1466,12 +1487,32 @@ class TestBooleanQueryExpression:
                 cache_write_tokens=0,
                 duration_ms=100,
             )
+            .add_message(
+                "m-lower-boundary",
+                role="assistant",
+                text="token lower boundary",
+                input_tokens=1200,
+                output_tokens=400,
+                cache_read_tokens=300,
+                cache_write_tokens=20,
+                duration_ms=2000,
+            )
+            .add_message(
+                "m-upper-boundary",
+                role="assistant",
+                text="token upper boundary",
+                input_tokens=1200,
+                output_tokens=400,
+                cache_read_tokens=300,
+                cache_write_tokens=20,
+                duration_ms=3000,
+            )
             .save()
         )
 
         source = parse_unit_source_expression(
             "messages where input_tokens >= 1000 AND output_tokens >= 300 "
-            "AND cache_read_tokens >= 100 AND duration_ms between 2000 and 3000"
+            "AND cache_read_tokens >= 100 AND duration_ms > 2000 AND duration_ms < 3000"
         )
         assert source is not None
         with ArchiveStore.open_existing(index_db.parent) as archive:
@@ -2025,10 +2066,25 @@ class TestBooleanQueryExpression:
                 ],
             )
             .add_message(
+                "m-boundary",
+                role="assistant",
+                text="boundary edit",
+                timestamp="2026-01-02T00:00:00+00:00",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-boundary",
+                        "input": {"file_path": "polylogue/archive/boundary.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
                 "m-new",
                 role="assistant",
                 text="new edit",
-                timestamp="2026-01-02T00:00:00+00:00",
+                timestamp="2026-01-03T00:00:00+00:00",
                 blocks=[
                     {
                         "type": "tool_use",
@@ -2042,7 +2098,7 @@ class TestBooleanQueryExpression:
             .save()
         )
 
-        source = parse_unit_source_expression("actions where time >= 2026-01-02T00:00:00+00:00")
+        source = parse_unit_source_expression("actions where time > 2026-01-02T00:00:00+00:00")
         assert source is not None
         with ArchiveStore.open_existing(index_db.parent) as archive:
             rows = archive.query_actions(source.predicate, limit=100)
@@ -2682,6 +2738,24 @@ class TestBooleanQueryExpression:
             .add_message("m-control", role="user", text="one two three four five", has_paste=1)
             .save()
         )
+        (
+            SessionBuilder(index_db, "summary-boundary")
+            .provider("codex")
+            .created_at("2026-01-02T00:00:00+00:00")
+            .updated_at("2026-01-02T00:00:00+00:00")
+            .title("summary comparison boundary")
+            .add_message("m-boundary-1", role="user", text="one two")
+            .add_message(
+                "m-boundary-2",
+                role="assistant",
+                text="three four",
+                blocks=[
+                    {"type": "tool_use", "tool_name": "bash", "text": "pytest"},
+                    {"type": "thinking", "text": "plan"},
+                ],
+            )
+            .save()
+        )
         with sqlite3.connect(index_db) as conn:
             conn.execute(
                 "UPDATE sessions SET reported_duration_ms = ? WHERE session_id = ?",
@@ -2691,6 +2765,10 @@ class TestBooleanQueryExpression:
                 "UPDATE sessions SET reported_duration_ms = ? WHERE session_id = ?",
                 (5_000, "codex-session:ext-summary-control"),
             )
+            conn.execute(
+                "UPDATE sessions SET reported_duration_ms = ? WHERE session_id = ?",
+                (60_000, "codex-session:ext-summary-boundary"),
+            )
             conn.commit()
 
         source = parse_unit_source_expression(
@@ -2699,8 +2777,8 @@ class TestBooleanQueryExpression:
             "AND session.tool_use_messages:>=1 "
             "AND session.thinking_messages:>=1 "
             "AND session.paste_messages:=0 "
-            "AND session.duration_ms:>=60000 "
-            "AND session.date:>=2026-01-02 "
+            "AND session.duration_ms:>60000 "
+            "AND session.date:>2026-01-02 "
             "AND boundary:session_start"
         )
         assert source is not None
@@ -2714,8 +2792,8 @@ class TestBooleanQueryExpression:
                     "AND session.tool_use_messages:>=1 "
                     "AND session.thinking_messages:>=1 "
                     "AND session.paste_messages:=0 "
-                    "AND session.duration_ms:>=60000 "
-                    "AND session.date:>=2026-01-02 "
+                    "AND session.duration_ms:>60000 "
+                    "AND session.date:>2026-01-02 "
                     "AND boundary:session_start"
                 ),
                 limit=10,


### PR DESCRIPTION
## Summary
Preserves `>` and `<` as first-class query comparison operators in the Boolean and terminal DSL instead of normalizing them into inclusive bounds. The change keeps the old flat root `SessionQuerySpec` compatibility path working by converting `messages > N` / `words < N` into inclusive integer min/max bounds only where that older request shape has no exclusive-bound representation.

## Problem
The grammar and completions advertised `>` and `<`, but the typed predicate model and parser/lowerers collapsed them into `>=` / `<=`. That made `sessions where duration_ms < 120000`, terminal `time > ...`, and runtime-transform scoped session predicates less precise than the query string claimed.

## Solution
- Extended `QueryCompareOp` and explain payloads to carry `>` and `<`.
- Preserved exclusive operators through Lark parser normalization for Boolean, terminal, compact count, date, and time predicates.
- Updated SQLite lowerers for session date, count/numeric fields, and terminal row time fields to emit exclusive SQL comparisons.
- Updated runtime-transform summary matching for runs, observed events, and context snapshots to evaluate exclusive numeric/date comparisons in Python.
- Documented the distinction between exact Boolean/terminal semantics and the legacy flat root min/max compatibility path.

## Verification
- `devtools test tests/unit/cli/test_query_expression.py -q` → `331 passed in 87.70s (0:01:27)`
- `devtools verify --quick` → exit 0 (`ruff format`, `ruff check`, `mypy`, `render all`, topology/layering/manifests/doc-command/test-infra/test-clock gates all ok)
- pre-push `devtools verify --quick` → exit 0 on `091415d03`

Closes no issue; Ref #2006.