### PR TITLE
fix(query): require bound field refs during execution (#2006)

### DIFF
--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -56,6 +56,20 @@ class QueryFieldPredicate:
             payload["field_ref"] = self.field_ref.to_payload()
         return payload
 
+    def require_field_ref(self, *, context: str) -> QueryFieldRef:
+        """Return the validated field identity or fail at an execution boundary."""
+
+        if self.field_ref is None:
+            raise ValueError(
+                f"unbound query field predicate {self.field!r}; bind query predicate context before {context}"
+            )
+        return self.field_ref
+
+    def bound_field_name(self, *, context: str) -> str:
+        """Return the validated field name for executable lowerers."""
+
+        return self.require_field_ref(context=context).name
+
 
 @dataclass(frozen=True)
 class QueryNotPredicate:

--- a/polylogue/archive/query/runtime_matching.py
+++ b/polylogue/archive/query/runtime_matching.py
@@ -115,7 +115,7 @@ def _matches_action_field(predicate: QueryFieldPredicate, action: Action) -> boo
     values = tuple(value.strip().lower() for value in predicate.values if value.strip())
     if not values:
         return False
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="matching action predicates")
     if field in {"action", "type"}:
         return _matches_exact_values(action.kind.value, values)
     if field == "tool":

--- a/polylogue/archive/query/spec.py
+++ b/polylogue/archive/query/spec.py
@@ -12,7 +12,13 @@ from polylogue.archive.filter.types import SortField
 from polylogue.archive.message.types import validate_message_type_filter
 from polylogue.archive.query.fields import describe_spec_fields, query_spec_has_selection_filters
 from polylogue.archive.query.plan import SessionQueryPlan
-from polylogue.archive.query.predicate import QueryPredicate
+from polylogue.archive.query.predicate import (
+    QueryBoolPredicate,
+    QueryExistsPredicate,
+    QueryNotPredicate,
+    QueryPredicate,
+    QuerySequencePredicate,
+)
 from polylogue.archive.viewport.viewports import ToolCategory
 from polylogue.core.dates import parse_date
 from polylogue.core.enums import Origin
@@ -354,11 +360,26 @@ def build_query_spec_from_params(
     )
 
 
+def _predicate_contains_action_sequence(predicate: QueryPredicate | None) -> bool:
+    if predicate is None:
+        return False
+    if isinstance(predicate, QuerySequencePredicate):
+        return True
+    if isinstance(predicate, QueryBoolPredicate):
+        return any(_predicate_contains_action_sequence(child) for child in predicate.children)
+    if isinstance(predicate, QueryNotPredicate):
+        return _predicate_contains_action_sequence(predicate.child)
+    if isinstance(predicate, QueryExistsPredicate):
+        return _predicate_contains_action_sequence(predicate.child)
+    return False
+
+
 def query_spec_to_plan(
     spec: SessionQuerySpec,
     *,
     vector_provider: VectorProvider | None = None,
 ) -> SessionQueryPlan:
+    action_sequence = () if _predicate_contains_action_sequence(spec.boolean_predicate) else spec.action_sequence
     plan = SessionQueryPlan(
         query_terms=spec.query_terms,
         contains_terms=spec.contains_terms,
@@ -368,7 +389,7 @@ def query_spec_to_plan(
         cwd_prefix=spec.cwd_prefix,
         action_terms=spec.action_terms,
         excluded_action_terms=spec.excluded_action_terms,
-        action_sequence=spec.action_sequence,
+        action_sequence=action_sequence,
         action_text_terms=spec.action_text_terms,
         tool_terms=spec.tool_terms,
         excluded_tool_terms=spec.excluded_tool_terms,

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -258,11 +258,10 @@ def _summary_timestamp_matches(summary: ArchiveSessionSummary, field: str, predi
 
 
 def _summary_field_matches(summary: ArchiveSessionSummary, predicate: QueryFieldPredicate) -> bool:
-    field = (
-        predicate.field_ref.name
-        if predicate.field_ref is not None and predicate.field_ref.scope == "session"
-        else predicate.field.removeprefix("session.")
-    )
+    field_ref = predicate.require_field_ref(context="matching runtime-transform session predicates")
+    if field_ref.scope != "session":
+        return False
+    field = field_ref.name
     values = predicate.values
     if field == "id":
         return _exact_or_contains(str(summary.session_id), values)
@@ -311,10 +310,9 @@ def _observed_event_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
-    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
-        return _summary_field_matches(summary, predicate)
-    if field.startswith("session."):
+    field_ref = predicate.require_field_ref(context="matching observed-event predicates")
+    field = field_ref.name
+    if field_ref.scope == "session":
         return _summary_field_matches(summary, predicate)
     if field == "kind":
         return _exact_or_contains(event.kind, predicate.values, exact=True)
@@ -381,10 +379,9 @@ def _context_snapshot_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
-    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
-        return _summary_field_matches(summary, predicate)
-    if field.startswith("session."):
+    field_ref = predicate.require_field_ref(context="matching context-snapshot predicates")
+    field = field_ref.name
+    if field_ref.scope == "session":
         return _summary_field_matches(summary, predicate)
     if field == "boundary":
         return _exact_or_contains(snapshot.boundary, predicate.values, exact=True)
@@ -435,10 +432,9 @@ def _run_field_matches(
     summary: ArchiveSessionSummary,
     predicate: QueryFieldPredicate,
 ) -> bool:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
-    if predicate.field_ref is not None and predicate.field_ref.scope == "session":
-        return _summary_field_matches(summary, predicate)
-    if field.startswith("session."):
+    field_ref = predicate.require_field_ref(context="matching run predicates")
+    field = field_ref.name
+    if field_ref.scope == "session":
         return _summary_field_matches(summary, predicate)
     if field in {"run", "run_ref"}:
         return _contains_value((_object_ref_text(run.run_ref),), predicate.values)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -17,6 +17,7 @@ from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
     QueryExistsPredicate,
     QueryFieldPredicate,
+    QueryFieldRef,
     QueryLineagePredicate,
     QueryNotPredicate,
     QueryPredicate,
@@ -4691,7 +4692,7 @@ def _field_predicate_clause(
     *,
     tags_relation: str,
 ) -> tuple[str, list[object]]:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="lowering session Boolean predicates")
     values = predicate.values
     kwargs: dict[str, Any] = {}
     if field == "id":
@@ -4769,7 +4770,12 @@ def _scoped_session_field(field: str) -> str | None:
 def _predicate_session_field(predicate: QueryFieldPredicate) -> str | None:
     if predicate.field_ref is not None and predicate.field_ref.scope == "session":
         return predicate.field_ref.name
-    return _scoped_session_field(predicate.field)
+    if _scoped_session_field(predicate.field) is not None:
+        raise ValueError(
+            f"unbound session-scoped query field predicate {predicate.field!r}; "
+            "bind query predicate context before lowering structural predicates"
+        )
+    return None
 
 
 def _in_or_equals_clause(column: str, values: tuple[str, ...], *, lower: bool = False) -> tuple[str, list[object]]:
@@ -4866,7 +4872,7 @@ def _like_clause(
 
 
 def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="lowering message predicates")
     if field == "role":
         return _in_or_equals_clause(f"{message_alias}.role", predicate.values, lower=True)
     if field == "type":
@@ -4933,7 +4939,7 @@ def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPre
 
 
 def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="lowering action predicates")
     if field == "tool":
         return _in_or_equals_clause(f"{action_alias}.tool_name", predicate.values, lower=True)
     if field in {"action", "type"}:
@@ -4962,7 +4968,7 @@ def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredi
 
 
 def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="lowering block predicates")
     if field == "type":
         return _in_or_equals_clause(f"{block_alias}.block_type", predicate.values, lower=True)
     if field == "time":
@@ -4984,7 +4990,7 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
 
 
 def _assertion_field_predicate_clause(assertion_alias: str, predicate: QueryFieldPredicate) -> tuple[str, list[object]]:
-    field = predicate.field_ref.name if predicate.field_ref is not None else predicate.field
+    field = predicate.bound_field_name(context="lowering assertion predicates")
     if field == "time":
         return _time_predicate_clause(_query_unit_time_expression("assertion", assertion_alias), predicate)
     if field == "status":
@@ -5034,14 +5040,9 @@ def _structural_predicate_clause(
         if session_field is not None:
             if session_alias is None:
                 raise ValueError(f"session-scoped {unit} predicate requires a session alias")
-            session_predicate = (
-                predicate
-                if predicate.field_ref is not None and predicate.field_ref.scope == "session"
-                else QueryFieldPredicate(field=session_field, values=predicate.values, op=predicate.op)
-            )
             return _field_predicate_clause(
                 session_alias,
-                session_predicate,
+                predicate,
                 tags_relation="session_tags",
             )
         if unit == "message":
@@ -5524,7 +5525,11 @@ def _session_filter_clause(
 
 def _action_sequence_clause(table_alias: str, action_sequence: tuple[str, ...]) -> tuple[str, list[object]]:
     steps = tuple(
-        QueryFieldPredicate(field="action", values=(term,), op="=") for term in action_sequence if term.strip()
+        QueryFieldPredicate(field="action", values=(term,), op="=").with_field_ref(
+            QueryFieldRef(scope="unit", name="action", source_name="action", unit="action")
+        )
+        for term in action_sequence
+        if term.strip()
     )
     return _action_sequence_steps_clause(table_alias, steps)
 

--- a/tests/unit/archive/test_query_runtime_matching.py
+++ b/tests/unit/archive/test_query_runtime_matching.py
@@ -7,7 +7,7 @@ import pytest
 from polylogue.archive.actions.actions import Action
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.query.plan import SessionQueryPlan
-from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate
+from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate, QueryFieldRef
 from polylogue.archive.query.runtime_matching import (
     matches_action_predicate_sequence,
     matches_action_sequence,
@@ -67,6 +67,12 @@ def _patch_events(
     events: tuple[Action, ...],
 ) -> None:
     monkeypatch.setattr("polylogue.archive.query.runtime_matching._actions_for", lambda _session: events)
+
+
+def _action_predicate(field: str, *values: str) -> QueryFieldPredicate:
+    return QueryFieldPredicate(field=field, values=values).with_field_ref(
+        QueryFieldRef(scope="unit", name=field, source_name=field, unit="action")
+    )
 
 
 def test_matches_referenced_path_requires_each_term_across_affected_paths(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -138,31 +144,39 @@ def test_matches_action_predicate_sequence_filters_step_fields(monkeypatch: pyte
         ),
     )
     steps = (
-        QueryFieldPredicate(field="action", values=("file_edit",)),
+        _action_predicate("action", "file_edit"),
         QueryBoolPredicate(
             op="and",
             children=(
-                QueryFieldPredicate(field="tool", values=("bash",)),
-                QueryFieldPredicate(field="output", values=("failed",)),
+                _action_predicate("tool", "bash"),
+                _action_predicate("output", "failed"),
             ),
         ),
-        QueryFieldPredicate(field="path", values=("archive/query",)),
+        _action_predicate("path", "archive/query"),
     )
 
     assert matches_action_predicate_sequence(steps, session) is True
 
     missed_steps = (
-        QueryFieldPredicate(field="action", values=("file_edit",)),
+        _action_predicate("action", "file_edit"),
         QueryBoolPredicate(
             op="and",
             children=(
-                QueryFieldPredicate(field="tool", values=("bash",)),
-                QueryFieldPredicate(field="output", values=("passed",)),
+                _action_predicate("tool", "bash"),
+                _action_predicate("output", "passed"),
             ),
         ),
-        QueryFieldPredicate(field="path", values=("archive/query",)),
+        _action_predicate("path", "archive/query"),
     )
     assert matches_action_predicate_sequence(missed_steps, session) is False
+
+
+def test_matches_action_predicate_sequence_rejects_unbound_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session()
+    _patch_events(monkeypatch, (_event(ToolCategory.FILE_EDIT),))
+
+    with pytest.raises(ValueError, match="unbound query field predicate"):
+        matches_action_predicate_sequence((QueryFieldPredicate(field="action", values=("file_edit",)),), session)
 
 
 def test_matches_action_predicate_sequence_treats_field_values_as_alternatives(
@@ -183,15 +197,15 @@ def test_matches_action_predicate_sequence_treats_field_values_as_alternatives(
         ),
     )
     steps = (
-        QueryFieldPredicate(field="action", values=("file_edit",)),
+        _action_predicate("action", "file_edit"),
         QueryBoolPredicate(
             op="and",
             children=(
-                QueryFieldPredicate(field="command", values=("ruff", "pytest")),
-                QueryFieldPredicate(field="output", values=("error", "failed")),
+                _action_predicate("command", "ruff", "pytest"),
+                _action_predicate("output", "error", "failed"),
             ),
         ),
-        QueryFieldPredicate(field="path", values=("missing/path", "archive/query")),
+        _action_predicate("path", "missing/path", "archive/query"),
     )
 
     assert matches_action_predicate_sequence(steps, session) is True

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -2936,6 +2936,38 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="field 'session.path' is not supported"):
             parse_unit_source_expression("context-snapshots where session.path:polylogue AND boundary:session_start")
 
+    def test_runtime_transform_unit_rejects_unbound_session_predicate(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        archive_root = workspace_env["archive_root"]
+        index_db = archive_root / "index.db"
+        (
+            SessionBuilder(index_db, "unbound-context")
+            .provider("codex")
+            .git_repository_url("polylogue")
+            .title("unbound context")
+            .add_message("m-unbound", role="user", text="Initial prompt")
+            .save()
+        )
+
+        source = QueryUnitSource(
+            unit="context-snapshot",
+            predicate=QueryFieldPredicate(field="session.repo", values=("polylogue",)),
+        )
+        with ArchiveStore.open_existing(archive_root) as archive:
+            with pytest.raises(ValueError, match="unbound query field predicate"):
+                query_unit_rows(
+                    archive,
+                    source,
+                    query="context-snapshots where session.repo:polylogue",
+                    limit=10,
+                )
+
     def test_context_snapshot_session_since_uses_created_at_fallback(self, workspace_env: dict[str, Path]) -> None:
         """Runtime-transform session date filters match normal session timestamp semantics."""
         import sqlite3


### PR DESCRIPTION
## Summary

Require executable query predicates to carry descriptor-bound field identity before SQL lowering or runtime-transform matching. The parser/binder remains the place that interprets raw field text; execution paths now fail closed when handed stale or manually constructed unbound predicates.

## Problem

#2006 depends on one query pipeline, not parser-time strings leaking into independent lowerers. Runtime-transform terminal units such as `context-snapshots where ...` previously had fallback matching for raw `session.<field>` names. That could silently broaden results if an unbound predicate reached execution, especially for observed-event/context-snapshot/run transforms that scan session summaries in memory.

## Solution

`QueryFieldPredicate` now exposes `require_field_ref()` / `bound_field_name()` as the execution boundary. SQLite structural lowerers, action-sequence matching, and runtime-transform unit matchers use those helpers instead of falling back to `predicate.field`. The older tuple `action_sequence` adapter binds its generated action leaves, and plan construction suppresses that tuple path when the Boolean predicate already contains a bound `seq(...)` predicate.

Regression coverage now checks that action predicate sequences are bound before runtime matching and that an unbound runtime-transform `session.repo` predicate raises instead of matching broadly.

## Verification

- `devtools test tests/unit/archive/test_query_runtime_matching.py tests/unit/cli/test_query_expression.py -q` -> `343 passed in 97.44s`
- `devtools verify --quick` -> exit 0 (run `20260621T145606Z-quick-125829-83af51d1`)
- `devtools verify` -> exit 0; pytest-testmon selected 4,842, ran `2267 passed in 2382.63s`; peak tree RSS 1,958.6 MiB (run `20260621T145647Z-testmon-126482-6e8faa78`)

Ref #2006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of query predicates to require explicit field binding with clearer error messages for malformed queries.

* **Tests**
  * Added test coverage for predicate field binding validation and rejection of unbound session-field predicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->