### PR TITLE
chore(dev): summarize dev-loop failure artifacts (#2248)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -904,6 +904,29 @@ def _read_event_rows(path: Path) -> tuple[list[dict[str, object]], list[dict[str
     return rows, malformed
 
 
+def _payload_artifacts(payload: object) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        return {}
+    artifacts = payload.get("artifacts")
+    return artifacts if isinstance(artifacts, dict) else {}
+
+
+def _payload_duration_ms(payload: object) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    duration = payload.get("duration_ms")
+    if isinstance(duration, int):
+        return duration
+    if isinstance(duration, float):
+        return int(duration)
+    return None
+
+
+def _timed_event_duration(row: dict[str, object]) -> int:
+    duration = row.get("duration_ms")
+    return duration if isinstance(duration, int) else 0
+
+
 def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
     """Summarize one dev-loop run directory from persisted local artifacts."""
 
@@ -915,6 +938,7 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
     event_status_counts: dict[str, int] = {}
     event_surface_counts: dict[str, int] = {}
     problem_events: list[dict[str, object]] = []
+    timed_events: list[dict[str, object]] = []
     for row in events:
         status = str(row.get("status") or "unknown")
         surface = str(row.get("surface") or "unknown")
@@ -922,6 +946,16 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
         event_surface_counts[surface] = event_surface_counts.get(surface, 0) + 1
         if status in {"failed", "blocked"}:
             problem_events.append(row)
+        duration_ms = _payload_duration_ms(row.get("payload"))
+        if duration_ms is not None:
+            timed_events.append(
+                {
+                    "surface": surface,
+                    "event_type": str(row.get("event_type") or "unknown"),
+                    "status": status,
+                    "duration_ms": duration_ms,
+                }
+            )
 
     summary_files = {
         "daemon_launch": run_dir / "polylogued.launch.json",
@@ -935,6 +969,36 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
     loaded_terminal = [
         payload for payload in (_read_json_file(path) for path in terminal_summaries) if isinstance(payload, dict)
     ]
+    failed_summaries = [
+        {
+            "name": name,
+            "exit_code": payload.get("exit_code"),
+            "duration_ms": payload.get("duration_ms"),
+            "artifacts": _payload_artifacts(payload),
+        }
+        for name, payload in loaded_summaries.items()
+        if isinstance(payload, dict) and payload.get("ok") is False
+    ]
+    failed_terminal = [
+        {
+            "command_text": payload.get("command_text"),
+            "exit_code": payload.get("exit_code"),
+            "duration_ms": payload.get("duration_ms"),
+            "artifacts": _payload_artifacts(payload),
+        }
+        for payload in loaded_terminal
+        if payload.get("ok") is False
+    ]
+    artifact_index: dict[str, object] = {}
+    for name, payload in loaded_summaries.items():
+        artifacts = _payload_artifacts(payload)
+        if artifacts:
+            artifact_index[name] = artifacts
+    if loaded_terminal:
+        artifact_index["terminal_captures"] = [
+            _payload_artifacts(payload) for payload in loaded_terminal if _payload_artifacts(payload)
+        ]
+    slowest_events = sorted(timed_events, key=_timed_event_duration, reverse=True)[:10]
     missing_artifacts = [
         str(path)
         for path in (
@@ -953,6 +1017,10 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
         warnings.append(f"{len(malformed_event_lines)} malformed dev-loop event row(s) were skipped")
     if problem_events:
         warnings.append(f"{len(problem_events)} event(s) have failed/blocked status")
+    if failed_summaries:
+        warnings.append(f"{len(failed_summaries)} run summary file(s) report failure")
+    if failed_terminal:
+        warnings.append(f"{len(failed_terminal)} terminal capture(s) report failure")
     return {
         "ok": not warnings,
         "run_dir": str(run_dir),
@@ -964,9 +1032,13 @@ def summarize_dev_loop_run(run_dir: Path) -> dict[str, object]:
         "last_event": events[-1] if events else None,
         "problem_events": problem_events,
         "malformed_event_lines": malformed_event_lines,
+        "slowest_events": slowest_events,
         "summaries": loaded_summaries,
+        "failed_summaries": failed_summaries,
         "terminal_captures": loaded_terminal,
         "terminal_capture_count": len(loaded_terminal),
+        "failed_terminal_captures": failed_terminal,
+        "artifact_index": artifact_index,
         "missing_artifacts": missing_artifacts,
         "warnings": warnings,
     }
@@ -1551,6 +1623,11 @@ def _print_run_summary(payload: dict[str, object]) -> None:
     print(f"  ok:         {payload.get('ok')}")
     print(f"  events:     {payload.get('event_count')}")
     print(f"  terminals:  {payload.get('terminal_capture_count')}")
+    slowest = payload.get("slowest_events")
+    if isinstance(slowest, list) and slowest:
+        first = slowest[0]
+        if isinstance(first, dict):
+            print(f"  slowest:    {first.get('surface')}/{first.get('event_type')} {first.get('duration_ms')} ms")
     warnings = payload.get("warnings")
     if isinstance(warnings, list) and warnings:
         print("  warnings:")
@@ -1562,6 +1639,11 @@ def _print_run_summary(payload: dict[str, object]) -> None:
             "  last event: "
             f"{last_event.get('surface')}/{last_event.get('event_type')} status={last_event.get('status')}"
         )
+    artifacts = payload.get("artifact_index")
+    if isinstance(artifacts, dict) and artifacts:
+        print("  artifacts:")
+        for name in sorted(artifacts):
+            print(f"    - {name}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -380,9 +380,11 @@ devtools workspace dev-loop --inspect-run .cache/dev-loop/<run-id> --json
 The summary reads `preflight.json`, `dev-loop.events.jsonl`, daemon launch
 summaries, browser/extension/TUI plans, and terminal capture summaries. It
 reports event counts by status/surface, the last event, failed or blocked
-events, missing core artifacts, and captured terminal command summaries. Use it
-as the first stop when a daemon/web/extension loop looks stuck: it tells you
-which artifact to open next instead of making you scan the whole run directory.
+events, failed summary files, failed terminal captures, slowest timed events,
+missing core artifacts, and an artifact index grouped by surface. Use it as the
+first stop when a daemon/web/extension loop looks stuck: it tells you which
+surface failed, which command or smoke was slow, and which stdout/stderr/log
+artifact to open next instead of making you scan the whole run directory.
 
 ## Current Boundary
 

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -652,8 +652,21 @@ def test_inspect_run_summarizes_dev_loop_artifacts(
     (run_dir / "preflight.json").write_text(json.dumps(preflight), encoding="utf-8")
     events = [
         {"surface": "daemon", "event_type": "launch_requested", "status": "starting"},
-        {"surface": "cli", "event_type": "cli_capture_finished", "status": "ok"},
-        {"surface": "browser_extension", "event_type": "extension_smoke_finished", "status": "failed"},
+        {
+            "surface": "cli",
+            "event_type": "cli_capture_finished",
+            "status": "ok",
+            "payload": {"duration_ms": 120},
+        },
+        {
+            "surface": "browser_extension",
+            "event_type": "extension_smoke_finished",
+            "status": "failed",
+            "payload": {
+                "duration_ms": 450,
+                "artifacts": {"stdout": "/tmp/ext.stdout", "stderr": "/tmp/ext.stderr"},
+            },
+        },
     ]
     (run_dir / "dev-loop.events.jsonl").write_text(
         "\n".join([json.dumps(events[0]), "{not-json", *(json.dumps(row) for row in events[1:])]) + "\n",
@@ -662,10 +675,13 @@ def test_inspect_run_summarizes_dev_loop_artifacts(
     (run_dir / "polylogued.log").write_text("daemon log\n", encoding="utf-8")
     (run_dir / "polylogued.launch.json").write_text(json.dumps({"ok": True, "pid": 1234}), encoding="utf-8")
     (browser_dir / "browser-plan.json").write_text(json.dumps({"ok": True}), encoding="utf-8")
-    (browser_dir / "extension-smoke.json").write_text(json.dumps({"ok": False}), encoding="utf-8")
+    (browser_dir / "extension-smoke.json").write_text(
+        json.dumps({"ok": False, "exit_code": 1, "duration_ms": 450, "artifacts": {"stderr": "/tmp/ext.stderr"}}),
+        encoding="utf-8",
+    )
     (tui_dir / "tui-plan.json").write_text(json.dumps({"ok": True}), encoding="utf-8")
     (terminal_dir / "polylogue.summary.json").write_text(
-        json.dumps({"ok": True, "exit_code": 0}),
+        json.dumps({"ok": False, "exit_code": 2, "duration_ms": 80, "artifacts": {"stderr": "/tmp/cli.stderr"}}),
         encoding="utf-8",
     )
 
@@ -680,14 +696,40 @@ def test_inspect_run_summarizes_dev_loop_artifacts(
     assert payload["problem_events"][0]["event_type"] == "extension_smoke_finished"
     assert payload["malformed_event_lines"][0]["line"] == 2
     assert payload["malformed_event_lines"][0]["text"] == "{not-json"
+    assert payload["slowest_events"][0] == {
+        "duration_ms": 450,
+        "event_type": "extension_smoke_finished",
+        "status": "failed",
+        "surface": "browser_extension",
+    }
     assert payload["summaries"]["daemon_launch"]["pid"] == 1234
     assert payload["summaries"]["tui_plan"]["ok"] is True
+    assert payload["failed_summaries"] == [
+        {
+            "name": "extension_smoke",
+            "exit_code": 1,
+            "duration_ms": 450,
+            "artifacts": {"stderr": "/tmp/ext.stderr"},
+        }
+    ]
     assert payload["terminal_capture_count"] == 1
-    assert payload["terminal_captures"][0]["exit_code"] == 0
+    assert payload["terminal_captures"][0]["exit_code"] == 2
+    assert payload["failed_terminal_captures"] == [
+        {
+            "command_text": None,
+            "exit_code": 2,
+            "duration_ms": 80,
+            "artifacts": {"stderr": "/tmp/cli.stderr"},
+        }
+    ]
+    assert payload["artifact_index"]["extension_smoke"]["stderr"] == "/tmp/ext.stderr"
+    assert payload["artifact_index"]["terminal_captures"][0]["stderr"] == "/tmp/cli.stderr"
     assert payload["missing_artifacts"] == []
     assert payload["warnings"] == [
         "1 malformed dev-loop event row(s) were skipped",
         "1 event(s) have failed/blocked status",
+        "1 run summary file(s) report failure",
+        "1 terminal capture(s) report failure",
     ]
 
 


### PR DESCRIPTION
## Summary

Completes the branch-local dev-loop close-out by making `devtools workspace dev-loop --inspect-run` useful as the first diagnostic stop after daemon, web, CLI, receiver, extension, or browser-loop failures. The helper now surfaces failed summary files, failed terminal captures, slowest timed events, and artifact paths grouped by surface, so a developer can move directly from one run id to the log/stdout/stderr artifact that explains the failure.

## Problem

#2248 had already landed branch-local preflight, isolated ports, daemon launch artifacts, `/api/dev-loop`, CLI capture, receiver request ids, extension diagnostics, browser plans, and real Chrome unpacked-extension smoke. The remaining weakness was the final debugging step: when a run produced many local artifacts, `--inspect-run` mostly reported counts and raw failed events, so agents still had to scan the run directory to find the useful next file.

## Solution

This PR extends the existing run inspector rather than adding a second observability ledger:

- reads duration and artifact metadata from existing `dev-loop.events.jsonl`, daemon/browser/extension/TUI summary JSON, and terminal capture summaries;
- reports `failed_summaries`, `failed_terminal_captures`, `slowest_events`, and `artifact_index` in JSON output;
- shows the slowest event and available artifact groups in human output;
- updates the dev-loop documentation to describe the postmortem workflow;
- expands the focused dev-loop test to cover the new failure-postmortem behavior.

## Acceptance Matrix

| Requirement | Evidence |
| --- | --- |
| Branch-local daemon/web/browser-capture runs are isolated from the deployed service | Landed in prior #2248 PRs: preflight, isolated ports, dev archive root, daemon launcher, `/api/dev-loop`; confirmed in issue comments with local smoke run ids. |
| CLI/TUI capture artifacts are tied to the same run id | Existing `--capture-cli` and `--tui-plan` write run-local artifacts; this PR indexes terminal capture summaries in `--inspect-run`. |
| Browser-extension loop is exercised from the branch | #2280 added real Chrome unpacked-extension smoke and fixed the CORS request-id preflight gap; issue comment records `ok=True` local evidence. |
| Failed or slow dev-loop runs are diagnosable from local artifacts | This PR adds failed summaries, failed terminal captures, slowest timed events, and per-surface artifact index to `--inspect-run`. |
| No new ops-tier table unless logs are insufficient | No table added. Existing structured launcher JSONL, summary files, `/api/dev-loop`, and daemon events answer the current debugging questions. |
| Browser-control boundary stays local/operator-owned | `docs/dev-loop.md` continues to treat real authenticated browser/profile work as local operator/agent procedure; repo owns URLs/config/artifacts and smokes only. |

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -q` → `19 passed in 41.44s` after formatting.
- `devtools render all --check` → all generated surfaces sync OK.
- `devtools verify --quick` → all checks passed in 13.1s locally.
- Pre-push `devtools verify --quick` → all checks passed in 11.83s, run id `20260621T143839Z-quick-67399-bf5fa775`.

## Notes

I did not run a fresh real-browser smoke in this PR because #2280 already added and verified that path. This change is the postmortem layer over the run artifacts produced by those existing commands.

Closes #2248