### PR TITLE
feat(query): lower session stages in terminal pipelines (#2006)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -117,16 +117,23 @@ polylogue 'messages where role:assistant | sort by time desc | limit 10'
 polylogue 'actions where action:file_edit | limit 20 | offset 40'
 polylogue 'sessions where repo:polylogue AND origin:claude-code-session | messages where role:assistant'
 polylogue 'sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit'
+polylogue 'sessions where ~"timeout failure" | messages where role:user'
+polylogue 'sessions where exists block(type:code) | messages where role:user'
+polylogue 'sessions where seq(action:file_edit -> action:shell) | messages where role:user'
+polylogue 'sessions where lineage:id:chatgpt-export:ext-child | messages where role:user'
 polylogue 'sessions where repo:polylogue | messages where role:assistant | limit 10 | offset 20'
 polylogue 'sessions where repo:polylogue | messages where role:assistant | sort by time desc | limit 10'
 ```
 
 When a pipeline starts with `sessions where ...`, the left stage is lowered into
-`session.<field>` predicates on the terminal unit query, so it uses the same row
-executor as direct `messages/actions/...` pipelines. For now the session stage
-accepts field/count/date predicates only; FTS, semantic, `exists`, lineage, and
-sequence stages are typed errors until they have dedicated unit-changing
-lowerers. Terminal pipeline stages currently support `sort by time [asc|desc]`,
+predicates on the terminal unit query, so it uses the same row executor as direct
+`messages/actions/...` pipelines. Field/count/date predicates become
+`session.<field>` row predicates. FTS (`~"..."`), `exists ...`, sequence
+(`seq(...)`), and `lineage:id:<session-id>` stages lower through the existing
+session Boolean lowerers against the terminal row's owning session. Semantic
+vector predicates still reject in a session pipeline stage until terminal row
+queries have explicit ranked-result semantics. Terminal pipeline stages
+currently support `sort by time [asc|desc]`,
 `group by FIELD | count`, aggregate `sort by count|key [asc|desc]`, `limit N`,
 and `offset N` for SQL-backed terminal rows (`messages`, `actions`, `blocks`,
 `assertions`). Query-string limits narrow the surface limit instead of expanding

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -925,8 +925,6 @@ def _validate_predicate_context(predicate: QueryPredicate, *, unit: Literal["ses
         _validate_predicate_context(predicate.child, unit=predicate.unit)
         return
     if isinstance(predicate, QueryLineagePredicate):
-        if unit != "session":
-            raise ExpressionCompileError("lineage predicates are only supported from sessions", field=None)
         if not predicate.seed_session_id.strip():
             raise ExpressionCompileError("lineage predicate requires a session id", field="lineage")
         return
@@ -1266,11 +1264,29 @@ def _scope_session_predicate(predicate: QueryPredicate) -> QueryPredicate:
         return QueryBoolPredicate(predicate.op, tuple(_scope_session_predicate(child) for child in predicate.children))
     if isinstance(predicate, QueryNotPredicate):
         return QueryNotPredicate(_scope_session_predicate(predicate.child))
+    if isinstance(
+        predicate, QueryTextPredicate | QueryExistsPredicate | QueryLineagePredicate | QuerySequencePredicate
+    ):
+        return predicate
     raise ExpressionCompileError(
-        "pipeline session stages currently support field/count/date predicates only; "
-        "FTS, semantic, exists, lineage, and sequence stages need dedicated lowerers.",
+        "pipeline session stages currently support SQL-backed Boolean session predicates only; "
+        "semantic stages need a ranked terminal lowerer.",
         field=None,
     )
+
+
+def _bind_scoped_session_predicate(predicate: QueryPredicate, *, terminal_unit: QueryUnitName) -> QueryPredicate:
+    scoped = _scope_session_predicate(predicate)
+    if isinstance(scoped, QueryFieldPredicate):
+        return _bind_predicate_context(scoped, unit=terminal_unit)
+    if isinstance(scoped, QueryBoolPredicate):
+        return QueryBoolPredicate(
+            scoped.op,
+            tuple(_bind_scoped_session_predicate(child, terminal_unit=terminal_unit) for child in scoped.children),
+        )
+    if isinstance(scoped, QueryNotPredicate):
+        return QueryNotPredicate(_bind_scoped_session_predicate(scoped.child, terminal_unit=terminal_unit))
+    return _bind_predicate_context(scoped, unit="session")
 
 
 def _parse_non_negative_int_stage(stage: str, keyword: str) -> int | None:
@@ -1499,9 +1515,8 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
                 "pipeline terminal stage must be an executable `<unit>s where ...` query",
                 field=None,
             )
-        scoped_session_predicate = _scope_session_predicate(session_predicate)
-        combined = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
-        bound = _bind_predicate_context(combined, unit=terminal_source.unit)
+        scoped_session_predicate = _bind_scoped_session_predicate(session_predicate, terminal_unit=terminal_source.unit)
+        bound = QueryBoolPredicate("and", (scoped_session_predicate, terminal_source.predicate))
         source = QueryUnitSource(
             unit=terminal_source.unit,
             predicate=bound,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5062,6 +5062,12 @@ def _structural_predicate_clause(
             return "", merged_params
         joiner = " OR " if predicate.op == "or" else " AND "
         return joiner.join(child_clauses), merged_params
+    if isinstance(
+        predicate, QueryTextPredicate | QueryExistsPredicate | QuerySequencePredicate | QueryLineagePredicate
+    ):
+        if session_alias is None:
+            raise ValueError(f"session-scoped {unit} predicate requires a session alias")
+        return _boolean_predicate_clause(session_alias, predicate, tags_relation="session_tags")
     raise ValueError(f"unsupported nested structural predicate for {unit}: {predicate!r}")
 
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -29,6 +29,7 @@ from click.testing import CliRunner
 from polylogue.archive.query.expression import (
     EXPRESSION_FIELD_REGISTRY,
     ExpressionCompileError,
+    QueryUnitPipelineStage,
     QueryUnitSource,
     _CountRangeToken,
     _CountToken,
@@ -676,6 +677,28 @@ class TestBooleanQueryExpression:
         assert role.field_ref.name == "role"
         assert role.field_ref.unit == "message"
 
+    def test_pipeline_session_source_accepts_lineage_predicate(self) -> None:
+        source = parse_unit_source_expression(
+            "sessions where lineage:id:chatgpt-export:ext-child | messages where role:user"
+        )
+
+        assert source is not None
+        assert source.unit == "message"
+        assert source.session_predicate == QueryLineagePredicate(seed_session_id="chatgpt-export:ext-child")
+        assert source.predicate == QueryBoolPredicate(
+            op="and",
+            children=(
+                QueryLineagePredicate(seed_session_id="chatgpt-export:ext-child"),
+                QueryFieldPredicate(field="role", values=("user",)),
+            ),
+        )
+        assert source.pipeline_stages == (
+            QueryUnitPipelineStage(
+                kind="session_scope",
+                predicate=QueryLineagePredicate(seed_session_id="chatgpt-export:ext-child"),
+            ),
+        )
+
     def test_pipeline_split_ignores_field_alternation_pipe(self) -> None:
         source = parse_unit_source_expression(
             "sessions where origin:(codex-session|claude-code-session) | actions where action:file_edit"
@@ -822,9 +845,9 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="cannot feed aggregate stages"):
             parse_unit_source_expression("messages where role:assistant | sort by time asc | group by role | count")
 
-    def test_pipeline_rejects_unlowered_session_stage_predicates(self) -> None:
-        with pytest.raises(ExpressionCompileError, match="FTS, semantic, exists, lineage, and sequence"):
-            parse_unit_source_expression('sessions where ~"timeout" | messages where role:assistant')
+    def test_pipeline_rejects_ranked_semantic_session_stage(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="semantic stages need a ranked terminal lowerer"):
+            parse_unit_source_expression('sessions where semantic:"timeout" | messages where role:assistant')
 
     def test_compile_expression_rejects_terminal_pipelines_as_session_selector(self) -> None:
         with pytest.raises(ExpressionCompileError, match="pipeline unit queries return terminal rows"):
@@ -1641,6 +1664,193 @@ class TestBooleanQueryExpression:
             )
         ]
 
+    def test_session_to_message_pipeline_fts_stage_executes_against_archive(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("fts pipeline hit")
+            .add_message(
+                "m-fts",
+                role="assistant",
+                text="diagnostic",
+                blocks=[{"type": "text", "text": "timeout failure in lowerer"}],
+            )
+            .add_message("m-selected", role="user", text="selected terminal row")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("fts pipeline miss")
+            .add_message(
+                "m-fts",
+                role="assistant",
+                text="diagnostic",
+                blocks=[{"type": "text", "text": "ordinary lowerer"}],
+            )
+            .add_message("m-selected", role="user", text="wrong terminal row")
+            .save()
+        )
+
+        source = parse_unit_source_expression('sessions where ~"timeout failure" | messages where role:user')
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.session_id, row.message_id, row.text) for row in rows] == [
+            (
+                "chatgpt-export:ext-hit",
+                "chatgpt-export:ext-hit:m-selected",
+                "selected terminal row",
+            )
+        ]
+
+    def test_session_to_message_pipeline_exists_stage_executes_against_archive(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("chatgpt")
+            .title("exists pipeline hit")
+            .add_message(
+                "m-code",
+                role="assistant",
+                text="diagnostic",
+                blocks=[{"type": "code", "text": "pipeline_sentinel()"}],
+            )
+            .add_message("m-selected", role="user", text="selected terminal row")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("chatgpt")
+            .title("exists pipeline miss")
+            .add_message("m-code", role="assistant", text="no code here")
+            .add_message("m-selected", role="user", text="wrong terminal row")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where exists block(type:code AND text:pipeline_sentinel) | messages where role:user"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.session_id, row.message_id, row.text) for row in rows] == [
+            (
+                "chatgpt-export:ext-hit",
+                "chatgpt-export:ext-hit:m-selected",
+                "selected terminal row",
+            )
+        ]
+
+    def test_session_to_message_pipeline_sequence_stage_executes_against_archive(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("sequence pipeline hit")
+            .add_message(
+                "m-edit",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-edit",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message(
+                "m-shell",
+                role="assistant",
+                text="shell",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "tool-shell",
+                        "input": {"command": "pytest"},
+                        "semantic_type": "shell",
+                    }
+                ],
+            )
+            .add_message("m-selected", role="user", text="selected terminal row")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "miss")
+            .provider("claude-code")
+            .title("sequence pipeline miss")
+            .add_message(
+                "m-shell",
+                role="assistant",
+                text="shell",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": "tool-shell-miss",
+                        "input": {"command": "pytest"},
+                        "semantic_type": "shell",
+                    }
+                ],
+            )
+            .add_message(
+                "m-edit",
+                role="assistant",
+                text="edit",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-edit-miss",
+                        "input": {"file_path": "polylogue/archive/query/expression.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .add_message("m-selected", role="user", text="wrong terminal row")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where seq(action:file_edit -> action:shell) | messages where role:user"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            rows = archive.query_messages(source.predicate, limit=100)
+
+        assert [(row.session_id, row.message_id, row.text) for row in rows] == [
+            (
+                "claude-code-session:ext-hit",
+                "claude-code-session:ext-hit:m-selected",
+                "selected terminal row",
+            )
+        ]
+
     def test_session_to_message_pipeline_limit_offset_executes_terminal_window(
         self,
         workspace_env: dict[str, Path],
@@ -1694,6 +1904,64 @@ class TestBooleanQueryExpression:
         assert isinstance(next_row, MessageQueryRowPayload)
         assert next_row.message_id == "claude-code-session:ext-hit:m-3"
         assert next_row.text == "third"
+
+    def test_session_to_message_pipeline_lineage_executes_against_archive(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import MessageQueryRowPayload
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "root")
+            .provider("chatgpt")
+            .title("lineage root")
+            .add_message("m-root", role="user", text="root message")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "child")
+            .provider("chatgpt")
+            .title("lineage child")
+            .parent_session("ext-root")
+            .add_message("m-child", role="user", text="child message")
+            .save()
+        )
+        (
+            SessionBuilder(index_db, "other")
+            .provider("chatgpt")
+            .title("lineage other")
+            .add_message("m-other", role="user", text="other message")
+            .save()
+        )
+
+        source = parse_unit_source_expression(
+            "sessions where lineage:id:chatgpt-export:ext-child | messages where role:user | sort by time asc"
+        )
+        assert source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="pipeline-lineage", limit=20)
+
+        assert envelope.pipeline_stages == (
+            {
+                "kind": "session_scope",
+                "predicate": {
+                    "kind": "lineage",
+                    "seed_session_id": "chatgpt-export:ext-child",
+                    "unit": "session",
+                },
+            },
+            {"kind": "sort", "sort": {"field": "time", "direction": "asc"}},
+        )
+        rows = [row for row in envelope.items if isinstance(row, MessageQueryRowPayload)]
+        assert [row.session_id for row in rows] == [
+            "chatgpt-export:ext-root",
+            "chatgpt-export:ext-child",
+        ]
+        assert [row.text for row in rows] == ["root message", "child message"]
 
     def test_cli_json_reports_terminal_pipeline_stages(
         self,


### PR DESCRIPTION
## Summary
Allows terminal query pipelines to use executable SQL-backed session stages before returning row-level results. Pipelines such as `sessions where ~\"timeout failure\" | messages where role:user`, `sessions where exists block(type:code) | messages where role:user`, `sessions where seq(action:file_edit -> action:shell) | messages where role:user`, and `sessions where lineage:id:<seed> | messages where role:user` now scope terminal rows through the owning session instead of being rejected or broadened.

## Problem
#2006 already had session-level lowerers for FTS, structural `exists`, action `seq(...)`, and topology lineage, and terminal row pipelines already joined rows to their owning session. The session-stage binder still treated those predicates as if they belonged to the terminal row unit, so only simple field/count/date predicates worked across the `sessions where ... | <unit>s where ...` boundary.

## Solution
The pipeline parser now validates and binds the left `sessions where ...` stage in session scope while keeping the right terminal unit predicate in row scope. Storage terminal-row lowering delegates SQL-backed session predicates through the existing session Boolean lowerers against the joined session alias. Semantic/vector session stages still reject because they produce ranked result sets rather than plain Boolean filters; the docs call out that boundary explicitly.

## Verification
- `devtools test tests/unit/cli/test_query_expression.py -k "pipeline_rejects_ranked_semantic_session_stage or session_to_message_pipeline_fts_stage or session_to_message_pipeline_exists_stage or session_to_message_pipeline_sequence_stage or session_to_message_pipeline_lineage" -q` -> `5 passed, 331 deselected`
- `devtools test tests/unit/cli/test_query_expression.py -q` -> `336 passed in 92.58s`
- `devtools verify --quick` -> exit code 0 (`20260621T123742Z-quick-3500587-4c1a1e80`)
- pre-push `devtools verify --quick` -> exit code 0 (`20260621T123820Z-quick-3504208-18a8be7f`)

Ref #2006