### PR TITLE
refactor(assertions): type assertion kinds at surface boundaries

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -966,6 +966,40 @@ components:
       - tool_use_block_id
       title: ActionQueryRowPayload
       type: object
+    AssertionKind:
+      description: 'Closed vocabulary for ``user.db`` assertion rows.
+
+
+        The unified assertions table collapses the old user-tier overlay
+
+        mini-systems. The SQLite column is stored as ``TEXT`` so the vocabulary can
+
+        grow without forcing a user-tier schema bump; this enum is the typed
+
+        runtime and surface boundary.'
+      enum:
+      - mark
+      - highlight
+      - annotation
+      - correction
+      - suppression
+      - tag
+      - metadata
+      - saved_query
+      - recall_pack
+      - workspace_note
+      - note
+      - decision
+      - caveat
+      - lesson
+      - blocker
+      - handoff
+      - judgment
+      - run_state
+      - prompt_eval
+      - transform_candidate
+      title: AssertionKind
+      type: string
     AssertionQueryRowPayload:
       additionalProperties: false
       description: Shared terminal-query row for user-tier assertions.
@@ -988,8 +1022,7 @@ components:
           default: null
           title: Scope Ref
         kind:
-          title: Kind
-          type: string
+          $ref: '#/components/schemas/AssertionKind'
         key:
           anyOf:
           - type: string
@@ -1821,8 +1854,7 @@ components:
           default: null
           title: Key
         kind:
-          title: Kind
-          type: string
+          $ref: '#/components/schemas/AssertionKind'
         value:
           anyOf:
           - {}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -24,7 +24,7 @@ over the `CREATE TABLE` statement.
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 1` |
 | `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 4` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 1` |
-| `user.py` | `user.db` | `USER_SCHEMA_VERSION = 1` |
+| `user.py` | `user.db` | `USER_SCHEMA_VERSION = 3` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |
 
 There is no single global "schema version" number. Each tier is versioned and

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -120,6 +120,33 @@
       "title": "ActionQueryRowPayload",
       "type": "object"
     },
+    "AssertionKind": {
+      "description": "Closed vocabulary for ``user.db`` assertion rows.\n\nThe unified assertions table collapses the old user-tier overlay\nmini-systems. The SQLite column is stored as ``TEXT`` so the vocabulary can\ngrow without forcing a user-tier schema bump; this enum is the typed\nruntime and surface boundary.",
+      "enum": [
+        "mark",
+        "highlight",
+        "annotation",
+        "correction",
+        "suppression",
+        "tag",
+        "metadata",
+        "saved_query",
+        "recall_pack",
+        "workspace_note",
+        "note",
+        "decision",
+        "caveat",
+        "lesson",
+        "blocker",
+        "handoff",
+        "judgment",
+        "run_state",
+        "prompt_eval",
+        "transform_candidate"
+      ],
+      "title": "AssertionKind",
+      "type": "string"
+    },
     "AssertionQueryRowPayload": {
       "additionalProperties": false,
       "description": "Shared terminal-query row for user-tier assertions.",
@@ -175,8 +202,7 @@
           "title": "Key"
         },
         "kind": {
-          "title": "Kind",
-          "type": "string"
+          "$ref": "#/$defs/AssertionKind"
         },
         "scope_ref": {
           "anyOf": [

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -329,7 +329,45 @@ class ExerciseIOMode(PolylogueStrEnum):
         return cls(str(value).strip().lower())
 
 
+class AssertionKind(PolylogueStrEnum):
+    """Closed vocabulary for ``user.db`` assertion rows.
+
+    The unified assertions table collapses the old user-tier overlay
+    mini-systems. The SQLite column is stored as ``TEXT`` so the vocabulary can
+    grow without forcing a user-tier schema bump; this enum is the typed
+    runtime and surface boundary.
+    """
+
+    MARK = "mark"
+    HIGHLIGHT = "highlight"
+    ANNOTATION = "annotation"
+    CORRECTION = "correction"
+    SUPPRESSION = "suppression"
+    TAG = "tag"
+    METADATA = "metadata"
+    SAVED_QUERY = "saved_query"
+    RECALL_PACK = "recall_pack"
+    WORKSPACE_NOTE = "workspace_note"
+    NOTE = "note"
+    DECISION = "decision"
+    CAVEAT = "caveat"
+    LESSON = "lesson"
+    BLOCKER = "blocker"
+    HANDOFF = "handoff"
+    JUDGMENT = "judgment"
+    RUN_STATE = "run_state"
+    PROMPT_EVAL = "prompt_eval"
+    TRANSFORM_CANDIDATE = "transform_candidate"
+
+    @classmethod
+    def from_string(cls, value: str | AssertionKind) -> AssertionKind:
+        if isinstance(value, cls):
+            return value
+        return cls(str(value).strip().lower())
+
+
 __all__ = [
+    "AssertionKind",
     "ArtifactSupportStatus",
     "BlockType",
     "BranchType",

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -12,46 +12,14 @@ import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from enum import StrEnum
 from typing import TYPE_CHECKING, Final
 
+from polylogue.core.enums import AssertionKind
 from polylogue.core.json import JSONValue, require_json_value
 from polylogue.core.refs import ObjectRef, normalize_object_ref_text, normalize_public_ref_text
 
 if TYPE_CHECKING:
     from polylogue.insights.transforms import DecisionCandidate, RecoveryDigest, TransformRawRef
-
-
-class AssertionKind(StrEnum):
-    """Closed vocabulary for ``assertions.kind``.
-
-    The unified assertions table collapses the legacy user-tier overlays; each
-    kind below corresponds to a meaning carried by one of those mini-systems or
-    by the agent-blackboard surface. The DDL stores ``kind`` as plain ``TEXT``
-    (no CHECK) so the vocabulary can grow without a schema bump; this enum is
-    the authoritative documentation and typing aid.
-    """
-
-    MARK = "mark"
-    HIGHLIGHT = "highlight"
-    ANNOTATION = "annotation"
-    CORRECTION = "correction"
-    SUPPRESSION = "suppression"
-    TAG = "tag"
-    METADATA = "metadata"
-    SAVED_QUERY = "saved_query"
-    RECALL_PACK = "recall_pack"
-    WORKSPACE_NOTE = "workspace_note"
-    NOTE = "note"
-    DECISION = "decision"
-    CAVEAT = "caveat"
-    LESSON = "lesson"
-    BLOCKER = "blocker"
-    HANDOFF = "handoff"
-    JUDGMENT = "judgment"
-    RUN_STATE = "run_state"
-    PROMPT_EVAL = "prompt_eval"
-    TRANSFORM_CANDIDATE = "transform_candidate"
 
 
 ASSERTION_DEFAULT_STATUS: Final = "active"

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import TypedDict
 
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
+from polylogue.core.enums import AssertionKind
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document
 from polylogue.core.refs import normalize_object_ref_text, normalize_public_ref_text
 
@@ -1164,7 +1165,7 @@ class AssertionQueryRowPayload(SurfacePayloadModel):
     assertion_id: str
     target_ref: str
     scope_ref: str | None = None
-    kind: str
+    kind: AssertionKind
     key: str | None = None
     body_text: str | None = None
     value: object
@@ -1199,7 +1200,7 @@ class AssertionQueryRowPayload(SurfacePayloadModel):
             assertion_id=row.assertion_id,
             target_ref=row.target_ref,
             scope_ref=row.scope_ref,
-            kind=row.kind,
+            kind=AssertionKind.from_string(row.kind),
             key=row.key,
             body_text=row.body_text,
             value=row.value,
@@ -1222,7 +1223,7 @@ class AssertionClaimPayload(SurfacePayloadModel):
     scope_ref: str | None = None
     target_ref: str
     key: str | None = None
-    kind: str
+    kind: AssertionKind
     value: object | None = None
     body_text: str | None = None
     author_ref: str | None = None
@@ -1259,7 +1260,7 @@ class AssertionClaimPayload(SurfacePayloadModel):
             scope_ref=envelope.scope_ref,
             target_ref=envelope.target_ref,
             key=envelope.key,
-            kind=envelope.kind,
+            kind=AssertionKind.from_string(envelope.kind),
             value=envelope.value,
             body_text=envelope.body_text,
             author_ref=envelope.author_ref,

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -37,7 +37,7 @@ import pytest
 from polylogue import Polylogue
 from polylogue.api.archive import SessionNotFoundError
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import BlockType, Origin, Provider
+from polylogue.core.enums import AssertionKind, BlockType, Origin, Provider
 from polylogue.errors import DatabaseError, PolylogueError
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -4206,7 +4206,7 @@ async def test_facade_judges_candidate_assertion_in_user_tier(workspace_env: dic
             conn,
             assertion_id="candidate-api-1",
             target_ref="session:claude-ai-export:conv-alpha",
-            kind="transform_candidate",
+            kind=AssertionKind.TRANSFORM_CANDIDATE,
             value={"candidate_kind": "decision"},
             body_text="Use the shared assertion lifecycle.",
             evidence_refs=("session:claude-ai-export:conv-alpha",),

--- a/tests/unit/cli/test_assertion_candidates.py
+++ b/tests/unit/cli/test_assertion_candidates.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 from click.testing import CliRunner
 
 from polylogue.cli.query_verbs import mark_candidates_group
+from polylogue.core.enums import AssertionKind
 from polylogue.surfaces.payloads import AssertionClaimPayload, AssertionJudgmentPayload, AssertionJudgmentResultPayload
 
 
@@ -14,7 +15,7 @@ def _claim(status: str = "candidate") -> AssertionClaimPayload:
     return AssertionClaimPayload(
         assertion_id="candidate-cli-1",
         target_ref="session:cli",
-        kind="transform_candidate",
+        kind=AssertionKind.TRANSFORM_CANDIDATE,
         value={"candidate_kind": "decision"},
         body_text="Keep candidate review explicit.",
         evidence_refs=("session:cli",),
@@ -54,7 +55,11 @@ def test_candidates_accept_emits_judgment_result_payload() -> None:
         candidate=_claim(status="accepted"),
         judgment=judgment,
         resulting_assertion=_claim(status="active").model_copy(
-            update={"assertion_id": "active-cli-1", "kind": "decision", "supersedes": ("assertion:candidate-cli-1",)}
+            update={
+                "assertion_id": "active-cli-1",
+                "kind": AssertionKind.DECISION,
+                "supersedes": ("assertion:candidate-cli-1",),
+            }
         ),
     )
     env = SimpleNamespace(polylogue=SimpleNamespace(judge_assertion_candidate=AsyncMock(return_value=payload)))

--- a/tests/unit/cli/test_context_view.py
+++ b/tests/unit/cli/test_context_view.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from polylogue.context.preamble import compose_context_preamble
+from polylogue.core.enums import AssertionKind
 
 
 def _session() -> SimpleNamespace:
@@ -52,7 +53,7 @@ def test_compose_context_preamble_includes_injectable_assertion_claims() -> None
     env.polylogue.list_assertion_claim_payloads = AsyncMock(
         return_value=[
             SimpleNamespace(
-                kind="decision",
+                kind=AssertionKind.DECISION,
                 body_text="Keep context claims behind explicit injection.",
                 target_ref="session:target",
                 scope_ref="repo:polylogue",

--- a/tests/unit/context/test_compiler.py
+++ b/tests/unit/context/test_compiler.py
@@ -12,7 +12,7 @@ from polylogue.context.compiler import (
     context_image_from_recovery,
     context_snapshot_record_from_image,
 )
-from polylogue.core.enums import Origin
+from polylogue.core.enums import AssertionKind, Origin
 from polylogue.core.refs import EvidenceRef, ObjectRef
 from polylogue.insights.transforms import RecoveryWorkPacketEntry, compile_recovery_digest
 from polylogue.types import SessionId
@@ -151,7 +151,7 @@ def test_context_image_from_recovery_preserves_assertion_refs() -> None:
     claim = AssertionClaimPayload(
         assertion_id="claim-1",
         target_ref="session:codex-session:compiler",
-        kind="decision",
+        kind=AssertionKind.DECISION,
         body_text="Keep context compilation evidence-backed.",
         evidence_refs=("codex-session:compiler",),
         status="active",

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -2192,6 +2192,7 @@ class TestSharedQueryPayloads:
         assert d["time_range"]["min"] == "2024-01-01"
 
     def test_assertion_claim_payloads_are_shared_surface_dtos(self) -> None:
+        from polylogue.core.enums import AssertionKind
         from polylogue.storage.sqlite.archive_tiers.user_write import ArchiveAssertionEnvelope
         from polylogue.surfaces.payloads import AssertionClaimListPayload, AssertionClaimPayload
 
@@ -2200,7 +2201,7 @@ class TestSharedQueryPayloads:
             scope_ref="repo:polylogue",
             target_ref="session:c1",
             key=None,
-            kind="decision",
+            kind=AssertionKind.DECISION,
             value=None,
             body_text="Keep assertion payloads shared.",
             author_ref="agent:test",

--- a/tests/unit/mcp/test_compose_context_preamble.py
+++ b/tests/unit/mcp/test_compose_context_preamble.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from polylogue.core.enums import AssertionKind
 from tests.infra.mcp import MCPServerUnderTest, invoke_surface_async, make_polylogue_mock
 
 
@@ -424,7 +425,7 @@ class TestContextPreambleModel:
             guidance=ContextPreambleGuidance(
                 assertions=[
                     ContextPreambleAssertionGuidance(
-                        kind="decision",
+                        kind=AssertionKind.DECISION,
                         text="Use the shared context-preamble builder.",
                         target_ref="session:target",
                         scope_ref="repo:polylogue",

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -15,7 +15,7 @@ import pytest
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Session, SessionSummary
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
-from polylogue.core.enums import BlockType, Provider
+from polylogue.core.enums import AssertionKind, BlockType, Provider
 from polylogue.core.refs import EvidenceRef
 from polylogue.insights.transforms import RecoveryWorkPacket, RecoveryWorkPacketEntry
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
@@ -1109,7 +1109,7 @@ class TestArchiveGenericToolSurfaces:
             scope_ref="repo:polylogue",
             target_ref="session:session-1",
             key=None,
-            kind="decision",
+            kind=AssertionKind.DECISION,
             value=None,
             body_text="Use shared assertion claim reads.",
             author_ref="agent:codex",

--- a/tests/unit/surfaces/test_evidence_ref_payloads.py
+++ b/tests/unit/surfaces/test_evidence_ref_payloads.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 from pydantic import ValidationError
 
+from polylogue.core.enums import AssertionKind
 from polylogue.surfaces.payloads import (
     AssertionClaimPayload,
     AssertionQueryRowPayload,
@@ -18,7 +21,7 @@ def test_assertion_query_payload_rejects_unparseable_target_ref() -> None:
         AssertionQueryRowPayload(
             assertion_id="a1",
             target_ref="claim-target",
-            kind="note",
+            kind=AssertionKind.NOTE,
             value={"ok": True},
             author_ref="user:local",
             author_kind="user",
@@ -32,12 +35,31 @@ def test_assertion_query_payload_rejects_unparseable_target_ref() -> None:
         )
 
 
+def test_assertion_query_payload_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError, match="Input should be"):
+        AssertionQueryRowPayload(
+            assertion_id="a1",
+            target_ref="session:codex-session:s1",
+            kind=cast(Any, "review"),
+            value={"ok": True},
+            author_ref="user:local",
+            author_kind="user",
+            status="active",
+            visibility="private",
+            evidence_refs=(),
+            staleness={},
+            context_policy={"inject": False},
+            created_at_ms=1,
+            updated_at_ms=1,
+        )
+
+
 def test_assertion_claim_payload_accepts_object_and_evidence_refs() -> None:
     payload = AssertionClaimPayload(
         assertion_id="a1",
         scope_ref="workspace:polylogue",
         target_ref="message:codex-session:s1:m1",
-        kind="note",
+        kind=AssertionKind.NOTE,
         body_text="needs review",
         author_ref="user:local",
         evidence_refs=(
@@ -50,10 +72,23 @@ def test_assertion_claim_payload_accepts_object_and_evidence_refs() -> None:
 
     assert payload.scope_ref == "workspace:polylogue"
     assert payload.target_ref == "message:codex-session:s1:m1"
+    assert payload.kind is AssertionKind.NOTE
     assert payload.evidence_refs == (
         "session:codex-session:s1",
         "codex-session:s1::m1",
     )
+
+
+def test_assertion_claim_payload_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError, match="Input should be"):
+        AssertionClaimPayload(
+            assertion_id="a1",
+            target_ref="message:codex-session:s1:m1",
+            kind=cast(Any, "review"),
+            body_text="needs review",
+            created_at_ms=1,
+            updated_at_ms=1,
+        )
 
 
 def test_observed_event_payload_rejects_unparseable_evidence_refs() -> None:


### PR DESCRIPTION
## Summary

Moves `AssertionKind` into the core enum vocabulary and makes shared assertion payloads use that enum instead of raw strings. Assertion terminal query rows and assertion claim DTOs now reject unsupported assertion kinds at the shared CLI/API/MCP/web payload boundary, and generated OpenAPI/CLI schemas expose the closed assertion-kind vocabulary.

## Problem

#1883 made assertions the user-overlay substrate, but some surface DTOs still treated `kind` as arbitrary text. That kept assertion lifecycle/read payloads stringly typed even though storage and writers already used a closed assertion vocabulary. #2246 also had stale schema documentation claiming `user.db` was still schema version 1 while the canonical DDL is version 3.

## Solution

- Moved `AssertionKind` from the user-tier storage helper into `polylogue.core.enums`.
- Re-exported it through `user_write` by import, so existing storage call sites keep their current import path.
- Updated `AssertionQueryRowPayload` and `AssertionClaimPayload` to require `AssertionKind` and convert storage/envelope strings through `AssertionKind.from_string`.
- Added focused validation coverage for unknown assertion kinds at the payload boundary.
- Regenerated CLI output schema and OpenAPI artifacts.
- Corrected `docs/schema.md` for `USER_SCHEMA_VERSION = 3`.

This does not claim #1883 is closed. The broader live public names around blackboard/user-state/overlay absorption still need a behavior-preserving cleanup pass.

## Verification

- `devtools test tests/unit/surfaces/test_evidence_ref_payloads.py tests/unit/storage/test_archive_tiers_assertions.py` -> 23 passed
- `mypy polylogue/core/enums.py polylogue/storage/sqlite/archive_tiers/user_write.py polylogue/surfaces/payloads.py tests/unit/surfaces/test_evidence_ref_payloads.py` -> Success
- `devtools render all --check` -> sync OK
- `devtools verify --quick` -> exit_code 0

Ref #1883
Ref #2246