### PR TITLE
fix: prevent silent raw materialization gaps

### DIFF
--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -247,7 +247,12 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
                 """
             )
         )
-        missing_rows = [row for row in candidate_rows if not _raw_materialized_by_source_path_native(conn, row)]
+        missing_rows = [
+            row
+            for row in candidate_rows
+            if _raw_materialization_category(row, archive_root) != "parsed-without-session"
+            or not _raw_materialized_by_source_path_native(conn, row)
+        ]
     except sqlite3.Error:
         return []
     finally:

--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sqlite3
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
@@ -215,7 +216,7 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
     except sqlite3.Error:
         return []
     try:
-        missing_rows = list(
+        candidate_rows = list(
             conn.execute(
                 """
                 SELECT
@@ -246,6 +247,7 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
                 """
             )
         )
+        missing_rows = [row for row in candidate_rows if not _raw_materialized_by_source_path_native(conn, row)]
     except sqlite3.Error:
         return []
     finally:
@@ -263,6 +265,45 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
     for (origin, category), group_rows in grouped.items():
         rows.append(_raw_materialization_debt_row(archive_root, origin=origin, category=category, rows=group_rows))
     return rows
+
+
+def _raw_materialized_by_source_path_native(conn: sqlite3.Connection, row: sqlite3.Row) -> bool:
+    origin = str(row["origin"] or "")
+    if not origin:
+        return False
+    for native_id in _source_path_native_id_candidates(str(row["source_path"] or "")):
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM index_tier.sessions
+            WHERE origin = ?
+              AND native_id = ?
+            LIMIT 1
+            """,
+            (origin, native_id),
+        ).fetchone()
+        if existing is not None:
+            return True
+    return False
+
+
+def _source_path_native_id_candidates(source_path: str) -> tuple[str, ...]:
+    if not source_path:
+        return ()
+    name = Path(source_path).name
+    candidates: list[str] = []
+    current = name
+    for _ in range(4):
+        stem = Path(current).stem
+        if stem == current:
+            break
+        current = stem
+        if current and current not in candidates:
+            candidates.append(current)
+        unsplit = re.sub(r"_\d+$", "", current)
+        if unsplit and unsplit != current and unsplit not in candidates:
+            candidates.append(unsplit)
+    return tuple(candidates)
 
 
 def _raw_materialization_category(row: sqlite3.Row, archive_root: Path) -> str:

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -394,10 +394,51 @@ def _delete_stale_sessions_for_raw_entries(conn: sqlite3.Connection, ready_entri
         if not expected_session_ids:
             continue
         placeholders = ",".join("?" for _ in expected_session_ids)
+        stale_session_ids = [
+            str(row[0])
+            for row in conn.execute(
+                f"SELECT session_id FROM sessions WHERE raw_id = ? AND session_id NOT IN ({placeholders})",
+                (raw_id, *sorted(expected_session_ids)),
+            ).fetchall()
+        ]
+        if not stale_session_ids:
+            continue
+        _delete_sessions_without_fk_cascade(conn, stale_session_ids)
         conn.execute(
             f"DELETE FROM sessions WHERE raw_id = ? AND session_id NOT IN ({placeholders})",
             (raw_id, *sorted(expected_session_ids)),
         )
+
+
+def _delete_sessions_without_fk_cascade(conn: sqlite3.Connection, session_ids: Sequence[str]) -> None:
+    """Apply sessions FK actions manually while bulk ingest has FKs disabled."""
+    if not session_ids:
+        return
+    placeholders = ",".join("?" for _ in session_ids)
+    params = tuple(session_ids)
+    for table_name, from_column, on_delete in _session_foreign_key_actions(conn):
+        table = _quote_identifier(table_name)
+        column = _quote_identifier(from_column)
+        if table_name == "sessions" or on_delete.upper() == "SET NULL":
+            conn.execute(f"UPDATE {table} SET {column} = NULL WHERE {column} IN ({placeholders})", params)
+        elif on_delete.upper() == "CASCADE":
+            conn.execute(f"DELETE FROM {table} WHERE {column} IN ({placeholders})", params)
+
+
+def _session_foreign_key_actions(conn: sqlite3.Connection) -> list[tuple[str, str, str]]:
+    actions: list[tuple[str, str, str]] = []
+    table_rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    for table_row in table_rows:
+        table_name = str(table_row[0])
+        for fk in conn.execute(f"PRAGMA foreign_key_list({_quote_identifier(table_name)})").fetchall():
+            if str(fk[2]) == "sessions":
+                actions.append((table_name, str(fk[3]), str(fk[6] or "")))
+    actions.sort(key=lambda item: item[0] == "sessions")
+    return actions
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
 
 
 def _drain_ready_session_entries(

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -384,6 +384,22 @@ def _write_session_entry(
         return False
 
 
+def _delete_stale_sessions_for_raw_entries(conn: sqlite3.Connection, ready_entries: list[_SessionEntry]) -> None:
+    expected_by_raw_id: dict[str, set[str]] = {}
+    for raw_id, cdata in ready_entries:
+        if raw_id:
+            expected_by_raw_id.setdefault(raw_id, set()).add(cdata.session_id)
+
+    for raw_id, expected_session_ids in expected_by_raw_id.items():
+        if not expected_session_ids:
+            continue
+        placeholders = ",".join("?" for _ in expected_session_ids)
+        conn.execute(
+            f"DELETE FROM sessions WHERE raw_id = ? AND session_id NOT IN ({placeholders})",
+            (raw_id, *sorted(expected_session_ids)),
+        )
+
+
 def _drain_ready_session_entries(
     conn: sqlite3.Connection,
     ready_entries: list[_SessionEntry],
@@ -392,6 +408,7 @@ def _drain_ready_session_entries(
     materialized_ids: set[str],
     force_write: bool = False,
 ) -> None:
+    _delete_stale_sessions_for_raw_entries(conn, ready_entries)
     for raw_id, cdata in _topo_sort_session_entries(ready_entries):
         wrote = _write_session_entry(conn, raw_id, cdata, summary=summary, force_write=force_write)
         discard_session_data_payload(cdata)

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -189,7 +189,10 @@ def _is_stream_record_provider(source_path: str | None, provider: str | Provider
 
 
 def _is_jsonl_source_path(source_path: str | None) -> bool:
-    return (source_path or "").lower().endswith((".jsonl", ".jsonl.txt", ".ndjson"))
+    normalized = (source_path or "").lower()
+    return normalized.endswith((".jsonl", ".jsonl.txt", ".ndjson")) or any(
+        marker in normalized for marker in (".jsonl.", ".ndjson.")
+    )
 
 
 def _record_result(
@@ -492,6 +495,17 @@ def _materialize_parsed_sessions(
     validation: _PlanValidation,
     parsed_sessions: list[ParsedSession],
 ) -> IngestRecordResult:
+    if not parsed_sessions:
+        error = "parse: session artifact produced no materializable sessions"
+        return _record_result(
+            context,
+            plan.payload_provider,
+            validation_status=validation.status,
+            validation_error=validation.validation_error,
+            parse_error=error,
+            error=error,
+        )
+
     session_payloads: list[SessionWritePayload] = []
     for convo in parsed_sessions:
         normalized_convo = _normalized_session(

--- a/polylogue/sources/decoder_json.py
+++ b/polylogue/sources/decoder_json.py
@@ -251,7 +251,10 @@ def iter_json_stream_with(
     path_name: str,
     unpack_lists: bool = True,
 ) -> Iterable[JsonValue]:
-    if path_name.lower().endswith((".jsonl", ".jsonl.txt", ".ndjson")):
+    normalized_path = path_name.lower()
+    if normalized_path.endswith((".jsonl", ".jsonl.txt", ".ndjson")) or any(
+        marker in normalized_path for marker in (".jsonl.", ".ndjson.")
+    ):
         yield from _iter_jsonl_stream(logger_obj, handle, path_name)
         return
 

--- a/polylogue/storage/raw/models.py
+++ b/polylogue/storage/raw/models.py
@@ -124,6 +124,7 @@ class RawSessionStateUpdate:
                 self.validation_drift_count,
                 self.validation_provider,
                 self.validation_mode,
+                self.detection_warnings,
             )
         )
 

--- a/polylogue/storage/repository/raw/repository_raw.py
+++ b/polylogue/storage/repository/raw/repository_raw.py
@@ -13,6 +13,7 @@ from polylogue.storage.runtime import (
     RawSessionRecord,
 )
 from polylogue.storage.sqlite.queries import artifacts as artifacts_q
+from polylogue.storage.sqlite.queries import cursor as cursor_queries
 from polylogue.storage.sqlite.queries import raw as raw_queries
 
 
@@ -100,25 +101,12 @@ class RepositoryRawMixin:
             return await raw_queries.get_known_source_mtimes(conn)
 
     async def get_known_source_cursors(self) -> dict[str, dict[str, object]]:
-        """Return live_cursor stat fields for the stat-based fast path."""
+        """Return ingest_cursor stat fields for the stat-based fast path."""
         async with self._backend.connection() as conn:
             try:
-                rows = await conn.execute(
-                    "SELECT source_path, st_dev, st_ino, byte_size, mtime_ns "
-                    "FROM live_cursor WHERE excluded = 0 AND st_dev IS NOT NULL"
-                )
-                records = await rows.fetchall()
+                return await cursor_queries.get_known_source_cursors(conn)
             except Exception:
                 return {}
-        return {
-            str(row[0]): {
-                "st_dev": row[1],
-                "st_ino": row[2],
-                "st_size": row[3],
-                "mtime_ns": row[4],
-            }
-            for row in records
-        }
 
     async def upsert_source_file_cursor(
         self,

--- a/tests/unit/operations/test_archive_debt.py
+++ b/tests/unit/operations/test_archive_debt.py
@@ -349,3 +349,26 @@ def test_archive_debt_raw_materialization_ignores_native_id_matches(tmp_path: Pa
     refs = {row.debt_ref for row in payload.rows}
     assert "debt:raw-materialization:aistudio-drive:parsed-without-session" not in refs
     assert "debt:raw-materialization:codex-session:missing-blob" in refs
+
+
+def test_archive_debt_raw_materialization_ignores_source_path_native_aliases(tmp_path: Path) -> None:
+    _source_db, index_db, _source_file = _init_raw_materialization_fixture(tmp_path)
+    source_path = tmp_path / "drive-cache" / "gemini" / "native-alias_1.jsonl.txt.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            "UPDATE raw_sessions SET origin = ?, source_path = ? WHERE raw_id = ?",
+            ("claude-code-session", str(source_path), "raw-parsed-no-session"),
+        )
+    with sqlite3.connect(index_db) as conn:
+        conn.execute(
+            "INSERT INTO sessions (session_id, origin, native_id, raw_id) VALUES (?, ?, ?, ?)",
+            ("claude-code-session:native-alias", "claude-code-session", "native-alias", "older-raw"),
+        )
+
+    payload = archive_debt_list(archive_root=tmp_path, kinds=("raw-materialization",))
+
+    refs = {row.debt_ref for row in payload.rows}
+    assert "debt:raw-materialization:claude-code-session:parsed-without-session" not in refs
+    assert "debt:raw-materialization:codex-session:missing-blob" in refs

--- a/tests/unit/operations/test_archive_debt.py
+++ b/tests/unit/operations/test_archive_debt.py
@@ -372,3 +372,29 @@ def test_archive_debt_raw_materialization_ignores_source_path_native_aliases(tmp
     refs = {row.debt_ref for row in payload.rows}
     assert "debt:raw-materialization:claude-code-session:parsed-without-session" not in refs
     assert "debt:raw-materialization:codex-session:missing-blob" in refs
+
+
+def test_archive_debt_source_path_aliases_do_not_hide_parse_failures(tmp_path: Path) -> None:
+    _source_db, index_db, _source_file = _init_raw_materialization_fixture(tmp_path)
+    source_path = tmp_path / "drive-cache" / "codex-native.jsonl.txt.json"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}", encoding="utf-8")
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """
+            UPDATE raw_sessions
+            SET native_id = NULL, source_path = ?, blob_hash = ?, parsed_at_ms = ?, parse_error = ?
+            WHERE raw_id = ?
+            """,
+            (str(source_path), bytes.fromhex("bb" * 32), 123, "parser failed", "raw-missing-blob"),
+        )
+    with sqlite3.connect(index_db) as conn:
+        conn.execute(
+            "INSERT INTO sessions (session_id, origin, native_id, raw_id) VALUES (?, ?, ?, ?)",
+            ("codex-session:codex-native", "codex-session", "codex-native", "older-raw"),
+        )
+
+    payload = archive_debt_list(archive_root=tmp_path, kinds=("raw-materialization",))
+
+    refs = {row.debt_ref for row in payload.rows}
+    assert "debt:raw-materialization:codex-session:parse-failed" in refs

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1001,6 +1001,88 @@ def test_process_ingest_batch_sync_commits_fts_repair_and_invalidates_search_cac
     assert [hit.session_id for hit in second_result.hits] == [session_id]
 
 
+def test_process_ingest_batch_sync_replaces_stale_sessions_for_same_raw_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "index.db"
+    archive_root = tmp_path / "archive"
+    blob_root = tmp_path / "blob"
+    source_path = tmp_path / "raw.jsonl.txt.json"
+    source_path.write_text("{}", encoding="utf-8")
+    raw_id = "raw-provider-redetected"
+    stale_session_id = "aistudio-drive:provider-redetected"
+    replacement_session_id = "codex-session:provider-redetected"
+
+    raw_record = RawSessionRecord(
+        raw_id=raw_id,
+        source_name="gemini",
+        source_path=str(source_path),
+        blob_size=source_path.stat().st_size,
+        acquired_at="2026-04-02T00:00:00Z",
+    )
+    stale = _session_data(
+        stale_session_id,
+        content_hash="stale-provider-session",
+        raw_id=raw_id,
+        message_tuples=[],
+    )
+    replacement = _session_data(
+        replacement_session_id,
+        content_hash="replacement-provider-session",
+        raw_id=raw_id,
+        message_tuples=[
+            _message_tuple(
+                "msg-provider-redetected",
+                replacement_session_id,
+                role="user",
+                text="redetected stream payload",
+                content_hash="replacement-message",
+                sort_key=0.0,
+            )
+        ],
+    )
+
+    with open_connection(db_path) as conn:
+        _write_session(conn, stale)
+        conn.commit()
+
+    def fake_ingest_record(
+        record: RawSessionRecord,
+        archive_root_str: str,
+        validation_mode: str,
+        measure_ingest_result_size: bool,
+        *,
+        blob_root_str: str | None,
+    ) -> IngestRecordResult:
+        del archive_root_str, validation_mode, measure_ingest_result_size, blob_root_str
+        assert record.raw_id == raw_id
+        return IngestRecordResult(raw_id=record.raw_id, sessions=[replacement])
+
+    monkeypatch.setattr(ingest_batch_core, "ingest_record", fake_ingest_record)
+
+    _process_ingest_batch_sync(
+        [raw_record],
+        db_path=db_path,
+        archive_root_str=str(archive_root),
+        blob_root_str=str(blob_root),
+        validation_mode="off",
+        ingest_workers=1,
+        measure_ingest_result_size=False,
+        force_write=True,
+    )
+
+    with open_connection(db_path) as conn:
+        rows = conn.execute(
+            "SELECT session_id FROM sessions WHERE raw_id = ? ORDER BY session_id", (raw_id,)
+        ).fetchall()
+        assert [row[0] for row in rows] == [replacement_session_id]
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (replacement_session_id,)).fetchone()[0]
+            == 1
+        )
+
+
 def test_select_ingest_worker_count_uses_cpu_count(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
     raw_artifacts = [SimpleNamespace(blob_size=16 * 1024 * 1024) for _ in range(6)]

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1025,7 +1025,16 @@ def test_process_ingest_batch_sync_replaces_stale_sessions_for_same_raw_id(
         stale_session_id,
         content_hash="stale-provider-session",
         raw_id=raw_id,
-        message_tuples=[],
+        message_tuples=[
+            _message_tuple(
+                "msg-stale-provider-redetected",
+                stale_session_id,
+                role="user",
+                text="stale drive payload",
+                content_hash="stale-message",
+                sort_key=0.0,
+            )
+        ],
     )
     replacement = _session_data(
         replacement_session_id,
@@ -1078,9 +1087,14 @@ def test_process_ingest_batch_sync_replaces_stale_sessions_for_same_raw_id(
         ).fetchall()
         assert [row[0] for row in rows] == [replacement_session_id]
         assert (
+            conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (stale_session_id,)).fetchone()[0] == 0
+        )
+        assert conn.execute("SELECT COUNT(*) FROM blocks WHERE session_id = ?", (stale_session_id,)).fetchone()[0] == 0
+        assert (
             conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (replacement_session_id,)).fetchone()[0]
             == 1
         )
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
 
 def test_select_ingest_worker_count_uses_cpu_count(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -188,6 +188,41 @@ def test_parse_mixed_valid_invalid_jsonl_lines(tmp_path: Path) -> None:
         assert result.sessions[0].parsed_session.source_name == "claude-code"
 
 
+def test_jsonl_stream_shape_beats_drive_cache_json_suffix(tmp_path: Path) -> None:
+    """Drive-acquired JSONL snapshots may carry a trailing ``.json`` suffix."""
+    from polylogue.pipeline.services.ingest_worker import ingest_record
+
+    content = (
+        b'{"type":"summary","summary":"continued session","leafUuid":"leaf-1"}\n'
+        b'{"parentUuid":null,"isSidechain":false,"userType":"external",'
+        b'"cwd":"/realm/project/polylogue","sessionId":"session-from-drive",'
+        b'"version":"1.0.6","type":"user","timestamp":"2025-06-06T12:55:19.000Z",'
+        b'"message":{"role":"user","content":[{"type":"text","text":"hello from drive cache"}]}}\n'
+        b'{"parentUuid":"m1","isSidechain":false,"userType":"external",'
+        b'"cwd":"/realm/project/polylogue","sessionId":"session-from-drive",'
+        b'"version":"1.0.6","type":"assistant","timestamp":"2025-06-06T12:55:20.000Z",'
+        b'"message":{"role":"assistant","content":[{"type":"text","text":"parsed as stream"}]}}\n'
+    )
+    record = _make_raw_record(
+        "drive-jsonl",
+        "gemini",
+        content,
+        "/drive-cache/gemini/session-from-drive.jsonl.txt.json",
+    )
+
+    result = ingest_record(record, str(tmp_path / "archive"), "off")
+
+    assert result.error is None
+    assert len(result.sessions) == 1
+    parsed = result.sessions[0].parsed_session
+    assert parsed.source_name == "claude-code"
+    assert parsed.provider_session_id == "session-from-drive"
+    assert [message.text for message in parsed.messages if message.text] == [
+        "hello from drive cache",
+        "parsed as stream",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Fault 5: Parsing handles valid JSON for unknown provider gracefully
 # ---------------------------------------------------------------------------
@@ -538,10 +573,42 @@ def test_ingest_worker_decodes_and_dispatches_provider(tmp_path: Path) -> None:
     # Verify the result structure
     assert result.raw_id is not None  # Should be the actual hash
     assert result.payload_provider is not None  # Provider detected
-    # ingest_record returns SessionData list; empty mapping results in empty sessions
+    # ingest_record returns a materializable SessionWritePayload even when
+    # the source has no messages yet; that still produces an index.db session.
     assert isinstance(result.sessions, list)
-    # Result should be clean with no errors
+    assert len(result.sessions) == 1
     assert result.error is None
+
+
+def test_ingest_worker_quarantines_session_artifact_with_no_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A parser that emits no sessions must not stamp raw state as clean."""
+    from polylogue.pipeline.services import ingest_worker
+
+    payload = json.dumps(
+        {
+            "id": "conv-empty",
+            "title": "Empty parser result",
+            "mapping": {},
+            "create_time": 1700000000,
+            "update_time": 1700000001,
+        }
+    ).encode()
+    raw_record = _make_raw_record(
+        raw_id="ignored",
+        provider="chatgpt",
+        content=payload,
+        path="/tmp/session.json",
+    )
+
+    monkeypatch.setattr(ingest_worker, "_parse_plan_sessions", lambda *_args, **_kwargs: [])
+
+    result = ingest_worker.ingest_record(raw_record, str(tmp_path / "archive"), "off")
+
+    assert result.sessions == []
+    assert result.error == "parse: session artifact produced no materializable sessions"
+    assert result.parse_error == result.error
 
 
 def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(

--- a/tests/unit/storage/test_repository_insight_runtime.py
+++ b/tests/unit/storage/test_repository_insight_runtime.py
@@ -251,6 +251,10 @@ async def test_repository_raw_forwards_query_and_mutation_calls() -> None:
             new=AsyncMock(return_value={"inbox": "1"}),
         ) as mock_mtimes,
         patch(
+            "polylogue.storage.repository.raw.repository_raw.cursor_queries.get_known_source_cursors",
+            new=AsyncMock(return_value={"inbox": {"st_dev": 1, "st_ino": 2, "st_size": 3, "mtime_ns": 4}}),
+        ) as mock_cursors,
+        patch(
             "polylogue.storage.repository.raw.repository_raw.raw_queries.reset_parse_status",
             new=AsyncMock(return_value=3),
         ) as mock_reset_parse,
@@ -290,6 +294,9 @@ async def test_repository_raw_forwards_query_and_mutation_calls() -> None:
             payload_provider="chatgpt",
         )
         assert await repo.get_known_source_mtimes() == {"inbox": "1"}
+        assert await repo.get_known_source_cursors() == {
+            "inbox": {"st_dev": 1, "st_ino": 2, "st_size": 3, "mtime_ns": 4}
+        }
         assert await repo.reset_parse_status(provider="chatgpt", source_names=["inbox"]) == 3
         assert await repo.reset_validation_status(provider="chatgpt", source_names=["inbox"]) == 4
         assert await repo.get_raw_sessions_batch(["raw-1"]) == ["a"]
@@ -320,6 +327,7 @@ async def test_repository_raw_forwards_query_and_mutation_calls() -> None:
         transaction_depth=7,
     )
     mock_mtimes.assert_awaited_once_with(conn)
+    mock_cursors.assert_awaited_once_with(conn)
     mock_reset_parse.assert_awaited_once_with(conn, provider="chatgpt", source_names=["inbox"], transaction_depth=7)
     mock_reset_validation.assert_awaited_once_with(
         conn,


### PR DESCRIPTION
## Summary

This PR turns the acquired-but-not-materialized raw-session failure mode into an explicit ingest invariant. JSONL stream detection now handles drive-cache filenames such as `*.jsonl.txt.json`, session artifacts that parse to zero sessions are quarantined instead of stamped clean, reparse removes stale same-raw sessions in the same batch transaction, and raw-materialization debt recognizes duplicate raw aliases whose source filenames encode an already-materialized native session id.

## Problem

Live archive evidence showed raw acquisition could be marked clean while user-visible sessions/messages were absent or wrong. The concrete production case was AI Studio Drive cache files that were actually Claude Code JSONL streams behind a trailing `.json` suffix; they had materialized as zero-message `aistudio-drive:*` sessions instead of real Claude Code sessions. Treating this as manual repair would leave the same class of bug available to recur.

## Solution

- Route embedded `.jsonl.` / `.ndjson.` filenames through the stream parser in both the ingest worker and shared JSON decoder.
- Reject session parser outputs that contain zero sessions, so raw rows cannot become parse-success/no-session artifacts silently.
- Delete stale sessions for the same `raw_id` before writing replacement parse results, inside the ingest batch transaction.
- Suppress raw-materialization debt for parsed duplicate aliases whose source filename maps to an existing native session for the same origin, including split suffixes such as `_1`.
- Count detection-warning-only raw-state updates as real updates.

Live production replay with this source tree:

- Replayed 15 affected AI Studio JSONL-cache raw rows.
- Wrote 15 changed sessions and 6,418 messages with 0 parse failures.
- Replayed one missing `ac49922f...` raw row and restored 782 messages.
- Source-tree raw-materialization debt after replay: `0` rows.
- FTS coverage after replay: `messages_fts_docsize=3,987,982`, indexable blocks `3,987,982`.

## Verification

Focused tests:

```text
devtools test \
  tests/unit/operations/test_archive_debt.py::test_archive_debt_raw_materialization_ignores_source_path_native_aliases \
  tests/unit/operations/test_archive_debt.py::test_archive_debt_raw_materialization_ignores_native_id_matches \
  tests/unit/pipeline/test_ingest_batch.py::test_process_ingest_batch_sync_replaces_stale_sessions_for_same_raw_id \
  tests/unit/pipeline/test_ingest_batch.py::test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw \
  tests/unit/pipeline/test_resilience.py::test_jsonl_stream_shape_beats_drive_cache_json_suffix \
  tests/unit/pipeline/test_resilience.py::test_ingest_worker_quarantines_session_artifact_with_no_sessions
# 6 passed
```

Static/generated quick gate:

```text
devtools verify --quick
# ruff format/check, mypy, render all, topology, layering, closure-matrix,
# schema roundtrip, manifests, ci-workflows, doc-commands,
# test-infra-currency, test-clock-hygiene all ok
```

Push hook reran `devtools verify --quick` at `33c998c57` and passed.

Default `devtools verify` was not run because this fresh worktree has no pytest-testmon seed and the command exits with guidance to run `devtools verify --seed-testmon` first.

## Follow-up

Targeted replay performance is not acceptable: a 2.2 MiB / 782-message single-row replay spent ~459s in commit/FTS work. That is now live-measured evidence for the dogfooding performance lane.

Ref #2308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session deduplication now automatically removes outdated entries when processing updated batches
  * JSONL file format detection improved to recognize additional naming patterns beyond standard extensions
  * Raw-materialization debt tracking now correctly handles native-alias source path mappings

* **Bug Fixes**
  * Added error handling for parse operations that produce no materializable sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->