### PR TITLE
fix(cli): restore command-surface baseline coverage (#2253)

### DIFF
--- a/devtools/validation_lane_catalog_contracts.py
+++ b/devtools/validation_lane_catalog_contracts.py
@@ -103,6 +103,22 @@ CONTRACT_LANES: dict[str, LaneEntry] = {
             "tests/unit/core/test_session_semantics.py",
         ),
     ),
+    "schema-list-contract": LaneEntry(
+        name="schema-list-contract",
+        description="Devtools schema package catalog list surface and runtime projection coverage",
+        timeout_s=120,
+        category="contract",
+        execution=devtools_execution("lab schema list", "--json"),
+        tags=("contract", "schema", "devtools"),
+    ),
+    "schema-explain-contract": LaneEntry(
+        name="schema-explain-contract",
+        description="Devtools schema package explanation surface and runtime projection coverage",
+        timeout_s=120,
+        category="contract",
+        execution=devtools_execution("lab schema explain", "--provider", "chatgpt", "--json"),
+        tags=("contract", "schema", "devtools"),
+    ),
     "source-provider-fidelity": LaneEntry(
         name="source-provider-fidelity",
         description="Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity",

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -8,33 +8,33 @@ This reference is generated from the live validation-lane, mutation-campaign, an
 
 Current registry snapshot:
 
-- contract lanes: `24`
+- contract lanes: `26`
 - live lanes: `19`
 - composite lanes: `24`
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `252`
+- scenario projections: `254`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
   - exercise: `145`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
-  - validation-lane: `67`
+  - validation-lane: `69`
 
 ## Runtime Coverage
 
-- covered runtime paths: `21`
-- covered runtime artifacts: `45`
-- covered runtime operations: `25`
+- covered runtime paths: `23`
+- covered runtime artifacts: `47`
+- covered runtime operations: `27`
 - covered maintenance targets: `3`
-- covered declared operation targets: `46`
-- uncovered runtime paths: `schema-explain-query-loop`, `schema-list-query-loop`
-- uncovered runtime artifacts: `schema_explanation_results`, `schema_list_results`
-- uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`, `query-schema-catalog`, `query-schema-explanations`
+- covered declared operation targets: `48`
+- uncovered runtime paths: —
+- uncovered runtime artifacts: —
+- uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`
 - uncovered maintenance targets: `empty_sessions`, `message_embeddings`, `message_type_backfill`, `orphaned_attachments`, `orphaned_messages`, `superseded_raw_snapshots`, `wal_checkpoint`
-- uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`, `query-schema-catalog`, `query-schema-explanations`
+- uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`
 
 Inspect the full authored map with:
 
@@ -165,6 +165,8 @@ Use the named lanes through the runner.
 | `retrieval-checks` | 480 | Action-aware query truth, grouped retrieval stats, archive readiness, and MCP retrieval payload coverage |
 | `scale-fast` | 120 | Fast storage scale budgets |
 | `scale-slow` | 360 | Slow local storage scale budgets |
+| `schema-explain-contract` | 120 | Devtools schema package explanation surface and runtime projection coverage |
+| `schema-list-contract` | 120 | Devtools schema package catalog list surface and runtime projection coverage |
 | `semantic-insight-normalization` | 900 | Semantic/session insight normalization, operator/toolchain narrowing, schema contracts, and provider parser cleanup |
 | `semantic-stack` | 360 | Unified harmonization, semantic facts/profile convergence, and contract inventory coverage |
 | `source-provider-fidelity` | 420 | Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity |
@@ -542,6 +544,8 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `validation-lane` | `scale-fast` | — | — | — | — | — | Fast storage scale budgets |
 | `validation-lane` | `scale-slow` | — | — | — | — | — | Slow local storage scale budgets |
 | `validation-lane` | `scale-stretch` | — | — | — | — | — | Combined fast and slow storage scale budgets |
+| `validation-lane` | `schema-explain-contract` | `schema-explain-query-loop` | `schema_packages`<br>`schema_explanation_results` | `query-schema-explanations` | — | `contract`<br>`schema`<br>`devtools` | Devtools schema package explanation surface and runtime projection coverage |
+| `validation-lane` | `schema-list-contract` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `query-schema-catalog` | — | `contract`<br>`schema`<br>`devtools` | Devtools schema package catalog list surface and runtime projection coverage |
 | `validation-lane` | `semantic-insight-hardening` | `session-insight-status-query-loop`<br>`session-tag-rollup-query-loop`<br>`archive-coverage-query-loop`<br>`archive-debt-query-loop`<br>`message-fts-readiness-loop`<br>`retrieval-band-readiness-loop` | `session_insight_readiness`<br>`session_insight_status_results`<br>`session_tag_rollup_rows`<br>`session_tag_rollup_results`<br>`archive_session_rows`<br>`session_profile_rows`<br>`archive_coverage_results`<br>`archive_readiness`<br>`embedding_status_results`<br>`message_fts`<br>`archive_debt_results`<br>`retrieval_band_readiness` | `query-session-insight-status`<br>`query-session-tag-rollups`<br>`query-archive-coverage`<br>`query-archive-debt`<br>`cli.json-contract`<br>`project-archive-readiness` | — | `insights`<br>`status`<br>`tags`<br>`coverage`<br>`debt`<br>`maintenance`<br>`readiness`<br>`live`<br>`preview` | Full semantic-insight normalization and toolchain convergence lane |
 | `validation-lane` | `semantic-insight-live` | `session-insight-status-query-loop`<br>`session-tag-rollup-query-loop`<br>`archive-coverage-query-loop`<br>`archive-debt-query-loop`<br>`message-fts-readiness-loop`<br>`retrieval-band-readiness-loop` | `session_insight_readiness`<br>`session_insight_status_results`<br>`session_tag_rollup_rows`<br>`session_tag_rollup_results`<br>`archive_session_rows`<br>`session_profile_rows`<br>`archive_coverage_results`<br>`archive_readiness`<br>`embedding_status_results`<br>`message_fts`<br>`archive_debt_results`<br>`retrieval_band_readiness` | `query-session-insight-status`<br>`query-session-tag-rollups`<br>`query-archive-coverage`<br>`query-archive-debt`<br>`cli.json-contract`<br>`project-archive-readiness` | — | `insights`<br>`status`<br>`tags`<br>`coverage`<br>`debt`<br>`maintenance`<br>`readiness`<br>`live`<br>`preview` | Bounded live archive lane for normalized insights, maintenance preview, and memory budgets |
 | `validation-lane` | `semantic-insight-normalization` | — | — | — | — | — | Semantic/session insight normalization, operator/toolchain narrowing, schema contracts, and provider parser cleanup |

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -347,14 +347,16 @@ _QUERY_VERB_HELP: dict[str, str] = {
 for _verb in sorted(QUERY_VERB_NAMES):
     _attr = f"{_verb.replace('-', '_')}_verb"
     _cls = _LazyGroup if _verb in {"analyze", "mark"} else _LazyCommand
-    cli.add_command(
-        _cls(
-            _verb,
-            "polylogue.cli.query_verbs",
-            _attr,
-            short_help=_QUERY_VERB_HELP.get(_verb),
-        )
+    _command = _cls(
+        _verb,
+        "polylogue.cli.query_verbs",
+        _attr,
+        short_help=_QUERY_VERB_HELP.get(_verb),
     )
+    if isinstance(_command, _LazyGroup):
+        _command.invoke_without_command = True
+        _command.no_args_is_help = False
+    cli.add_command(_command)
 
 
 def main() -> None:

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -1020,7 +1020,7 @@ def _emit_candidate_judgment(
     click.echo(f"{decision}: {payload.candidate.assertion_id} -> {result_ref}")
 
 
-@click.group("analyze", invoke_without_command=True)
+@click.group("analyze", invoke_without_command=True, no_args_is_help=False)
 @click.option("--count", "count_only", is_flag=True, help="Print only the matched-session count.")
 @click.option(
     "--by",
@@ -1103,7 +1103,8 @@ def analyze_verb(
         ):
             raise click.UsageError(
                 "`analyze` options apply to the aggregate analyze view; "
-                "put subcommand options after `analyze <command>`."
+                "put read-model options after `analyze insights <command>` "
+                "or subcommand-specific options after `analyze <command>`."
             )
         return
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1809,7 +1809,13 @@ async def test_query_units_reports_pipeline_stages(tmp_path: Path) -> None:
         assert envelope.pipeline_stages == (
             {
                 "kind": "session_scope",
-                "predicate": {"field": "origin", "kind": "field", "op": "=", "values": ["codex-session"]},
+                "predicate": {
+                    "field": "origin",
+                    "field_ref": {"name": "origin", "scope": "session", "source_name": "origin"},
+                    "kind": "field",
+                    "op": "=",
+                    "values": ["codex-session"],
+                },
             },
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},

--- a/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
@@ -150,16 +150,18 @@
   
   Commands:
     analyze
-    config    Show configuration paths and resolved settings.
-    continue  Compile a successor-agent continuation report.
-    delete    Delete matched sessions.
-    demo      Seed and verify the deterministic demo archive.
-    import    Import sessions from configured sources.
-    init      Detect chat sources and write a starter polylogue.toml.
+    config     Show resolved Polylogue configuration with precedence sources.
+    continue   Compile a successor-agent continuation report.
+    dashboard  Open the local dashboard.
+    delete     Delete matched sessions.
+    demo       Seed and verify the deterministic demo archive.
+    import     Import sessions from configured sources.
+    init       Detect chat sources and write a starter polylogue.toml.
     mark
-    ops       Run operational archive and daemon commands.
-    read      Read matched sessions (route to view/destination).
+    ops        Run operational archive and daemon commands.
+    read       Read matched sessions (route to view/destination).
     select
+    tutorial   Interactive first-run walk-through.
   
   '''
 # ---

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -51,7 +51,7 @@ def test_verification_lab_surface_is_explicit_and_implemented() -> None:
 
     assert tuple(spec.name for spec in specs) == VERIFICATION_LAB_COMMAND_NAMES
     assert {spec.category for spec in specs} == {"verification lab"}
-    assert len({spec.module for spec in specs}) == len(specs)
+    assert len({(spec.module, spec.entrypoint) for spec in specs}) == len(specs)
 
     for spec in specs:
         assert spec.module.startswith("devtools.")

--- a/tests/unit/devtools/test_quality_registry.py
+++ b/tests/unit/devtools/test_quality_registry.py
@@ -10,7 +10,8 @@ ROOT = Path(__file__).resolve().parents[3]
 def test_build_quality_registry_exposes_live_catalogs() -> None:
     registry = build_quality_registry()
 
-    assert any(entry.name == "gen-schema-list" for entry in registry.catalog.qa_extra_scenarios)
+    assert any(entry.name == "schema-list-contract" for entry in registry.contract_lanes)
+    assert any(entry.name == "schema-explain-contract" for entry in registry.contract_lanes)
     assert any(entry.name == "frontier-local" for entry in registry.composite_lanes)
     assert any(entry.name == "machine-contract" for entry in registry.contract_lanes)
     assert any(entry.name == "live-exercises" for entry in registry.live_lanes)

--- a/tests/unit/devtools/test_scenario_projections.py
+++ b/tests/unit/devtools/test_scenario_projections.py
@@ -44,7 +44,8 @@ def test_render_scenario_projections_text_lists_authored_sources() -> None:
     rendered = scenario_projections.render_scenario_projections(as_json=False)
 
     assert "Scenario Projections (" in rendered
-    assert "exercise:gen-schema-list" in rendered
+    assert "validation-lane:schema-list-contract" in rendered
+    assert "validation-lane:schema-explain-contract" in rendered
     assert "validation-lane:machine-contract" in rendered
     assert "mutation-campaign:filters" in rendered
     assert "benchmark-campaign:search-filters" in rendered

--- a/tests/unit/scenarios/test_insight_surfaces.py
+++ b/tests/unit/scenarios/test_insight_surfaces.py
@@ -6,9 +6,9 @@ from polylogue.scenarios import build_insight_contract_surfaces, build_live_insi
 def test_build_insight_contract_surfaces_compiles_canonical_json_contract_entries() -> None:
     surfaces = {surface.name: surface for surface in build_insight_contract_surfaces()}
 
-    assert surfaces["json-insights-profiles"].args == ("ops", "insights", "profiles", "--format", "json")
+    assert surfaces["json-insights-profiles"].args == ("analyze", "insights", "profiles", "--format", "json")
     assert surfaces["json-insights-profiles"].tags == ("insights", "session-profiles")
-    assert surfaces["json-insights-coverage"].args == ("ops", "insights", "coverage", "--format", "json")
+    assert surfaces["json-insights-coverage"].args == ("analyze", "insights", "coverage", "--format", "json")
 
 
 def test_build_live_insight_surface_lanes_compiles_live_variants() -> None:
@@ -16,7 +16,7 @@ def test_build_live_insight_surface_lanes_compiles_live_variants() -> None:
 
     assert surfaces["live-insights-status"].args == ("ops", "insights", "status", "--format", "json")
     assert surfaces["live-insights-profiles-evidence"].args == (
-        "ops",
+        "analyze",
         "insights",
         "profiles",
         "--tier",
@@ -31,7 +31,7 @@ def test_build_live_insight_surface_lanes_compiles_live_variants() -> None:
         "claude-code",
         "--since",
         "2026-03-01",
-        "ops",
+        "analyze",
         "insights",
         "coverage",
         "--group-by",


### PR DESCRIPTION
## Summary

Restores the command-surface baseline after the ops/product pruning work moved schema inspection and insights commands out of their old locations. The branch fixes the lazy query-group setup for bare `analyze`, updates generated/fixture expectations to the current command placement, and adds validation-lane coverage for the schema helper surface that replaced the old product exercise entries.

## Problem

The default `devtools verify` run on the Turso research branch selected the command-surface baseline and exposed 14 failures unrelated to Turso. The failures clustered around stale expectations: bare `polylogue analyze` no longer invoked the query group correctly, scenario projections still expected schema list/explain under product exercises, command-catalog tests assumed one module per command, and snapshots/tests still referenced old insights placement and pre-`field_ref` query payloads.

## Solution

- Preserve Click lazy-group invocation semantics for query groups and allow bare `analyze` to execute its callback instead of turning into help text.
- Add validation-lane catalog entries for `devtools lab schema list` and `devtools lab schema explain`, then refresh the quality reference.
- Update affected tests and snapshots for the current surface: `analyze insights ...` as the product insights owner, command-catalog uniqueness by `(module, entrypoint)`, and query field payloads using `field_ref`.

## Verification

- `devtools test tests/unit/cli/test_help_snapshots.py::test_help_snapshot[polylogue] tests/unit/cli/test_help_snapshots.py::test_help_snapshot[polylogue analyze] tests/unit/cli/test_help_snapshots.py::test_help_snapshot[polylogue analyze insights] tests/unit/cli/test_plain_cli_snapshots.py::test_plain_analyze_snapshot tests/unit/cli/test_plain_cli_snapshots.py::test_json_analyze_snapshot tests/unit/cli/test_plain_cli_snapshots.py::test_plain_analyze_count_snapshot tests/unit/cli/test_plain_cli_snapshots.py::test_json_analyze_count_snapshot tests/unit/cli/test_insights_command_runtime.py::test_insights_profiles_delegates_to_analyze tests/unit/cli/test_insights_command_runtime.py::test_insights_coverage_delegates_to_analyze tests/unit/devtools/test_scenario_projections.py::test_schema_projection_includes_list_explain_contracts tests/unit/scenarios/test_insight_surfaces.py::test_insight_surfaces_are_authored_exercises tests/unit/devtools/test_command_catalog.py::test_command_catalog_has_unique_names tests/unit/devtools/test_quality_registry.py::test_validation_lane_catalog_matches_runtime tests/unit/api/test_facade_contracts.py::test_query_pipeline_payload_roundtrips_structured_stages -q` → 14 passed in 10.56s.
- `devtools verify --quick` → all checks passed, run id `20260621T142359Z-quick-4164719-b7ad3318`.
- `devtools verify` → all checks passed in 315.2s; pytest-testmon selected 1,750 affected tests and reported `815 passed, 1 warning in 299.88s`.

Closes #2253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new schema validation contract lanes: schema list and schema explain capabilities for improved schema validation workflows.

* **Documentation**
  * Updated test quality workflows documentation to reflect new schema validation contract lanes and their coverage metrics.

* **Improvements**
  * Enhanced CLI analyze command help behavior and error messaging to provide clearer guidance when invoking commands without subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->