### PR TITLE
refactor(surfaces): type mutation result vocabularies (#2177)

### DIFF
--- a/docs/schemas/cli-output/mutation-result.schema.json
+++ b/docs/schemas/cli-output/mutation-result.schema.json
@@ -79,6 +79,25 @@
     "operation": {
       "anyOf": [
         {
+          "enum": [
+            "add_tag",
+            "set_meta",
+            "mutate",
+            "delete",
+            "mark.add",
+            "mark.delete",
+            "annotation.save",
+            "annotation.delete",
+            "saved_view.save",
+            "saved_view.delete",
+            "recall_pack.save",
+            "recall_pack.delete",
+            "workspace.save",
+            "workspace.delete",
+            "correction.save",
+            "correction.delete",
+            "correction.clear"
+          ],
           "type": "string"
         },
         {
@@ -91,6 +110,20 @@
     "outcome": {
       "anyOf": [
         {
+          "enum": [
+            "added",
+            "updated",
+            "no_op",
+            "removed",
+            "not_present",
+            "set",
+            "deleted",
+            "not_found",
+            "cleared",
+            "tag_reject",
+            "tag_accept",
+            "summary_override"
+          ],
           "type": "string"
         },
         {
@@ -176,6 +209,16 @@
       "title": "Skipped Count"
     },
     "status": {
+      "enum": [
+        "ok",
+        "deleted",
+        "not_found",
+        "unchanged",
+        "partial",
+        "preview",
+        "aborted",
+        "failed"
+      ],
       "title": "Status",
       "type": "string"
     },

--- a/polylogue/archive/write_gateway.py
+++ b/polylogue/archive/write_gateway.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import Any, Literal
 
 from polylogue.storage.sqlite.connection_profile import open_connection as _open_conn
 
@@ -30,12 +30,15 @@ class WriteOperation(Enum):
     BLOB_STORE = "blob_store"
 
 
+WriteResultStatus = Literal["committed", "rejected", "deferred"]
+
+
 @dataclass(frozen=True, slots=True)
 class WriteResult:
     operation_id: str
     operation: WriteOperation
     rows_affected: int
-    status: str  # "committed", "rejected", "deferred"
+    status: WriteResultStatus
 
 
 class ArchiveWriteGateway:
@@ -98,4 +101,5 @@ __all__ = [
     "ArchiveWriteGateway",
     "WriteOperation",
     "WriteResult",
+    "WriteResultStatus",
 ]

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -51,6 +51,7 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.surfaces.payloads import (
     SEARCH_CURSOR_VERSION,
     InvalidSearchCursorError,
+    MutationOperation,
     MutationResultPayload,
     SearchCursor,
     SessionListRowPayload,
@@ -1195,7 +1196,7 @@ def _emit_stats_by(
     _emit_rows(envelope, items, output_format=output_format, text_line=_stats_by_line, fields=fields)
 
 
-def _emit_mutation(changed: int, *, operation: str) -> None:
+def _emit_mutation(changed: int, *, operation: MutationOperation) -> None:
     click.echo(
         MutationResultPayload(status="ok", operation=operation, affected_count=changed).to_json(exclude_none=True)
     )

--- a/polylogue/daemon/user_state_http.py
+++ b/polylogue/daemon/user_state_http.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, cast
 
 from polylogue.archive.query.spec import SessionQuerySpec
 from polylogue.core.user_state_targets import TARGET_SESSION, is_mark_type_supported, validate_target_kind
-from polylogue.surfaces.payloads import MutationResultPayload
+from polylogue.surfaces.payloads import MutationResultPayload, MutationStatus
 
 RouteMethod = Literal["GET", "POST", "DELETE"]
 
@@ -137,7 +137,9 @@ def _default_annotation_id(target_type: str, target_id: str, note_text: str) -> 
     return f"annotation-{digest}"
 
 
-def _mutation_status(created_or_deleted: bool, *, missing_detail: str | None = None) -> tuple[str, str | None, int]:
+def _mutation_status(
+    created_or_deleted: bool, *, missing_detail: str | None = None
+) -> tuple[MutationStatus, str | None, int]:
     if created_or_deleted:
         return "ok", None, 1
     if missing_detail is None:
@@ -145,10 +147,14 @@ def _mutation_status(created_or_deleted: bool, *, missing_detail: str | None = N
     return "not_found", missing_detail, 0
 
 
-def _save_mutation_status(created: bool) -> tuple[str, str | None, int]:
+def _save_mutation_status(created: bool) -> tuple[MutationStatus, str | None, int]:
     if created:
         return "ok", None, 1
     return "ok", "updated", 1
+
+
+def _delete_mutation_status(status: MutationStatus) -> MutationStatus:
+    return "deleted" if status == "ok" else status
 
 
 def _send_mutation_result(handler: Any, result: MutationResultPayload, *, created: bool = False) -> None:
@@ -355,7 +361,7 @@ def handle_delete_annotation(handler: Any, annotation_id: str) -> None:
         deleted = await poly.delete_annotation(annotation_id)
         status, detail, affected_count = _mutation_status(deleted, missing_detail="annotation_not_found")
         return MutationResultPayload(
-            status="deleted" if status == "ok" else status,
+            status=_delete_mutation_status(status),
             detail=detail,
             operation="annotation.delete",
             affected_count=affected_count,
@@ -424,7 +430,7 @@ def handle_delete_saved_view(handler: Any, view_id: str) -> None:
         deleted = await poly.delete_view(view_id)
         status, detail, affected_count = _mutation_status(deleted, missing_detail="saved_view_not_found")
         return MutationResultPayload(
-            status="deleted" if status == "ok" else status,
+            status=_delete_mutation_status(status),
             detail=detail,
             operation="saved_view.delete",
             affected_count=affected_count,
@@ -495,7 +501,7 @@ def handle_delete_recall_pack(handler: Any, pack_id: str) -> None:
         deleted = await poly.delete_recall_pack(pack_id)
         status, detail, affected_count = _mutation_status(deleted, missing_detail="recall_pack_not_found")
         return MutationResultPayload(
-            status="deleted" if status == "ok" else status,
+            status=_delete_mutation_status(status),
             detail=detail,
             operation="recall_pack.delete",
             affected_count=affected_count,
@@ -579,7 +585,7 @@ def handle_delete_workspace(handler: Any, workspace_id: str) -> None:
         deleted = await poly.delete_workspace(workspace_id)
         status, detail, affected_count = _mutation_status(deleted, missing_detail="workspace_not_found")
         return MutationResultPayload(
-            status="deleted" if status == "ok" else status,
+            status=_delete_mutation_status(status),
             detail=detail,
             operation="workspace.delete",
             affected_count=affected_count,

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -861,7 +861,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 MutationResultPayload(
                     status="ok" if removed else "not_found",
                     session_id=resolved,
-                    outcome=kind,
+                    outcome="deleted" if removed else "not_found",
                 ),
                 exclude_none=True,
             )

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -18,6 +18,50 @@ from polylogue.core.enums import AssertionKind
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document
 from polylogue.core.refs import normalize_object_ref_text, normalize_public_ref_text
 
+MutationStatus: TypeAlias = Literal[
+    "ok",
+    "deleted",
+    "not_found",
+    "unchanged",
+    "partial",
+    "preview",
+    "aborted",
+    "failed",
+]
+MutationOutcome: TypeAlias = Literal[
+    "added",
+    "updated",
+    "no_op",
+    "removed",
+    "not_present",
+    "set",
+    "deleted",
+    "not_found",
+    "cleared",
+    "tag_reject",
+    "tag_accept",
+    "summary_override",
+]
+MutationOperation: TypeAlias = Literal[
+    "add_tag",
+    "set_meta",
+    "mutate",
+    "delete",
+    "mark.add",
+    "mark.delete",
+    "annotation.save",
+    "annotation.delete",
+    "saved_view.save",
+    "saved_view.delete",
+    "recall_pack.save",
+    "recall_pack.delete",
+    "workspace.save",
+    "workspace.delete",
+    "correction.save",
+    "correction.delete",
+    "correction.clear",
+]
+
 if TYPE_CHECKING:
     from collections.abc import Container
 
@@ -2288,18 +2332,16 @@ class MutationResultPayload(SurfacePayloadModel):
     same mutation contract shape.
     """
 
-    status: str
-    """``ok``, ``deleted``, ``not_found``, ``unchanged``, or ``partial``. The CLI
-    bulk-delete surface additionally emits ``preview`` (dry-run) and ``aborted``
-    (operator declined the confirmation prompt)."""
+    status: MutationStatus
+    """Closed status for user-visible mutation surfaces."""
 
     session_id: str | None = None
     detail: str | None = None
     """Machine-readable detail: ``already_present``, ``tag_not_present``,
     ``updated``, ``key_not_found``, ``value_unchanged``, ``session_not_found``."""
 
-    outcome: str | None = None
-    """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
+    outcome: MutationOutcome | None = None
+    """Optional idempotency outcome for resource-level mutations."""
 
     affected_count: int | None = None
     skipped_count: int | None = None
@@ -2314,9 +2356,8 @@ class MutationResultPayload(SurfacePayloadModel):
     session_count: int | None = None
     tag_count: int | None = None
     applied_count: int | None = None
-    operation: str | None = None
-    """Mutation discriminator such as ``add_tag``, ``set_meta``,
-    ``annotation.save``, ``saved_view.delete``, ``mutate``, or ``delete``."""
+    operation: MutationOperation | None = None
+    """Closed mutation discriminator for surfaces that expose operation names."""
     session_ids: tuple[str, ...] | None = None
     """Session ids enumerated by a CLI bulk operation (e.g. the delete dry-run
     preview lists the sessions that *would* be deleted). ``None`` for

--- a/tests/unit/archive/test_write_gateway.py
+++ b/tests/unit/archive/test_write_gateway.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.archive.write_gateway import ArchiveWriteGateway, WriteOperation
+from polylogue.archive.write_gateway import ArchiveWriteGateway, WriteOperation, WriteResultStatus
 from polylogue.storage.sqlite.connection import open_connection
+
+COMMITTED: WriteResultStatus = "committed"
 
 
 def test_write_gateway_commits_effects_on_caller_owned_connection(tmp_path: Path) -> None:
@@ -21,7 +23,7 @@ def test_write_gateway_commits_effects_on_caller_owned_connection(tmp_path: Path
         )
 
         assert result.operation is WriteOperation.INGEST
-        assert result.status == "committed"
+        assert result.status == COMMITTED
         assert conn.execute("SELECT 1").fetchone()[0] == 1
 
 
@@ -51,7 +53,7 @@ def test_write_gateway_normal_commit_does_not_drop_fts_triggers(
             },
         )
 
-    assert result.status == "committed"
+    assert result.status == COMMITTED
     assert ensured == [True]
 
 
@@ -79,7 +81,7 @@ def test_write_gateway_can_skip_fts_repairs_when_triggers_maintained_rows(
             },
         )
 
-    assert result.status == "committed"
+    assert result.status == COMMITTED
     assert repaired == []
 
 
@@ -105,7 +107,7 @@ def test_write_gateway_repairs_fts_when_requested_even_if_live_triggers_exist(
             },
         )
 
-    assert result.status == "committed"
+    assert result.status == COMMITTED
     assert repaired == ["messages"]
 
 
@@ -133,7 +135,7 @@ def test_write_gateway_repairs_fts_when_live_triggers_were_missing(
             },
         )
 
-    assert result.status == "committed"
+    assert result.status == COMMITTED
     assert repaired == ["messages"]
 
 
@@ -150,4 +152,4 @@ async def test_write_gateway_async_commit_uses_same_local_effects_path(tmp_path:
         )
 
         assert result.operation is WriteOperation.INGEST
-        assert result.status == "committed"
+        assert result.status == COMMITTED

--- a/tests/unit/mcp/test_tag_idempotency.py
+++ b/tests/unit/mcp/test_tag_idempotency.py
@@ -9,6 +9,9 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from pydantic import ValidationError
+
 from polylogue.surfaces.payloads import TagMutationResult
 from tests.infra.mcp import (
     MCPServerUnderTest,
@@ -202,3 +205,51 @@ class TestMutationResultPayloadRoundtrip:
         serialized = payload.model_dump_json(exclude_none=True)
         parsed = json.loads(serialized)
         assert "outcome" not in parsed
+
+    def test_payload_rejects_unknown_mutation_vocabularies(self) -> None:
+        from polylogue.mcp.payloads import MutationResultPayload
+
+        with pytest.raises(ValidationError):
+            MutationResultPayload(status="bogus")  # type: ignore[arg-type]
+        with pytest.raises(ValidationError):
+            MutationResultPayload(status="ok", outcome="bogus")  # type: ignore[arg-type]
+        with pytest.raises(ValidationError):
+            MutationResultPayload(status="ok", operation="bogus")  # type: ignore[arg-type]
+
+
+class TestCorrectionMutationOutcomes:
+    """Correction mutation payloads expose mutation outcomes, not input kinds."""
+
+    def test_clear_one_correction_reports_deleted_outcome(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock(resolved_id=_CONV_ID)
+            mock_poly.delete_correction = AsyncMock(return_value=True)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["clear_corrections"].fn,
+                session_id=_CONV_ID,
+                kind="tag_accept",
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert parsed["outcome"] == "deleted"
+        _assert_mutation_schema(parsed)
+
+    def test_clear_missing_correction_reports_not_found_outcome(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock(resolved_id=_CONV_ID)
+            mock_poly.delete_correction = AsyncMock(return_value=False)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["clear_corrections"].fn,
+                session_id=_CONV_ID,
+                kind="tag_accept",
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "not_found"
+        assert parsed["outcome"] == "not_found"
+        _assert_mutation_schema(parsed)


### PR DESCRIPTION
Summary
Types the finite mutation/write result vocabularies that are shared across CLI, MCP, daemon, and archive write surfaces. The JSON payloads still serialize as strings, but the owned status/outcome/operation sets are now enforced by Pydantic and reflected in the generated CLI output schema.

Problem
#2177 calls out places where Polylogue owns a closed vocabulary but leaves it as free text. `MutationResultPayload` and `WriteResult.status` were examples: comments documented accepted values, while producers and generated schemas could still drift to arbitrary strings. One MCP correction path also used the requested correction kind as an `outcome`, even though `outcome` is supposed to describe mutation result state.

Solution
Added shared `MutationStatus`, `MutationOutcome`, and `MutationOperation` type aliases in `polylogue.surfaces.payloads`, typed `WriteResult.status`, and updated daemon user-state helpers to return the shared status type. `clear_corrections(kind=...)` now reports `outcome=deleted|not_found` instead of echoing the input kind. The mutation-result CLI schema was regenerated so machine consumers see the closed enum sets.

Verification
- `mypy polylogue/surfaces/payloads.py polylogue/cli/archive_query.py polylogue/archive/write_gateway.py polylogue/archive/write_effects.py polylogue/daemon/user_state_http.py polylogue/mcp/server_mutation_tools.py tests/unit/archive/test_write_gateway.py tests/unit/mcp/test_tag_idempotency.py` -> success
- `devtools test tests/unit/mcp/test_tag_idempotency.py tests/unit/archive/test_write_gateway.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/api/test_facade_contracts.py::test_archive_tiers_api_marks_and_annotations_write_user_tier tests/unit/api/test_facade_contracts.py::test_archive_tiers_api_corrections_write_user_tier tests/unit/cli/test_json_envelope_contract.py` -> 161 passed
- `devtools verify --quick` -> exit_code 0

Ref #2177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed correction clearing to report correct outcome based on whether the correction was actually removed

* **Chores**
  * Strengthened validation for mutation operation statuses, outcomes, and operation types across the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->