### PR TITLE
fix(dev): compose dev-loop browser artifacts (#2248)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -1494,17 +1494,6 @@ def main(argv: list[str] | None = None) -> int:
         or args.tui_plan,
         port_selection=port_selection,
     )
-    if args.receiver_smoke:
-        smoke_payload: dict[str, Any] = {
-            "preflight": payload,
-            "receiver_smoke": run_receiver_smoke(spool_path=Path(str(payload["run_log_dir"])) / "receiver-smoke-spool"),
-        }
-        if args.json:
-            json.dump(smoke_payload, sys.stdout, indent=2, sort_keys=True)
-            sys.stdout.write("\n")
-        else:
-            _print_receiver_smoke(smoke_payload)
-        return 0 if smoke_payload["receiver_smoke"]["ok"] else 1
     if args.capture_cli:
         try:
             capture_payload = run_cli_capture(
@@ -1514,15 +1503,15 @@ def main(argv: list[str] | None = None) -> int:
             )
         except ValueError as exc:
             parser.error(str(exc))
-        combined_payload: dict[str, Any] = {
+        cli_payload: dict[str, Any] = {
             "preflight": payload,
             "cli_capture": capture_payload,
         }
         if args.json:
-            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
+            json.dump(cli_payload, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         else:
-            _print_cli_capture(combined_payload)
+            _print_cli_capture(cli_payload)
         capture_exit = capture_payload["exit_code"]
         if not isinstance(capture_exit, int):
             capture_exit = 1
@@ -1535,58 +1524,55 @@ def main(argv: list[str] | None = None) -> int:
             )
         except ValueError as exc:
             parser.error(str(exc))
-        combined_payload = {
+        daemon_payload = {
             "preflight": payload,
             "daemon_launch": launch_payload,
         }
         if args.json:
-            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
+            json.dump(daemon_payload, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         else:
-            _print_daemon_launch(combined_payload)
+            _print_daemon_launch(daemon_payload)
         return 0 if launch_payload.get("ok") is True else 1
+
+    combined_payload: dict[str, Any] = {"preflight": payload}
+    combined_ok = True
+    if args.receiver_smoke:
+        receiver_smoke = run_receiver_smoke(spool_path=Path(str(payload["run_log_dir"])) / "receiver-smoke-spool")
+        combined_payload["receiver_smoke"] = receiver_smoke
+        combined_ok = combined_ok and receiver_smoke.get("ok") is True
     if args.extension_smoke:
         smoke_payload = run_extension_smoke(preflight=payload)
-        combined_payload = {
-            "preflight": payload,
-            "extension_smoke": smoke_payload,
-        }
-        if args.json:
-            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
-            sys.stdout.write("\n")
-        else:
-            _print_extension_smoke(combined_payload)
-        return 0 if smoke_payload.get("ok") is True else 1
+        combined_payload["extension_smoke"] = smoke_payload
+        combined_ok = combined_ok and smoke_payload.get("ok") is True
     if args.browser_plan:
         try:
             browser_plan = build_browser_plan(preflight=payload)
         except ValueError as exc:
             parser.error(str(exc))
-        combined_payload = {
-            "preflight": payload,
-            "browser_plan": browser_plan,
-        }
-        if args.json:
-            json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
-            sys.stdout.write("\n")
-        else:
-            _print_browser_plan(combined_payload)
-        return 0 if browser_plan.get("ok") is True else 1
+        combined_payload["browser_plan"] = browser_plan
+        combined_ok = combined_ok and browser_plan.get("ok") is True
     if args.tui_plan:
         try:
             tui_plan = build_tui_plan(preflight=payload)
         except ValueError as exc:
             parser.error(str(exc))
-        combined_payload = {
-            "preflight": payload,
-            "tui_plan": tui_plan,
-        }
+        combined_payload["tui_plan"] = tui_plan
+        combined_ok = combined_ok and tui_plan.get("ok") is True
+    if len(combined_payload) > 1:
         if args.json:
             json.dump(combined_payload, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         else:
-            _print_tui_plan(combined_payload)
-        return 0 if tui_plan.get("ok") is True else 1
+            if "receiver_smoke" in combined_payload:
+                _print_receiver_smoke(combined_payload)
+            if "extension_smoke" in combined_payload:
+                _print_extension_smoke(combined_payload)
+            if "browser_plan" in combined_payload:
+                _print_browser_plan(combined_payload)
+            if "tui_plan" in combined_payload:
+                _print_tui_plan(combined_payload)
+        return 0 if combined_ok else 1
     if args.json:
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -279,6 +279,7 @@ For service-worker-to-receiver coverage, run the extension smoke:
 ```bash
 devtools workspace dev-loop --extension-smoke
 devtools workspace dev-loop --extension-smoke --json
+devtools workspace dev-loop --browser-plan --extension-smoke --json
 ```
 
 This starts a temporary local browser-capture receiver, imports the actual
@@ -299,6 +300,9 @@ It does not need authenticated ChatGPT/Claude.ai cookies and does not claim to
 prove GUI content-script injection. Use the same run id and receiver settings
 when you then load `browser-extension/` unpacked into an agent/private Chrome
 profile for real-page inspection.
+Combine it with `--browser-plan` when you want one run id and browser artifact
+directory containing both the synthetic extension proof and the real-browser
+handoff plan.
 
 For GUI/browser inspection, generate a branch-local browser plan:
 

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -385,6 +385,57 @@ def test_browser_plan_writes_local_extension_launch_artifacts(
     assert event_rows[-1]["payload"]["receiver_url"] == "http://127.0.0.1:9875"
 
 
+def test_browser_plan_and_extension_smoke_can_share_one_dev_loop_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--log-dir",
+                str(tmp_path / "dev-loop-logs"),
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--api-port",
+                "9876",
+                "--browser-capture-port",
+                "9875",
+                "--browser-plan",
+                "--extension-smoke",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["browser_plan"]["ok"] is True
+    assert payload["extension_smoke"]["ok"] is True
+    browser_artifacts = payload["browser_plan"]["artifacts"]
+    smoke_artifacts = payload["extension_smoke"]["artifacts"]
+    assert Path(browser_artifacts["json"]).is_file()
+    assert Path(smoke_artifacts["summary"]).is_file()
+
+    event_rows = [
+        json.loads(line)
+        for line in Path(payload["preflight"]["artifacts"]["dev_events"]).read_text(encoding="utf-8").splitlines()
+    ]
+    event_types = [row["event_type"] for row in event_rows]
+    assert "browser_plan_written" in event_types
+    assert event_types[-3:] == ["extension_smoke_requested", "extension_smoke_finished", "browser_plan_written"]
+
+
 def test_tui_plan_writes_visual_inspection_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Makes `devtools workspace dev-loop` compose browser artifact actions, so `--browser-plan --extension-smoke` produces both the real-browser handoff plan and the synthetic extension proof under one run id.

## Problem

While exercising #2248 on `master`, `devtools workspace dev-loop --isolated-ports --prepare --browser-plan --extension-smoke --json` only returned the extension-smoke payload. The command returned before building `browser-plan.json`, so the exact workflow meant to pair the synthetic receiver proof with the browser-control handoff silently skipped half the artifacts.

## Solution

Kept daemon launch and CLI capture as dedicated actions, but changed the non-exclusive artifact actions (`receiver-smoke`, `extension-smoke`, `browser-plan`, `tui-plan`) to accumulate into one payload and one exit decision. Added a regression test for the combined browser-plan plus extension-smoke path and documented the combined command.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` -> `18 passed in 16.66s`
- `devtools workspace dev-loop --isolated-ports --prepare --browser-plan --extension-smoke --json > /realm/tmp/polylogue-dev-loop-combined-2248.json` -> run id `feature-fix-dev-loop-combined-browser-artifacts-2248-45b160c80-api54781-capture37625`, warnings `[]`, `browser_plan.ok=true`, `extension_smoke.ok=true`, both summary JSON files present
- `devtools verify --quick` -> exit 0 (`20260621T130601Z-quick-3667882-a331423c`)

Ref #2248