### PR TITLE
chore(dev): add real browser extension smoke (#2248)

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src/ tests/",
     "validate": "node scripts/validate-manifest.mjs",
     "dev-loop-smoke": "node scripts/dev-loop-smoke.mjs",
+    "dev-loop-browser-smoke": "node scripts/dev-loop-browser-smoke.mjs",
     "build": "node scripts/build.mjs",
     "screenshots": "node scripts/screenshots.mjs",
     "sync-version": "node scripts/build.mjs --sync-only"

--- a/browser-extension/scripts/dev-loop-browser-smoke.mjs
+++ b/browser-extension/scripts/dev-loop-browser-smoke.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Launch Chrome with the unpacked extension, verify the MV3 service worker is
+// the Polylogue extension, then exercise the local receiver from the extension
+// service-worker origin. This intentionally has no npm dependencies.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const receiverBaseUrl = (process.env.POLYLOGUE_BROWSER_SMOKE_RECEIVER_URL || "http://127.0.0.1:8765").replace(/\/+$/, "");
+const receiverAuthToken = process.env.POLYLOGUE_BROWSER_SMOKE_RECEIVER_TOKEN || "";
+const extensionRoot = path.resolve(process.env.POLYLOGUE_BROWSER_SMOKE_EXTENSION_ROOT || ".");
+const chromeBinary = process.env.POLYLOGUE_BROWSER_SMOKE_CHROME || "google-chrome-stable";
+const outputPath = process.env.POLYLOGUE_BROWSER_SMOKE_OUT || "";
+const profileDir =
+  process.env.POLYLOGUE_BROWSER_SMOKE_PROFILE_DIR || mkdtempSync(path.join(tmpdir(), "polylogue-browser-smoke-"));
+const keepProfile = process.env.POLYLOGUE_BROWSER_SMOKE_KEEP_PROFILE === "1";
+const timeoutMs = Number(process.env.POLYLOGUE_BROWSER_SMOKE_TIMEOUT_MS || "20000");
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitJson(url, timeout = timeoutMs) {
+  const deadline = Date.now() + timeout;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return await response.json();
+      lastError = `${response.status} ${await response.text()}`;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+  throw new Error(`timed out waiting for ${url}: ${lastError}`);
+}
+
+let nextCdpId = 0;
+
+function connectCdp(webSocketDebuggerUrl) {
+  const socket = new WebSocket(webSocketDebuggerUrl);
+  const pending = new Map();
+  socket.onmessage = (event) => {
+    const message = JSON.parse(event.data);
+    if (!message.id || !pending.has(message.id)) return;
+    const callbacks = pending.get(message.id);
+    pending.delete(message.id);
+    if (message.error) callbacks.reject(new Error(JSON.stringify(message.error)));
+    else callbacks.resolve(message.result);
+  };
+  return new Promise((resolve, reject) => {
+    socket.onerror = reject;
+    socket.onopen = () => {
+      resolve({
+        call(method, params = {}) {
+          const id = ++nextCdpId;
+          socket.send(JSON.stringify({ id, method, params }));
+          return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+        },
+        close() {
+          socket.close();
+        },
+      });
+    };
+  });
+}
+
+function fixtureEnvelope() {
+  return {
+    polylogue_capture_kind: "browser_llm_session",
+    schema_version: 1,
+    capture_id: "browser-smoke:dev-loop-browser-smoke",
+    source: "browser-extension",
+    provenance: {
+      source_url: "https://chatgpt.com/c/dev-loop-browser-smoke",
+      page_title: "Polylogue real browser smoke",
+      captured_at: "2026-06-21T00:00:00+00:00",
+      adapter_name: "dev-loop-real-browser-smoke",
+      capture_mode: "snapshot",
+    },
+    session: {
+      provider: "chatgpt",
+      provider_session_id: "dev-loop-browser-smoke",
+      title: "Polylogue real browser smoke",
+      turns: [{ provider_turn_id: "turn-1", role: "user", text: "real browser smoke" }],
+    },
+  };
+}
+
+async function evaluateJson(client, expression) {
+  const result = await client.call("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text || "CDP evaluation failed");
+  }
+  return result.result?.value;
+}
+
+async function main() {
+  const localManifest = JSON.parse(readFileSync(path.join(extensionRoot, "manifest.json"), "utf8"));
+  const debuggingPort = await freePort();
+  const chromeArgs = [
+    `--user-data-dir=${profileDir}`,
+    `--remote-debugging-port=${debuggingPort}`,
+    "--headless=new",
+    `--disable-extensions-except=${extensionRoot}`,
+    `--load-extension=${extensionRoot}`,
+    "about:blank",
+  ];
+  const chrome = spawn(chromeBinary, chromeArgs, { stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  chrome.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  chrome.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    const deadline = Date.now() + timeoutMs;
+    let worker = null;
+    let workerClient = null;
+    let targets = [];
+    while (Date.now() < deadline && !worker) {
+      targets = await waitJson(`http://127.0.0.1:${debuggingPort}/json/list`, Math.min(2000, timeoutMs));
+      const candidates = targets.filter(
+        (target) => target.type === "service_worker" && target.url.endsWith("/service_worker.js")
+      );
+      for (const candidate of candidates) {
+        const client = await connectCdp(candidate.webSocketDebuggerUrl);
+        await client.call("Runtime.enable");
+        worker = candidate;
+        workerClient = client;
+        break;
+      }
+      if (!worker) await sleep(250);
+    }
+    if (!worker || !workerClient) {
+      throw new Error(`Polylogue extension service worker not found; targets=${JSON.stringify(targets)}`);
+    }
+    const extensionId = new URL(worker.url).host;
+    const authHeader = JSON.stringify(`Bearer ${receiverAuthToken}`);
+    const receiverUrl = JSON.stringify(receiverBaseUrl);
+    const envelope = JSON.stringify(fixtureEnvelope());
+    const fetchProbe = await evaluateJson(
+      workerClient,
+      `(async () => {
+        async function request(label, url, init) {
+          try {
+            const response = await fetch(url, init);
+            return {
+              label,
+              status: response.status,
+              request_id: response.headers.get("X-Request-ID"),
+              body: await response.json().catch(() => ({}))
+            };
+          } catch (error) {
+            return {label, threw: String(error && error.message ? error.message : error)};
+          }
+        }
+        return Promise.all([
+          request("unauthenticated", ${receiverUrl} + "/v1/browser-captures", {
+            method: "POST",
+            headers: {"Content-Type": "application/json", "X-Request-ID": "browser-smoke-reject"},
+            body: JSON.stringify(${envelope})
+          }),
+          request("status", ${receiverUrl} + "/v1/status", {
+            headers: {"Authorization": ${authHeader}, "X-Request-ID": "browser-smoke-status"}
+          }),
+          request("capture", ${receiverUrl} + "/v1/browser-captures", {
+            method: "POST",
+            headers: {"Content-Type": "application/json", "Authorization": ${authHeader}, "X-Request-ID": "browser-smoke-capture"},
+            body: JSON.stringify(${envelope})
+          })
+        ]);
+      })()`
+    );
+    workerClient.close();
+    const [unauthenticated, status, capture] = fetchProbe;
+    const summary = {
+      ok:
+        unauthenticated.status === 401 &&
+        status.status === 200 &&
+        capture.status === 202 &&
+        Boolean(capture.body?.artifact_ref),
+      chrome_binary: chromeBinary,
+      chrome_args: chromeArgs,
+      debugging_port: debuggingPort,
+      extension_id: extensionId,
+      extension_root: extensionRoot,
+      manifest: {
+        name: localManifest.name,
+        version: localManifest.version,
+        manifest_version: localManifest.manifest_version,
+      },
+      profile_dir: profileDir,
+      receiver_base_url: receiverBaseUrl,
+      service_worker_url: worker.url,
+      unauthenticated,
+      status,
+      capture,
+    };
+    if (outputPath) writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+    if (!summary.ok) process.exitCode = 1;
+  } finally {
+    chrome.kill("SIGTERM");
+    await new Promise((resolve) => chrome.once("exit", resolve));
+    if (!keepProfile && !process.env.POLYLOGUE_BROWSER_SMOKE_PROFILE_DIR) {
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+    if (stderr && process.exitCode) process.stderr.write(stderr);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message || error}\n`);
+  process.exit(1);
+});

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -410,6 +410,158 @@ def run_extension_smoke(*, preflight: dict[str, Any]) -> dict[str, object]:
     return payload
 
 
+def run_browser_smoke(*, preflight: dict[str, Any]) -> dict[str, object]:
+    """Run real Chrome with the unpacked extension against a local receiver."""
+
+    artifacts = preflight.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("preflight payload is missing artifact paths")
+    browser_dir = Path(str(artifacts["browser_dir"]))
+    browser_dir.mkdir(parents=True, exist_ok=True)
+    event_path = Path(str(artifacts.get("dev_events", Path(str(preflight["run_log_dir"])) / "dev-loop.events.jsonl")))
+    extension_root = Path(str(preflight["repo_root"])) / "browser-extension"
+    spool_path = browser_dir / "browser-smoke-spool"
+    profile_dir = browser_dir / "browser-smoke-profile"
+    summary_path = browser_dir / "browser-smoke.json"
+    result_path = browser_dir / "browser-smoke-result.json"
+    stdout_path = browser_dir / "browser-smoke.stdout"
+    stderr_path = browser_dir / "browser-smoke.stderr"
+    env_path = browser_dir / "browser-smoke.env.json"
+
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="browser",
+        event_type="browser_smoke_requested",
+        status="starting",
+        payload={
+            "extension_root": str(extension_root),
+            "profile_dir": str(profile_dir),
+            "spool_path": str(spool_path),
+        },
+    )
+
+    spool_path.mkdir(parents=True, exist_ok=True)
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    server = make_server(
+        "127.0.0.1",
+        0,
+        spool_path=spool_path,
+        auth_token=_RECEIVER_SMOKE_TOKEN,
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    if isinstance(host, bytes):
+        host = host.decode("ascii")
+    receiver_url = f"http://{host}:{port}"
+    env = os.environ.copy()
+    env.update(
+        {
+            "POLYLOGUE_BROWSER_SMOKE_EXTENSION_ROOT": str(extension_root),
+            "POLYLOGUE_BROWSER_SMOKE_KEEP_PROFILE": "1",
+            "POLYLOGUE_BROWSER_SMOKE_OUT": str(result_path),
+            "POLYLOGUE_BROWSER_SMOKE_PROFILE_DIR": str(profile_dir),
+            "POLYLOGUE_BROWSER_SMOKE_RECEIVER_TOKEN": _RECEIVER_SMOKE_TOKEN,
+            "POLYLOGUE_BROWSER_SMOKE_RECEIVER_URL": receiver_url,
+        }
+    )
+    env_path.write_text(json.dumps(_dev_loop_env_snapshot(env), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["npm", "run", "dev-loop-browser-smoke", "--silent"],
+            cwd=str(extension_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=35,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _decode_timeout_stream(exc.stdout)
+        stderr = _decode_timeout_stream(exc.stderr)
+        result_payload: dict[str, object] | None = None
+        exit_code = 124
+        stderr = (stderr + "\n" if stderr else "") + "browser smoke timed out after 35s\n"
+    except OSError as exc:
+        stdout = ""
+        stderr = f"{type(exc).__name__}: {exc}\n"
+        result_payload = None
+        exit_code = 127
+    else:
+        stdout = result.stdout
+        stderr = result.stderr
+        exit_code = int(result.returncode)
+        result_payload = None
+        if result_path.exists():
+            result_payload = json.loads(result_path.read_text(encoding="utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    artifact_ref = None
+    artifact_path: Path | None = None
+    extension_id = None
+    manifest = None
+    if isinstance(result_payload, dict):
+        extension_id = result_payload.get("extension_id")
+        raw_manifest = result_payload.get("manifest")
+        manifest = raw_manifest if isinstance(raw_manifest, dict) else None
+        capture = result_payload.get("capture")
+        if isinstance(capture, dict):
+            body = capture.get("body")
+            if isinstance(body, dict):
+                artifact_ref = body.get("artifact_ref")
+                if isinstance(artifact_ref, str):
+                    artifact_path = spool_path / artifact_ref
+    ok = exit_code == 0 and artifact_path is not None and artifact_path.exists()
+    payload: dict[str, object] = {
+        "ok": ok,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "extension_id": extension_id,
+        "extension_root": str(extension_root),
+        "manifest": manifest,
+        "profile_dir": str(profile_dir),
+        "receiver_url": receiver_url,
+        "spool_path": str(spool_path),
+        "artifact_ref": artifact_ref,
+        "artifact_path": str(artifact_path) if artifact_path is not None else None,
+        "result": result_payload,
+        "artifacts": {
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "summary": str(summary_path),
+            "result": str(result_path),
+            "env": str(env_path),
+            "profile": str(profile_dir),
+            "spool": str(spool_path),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_dev_loop_event(
+        event_path,
+        preflight=preflight,
+        surface="browser",
+        event_type="browser_smoke_finished",
+        status="ok" if ok else "failed",
+        payload={
+            "exit_code": exit_code,
+            "duration_ms": duration_ms,
+            "extension_id": extension_id,
+            "artifact_ref": artifact_ref,
+            "artifact_path": str(artifact_path) if artifact_path is not None else None,
+            "artifacts": payload["artifacts"],
+        },
+    )
+    return payload
+
+
 def _decode_timeout_stream(value: bytes | str | None) -> str:
     if value is None:
         return ""
@@ -774,6 +926,7 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
     summary_files = {
         "daemon_launch": run_dir / "polylogued.launch.json",
         "browser_plan": run_dir / "browser" / "browser-plan.json",
+        "browser_smoke": run_dir / "browser" / "browser-smoke.json",
         "extension_smoke": run_dir / "browser" / "extension-smoke.json",
         "tui_plan": run_dir / "tui" / "tui-plan.json",
     }
@@ -1336,6 +1489,23 @@ def _print_extension_smoke(payload: dict[str, Any]) -> None:
     print(f"  summary:  {artifacts['summary']}")
 
 
+def _print_browser_smoke(payload: dict[str, Any]) -> None:
+    preflight = payload["preflight"]
+    smoke = payload["browser_smoke"]
+    assert isinstance(preflight, dict)
+    assert isinstance(smoke, dict)
+    artifacts = smoke["artifacts"]
+    assert isinstance(artifacts, dict)
+    print("Polylogue dev-loop real browser smoke")
+    print(f"  run id:    {preflight['run_id']}")
+    print(f"  ok:        {smoke['ok']}")
+    print(f"  receiver:  {smoke['receiver_url']}")
+    print(f"  extension: {smoke.get('extension_id')}")
+    print(f"  artifact:  {smoke.get('artifact_ref')}")
+    print(f"  profile:   {artifacts['profile']}")
+    print(f"  summary:   {artifacts['summary']}")
+
+
 def _print_browser_plan(payload: dict[str, Any]) -> None:
     preflight = payload["preflight"]
     plan = payload["browser_plan"]
@@ -1439,6 +1609,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Run the browser-extension background worker against a temporary local receiver.",
     )
     parser.add_argument(
+        "--browser-smoke",
+        action="store_true",
+        help="Launch real Chrome headless with the unpacked extension against a temporary receiver.",
+    )
+    parser.add_argument(
         "--browser-plan",
         action="store_true",
         help="Write branch-local browser profile, extension load, receiver, and inspection plan artifacts.",
@@ -1490,6 +1665,7 @@ def main(argv: list[str] | None = None) -> int:
         or args.receiver_smoke
         or args.launch_daemon
         or args.extension_smoke
+        or args.browser_smoke
         or args.browser_plan
         or args.tui_plan,
         port_selection=port_selection,
@@ -1545,6 +1721,10 @@ def main(argv: list[str] | None = None) -> int:
         smoke_payload = run_extension_smoke(preflight=payload)
         combined_payload["extension_smoke"] = smoke_payload
         combined_ok = combined_ok and smoke_payload.get("ok") is True
+    if args.browser_smoke:
+        smoke_payload = run_browser_smoke(preflight=payload)
+        combined_payload["browser_smoke"] = smoke_payload
+        combined_ok = combined_ok and smoke_payload.get("ok") is True
     if args.browser_plan:
         try:
             browser_plan = build_browser_plan(preflight=payload)
@@ -1568,6 +1748,8 @@ def main(argv: list[str] | None = None) -> int:
                 _print_receiver_smoke(combined_payload)
             if "extension_smoke" in combined_payload:
                 _print_extension_smoke(combined_payload)
+            if "browser_smoke" in combined_payload:
+                _print_browser_smoke(combined_payload)
             if "browser_plan" in combined_payload:
                 _print_browser_plan(combined_payload)
             if "tui_plan" in combined_payload:

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -304,6 +304,36 @@ Combine it with `--browser-plan` when you want one run id and browser artifact
 directory containing both the synthetic extension proof and the real-browser
 handoff plan.
 
+For a local proof that real Chrome can load the unpacked extension and reach the
+branch-local receiver from the extension-origin service-worker context, run:
+
+```bash
+devtools workspace dev-loop --browser-smoke
+devtools workspace dev-loop --browser-smoke --json
+devtools workspace dev-loop --browser-plan --extension-smoke --browser-smoke --json
+```
+
+This launches `google-chrome-stable` in headless mode with
+`--load-extension=browser-extension`, discovers the Polylogue MV3 service worker
+over Chrome DevTools Protocol, reads the extension manifest, starts a temporary
+branch-local receiver, then sends unauthenticated and authenticated receiver
+requests from the extension service-worker context. It writes
+`browser_smoke_requested` / `browser_smoke_finished` rows to
+`dev-loop.events.jsonl` plus:
+
+```text
+.cache/dev-loop/<run-id>/browser/browser-smoke.json
+.cache/dev-loop/<run-id>/browser/browser-smoke-result.json
+.cache/dev-loop/<run-id>/browser/browser-smoke-profile/
+.cache/dev-loop/<run-id>/browser/browser-smoke-spool/
+```
+
+This still does not claim authenticated ChatGPT/Claude.ai DOM adapter coverage.
+It proves the repo-owned unpacked-extension + real-browser + receiver plumbing.
+Use `--browser-plan` for the visible/private browser handoff when content-script
+diagnostics, screenshots, copied-profile cookies, or real provider pages are
+needed.
+
 For GUI/browser inspection, generate a branch-local browser plan:
 
 ```bash

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -170,7 +170,7 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         self.send_header("X-Request-ID", self._request_id())
         self.send_header("Access-Control-Allow-Origin", origin or "null")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
         self.send_header("Access-Control-Max-Age", "600")
         self.end_headers()
 

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -264,14 +264,17 @@ def test_receiver_auth_allows_cors_preflight_without_bearer_token(tmp_path: Path
             "/v1/browser-captures",
             headers={
                 "Origin": _CHATGPT_ORIGIN,
-                "Access-Control-Request-Headers": "authorization, content-type",
+                "Access-Control-Request-Headers": "authorization, content-type, x-request-id",
             },
         )
         response = conn.getresponse()
+        allow_headers = response.getheader("Access-Control-Allow-Headers")
         response.read()
         conn.close()
 
     assert response.status == HTTPStatus.NO_CONTENT
+    assert allow_headers is not None
+    assert "X-Request-ID" in allow_headers
 
 
 def test_receiver_allows_extra_web_origin_only_with_token(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -436,6 +436,83 @@ def test_browser_plan_and_extension_smoke_can_share_one_dev_loop_run(
     assert event_types[-3:] == ["extension_smoke_requested", "extension_smoke_finished", "browser_plan_written"]
 
 
+def test_browser_smoke_records_real_chrome_extension_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(dev_loop, "system_service_status", lambda: {"active": False})
+    monkeypatch.setattr(
+        dev_loop,
+        "port_status",
+        lambda port: {"port": port, "connectable": False, "owner_count": 0, "owners": []},
+    )
+    monkeypatch.setattr(
+        dev_loop, "_git_value", lambda args, *, cwd: "feature/dev-loop" if args[0] == "branch" else "abc1234"
+    )
+
+    class Completed:
+        returncode = 0
+        stdout = '{"ok":true}\n'
+        stderr = ""
+
+    def fake_run(*args: object, **kwargs: object) -> Completed:
+        env_obj = kwargs.get("env")
+        if not isinstance(env_obj, dict) or "POLYLOGUE_BROWSER_SMOKE_OUT" not in env_obj:
+            return Completed()
+        env = env_obj
+        output_path = Path(env["POLYLOGUE_BROWSER_SMOKE_OUT"])
+        artifact_ref = "chatgpt/dev-loop-browser-smoke.json"
+        artifact_path = output_path.parent / "browser-smoke-spool" / artifact_ref
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text('{"ok": true}\n', encoding="utf-8")
+        output_path.write_text(
+            json.dumps(
+                {
+                    "ok": True,
+                    "extension_id": "extension-id",
+                    "manifest": {"manifest_version": 3, "name": "Polylogue Browser Capture", "version": "0.1.0"},
+                    "capture": {"body": {"artifact_ref": artifact_ref}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return Completed()
+
+    monkeypatch.setattr("devtools.dev_loop.subprocess.run", fake_run)
+
+    assert (
+        dev_loop.main(
+            [
+                "--json",
+                "--log-dir",
+                str(tmp_path / "dev-loop-logs"),
+                "--archive-root",
+                str(tmp_path / "archive"),
+                "--browser-smoke",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    smoke = payload["browser_smoke"]
+    assert smoke["ok"] is True
+    assert smoke["extension_id"] == "extension-id"
+    assert smoke["artifact_ref"] == "chatgpt/dev-loop-browser-smoke.json"
+    assert Path(smoke["artifact_path"]).is_file()
+    artifacts = smoke["artifacts"]
+    assert Path(artifacts["summary"]).is_file()
+    assert Path(artifacts["profile"]).is_dir()
+    event_rows = [
+        json.loads(line)
+        for line in Path(payload["preflight"]["artifacts"]["dev_events"]).read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event_type"] for row in event_rows[-2:]] == ["browser_smoke_requested", "browser_smoke_finished"]
+    assert event_rows[-1]["surface"] == "browser"
+    assert event_rows[-1]["payload"]["extension_id"] == "extension-id"
+
+
 def test_tui_plan_writes_visual_inspection_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Add a repo-owned real-browser dev-loop smoke for #2248. The new `devtools workspace dev-loop --browser-smoke` launches Chrome with the unpacked `browser-extension/`, discovers the Polylogue MV3 service worker over CDP, and exercises a temporary branch-local receiver from the extension-origin context. It writes browser smoke summaries, stdout/stderr, env, profile, spool, and dev-loop event rows under the run-local artifact directory.

## Problem

The branch-local dev loop had preflight, daemon launch, CLI capture, browser-plan handoff, receiver smoke, and mocked extension-background smoke, but it still did not prove that a real Chrome instance could load the unpacked extension and reach the branch-local receiver. During the real-browser probe, receiver CORS preflight also rejected the extension's `X-Request-ID` header, which made request-id correlation fail in actual browser fetches despite passing non-browser mocks.

## Solution

- Added `browser-extension/scripts/dev-loop-browser-smoke.mjs`, a no-dependency Node/CDP script that launches Chrome headless with `--load-extension`, identifies the Polylogue service worker, and sends unauthenticated/authenticated receiver status/capture requests from the extension context.
- Wired `--browser-smoke` into `devtools workspace dev-loop`, including run-local artifacts, event rows, human/JSON output, and `--inspect-run` summaries.
- Updated `docs/dev-loop.md` to distinguish `--extension-smoke`, `--browser-smoke`, and `--browser-plan`.
- Fixed browser-capture receiver CORS preflight to allow `X-Request-ID`, with focused receiver coverage.

## Verification

- `node --check browser-extension/scripts/dev-loop-browser-smoke.mjs`
- `devtools workspace dev-loop --isolated-ports --prepare --browser-smoke --json`
  - run id: `feature-chore-dev-loop-browser-e2e-2248-c6f0820c2-api45189-capture52773`
  - result: `ok=True`
  - extension id: `fignfifoniblkonapihmkfakmlgkbkcf`
  - artifact: `chatgpt/dev-loop-browser-smoke-097ac33d4373.json`
- `devtools test tests/unit/devtools/test_dev_loop.py tests/unit/browser_capture/test_receiver.py -q`
  - `33 passed`
- `devtools verify --quick`
  - exit code 0, run id `20260621T132155Z-quick-3804056-eace7b81`

Ref #2248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser smoke testing capability to verify the extension works in headless Chrome with the local receiver.

* **Bug Fixes**
  * Added missing CORS header support for request tracing headers.

* **Documentation**
  * Updated development workflow documentation with browser testing instructions.

* **Tests**
  * Added automated test coverage for browser extension integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->