### PR TITLE
refactor(verifiability): rename scenario contract surfaces

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -243,7 +243,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=(
             "devtools lab lanes --list",
             "devtools lab lanes --lane frontier-local",
-            "devtools lab lanes --lane live-exercises --dry-run",
+            "devtools lab lanes --lane live-archive-smoke --dry-run",
         ),
     ),
     CommandSpec(
@@ -337,7 +337,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         use_when="Inspect the unified projection inventory that feeds runtime coverage, generated docs, and control-plane maps.",
         examples=(
             "devtools lab projections",
-            "devtools lab projections --source-kind exercise --artifact-target message_fts",
+            "devtools lab projections --source-kind validation-lane --artifact-target session_insight_rows",
             "devtools lab projections --json",
         ),
     ),

--- a/devtools/render_quality_reference.py
+++ b/devtools/render_quality_reference.py
@@ -220,7 +220,7 @@ def build_document(registry: QualityRegistry, *, runtime_coverage: RuntimeScenar
         "```bash",
         control_plane_command("lab lanes", "--list"),
         control_plane_command("lab lanes", "--lane", "frontier-local"),
-        control_plane_command("lab lanes", "--lane", "live-exercises", "--dry-run"),
+        control_plane_command("lab lanes", "--lane", "live-archive-smoke", "--dry-run"),
         "```",
         "",
         "### Schema upgrade lane (#1302)",

--- a/devtools/validation_lane_catalog_contracts.py
+++ b/devtools/validation_lane_catalog_contracts.py
@@ -625,7 +625,7 @@ COMPOSITE_LANES: dict[str, LaneEntry] = {
         timeout_s=2400,
         category="composite",
         origin=_COMPOSITE_ORIGIN,
-        execution=composite_execution("live-archive-small", "live-exercises"),
+        execution=composite_execution("live-archive-small", "live-archive-smoke"),
     ),
     "archive-intelligence": LaneEntry(
         name="archive-intelligence",

--- a/devtools/validation_lane_catalog_live.py
+++ b/devtools/validation_lane_catalog_live.py
@@ -78,9 +78,9 @@ LIVE_LANES: dict[str, LaneEntry] = {
         ),
         tags=("live", "probe", "parse"),
     ),
-    "live-exercises": LaneEntry(
-        name="live-exercises",
-        description="Manual verification-lab archive-smoke exercise lane",
+    "live-archive-smoke": LaneEntry(
+        name="live-archive-smoke",
+        description="Manual verification-lab archive-smoke lane",
         timeout_s=1800,
         category="live",
         execution=devtools_execution("lab scenario", "run", "archive-smoke", "--live", "--tier", "0", "--json"),

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -77,7 +77,7 @@ per-suite JSON parsing, surface invocation, archive seeding, or cross-surface or
 ```bash
 devtools lab lanes --list
 devtools lab lanes --lane frontier-local
-devtools lab lanes --lane live-exercises --dry-run
+devtools lab lanes --lane live-archive-smoke --dry-run
 ```
 
 ### Schema upgrade lane (#1302)
@@ -176,9 +176,9 @@ Use the named lanes through the runner.
 
 | Lane | Timeout (s) | Description |
 | --- | ---: | --- |
+| `live-archive-smoke` | 1800 | Manual verification-lab archive-smoke lane |
 | `live-archive-subset-parse-probe` | 1800 | Live archive medium archive-subset parse probe with persisted manifest/workdir artifacts |
 | `live-embed-stats` | 120 | Live archive embedding status JSON view |
-| `live-exercises` | 1800 | Manual verification-lab archive-smoke exercise lane |
 | `live-insights-coverage-day` | 180 | Live archive day coverage insight surface over the recent semantic slice |
 | `live-insights-coverage-provider` | 180 | Live archive provider coverage insight surface |
 | `live-insights-debt` | 180 | Live archive debt and cleanup insight view |
@@ -210,7 +210,7 @@ Use the named lanes through the runner.
 | `evidence-live` | 2400 | `live-session-insight-repair`<br>`live-insights-status`<br>`live-insights-profiles-evidence`<br>`live-insights-profiles-inference`<br>`live-insights-work-events`<br>`live-insights-phases`<br>`live-embed-stats`<br>`live-readiness-json`<br>`maintenance-memory-budget` | Bounded live archive lane for tiered insight views, live repair, health, and retrieval-band budgets |
 | `frontier-extended` | 3600 | `frontier-local`<br>`pipeline-probe-chatgpt`<br>`scale-fast`<br>`long-haul-small` | Local closure lane plus fast scale and small long-haul campaign |
 | `frontier-local` | 1500 | `machine-contract`<br>`query-routing`<br>`demo-visual`<br>`semantic-stack`<br>`tui`<br>`chaos` | Non-live local closure lane for machine/query/semantic/TUI/chaos validation |
-| `live-archive-slow` | 2400 | `live-archive-small`<br>`live-exercises` | Broader live archive dogfood lane including retrieval/readiness and live scenario checks |
+| `live-archive-slow` | 2400 | `live-archive-small`<br>`live-archive-smoke` | Broader live archive dogfood lane including retrieval/readiness and live scenario checks |
 | `live-archive-small` | 480 | `live-embed-stats`<br>`live-retrieval-checks`<br>`live-insights-status`<br>`live-readiness-json` | Bounded live archive retrieval/readiness/health dogfood lane |
 | `live-insights-small` | 480 | `live-insights-status`<br>`live-insights-tags`<br>`live-project-stats` | Bounded live archive insight and grouped-stats lane |
 | `live-maintenance-small` | 720 | `live-readiness-json`<br>`live-maintenance-preview`<br>`maintenance-memory-budget` | Bounded live archive lane for health, maintenance preview, and maintenance memory budget |
@@ -359,9 +359,9 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `validation-lane` | `inference-tier-contracts` | — | — | — | — | — | Inference-tier work-event/phase/profile contracts with confidence/provenance-bearing semantic payloads |
 | `validation-lane` | `live-archive-slow` | `retrieval-band-readiness-loop`<br>`embedding-status-query-loop`<br>`session-query-loop`<br>`session-insight-status-query-loop`<br>`message-fts-readiness-loop` | `embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`embedding_status_results`<br>`message_fts`<br>`session_query_results`<br>`session_insight_status_results`<br>`archive_readiness` | `project-retrieval-band-readiness`<br>`query-embedding-status`<br>`cli.json-contract`<br>`query-sessions`<br>`query-session-insight-status`<br>`project-archive-readiness` | — | `live`<br>`embeddings`<br>`readiness`<br>`retrieval`<br>`insights`<br>`status`<br>`maintenance` | Broader live archive dogfood lane including retrieval/readiness and live scenario checks |
 | `validation-lane` | `live-archive-small` | `retrieval-band-readiness-loop`<br>`embedding-status-query-loop`<br>`session-query-loop`<br>`session-insight-status-query-loop`<br>`message-fts-readiness-loop` | `embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`embedding_status_results`<br>`message_fts`<br>`session_query_results`<br>`session_insight_status_results`<br>`archive_readiness` | `project-retrieval-band-readiness`<br>`query-embedding-status`<br>`cli.json-contract`<br>`query-sessions`<br>`query-session-insight-status`<br>`project-archive-readiness` | — | `live`<br>`embeddings`<br>`readiness`<br>`retrieval`<br>`insights`<br>`status`<br>`maintenance` | Bounded live archive retrieval/readiness/health dogfood lane |
+| `validation-lane` | `live-archive-smoke` | — | — | — | — | — | Manual verification-lab archive-smoke lane |
 | `validation-lane` | `live-archive-subset-parse-probe` | `source-acquisition-loop`<br>`raw-reparse-loop`<br>`raw-archive-ingest-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows`<br>`validation_backlog`<br>`parse_backlog`<br>`parse_quarantine`<br>`archive_session_rows` | `acquire-raw-sessions`<br>`plan-validation-backlog`<br>`plan-parse-backlog`<br>`ingest-archive-runtime` | — | `live`<br>`probe`<br>`parse` | Live archive medium archive-subset parse probe with persisted manifest/workdir artifacts |
 | `validation-lane` | `live-embed-stats` | `retrieval-band-readiness-loop`<br>`embedding-status-query-loop` | `embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`embedding_status_results` | `project-retrieval-band-readiness`<br>`query-embedding-status`<br>`cli.json-contract` | — | `live`<br>`embeddings`<br>`readiness` | Live archive embedding status JSON view |
-| `validation-lane` | `live-exercises` | — | — | — | — | — | Manual verification-lab archive-smoke exercise lane |
 | `validation-lane` | `live-insights-coverage-day` | `archive-coverage-query-loop` | `archive_session_rows`<br>`session_profile_rows`<br>`archive_coverage_results` | `query-archive-coverage` | — | `insights`<br>`coverage` | Live archive day coverage insight surface over the recent semantic slice |
 | `validation-lane` | `live-insights-coverage-provider` | `archive-coverage-query-loop` | `archive_session_rows`<br>`session_profile_rows`<br>`archive_coverage_results` | `query-archive-coverage` | — | `insights`<br>`coverage` | Live archive provider coverage insight surface |
 | `validation-lane` | `live-insights-debt` | `archive-debt-query-loop` | `archive_readiness`<br>`embedding_status_results`<br>`message_fts`<br>`archive_debt_results` | `query-archive-debt` | — | `insights`<br>`debt` | Live archive debt and cleanup insight view |

--- a/polylogue/scenarios/__init__.py
+++ b/polylogue/scenarios/__init__.py
@@ -5,7 +5,7 @@ from .cli_surfaces import (
     CliSurfaceFamily,
     CliSurfaceVariant,
     CompiledCliSurface,
-    build_cli_surface_exercises,
+    build_cli_surface_contracts,
     build_cli_surface_live_variants,
     build_cli_surface_memory_budget_variants,
 )
@@ -90,7 +90,7 @@ __all__ = [
     "seed_demo_user_overlays",
     "build_corpus_scenarios",
     "build_inferred_corpus_specs",
-    "build_cli_surface_exercises",
+    "build_cli_surface_contracts",
     "build_cli_surface_live_variants",
     "build_cli_surface_memory_budget_variants",
     "composite_execution",

--- a/polylogue/scenarios/cli_surfaces.py
+++ b/polylogue/scenarios/cli_surfaces.py
@@ -33,7 +33,7 @@ class CliSurfaceFamily:
     slug: str
     command_args: tuple[str, ...]
     tags: tuple[str, ...]
-    exercise: CliSurfaceVariant | None = None
+    contract_variant: CliSurfaceVariant | None = None
     live_variants: tuple[CliSurfaceVariant, ...] = ()
     memory_budget_variants: tuple[CliSurfaceVariant, ...] = ()
 
@@ -74,11 +74,13 @@ def compile_cli_surface_variant(family: CliSurfaceFamily, variant: CliSurfaceVar
     )
 
 
-def build_cli_surface_exercises(families: tuple[CliSurfaceFamily, ...]) -> tuple[CompiledCliSurface, ...]:
-    """Compile exercise projections from authored families."""
+def build_cli_surface_contracts(families: tuple[CliSurfaceFamily, ...]) -> tuple[CompiledCliSurface, ...]:
+    """Compile seeded JSON-contract surfaces from authored families."""
 
     return tuple(
-        compile_cli_surface_variant(family, family.exercise) for family in families if family.exercise is not None
+        compile_cli_surface_variant(family, family.contract_variant)
+        for family in families
+        if family.contract_variant is not None
     )
 
 
@@ -104,7 +106,7 @@ __all__ = [
     "CliSurfaceFamily",
     "CliSurfaceVariant",
     "CompiledCliSurface",
-    "build_cli_surface_exercises",
+    "build_cli_surface_contracts",
     "build_cli_surface_live_variants",
     "build_cli_surface_memory_budget_variants",
     "compile_cli_surface_variant",

--- a/polylogue/scenarios/insight_surfaces.py
+++ b/polylogue/scenarios/insight_surfaces.py
@@ -6,7 +6,7 @@ from .cli_surfaces import (
     CliSurfaceFamily,
     CliSurfaceVariant,
     CompiledCliSurface,
-    build_cli_surface_exercises,
+    build_cli_surface_contracts,
     build_cli_surface_live_variants,
 )
 
@@ -15,7 +15,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="profiles",
         command_args=("analyze", "insights", "profiles"),
         tags=("insights", "session-profiles"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-profiles",
             description="insights profiles JSON contract",
         ),
@@ -38,7 +38,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="work-events",
         command_args=("analyze", "insights", "work-events"),
         tags=("insights", "work-events"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-work-events",
             description="insights work-events JSON contract",
         ),
@@ -55,7 +55,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="phases",
         command_args=("analyze", "insights", "phases"),
         tags=("insights", "phases"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-phases",
             description="insights phases JSON contract",
         ),
@@ -72,7 +72,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="threads",
         command_args=("analyze", "insights", "threads"),
         tags=("insights", "threads"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-threads",
             description="insights threads JSON contract",
         ),
@@ -81,7 +81,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="tags",
         command_args=("analyze", "insights", "tags"),
         tags=("insights", "tags"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-tags",
             description="insights tags JSON contract",
         ),
@@ -98,7 +98,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="coverage",
         command_args=("analyze", "insights", "coverage"),
         tags=("insights", "coverage"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-insights-coverage",
             description="insights coverage JSON contract",
         ),
@@ -147,7 +147,7 @@ INSIGHT_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
 
 
 def build_insight_contract_surfaces() -> tuple[CompiledCliSurface, ...]:
-    return build_cli_surface_exercises(INSIGHT_SURFACE_FAMILIES)
+    return build_cli_surface_contracts(INSIGHT_SURFACE_FAMILIES)
 
 
 def build_live_insight_surface_lanes() -> tuple[CompiledCliSurface, ...]:

--- a/polylogue/scenarios/operational_surfaces.py
+++ b/polylogue/scenarios/operational_surfaces.py
@@ -6,7 +6,7 @@ from .cli_surfaces import (
     CliSurfaceFamily,
     CliSurfaceVariant,
     CompiledCliSurface,
-    build_cli_surface_exercises,
+    build_cli_surface_contracts,
     build_cli_surface_live_variants,
     build_cli_surface_memory_budget_variants,
 )
@@ -16,7 +16,7 @@ OPERATIONAL_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="doctor-readiness",
         command_args=("ops", "doctor", "--format", "json"),
         tags=("maintenance", "readiness"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-doctor",
             description="doctor JSON contract",
             suffix_args=(),
@@ -37,7 +37,7 @@ OPERATIONAL_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
         slug="doctor-session-insights-preview",
         command_args=("ops", "doctor", "--format", "json", "--repair", "--preview", "--target", "session_insights"),
         tags=("maintenance", "session-insights"),
-        exercise=CliSurfaceVariant(
+        contract_variant=CliSurfaceVariant(
             name="json-doctor-session-insights-preview",
             description="doctor JSON contract",
             suffix_args=(),
@@ -159,7 +159,7 @@ OPERATIONAL_SURFACE_FAMILIES: tuple[CliSurfaceFamily, ...] = (
 
 
 def build_operational_contract_surfaces() -> tuple[CompiledCliSurface, ...]:
-    return build_cli_surface_exercises(OPERATIONAL_SURFACE_FAMILIES)
+    return build_cli_surface_contracts(OPERATIONAL_SURFACE_FAMILIES)
 
 
 def build_live_operational_surface_lanes() -> tuple[CompiledCliSurface, ...]:

--- a/polylogue/scenarios/projections.py
+++ b/polylogue/scenarios/projections.py
@@ -12,7 +12,6 @@ from .metadata import ScenarioMetadata
 
 
 class ScenarioProjectionSourceKind(str, Enum):
-    EXERCISE = "exercise"
     VALIDATION_LANE = "validation-lane"
     MUTATION_CAMPAIGN = "mutation-campaign"
     BENCHMARK_CAMPAIGN = "benchmark-campaign"

--- a/tests/unit/devtools/test_quality_registry.py
+++ b/tests/unit/devtools/test_quality_registry.py
@@ -14,7 +14,7 @@ def test_build_quality_registry_exposes_live_catalogs() -> None:
     assert any(entry.name == "schema-explain-contract" for entry in registry.contract_lanes)
     assert any(entry.name == "frontier-local" for entry in registry.composite_lanes)
     assert any(entry.name == "machine-contract" for entry in registry.contract_lanes)
-    assert any(entry.name == "live-exercises" for entry in registry.live_lanes)
+    assert any(entry.name == "live-archive-smoke" for entry in registry.live_lanes)
     assert any(entry.name == "filters" for entry in registry.mutation_campaigns)
     assert any(entry.name == "search-filters" for entry in registry.benchmark_campaigns)
     assert any(entry.name == "pipeline" for entry in registry.benchmark_campaigns)

--- a/tests/unit/devtools/test_render_quality_reference.py
+++ b/tests/unit/devtools/test_render_quality_reference.py
@@ -33,8 +33,8 @@ def test_build_document_includes_live_registry_sections() -> None:
                     execution=pytest_execution("-m", "machine_contract"),
                 ),
                 LaneEntry(
-                    name="live-exercises",
-                    description="Read-only live archive exercises.",
+                    name="live-archive-smoke",
+                    description="Read-only live archive smoke lane.",
                     timeout_s=300,
                     category="live",
                     execution=devtools_execution("lab scenario", "run", "archive-smoke", "--live", "--tier", "0"),
@@ -44,7 +44,7 @@ def test_build_document_includes_live_registry_sections() -> None:
                     description="Runtime substrate hardening lane.",
                     timeout_s=900,
                     category="composite",
-                    execution=composite_execution("machine-contract", "live-exercises"),
+                    execution=composite_execution("machine-contract", "live-archive-smoke"),
                     family="runtime-substrate",
                 ),
                 LaneEntry(

--- a/tests/unit/devtools/test_scenario_projections.py
+++ b/tests/unit/devtools/test_scenario_projections.py
@@ -29,7 +29,7 @@ class _PresentationScenario(ScenarioProjectionSource):
 
     @property
     def projection_source_kind(self) -> ScenarioProjectionSourceKind:
-        return ScenarioProjectionSourceKind.EXERCISE
+        return ScenarioProjectionSourceKind.VALIDATION_LANE
 
     @property
     def projection_name(self) -> str:
@@ -111,6 +111,7 @@ def test_validation_lane_projection_entries_include_composite_metadata_unions() 
 def test_projection_entries_preserve_presentation_metadata() -> None:
     entry = _PresentationScenario().to_projection_entry()
 
+    assert entry.source_kind is ScenarioProjectionSourceKind.VALIDATION_LANE
     assert entry.to_payload()["docs_role"] == "tour"
     assert entry.to_payload()["caption"] == "Query recall demo"
     assert entry.to_payload()["demonstrates"] == ["recall", "json-output"]

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -424,7 +424,7 @@ class TestCommandConstruction:
         assert "small" in cmd
 
     def test_live_lane_uses_module_entrypoint(self) -> None:
-        cmd = build_lane_command(LANES["live-exercises"])
+        cmd = build_lane_command(LANES["live-archive-smoke"])
         assert cmd[:3] == ["devtools", "lab", "scenario"]
         assert "archive-smoke" in cmd
         assert "--live" in cmd

--- a/tests/unit/scenarios/test_sources.py
+++ b/tests/unit/scenarios/test_sources.py
@@ -9,23 +9,23 @@ from polylogue.scenarios import NamedScenarioSource, ScenarioProjectionSourceKin
 class _NamedFixture(NamedScenarioSource):
     @property
     def projection_source_kind(self) -> ScenarioProjectionSourceKind:
-        return ScenarioProjectionSourceKind.EXERCISE
+        return ScenarioProjectionSourceKind.VALIDATION_LANE
 
 
 def test_named_scenario_source_projects_name_and_description() -> None:
     source = _NamedFixture(
-        name="exercise-help",
-        description="exercise help text",
+        name="contract-help",
+        description="contract help text",
         origin="generated.test",
         artifact_targets=("archive_readiness",),
-        tags=("exercise", "help"),
+        tags=("contract", "help"),
     )
 
     projection = source.to_projection_entry()
 
-    assert projection.source_kind is ScenarioProjectionSourceKind.EXERCISE
-    assert projection.name == "exercise-help"
-    assert projection.description == "exercise help text"
+    assert projection.source_kind is ScenarioProjectionSourceKind.VALIDATION_LANE
+    assert projection.name == "contract-help"
+    assert projection.description == "contract help text"
     assert projection.origin == "generated.test"
     assert projection.artifact_targets == ("archive_readiness",)
-    assert projection.tags == ("exercise", "help")
+    assert projection.tags == ("contract", "help")


### PR DESCRIPTION
## Summary

Removes the last `exercise` projection vocabulary left after the showcase exercise catalog was deleted. Seeded CLI verification variants are now described as contract surfaces, and the live archive smoke lane is named for the behavior it runs.

## Problem

#2196 has been removing the showcase QA/exercise stack in favor of ordinary demo, CLI, and visual behavior checks. After #2300 removed the exercise catalog itself, the remaining projection layer still exposed an `exercise` source kind, `exercise=` CLI surface variants, and a `live-exercises` lane. That kept dead vocabulary in devtools and tests after the implementation had been removed.

## Solution

- Removed `ScenarioProjectionSourceKind.EXERCISE`.
- Renamed CLI surface `exercise` variants to `contract_variant` and `build_cli_surface_contracts`.
- Renamed `live-exercises` to `live-archive-smoke` while keeping the same archive-smoke command behavior.
- Updated devtools examples, generated quality docs, and tests to assert retained validation-lane/contract behavior instead of fake exercise projections.

This intentionally does not add absence-only tests. The replacement coverage is the existing projection/render/lane tests over real validation-lane entries and the archive-smoke lane command shape.

Ref #2196

## Verification

- `devtools test tests/unit/scenarios/test_sources.py tests/unit/scenarios/test_scenario_specs.py tests/unit/devtools/test_scenario_projections.py tests/unit/devtools/test_render_quality_reference.py tests/unit/devtools/test_quality_registry.py tests/unit/devtools/test_validation_lanes.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_generated_surfaces.py` -> 170 passed.
- `devtools render devtools-reference --check && devtools render quality-reference --check && devtools render topology-status --check` -> sync OK for devtools reference and quality reference; topology status exited 0.
- `devtools verify --quick` -> exit_code 0, 13 steps ok.
- pre-push hook reran `devtools verify --quick` -> exit_code 0, 13 steps ok.