### PR TITLE
refactor(query): bind unit fields through descriptors (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -112,6 +112,7 @@ from polylogue.archive.query.metadata import (
     date_query_fields,
     date_query_operators,
     query_unit_descriptor,
+    query_unit_field_info,
     query_unit_field_names,
     structural_query_fields,
     structural_query_units,
@@ -963,13 +964,17 @@ def _field_ref_for_predicate(
     if unit == "session":
         return QueryFieldRef(scope="session", name=predicate.field, source_name=predicate.field)
     if session_field is not None:
+        field_info = query_unit_field_info(unit, predicate.field)
+        source_name = field_info.name if field_info is not None else predicate.field
         return QueryFieldRef(
             scope="session",
             name=session_field,
-            source_name=predicate.field,
+            source_name=source_name,
             unit=unit,
         )
-    return QueryFieldRef(scope="unit", name=predicate.field, source_name=predicate.field, unit=unit)
+    field_info = query_unit_field_info(unit, predicate.field)
+    field_name = field_info.name if field_info is not None else predicate.field
+    return QueryFieldRef(scope="unit", name=field_name, source_name=field_name, unit=unit)
 
 
 def _bind_predicate_context(

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -1061,17 +1061,26 @@ def query_unit_field_names(unit_or_source: str) -> tuple[str, ...]:
     return tuple(field.name for field in descriptor.fields)
 
 
-def terminal_query_field_info(source: str, field: str) -> StructuralQueryFieldInfo | None:
-    """Return metadata for a field accepted after ``<source> where``."""
+def query_unit_field_info(unit_or_source: str, field: str) -> StructuralQueryFieldInfo | None:
+    """Return descriptor-owned metadata for a query-unit field."""
 
-    descriptor = query_unit_descriptor(source)
-    if descriptor is None or not descriptor.terminal_supported:
+    descriptor = query_unit_descriptor(unit_or_source)
+    if descriptor is None:
         return None
     normalized = field.lower()
     for field_info in descriptor.fields:
         if field_info.name == normalized:
             return field_info
     return None
+
+
+def terminal_query_field_info(source: str, field: str) -> StructuralQueryFieldInfo | None:
+    """Return metadata for a field accepted after ``<source> where``."""
+
+    descriptor = query_unit_descriptor(source)
+    if descriptor is None or not descriptor.terminal_supported:
+        return None
+    return query_unit_field_info(source, field)
 
 
 def terminal_query_pipeline_stage_infos(source: str) -> tuple[QueryPipelineStageInfo, ...]:
@@ -1229,6 +1238,7 @@ __all__ = [
     "numeric_query_operators",
     "query_unit_descriptor",
     "query_unit_descriptors",
+    "query_unit_field_info",
     "structural_query_field_info",
     "structural_query_fields",
     "structural_query_units",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5034,9 +5034,14 @@ def _structural_predicate_clause(
         if session_field is not None:
             if session_alias is None:
                 raise ValueError(f"session-scoped {unit} predicate requires a session alias")
+            session_predicate = (
+                predicate
+                if predicate.field_ref is not None and predicate.field_ref.scope == "session"
+                else QueryFieldPredicate(field=session_field, values=predicate.values, op=predicate.op)
+            )
             return _field_predicate_clause(
                 session_alias,
-                QueryFieldPredicate(field=session_field, values=predicate.values, op=predicate.op),
+                session_predicate,
                 tags_relation="session_tags",
             )
         if unit == "message":

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -639,6 +639,19 @@ class TestBooleanQueryExpression:
                 QueryFieldPredicate(field="origin", values=("claude-code-session",)),
             ),
         )
+        session_predicate = source.session_predicate
+        session_repo = cast(QueryFieldPredicate, session_predicate.children[0])
+        session_origin = cast(QueryFieldPredicate, session_predicate.children[1])
+        assert session_repo.field_ref is not None
+        assert session_repo.field_ref.scope == "session"
+        assert session_repo.field_ref.name == "repo"
+        assert session_repo.field_ref.source_name == "repo"
+        assert session_repo.field_ref.unit is None
+        assert session_origin.field_ref is not None
+        assert session_origin.field_ref.scope == "session"
+        assert session_origin.field_ref.name == "origin"
+        assert session_origin.field_ref.source_name == "origin"
+        assert session_origin.field_ref.unit is None
         assert source.predicate == QueryBoolPredicate(
             op="and",
             children=(


### PR DESCRIPTION
## Summary

Tightens the query DSL field-binding path so terminal-unit predicates use descriptor-owned field metadata when attaching executable `QueryFieldRef`s.

## Problem

#2006's remaining typedness work is no longer a missing `QueryFieldRef` concept: the parser already attaches refs. The weaker point was that `_field_ref_for_predicate` reproduced string field names directly, and SQL structural session delegation created a fresh unbound session predicate even when the parser had already validated the field. That kept descriptor metadata from being the actual field identity source in a few executable paths.

## Solution

Added `query_unit_field_info(...)` as a descriptor-owned lookup for query-unit field metadata, used it when binding unit and session-scoped terminal predicates, and preserved already-bound session predicates when SQL structural lowerers delegate `session.*` filters into the session clause. The new test coverage asserts that pipeline session stages keep validated session `field_ref`s before they are folded into terminal predicates.

This deliberately does not add any absence/rename test or a parallel query registry; it tightens the current descriptor/AST/lowering path.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k "field_ref or descriptor_backed or pipeline_session_source_scopes_terminal_unit_query or runtime_terminal_unit_accepts_descriptor_backed_session_scope" -q` -> `3 passed, 333 deselected`
- `devtools test tests/unit/cli/test_query_expression.py tests/unit/core/test_query_descriptor_parity.py -q` -> `341 passed in 92.16s`
- `devtools verify --quick` -> exit 0 (`20260621T125819Z-quick-3652921-0294d7fa`)

Ref #2006