### PR TITLE
fix(cli): explain query terminal actions (#2006)

### DIFF
--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -76,7 +76,11 @@ def _create_query_vector_provider(config: Config, *, db_path: Path | None = None
         return None
 
 
-def _explain_query_request(request: RootModeRequest) -> None:
+def explain_query_request(
+    request: RootModeRequest,
+    *,
+    terminal_action: dict[str, object] | None = None,
+) -> None:
     if not request.query_terms:
         raise click.UsageError("--explain requires query terms. Use `polylogue find QUERY --explain`.")
     from polylogue.cli.query_explain import explain_query_expression
@@ -85,7 +89,15 @@ def _explain_query_request(request: RootModeRequest) -> None:
     if output_format not in {"plain", "plaintext", "markdown", "json"}:
         raise click.UsageError(f"--explain does not support --format {output_format}.")
     render_format = "json" if output_format == "json" else "plain"
-    explain_query_expression(" ".join(request.query_terms), output_format=render_format)
+    explain_query_expression(
+        " ".join(request.query_terms),
+        output_format=render_format,
+        terminal_action=terminal_action,
+    )
+
+
+def _explain_query_request(request: RootModeRequest) -> None:
+    explain_query_request(request)
 
 
 def execute_query_request(env: AppEnv, request: RootModeRequest) -> None:

--- a/polylogue/cli/query_explain.py
+++ b/polylogue/cli/query_explain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from typing import cast
 
 import click
@@ -10,11 +11,25 @@ import click
 from polylogue.archive.query.expression import explain_expression
 
 
-def explain_query_expression(source: str, *, output_format: str = "plain") -> None:
+def explain_query_expression(
+    source: str,
+    *,
+    output_format: str = "plain",
+    terminal_action: Mapping[str, object] | None = None,
+) -> None:
     """Render how a query expression parses and lowers before execution."""
 
     explanation = explain_expression(source)
     payload = explanation.to_payload()
+    if terminal_action is not None:
+        payload["terminal_action"] = dict(terminal_action)
+        lowering_plan = payload.get("lowering_plan")
+        if isinstance(lowering_plan, dict):
+            lowering_plan["terminal_action"] = dict(terminal_action)
+        plan_description = payload.get("plan_description")
+        action_name = str(terminal_action.get("action") or "action")
+        if isinstance(plan_description, list):
+            plan_description.append(f"terminal action: {action_name}")
     if output_format == "json":
         click.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
@@ -27,6 +42,7 @@ def explain_query_expression(source: str, *, output_format: str = "plain") -> No
     execution_legs = cast(list[str], payload["execution_legs"])
     plan_description = cast(list[str], payload["plan_description"])
     lowering_plan = cast(dict[str, object] | None, payload["lowering_plan"])
+    terminal_action_payload = cast(dict[str, object] | None, payload.get("terminal_action"))
     unsupported_nodes = cast(list[str], payload["unsupported_nodes"])
     if selected_units:
         click.echo("units: " + ", ".join(selected_units))
@@ -42,6 +58,9 @@ def explain_query_expression(source: str, *, output_format: str = "plain") -> No
     if lowering_plan is not None:
         click.echo("lowering plan:")
         click.echo(json.dumps(lowering_plan, indent=2, sort_keys=True))
+    if terminal_action_payload is not None and (lowering_plan is None or "terminal_action" not in lowering_plan):
+        click.echo("terminal action:")
+        click.echo(json.dumps(terminal_action_payload, indent=2, sort_keys=True))
     if plan_description:
         click.echo("plan:")
         for line in plan_description:

--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -250,7 +250,7 @@ class QueryFirstGroupBase(click.Group):
 
         parse_args, query_terms, has_subcommand, explicit_query = _split_query_mode_args(self, args)
         ctx.meta["polylogue_has_subcommand"] = has_subcommand
-        ctx.meta["polylogue_query_terms"] = query_terms if not has_subcommand else ()
+        ctx.meta["polylogue_query_terms"] = query_terms
         ctx.meta["polylogue_explicit_query"] = explicit_query
         subcommand, verb = _detect_subcommand_and_verb(self, original_args)
         ctx.meta["polylogue_dispatch_subcommand"] = subcommand

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -282,7 +282,15 @@ def select_verb(ctx: click.Context, limit: int, print_field: str, json_output: b
     from polylogue.cli.select import run_select
 
     field: SelectPrintField = "json" if json_output else cast("SelectPrintField", print_field)
-    run_select(ctx.obj, _parent_request(ctx), limit=limit, print_field=field)
+    request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="select",
+        limit=limit,
+        print_field=field,
+    ):
+        return
+    run_select(ctx.obj, request, limit=limit, print_field=field)
 
 
 @click.command("read")
@@ -473,6 +481,15 @@ def read_verb(
         _emit_read_view_profiles(output_format)
         return
     request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="read",
+        view=view,
+        destination=destination,
+        format=_effective_read_output_format(request, view=view, output_format=output_format) or "default",
+        all=export_all,
+    ):
+        return
     if ref is not None:
         if output_format not in (None, "json"):
             raise click.UsageError("Direct ref reads currently support --format json only.")
@@ -505,10 +522,7 @@ def read_verb(
         return
 
     session_id = _resolve_target_session_id(request)
-    effective_format = output_format
-    if view == "recovery" and effective_format is None:
-        root_format = request.params.get("output_format")
-        effective_format = root_format if isinstance(root_format, str) else None
+    effective_format = _effective_read_output_format(request, view=view, output_format=output_format)
     explicit_options = _explicit_read_view_options(ctx)
     if destination == "browser":
         run_read_view(
@@ -630,6 +644,14 @@ def continue_verb(
     """
     env: AppEnv = ctx.obj
     request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="continue",
+        destination=destination,
+        format=output_format or request.params.get("output_format") or "default",
+        candidates=candidates,
+    ):
+        return
     if candidates:
         if destination not in ("terminal", "stdout") or out_path is not None:
             raise click.UsageError("continue --candidates writes to terminal/stdout; omit --to/--out.")
@@ -720,6 +742,14 @@ def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: boo
 
     env: AppEnv = ctx.obj
     request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="delete",
+        dry_run=dry_run,
+        yes=yes_flag,
+        all=all_flag,
+    ):
+        return
 
     from polylogue.cli.archive_query import execute_delete_by_session_ids
 
@@ -802,6 +832,22 @@ def mark_verb(
 
     env: AppEnv = ctx.obj
     request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="mark",
+        tag_add=tags_to_add,
+        tag_remove=tags_to_remove,
+        star=star,
+        unstar=unstar,
+        pin=pin,
+        unpin=unpin,
+        archive=do_archive,
+        unarchive=do_unarchive,
+        note=note_text is not None,
+        all=apply_all,
+        first=first_only,
+    ):
+        return
 
     # Resolve matched sessions and enforce cardinality.
     session_ids = resolve_session_ids_for_verb(env, request)
@@ -1117,6 +1163,17 @@ def analyze_verb(
 
     env: AppEnv = ctx.obj
     request = _parent_request(ctx)
+    if _explain_terminal_action(
+        request,
+        action="analyze",
+        count=count_only,
+        by=stats_by,
+        facets=show_facets,
+        cost_outlook=cost_outlook,
+        format=output_format or request.params.get("output_format") or "default",
+        limit=limit,
+    ):
+        return
 
     selected_modes = sum(bool(flag) for flag in (count_only, show_facets, cost_outlook, stats_by is not None))
     if selected_modes > 1:
@@ -1231,6 +1288,24 @@ def _parent_query_terms(ctx: click.Context) -> tuple[str, ...]:
     """Load query terms captured on the parent query context."""
     raw_terms = _require_parent_context(ctx).meta.get("polylogue_query_terms", ())
     return tuple(str(term) for term in raw_terms)
+
+
+def _explain_terminal_action(request: RootModeRequest, **terminal_action: object) -> bool:
+    """Render query explain output for a terminal query action when requested."""
+    if not request.explain_query:
+        return False
+    from polylogue.cli.query import explain_query_request
+
+    explain_query_request(request, terminal_action=terminal_action)
+    return True
+
+
+def _effective_read_output_format(request: RootModeRequest, *, view: str, output_format: str | None) -> str | None:
+    effective_format = output_format
+    if view == "recovery" and effective_format is None:
+        root_format = request.params.get("output_format")
+        effective_format = root_format if isinstance(root_format, str) else None
+    return effective_format
 
 
 def _parent_request(ctx: click.Context) -> RootModeRequest:

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -300,6 +300,158 @@ def test_root_query_explain_json_outputs_terminal_pipeline_stages(cli_runner: Cl
     assert lowering_plan["pipeline_stages"] == expected_stages
 
 
+def test_query_action_read_explain_json_outputs_terminal_action(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "--explain",
+            "find",
+            "repo:polylogue",
+            "then",
+            "read",
+            "--view",
+            "messages",
+            "--limit",
+            "3",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = cast(dict[str, Any], json.loads(result.output))
+    terminal_action = cast(dict[str, Any], payload["terminal_action"])
+    assert terminal_action == {
+        "action": "read",
+        "all": False,
+        "destination": "terminal",
+        "format": "default",
+        "view": "messages",
+    }
+    lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
+    assert lowering_plan["terminal_action"] == terminal_action
+    assert payload["plan_description"][-1] == "terminal action: read"
+
+
+def test_query_action_read_explain_recovery_inherits_root_format(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "--explain",
+            "find",
+            "repo:polylogue",
+            "then",
+            "read",
+            "--view",
+            "recovery",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = cast(dict[str, Any], json.loads(result.output))
+    assert cast(dict[str, Any], payload["terminal_action"])["format"] == "json"
+
+
+def test_query_action_read_explain_uses_local_read_format(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "--explain",
+            "find",
+            "repo:polylogue",
+            "then",
+            "read",
+            "--view",
+            "messages",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = cast(dict[str, Any], json.loads(result.output))
+    assert cast(dict[str, Any], payload["terminal_action"])["format"] == "json"
+
+
+@pytest.mark.parametrize(
+    "action_args,expected",
+    [
+        (
+            ["select", "--limit", "5", "--print", "title"],
+            {"action": "select", "limit": 5, "print_field": "title"},
+        ),
+        (
+            ["continue"],
+            {"action": "continue", "candidates": False, "destination": "terminal", "format": "json"},
+        ),
+        (
+            ["delete", "--dry-run"],
+            {"action": "delete", "all": False, "dry_run": True, "yes": False},
+        ),
+        (
+            ["mark", "--tag-add", "reviewed"],
+            {
+                "action": "mark",
+                "all": False,
+                "archive": False,
+                "first": False,
+                "note": False,
+                "pin": False,
+                "star": False,
+                "tag_add": ["reviewed"],
+                "tag_remove": [],
+                "unarchive": False,
+                "unpin": False,
+                "unstar": False,
+            },
+        ),
+        (
+            ["analyze", "--count"],
+            {
+                "action": "analyze",
+                "by": None,
+                "cost_outlook": False,
+                "count": True,
+                "facets": False,
+                "format": "json",
+                "limit": None,
+            },
+        ),
+    ],
+)
+def test_query_action_explain_json_outputs_terminal_action_floor(
+    cli_runner: CliRunner,
+    action_args: list[str],
+    expected: dict[str, object],
+) -> None:
+    result = cli_runner.invoke(
+        click_cli,
+        [
+            "--plain",
+            "--format",
+            "json",
+            "find",
+            "repo:polylogue",
+            "--explain",
+            "then",
+            *action_args,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = cast(dict[str, Any], json.loads(result.output))
+    assert payload["terminal_action"] == expected
+    assert cast(dict[str, Any], payload["lowering_plan"])["terminal_action"] == expected
+    assert payload["plan_description"][-1] == f"terminal action: {expected['action']}"
+
+
 def test_root_query_explain_json_marks_runtime_transform_unit_payload(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(
         click_cli,

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2478,7 +2478,7 @@ SEARCH_FILTER_CASES = [
 ]
 
 SEARCH_FORMAT_CASES = [
-    ("json_read", ["Python", "then", "read", "-f", "json"], "json_list"),
+    ("json_read", ["Python", "then", "read", "-f", "json"], "json_read"),
     ("json_single", ["JavaScript", "-f", "json", "--limit", "1"], "json_single"),
     (
         "json_unit_messages",
@@ -2545,6 +2545,14 @@ class TestSearchQueryContracts:
             assert isinstance(data, dict), case_id
             assert isinstance(data.get("items"), list), case_id
             assert data["items"] and "id" in data["items"][0], case_id
+        elif expectation == "json_read":
+            data = json.loads(result.output)
+            assert isinstance(data, dict), case_id
+            assert isinstance(data.get("items"), list), case_id
+            assert data["items"], case_id
+            first = data["items"][0]
+            assert "match" in first, case_id
+            assert first["session"]["id"] == "chatgpt-export:ext-conv1", case_id
         elif expectation == "json_single":
             data = json.loads(result.output)
             assert isinstance(data, (list, dict)), case_id


### PR DESCRIPTION
## Summary

Adds a side-effect-free explain bridge for query-action verbs. `polylogue --explain find QUERY then select|read|continue|delete|mark|analyze ... --format json` now returns the normal DSL parse/lowering payload plus terminal-action metadata instead of falling through into the action implementation.

## Problem

#2006 calls out the larger target shape where `find QUERY then ACTION` is represented as `Source(sessions) -> Filter(...) -> Terminal(action)`. Root query explain already described compact/Boolean expressions and terminal query-unit pipelines, but query verbs were opaque. In practice, `find repo:polylogue --explain then read --view messages` tried to resolve a session and failed, so explain could not inspect the action boundary at all.

## Solution

- Preserve parsed query terms in `QueryFirstGroupBase` even when dispatching to a query verb.
- Promote the query explain helper so query verbs can attach a `terminal_action` payload.
- Short-circuit `select`, `read`, `continue`, `delete`, `mark`, and `analyze` when `--explain` is present, before any selector, renderer, mutation, or delete path runs.
- Add focused CLI tests over the action floor, asserting the terminal action appears in both top-level explain output and the lowering plan.

This deliberately does not claim that terminal action execution has fully moved into a pipeline AST. It creates the first executable bridge in explain/diagnostics without changing normal action execution.

## Verification

- `devtools test tests/unit/cli/test_click_app.py -k explain -q` -> 12 passed.
- `devtools test tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec_laws.py -k 'query_action or unit_source or read_verb_messages_requires_id or assertion_unit_source or run_unit_source or context_snapshot_unit_source' -q` -> 13 passed.
- `devtools verify --quick` -> exit_code 0, run `20260621T160042Z-quick-523073-1350e9f2`.

Ref #2006
