### PR TITLE
chore(dev): add isolated ports to dev-loop preflight (#2248)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -100,6 +100,23 @@ def _socket_connectable(port: int, *, host: str = "127.0.0.1", timeout_s: float 
         return False
 
 
+def _allocate_loopback_port(*, reserved: set[int] | None = None) -> int:
+    reserved_ports = reserved or set()
+    for _attempt in range(20):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = int(sock.getsockname()[1])
+        if port not in reserved_ports and not _socket_connectable(port):
+            return port
+    raise RuntimeError("could not allocate an unused loopback port for the dev-loop")
+
+
+def allocate_isolated_ports() -> tuple[int, int]:
+    api_port = _allocate_loopback_port()
+    browser_capture_port = _allocate_loopback_port(reserved={api_port})
+    return api_port, browser_capture_port
+
+
 def system_service_status(unit: str = "polylogued.service") -> dict[str, Any]:
     result = _run_command(
         [
@@ -1115,6 +1132,7 @@ def build_dev_loop_status(
     archive_root: Path | None = None,
     log_dir: Path | None = None,
     prepare: bool = False,
+    port_selection: str = "explicit",
 ) -> dict[str, Any]:
     root = repo_root or _repo_root()
     archive = archive_root or root / ".local" / "dev-archive"
@@ -1144,7 +1162,7 @@ def build_dev_loop_status(
         terminal_artifact_dir.mkdir(parents=True, exist_ok=True)
         tui_artifact_dir.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
-    if service.get("active"):
+    if service.get("active") and port_selection != "isolated":
         warnings.append(
             "systemwide polylogued.service is active; stop it or use isolated ports before branch-local runs"
         )
@@ -1157,6 +1175,7 @@ def build_dev_loop_status(
         "branch": branch,
         "commit": commit,
         "run_id": run_id,
+        "port_selection": port_selection,
         "prepared": prepare,
         "preflight_json_written": False,
         "dev_archive_root": str(archive),
@@ -1184,9 +1203,19 @@ def build_dev_loop_status(
         },
         "commands": {
             "stop_system_service": "systemctl --user stop polylogued.service",
-            "prepare": "devtools workspace dev-loop --prepare",
-            "save_preflight": f"mkdir -p {run_log_dir} && devtools workspace dev-loop --json > {preflight_json}",
-            "receiver_smoke": "devtools workspace dev-loop --receiver-smoke --json",
+            "prepare": (
+                f"devtools workspace dev-loop --api-port {api_port} "
+                f"--browser-capture-port {browser_capture_port} --prepare"
+            ),
+            "prepare_isolated": "devtools workspace dev-loop --isolated-ports --prepare",
+            "save_preflight": (
+                f"mkdir -p {run_log_dir} && devtools workspace dev-loop --api-port {api_port} "
+                f"--browser-capture-port {browser_capture_port} --json > {preflight_json}"
+            ),
+            "receiver_smoke": (
+                f"devtools workspace dev-loop --api-port {api_port} "
+                f"--browser-capture-port {browser_capture_port} --receiver-smoke --json"
+            ),
             "run_daemon": (
                 f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
                 f"POLYLOGUE_API_PORT={api_port} "
@@ -1375,6 +1404,11 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=int(os.environ.get("POLYLOGUE_BROWSER_CAPTURE_PORT", DEFAULT_BROWSER_CAPTURE_PORT)),
     )
+    parser.add_argument(
+        "--isolated-ports",
+        action="store_true",
+        help="Pick currently-free loopback API and browser-capture ports for this dev-loop run.",
+    )
     parser.add_argument("--archive-root", type=Path, help="Branch-local archive root to report/use.")
     parser.add_argument("--log-dir", type=Path, help="Branch-local dev-loop log directory to report/use.")
     parser.add_argument("--prepare", action="store_true", help="Create the reported archive/log directories.")
@@ -1441,9 +1475,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.capture_cli and not args.json and "--" not in original_argv and capture_command[-1:] == ["--json"]:
         args.json = True
         capture_command = capture_command[:-1]
+    api_port = args.api_port
+    browser_capture_port = args.browser_capture_port
+    port_selection = "explicit"
+    if args.isolated_ports:
+        api_port, browser_capture_port = allocate_isolated_ports()
+        port_selection = "isolated"
     payload = build_dev_loop_status(
-        api_port=args.api_port,
-        browser_capture_port=args.browser_capture_port,
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
         archive_root=args.archive_root,
         log_dir=args.log_dir,
         prepare=args.prepare
@@ -1452,6 +1492,7 @@ def main(argv: list[str] | None = None) -> int:
         or args.extension_smoke
         or args.browser_plan
         or args.tui_plan,
+        port_selection=port_selection,
     )
     if args.receiver_smoke:
         smoke_payload: dict[str, Any] = {

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -62,12 +62,20 @@ If you keep the deployed service running, use different ports and verify the
 preflight output before starting the branch daemon:
 
 ```bash
+devtools workspace dev-loop --isolated-ports --prepare
 devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875
 ```
+
+`--isolated-ports` asks the dev-loop helper to allocate currently-free loopback
+ports and writes those exact ports into `preflight.json`, generated browser/TUI
+plans, and the copy-pastable daemon/CLI commands. Use explicit `--api-port` /
+`--browser-capture-port` when you need stable numbers for a longer debugging
+session.
 
 Then launch the branch-local daemon with the managed helper:
 
 ```bash
+devtools workspace dev-loop --isolated-ports --launch-daemon
 devtools workspace dev-loop --api-port 8876 --browser-capture-port 8875 --launch-daemon
 ```
 

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -128,6 +128,90 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     ]
 
 
+def test_build_dev_loop_status_marks_isolated_ports_without_service_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        dev_loop,
+        "system_service_status",
+        lambda: {
+            "unit": "polylogued.service",
+            "available": True,
+            "active": True,
+            "active_state": "active",
+            "main_pid": 123,
+            "archive_root": "/prod",
+        },
+    )
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    payload = dev_loop.build_dev_loop_status(
+        repo_root=repo,
+        api_port=9911,
+        browser_capture_port=9912,
+        prepare=True,
+        port_selection="isolated",
+    )
+
+    assert payload["port_selection"] == "isolated"
+    assert payload["run_id"] == "feature-dev-loop-abc1234-api9911-capture9912"
+    assert payload["warnings"] == []
+    assert payload["suggested_env"]["POLYLOGUE_API_PORT"] == "9911"
+    assert payload["suggested_env"]["POLYLOGUE_BROWSER_CAPTURE_PORT"] == "9912"
+    assert "--api-port 9911 --browser-capture-port 9912 --prepare" in payload["commands"]["prepare"]
+    assert payload["commands"]["prepare_isolated"] == "devtools workspace dev-loop --isolated-ports --prepare"
+    assert "--api-port 9911 --browser-capture-port 9912 --json" in payload["commands"]["save_preflight"]
+
+
+def test_main_isolated_ports_allocates_free_ports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": True})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+    monkeypatch.setattr(dev_loop, "allocate_isolated_ports", lambda: (9921, 9922))
+
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--isolated-ports",
+                "--log-dir",
+                str(tmp_path / "dev-loop-logs"),
+                "--archive-root",
+                str(tmp_path / "archive"),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["port_selection"] == "isolated"
+    assert payload["ports"]["api"]["port"] == 9921
+    assert payload["ports"]["browser_capture"]["port"] == 9922
+    assert payload["warnings"] == []
+    assert payload["commands"]["open_web_shell"] == "http://127.0.0.1:9921/"
+
+
 def test_main_json_outputs_machine_payload(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
Adds `devtools workspace dev-loop --isolated-ports` so branch-local daemon, browser, extension, and TUI plans can pick currently-free loopback ports instead of colliding with the deployed `polylogued.service` on 8765/8766.

## Problem
#2248’s dev-loop tooling could report port conflicts and document manual alternate ports, but the easy path still generated plans against the default deployed-service ports. On this workstation the deployed service commonly owns 8765/8766, so `--browser-plan` and related artifacts could point at the wrong process unless the operator manually chose ports first.

## Solution
The dev-loop helper now allocates isolated API and browser-capture ports on request, records `port_selection: isolated` in the preflight payload, and writes the selected ports into generated commands, browser/TUI plans, and environment snapshots. When isolated ports are selected, an active deployed service no longer produces the stop-service warning unless the chosen ports themselves are occupied. The docs now recommend `--isolated-ports` for branch-local work while production is still running.

## Verification
- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> `17 passed in 10.85s`
- `devtools workspace dev-loop --isolated-ports --prepare --browser-plan --json | python3 -c '...'` -> printed `isolated 37353 48751 []` and branch-local receiver/web URLs on those ports
- `devtools verify --quick` -> exit code 0 (`20260621T124603Z-quick-3555186-1260fe4f`)
- pre-push `devtools verify --quick` -> exit code 0 (`20260621T124635Z-quick-3556239-b3c57b0b`)

Ref #2248