### PR TITLE
docs: simplify README archive overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,12 @@ Polylogue is that substrate, and a cockpit over it:
   to guess at), blob storage is content-addressed, and the daemon exposes
   health checks and Prometheus metrics.
 
-## Architecture at a glance
+## Archive model
 
-```
-source files (JSON/JSONL/ZIP)
-  → detect_provider()          shape-based, not filename
-  → provider parser            parsers/{chatgpt,claude,codex,drive,…}.py
-  → content hash (NFC)         SHA-256 over normalized payload
-  → store (upsert-if-changed)  idempotent by content hash
-  → session insights           profiles, work events, phases, threads
-  → FTS index                  unicode61 tokenizer
-
-           CLI / MCP / HTTP Reader / Python API
-                       ↑
-                 filter chain → query → storage
-```
-
-Polylogue has four rings: archive substrate, derived read models, user and
-machine surfaces, and verification/maintenance. The substrate owns stored
-meaning; everything else derives from it, exposes it, or verifies it. The
-archive itself is a split-tier SQLite file set:
+Polylogue is organized around one rule: source evidence and user-authored
+state are durable; search indexes, insight read models, embeddings, and daemon
+telemetry are rebuildable. The archive uses a split-tier SQLite file set so
+each class can be backed up, rebuilt, and inspected independently:
 
 - `source.db` — raw acquisition evidence and source artifacts;
 - `index.db` — parsed sessions, messages, FTS/search indexes, and derived
@@ -97,9 +83,12 @@ archive itself is a split-tier SQLite file set:
   operational state.
 
 Large binary content lives in a content-addressed blob store keyed by SHA-256.
+The CLI, MCP server, daemon reader, and Python API all read through the same
+archive/query substrate rather than maintaining separate stores.
 
-See [docs/architecture.md](docs/architecture.md) for the ring boundaries and
-[docs/internals.md](docs/internals.md) for hot files and extension points.
+See [docs/architecture.md](docs/architecture.md) for the system rings and data
+flow, and [docs/internals.md](docs/internals.md) for hot files, invariants, and
+extension points.
 
 ## Privacy and local-first
 


### PR DESCRIPTION
## Summary

Simplifies the top-level README by replacing the duplicated ASCII architecture diagram with a shorter archive-model summary.

## Problem

The README was carrying a second architecture overview that duplicated the canonical architecture and internals docs. That made the top-level page heavier than it needs to be and increased the chance of stale architecture wording.

## Solution

Removed the large inline architecture flow diagram and rewrote the section as a concise split-tier archive model: durable source/user tiers, rebuildable index/embedding tiers, disposable ops telemetry, and shared archive/query substrate across surfaces.

## Verification

- `devtools verify doc-commands` -> `76 doc files scanned, no stale commands`
- `devtools render docs-surface --check` -> `render docs-surface: sync OK`
- pre-push `devtools verify --quick` -> exit 0 (`20260621T125046Z-quick-3593880-60f1cafa`)