### PR TITLE
fix(query): execute shell-quoted unit-source actions (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1126,15 +1126,15 @@ _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()
 def _is_boolean_expression(expression: str) -> bool:
     stripped = expression.lstrip()
     lower = stripped.lower()
+    exists_prefixes = tuple(
+        prefix
+        for unit in ("message", "action", "block", "assertion", "file")
+        for prefix in (f"exists {unit}(", f"exists {unit} (")
+    )
     if (
         stripped.startswith("(")
         or lower.startswith("sessions where ")
-        or lower.startswith("exists message(")
-        or lower.startswith("exists message (")
-        or lower.startswith("exists action(")
-        or lower.startswith("exists action (")
-        or lower.startswith("exists block(")
-        or lower.startswith("exists block (")
+        or lower.startswith(exists_prefixes)
         or lower.startswith("seq(")
         or lower.startswith("seq (")
         or lower.startswith("lineage:")

--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -839,6 +839,8 @@ def describe_plan_fields(plan: object) -> list[str]:
 
 
 def query_spec_has_selection_filters(spec: object) -> bool:
+    if getattr(spec, "boolean_predicate", None) is not None:
+        return True
     return any(
         descriptor.selection_filter and descriptor.is_active_for_spec(spec) for descriptor in QUERY_FIELD_DESCRIPTORS
     )

--- a/polylogue/cli/root_request.py
+++ b/polylogue/cli/root_request.py
@@ -13,6 +13,37 @@ if TYPE_CHECKING:
     import click
 
 
+def _is_shell_quoted_structured_query(term: str) -> bool:
+    """Return whether one shell term should be compiled as DSL, not a phrase."""
+
+    stripped = term.strip()
+    lowered = stripped.lower()
+    if not stripped:
+        return False
+    if lowered.startswith(("exists ", "exists(", "seq(", "lineage:id:")):
+        return True
+    if " where " in lowered:
+        from polylogue.archive.query.metadata import terminal_query_sources
+
+        prefixes = tuple(f"{source} where " for source in terminal_query_sources()) + ("sessions where ",)
+        return lowered.startswith(prefixes)
+    return False
+
+
+def _expression_from_query_terms(query_terms: tuple[str, ...]) -> str:
+    if len(query_terms) == 1 and _is_shell_quoted_structured_query(query_terms[0]):
+        return query_terms[0].strip()
+
+    parts: list[str] = []
+    for term in query_terms:
+        if any(char.isspace() for char in term):
+            escaped = term.replace('"', '\\"')
+            parts.append(f'"{escaped}"')
+        else:
+            parts.append(term)
+    return " ".join(parts)
+
+
 @dataclass(frozen=True)
 class RootModeRequest:
     """Canonical root request for stats-or-query dispatch."""
@@ -81,21 +112,7 @@ class RootModeRequest:
         if not self.query_terms:
             return base
 
-        # Re-join query_terms into a DSL expression string.  Terms that
-        # contain spaces (e.g. shell-quoted phrases) are re-wrapped in
-        # double-quotes so the lexer treats them as quoted phrases.
-        parts: list[str] = []
-        for term in self.query_terms:
-            if " " in term:
-                # Quote term with embedded spaces so the lexer handles them
-                # as quoted phrases rather than splitting on the space.
-                escaped = term.replace('"', '\\"')
-                parts.append(f'"{escaped}"')
-            else:
-                parts.append(term)
-        expression = " ".join(parts)
-
-        return compile_expression_into(expression, base)
+        return compile_expression_into(_expression_from_query_terms(self.query_terms), base)
 
     @property
     def verbose(self) -> bool:

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -4429,6 +4429,24 @@ class TestCLIRootRequestWiring:
         assert spec.has_filters()
         assert spec.query_terms == ()
 
+    @pytest.mark.parametrize(
+        ("expression", "unit"),
+        [
+            ("exists file(path:archive/query)", "file"),
+            ("exists assertion(kind:decision)", "assertion"),
+        ],
+    )
+    def test_shell_quoted_extended_exists_units_compile_as_structural_query(self, expression: str, unit: str) -> None:
+        from polylogue.cli.root_request import RootModeRequest
+
+        request = RootModeRequest(params={}, query_terms=(expression,))
+        spec = request.query_spec()
+
+        assert isinstance(spec.boolean_predicate, QueryExistsPredicate)
+        assert spec.boolean_predicate.unit == unit
+        assert spec.has_filters()
+        assert spec.query_terms == ()
+
     def test_unknown_field_raises(self) -> None:
         from polylogue.cli.root_request import RootModeRequest
 

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -2560,6 +2560,54 @@ class TestBooleanQueryExpression:
         assert payload["unit"] == "file"
         assert payload["items"][0]["path"] == "polylogue/archive/query/expression.py"
 
+    def test_query_action_read_accepts_shell_quoted_terminal_action_source(
+        self, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.cli import cli
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .title("action read hit")
+            .add_message(
+                "m-edit",
+                role="assistant",
+                text="edited file",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "tool_id": "tool-hit",
+                        "input": {"file_path": "polylogue/cli/query_verbs.py"},
+                        "semantic_type": "file_edit",
+                    }
+                ],
+            )
+            .save()
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "--plain",
+                "find",
+                "actions where action:file_edit AND path:query_verbs",
+                "then",
+                "read",
+                "--view",
+                "messages",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["session_id"] == "claude-code-session:ext-hit"
+        assert payload["messages"][0]["id"] == "claude-code-session:ext-hit:m-edit"
+
     def test_terminal_action_source_filters_by_row_time(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from tests.infra.storage_records import SessionBuilder
@@ -4359,6 +4407,27 @@ class TestCLIRootRequestWiring:
         spec = request.query_spec()
         # Should end up in query_terms as the phrase "json envelope"
         assert any("json envelope" in t for t in spec.query_terms)
+
+    def test_shell_quoted_terminal_source_compiles_as_structural_query(self) -> None:
+        from polylogue.cli.root_request import RootModeRequest
+
+        request = RootModeRequest(params={}, query_terms=("actions where action:file_edit AND path:archive/query",))
+        spec = request.query_spec()
+
+        assert isinstance(spec.boolean_predicate, QueryExistsPredicate)
+        assert spec.boolean_predicate.unit == "action"
+        assert spec.has_filters()
+        assert spec.query_terms == ()
+
+    def test_shell_quoted_sessions_where_compiles_as_structural_query(self) -> None:
+        from polylogue.cli.root_request import RootModeRequest
+
+        request = RootModeRequest(params={}, query_terms=("sessions where origin:claude-code-session",))
+        spec = request.query_spec()
+
+        assert spec.boolean_predicate is not None
+        assert spec.has_filters()
+        assert spec.query_terms == ()
 
     def test_unknown_field_raises(self) -> None:
         from polylogue.cli.root_request import RootModeRequest


### PR DESCRIPTION
## Summary

Structured DSL expressions passed as one shell-quoted `find` term now stay structured when query-result actions execute. This makes advertised forms such as `polylogue find 'actions where action:file_edit AND path:polylogue/cli' then read --view messages` resolve the matched session instead of re-wrapping the entire expression as an FTS phrase.

## Problem

The query-first help advertised terminal unit-source selectors feeding `then read`, but `RootModeRequest.query_spec()` quoted every query term containing whitespace. A shell-quoted structured expression like `actions where ...` therefore became a phrase literal before reaching the Lark parser. After fixing that boundary, the action resolver still treated `SessionQuerySpec.boolean_predicate` as non-filtering, so a valid terminal-source selector could fail single-session action resolution.

## Solution

`polylogue/cli/root_request.py` now preserves a single shell term as DSL only when it clearly starts as a structured query (`<unit> where ...`, `sessions where ...`, `exists ...`, `seq(...)`, or `lineage:id:...`). Ordinary shell-quoted phrases such as `json envelope` are still re-quoted for FTS phrase semantics.

`polylogue/archive/query/fields.py` now treats `boolean_predicate` as a selection filter, so action resolvers can use structured Boolean/terminal predicates to resolve one matched session.

The tests cover both boundaries and the full advertised CLI execution path.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py -k 'CLIRootRequestWiring or query_action_read_accepts_shell_quoted_terminal_action_source' -q`
  - `9 passed, 337 deselected`
- `nix develop --command devtools verify --quick`
  - exit_code 0
- `nix develop --command devtools verify`
  - exit_code 0
  - pytest testmon: `599 passed, 1 warning in 158.28s`, diagnosis `pytest_passed`
  - peak pytest tree RSS: 1112.0 MiB

Ref #2006
