### PR TITLE
feat(cli): expose query completion metadata (#1844)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -605,8 +605,9 @@ Options:
   --help                    Show this message and exit.
 
 Commands:
-  completions  Generate shell completion scripts.
-  paths        Print canonical archive paths and filesystem topology.
+  completions        Generate shell completion scripts.
+  paths              Print canonical archive paths and filesystem topology.
+  query-completions  Print shared query-builder completion metadata as JSON.
 ```
 
 ## Completions

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `254`
+- scenario projections: `255`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
-  - exercise: `145`
+  - exercise: `146`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -356,6 +356,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-config` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | config help |
 | `exercise` | `help-config-completions` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | config completions help |
 | `exercise` | `help-config-paths` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | config paths help |
+| `exercise` | `help-config-query-completions` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | config query-completions help |
 | `exercise` | `help-continue` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | continue help |
 | `exercise` | `help-dashboard` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | dashboard help |
 | `exercise` | `help-delete` | `session-query-loop` | `message_fts`<br>`session_query_results` | `cli.help`<br>`query-sessions` | — | `generated`<br>`help`<br>`structural` | delete help |

--- a/polylogue/cli/commands/completions.py
+++ b/polylogue/cli/commands/completions.py
@@ -32,8 +32,12 @@ is exercised by ``tests/unit/cli/test_completion_matrix.py``.
 
 from __future__ import annotations
 
+import json
+
 import click
 from click.shell_completion import get_completion_class
+
+from polylogue.archive.query.completions import QUERY_COMPLETION_KINDS, QueryCompletionError, query_completion_payload
 
 _INSTALL_EPILOG = """\
 \b
@@ -63,4 +67,19 @@ def completions_command(ctx: click.Context, shell: str) -> None:
     click.echo(comp.source())
 
 
-__all__ = ["completions_command"]
+@click.command("query-completions")
+@click.option("--kind", type=click.Choice(QUERY_COMPLETION_KINDS), required=True)
+@click.option("--incomplete", default="", show_default=True, help="Current token or partial text to complete.")
+@click.option("--unit", help="Structural or terminal query unit for unit-scoped completion.")
+@click.option("--field", help="Query field for operator completion.")
+def query_completions_command(kind: str, incomplete: str, unit: str | None, field: str | None) -> None:
+    """Print shared query-builder completion metadata as JSON."""
+
+    try:
+        payload = query_completion_payload(kind, incomplete=incomplete, unit=unit, field=field)
+    except QueryCompletionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+__all__ = ["completions_command", "query_completions_command"]

--- a/polylogue/cli/commands/config.py
+++ b/polylogue/cli/commands/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from polylogue.cli.commands.completions import completions_command
+from polylogue.cli.commands.completions import completions_command, query_completions_command
 from polylogue.cli.commands.paths import paths_command
 from polylogue.cli.shared.types import AppEnv
 
@@ -35,6 +35,7 @@ def config_command(ctx: click.Context, output_format: str, show_layers: bool) ->
 
 
 config_command.add_command(completions_command)
+config_command.add_command(query_completions_command)
 config_command.add_command(paths_command)
 
 

--- a/tests/unit/cli/test_completions_contract.py
+++ b/tests/unit/cli/test_completions_contract.py
@@ -10,6 +10,8 @@ Companion to ``test_plain_output_contract.py`` and ``test_help_contract.py``.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from click.testing import CliRunner
 
@@ -97,3 +99,49 @@ class TestCompletionsErrorPaths:
             f"expected Click usage error on stderr, got stderr={result.stderr!r}"
         )
         assert "Missing option" not in result.stdout
+
+
+class TestQueryCompletionMetadata:
+    """The CLI exposes the shared query-builder metadata payload directly."""
+
+    def test_query_completions_prints_shared_field_payload(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["config", "query-completions", "--kind", "field", "--incomplete", "da"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["kind"] == "field"
+        candidates = payload["candidates"]
+        assert isinstance(candidates, list)
+        date_candidate = next(candidate for candidate in candidates if candidate["value"] == "date")
+        assert date_candidate["insert"] == "date "
+        assert date_candidate["source"] == "DATE_QUERY_FIELD_REGISTRY"
+
+    def test_query_completions_prints_unit_scoped_terminal_fields(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                "query-completions",
+                "--kind",
+                "terminal-field",
+                "--unit",
+                "context-snapshots",
+                "--incomplete",
+                "bound",
+            ],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["kind"] == "terminal-field"
+        assert payload["unit"] == "context-snapshots"
+        candidates = payload["candidates"]
+        assert isinstance(candidates, list)
+        assert [candidate["value"] for candidate in candidates] == ["boundary"]
+
+    def test_query_completions_reports_missing_context_cleanly(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["config", "query-completions", "--kind", "terminal-field"])
+
+        assert result.exit_code != 0
+        assert "--unit is required for terminal-field completion" in result.output
+        assert TRACEBACK_SENTINEL not in result.output


### PR DESCRIPTION
## Summary

Adds `polylogue config query-completions`, a read-only CLI bridge to the shared query-completion payload already used by Python API, MCP, and daemon web routes. This makes the query-builder metadata inspectable from the CLI without speaking shell completion protocol or reimplementing grammar/action/unit lists.

## Problem

#1844 had real metadata and shell completion support, but the CLI still lacked a direct way to inspect the structured `QueryCompletionCandidate` payload that future query builders and agents should consume. That left the shared completion contract available through API/MCP/daemon, while local CLI users had only shell script generation or shell-specific completion protocol behavior.

## Solution

- Add `polylogue config query-completions --kind ... [--incomplete ...] [--unit ...] [--field ...]`.
- Source candidates from `polylogue.archive.query.completions.query_completion_payload` and `QUERY_COMPLETION_KINDS`.
- Keep errors clean through `QueryCompletionError` -> ClickException, e.g. missing `--unit` for terminal-field completion.
- Add CLI tests for field payloads, unit-scoped terminal fields, and missing-context errors.
- Regenerate CLI reference and quality reference docs.

This is not a claim that #1844 is complete. It closes a concrete local-CLI/query-builder metadata gap; remaining UX work includes true interactive/fuzzy query construction and real shell behavior verification across quoted DSL expressions.

## Verification

- `devtools test tests/unit/cli/test_completions_contract.py` -> 12 passed
- `devtools test tests/unit/cli/test_completions_contract.py tests/unit/api/test_facade_contracts.py::test_query_completions_exposes_shared_completion_payload tests/unit/daemon/test_web_reader.py -k query_completions_endpoint` -> 4 daemon query-completion endpoint tests passed (the selected CLI/API nodes were deselected by the `-k`; the CLI file was verified separately above)
- `devtools verify --quick` -> exit_code 0

Ref #1844