### PR TITLE
refactor(verifiability): run archive smoke as direct CLI checks (#2196)

### DIFF
--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -6,21 +6,18 @@ import argparse
 import json
 import subprocess
 import sys
+import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TextIO
 
 from devtools import repo_root as _get_root
 from polylogue.core.outcomes import OutcomeStatus
+from polylogue.scenarios import AssertionSpec, ExecutionSpec, polylogue_execution
 from polylogue.showcase.cli_boundary import invoke_showcase_cli
-from polylogue.showcase.exercises import EXERCISES, Exercise
-from polylogue.showcase.invariants import InvariantResult, check_invariants
-from polylogue.showcase.runner import ShowcaseRunner
-from polylogue.showcase.showcase_runner_models import ShowcaseResult
-from polylogue.showcase.showcase_runner_support import run_exercise
 
 _SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke")
-TIER_0_GROUPS = frozenset({"structural"})
-_ENV_DEPENDENT: frozenset[str] = frozenset({"version"})
+_ARCHIVE_SMOKE_TIER = 0
 
 
 class _ScenarioResult(Protocol):
@@ -31,65 +28,95 @@ class _ScenarioResult(Protocol):
     def failed_stages(self) -> tuple[str, ...]: ...
 
 
+@dataclass(frozen=True, slots=True)
+class ArchiveSmokeCheck:
+    name: str
+    execution: ExecutionSpec
+    assertion: AssertionSpec
+    timeout_s: float = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveSmokeCheckResult:
+    check: ArchiveSmokeCheck
+    passed: bool
+    exit_code: int
+    output: str
+    duration_ms: float
+    error: str | None = None
+
+
+_ARCHIVE_SMOKE_CHECKS: tuple[ArchiveSmokeCheck, ...] = (
+    ArchiveSmokeCheck(
+        name="help-main",
+        execution=polylogue_execution("--help"),
+        assertion=AssertionSpec(stdout_contains=("polylogue",)),
+    ),
+    ArchiveSmokeCheck(
+        name="help-mark-candidates",
+        execution=polylogue_execution("mark", "candidates", "--help"),
+        assertion=AssertionSpec(stdout_contains=("candidates",)),
+    ),
+    ArchiveSmokeCheck(
+        name="completions-bash",
+        execution=polylogue_execution("config", "completions", "--shell", "bash"),
+        assertion=AssertionSpec(stdout_contains=("complete",)),
+    ),
+)
+
+
 class ArchiveSmokeResult:
     """Direct result wrapper for the archive-smoke lab scenario."""
 
     def __init__(
         self,
         *,
-        showcase_result: ShowcaseResult,
-        invariant_results: list[InvariantResult],
+        check_results: list[ArchiveSmokeCheckResult],
         report_dir: Path | None,
+        unsupported_reason: str | None = None,
     ) -> None:
-        self.showcase_result = showcase_result
-        self.invariant_results = invariant_results
+        self.check_results = check_results
         self.report_dir = report_dir
+        self.unsupported_reason = unsupported_reason
 
     @property
     def all_passed(self) -> bool:
         return not self.failed_stages()
 
     def stage_statuses(self) -> dict[str, OutcomeStatus]:
-        invariant_status = (
+        status = (
             OutcomeStatus.ERROR
-            if any(result.status is OutcomeStatus.ERROR for result in self.invariant_results)
+            if self.unsupported_reason is not None or any(not result.passed for result in self.check_results)
             else OutcomeStatus.OK
         )
         return {
-            "showcase": OutcomeStatus.OK if self.showcase_result.failed == 0 else OutcomeStatus.ERROR,
-            "invariants": invariant_status,
+            "cli": status,
         }
 
     def failed_stages(self) -> tuple[str, ...]:
         return tuple(name for name, status in self.stage_statuses().items() if status is OutcomeStatus.ERROR)
 
 
-def get_tier_0_exercises() -> list[Exercise]:
-    """Return tier-0 exercises with stable committed baseline output."""
-    return [ex for ex in EXERCISES if ex.group in TIER_0_GROUPS and not ex.needs_data and ex.name not in _ENV_DEPENDENT]
+def get_archive_smoke_checks() -> tuple[ArchiveSmokeCheck, ...]:
+    """Return direct CLI checks for the archive-smoke lab scenario."""
+    return _ARCHIVE_SMOKE_CHECKS
 
 
 def run_tier_0() -> dict[str, str]:
-    """Run tier-0 showcase exercises and return output by exercise name."""
-    from polylogue.showcase.exercises import topological_order
-
-    exercises = topological_order(get_tier_0_exercises())
+    """Run direct archive-smoke checks and return output by check name."""
+    checks = get_archive_smoke_checks()
     results: dict[str, str] = {}
     failures: list[str] = []
-    total = len(exercises)
-    for index, exercise in enumerate(exercises, start=1):
-        print(f"  [{index:03d}/{total:03d}] {exercise.name}", flush=True)
-        result = run_exercise(
-            exercise,
-            env_vars={},
-            invoke_showcase_cli_fn=invoke_showcase_cli,
-        )
-        results[exercise.name] = result.output or ""
+    total = len(checks)
+    for index, check in enumerate(checks, start=1):
+        print(f"  [{index:03d}/{total:03d}] {check.name}", flush=True)
+        result = _run_archive_smoke_check(check)
+        results[check.name] = result.output or ""
         if not result.passed:
-            failures.append(f"{exercise.name}: exit {result.exit_code}: {result.error or 'failed'}")
+            failures.append(f"{check.name}: exit {result.exit_code}: {result.error or 'failed'}")
     if failures:
         joined = "\n  - ".join(failures)
-        raise RuntimeError(f"tier-0 showcase exercises failed:\n  - {joined}")
+        raise RuntimeError(f"archive-smoke checks failed:\n  - {joined}")
     return results
 
 
@@ -113,13 +140,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def list_scenarios(*, as_json: bool) -> int:
-    """List available showcase scenarios with their tier-0 exercise inventory."""
-    tier_0 = get_tier_0_exercises()
+    """List available scenario checks."""
+    archive_checks = get_archive_smoke_checks()
     scenarios: list[dict[str, object]] = [
         {
             "name": "archive-smoke",
-            "kind": "showcase",
-            "tier_0_exercise_count": len(tier_0),
+            "kind": "cli-smoke",
+            "tier_0_check_count": len(archive_checks),
         },
         {
             "name": "reader-visual-smoke",
@@ -136,7 +163,7 @@ def list_scenarios(*, as_json: bool) -> int:
         if name == "reader-visual-smoke":
             print(f"{name:<20s}  command: {entry['command']}")
             continue
-        print(f"{name:<20s}  tier-0 exercises: {entry['tier_0_exercise_count']}")
+        print(f"{name:<20s}  tier-0 checks: {entry['tier_0_check_count']}")
     return 0
 
 
@@ -194,21 +221,24 @@ def run_archive_smoke(
     report_dir: Path | None,
     verbose: bool,
     fail_fast: bool,
+    as_json: bool = False,
 ) -> ArchiveSmokeResult:
-    """Run the archive-smoke lab scenario without QA session wrapping."""
-    runner = ShowcaseRunner(
-        live=live,
-        output_dir=report_dir,
-        fail_fast=fail_fast,
+    """Run direct archive-smoke CLI checks without showcase catalog wrapping."""
+    if tier not in (None, _ARCHIVE_SMOKE_TIER):
+        return ArchiveSmokeResult(
+            check_results=[],
+            report_dir=report_dir,
+            unsupported_reason=f"archive-smoke only supports tier {_ARCHIVE_SMOKE_TIER} direct CLI checks",
+        )
+    check_results = _run_archive_smoke_checks(
         verbose=verbose,
-        tier_filter=tier,
+        fail_fast=fail_fast,
+        progress_stream=sys.stderr if as_json else sys.stdout,
     )
-    showcase_result = runner.run()
-    invariant_results = check_invariants(showcase_result.results)
+    _write_archive_smoke_report(report_dir, check_results=check_results, live=live, tier=tier)
     return ArchiveSmokeResult(
-        showcase_result=showcase_result,
-        invariant_results=invariant_results,
-        report_dir=showcase_result.output_dir,
+        check_results=check_results,
+        report_dir=report_dir,
     )
 
 
@@ -223,6 +253,90 @@ def _scenario_payload(result: _ScenarioResult) -> dict[str, object]:
         "ok": not failed_stages,
         "report_dir": str(result.report_dir) if result.report_dir is not None else None,
     }
+
+
+def _run_archive_smoke_check(check: ArchiveSmokeCheck) -> ArchiveSmokeCheckResult:
+    started = time.monotonic()
+    try:
+        cli_result = invoke_showcase_cli(check.execution, env={"POLYLOGUE_FORCE_PLAIN": "1"}, timeout=check.timeout_s)
+    except subprocess.TimeoutExpired:
+        duration_ms = (time.monotonic() - started) * 1000
+        return ArchiveSmokeCheckResult(
+            check=check,
+            passed=False,
+            exit_code=-1,
+            output="",
+            duration_ms=duration_ms,
+            error=f"timed out after {check.timeout_s:.0f}s",
+        )
+    except Exception as exc:
+        duration_ms = (time.monotonic() - started) * 1000
+        return ArchiveSmokeCheckResult(
+            check=check,
+            passed=False,
+            exit_code=-1,
+            output="",
+            duration_ms=duration_ms,
+            error=f"invoke crashed: {exc}",
+        )
+    output = cli_result.output
+    error = check.assertion.validate_process(output, cli_result.exit_code)
+    duration_ms = (time.monotonic() - started) * 1000
+    return ArchiveSmokeCheckResult(
+        check=check,
+        passed=error is None,
+        exit_code=cli_result.exit_code,
+        output=output,
+        duration_ms=duration_ms,
+        error=error,
+    )
+
+
+def _run_archive_smoke_checks(
+    *,
+    verbose: bool,
+    fail_fast: bool,
+    progress_stream: TextIO,
+) -> list[ArchiveSmokeCheckResult]:
+    results: list[ArchiveSmokeCheckResult] = []
+    checks = get_archive_smoke_checks()
+    for index, check in enumerate(checks, start=1):
+        print(f"  [{index:03d}/{len(checks):03d}] {check.name}", flush=True, file=progress_stream)
+        result = _run_archive_smoke_check(check)
+        results.append(result)
+        if verbose and result.output:
+            print(result.output, end="" if result.output.endswith("\n") else "\n", file=progress_stream)
+        if fail_fast and not result.passed:
+            break
+    return results
+
+
+def _write_archive_smoke_report(
+    report_dir: Path | None,
+    *,
+    check_results: list[ArchiveSmokeCheckResult],
+    live: bool,
+    tier: int | None,
+) -> None:
+    if report_dir is None:
+        return
+    report_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "scenario": "archive-smoke",
+        "live": live,
+        "tier": tier,
+        "checks": [
+            {
+                "name": result.check.name,
+                "exit_code": result.exit_code,
+                "passed": result.passed,
+                "duration_ms": round(result.duration_ms, 1),
+                "error": result.error,
+            }
+            for result in check_results
+        ],
+    }
+    (report_dir / "archive-smoke.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -240,6 +354,7 @@ def main(argv: list[str] | None = None) -> int:
         report_dir=args.report_dir,
         verbose=bool(args.verbose),
         fail_fast=bool(args.fail_fast),
+        as_json=bool(args.json),
     )
     if args.json:
         print(json.dumps(_scenario_payload(result), indent=2))

--- a/tests/unit/showcase/test_verification_lane.py
+++ b/tests/unit/showcase/test_verification_lane.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 import json
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -13,14 +15,19 @@ def test_module_imports() -> None:
     assert importlib.import_module("devtools.lab_scenario") is not None
 
 
-def test_get_tier_0_exercises_returns_structural_data_free_cases() -> None:
-    from devtools.lab_scenario import get_tier_0_exercises
+def test_get_archive_smoke_checks_returns_direct_cli_cases() -> None:
+    from devtools.lab_scenario import get_archive_smoke_checks
 
-    exercises = get_tier_0_exercises()
+    checks = get_archive_smoke_checks()
 
-    assert exercises
-    assert all(ex.group == "structural" for ex in exercises)
-    assert all(not ex.needs_data for ex in exercises)
+    assert [check.name for check in checks] == [
+        "help-main",
+        "help-mark-candidates",
+        "completions-bash",
+    ]
+    assert checks[0].execution.polylogue_args == ("--help",)
+    assert checks[1].execution.polylogue_args == ("mark", "candidates", "--help")
+    assert checks[2].execution.polylogue_args == ("config", "completions", "--shell", "bash")
 
 
 def test_list_scenarios_reports_live_paths_without_baseline_counts(capsys: pytest.CaptureFixture[str]) -> None:
@@ -33,50 +40,98 @@ def test_list_scenarios_reports_live_paths_without_baseline_counts(capsys: pytes
     visual = next(entry for entry in payload["scenarios"] if entry["name"] == "reader-visual-smoke")
     assert archive == {
         "name": "archive-smoke",
-        "kind": "showcase",
-        "tier_0_exercise_count": archive["tier_0_exercise_count"],
+        "kind": "cli-smoke",
+        "tier_0_check_count": archive["tier_0_check_count"],
     }
-    assert archive["tier_0_exercise_count"] > 0
+    assert archive["tier_0_check_count"] > 0
     assert visual["command"]
 
 
 def test_main_prints_direct_stage_summary(capsys: pytest.CaptureFixture[str]) -> None:
     from devtools.lab_scenario import main
-    from polylogue.showcase.showcase_runner_models import ShowcaseResult
 
-    with (
-        patch("devtools.lab_scenario.ShowcaseRunner") as runner_class,
-        patch("devtools.lab_scenario.check_invariants", return_value=[]),
-    ):
-        runner_class.return_value.run.return_value = ShowcaseResult()
+    def _invoke(execution: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(output=f"{execution}\npolylogue candidates complete", exit_code=0)
+
+    with patch("devtools.lab_scenario.invoke_showcase_cli", side_effect=_invoke):
         assert main(["run", "archive-smoke", "--tier", "0"]) == 0
 
     out = capsys.readouterr().out
     assert "Scenario stages:" in out
-    assert "showcase: ok" in out
-    assert "invariants: ok" in out
+    assert "cli: ok" in out
     assert "Failed stages: none" in out
 
 
 def test_main_json_reports_direct_scenario_payload(capsys: pytest.CaptureFixture[str]) -> None:
     from devtools.lab_scenario import main
-    from polylogue.showcase.showcase_runner_models import ShowcaseResult
 
-    with (
-        patch("devtools.lab_scenario.ShowcaseRunner") as runner_class,
-        patch("devtools.lab_scenario.check_invariants", return_value=[]),
-    ):
-        runner_class.return_value.run.return_value = ShowcaseResult()
+    def _invoke(_execution: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(output="polylogue candidates complete", exit_code=0)
+
+    with patch("devtools.lab_scenario.invoke_showcase_cli", side_effect=_invoke):
         assert main(["run", "archive-smoke", "--tier", "0", "--json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
     assert payload == {
         "scenario": "archive-smoke",
         "stages": {
-            "showcase": "ok",
-            "invariants": "ok",
+            "cli": "ok",
         },
         "failed_stages": [],
         "ok": True,
         "report_dir": None,
     }
+
+
+def test_main_json_reports_direct_check_failures(capsys: pytest.CaptureFixture[str]) -> None:
+    from devtools.lab_scenario import main
+
+    def _invoke(_execution: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(output="", exit_code=3)
+
+    with patch("devtools.lab_scenario.invoke_showcase_cli", side_effect=_invoke):
+        assert main(["run", "archive-smoke", "--tier", "0", "--json", "--fail-fast"]) == 1
+
+    output = capsys.readouterr().out
+    payload = json.loads(output[output.index("{") :])
+    assert payload == {
+        "scenario": "archive-smoke",
+        "stages": {
+            "cli": "error",
+        },
+        "failed_stages": ["cli"],
+        "ok": False,
+        "report_dir": None,
+    }
+
+
+def test_main_writes_direct_archive_smoke_report(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    from devtools.lab_scenario import main
+
+    def _invoke(_execution: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(output="polylogue candidates complete", exit_code=0)
+
+    report_dir = tmp_path / "reports"
+    with patch("devtools.lab_scenario.invoke_showcase_cli", side_effect=_invoke):
+        assert main(["run", "archive-smoke", "--tier", "0", "--report-dir", str(report_dir), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_dir"] == str(report_dir)
+    report_payload = json.loads((report_dir / "archive-smoke.json").read_text(encoding="utf-8"))
+    assert report_payload["scenario"] == "archive-smoke"
+    assert [check["name"] for check in report_payload["checks"]] == [
+        "help-main",
+        "help-mark-candidates",
+        "completions-bash",
+    ]
+    assert all(check["passed"] is True for check in report_payload["checks"])
+
+
+def test_main_reports_unsupported_archive_smoke_tier(capsys: pytest.CaptureFixture[str]) -> None:
+    from devtools.lab_scenario import main
+
+    assert main(["run", "archive-smoke", "--tier", "2", "--json"]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["stages"] == {"cli": "error"}
+    assert payload["failed_stages"] == ["cli"]


### PR DESCRIPTION
## Summary

Replaces the `archive-smoke` lab scenario's remaining `ShowcaseRunner`/exercise-catalog execution path with a small direct CLI smoke set over the real `polylogue` entrypoint. The scenario still emits a compact machine payload and can write a direct `archive-smoke.json` report artifact, but it no longer depends on the showcase runner just to exercise tier-0 command behavior.

## Problem

#2196 is about removing showcase QA bureaucracy after ordinary demo, CLI, and visual checks exist. #2295 removed the QA report/session layers, but `devtools lab scenario run archive-smoke --tier 0` still routed through the broader showcase exercise catalog and runner. That kept the old scaffold in the default verification lane even for three simple no-data CLI checks.

## Solution

- Adds typed direct `ArchiveSmokeCheck` / `ArchiveSmokeCheckResult` models inside `devtools/lab_scenario.py`.
- Runs the tier-0 archive smoke path as direct CLI checks for main help, mark candidate help, and bash completions.
- Keeps `--json` stdout machine-readable by sending progress to stderr.
- Writes a compact `archive-smoke.json` report when `--report-dir` is provided.
- Updates verification-lab tests to cover success, failure, unsupported tier, and report artifact behavior.

This does not close #2196. The remaining showcase catalog/runner files still exist for scenario projection, VHS, workspace, and broader catalog tests. They should be removed only after those consumers have direct replacement coverage.

## Verification

- `devtools test tests/unit/showcase/test_verification_lane.py` -> 8 passed
- `devtools lab scenario run archive-smoke --tier 0 --json >/tmp/polylogue-archive-smoke.json && jq -e '.ok == true and .stages.cli == \"ok\"' /tmp/polylogue-archive-smoke.json` -> `true`
- `devtools verify --quick` -> exit_code 0
- pre-push hook reran `devtools verify --quick` -> exit_code 0

Ref #2196