### PR TITLE
feat: harden reader, context, and config surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ can agree on what is really running. For the narrated first run, see
 [docs/onboarding.md](docs/onboarding.md). Other install channels (Nix, Homebrew,
 container) are in [docs/installation.md](docs/installation.md).
 
+Ordinary Linux hosts can keep the tools isolated with `pipx` or a venv:
+
+```bash
+pipx install polylogue
+polylogue --help
+polylogue init
+polylogued run
+polylogued browser-capture status
+```
+
+Nix users can run the packaged apps without installing them globally:
+
+```bash
+nix run github:Sinity/polylogue -- --help
+nix run github:Sinity/polylogue#polylogued -- run
+nix run github:Sinity/polylogue#polylogued -- browser-capture status
+```
+
 ## Why this exists
 
 AI sessions are scattered across one JSON dump per vendor, one JSONL stream
@@ -282,8 +300,8 @@ Operators choose focused checks via the verification baseline:
 
 ```bash
 devtools verify --quick
-devtools lab scenario run archive-smoke --tier 0
-devtools lab scenario run reader-visual-smoke
+devtools lab smoke run archive-smoke --tier 0
+devtools lab smoke run reader-visual-smoke
 ```
 
 <!-- BEGIN GENERATED: docs-surface -->

--- a/README.md
+++ b/README.md
@@ -39,29 +39,11 @@ polylogue --latest read --to browser  # open it in the local reader instead
 `polylogue init` detects known session sources and writes a starter
 `polylogue.toml`; the daemon takes it from there. `polylogue config --format
 json` prints the redacted effective state, source layer, and inventory metadata
-for every public config key, so deployments and smoke diagnostics can agree on
-what is really running. For the narrated first run, see
+for every public knob, so Nix/HM deployments, MCP clients, and smoke diagnostics
+can agree on what is really running. For the narrated first run, see
 [docs/getting-started.md](docs/getting-started.md) and
 [docs/onboarding.md](docs/onboarding.md). Other install channels (Nix, Homebrew,
 container) are in [docs/installation.md](docs/installation.md).
-
-Ordinary Linux hosts can keep the tools isolated with `pipx` or a venv:
-
-```bash
-pipx install polylogue
-polylogue --help
-polylogue init
-polylogued run
-polylogued browser-capture status
-```
-
-Nix users can run the packaged apps without installing them globally:
-
-```bash
-nix run github:Sinity/polylogue -- --help
-nix run github:Sinity/polylogue#polylogued -- run
-nix run github:Sinity/polylogue#polylogued -- browser-capture status
-```
 
 ## Why this exists
 
@@ -300,8 +282,8 @@ Operators choose focused checks via the verification baseline:
 
 ```bash
 devtools verify --quick
-devtools lab smoke run archive-smoke --tier 0
-devtools lab smoke run reader-visual-smoke
+devtools lab scenario run archive-smoke --tier 0
+devtools lab scenario run reader-visual-smoke
 ```
 
 <!-- BEGIN GENERATED: docs-surface -->

--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -38,8 +38,8 @@ REQUIRED_DAEMON_ROUTES = (
 REQUIRED_WEB_ROUTES = (
     "/",
     "/api/sessions?limit=1&offset=0",
-    "/api/facets",
 )
+OPTIONAL_WEB_ROUTES = ("/api/facets",)
 REQUIRED_RECEIVER_ROUTES = ("/v1/status",)
 COMPLETION_PROBES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("query-then-connector", "polylogue find id:abc t", ("then",)),
@@ -881,8 +881,10 @@ def _diagnose(
         likely_causes.append("deployed daemon API predates /api/read-view-profiles or is not restarted")
         next_actions.append("restart polylogued after deploying a build that contains the read-view profiles route")
     if facets_route is not None and not facets_route.ok:
-        likely_causes.append("web-shell facets route exceeds the deployed smoke timeout")
-        next_actions.append("profile /api/facets and move expensive facet aggregation behind caching or bounded reads")
+        likely_causes.append("optional web-shell facets route exceeds the deployed smoke timeout")
+        next_actions.append(
+            "verify first paint still succeeds from / and /api/sessions, then profile deferred /api/facets families"
+        )
     if root_route is not None and not root_route.ok:
         likely_causes.append("web-shell root document is unavailable or exceeds the deployed smoke timeout")
         next_actions.append("verify the daemon can serve the workbench root before debugging browser-side rendering")
@@ -1023,16 +1025,23 @@ def build_report(
     routes = [
         *(
             _probe_route(f"{daemon_base_url.rstrip('/')}{route}", timeout_s=timeout_s)
-            for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES)
+            for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES, *OPTIONAL_WEB_ROUTES)
         ),
         *(
             _probe_route(f"{receiver_base_url.rstrip('/')}{route}", timeout_s=timeout_s)
             for route in REQUIRED_RECEIVER_ROUTES
         ),
     ]
+    required_route_urls = {
+        f"{daemon_base_url.rstrip('/')}{route}" for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES)
+    } | {f"{receiver_base_url.rstrip('/')}{route}" for route in REQUIRED_RECEIVER_ROUTES}
     failures: list[str] = []
     failures.extend(f"command:{probe.name}:{probe.error or probe.exit_code}" for probe in commands if not probe.ok)
-    failures.extend(f"route:{probe.url}:{probe.error or probe.status}" for probe in routes if not probe.ok)
+    failures.extend(
+        f"route:{probe.url}:{probe.error or probe.status}"
+        for probe in routes
+        if not probe.ok and probe.url in required_route_urls
+    )
     failures.extend(
         f"completion:{probe.name}:{probe.error or 'missing=' + ','.join(probe.missing)}"
         for probe in completions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,45 +86,78 @@ same directory tree.
 
 ## Configuration Model
 
-Polylogue has a layered configuration system and a separate archive state
-surface. Keep them apart: startup config tells processes where to bind, where
-to read/write, which provider work is allowed, and how to render output. User
-annotations, saved views, daemon cursors, convergence debt, and one-shot smoke
-results live in SQLite/log state instead.
+Polylogue has a small layered configuration surface and a larger archive state
+surface. Keep those apart: startup config tells processes how to bind, where to
+read/write, which provider work is allowed, and how to present output. User
+annotations, saved views, daemon cursors, telemetry, and one-shot smoke results
+live in SQLite/log state instead.
 
 Layer precedence is highest first:
 
 1. CLI flag overrides for that invocation.
-2. `POLYLOGUE_*`, provider credential, and presentation environment variables.
+2. `POLYLOGUE_*`, provider-specific, and presentation environment variables.
 3. User `polylogue.toml`, resolved from `$POLYLOGUE_CONFIG`, then
    `$XDG_CONFIG_HOME/polylogue/polylogue.toml`, then `./polylogue.toml`.
 4. Site `polylogue.toml`, resolved from `$POLYLOGUE_SITE_CONFIG` or
    `/etc/polylogue/polylogue.toml`.
-5. Built-in defaults: local loopback binds, browser capture restricted to
-   extension origins, embeddings off, and no provider spend unless explicitly
-   enabled.
+5. Built-in defaults: local loopback binds, embeddings off, browser capture
+   restricted to extension origins, and no remote auth-free write surface.
 
-Use `polylogue config` to print the resolved configuration as redacted TOML.
-Use `polylogue config --show-layers` for human provenance. Use
-`polylogue config --format json` for automation; it returns `layers`, `values`,
-and `inventory`. Each value includes its redacted effective value,
-`source_layer`, secret policy, TOML path, env var, owner class, and reload
-behavior.
+Use `polylogue config` to print the effective configuration as redacted TOML.
+Use `polylogue config --show-layers` for a human provenance view. Use
+`polylogue config --format json` for the machine contract; it returns the
+redacted effective value, source layer, owner class, reload behavior, TOML path,
+environment variable, CLI override, default, and inventory row for each public
+key.
 
-Secrets are never printed in cleartext. Set secrets show as `<set>` and unset
-or empty secrets show as `<unset>`, while `secret_present` preserves the useful
-diagnostic bit.
+The JSON shape is intentionally stable for automation:
 
-State classes:
+```json
+{
+  "layers": {
+    "default": "built-in defaults",
+    "site": {"path": "/etc/polylogue/polylogue.toml", "exists": false},
+    "user": {"path": "/home/user/.config/polylogue/polylogue.toml", "exists": true},
+    "env": "POLYLOGUE_*, provider credential, and presentation environment variables",
+    "cli": "CLI overrides (per-invocation)"
+  },
+  "values": {
+    "api_auth_token": {
+      "value": "<set>",
+      "source_layer": "env",
+      "secret": true,
+      "secret_present": true,
+      "toml_path": "daemon.api.auth_token",
+      "env_var": "POLYLOGUE_API_AUTH_TOKEN",
+      "owner_class": "network-security",
+      "reload_behavior": "startup-bound"
+    }
+  },
+  "inventory": [
+    {
+      "key": "api_auth_token",
+      "toml_path": "daemon.api.auth_token",
+      "env_var": "POLYLOGUE_API_AUTH_TOKEN",
+      "redaction": "presence"
+    }
+  ]
+}
+```
+
+Secrets are never printed in cleartext. Set secrets show as `<set>` and unset or
+empty secrets show as `<unset>`, while `secret_present` preserves the useful bit
+for diagnostics.
+
+### State classes
 
 | Class | Where it lives | Examples | Reload behavior |
 | --- | --- | --- | --- |
 | Static startup config | TOML/env/CLI | archive root, API host/port/token, browser-capture host/port/spool/origins, source roots | Restart `polylogued` after changing. |
-| Deployment policy | TOML/env/Nix/HM/systemd | schema validation mode, remote-bind posture, systemd memory/IO limits | Restart the managed service; policy is outside archive content hashes. |
+| Deployment policy | TOML/env/Nix/HM/systemd | remote-bind opt-in, auth requirements, systemd memory/IO limits, schema validation mode | Restart the managed service; policy is outside archive content hashes. |
 | Runtime mutable user state | `user.db` | tags, marks, saved views, workspaces, assertions, authored overlays | Mutated through CLI/API; not TOML and not source content. |
-| Provider/cost controls | TOML/env | `embedding.enabled`, `embedding.max_cost_usd`, `VOYAGE_API_KEY` | Daemon/provider loops must see explicit enablement before spending. |
-| Presentation preferences | TOML/env/CLI | `logging.force_plain`, `ui.theme`, `NO_COLOR`, slow-query notices | Per CLI process or web render; does not change archive meaning. |
-| Disposable ops state | `ops.db`, logs, smoke JSON | health cursors, convergence debt, deployment-smoke evidence, cgroup signals | Rebuildable diagnostics; do not place in source archives. |
+| Provider/cost controls | TOML/env | `embedding.enabled`, `embedding.max_cost_usd`, `VOYAGE_API_KEY` | Embedding loops read the gate/cost controls; no provider call happens unless explicitly enabled and credentials are present. |
+| Presentation preferences | TOML/env/CLI | `logging.force_plain`, `no_color`, `ui.theme`, `NO_COLOR`, slow-query notices | Per CLI process or web render; does not change archive meaning. |
+| Disposable ops state | `ops.db`, logs, smoke JSON | health cursors, convergence debt, deployment-smoke evidence, cgroup signals | Rebuildable/diagnostic; do not place in source archives. |
 
 ### TOML schema
 
@@ -133,48 +166,69 @@ State classes:
 root = "/home/user/.local/share/polylogue"
 
 [daemon]
-host = "127.0.0.1"
-port = 8766
+host = "127.0.0.1" # legacy alias used by Nix/HM when api/browser host is omitted
+port = 8766         # legacy API port alias
 
 [daemon.api]
 host = "127.0.0.1"
 port = 8766
-# auth_token = "..."   # optional; required for non-loopback API binding
+# auth_token = "..."   # required for non-loopback API binding
 
 [daemon.browser_capture]
 host = "127.0.0.1"
 port = 8765
-allowed_origins = "127.0.0.1"
-spool_path = "/home/user/.local/share/polylogue/browser-capture"
-# auth_token = "..."   # required for non-loopback receiver binding
+allowed_origins = "chrome-extension://*"
+allow_remote = false
+# auth_token = "..."   # required for remote binding or web origins
+# spool_path = "/home/user/.local/share/polylogue/browser-capture"
+
+[daemon.watch]
+debounce_s = 2.0
+
+[sources]
+roots = ["/home/user/.claude/projects", "/home/user/.codex/sessions"]
 
 [embedding]
-# Supplying VOYAGE_API_KEY alone does not enable daemon provider spend.
-enabled = true
+enabled = false
 model = "voyage-4"
 dimension = 1024
 max_cost_usd = 5.0   # soft monthly cap; 0 = unlimited
+# voyage_api_key = "..." # prefer VOYAGE_API_KEY from a secret manager
+
+[observability]
+enabled = false
+otlp_max_body_bytes = 8388608
 
 [logging]
 level = "INFO"
 force_plain = false
 
 [ui]
-theme = "auto"   # auto, dark, or light
+theme = "auto" # auto, dark, or light
+# slow_query_notice_seconds = 2.5
+
+[schema]
+validation = "advisory" # off, advisory, or strict
 
 [notifications]
 backend = "log"
+# webhook_url = "https://..."
+# webhook_secret = "..."
+
+[notifications.email]
+port = 587
+use_tls = true
+use_starttls = true
+max_per_hour = 12
 
 [health]
 check_interval_s = 300
 check_tiers = "fast"
+fts_auto_restore = false
+blob_integrity_sample_size = 100
 
-# Convergence-debt alert thresholds (#1226). The daemon raises a typed
-# HealthAlert when the per-family count of `live_convergence_debt` rows
-# crosses these levels. Overrides per source family let a stuck
-# claude-code-session session escalate sooner than a long-tail chatgpt
-# export. dedup_window_s suppresses repeated alerts within the window;
-# severity escalations and resolution always fire immediately.
+# Convergence-debt alert thresholds. The daemon raises a typed HealthAlert
+# when the per-family count of live_convergence_debt rows crosses these levels.
 [health.convergence_debt]
 default_warning = 1
 default_error = 10
@@ -184,16 +238,78 @@ dedup_window_s = 3600
 warning = 1
 error = 5
 
-[health.convergence_debt.families.chatgpt-export]
-warning = 25
-error = 200
+[health.cursor_lag]
+default_warning_s = 300
+default_error_s = 900
+
+[[cost.subscription.plans]]
+name = "team-monthly"
+period = "monthly"
+included_usd = 0
 ```
 
-Filesystem layout is owned by `polylogue.paths`, which reads directory
-environment variables lazily when its path functions are called.
+The TOML key map is executable: `polylogue.config` owns the inventory consumed
+by the loader, redacted TOML renderer, and JSON effective-state payload. When a
+new public key is added, inventory coverage tests require a TOML/env/default
+classification instead of letting a second ledger drift away from the code.
 
-Path-safety helpers are separate from both surfaces. Code that sanitizes
-provider or session names imports from `polylogue.paths.sanitize`.
+### Safety gates
+
+Remote API binding fails closed. `polylogued run --api-host 0.0.0.0` requires
+both `--insecure-allow-remote` and an API auth token, or the equivalent TOML/env
+settings:
+
+```toml
+[daemon.api]
+host = "0.0.0.0"
+auth_token = "..."
+
+[daemon.browser_capture]
+allow_remote = true
+```
+
+Browser-capture web origins fail closed without a browser-capture auth token.
+Extension origins such as `chrome-extension://*` are allowed by default for the
+local receiver; ordinary web origins such as `https://workbench.example` require
+`daemon.browser_capture.auth_token` or `POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN`.
+
+Embeddings are provider-cost work. `VOYAGE_API_KEY` alone supplies a credential
+but does not enable daemon embedding convergence. Set `embedding.enabled = true`
+or `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=true` to opt in; without a provider key,
+readiness reports disabled/error state instead of attempting provider calls.
+
+### Presentation and theme policy
+
+`logging.force_plain` and `POLYLOGUE_FORCE_PLAIN` force plain CLI output and
+avoid Rich layout primitives. `NO_COLOR` appears in the config inventory as the
+env-only `no_color` presentation key and is honored by CLI formatting as a
+no-color/plain-output signal for terminal compatibility. `ui.theme` and
+`POLYLOGUE_THEME` select semantic token mode: `auto`, `dark`, or `light`. The
+semantic token names are stable; individual palettes are UI implementation, not
+a deployment policy knob.
+
+Presentation preferences never enter the source/archive content hash and should
+not be stored as user assertions. They are per process, per terminal, or per web
+render.
+
+### Nix and Home Manager semantics
+
+The bundled NixOS module (`services.polylogue`) and Home Manager module
+(`programs.polylogued`) render the same `polylogue.toml` schema that non-Nix
+users write by hand. `polylogued run` reads that TOML/env effective state, so
+module settings do not need to be duplicated as `ExecStart` flags; secret-bearing
+values should come from environment/secret-manager wiring whenever possible
+instead of being rendered into the Nix store.
+
+Nix/HM service settings such as `service.memoryHigh`, `service.memoryMax`,
+`service.nice`, and `service.ioWeight` are deployment policy. They affect the
+systemd unit and show up in deployment-smoke resource evidence when the platform
+exposes cgroup files, but they are not Polylogue archive config keys.
+
+Filesystem layout is owned by `polylogue.paths`, which reads directory
+environment variables lazily when its path functions are called. Path-safety
+helpers are separate from both surfaces. Code that sanitizes provider or session
+names imports from `polylogue.paths.sanitize`.
 
 ## Environment Policy
 
@@ -203,39 +319,38 @@ Environment variable precedence is:
 2. `POLYLOGUE_ARCHIVE_ROOT` overrides the archive root and the archive
    databases under it (`source.db`, `index.db`, `embeddings.db`, `user.db`,
    and `ops.db`).
-3. Source discovery is derived from resolved filesystem paths and Drive cache or
-   auth files.
-4. Drive authentication may override credential and token files through the
-   Drive-specific environment variables below.
-5. Vector indexing reads `VOYAGE_API_KEY` only when daemon embedding convergence
-   is explicitly enabled.
+3. `POLYLOGUE_CONFIG` and `POLYLOGUE_SITE_CONFIG` select config files.
+4. `POLYLOGUE_*` runtime variables override matching TOML values.
+5. Provider credentials such as `VOYAGE_API_KEY` supply secrets; they do not
+   enable provider spend by themselves.
 
-These are the supported runtime overrides:
+Common runtime overrides:
 
-| Variable | Description |
-|----------|-------------|
-| `XDG_CONFIG_HOME` | Base directory for `polylogue-credentials.json` |
-| `XDG_DATA_HOME` | Base directory for the database, blob store, browser-capture spool, and Drive cache |
-| `XDG_CACHE_HOME` | Base directory for cache/index output |
-| `XDG_STATE_HOME` | Base directory for OAuth token and runtime state |
-| `POLYLOGUE_ARCHIVE_ROOT` | Override the archive root instead of using `$XDG_DATA_HOME/polylogue` |
-| `POLYLOGUE_FORCE_PLAIN` | Force non-interactive plain output |
-| `NO_COLOR` | Standard no-color request; any non-empty value makes CLI output ANSI-free/plain |
-| `POLYLOGUE_THEME` | `auto`, `dark`, or `light` semantic theme for Rich and HTML rendering |
-| `VOYAGE_API_KEY` | Voyage AI API key for embeddings |
-| `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` | Set to `1`, `true`, or `yes` to let daemon convergence call the embedding provider |
-| `POLYLOGUE_CREDENTIAL_PATH` | Drive auth override for the OAuth client JSON path |
-| `POLYLOGUE_TOKEN_PATH` | Drive auth override for the OAuth token path |
-
-### Theme and no-color policy
-
-Human-facing terminal output becomes plain when `--plain`,
-`POLYLOGUE_FORCE_PLAIN`, `NO_COLOR`, or a non-interactive terminal path requests
-it. Plain mode removes Rich layout and ANSI escapes before any color theme is
-applied. When rich rendering is allowed, `POLYLOGUE_THEME` or `[ui] theme`
-selects semantic tokens for terminal panels, code/diff highlighting, and HTML
-exports. Future palette sources such as pywal should feed those semantic tokens
-rather than adding one-off colors at call sites.
+| Variable | Config key | Description |
+|----------|------------|-------------|
+| `XDG_CONFIG_HOME` | path base | Base directory for `polylogue.toml` and Drive credentials. |
+| `XDG_DATA_HOME` | path base | Base directory for the archive, blob store, Drive cache, and browser-capture spool. |
+| `XDG_CACHE_HOME` | path base | Base directory for cache/index output. |
+| `XDG_STATE_HOME` | path base | Base directory for OAuth token and runtime state. |
+| `POLYLOGUE_CONFIG` | config layer | Explicit user config path. |
+| `POLYLOGUE_SITE_CONFIG` | config layer | Explicit site config path; empty disables site config. |
+| `POLYLOGUE_ARCHIVE_ROOT` | `archive_root` | Override the archive root. |
+| `POLYLOGUE_DAEMON_URL` | `daemon_url` | CLI/MCP client daemon base URL. |
+| `POLYLOGUE_API_HOST` / `POLYLOGUE_API_PORT` | `api_host` / `api_port` | Daemon HTTP API bind. |
+| `POLYLOGUE_API_AUTH_TOKEN` | `api_auth_token` | API bearer token; redacted in config output. |
+| `POLYLOGUE_BROWSER_CAPTURE_HOST` / `POLYLOGUE_BROWSER_CAPTURE_PORT` | browser-capture bind | Receiver bind host/port. |
+| `POLYLOGUE_BROWSER_CAPTURE_ALLOWED_ORIGINS` | `browser_capture_allowed_origins` | Comma-separated receiver CORS origins. |
+| `POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE` | `browser_capture_allow_remote` | Explicit remote-bind opt-in. |
+| `POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN` | `browser_capture_auth_token` | Receiver bearer token; redacted. |
+| `POLYLOGUE_BROWSER_CAPTURE_SPOOL_PATH` | `browser_capture_spool_path` | Receiver spool override. |
+| `POLYLOGUE_FORCE_PLAIN` | `force_plain` | Force plain output. |
+| `POLYLOGUE_THEME` | `theme` | `auto`, `dark`, or `light`. |
+| `NO_COLOR` | `no_color` | Disable color/plain terminal formatting. |
+| `VOYAGE_API_KEY` | `voyage_api_key` | Voyage credential; redacted and spend-gated. |
+| `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` | `embedding_enabled` | Enable daemon embedding convergence. |
+| `POLYLOGUE_OBSERVABILITY_ENABLED` | `observability_enabled` | Enable OTLP/observability HTTP ingestion. |
+| `POLYLOGUE_CREDENTIAL_PATH` | Drive auth | OAuth client JSON path. |
+| `POLYLOGUE_TOKEN_PATH` | Drive auth | OAuth token path. |
 
 ## Backup and Export
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -345,12 +345,22 @@ Common runtime overrides:
 | `POLYLOGUE_BROWSER_CAPTURE_SPOOL_PATH` | `browser_capture_spool_path` | Receiver spool override. |
 | `POLYLOGUE_FORCE_PLAIN` | `force_plain` | Force plain output. |
 | `POLYLOGUE_THEME` | `theme` | `auto`, `dark`, or `light`. |
-| `NO_COLOR` | `no_color` | Disable color/plain terminal formatting. |
+| `NO_COLOR` | `no_color` | Standard no-color request; any non-empty value makes CLI output ANSI-free/plain. |
 | `VOYAGE_API_KEY` | `voyage_api_key` | Voyage credential; redacted and spend-gated. |
 | `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` | `embedding_enabled` | Enable daemon embedding convergence. |
 | `POLYLOGUE_OBSERVABILITY_ENABLED` | `observability_enabled` | Enable OTLP/observability HTTP ingestion. |
 | `POLYLOGUE_CREDENTIAL_PATH` | Drive auth | OAuth client JSON path. |
 | `POLYLOGUE_TOKEN_PATH` | Drive auth | OAuth token path. |
+
+### Theme and no-color policy
+
+Human-facing terminal output becomes plain when `--plain`,
+`POLYLOGUE_FORCE_PLAIN`, `NO_COLOR`, or a non-interactive terminal path requests
+it. Plain mode removes Rich layout and ANSI escapes before any color theme is
+applied. When rich rendering is allowed, `POLYLOGUE_THEME` or `[ui] theme`
+selects semantic tokens for terminal panels, code/diff highlighting, and HTML
+exports. Future palette sources such as pywal should feed those semantic tokens
+rather than adding one-off colors at call sites.
 
 ## Backup and Export
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -147,7 +147,14 @@ Query params include `target_ref`, `scope_ref`, `kind`, `status`,
 
 ### GET /api/facets
 
-Query faceted aggregations.
+Query faceted aggregations. The route returns `FacetsResponse`, including
+`complete_families`, `deferred_families`, `generated_at`, `stale`,
+`stale_age_s`, `budget_exceeded`, and `family_status`. Repo and action
+families are deferred from first-paint responses by default; request them
+with `include_deferred=1` or `families=repos,action_types`, optionally
+bounded by `budget_ms`. The daemon also polls the client socket from SQLite
+progress handlers while computing facet SQL, so browser aborts/timeouts can
+stop already-started archive scans instead of waiting for response write.
 
 ### GET /api/sources
 

--- a/docs/design/query-action-workflows.md
+++ b/docs/design/query-action-workflows.md
@@ -1,10 +1,14 @@
 # Query-Action Workflows
 
-The executable `find QUERY then ACTION` product contract moved to the generated product surface:
+The executable `find QUERY then ACTION` product contract moved to the generated
+product surface:
 
 - [Executable Query-Action Workflows](../product/workflows.md)
 
-That document is rendered from `polylogue/product/workflows.py` and the live CLI action contracts, and it powers the demo-archive golden-path tests for #2305. Edit the registry or action contracts, then run:
+That document is rendered from `polylogue/product/workflows.py` and the live CLI
+action contracts, including context-pack and continuation handoff flows. It
+powers the demo-archive golden-path tests for #2305/#2306. Edit the registry or
+action contracts, then run:
 
 ```bash
 devtools render product-workflows

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -91,7 +91,9 @@ workflow/hook points at a removed command.
      durable decisions unless evidence supports the claim.
    - Evidence: demo/live fixtures with instruction dumps and real decisions;
      JSON and Markdown handoff outputs distinguish quoted evidence, inferred
-     summary, accepted/rejected candidates, and unavailable source material.
+     summary, accepted/rejected/deferred candidates, unavailable source
+     material, and disabled review actions with reasons. Default handoffs redact
+     raw absolute paths unless an explicit raw/no-redact path is requested.
 
 6. **Make configuration explicit before adding more knobs (#2309).**
    - Classify settings as startup config, deployment policy, mutable user

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,8 +10,67 @@ matches how you run other tools on the host.
 | `nix run github:Sinity/polylogue` | NixOS / nix-darwin users | [`flake.nix`](../flake.nix) |
 | `ghcr.io/sinity/polylogue` | Container / Kubernetes / Compose | see below |
 
-This document focuses on the container channel; the other channels are linked
-out so they can evolve independently.
+The sections below cover ordinary Linux/Python installs, Nix/NixOS, containers,
+and Homebrew. The same three console scripts are exposed by every channel:
+`polylogue`, `polylogued`, and `polylogue-mcp`.
+
+## Ordinary Linux / Python
+
+Use `pipx` when you want Polylogue as a user-level tool without mixing it into
+an application virtualenv:
+
+```bash
+python -m pip install --user pipx
+python -m pipx ensurepath
+pipx install polylogue
+polylogue --help
+polylogue init
+polylogued run
+polylogued browser-capture status
+```
+
+A plain virtualenv works the same way and keeps the installed scripts under one
+explicit directory:
+
+```bash
+python -m venv ~/.local/share/polylogue-venv
+~/.local/share/polylogue-venv/bin/pip install --upgrade pip polylogue
+~/.local/share/polylogue-venv/bin/polylogue init
+~/.local/share/polylogue-venv/bin/polylogued run
+```
+
+For a system service, point the unit at the venv or package-managed
+`polylogued` executable and set `POLYLOGUE_ARCHIVE_ROOT` only when the default
+XDG archive location is not desired.
+
+## Nix / NixOS quick start
+
+The flake exposes app outputs for the CLI, daemon, and MCP server. One-shot
+commands are enough for smoke testing a host:
+
+```bash
+nix run github:Sinity/polylogue -- --help
+nix run github:Sinity/polylogue#polylogued -- run
+nix run github:Sinity/polylogue#polylogued -- browser-capture status
+nix run github:Sinity/polylogue#polylogue-mcp -- --help
+```
+
+Inside a checkout, use the dev shell when you want the repo-local command
+surface and verification helpers:
+
+```bash
+nix develop -c polylogue --help
+nix develop -c polylogued run
+nix develop -c devtools workspace deployment-smoke --browser --browser-executable "$(command -v google-chrome)"
+```
+
+On NixOS, import the flake module shown in the Nix section below. It creates a
+managed `polylogued.service`; check that deployed surface with:
+
+```bash
+systemctl status polylogued.service
+polylogue ops status
+```
 
 ## Container image
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,67 +10,8 @@ matches how you run other tools on the host.
 | `nix run github:Sinity/polylogue` | NixOS / nix-darwin users | [`flake.nix`](../flake.nix) |
 | `ghcr.io/sinity/polylogue` | Container / Kubernetes / Compose | see below |
 
-The sections below cover ordinary Linux/Python installs, Nix/NixOS, containers,
-and Homebrew. The same three console scripts are exposed by every channel:
-`polylogue`, `polylogued`, and `polylogue-mcp`.
-
-## Ordinary Linux / Python
-
-Use `pipx` when you want Polylogue as a user-level tool without mixing it into
-an application virtualenv:
-
-```bash
-python -m pip install --user pipx
-python -m pipx ensurepath
-pipx install polylogue
-polylogue --help
-polylogue init
-polylogued run
-polylogued browser-capture status
-```
-
-A plain virtualenv works the same way and keeps the installed scripts under one
-explicit directory:
-
-```bash
-python -m venv ~/.local/share/polylogue-venv
-~/.local/share/polylogue-venv/bin/pip install --upgrade pip polylogue
-~/.local/share/polylogue-venv/bin/polylogue init
-~/.local/share/polylogue-venv/bin/polylogued run
-```
-
-For a system service, point the unit at the venv or package-managed
-`polylogued` executable and set `POLYLOGUE_ARCHIVE_ROOT` only when the default
-XDG archive location is not desired.
-
-## Nix / NixOS quick start
-
-The flake exposes app outputs for the CLI, daemon, and MCP server. One-shot
-commands are enough for smoke testing a host:
-
-```bash
-nix run github:Sinity/polylogue -- --help
-nix run github:Sinity/polylogue#polylogued -- run
-nix run github:Sinity/polylogue#polylogued -- browser-capture status
-nix run github:Sinity/polylogue#polylogue-mcp -- --help
-```
-
-Inside a checkout, use the dev shell when you want the repo-local command
-surface and verification helpers:
-
-```bash
-nix develop -c polylogue --help
-nix develop -c polylogued run
-nix develop -c devtools workspace deployment-smoke --browser --browser-executable "$(command -v google-chrome)"
-```
-
-On NixOS, import the flake module shown in the Nix section below. It creates a
-managed `polylogued.service`; check that deployed surface with:
-
-```bash
-systemctl status polylogued.service
-polylogue ops status
-```
+This document focuses on the container channel; the other channels are linked
+out so they can evolve independently.
 
 ## Container image
 
@@ -290,30 +231,31 @@ cachix use polylogue
   services.polylogue = {
     enable = true;
     package = inputs.polylogue.packages.${pkgs.system}.default;
-    discoverSources = [ "claude-code" "codex" ];
     settings = {
       archive.root = "/var/lib/polylogue";
-      daemon.port = 8766;
-      daemon.watch-debounce-s = 30;
-      browser-capture = {
-        host = "127.0.0.1";
-        port = 8765;
-        spool-path = "/var/lib/polylogue/browser-capture";
-      };
+      daemon-api.port = 8766;
+      browser-capture.port = 8765;
+      embedding.enabled = false;
     };
   };
 }
 ```
 
 The module wires a `polylogued.service` systemd unit running `polylogued run`
-(watch + browser-capture + HTTP API). All `services.polylogue.settings.*`
-options map to runtime-loadable entries in the generated `polylogue.toml`;
-startup-bound values such as watch roots, debounce, API bind, and
-browser-capture bind/spool/auth/origins are also passed as `polylogued run`
-flags so the systemd process matches the rendered config. Options are
-documented inline in [`nix/module.nix`](../nix/module.nix). Per-unit hardening
-defaults (`Nice = 10`, `IOSchedulingClass = idle`, `MemoryHigh = 2G`,
-`MemoryMax = 2G`) are tunable under `services.polylogue.service.*`.
+(watch + browser-capture + HTTP API). `services.polylogue.settings.*` renders
+the same `polylogue.toml` schema used outside Nix; `polylogued run` reads that
+effective config instead of receiving duplicated `ExecStart` flags. Keep bearer
+tokens in environment/secret-manager wiring when possible, because setting them
+in `settings.*` writes them into the generated TOML. Per-unit hardening defaults
+(`Nice = 10`, `IOSchedulingClass = idle`, `MemoryHigh = 2G`, `MemoryMax = 2G`)
+are tunable under `services.polylogue.service.*`; they are deployment policy,
+not archive config.
+
+After deploying, use `polylogue config --format json` to inspect effective
+values and source layers, and `devtools workspace deployment-smoke --json` to capture the
+package versions, archive root, daemon URL, browser-capture receiver URL,
+optional browser executable path, and cgroup resource signals visible on the
+host.
 
 ### Home Manager module
 
@@ -324,22 +266,14 @@ defaults (`Nice = 10`, `IOSchedulingClass = idle`, `MemoryHigh = 2G`,
   programs.polylogued = {
     enable = true;
     package = inputs.polylogue.packages.${pkgs.system}.default;
-    discoverSources = [ "claude-code" "codex" ];
-    settings = {
-      daemon.port = 8766;
-      daemon.watch-debounce-s = 30;
-      browser-capture.port = 8765;
-    };
+    settings.daemon-api.port = 8766;
   };
 }
 ```
 
-The HM module declares a `systemd.user.services.polylogued` unit. Set
-`programs.polylogued.autoStart = false;` to keep the unit available but not
-started at login. By default it writes
-`$XDG_CONFIG_HOME/polylogue/polylogue.toml`; set
-`programs.polylogued.configLocation = "store";` when you want only a Nix store
-config path passed via `POLYLOGUE_CONFIG`.
+The HM module declares a `systemd.user.services.polylogued` unit and renders the
+same TOML schema as the NixOS module. Set `programs.polylogued.autoStart =
+false;` to keep the unit available but not started at login.
 
 ### Building locally
 

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -2544,7 +2544,8 @@ x-polylogue-route-contracts:
   kind: read_query
   stability: stable
   auth_policy: bearer_if_configured
-  response_contract: Facets envelope
+  response_contract: FacetsResponse with route-state metadata
+  notes: Repo and action facet families are deferred from first paint unless explicitly requested.
 - method: GET
   pattern: /api/query-units
   kind: read_query

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -519,6 +519,7 @@ components:
           - path
           - config
           - runtime
+          - candidate
           title: Target
           type: string
         input:
@@ -539,6 +540,7 @@ components:
           - path
           - config
           - runtime
+          - assertion_candidate
           title: Input Unit
           type: string
         cardinality_state:
@@ -727,6 +729,7 @@ components:
           - path
           - config
           - runtime
+          - assertion_candidate
           title: Unit
           type: string
         completion_context:

--- a/docs/schemas/cli-output/action-affordance-list.schema.json
+++ b/docs/schemas/cli-output/action-affordance-list.schema.json
@@ -146,7 +146,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "assertion_candidate"
           ],
           "title": "Input Unit",
           "type": "string"
@@ -216,7 +217,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "candidate"
           ],
           "title": "Target",
           "type": "string"
@@ -347,7 +349,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "assertion_candidate"
           ],
           "title": "Unit",
           "type": "string"

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -146,7 +146,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "assertion_candidate"
           ],
           "title": "Input Unit",
           "type": "string"
@@ -216,7 +217,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "candidate"
           ],
           "title": "Target",
           "type": "string"
@@ -347,7 +349,8 @@
             "session",
             "path",
             "config",
-            "runtime"
+            "runtime",
+            "assertion_candidate"
           ],
           "title": "Unit",
           "type": "string"

--- a/docs/search.md
+++ b/docs/search.md
@@ -903,6 +903,12 @@ A facets response carries both views explicitly:
   buckets if the filter chain narrows away every value.
 - `global` — counts over the unfiltered archive. Always populated.
 - `scoped_to_query` — `true` whenever any filter narrowed the view.
+- `complete_families` / `deferred_families` / `family_status` — route-state
+  metadata for each facet family. HTTP readers use this to distinguish an
+  actually-empty bucket from a family intentionally not materialized in the
+  current response.
+- `generated_at`, `stale`, `stale_age_s`, `budget_exceeded` — freshness and
+  budget metadata surfaced to the web workbench.
 - `idf` — inverse-document-frequency per facet value, computed against
   the global universe. Higher = rarer = stronger signal; near zero =
   value appears in almost every session. Disable with
@@ -912,6 +918,17 @@ Top-level fields (`origins`, `tags`, `total_sessions` etc.)
 mirror the *active* view (scoped when filtered, global otherwise) for
 backward compatibility with surfaces written before #1269. Consumers
 that need both views should read `scoped` and `global` directly.
+
+Daemon HTTP keeps expensive archive-wide families lazy for workbench
+first paint. `GET /api/facets` includes origin/tag/count buckets and marks
+`repos` plus `action_types` as `deferred_by_default`. Clients that need the
+full set can call `GET /api/facets?include_deferred=1&budget_ms=5000` or
+`GET /api/facets?families=repos,action_types`; a budget overrun returns
+the existing bucket fields plus `budget_exceeded=true` and per-family
+deferred reasons instead of blocking the page indefinitely. HTTP workbench
+requests attach request IDs and bounded `AbortController` timeouts; the daemon
+observes closed client sockets inside facet SQLite progress handlers so
+cancelled/timed-out browser requests can interrupt already-started scans.
 
 ```bash
 polylogue facets                     # global only (no filters)

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -3,12 +3,7 @@
 # Pairs with ``nix/module.nix`` for system-mode deployments. Both
 # share their option tree and TOML rendering via ``nix/lib/settings.nix``
 # so the polylogue.toml schema cannot drift between deployment modes.
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.programs.polylogued;
@@ -22,9 +17,7 @@ let
   };
 
   effectiveSettings = cfg.settings // {
-    daemon = cfg.settings.daemon // {
-      inherit watch;
-    };
+    daemon = cfg.settings.daemon // { inherit watch; };
   };
 
   storeConfigFile = settingsLib.renderConfigFile effectiveSettings;
@@ -37,55 +30,8 @@ let
   # ``store`` the unit gets a /nix/store path passed via the env var.
   useXdg = cfg.configLocation == "xdg";
 
-  # polylogued run reads its component ports from CLI flags, not the
-  # TOML. Build the flag list so the ExecStart matches what the user
-  # configured in settings. Omitted flags fall back to the daemon
-  # defaults (127.0.0.1 / 8765 / 8766).
-  bcHost =
-    if cfg.settings."browser-capture".host != null then
-      cfg.settings."browser-capture".host
-    else
-      cfg.settings.daemon.host;
-  bcPort = cfg.settings."browser-capture".port;
-  bcSpoolPath = cfg.settings."browser-capture".spool-path;
-  bcAuthToken = cfg.settings."browser-capture".auth-token;
-  bcAllowedOrigins = cfg.settings."browser-capture".allowed-origins;
-  bcAllowRemote = cfg.settings."browser-capture".allow-remote;
-  apiHost =
-    if cfg.settings."daemon-api".host != null then
-      cfg.settings."daemon-api".host
-    else
-      cfg.settings.daemon.host;
-  apiPort =
-    if cfg.settings."daemon-api".port != null then
-      cfg.settings."daemon-api".port
-    else
-      cfg.settings.daemon.port;
-  apiAuthToken = cfg.settings."daemon-api".auth-token;
-  watchDebounceS = cfg.settings.daemon.watch-debounce-s;
-
-  flag = name: value: "--${name} ${lib.escapeShellArg (toString value)}";
-  repeatFlag = name: values: map (value: flag name value) values;
-  originValues =
-    if bcAllowedOrigins == null then
-      [ ]
-    else
-      lib.filter (value: value != "") (lib.splitString "," bcAllowedOrigins);
-  watchValues = if watch == null then [ ] else watch;
-
-  daemonFlags = lib.concatStringsSep " " (
-    repeatFlag "root" watchValues
-    ++ lib.optional (watchDebounceS != null) (flag "debounce-s" watchDebounceS)
-    ++ lib.optional (bcHost != null) (flag "host" bcHost)
-    ++ lib.optional (bcPort != null) (flag "port" bcPort)
-    ++ lib.optional (bcSpoolPath != null) (flag "spool" bcSpoolPath)
-    ++ lib.optional (bcAllowRemote == true) "--insecure-allow-remote"
-    ++ lib.optional (bcAuthToken != null) (flag "browser-capture-auth-token" bcAuthToken)
-    ++ repeatFlag "browser-capture-origin" originValues
-    ++ lib.optional (apiHost != null) (flag "api-host" apiHost)
-    ++ lib.optional (apiPort != null) (flag "api-port" apiPort)
-    ++ lib.optional (apiAuthToken != null) (flag "api-auth-token" apiAuthToken)
-  );
+  # polylogued run consumes the generated TOML directly; keep
+  # secret-bearing values out of ExecStart arguments.
 
 in
 {
@@ -148,7 +94,7 @@ in
       Service = lib.mkMerge [
         {
           Type = "simple";
-          ExecStart = "${cfg.package}/bin/polylogued run ${daemonFlags}";
+          ExecStart = "${cfg.package}/bin/polylogued run";
           Restart = "on-failure";
           RestartSec = "5s";
         }

--- a/nix/lib/settings.nix
+++ b/nix/lib/settings.nix
@@ -37,25 +37,26 @@ let
       host = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Daemon listen host (polylogue default: 127.0.0.1).";
+        description = "Legacy daemon listen host alias (polylogue default: 127.0.0.1).";
       };
       port = mkOption {
         type = types.nullOr types.port;
         default = null;
-        description = "Daemon HTTP API port (polylogue default: 8766).";
+        description = "Legacy daemon HTTP API port alias (polylogue default: 8766).";
       };
       watch = mkOption {
         type = types.nullOr (types.listOf types.str);
         default = null;
         description = ''
-          Additional watch roots for live ingestion. Merged with any
+          Additional source roots for live ingestion. Rendered as
+          ``[sources] roots`` in polylogue.toml and merged with any
           paths produced by ``discoverSources``.
         '';
       };
-      watch-debounce-s = mkOption {
+      debounce-s = mkOption {
         type = types.nullOr types.number;
         default = null;
-        description = "Live watcher quiet period in seconds.";
+        description = "Live watcher debounce in seconds (polylogue default: 2.0).";
       };
     };
 
@@ -73,7 +74,11 @@ let
       auth-token = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "API Bearer auth token.";
+        description = ''
+          API Bearer auth token. Prefer sourcing this from a secret manager
+          into ``POLYLOGUE_API_AUTH_TOKEN``; setting it here renders it into
+          the generated TOML.
+        '';
       };
     };
 
@@ -81,7 +86,7 @@ let
       host = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Browser-capture receiver listen host.";
+        description = "Browser-capture receiver host (polylogue default: 127.0.0.1).";
       };
       port = mkOption {
         type = types.nullOr types.port;
@@ -91,22 +96,26 @@ let
       allowed-origins = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Comma-separated allowed CORS origins.";
+        description = "Comma-separated allowed CORS origins (default: chrome-extension://*).";
       };
       allow-remote = mkOption {
         type = types.nullOr types.bool;
         default = null;
-        description = "Allow non-loopback browser-capture receiver binds.";
+        description = "Explicitly allow non-loopback browser-capture/API binding.";
       };
       auth-token = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Browser-capture receiver Bearer auth token.";
+        description = ''
+          Browser-capture Bearer auth token. Required when remote binding or
+          non-extension web origins are configured. Prefer an environment
+          secret over rendering this into TOML.
+        '';
       };
       spool-path = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Browser-capture artifact spool path.";
+        description = "Browser-capture spool path.";
       };
     };
 
@@ -131,18 +140,32 @@ let
         default = null;
         description = "Maximum USD cost for embeddings (0 = unlimited).";
       };
+      voyage-api-key = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Voyage API key. Prefer ``VOYAGE_API_KEY`` from a secret manager;
+          setting this here renders it into the generated TOML.
+        '';
+      };
+    };
+
+    observability = {
+      enabled = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable OTLP/observability HTTP ingestion routes.";
+      };
+      otlp-max-body-bytes = mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        description = "Maximum accepted OTLP request body size.";
+      };
     };
 
     logging = {
       level = mkOption {
-        type = types.nullOr (
-          types.enum [
-            "DEBUG"
-            "INFO"
-            "WARNING"
-            "ERROR"
-          ]
-        );
+        type = types.nullOr (types.enum [ "DEBUG" "INFO" "WARNING" "ERROR" ]);
         default = null;
         description = "Log level.";
       };
@@ -150,6 +173,77 @@ let
         type = types.nullOr types.bool;
         default = null;
         description = "Force plain (non-rich) output.";
+      };
+    };
+
+    ui = {
+      theme = mkOption {
+        type = types.nullOr (types.enum [ "dark" "light" "auto" ]);
+        default = null;
+        description = "Semantic theme mode.";
+      };
+      slow-query-notice-seconds = mkOption {
+        type = types.nullOr types.number;
+        default = null;
+        description = "Threshold for slow-query user notices.";
+      };
+    };
+
+    schema = {
+      validation = mkOption {
+        type = types.nullOr (types.enum [ "off" "advisory" "strict" ]);
+        default = null;
+        description = "Schema validation mode.";
+      };
+    };
+
+    notifications = {
+      backend = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Notification backend: log/stdout/webhook/apprise/email.";
+      };
+      webhook-url = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Notification webhook URL.";
+      };
+      webhook-secret = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Notification webhook secret; prefer environment secrets over rendered TOML.";
+      };
+      apprise-urls = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = "Apprise notification URLs.";
+      };
+      email = {
+        host = mkOption { type = types.nullOr types.str; default = null; description = "SMTP host."; };
+        port = mkOption { type = types.nullOr types.port; default = null; description = "SMTP port."; };
+        username = mkOption { type = types.nullOr types.str; default = null; description = "SMTP username."; };
+        password = mkOption { type = types.nullOr types.str; default = null; description = "SMTP password; prefer environment secrets over rendered TOML."; };
+        from = mkOption { type = types.nullOr types.str; default = null; description = "SMTP sender address."; };
+        to = mkOption { type = types.nullOr (types.listOf types.str); default = null; description = "SMTP recipient list."; };
+        subject-prefix = mkOption { type = types.nullOr types.str; default = null; description = "SMTP subject prefix."; };
+        use-tls = mkOption { type = types.nullOr types.bool; default = null; description = "Use implicit TLS for SMTP."; };
+        use-starttls = mkOption { type = types.nullOr types.bool; default = null; description = "Use STARTTLS for SMTP."; };
+        max-per-hour = mkOption { type = types.nullOr types.ints.unsigned; default = null; description = "Max notification emails per hour."; };
+      };
+    };
+
+    health = {
+      check-interval-s = mkOption { type = types.nullOr types.ints.unsigned; default = null; description = "Daemon health-check interval."; };
+      check-tiers = mkOption { type = types.nullOr types.str; default = null; description = "Health-check tiers."; };
+      fts-auto-restore = mkOption { type = types.nullOr types.bool; default = null; description = "Allow health checks to repair FTS trigger drift."; };
+      blob-integrity-sample-size = mkOption { type = types.nullOr types.ints.unsigned; default = null; description = "Blob-integrity sample size."; };
+    };
+
+    cost = {
+      subscription-plans = mkOption {
+        type = types.nullOr (types.listOf (types.attrsOf types.unspecified));
+        default = null;
+        description = "Subscription plan rows rendered as [[cost.subscription.plans]].";
       };
     };
   };
@@ -189,11 +283,7 @@ let
   discoverSourcesOption = mkOption {
     type = types.listOf (types.enum providerNames);
     default = [ ];
-    example = [
-      "claude-code"
-      "codex"
-      "gemini"
-    ];
+    example = [ "claude-code" "codex" "gemini" ];
     description = ''
       Convenience: select one or more known provider names and the
       module will add their canonical source paths to
@@ -205,10 +295,7 @@ let
   };
 
   configLocationOption = mkOption {
-    type = types.enum [
-      "xdg"
-      "store"
-    ];
+    type = types.enum [ "xdg" "store" ];
     default = "xdg";
     description = ''
       Where to render polylogue.toml.
@@ -229,11 +316,11 @@ let
   # pkgs.formats.toml expects. Mirrors polylogue/config.py's TOML
   # schema (section names use snake_case keys like auth_token,
   # allowed_origins, max_cost_usd, force_plain).
-  renderSettings =
-    settings:
+  renderSettings = settings:
     let
       dropNulls = lib.filterAttrs (_: v: v != null);
-      maybe = section: rendered: if rendered == { } then { } else { ${section} = rendered; };
+      maybe = section: rendered:
+        if rendered == { } then { } else { ${section} = rendered; };
 
       archive = maybe "archive" (
         lib.optionalAttrs (settings.archive.root != null) {
@@ -246,79 +333,131 @@ let
           host = settings.daemon.host;
           port = settings.daemon.port;
         }
-        //
-          lib.optionalAttrs
-            (
-              settings.daemon-api.host != null
-              || settings.daemon-api.port != null
-              || settings.daemon-api.auth-token != null
-            )
-            {
-              api = dropNulls {
-                host = settings.daemon-api.host;
-                port = settings.daemon-api.port;
-                auth_token = settings.daemon-api.auth-token;
-              };
-            }
-        //
-          lib.optionalAttrs
-            (
-              settings.browser-capture.host != null
-              || settings.browser-capture.port != null
-              || settings.browser-capture.allowed-origins != null
-              || settings.browser-capture.allow-remote != null
-              || settings.browser-capture.auth-token != null
-              || settings.browser-capture.spool-path != null
-            )
-            {
-              browser_capture = dropNulls {
-                host = settings.browser-capture.host;
-                port = settings.browser-capture.port;
-                allowed_origins = settings.browser-capture.allowed-origins;
-                allow_remote = settings.browser-capture.allow-remote;
-                auth_token = settings.browser-capture.auth-token;
-                spool_path = settings.browser-capture.spool-path;
-              };
-            }
-        // lib.optionalAttrs (settings.daemon.watch-debounce-s != null) {
-          watch = {
-            debounce_s = settings.daemon.watch-debounce-s;
+        // lib.optionalAttrs (settings.daemon.debounce-s != null) {
+          watch = { debounce_s = settings.daemon.debounce-s; };
+        }
+        // lib.optionalAttrs (
+          settings.daemon-api.host != null
+          || settings.daemon-api.port != null
+          || settings.daemon-api.auth-token != null
+        ) {
+          api = dropNulls {
+            host = settings.daemon-api.host;
+            port = settings.daemon-api.port;
+            auth_token = settings.daemon-api.auth-token;
+          };
+        }
+        // lib.optionalAttrs (
+          settings.browser-capture.host != null
+          || settings.browser-capture.port != null
+          || settings.browser-capture.allowed-origins != null
+          || settings.browser-capture.allow-remote != null
+          || settings.browser-capture.auth-token != null
+          || settings.browser-capture.spool-path != null
+        ) {
+          browser_capture = dropNulls {
+            host = settings.browser-capture.host;
+            port = settings.browser-capture.port;
+            allowed_origins = settings.browser-capture.allowed-origins;
+            allow_remote = settings.browser-capture.allow-remote;
+            auth_token = settings.browser-capture.auth-token;
+            spool_path = settings.browser-capture.spool-path;
           };
         }
       );
 
-      sources = maybe "sources" (
-        lib.optionalAttrs (settings.daemon.watch != null) {
-          roots = settings.daemon.watch;
-        }
-      );
+      sources = maybe "sources" (dropNulls {
+        roots = settings.daemon.watch;
+      });
 
       embedding = maybe "embedding" (dropNulls {
         enabled = settings.embedding.enabled;
         model = settings.embedding.model;
         dimension = settings.embedding.dimension;
         max_cost_usd = settings.embedding.max-cost-usd;
+        voyage_api_key = settings.embedding.voyage-api-key;
+      });
+
+      observability = maybe "observability" (dropNulls {
+        enabled = settings.observability.enabled;
+        otlp_max_body_bytes = settings.observability.otlp-max-body-bytes;
       });
 
       logging = maybe "logging" (dropNulls {
         level = settings.logging.level;
         force_plain = settings.logging.force-plain;
       });
-    in
-    archive // daemon // sources // embedding // logging;
 
-  renderConfigFile =
-    settings: (pkgs.formats.toml { }).generate "polylogue.toml" (renderSettings settings);
+      ui = maybe "ui" (dropNulls {
+        theme = settings.ui.theme;
+        slow_query_notice_seconds = settings.ui.slow-query-notice-seconds;
+      });
+
+      schema = maybe "schema" (dropNulls {
+        validation = settings.schema.validation;
+      });
+
+      notifications = maybe "notifications" (
+        dropNulls {
+          backend = settings.notifications.backend;
+          webhook_url = settings.notifications.webhook-url;
+          webhook_secret = settings.notifications.webhook-secret;
+          apprise_urls = settings.notifications.apprise-urls;
+        }
+        // lib.optionalAttrs (
+          settings.notifications.email.host != null
+          || settings.notifications.email.port != null
+          || settings.notifications.email.username != null
+          || settings.notifications.email.password != null
+          || settings.notifications.email.from != null
+          || settings.notifications.email.to != null
+          || settings.notifications.email.subject-prefix != null
+          || settings.notifications.email.use-tls != null
+          || settings.notifications.email.use-starttls != null
+          || settings.notifications.email.max-per-hour != null
+        ) {
+          email = dropNulls {
+            host = settings.notifications.email.host;
+            port = settings.notifications.email.port;
+            username = settings.notifications.email.username;
+            password = settings.notifications.email.password;
+            from = settings.notifications.email.from;
+            to = settings.notifications.email.to;
+            subject_prefix = settings.notifications.email.subject-prefix;
+            use_tls = settings.notifications.email.use-tls;
+            use_starttls = settings.notifications.email.use-starttls;
+            max_per_hour = settings.notifications.email.max-per-hour;
+          };
+        }
+      );
+
+      health = maybe "health" (dropNulls {
+        check_interval_s = settings.health.check-interval-s;
+        check_tiers = settings.health.check-tiers;
+        fts_auto_restore = settings.health.fts-auto-restore;
+        blob_integrity_sample_size = settings.health.blob-integrity-sample-size;
+      });
+
+      cost = maybe "cost" (
+        lib.optionalAttrs (settings.cost.subscription-plans != null) {
+          subscription = { plans = settings.cost.subscription-plans; };
+        }
+      );
+    in
+    archive // daemon // sources // embedding // observability // logging // ui // schema // notifications // health // cost;
+
+  renderConfigFile = settings:
+    (pkgs.formats.toml { }).generate "polylogue.toml" (renderSettings settings);
 
   # Translate ``discoverSources = [ ... ]`` into a list of watch
   # paths. Returned unchanged when the input is empty so callers can
   # safely concatenate.
-  expandDiscoverSources = discoverSources: map (name: knownProviderRoots.${name}) discoverSources;
+  expandDiscoverSources = discoverSources:
+    map (name: knownProviderRoots.${name}) discoverSources;
 
-  # Compose the effective ``daemon.watch`` list by combining the
+  # Compose the effective ``sources.roots`` list by combining the
   # explicit setting (if any) with the discover-sources expansion.
-  effectiveWatch =
-    { settings, discoverSources }:
+  effectiveWatch = { settings, discoverSources }:
     let
       explicit = settings.daemon.watch or null;
       discovered = expandDiscoverSources discoverSources;
@@ -331,14 +470,12 @@ let
   # systemd Service directive block built from service.* options.
   # Returns an attrset suitable for ``serviceConfig`` (system) or
   # ``Service`` (HM). Memory* keys are omitted entirely when null.
-  serviceDirectives =
-    service:
-    lib.filterAttrs (_: v: v != null) {
-      Nice = service.nice;
-      IOWeight = service.ioWeight;
-      MemoryHigh = service.memoryHigh;
-      MemoryMax = service.memoryMax;
-    };
+  serviceDirectives = service: lib.filterAttrs (_: v: v != null) {
+    Nice = service.nice;
+    IOWeight = service.ioWeight;
+    MemoryHigh = service.memoryHigh;
+    MemoryMax = service.memoryMax;
+  };
 
 in
 {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,12 +3,7 @@
 # Pairs with ``nix/hm-module.nix`` for user-mode deployments. Both
 # share their option tree and TOML rendering via ``nix/lib/settings.nix``
 # so the polylogue.toml schema cannot drift between deployment modes.
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.services.polylogue;
@@ -22,60 +17,13 @@ let
   };
 
   effectiveSettings = cfg.settings // {
-    daemon = cfg.settings.daemon // {
-      inherit watch;
-    };
+    daemon = cfg.settings.daemon // { inherit watch; };
   };
 
   configFile = settingsLib.renderConfigFile effectiveSettings;
 
-  # polylogued run reads component ports from CLI flags, not the TOML.
-  # Build the flag list so ExecStart honours the configured settings.
-  bcHost =
-    if cfg.settings."browser-capture".host != null then
-      cfg.settings."browser-capture".host
-    else
-      cfg.settings.daemon.host;
-  bcPort = cfg.settings."browser-capture".port;
-  bcSpoolPath = cfg.settings."browser-capture".spool-path;
-  bcAuthToken = cfg.settings."browser-capture".auth-token;
-  bcAllowedOrigins = cfg.settings."browser-capture".allowed-origins;
-  bcAllowRemote = cfg.settings."browser-capture".allow-remote;
-  apiHost =
-    if cfg.settings."daemon-api".host != null then
-      cfg.settings."daemon-api".host
-    else
-      cfg.settings.daemon.host;
-  apiPort =
-    if cfg.settings."daemon-api".port != null then
-      cfg.settings."daemon-api".port
-    else
-      cfg.settings.daemon.port;
-  apiAuthToken = cfg.settings."daemon-api".auth-token;
-  watchDebounceS = cfg.settings.daemon.watch-debounce-s;
-
-  flag = name: value: "--${name} ${lib.escapeShellArg (toString value)}";
-  repeatFlag = name: values: map (value: flag name value) values;
-  originValues =
-    if bcAllowedOrigins == null then
-      [ ]
-    else
-      lib.filter (value: value != "") (lib.splitString "," bcAllowedOrigins);
-  watchValues = if watch == null then [ ] else watch;
-
-  daemonFlags = lib.concatStringsSep " " (
-    repeatFlag "root" watchValues
-    ++ lib.optional (watchDebounceS != null) (flag "debounce-s" watchDebounceS)
-    ++ lib.optional (bcHost != null) (flag "host" bcHost)
-    ++ lib.optional (bcPort != null) (flag "port" bcPort)
-    ++ lib.optional (bcSpoolPath != null) (flag "spool" bcSpoolPath)
-    ++ lib.optional (bcAllowRemote == true) "--insecure-allow-remote"
-    ++ lib.optional (bcAuthToken != null) (flag "browser-capture-auth-token" bcAuthToken)
-    ++ repeatFlag "browser-capture-origin" originValues
-    ++ lib.optional (apiHost != null) (flag "api-host" apiHost)
-    ++ lib.optional (apiPort != null) (flag "api-port" apiPort)
-    ++ lib.optional (apiAuthToken != null) (flag "api-auth-token" apiAuthToken)
-  );
+  # polylogued run consumes the generated TOML through POLYLOGUE_CONFIG;
+  # avoid duplicating settings as CLI flags, especially secret-bearing tokens.
 
 in
 {
@@ -133,7 +81,7 @@ in
           # `polylogued run` enables watch + browser-capture + HTTP API by
           # default. Pass --no-watch / --no-browser-capture / --no-api at
           # the unit level if a deployment needs a narrower component set.
-          ExecStart = "${cfg.package}/bin/polylogued run ${daemonFlags}";
+          ExecStart = "${cfg.package}/bin/polylogued run";
           Restart = "on-failure";
           RestartSec = "5s";
           Environment = "POLYLOGUE_CONFIG=${cfg.configPath}";

--- a/polylogue/cli/commands/config.py
+++ b/polylogue/cli/commands/config.py
@@ -45,82 +45,48 @@ config_command.add_command(paths_command)
 
 
 def _show_config(env: AppEnv, output_format: str, show_layers: bool) -> None:
-    from polylogue.config import (
-        describe_config_layers,
-        effective_config_payload,
-        format_config_toml,
-        is_secret_config_key,
-        load_polylogue_config,
-        redact_secret_value,
-    )
+    from polylogue.config import effective_config_payload, format_config_toml, load_polylogue_config
 
     cfg = load_polylogue_config()
-
-    def _display_value(key: str) -> object:
-        raw_value = cfg.raw.get(key)
-        if is_secret_config_key(key):
-            return redact_secret_value(raw_value)
-        return raw_value
-
-    if show_layers:
-        # ``console.print`` interprets ``[brackets]`` as Rich markup; disable
-        # markup so JSON output and TOML section headers survive verbatim.
-        # Secret-bearing keys are redacted before display so the layer dump
-        # never reveals a cleartext secret.
-        layer_paths = describe_config_layers()
-        payload: dict[str, object] = {
-            "layers": {
-                "default": "built-in defaults",
-                "site": layer_paths["site"],
-                "user": layer_paths["user"],
-                "env": "POLYLOGUE_* environment variables",
-                "cli": "CLI overrides (per-invocation)",
-            },
-            "values": {
-                key: {"value": _display_value(key), "layer": cfg.layer_of(key)} for key in sorted(cfg.raw.keys())
-            },
-        }
-        if output_format == "json":
-            import json
-
-            env.ui.console.print(
-                json.dumps(effective_config_payload(cfg), indent=2, default=str),
-                markup=False,
-                highlight=False,
-            )
-        else:
-            lines = ["# Polylogue config layer sources", ""]
-            layers_section = payload["layers"]
-            assert isinstance(layers_section, dict)
-            lines.append("[layers]")
-            for layer_name, descriptor in layers_section.items():
-                lines.append(f"# {layer_name}: {descriptor}")
-            lines.append("")
-            lines.append("[values]")
-            values_section = payload["values"]
-            assert isinstance(values_section, dict)
-            for key, info in values_section.items():
-                assert isinstance(info, dict)
-                value = info.get("value")
-                layer = info.get("layer")
-                lines.append(f"{key} = {value!r}  # layer = {layer}")
-            env.ui.console.print("\n".join(lines), markup=False, highlight=False)
-        return
+    payload = effective_config_payload(cfg)
 
     if output_format == "json":
         import json
 
         # ``console.print`` interprets ``[brackets]`` as Rich markup, which
-        # would mangle JSON output. Print without markup parsing to preserve
-        # exact bytes. Secret-bearing keys are redacted in the effective
-        # config payload so the JSON dump never reveals a cleartext secret.
+        # would mangle JSON output and TOML section headers. Print without
+        # markup parsing to preserve exact bytes. Secret-bearing keys are
+        # redacted by ``effective_config_payload``.
         env.ui.console.print(
-            json.dumps(effective_config_payload(cfg), indent=2, default=str),
+            json.dumps(payload, indent=2, default=str),
             markup=False,
             highlight=False,
         )
-    else:
-        env.ui.console.print(format_config_toml(cfg.raw), markup=False, highlight=False)
+        return
+
+    if show_layers:
+        lines = ["# Polylogue config layer sources", ""]
+        layers_section = payload["layers"]
+        assert isinstance(layers_section, dict)
+        lines.append("[layers]")
+        for layer_name, descriptor in layers_section.items():
+            lines.append(f"# {layer_name}: {descriptor}")
+        lines.append("")
+        lines.append("[values]")
+        values_section = payload["values"]
+        assert isinstance(values_section, dict)
+        for key in sorted(values_section):
+            info = values_section[key]
+            assert isinstance(info, dict)
+            value = info.get("value")
+            layer = info.get("source_layer")
+            owner = info.get("owner_class")
+            reload_behavior = info.get("reload_behavior")
+            lines.append(f"{key} = {value!r}  # layer = {layer}; owner = {owner}; reload = {reload_behavior}")
+        env.ui.console.print("\n".join(lines), markup=False, highlight=False)
+        return
+
+    env.ui.console.print(format_config_toml(cfg.raw), markup=False, highlight=False)
 
 
 __all__ = ["config_command"]

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -30,8 +30,6 @@ from .paths import (
     active_index_db_path as default_db_path,
 )
 
-_MISSING = object()
-
 
 class ConfigError(PolylogueError):
     """Configuration error."""
@@ -226,7 +224,7 @@ class PolylogueConfig:
         The receiver is OFF by default (closes #1604 — the routes were
         previously unconditionally enabled in front of the auth gate
         despite a code comment claiming otherwise). Operators opt in
-        via TOML ``observability_enabled = true`` or the env var
+        via TOML ``[observability] enabled = true`` or the env var
         ``POLYLOGUE_OBSERVABILITY_ENABLED=1``.
         """
         return bool(self._data.get("observability_enabled"))
@@ -237,7 +235,7 @@ class PolylogueConfig:
 
         Default 8 MiB matches typical OTLP exporter batch sizes; clients
         sending more receive 413. Configurable via TOML
-        ``otlp_max_body_bytes`` or env ``POLYLOGUE_OTLP_MAX_BODY_BYTES``.
+        ``[observability] otlp_max_body_bytes = ...`` or env ``POLYLOGUE_OTLP_MAX_BODY_BYTES``.
         """
         return int(str(self._data.get("otlp_max_body_bytes", 8 * 1024 * 1024)))
 
@@ -265,6 +263,10 @@ class PolylogueConfig:
     @property
     def force_plain(self) -> bool:
         return bool(self._data.get("force_plain"))
+
+    @property
+    def no_color(self) -> bool:
+        return bool(self._data.get("no_color"))
 
     @property
     def theme(self) -> str:
@@ -304,7 +306,7 @@ class PolylogueConfig:
 
     @property
     def browser_capture_allowed_origins(self) -> str:
-        return str(self._data.get("browser_capture_allowed_origins", "127.0.0.1"))
+        return str(self._data.get("browser_capture_allowed_origins", "chrome-extension://*"))
 
     @property
     def notification_backend(self) -> str:
@@ -459,21 +461,478 @@ class PolylogueConfig:
         return tuple(rows)
 
 
-@dataclass(frozen=True, slots=True)
-class ConfigInventoryEntry:
-    """Public configuration key metadata for effective-state reporting."""
-
-    key: str
-    toml_path: str | None
-    env_var: str | None
-    cli_override: str | None
-    owner_class: str
-    reload_behavior: str
-
-
 #: Default site-wide configuration path. Overridable through the
 #: ``POLYLOGUE_SITE_CONFIG`` env var (primarily for tests and packaging).
 DEFAULT_SITE_CONFIG_PATH = Path("/etc/polylogue/polylogue.toml")
+
+
+_MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigInventoryEntry:
+    """Single public configuration knob and its inspection metadata.
+
+    The inventory owns TOML/env/CLI surface metadata. Loader/rendering code
+    below consumes the same entries, so the list is not a decorative ledger
+    that can drift away from implementation.
+    """
+
+    key: str
+    owner_class: str
+    reload_behavior: str
+    toml_path: str | None = None
+    env_var: str | None = None
+    cli_override: str | None = None
+    description: str = ""
+    toml_kind: str = "scalar"
+
+    @property
+    def effective_path(self) -> str:
+        return f"polylogue config --format json values.{self.key}"
+
+
+_CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
+    ConfigInventoryEntry(
+        "archive_root",
+        toml_path="archive.root",
+        env_var="POLYLOGUE_ARCHIVE_ROOT",
+        owner_class="path-layout",
+        reload_behavior="startup-bound",
+        description="Archive root containing source/index/embeddings/user/ops stores.",
+    ),
+    ConfigInventoryEntry(
+        "daemon_url",
+        env_var="POLYLOGUE_DAEMON_URL",
+        cli_override="polylogue status --daemon-url",
+        owner_class="network-security",
+        reload_behavior="per-invocation-client",
+        description="Client-side base URL used by CLI surfaces that call the daemon API.",
+    ),
+    ConfigInventoryEntry(
+        "daemon_host",
+        toml_path="daemon.host",
+        env_var="POLYLOGUE_DAEMON_HOST",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Legacy daemon listen host alias kept for TOML/Nix compatibility.",
+    ),
+    ConfigInventoryEntry(
+        "daemon_port",
+        toml_path="daemon.port",
+        env_var="POLYLOGUE_DAEMON_PORT",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Legacy daemon listen port alias kept for TOML/Nix compatibility.",
+    ),
+    ConfigInventoryEntry(
+        "api_host",
+        toml_path="daemon.api.host",
+        env_var="POLYLOGUE_API_HOST",
+        cli_override="polylogued run --api-host",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Daemon HTTP API listen host.",
+    ),
+    ConfigInventoryEntry(
+        "api_port",
+        toml_path="daemon.api.port",
+        env_var="POLYLOGUE_API_PORT",
+        cli_override="polylogued run --api-port",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Daemon HTTP API listen port.",
+    ),
+    ConfigInventoryEntry(
+        "api_auth_token",
+        toml_path="daemon.api.auth_token",
+        env_var="POLYLOGUE_API_AUTH_TOKEN",
+        cli_override="polylogued run --api-auth-token",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Bearer token required when the daemon API is exposed beyond loopback.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_host",
+        toml_path="daemon.browser_capture.host",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_HOST",
+        cli_override="polylogued run --host",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Browser-capture receiver listen host.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_port",
+        toml_path="daemon.browser_capture.port",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_PORT",
+        cli_override="polylogued run --port",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Browser-capture receiver listen port.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_allowed_origins",
+        toml_path="daemon.browser_capture.allowed_origins",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_ALLOWED_ORIGINS",
+        cli_override="polylogued run --browser-capture-origin",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Comma-separated browser-capture CORS origins.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_allow_remote",
+        toml_path="daemon.browser_capture.allow_remote",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE",
+        cli_override="polylogued run --insecure-allow-remote",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Explicit opt-in for non-loopback browser-capture/API binding.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_auth_token",
+        toml_path="daemon.browser_capture.auth_token",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN",
+        cli_override="polylogued run --browser-capture-auth-token",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Bearer token for browser-capture requests when web origins or remote binds are enabled.",
+    ),
+    ConfigInventoryEntry(
+        "browser_capture_spool_path",
+        toml_path="daemon.browser_capture.spool_path",
+        env_var="POLYLOGUE_BROWSER_CAPTURE_SPOOL_PATH",
+        cli_override="polylogued run --spool",
+        owner_class="path-layout",
+        reload_behavior="startup-bound",
+        description="Spool directory for browser-capture JSONL before archive ingestion.",
+    ),
+    ConfigInventoryEntry(
+        "watch_debounce_s",
+        toml_path="daemon.watch.debounce_s",
+        env_var="POLYLOGUE_WATCH_DEBOUNCE_S",
+        cli_override="polylogued run --debounce-s",
+        owner_class="resource-policy",
+        reload_behavior="startup-bound",
+        description="Quiet period before the live watcher parses a changed file.",
+    ),
+    ConfigInventoryEntry(
+        "source_roots",
+        toml_path="sources.roots",
+        cli_override="polylogued run --root",
+        owner_class="path-layout",
+        reload_behavior="startup-bound",
+        description="Additional source roots watched by the daemon.",
+    ),
+    ConfigInventoryEntry(
+        "embedding_enabled",
+        toml_path="embedding.enabled",
+        env_var="POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS",
+        owner_class="provider-cost-control",
+        reload_behavior="daemon-loop",
+        description="Explicit opt-in for daemon-driven embedding catch-up and spend.",
+    ),
+    ConfigInventoryEntry(
+        "embedding_model",
+        toml_path="embedding.model",
+        owner_class="provider-cost-control",
+        reload_behavior="daemon-loop",
+        description="Embedding provider model name.",
+    ),
+    ConfigInventoryEntry(
+        "embedding_dimension",
+        toml_path="embedding.dimension",
+        owner_class="provider-cost-control",
+        reload_behavior="daemon-loop",
+        description="Embedding vector dimension expected in the archive.",
+    ),
+    ConfigInventoryEntry(
+        "embedding_max_cost_usd",
+        toml_path="embedding.max_cost_usd",
+        owner_class="provider-cost-control",
+        reload_behavior="daemon-loop",
+        description="Soft spend cap for embedding work.",
+    ),
+    ConfigInventoryEntry(
+        "voyage_api_key",
+        toml_path="embedding.voyage_api_key",
+        env_var="VOYAGE_API_KEY",
+        owner_class="provider-cost-control",
+        reload_behavior="daemon-loop",
+        description="Voyage provider API key presence; always redacted in inspection output.",
+    ),
+    ConfigInventoryEntry(
+        "observability_enabled",
+        toml_path="observability.enabled",
+        env_var="POLYLOGUE_OBSERVABILITY_ENABLED",
+        owner_class="network-security",
+        reload_behavior="request-time",
+        description="Enable OTLP/observability HTTP ingestion routes.",
+    ),
+    ConfigInventoryEntry(
+        "otlp_max_body_bytes",
+        toml_path="observability.otlp_max_body_bytes",
+        env_var="POLYLOGUE_OTLP_MAX_BODY_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="request-time",
+        description="Maximum accepted OTLP request body size.",
+    ),
+    ConfigInventoryEntry(
+        "log_level",
+        toml_path="logging.level",
+        owner_class="presentation-preference",
+        reload_behavior="startup-bound",
+        description="Python logging verbosity.",
+    ),
+    ConfigInventoryEntry(
+        "force_plain",
+        toml_path="logging.force_plain",
+        env_var="POLYLOGUE_FORCE_PLAIN",
+        cli_override="polylogue --plain",
+        owner_class="presentation-preference",
+        reload_behavior="per-invocation-client",
+        description="Force plain output and avoid Rich layout primitives.",
+    ),
+    ConfigInventoryEntry(
+        "no_color",
+        env_var="NO_COLOR",
+        owner_class="presentation-preference",
+        reload_behavior="per-invocation-client",
+        description="Standards-based terminal request to suppress ANSI color output.",
+    ),
+    ConfigInventoryEntry(
+        "theme",
+        toml_path="ui.theme",
+        env_var="POLYLOGUE_THEME",
+        owner_class="presentation-preference",
+        reload_behavior="per-invocation-client",
+        description="Terminal/web semantic theme mode: dark, light, or auto.",
+    ),
+    ConfigInventoryEntry(
+        "schema_validation",
+        toml_path="schema.validation",
+        env_var="POLYLOGUE_SCHEMA_VALIDATION",
+        owner_class="deployment-policy",
+        reload_behavior="per-invocation-client",
+        description="Schema validation mode used by CLI/import surfaces.",
+    ),
+    ConfigInventoryEntry(
+        "slow_query_notice_seconds",
+        toml_path="ui.slow_query_notice_seconds",
+        env_var="POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS",
+        owner_class="presentation-preference",
+        reload_behavior="per-invocation-client",
+        description="Threshold for slow-query user notices.",
+    ),
+    ConfigInventoryEntry(
+        "notification_backend",
+        toml_path="notifications.backend",
+        env_var="POLYLOGUE_NOTIFICATION_BACKEND",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Health notification backend: log/stdout/webhook/apprise/email.",
+    ),
+    ConfigInventoryEntry(
+        "notification_webhook_url",
+        toml_path="notifications.webhook_url",
+        env_var="POLYLOGUE_NOTIFICATION_WEBHOOK_URL",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Webhook endpoint for daemon health notifications.",
+    ),
+    ConfigInventoryEntry(
+        "notification_webhook_secret",
+        toml_path="notifications.webhook_secret",
+        env_var="POLYLOGUE_NOTIFICATION_WEBHOOK_SECRET",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Shared webhook secret; always redacted in inspection output.",
+    ),
+    ConfigInventoryEntry(
+        "notification_apprise_urls",
+        toml_path="notifications.apprise_urls",
+        env_var="POLYLOGUE_NOTIFICATION_APPRISE_URLS",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Apprise notification URLs.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_host",
+        toml_path="notifications.email.host",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_HOST",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP host for health notifications.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_port",
+        toml_path="notifications.email.port",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_PORT",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP port for health notifications.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_username",
+        toml_path="notifications.email.username",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_USERNAME",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP username.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_password",
+        toml_path="notifications.email.password",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_PASSWORD",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP password; always redacted in inspection output.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_from",
+        toml_path="notifications.email.from",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_FROM",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP sender address.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_to",
+        toml_path="notifications.email.to",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_TO",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP recipient list.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_subject_prefix",
+        toml_path="notifications.email.subject_prefix",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_SUBJECT_PREFIX",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="SMTP subject prefix.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_use_tls",
+        toml_path="notifications.email.use_tls",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_USE_TLS",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Use implicit TLS for SMTP notifications.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_use_starttls",
+        toml_path="notifications.email.use_starttls",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_USE_STARTTLS",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Use STARTTLS for SMTP notifications.",
+    ),
+    ConfigInventoryEntry(
+        "notification_email_max_per_hour",
+        toml_path="notifications.email.max_per_hour",
+        env_var="POLYLOGUE_NOTIFICATION_EMAIL_MAX_PER_HOUR",
+        owner_class="deployment-policy",
+        reload_behavior="daemon-loop",
+        description="Throttle health notification email volume.",
+    ),
+    ConfigInventoryEntry(
+        "health_check_interval_s",
+        toml_path="health.check_interval_s",
+        env_var="POLYLOGUE_HEALTH_CHECK_INTERVAL_S",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Periodic health-check interval.",
+    ),
+    ConfigInventoryEntry(
+        "health_check_tiers",
+        toml_path="health.check_tiers",
+        env_var="POLYLOGUE_HEALTH_CHECK_TIERS",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Comma-separated health-check tiers.",
+    ),
+    ConfigInventoryEntry(
+        "health_fts_auto_restore",
+        toml_path="health.fts_auto_restore",
+        env_var="POLYLOGUE_HEALTH_FTS_AUTO_RESTORE",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Allow health checks to repair FTS trigger drift automatically.",
+    ),
+    ConfigInventoryEntry(
+        "health_blob_integrity_sample_size",
+        toml_path="health.blob_integrity_sample_size",
+        env_var="POLYLOGUE_HEALTH_BLOB_INTEGRITY_SAMPLE_SIZE",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Bounded sample size for blob-integrity health checks.",
+    ),
+    ConfigInventoryEntry(
+        "health_convergence_debt",
+        toml_path="health.convergence_debt",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Nested convergence-debt SLO thresholds.",
+        toml_kind="table",
+    ),
+    ConfigInventoryEntry(
+        "health_cursor_lag",
+        toml_path="health.cursor_lag",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description="Nested cursor-lag SLO thresholds.",
+        toml_kind="table",
+    ),
+    ConfigInventoryEntry(
+        "subscription_plans",
+        toml_path="cost.subscription.plans",
+        owner_class="provider-cost-control",
+        reload_behavior="per-invocation-client",
+        description="Subscription plan rows used by cost/outlook reporting.",
+        toml_kind="array-table",
+    ),
+)
+
+_CONFIG_INVENTORY_BY_KEY = {entry.key: entry for entry in _CONFIG_INVENTORY}
+_ENV_CONFIG_KEY_MAP = {entry.env_var: entry.key for entry in _CONFIG_INVENTORY if entry.env_var}
+_INT_CONFIG_KEYS = frozenset(
+    {
+        "api_port",
+        "daemon_port",
+        "browser_capture_port",
+        "embedding_dimension",
+        "health_check_interval_s",
+        "health_blob_integrity_sample_size",
+        "notification_email_port",
+        "notification_email_max_per_hour",
+        "otlp_max_body_bytes",
+    }
+)
+_FLOAT_CONFIG_KEYS = frozenset({"embedding_max_cost_usd", "slow_query_notice_seconds", "watch_debounce_s"})
+_BOOL_CONFIG_KEYS = frozenset(
+    {
+        "browser_capture_allow_remote",
+        "embedding_enabled",
+        "force_plain",
+        "no_color",
+        "health_fts_auto_restore",
+        "notification_email_use_tls",
+        "notification_email_use_starttls",
+        "observability_enabled",
+    }
+)
+
+
+def _toml_section_layout() -> list[tuple[str, list[tuple[str, str]]]]:
+    sections: dict[str, list[tuple[str, str]]] = {}
+    for entry in _CONFIG_INVENTORY:
+        if not entry.toml_path or entry.toml_kind != "scalar":
+            continue
+        section, _, short_key = entry.toml_path.rpartition(".")
+        if not section:
+            continue
+        sections.setdefault(section, []).append((short_key, entry.key))
+    return list(sections.items())
 
 
 def _site_config_path() -> Path | None:
@@ -539,7 +998,7 @@ def _default_config_values() -> dict[str, object]:
         "api_port": 8766,
         "api_auth_token": None,
         "browser_capture_port": 8765,
-        "browser_capture_allowed_origins": "127.0.0.1",
+        "browser_capture_allowed_origins": "chrome-extension://*",
         # Stays opt-in: the daemon embed stage is gated separately on a
         # config TOML flag or POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS so that
         # supplying VOYAGE_API_KEY (e.g., for one-off CLI use) does not
@@ -558,10 +1017,13 @@ def _default_config_values() -> dict[str, object]:
         # below is intentionally low enough to act as a safety net for a
         # first-time user without an explicit configuration.
         "embedding_max_cost_usd": 5.0,
+        "voyage_api_key": None,
         "log_level": "INFO",
         "force_plain": False,
+        "no_color": False,
         "theme": "",
         "schema_validation": "advisory",
+        "slow_query_notice_seconds": None,
         "notification_backend": "log",
         "notification_webhook_url": None,
         "notification_webhook_secret": None,
@@ -580,212 +1042,16 @@ def _default_config_values() -> dict[str, object]:
         "health_check_tiers": "fast",
         "health_fts_auto_restore": False,
         "health_blob_integrity_sample_size": 100,
+        "health_convergence_debt": {},
+        "health_cursor_lag": {},
         "watch_debounce_s": 2.0,
         "browser_capture_host": "127.0.0.1",
         "browser_capture_spool_path": "",
         "browser_capture_auth_token": None,
         "browser_capture_allow_remote": False,
         "source_roots": (),
+        "subscription_plans": (),
     }
-
-
-_ENV_CONFIG_KEY_MAP: dict[str, str] = {
-    "POLYLOGUE_ARCHIVE_ROOT": "archive_root",
-    "POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS": "embedding_enabled",
-    "POLYLOGUE_OBSERVABILITY_ENABLED": "observability_enabled",
-    "POLYLOGUE_OTLP_MAX_BODY_BYTES": "otlp_max_body_bytes",
-    "VOYAGE_API_KEY": "voyage_api_key",
-    "POLYLOGUE_FORCE_PLAIN": "force_plain",
-    "POLYLOGUE_THEME": "theme",
-    "POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS": "slow_query_notice_seconds",
-    "POLYLOGUE_SCHEMA_VALIDATION": "schema_validation",
-    "POLYLOGUE_NOTIFICATION_BACKEND": "notification_backend",
-    "POLYLOGUE_NOTIFICATION_WEBHOOK_URL": "notification_webhook_url",
-    "POLYLOGUE_NOTIFICATION_WEBHOOK_SECRET": "notification_webhook_secret",
-    "POLYLOGUE_NOTIFICATION_APPRISE_URLS": "notification_apprise_urls",
-    "POLYLOGUE_NOTIFICATION_EMAIL_HOST": "notification_email_host",
-    "POLYLOGUE_NOTIFICATION_EMAIL_PORT": "notification_email_port",
-    "POLYLOGUE_NOTIFICATION_EMAIL_USERNAME": "notification_email_username",
-    "POLYLOGUE_NOTIFICATION_EMAIL_PASSWORD": "notification_email_password",
-    "POLYLOGUE_NOTIFICATION_EMAIL_FROM": "notification_email_from",
-    "POLYLOGUE_NOTIFICATION_EMAIL_TO": "notification_email_to",
-    "POLYLOGUE_HEALTH_CHECK_INTERVAL_S": "health_check_interval_s",
-    "POLYLOGUE_HEALTH_CHECK_TIERS": "health_check_tiers",
-    "POLYLOGUE_HEALTH_FTS_AUTO_RESTORE": "health_fts_auto_restore",
-    "POLYLOGUE_HEALTH_BLOB_INTEGRITY_SAMPLE_SIZE": "health_blob_integrity_sample_size",
-    "POLYLOGUE_API_HOST": "api_host",
-    "POLYLOGUE_API_PORT": "api_port",
-    "POLYLOGUE_API_AUTH_TOKEN": "api_auth_token",
-    "POLYLOGUE_BROWSER_CAPTURE_PORT": "browser_capture_port",
-    "POLYLOGUE_BROWSER_CAPTURE_HOST": "browser_capture_host",
-    "POLYLOGUE_WATCH_DEBOUNCE_S": "watch_debounce_s",
-}
-
-
-_TOML_PATH_BY_CONFIG_KEY: dict[str, str] = {
-    "archive_root": "archive.root",
-    "daemon_host": "daemon.host",
-    "daemon_port": "daemon.port",
-    "api_host": "daemon.api.host",
-    "api_port": "daemon.api.port",
-    "api_auth_token": "daemon.api.auth_token",
-    "browser_capture_host": "daemon.browser_capture.host",
-    "browser_capture_port": "daemon.browser_capture.port",
-    "browser_capture_allowed_origins": "daemon.browser_capture.allowed_origins",
-    "browser_capture_allow_remote": "daemon.browser_capture.allow_remote",
-    "browser_capture_auth_token": "daemon.browser_capture.auth_token",
-    "browser_capture_spool_path": "daemon.browser_capture.spool_path",
-    "watch_debounce_s": "daemon.watch.debounce_s",
-    "source_roots": "sources.roots",
-    "embedding_enabled": "embedding.enabled",
-    "embedding_model": "embedding.model",
-    "embedding_dimension": "embedding.dimension",
-    "embedding_max_cost_usd": "embedding.max_cost_usd",
-    "voyage_api_key": "embedding.voyage_api_key",
-    "observability_enabled": "daemon.observability.enabled",
-    "otlp_max_body_bytes": "daemon.observability.otlp_max_body_bytes",
-    "log_level": "logging.level",
-    "force_plain": "logging.force_plain",
-    "theme": "ui.theme",
-    "slow_query_notice_seconds": "ui.slow_query_notice_seconds",
-    "schema_validation": "schema_validation",
-    "notification_backend": "notifications.backend",
-    "notification_webhook_url": "notifications.webhook_url",
-    "notification_webhook_secret": "notifications.webhook_secret",
-    "notification_apprise_urls": "notifications.apprise_urls",
-    "notification_email_host": "notifications.email.host",
-    "notification_email_port": "notifications.email.port",
-    "notification_email_username": "notifications.email.username",
-    "notification_email_password": "notifications.email.password",
-    "notification_email_from": "notifications.email.from",
-    "notification_email_to": "notifications.email.to",
-    "notification_email_subject_prefix": "notifications.email.subject_prefix",
-    "notification_email_use_tls": "notifications.email.use_tls",
-    "notification_email_use_starttls": "notifications.email.use_starttls",
-    "notification_email_max_per_hour": "notifications.email.max_per_hour",
-    "health_check_interval_s": "health.check_interval_s",
-    "health_check_tiers": "health.check_tiers",
-    "health_fts_auto_restore": "health.fts_auto_restore",
-    "health_blob_integrity_sample_size": "health.blob_integrity_sample_size",
-    "health_convergence_debt": "health.convergence_debt",
-    "health_cursor_lag": "health.cursor_lag",
-    "subscription_plans": "cost.subscription.plans",
-}
-
-
-_CONFIG_KEY_BY_ENV = {key: env for env, key in _ENV_CONFIG_KEY_MAP.items()}
-
-
-def _config_owner_class(key: str) -> str:
-    if key in {"archive_root", "source_roots", "browser_capture_spool_path"}:
-        return "path-layout"
-    if key.startswith(("api_", "browser_capture_", "notification_")) or key.startswith("observability_"):
-        return "network-security"
-    if key.startswith("embedding_") or key in {"voyage_api_key", "subscription_plans"}:
-        return "provider-cost-control"
-    if key in {"force_plain", "theme", "log_level", "slow_query_notice_seconds"}:
-        return "presentation-preference"
-    if key.startswith("health_") or key in {"watch_debounce_s", "otlp_max_body_bytes"}:
-        return "resource-policy"
-    if key in {"schema_validation"}:
-        return "deployment-policy"
-    return "runtime-config"
-
-
-def _config_reload_behavior(key: str) -> str:
-    if key in {"force_plain", "theme", "log_level", "slow_query_notice_seconds"}:
-        return "per-invocation-client"
-    if key.startswith("embedding_"):
-        return "daemon-loop"
-    if key.startswith("health_"):
-        return "daemon-loop"
-    return "startup-bound"
-
-
-def config_inventory() -> tuple[ConfigInventoryEntry, ...]:
-    """Return the maintained public config inventory."""
-    keys = set(_default_config_values()) | set(_TOML_PATH_BY_CONFIG_KEY) | set(_CONFIG_KEY_BY_ENV)
-    return tuple(
-        ConfigInventoryEntry(
-            key=key,
-            toml_path=_TOML_PATH_BY_CONFIG_KEY.get(key),
-            env_var=_CONFIG_KEY_BY_ENV.get(key),
-            cli_override=None,
-            owner_class=_config_owner_class(key),
-            reload_behavior=_config_reload_behavior(key),
-        )
-        for key in sorted(keys)
-    )
-
-
-def config_inventory_by_key() -> dict[str, ConfigInventoryEntry]:
-    """Return config inventory keyed by flat config key."""
-    return {entry.key: entry for entry in config_inventory()}
-
-
-def _inventory_entry_payload(entry: ConfigInventoryEntry, *, default: object = _MISSING) -> dict[str, object]:
-    secret = is_secret_config_key(entry.key)
-    payload: dict[str, object] = {
-        "key": entry.key,
-        "toml_path": entry.toml_path,
-        "env_var": entry.env_var,
-        "cli_override": entry.cli_override,
-        "owner_class": entry.owner_class,
-        "reload_behavior": entry.reload_behavior,
-        "secret": secret,
-        "redaction": "presence" if secret else "none",
-    }
-    if default is not _MISSING:
-        payload["default"] = redact_secret_value(default) if secret else default
-    return payload
-
-
-def config_inventory_payload() -> list[dict[str, object]]:
-    """Return JSON-serializable inventory metadata for public config keys."""
-    defaults = _default_config_values()
-    return [_inventory_entry_payload(entry, default=defaults.get(entry.key, _MISSING)) for entry in config_inventory()]
-
-
-def effective_config_payload(
-    resolved: PolylogueConfig,
-    *,
-    include_inventory: bool = True,
-) -> dict[str, object]:
-    """Return redacted effective config values with source-layer metadata."""
-    layer_paths = describe_config_layers()
-    inventory = config_inventory_by_key()
-    keys = [entry.key for entry in config_inventory()]
-    keys.extend(sorted(key for key in resolved.raw if key not in inventory))
-    values: dict[str, object] = {}
-    for key in keys:
-        value = resolved.raw.get(key)
-        entry = inventory.get(key)
-        secret = is_secret_config_key(key)
-        display_value = redact_secret_value(value) if secret else value
-        values[key] = {
-            "value": display_value,
-            "source_layer": resolved.layer_of(key),
-            "secret": secret,
-            "secret_present": bool(secret and display_value == SECRET_SET_PLACEHOLDER),
-            "toml_path": entry.toml_path if entry is not None else None,
-            "env_var": entry.env_var if entry is not None else None,
-            "cli_override": entry.cli_override if entry is not None else None,
-            "owner_class": entry.owner_class if entry is not None else "unknown",
-            "reload_behavior": entry.reload_behavior if entry is not None else "unknown",
-        }
-    payload: dict[str, object] = {
-        "layers": {
-            "default": "built-in defaults",
-            "site": layer_paths["site"],
-            "user": layer_paths["user"],
-            "env": "POLYLOGUE_*, provider credential, and presentation environment variables",
-            "cli": "CLI overrides (per-invocation)",
-        },
-        "values": values,
-    }
-    if include_inventory:
-        payload["inventory"] = config_inventory_payload()
-    return payload
 
 
 def _apply_toml_layer(
@@ -819,7 +1085,7 @@ def load_polylogue_config(
     site_config_path: Path | None = None,
     cli_overrides: dict[str, object] | None = None,
 ) -> PolylogueConfig:
-    """Load resolved Polylogue config with four-layer precedence.
+    """Load resolved Polylogue config with five-layer precedence.
 
     Precedence (low → high), per #829:
 
@@ -894,74 +1160,12 @@ def describe_config_layers(
 def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
     """Merge TOML sections into the flat config dict.
 
-    Each section maps short keys (as written in TOML) to canonical flat keys
-    in ``cfg``. For example, ``[archive] root = "/x"`` maps to
-    ``cfg["archive_root"] = "/x"``.
+    The scalar mapping is generated from :data:`_CONFIG_INVENTORY`, keeping
+    loader and inspection metadata on the same rails. Specialized nested
+    tables remain explicit because their shape is owned by downstream typed
+    decoders rather than by this flat config layer.
     """
-    section_keys: dict[str, dict[str, str]] = {
-        "archive": {"root": "archive_root"},
-        "daemon": {
-            "host": "daemon_host",
-            "port": "daemon_port",
-        },
-        "daemon.api": {
-            "host": "api_host",
-            "port": "api_port",
-            "auth_token": "api_auth_token",
-        },
-        "daemon.browser_capture": {
-            "host": "browser_capture_host",
-            "port": "browser_capture_port",
-            "allowed_origins": "browser_capture_allowed_origins",
-            "allow_remote": "browser_capture_allow_remote",
-            "auth_token": "browser_capture_auth_token",
-            "spool_path": "browser_capture_spool_path",
-        },
-        "daemon.watch": {
-            "debounce_s": "watch_debounce_s",
-        },
-        "sources": {
-            "roots": "source_roots",
-        },
-        "embedding": {
-            "enabled": "embedding_enabled",
-            "model": "embedding_model",
-            "dimension": "embedding_dimension",
-            "max_cost_usd": "embedding_max_cost_usd",
-            "voyage_api_key": "voyage_api_key",
-        },
-        "logging": {
-            "level": "log_level",
-            "force_plain": "force_plain",
-        },
-        "ui": {
-            "theme": "theme",
-        },
-        "notifications": {
-            "backend": "notification_backend",
-            "webhook_url": "notification_webhook_url",
-            "webhook_secret": "notification_webhook_secret",
-            "apprise_urls": "notification_apprise_urls",
-        },
-        "notifications.email": {
-            "host": "notification_email_host",
-            "port": "notification_email_port",
-            "username": "notification_email_username",
-            "password": "notification_email_password",
-            "from": "notification_email_from",
-            "to": "notification_email_to",
-            "subject_prefix": "notification_email_subject_prefix",
-            "use_tls": "notification_email_use_tls",
-            "use_starttls": "notification_email_use_starttls",
-            "max_per_hour": "notification_email_max_per_hour",
-        },
-        "health": {
-            "check_interval_s": "health_check_interval_s",
-            "check_tiers": "health_check_tiers",
-            "fts_auto_restore": "health_fts_auto_restore",
-        },
-    }
-    for section, key_map in section_keys.items():
+    for section, key_pairs in _toml_section_layout():
         # Walk dotted paths for nested TOML sections like [daemon.api]
         section_data: object = toml_data
         for part in section.split("."):
@@ -971,13 +1175,19 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
                 section_data = None
                 break
         if isinstance(section_data, dict):
-            for short_key, flat_key in key_map.items():
+            for short_key, flat_key in key_pairs:
                 if short_key in section_data:
                     value = section_data[short_key]
                     if isinstance(value, list):
                         cfg[flat_key] = tuple(value)
                     else:
                         cfg[flat_key] = value
+
+    # Back-compat for early observability TOML examples that used
+    # top-level scalar keys before the inventory made the section explicit.
+    for legacy_key in ("observability_enabled", "otlp_max_body_bytes"):
+        if legacy_key in toml_data:
+            cfg[legacy_key] = toml_data[legacy_key]
 
     # [health.convergence_debt] — typed nested table with per-family overrides.
     # See polylogue/daemon/convergence_debt_alert.py for shape and semantics.
@@ -1001,31 +1211,38 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
         cfg["subscription_plans"] = tuple(p for p in plans if isinstance(p, dict))
 
 
+def _coerce_env_value(cfg_key: str, value: str) -> object:
+    """Coerce environment values according to the config inventory key type."""
+    if cfg_key in _BOOL_CONFIG_KEYS:
+        lowered = value.strip().lower()
+        if lowered in ("1", "true", "yes", "on"):
+            return True
+        if lowered in ("0", "false", "no", "off"):
+            return False
+        return value
+    if cfg_key in _INT_CONFIG_KEYS:
+        try:
+            return int(value)
+        except ValueError:
+            return _MISSING
+    if cfg_key in _FLOAT_CONFIG_KEYS:
+        try:
+            return float(value)
+        except ValueError:
+            return _MISSING
+    return value
+
+
 def _apply_env_overrides(cfg: dict[str, object]) -> None:
-    """Apply POLYLOGUE_* environment variable overrides."""
-    # Keys that must be stored as int
-    _int_keys = {
-        "api_port",
-        "daemon_port",
-        "browser_capture_port",
-        "health_check_interval_s",
-        "health_blob_integrity_sample_size",
-        "notification_email_port",
-        "notification_email_max_per_hour",
-    }
+    """Apply public environment variable overrides from the config inventory."""
     for env_var, cfg_key in _ENV_CONFIG_KEY_MAP.items():
         value = os.environ.get(env_var)
-        if value is not None:
-            # Coerce booleans
-            if value.lower() in ("1", "true", "yes"):
-                cfg[cfg_key] = True
-            elif value.lower() in ("0", "false", "no"):
-                cfg[cfg_key] = False
-            elif cfg_key in _int_keys:
-                with __import__("contextlib").suppress(ValueError):
-                    cfg[cfg_key] = int(value)
-            else:
-                cfg[cfg_key] = value
+        if value is None:
+            continue
+        coerced = _coerce_env_value(cfg_key, value)
+        if coerced is _MISSING:
+            continue
+        cfg[cfg_key] = coerced
 
 
 #: Flat config keys whose values are secrets and must never be rendered in
@@ -1087,12 +1304,124 @@ def redact_config_mapping(cfg: Mapping[str, object]) -> dict[str, object]:
     return redacted
 
 
+def _json_safe_config_value(value: object) -> object:
+    """Return a JSON/TOML-display-safe value without losing scalar types."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple):
+        return [_json_safe_config_value(item) for item in value]
+    if isinstance(value, list):
+        return [_json_safe_config_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe_config_value(item) for key, item in value.items()}
+    return value
+
+
+def config_display_value(key: str, value: object) -> object:
+    """Return a public inspection value, redacting secret-bearing keys."""
+    if is_secret_config_key(key):
+        return redact_secret_value(value)
+    return _json_safe_config_value(value)
+
+
+def config_inventory() -> tuple[ConfigInventoryEntry, ...]:
+    """Return the maintained public configuration inventory."""
+    return _CONFIG_INVENTORY
+
+
+def config_inventory_by_key() -> dict[str, ConfigInventoryEntry]:
+    """Return configuration inventory entries keyed by flat config key."""
+    return dict(_CONFIG_INVENTORY_BY_KEY)
+
+
+def _inventory_entry_payload(entry: ConfigInventoryEntry, *, default: object = _MISSING) -> dict[str, object]:
+    secret = is_secret_config_key(entry.key)
+    payload: dict[str, object] = {
+        "key": entry.key,
+        "toml_path": entry.toml_path,
+        "toml_kind": entry.toml_kind,
+        "env_var": entry.env_var,
+        "cli_override": entry.cli_override,
+        "owner_class": entry.owner_class,
+        "secret": secret,
+        "redaction": "presence" if secret else "none",
+        "reload_behavior": entry.reload_behavior,
+        "effective_path": entry.effective_path,
+        "description": entry.description,
+    }
+    payload["default"] = None if default is _MISSING else config_display_value(entry.key, default)
+    return payload
+
+
+def config_inventory_payload() -> list[dict[str, object]]:
+    """Return inventory rows ready for JSON/docs consumption."""
+    defaults = _default_config_values()
+    return [_inventory_entry_payload(entry, default=defaults.get(entry.key, _MISSING)) for entry in _CONFIG_INVENTORY]
+
+
+def effective_config_payload(
+    cfg: PolylogueConfig | None = None,
+    *,
+    include_inventory: bool = True,
+) -> dict[str, object]:
+    """Return redacted effective config values with source/layer metadata.
+
+    This is the machine contract behind ``polylogue config --format json``.
+    Secret-bearing values expose presence only (``<set>``/``<unset>``) while
+    still reporting which layer supplied the value.
+    """
+    resolved = cfg if cfg is not None else load_polylogue_config()
+    defaults = _default_config_values()
+    values: dict[str, object] = {}
+
+    ordered_keys = [entry.key for entry in _CONFIG_INVENTORY]
+    ordered_keys.extend(sorted(key for key in resolved.raw if key not in _CONFIG_INVENTORY_BY_KEY))
+
+    for key in ordered_keys:
+        entry = _CONFIG_INVENTORY_BY_KEY.get(key)
+        value = resolved.raw.get(key, defaults.get(key))
+        layer = resolved.layer_of(key)
+        secret = is_secret_config_key(key)
+        secret_present = bool(secret and redact_secret_value(value) == SECRET_SET_PLACEHOLDER)
+        values[key] = {
+            "value": config_display_value(key, value),
+            "source_layer": layer,
+            # Kept for the original --show-layers JSON wording and simple jq paths.
+            "layer": layer,
+            "secret": secret,
+            "secret_present": secret_present,
+            "toml_path": entry.toml_path if entry is not None else None,
+            "env_var": entry.env_var if entry is not None else None,
+            "cli_override": entry.cli_override if entry is not None else None,
+            "owner_class": entry.owner_class if entry is not None else "unknown",
+            "reload_behavior": entry.reload_behavior if entry is not None else "unknown",
+            "effective_path": entry.effective_path
+            if entry is not None
+            else f"polylogue config --format json values.{key}",
+            "default": config_display_value(key, defaults.get(key)) if key in defaults else None,
+        }
+
+    layer_paths = describe_config_layers()
+    payload: dict[str, object] = {
+        "layers": {
+            "default": "built-in defaults",
+            "site": layer_paths["site"],
+            "user": layer_paths["user"],
+            "env": "POLYLOGUE_*, provider credential, and presentation environment variables",
+            "cli": "CLI overrides (per-invocation)",
+        },
+        "values": values,
+    }
+    if include_inventory:
+        payload["inventory"] = config_inventory_payload()
+    return payload
+
+
 def format_config_toml(cfg: dict[str, object]) -> str:
     """Render loaded config as TOML for display.
 
-    Round-trips with :func:`_merge_toml`: the generated TOML uses short keys
-    inside their sections (``[archive] root = ...``) so the output can be
-    written back as a ``polylogue.toml`` file and re-loaded.
+    Round-trips with :func:`_merge_toml`: scalar keys are rendered from the
+    same inventory-driven TOML layout that the loader consumes.
 
     Secret-bearing keys are redacted to a presence placeholder
     (:data:`SECRET_SET_PLACEHOLDER` / :data:`SECRET_UNSET_PLACEHOLDER`) so the
@@ -1100,103 +1429,10 @@ def format_config_toml(cfg: dict[str, object]) -> str:
     serialized with a real TOML emitter (``tomli_w``) rather than raw f-string
     interpolation so quotes/backslashes/newlines cannot corrupt the output.
     """
-    # (section_name, [(short_key, flat_key), ...])
-    sections_layout: list[tuple[str, list[tuple[str, str]]]] = [
-        ("archive", [("root", "archive_root")]),
-        (
-            "daemon",
-            [
-                ("host", "daemon_host"),
-                ("port", "daemon_port"),
-            ],
-        ),
-        (
-            "daemon.api",
-            [
-                ("host", "api_host"),
-                ("port", "api_port"),
-                ("auth_token", "api_auth_token"),
-            ],
-        ),
-        (
-            "daemon.browser_capture",
-            [
-                ("host", "browser_capture_host"),
-                ("port", "browser_capture_port"),
-                ("allowed_origins", "browser_capture_allowed_origins"),
-                ("allow_remote", "browser_capture_allow_remote"),
-                ("auth_token", "browser_capture_auth_token"),
-            ],
-        ),
-        (
-            "daemon.watch",
-            [("debounce_s", "watch_debounce_s")],
-        ),
-        (
-            "sources",
-            [("roots", "source_roots")],
-        ),
-        (
-            "embedding",
-            [
-                ("enabled", "embedding_enabled"),
-                ("model", "embedding_model"),
-                ("dimension", "embedding_dimension"),
-                ("max_cost_usd", "embedding_max_cost_usd"),
-                ("voyage_api_key", "voyage_api_key"),
-            ],
-        ),
-        (
-            "logging",
-            [
-                ("level", "log_level"),
-                ("force_plain", "force_plain"),
-            ],
-        ),
-        (
-            "ui",
-            [
-                ("theme", "theme"),
-            ],
-        ),
-        (
-            "notifications",
-            [
-                ("backend", "notification_backend"),
-                ("webhook_url", "notification_webhook_url"),
-                ("webhook_secret", "notification_webhook_secret"),
-                ("apprise_urls", "notification_apprise_urls"),
-            ],
-        ),
-        (
-            "notifications.email",
-            [
-                ("host", "notification_email_host"),
-                ("port", "notification_email_port"),
-                ("username", "notification_email_username"),
-                ("password", "notification_email_password"),
-                ("from", "notification_email_from"),
-                ("to", "notification_email_to"),
-                ("subject_prefix", "notification_email_subject_prefix"),
-                ("use_tls", "notification_email_use_tls"),
-                ("use_starttls", "notification_email_use_starttls"),
-                ("max_per_hour", "notification_email_max_per_hour"),
-            ],
-        ),
-        (
-            "health",
-            [
-                ("check_interval_s", "health_check_interval_s"),
-                ("check_tiers", "health_check_tiers"),
-                ("fts_auto_restore", "health_fts_auto_restore"),
-            ],
-        ),
-    ]
-
     import tomli_w
 
     lines: list[str] = []
-    for section, key_pairs in sections_layout:
+    for section, key_pairs in _toml_section_layout():
         section_table: dict[str, object] = {}
         for short_key, flat_key in key_pairs:
             if flat_key not in cfg:
@@ -1204,13 +1440,7 @@ def format_config_toml(cfg: dict[str, object]) -> str:
             value = cfg[flat_key]
             if value is None:
                 continue
-            if is_secret_config_key(flat_key):
-                section_table[short_key] = redact_secret_value(value)
-                continue
-            if isinstance(value, tuple):
-                section_table[short_key] = list(value)
-            else:
-                section_table[short_key] = value
+            section_table[short_key] = config_display_value(flat_key, value)
         if section_table:
             lines.append(f"[{section}]")
             # ``tomli_w`` escapes quotes/backslashes/newlines correctly, so a
@@ -1235,6 +1465,7 @@ __all__ = [
     "SECRET_SET_PLACEHOLDER",
     "SECRET_UNSET_PLACEHOLDER",
     "Source",
+    "config_display_value",
     "config_inventory",
     "config_inventory_by_key",
     "config_inventory_payload",

--- a/polylogue/context/compiler.py
+++ b/polylogue/context/compiler.py
@@ -24,7 +24,7 @@ from polylogue.surfaces.payloads import AssertionClaimPayload
 RecoveryContextKind = Literal["recovery_digest", "recovery_report", "work_packet"]
 ContextPurpose = Literal["continue", "review", "handoff", "debug", "export"]
 ContextSegmentKind = Literal["recovery", "read_view", "assertion", "caveat"]
-ContextOmissionReason = Literal["budget", "unsupported", "not_found", "policy", "redacted"]
+ContextOmissionReason = Literal["budget", "unsupported", "not_found", "policy", "redacted", "missing_evidence"]
 
 _SUPPORTED_REPORTS: frozenset[str] = frozenset({"continue", "blame", "work-packet"})
 
@@ -82,6 +82,8 @@ class ContextImage(ArchiveInsightModel):
     """Compiled, storage-free context payload over archive refs and views."""
 
     spec: ContextSpec
+    selection_strategy: str = "single_session_recovery_digest_v0"
+    redaction_policy: str = "default"
     segments: tuple[ContextSegment, ...]
     object_refs: tuple[ObjectRef, ...] = ()
     evidence_refs: tuple[EvidenceRef, ...] = ()
@@ -89,6 +91,7 @@ class ContextImage(ArchiveInsightModel):
     omitted: tuple[ContextOmission, ...] = ()
     caveats: tuple[str, ...] = ()
     token_estimate: int = 0
+    size_estimate: dict[str, int] = Field(default_factory=dict)
 
 
 class ContextSnapshotRecord(ArchiveInsightModel):
@@ -212,6 +215,19 @@ def compile_recovery_context(
 def context_image_from_recovery(compilation: RecoveryContextCompilation) -> ContextImage:
     """Promote a recovery compilation into the general context-image shape."""
 
+    packet = compilation.work_packet
+    packet_omitted: tuple[ContextOmission, ...] = ()
+    if packet is not None:
+        packet_omitted = tuple(
+            ContextOmission(
+                ref=omission.ref,
+                view=omission.view,
+                reason=omission.reason,
+                detail=omission.detail,
+            )
+            for omission in packet.omissions
+        )
+
     segment = ContextSegment(
         segment_id=f"recovery:{compilation.session_id}:{compilation.report or compilation.kind}",
         kind="recovery",
@@ -233,14 +249,24 @@ def context_image_from_recovery(compilation: RecoveryContextCompilation) -> Cont
         include_candidates=False,
     )
     assertion_refs = tuple(claim.assertion_id for claim in compilation.assertion_claims)
+    token_estimate = packet.token_estimate if packet is not None and packet.token_estimate else segment.token_estimate
+    size_estimate = (
+        packet.size_estimate.model_dump(mode="json")
+        if packet is not None
+        else {"markdown_bytes": len((compilation.markdown or "").encode("utf-8")), "token_estimate": token_estimate}
+    )
     return ContextImage(
         spec=spec,
+        selection_strategy=packet.selection_strategy if packet is not None else "single_session_recovery_digest_v0",
+        redaction_policy=packet.redaction_policy if packet is not None else spec.redaction_policy,
         segments=(segment,),
         object_refs=compilation.object_refs,
         evidence_refs=compilation.evidence_refs,
         assertion_refs=assertion_refs,
+        omitted=packet_omitted,
         caveats=compilation.caveats,
-        token_estimate=segment.token_estimate,
+        token_estimate=token_estimate,
+        size_estimate=cast(dict[str, int], size_estimate),
     )
 
 
@@ -295,6 +321,9 @@ def context_snapshot_record_from_image(
         "include_assertions": _metadata_value_to_text(image.spec.include_assertions),
         "include_candidates": _metadata_value_to_text(image.spec.include_candidates),
         "redaction_policy": _metadata_value_to_text(image.spec.redaction_policy),
+        "context_redaction_policy": _metadata_value_to_text(image.redaction_policy),
+        "selection_strategy": _metadata_value_to_text(image.selection_strategy),
+        "size_estimate": _metadata_value_to_text(image.size_estimate),
         "omitted_count": _metadata_value_to_text(len(image.omitted)),
         "assertion_refs": _metadata_value_to_text(image.assertion_refs),
         "caveats": _metadata_value_to_text(image.caveats),

--- a/polylogue/context/pack.py
+++ b/polylogue/context/pack.py
@@ -18,10 +18,13 @@ from polylogue.mcp.context_pack import (
     ContextPackDecisions,
     ContextPackIntent,
     ContextPackMessage,
+    ContextPackOmission,
     ContextPackPayload,
     ContextPackProvenance,
     ContextPackQueryContext,
+    ContextPackScope,
     ContextPackSession,
+    ContextPackSizeEstimate,
     _build_project_context,
     _summarize_actions,
     archive_context_pack_active,
@@ -62,6 +65,185 @@ def _date_text(value: object) -> str | None:
     if callable(isoformat):
         return str(isoformat())
     return str(value)
+
+
+def _context_pack_redaction_policy(redact_paths: bool) -> str:
+    if redact_paths:
+        return "public_refs_and_redacted_paths"
+    return "raw_paths_explicit_opt_in"
+
+
+def _context_pack_path_value(value: str | None, *, redact_paths: bool) -> str | None:
+    if value is None or not redact_paths or not value.startswith("/"):
+        return value
+    name = Path(value).name or "path"
+    return f"<redacted-path>/{name}"
+
+
+def _context_pack_provenance(
+    *,
+    archive_root: Path,
+    active_db_path: Path,
+    redact_paths: bool,
+) -> ContextPackProvenance:
+    return ContextPackProvenance(
+        generated_at=datetime.now(UTC).isoformat(),
+        redacted=redact_paths,
+        archive_runtime="archive_file_set",
+        archive_root=None if redact_paths else str(archive_root),
+        active_db_path=None if redact_paths else str(active_db_path),
+        redaction_policy=_context_pack_redaction_policy(redact_paths),
+    )
+
+
+def _context_pack_scope(
+    *,
+    seed_session_id: str | None,
+    project_path: str | None,
+    project_repo: str | None,
+    since: str | None,
+    until: str | None,
+    origin: str | None,
+    query: str | None,
+    conv_limit: int,
+    msg_limit: int,
+    max_text: int,
+    include_messages: bool,
+    redact_paths: bool,
+) -> ContextPackScope:
+    return ContextPackScope(
+        seed_refs=([f"session:{seed_session_id}"] if seed_session_id else []),
+        read_views=["context-pack"],
+        project_path=_context_pack_path_value(project_path, redact_paths=redact_paths),
+        project_repo=project_repo,
+        origin=origin,
+        since=since,
+        until=until,
+        query=query,
+        include_messages=include_messages,
+        limits={"sessions": conv_limit, "messages_per_session": msg_limit, "message_text_chars": max_text},
+    )
+
+
+def _context_pack_evidence_refs(pack_sessions: list[ContextPackSession]) -> list[str]:
+    return [session.session_id for session in pack_sessions]
+
+
+def _context_pack_message_text_bytes(pack_sessions: list[ContextPackSession]) -> int:
+    return sum(len(message.text.encode("utf-8")) for session in pack_sessions for message in session.messages)
+
+
+def _context_pack_token_estimate(
+    *,
+    pack_sessions: list[ContextPackSession],
+    decisions: list[str],
+    omissions: list[ContextPackOmission],
+) -> int:
+    texts: list[str] = [*decisions]
+    texts.extend(session.title or "" for session in pack_sessions)
+    texts.extend(message.text for session in pack_sessions for message in session.messages)
+    texts.extend(omission.detail for omission in omissions)
+    word_count = sum(len(text.split()) for text in texts if text)
+    return max(1, word_count) if texts or pack_sessions or omissions else 0
+
+
+def _context_pack_omissions(
+    *,
+    pack_sessions: list[ContextPackSession],
+    seed_session_id: str | None,
+    query: str | None,
+    include_messages: bool,
+    msg_limit: int,
+    max_text: int,
+    redact_paths: bool,
+) -> list[ContextPackOmission]:
+    omissions: list[ContextPackOmission] = []
+    if seed_session_id is not None and not pack_sessions:
+        omissions.append(
+            ContextPackOmission(
+                ref=f"session:{seed_session_id}",
+                view="context-pack",
+                reason="not_found",
+                detail="Requested seed session was not found in the archive index.",
+            )
+        )
+    elif query and not pack_sessions:
+        omissions.append(
+            ContextPackOmission(
+                query=query,
+                view="context-pack",
+                reason="not_found",
+                detail="No sessions matched the strict or recall context-pack selection attempts.",
+            )
+        )
+    if not include_messages:
+        omissions.append(
+            ContextPackOmission(
+                view="messages",
+                reason="policy",
+                detail="Message bodies were excluded by the caller; session-level metadata remains selected.",
+                evidence_refs=[session.session_id for session in pack_sessions],
+            )
+        )
+    for session in pack_sessions:
+        if len(session.messages) < session.message_count and include_messages:
+            omissions.append(
+                ContextPackOmission(
+                    ref=f"session:{session.session_id}",
+                    view="messages",
+                    reason="budget",
+                    detail=(
+                        f"Included {len(session.messages)} message snippets out of {session.message_count}; "
+                        f"limit={msg_limit}, max_text={max_text}."
+                    ),
+                    evidence_refs=[session.session_id],
+                )
+            )
+        if include_messages and session.message_count and not session.messages:
+            omissions.append(
+                ContextPackOmission(
+                    ref=f"session:{session.session_id}",
+                    view="messages",
+                    reason="not_found",
+                    detail="Session was selected, but message text was unavailable to this read view.",
+                    evidence_refs=[session.session_id],
+                )
+            )
+    if redact_paths:
+        omissions.append(
+            ContextPackOmission(
+                view="provenance.paths",
+                reason="redacted",
+                detail="Absolute archive and active database paths are omitted unless the caller opts into raw paths.",
+                evidence_refs=[session.session_id for session in pack_sessions],
+            )
+        )
+    return omissions
+
+
+def _context_pack_caveats(
+    *,
+    pack_sessions: list[ContextPackSession],
+    relaxed_filters: list[str],
+    omissions: list[ContextPackOmission],
+) -> list[str]:
+    caveats: list[str] = []
+    if not pack_sessions:
+        caveats.append("no_sessions_selected")
+    if relaxed_filters:
+        caveats.append("selection_relaxed:" + ",".join(relaxed_filters))
+    for omission in omissions:
+        caveat = f"omitted:{omission.view or omission.reason}:{omission.reason}"
+        if caveat not in caveats:
+            caveats.append(caveat)
+    return caveats
+
+
+def _finalize_context_pack_payload(payload: ContextPackPayload) -> ContextPackPayload:
+    json_bytes = len(payload.model_dump_json(exclude_none=True).encode("utf-8"))
+    return payload.model_copy(
+        update={"size_estimate": payload.size_estimate.model_copy(update={"json_bytes": json_bytes})}
+    )
 
 
 async def build_archive_context_pack_payload(
@@ -189,7 +371,51 @@ async def build_archive_context_pack_payload(
             )
 
     total_matching = len(sessions)
-    return ContextPackPayload(
+    omissions = _context_pack_omissions(
+        pack_sessions=pack_sessions,
+        seed_session_id=seed_session_id,
+        query=query,
+        include_messages=include_messages,
+        msg_limit=msg_limit,
+        max_text=max_text,
+        redact_paths=redact_paths,
+    )
+    token_estimate = _context_pack_token_estimate(
+        pack_sessions=pack_sessions,
+        decisions=assertion_decisions,
+        omissions=omissions,
+    )
+    payload = ContextPackPayload(
+        selection_strategy=match_strategy,
+        scope=_context_pack_scope(
+            seed_session_id=seed_session_id,
+            project_path=project_path,
+            project_repo=project_repo,
+            since=since,
+            until=until,
+            origin=origin,
+            query=query,
+            conv_limit=conv_limit,
+            msg_limit=msg_limit,
+            max_text=max_text,
+            include_messages=include_messages,
+            redact_paths=redact_paths,
+        ),
+        omissions=omissions,
+        evidence_refs=_context_pack_evidence_refs(pack_sessions),
+        caveats=_context_pack_caveats(
+            pack_sessions=pack_sessions,
+            relaxed_filters=relaxed_filters,
+            omissions=omissions,
+        ),
+        redaction_policy=_context_pack_redaction_policy(redact_paths),
+        token_estimate=token_estimate,
+        size_estimate=ContextPackSizeEstimate(
+            message_text_bytes=_context_pack_message_text_bytes(pack_sessions),
+            session_count=len(pack_sessions),
+            message_count=sum(len(session.messages) for session in pack_sessions),
+            token_estimate=token_estimate,
+        ),
         decisions=ContextPackDecisions(items=assertion_decisions),
         project=_build_project_context((), redact=redact_paths),
         date_range=ContextPackDateRange(
@@ -213,17 +439,16 @@ async def build_archive_context_pack_payload(
         ),
         sessions=pack_sessions,
         action_summaries=[],
-        provenance=ContextPackProvenance(
-            generated_at=datetime.now(UTC).isoformat(),
-            redacted=redact_paths,
-            archive_runtime="archive_file_set",
-            archive_root=str(archive_root),
-            active_db_path=str(archive_root / "index.db"),
+        provenance=_context_pack_provenance(
+            archive_root=archive_root,
+            active_db_path=archive_root / "index.db",
+            redact_paths=redact_paths,
         ),
         total_sessions=total_matching,
         total_messages=sum(int(conv.message_count) for conv in sessions[:conv_limit]),
         total_tool_calls=0,
     )
+    return _finalize_context_pack_payload(payload)
 
 
 def run_context_pack_view(
@@ -352,10 +577,55 @@ def run_context_pack_view(
             )
         )
 
+    redact_paths = not no_redact
+    omissions = _context_pack_omissions(
+        pack_sessions=pack_sessions,
+        seed_session_id=None,
+        query=query,
+        include_messages=True,
+        msg_limit=msg_limit,
+        max_text=0,
+        redact_paths=redact_paths,
+    )
+    token_estimate = _context_pack_token_estimate(
+        pack_sessions=pack_sessions,
+        decisions=assertion_decisions,
+        omissions=omissions,
+    )
     payload = ContextPackPayload(
+        selection_strategy=selection.match_strategy,
+        scope=_context_pack_scope(
+            seed_session_id=None,
+            project_path=project_path,
+            project_repo=project_repo,
+            since=since,
+            until=until,
+            origin=origin,
+            query=query,
+            conv_limit=conv_limit,
+            msg_limit=msg_limit,
+            max_text=0,
+            include_messages=True,
+            redact_paths=redact_paths,
+        ),
+        omissions=omissions,
+        evidence_refs=_context_pack_evidence_refs(pack_sessions),
+        caveats=_context_pack_caveats(
+            pack_sessions=pack_sessions,
+            relaxed_filters=list(selection.relaxed_filters),
+            omissions=omissions,
+        ),
+        redaction_policy=_context_pack_redaction_policy(redact_paths),
+        token_estimate=token_estimate,
+        size_estimate=ContextPackSizeEstimate(
+            message_text_bytes=_context_pack_message_text_bytes(pack_sessions),
+            session_count=len(pack_sessions),
+            message_count=sum(len(session.messages) for session in pack_sessions),
+            token_estimate=token_estimate,
+        ),
         intent=ContextPackIntent(),
         decisions=ContextPackDecisions(items=assertion_decisions),
-        project=_build_project_context(aggregated_events, redact=not no_redact),
+        project=_build_project_context(aggregated_events, redact=redact_paths),
         date_range=ContextPackDateRange(
             since=since,
             until=until,
@@ -377,18 +647,17 @@ def run_context_pack_view(
         ),
         sessions=pack_sessions,
         action_summaries=action_summaries,
-        provenance=ContextPackProvenance(
-            redacted=not no_redact,
-            archive_runtime="archive_file_set",
-            archive_root=str(env.config.archive_root),
-            active_db_path=str(env.config.db_path),
+        provenance=_context_pack_provenance(
+            archive_root=env.config.archive_root,
+            active_db_path=env.config.db_path,
+            redact_paths=redact_paths,
         ),
         total_sessions=total_matching,
         total_messages=total_msg,
         total_tool_calls=total_tools,
     )
 
-    click.echo(serialize_surface_payload(payload))
+    click.echo(serialize_surface_payload(_finalize_context_pack_payload(payload)))
 
 
 def _archive_context_pack_active(env: AppEnv) -> bool:
@@ -486,7 +755,51 @@ def _build_archive_context_pack(
                 )
             )
 
-    return ContextPackPayload(
+    omissions = _context_pack_omissions(
+        pack_sessions=pack_sessions,
+        seed_session_id=None,
+        query=query,
+        include_messages=True,
+        msg_limit=msg_limit,
+        max_text=0,
+        redact_paths=redact,
+    )
+    token_estimate = _context_pack_token_estimate(
+        pack_sessions=pack_sessions,
+        decisions=assertion_decisions,
+        omissions=omissions,
+    )
+    payload = ContextPackPayload(
+        selection_strategy=selection.match_strategy,
+        scope=_context_pack_scope(
+            seed_session_id=None,
+            project_path=project_path,
+            project_repo=project_repo,
+            since=since,
+            until=until,
+            origin=origin,
+            query=query,
+            conv_limit=conv_limit,
+            msg_limit=msg_limit,
+            max_text=0,
+            include_messages=True,
+            redact_paths=redact,
+        ),
+        omissions=omissions,
+        evidence_refs=_context_pack_evidence_refs(pack_sessions),
+        caveats=_context_pack_caveats(
+            pack_sessions=pack_sessions,
+            relaxed_filters=list(selection.relaxed_filters),
+            omissions=omissions,
+        ),
+        redaction_policy=_context_pack_redaction_policy(redact),
+        token_estimate=token_estimate,
+        size_estimate=ContextPackSizeEstimate(
+            message_text_bytes=_context_pack_message_text_bytes(pack_sessions),
+            session_count=len(pack_sessions),
+            message_count=sum(len(session.messages) for session in pack_sessions),
+            token_estimate=token_estimate,
+        ),
         intent=ContextPackIntent(),
         decisions=ContextPackDecisions(items=assertion_decisions),
         project=_build_project_context((), redact=redact),
@@ -511,13 +824,13 @@ def _build_archive_context_pack(
         ),
         sessions=pack_sessions,
         action_summaries=[],
-        provenance=ContextPackProvenance(
-            redacted=redact,
-            archive_runtime="archive_file_set",
-            archive_root=str(archive_root),
-            active_db_path=str(archive_root / "index.db"),
+        provenance=_context_pack_provenance(
+            archive_root=archive_root,
+            active_db_path=archive_root / "index.db",
+            redact_paths=redact,
         ),
         total_sessions=total_matching,
         total_messages=total_msg,
         total_tool_calls=total_tools,
     )
+    return _finalize_context_pack_payload(payload)

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -57,6 +57,18 @@ _DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS = 3600
 _pidfile_path: Path | None = None
 
 
+def _bind_hosts_overlap(left: str, right: str) -> bool:
+    """Return True when two bind hosts can occupy the same socket address space."""
+    left_norm = left.strip().lower()
+    right_norm = right.strip().lower()
+    wildcard_hosts = {"", "0.0.0.0", "::"}
+    if left_norm == right_norm:
+        return True
+    if left_norm in wildcard_hosts or right_norm in wildcard_hosts:
+        return True
+    return is_loopback_host(left_norm) and is_loopback_host(right_norm)
+
+
 def _cleanup_pidfile() -> None:
     """Remove the daemon pidfile on exit."""
     global _pidfile_path
@@ -707,6 +719,18 @@ async def run_daemon_services(
     _process_start.started_at_wall()
     archive_root_path = Path(archive_root())
 
+    if (
+        enable_api
+        and enable_browser_capture
+        and api_port == browser_capture_port
+        and _bind_hosts_overlap(api_host, browser_capture_host)
+    ):
+        raise click.UsageError(
+            f"Daemon API {api_host}:{api_port} conflicts with browser-capture "
+            f"receiver {browser_capture_host}:{browser_capture_port}. "
+            f"Set distinct --api-port/--port values or bind one component to a non-overlapping host."
+        )
+
     # Non-localhost API binding requires explicit opt-in AND an auth token.
     if enable_api and not is_loopback_host(api_host):
         if not browser_capture_allow_remote:
@@ -1324,7 +1348,9 @@ def health_command(
     default=None,
     help="Daemon API auth token (generate one if not provided; write to archive root).",
 )
+@click.pass_context
 def run_command(
+    ctx: click.Context,
     roots: tuple[Path, ...],
     debounce_s: float,
     host: str,
@@ -1346,6 +1372,48 @@ def run_command(
     """
     _enable_faulthandler_if_supported()
     configure_logging()
+
+    from polylogue.config import load_polylogue_config
+
+    cfg = load_polylogue_config()
+
+    def parameter_is_default(name: str) -> bool:
+        source = ctx.get_parameter_source(name)
+        return source is None or source is click.core.ParameterSource.DEFAULT
+
+    if not roots and cfg.source_roots:
+        roots = tuple(Path(root).expanduser() for root in cfg.source_roots)
+    if parameter_is_default("debounce_s"):
+        debounce_s = cfg.watch_debounce_s
+    if parameter_is_default("host"):
+        if cfg.layer_of("browser_capture_host") != "default":
+            host = cfg.browser_capture_host
+        elif cfg.layer_of("daemon_host") != "default":
+            host = cfg.daemon_host
+    if parameter_is_default("port") and cfg.layer_of("browser_capture_port") != "default":
+        port = cfg.browser_capture_port
+    if parameter_is_default("spool_path") and cfg.browser_capture_spool_path:
+        spool_path = Path(cfg.browser_capture_spool_path).expanduser()
+    if parameter_is_default("insecure_allow_remote"):
+        insecure_allow_remote = cfg.browser_capture_allow_remote
+    if parameter_is_default("browser_capture_auth_token") and cfg.browser_capture_auth_token:
+        browser_capture_auth_token = cfg.browser_capture_auth_token
+    if not browser_capture_origins and cfg.layer_of("browser_capture_allowed_origins") != "default":
+        browser_capture_origins = tuple(
+            origin.strip() for origin in cfg.browser_capture_allowed_origins.split(",") if origin.strip()
+        )
+    if parameter_is_default("api_host"):
+        if cfg.layer_of("api_host") != "default":
+            api_host = cfg.api_host
+        elif cfg.layer_of("daemon_host") != "default":
+            api_host = cfg.daemon_host
+    if parameter_is_default("api_port"):
+        if cfg.layer_of("api_port") != "default":
+            api_port = cfg.api_port
+        elif cfg.layer_of("daemon_port") != "default":
+            api_port = cfg.daemon_port
+    if parameter_is_default("api_auth_token") and cfg.api_auth_token:
+        api_auth_token = cfg.api_auth_token
 
     enable_watch = not no_watch
     enable_browser_capture = not no_browser_capture

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -7,14 +7,17 @@ import contextlib
 import functools
 import json
 import os
+import select
+import socket
 import sqlite3
+import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 from urllib.parse import parse_qs, urlparse
 
 from polylogue.core.json import JSONDocument
@@ -72,19 +75,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 RouteMethod = Literal["GET", "POST", "DELETE"]
-_FACET_CORE_FAMILIES = ("total_counts", "origins", "tags")
-_FACET_EXPENSIVE_FAMILIES = ("repos", "action_types")
-_FACET_COMPLETE_ARCHIVE_FAMILIES = (
-    "total_counts",
-    "origins",
-    "tags",
-    "repos",
-    "message_types",
-    "action_types",
-    "has_flags",
-)
-_FACET_DEFERRED_REASON = "deferred_by_default"
-_FACET_BUDGET_REASON = "budget_exceeded"
+_FacetQueryResult = TypeVar("_FacetQueryResult")
 
 
 @dataclass(frozen=True)
@@ -118,6 +109,74 @@ class _StaticPostRoute:
     segments: tuple[str, ...]
     handler_name: str
     passes_path: bool = False
+
+
+@dataclass(frozen=True)
+class _ArchiveFacetBucketResult:
+    payload: FacetBucketsPayload
+    complete_families: tuple[str, ...]
+    deferred_families: dict[str, str]
+    family_errors: dict[str, str]
+    budget_exceeded: bool = False
+
+
+_FACET_CORE_FAMILIES = ("total_counts", "origins", "tags")
+_FACET_EXPENSIVE_FAMILIES = ("repos", "action_types")
+_FACET_COMPLETE_ARCHIVE_FAMILIES = (
+    "total_counts",
+    "origins",
+    "tags",
+    "repos",
+    "message_types",
+    "action_types",
+    "has_flags",
+)
+_FACET_DEFAULT_OPTIONAL_BUDGET_MS = 1500
+_FACET_DEFERRED_REASON = "deferred_by_default"
+_FACET_BUDGET_REASON = "budget_exceeded"
+_FACET_CANCELLED_REASON = "client_disconnected"
+_CLIENT_DISCONNECT_ERRORS = (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)
+
+
+class _FacetBudgetExceededError(RuntimeError):
+    """Raised when a route-bounded optional facet family overruns its budget."""
+
+
+class _ClientDisconnectedDuringComputeError(ConnectionAbortedError):
+    """Raised when a long-running route sees its peer close the socket."""
+
+
+def _socket_peer_disconnected(connection: object | None) -> bool:
+    """Best-effort loopback HTTP peer-close probe without consuming request bytes.
+
+    ``BaseHTTPRequestHandler`` only observes many browser aborts when writing the
+    response, which is too late for archive-wide SQLite work. A readable socket
+    whose one-byte peek returns ``b""`` means the peer has closed; readable
+    bytes mean HTTP pipelining/keepalive data, so the current request should keep
+    running. Unsupported socket-like objects return ``False`` so tests and custom
+    servers do not get false cancellation.
+    """
+
+    if connection is None or not hasattr(connection, "recv"):
+        return False
+    flags = getattr(socket, "MSG_PEEK", None)
+    if flags is None:
+        return False
+    try:
+        readable, _, _ = select.select([connection], [], [], 0)
+    except (OSError, TypeError, ValueError):
+        return False
+    if not readable:
+        return False
+    try:
+        data = connection.recv(1, flags)
+    except BlockingIOError:
+        return False
+    except _CLIENT_DISCONNECT_ERRORS:
+        return True
+    except OSError:
+        return True
+    return bool(data == b"")
 
 
 def _route_segments(pattern: str) -> tuple[str, ...]:
@@ -374,6 +433,68 @@ def _archive_origin_filter(params: dict[str, list[str]]) -> tuple[str | None, tu
         )
         return (origins[0] if len(origins) == 1 else None), origins
     return None, ()
+
+
+def _utc_timestamp_json() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _truthy_query_param(params: dict[str, list[str]], key: str) -> bool:
+    values = params.get(key) or []
+    if not values:
+        return False
+    return values[-1].strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _facet_requested_optional_families(params: dict[str, list[str]]) -> set[str]:
+    requested: set[str] = set()
+    for key in ("family", "families", "include"):
+        for value in params.get(key) or []:
+            requested.update(token.strip().lower() for token in value.split(",") if token.strip())
+
+    if _truthy_query_param(params, "include_deferred") or _truthy_query_param(params, "include_expensive"):
+        requested.update(_FACET_EXPENSIVE_FAMILIES)
+    if "all" in requested or "*" in requested:
+        requested.update(_FACET_EXPENSIVE_FAMILIES)
+    if "repo" in requested:
+        requested.add("repos")
+    if "actions" in requested or "action" in requested:
+        requested.add("action_types")
+    return {family for family in requested if family in _FACET_EXPENSIVE_FAMILIES}
+
+
+def _facet_budget_ms(params: dict[str, list[str]]) -> int:
+    for key in ("budget_ms", "facet_budget_ms"):
+        values = params.get(key) or []
+        if not values:
+            continue
+        try:
+            return max(int(values[-1]), 0)
+        except (TypeError, ValueError):
+            return _FACET_DEFAULT_OPTIONAL_BUDGET_MS
+    return _FACET_DEFAULT_OPTIONAL_BUDGET_MS
+
+
+def _facet_family_status_map(
+    complete_families: Sequence[str],
+    deferred_families: Mapping[str, str],
+    family_errors: Mapping[str, str],
+) -> dict[str, dict[str, object]]:
+    statuses: dict[str, dict[str, object]] = {}
+    for family in complete_families:
+        statuses[family] = {"state": "complete", "stale": False}
+    for family, reason in deferred_families.items():
+        statuses[family] = {"state": "deferred", "reason": reason, "stale": False}
+    for family, error in family_errors.items():
+        statuses[family] = {"state": "error", "error": error, "stale": False}
+    return statuses
+
+
+def _facet_error_text(exc: BaseException) -> str:
+    message = str(exc).strip()
+    if not message:
+        message = exc.__class__.__name__
+    return f"{exc.__class__.__name__}: {message}"
 
 
 def _archive_tag_filter(params: dict[str, list[str]]) -> tuple[str, ...]:
@@ -801,7 +922,7 @@ def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
                     field=field,
                 ).model_dump(mode="json"),
             )
-        except (BrokenPipeError, ConnectionResetError):
+        except _CLIENT_DISCONNECT_ERRORS:
             logger.debug("daemon http client disconnected in %s", fn.__name__)
         except Exception:
             logger.exception("unhandled error in %s", fn.__name__)
@@ -965,6 +1086,24 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     # Helpers
     # ------------------------------------------------------------------
 
+    def _client_disconnected(self) -> bool:
+        return _socket_peer_disconnected(getattr(self, "connection", None))
+
+    def _raise_if_client_disconnected(self) -> None:
+        if self._client_disconnected():
+            raise _ClientDisconnectedDuringComputeError(_FACET_CANCELLED_REASON)
+
+    def _request_id_header(self) -> str | None:
+        request_id = self.headers.get("X-Request-ID", "")
+        if not request_id or len(request_id) > 128 or "\r" in request_id or "\n" in request_id:
+            return None
+        return request_id
+
+    def _send_request_id_header(self) -> None:
+        request_id = self._request_id_header()
+        if request_id:
+            self.send_header("X-Request-ID", request_id)
+
     def _send_json(
         self,
         status: HTTPStatus,
@@ -976,6 +1115,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         self.send_response(status.value)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(raw)))
+        self._send_request_id_header()
         if extra_headers:
             for name, value in extra_headers.items():
                 self.send_header(name, value)
@@ -987,6 +1127,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         self.send_response(status.value)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(raw)))
+        self._send_request_id_header()
         self.end_headers()
         self.wfile.write(raw)
 
@@ -1006,6 +1147,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         self.send_response(status.value)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(raw)))
+        self._send_request_id_header()
         self.end_headers()
         self.wfile.write(raw)
 
@@ -1170,7 +1312,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     # BrokenPipeError from wfile.write(). Stdlib lets that escape as a
     # traceback to journal; we demote it to debug — the client has already
     # given up by the time we know.
-    _CLIENT_DISCONNECT = (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)
+    _CLIENT_DISCONNECT = _CLIENT_DISCONNECT_ERRORS
 
     def do_GET(self) -> None:
         try:
@@ -3222,57 +3364,83 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         query = self._get_param(params, "query") or self._get_param(params, "contains") or ""
         origin, origins = _archive_origin_filter(params)
-        requested_families = self._requested_facet_families(params)
-        if requested_families & set(_FACET_EXPENSIVE_FAMILIES):
-            requested_families.update(_FACET_EXPENSIVE_FAMILIES)
-        include_heavy_families = bool(requested_families & set(_FACET_EXPENSIVE_FAMILIES))
-        budget_ms = self._facet_budget_ms(params)
-        budget_exceeded = include_heavy_families and budget_ms == 0
-        if budget_exceeded:
-            include_heavy_families = False
-        complete_families: tuple[str, ...] = _FACET_CORE_FAMILIES
-        if include_heavy_families:
-            complete_families = (
-                *complete_families,
-                *tuple(sorted(requested_families & set(_FACET_EXPENSIVE_FAMILIES))),
-            )
-        deferred_reason = _FACET_BUDGET_REASON if budget_exceeded else _FACET_DEFERRED_REASON
-        deferred_families = (
-            dict.fromkeys(sorted(set(_FACET_EXPENSIVE_FAMILIES) - set(complete_families)), deferred_reason)
-            if not include_heavy_families
-            else {}
-        )
         scoped_to_query = bool(query or origin or origins)
+        requested_optional = _facet_requested_optional_families(params)
+        optional_budget_ms = _facet_budget_ms(params) if requested_optional else None
+        deadline_s = None if optional_budget_ms is None else time.monotonic() + (optional_budget_ms / 1000)
+        default_deferred = {
+            family: _FACET_DEFERRED_REASON for family in _FACET_EXPENSIVE_FAMILIES if family not in requested_optional
+        }
         with ArchiveStore.open_existing(archive_root) as archive:
-            global_payload = self._archive_facet_bucket(archive, include_heavy_families=include_heavy_families)
+            global_result = self._archive_facet_bucket(
+                archive,
+                optional_families=requested_optional,
+                deadline_s=deadline_s,
+            )
             if scoped_to_query:
                 session_ids: tuple[str, ...] = ()
                 if query:
-                    hits = archive.search_summaries(query, limit=10_000, origin=origin, origins=origins)
+                    hits = self._run_archive_facet_query(
+                        archive,
+                        deadline_s=None,
+                        compute=lambda: archive.search_summaries(
+                            query,
+                            limit=10_000,
+                            origin=origin,
+                            origins=origins,
+                        ),
+                    )
                     session_ids = tuple(dict.fromkeys(hit.session_id for hit in hits))
                     if not session_ids:
-                        scoped_payload = FacetBucketsPayload()
+                        scoped_result = _ArchiveFacetBucketResult(
+                            payload=FacetBucketsPayload(),
+                            complete_families=_FACET_CORE_FAMILIES,
+                            deferred_families={},
+                            family_errors={},
+                        )
                     else:
-                        scoped_payload = self._archive_facet_bucket(
+                        scoped_result = self._archive_facet_bucket(
                             archive,
                             origin=origin,
                             origins=origins,
                             session_ids=session_ids,
-                            include_heavy_families=include_heavy_families,
+                            optional_families=requested_optional,
+                            deadline_s=deadline_s,
                         )
                 else:
-                    scoped_payload = self._archive_facet_bucket(
+                    scoped_result = self._archive_facet_bucket(
                         archive,
                         origin=origin,
                         origins=origins,
-                        include_heavy_families=include_heavy_families,
+                        optional_families=requested_optional,
+                        deadline_s=deadline_s,
                     )
             else:
-                scoped_payload = global_payload
-        active = scoped_payload if scoped_to_query else global_payload
+                scoped_result = global_result
+        active = scoped_result.payload if scoped_to_query else global_result.payload
+        deferred_families = {
+            **default_deferred,
+            **global_result.deferred_families,
+            **scoped_result.deferred_families,
+        }
+        family_errors = {**global_result.family_errors, **scoped_result.family_errors}
+        complete_families = tuple(
+            family
+            for family in _FACET_COMPLETE_ARCHIVE_FAMILIES
+            if family in set(global_result.complete_families) and family in set(scoped_result.complete_families)
+        )
+        budget_exceeded = global_result.budget_exceeded or scoped_result.budget_exceeded
         return FacetsResponse.model_validate(
             {
                 "scoped_to_query": scoped_to_query,
+                "generated_at": _utc_timestamp_json(),
+                "stale": False,
+                "stale_age_s": None,
+                "budget_exceeded": budget_exceeded,
+                "complete_families": complete_families,
+                "deferred_families": deferred_families,
+                "family_errors": family_errors,
+                "family_status": _facet_family_status_map(complete_families, deferred_families, family_errors),
                 "origins": active.origins,
                 "tags": active.tags,
                 "repos": active.repos,
@@ -3281,67 +3449,59 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 "has_flags": active.has_flags,
                 "total_sessions": active.total_sessions,
                 "total_messages": active.total_messages,
-                "scoped": scoped_payload,
-                "global": global_payload,
-                "complete_families": complete_families,
-                "deferred_families": deferred_families,
-                "family_errors": {},
-                "family_status": self._facet_family_status_map(
-                    complete_families=complete_families,
-                    deferred_families=deferred_families,
-                    family_errors={},
-                ),
-                "generated_at": datetime.now(UTC).isoformat(),
-                "stale": False,
-                "stale_age_s": None,
-                "budget_exceeded": budget_exceeded,
+                "scoped": scoped_result.payload,
+                "global": global_result.payload,
             }
         ).model_dump(mode="json", by_alias=True)
 
-    def _facet_budget_ms(self, params: dict[str, list[str]]) -> int | None:
-        for key in ("budget_ms", "facet_budget_ms"):
-            values = params.get(key) or []
-            if not values:
-                continue
-            try:
-                return max(int(values[-1]), 0)
-            except (TypeError, ValueError):
-                return None
-        return None
-
-    def _facet_family_status_map(
+    def _run_archive_facet_query(
         self,
+        archive: ArchiveStore,
         *,
-        complete_families: Sequence[str],
-        deferred_families: Mapping[str, str],
-        family_errors: Mapping[str, str],
-    ) -> dict[str, dict[str, object]]:
-        statuses: dict[str, dict[str, object]] = {}
-        for family in complete_families:
-            statuses[family] = {"state": "complete", "stale": False}
-        for family, reason in deferred_families.items():
-            statuses[family] = {"state": "deferred", "reason": reason, "stale": False}
-        for family, error in family_errors.items():
-            statuses[family] = {"state": "error", "error": error, "stale": False}
-        return statuses
+        deadline_s: float | None,
+        compute: Callable[[], _FacetQueryResult],
+    ) -> _FacetQueryResult:
+        """Run one facet SQL step with budget and client-abort interruption.
 
-    def _requested_facet_families(self, params: dict[str, list[str]]) -> set[str]:
-        requested = {"origins", "tags"}
-        families_raw = self._get_param(params, "families") or ""
-        for family in families_raw.split(","):
-            normalized = family.strip().replace("-", "_")
-            if normalized in {"origin", "origins"}:
-                requested.add("origins")
-            elif normalized in {"tag", "tags"}:
-                requested.add("tags")
-            elif normalized in {"repo", "repos"}:
-                requested.add("repos")
-            elif normalized in {"action", "actions", "action_type", "action_types"}:
-                requested.add("action_types")
-        include_expensive = (self._get_param(params, "include_expensive") or "").strip().lower()
-        if include_expensive in {"1", "true", "yes", "on"}:
-            requested.update({"repos", "action_types"})
-        return requested
+        Browser-side ``AbortController`` cancellation only helps the server if
+        the request thread periodically observes the dead socket. SQLite's
+        progress handler gives long scans/joins that observation point while
+        preserving the existing optional-family budget contract.
+        """
+
+        conn = getattr(archive, "_conn", None)
+
+        def _deadline_expired() -> bool:
+            return deadline_s is not None and time.monotonic() >= deadline_s
+
+        def _raise_if_interrupted() -> None:
+            self._raise_if_client_disconnected()
+            if _deadline_expired():
+                raise _FacetBudgetExceededError(_FACET_BUDGET_REASON)
+
+        _raise_if_interrupted()
+
+        def _sqlite_progress() -> int:
+            if self._client_disconnected():
+                return 1
+            return 1 if _deadline_expired() else 0
+
+        if conn is not None:
+            conn.set_progress_handler(_sqlite_progress, 1000)
+        try:
+            result = compute()
+            _raise_if_interrupted()
+            return result
+        except sqlite3.OperationalError as exc:
+            if "interrupted" in str(exc).lower():
+                if self._client_disconnected():
+                    raise _ClientDisconnectedDuringComputeError(_FACET_CANCELLED_REASON) from exc
+                if _deadline_expired():
+                    raise _FacetBudgetExceededError(_FACET_BUDGET_REASON) from exc
+            raise
+        finally:
+            if conn is not None:
+                conn.set_progress_handler(None, 0)
 
     def _archive_facet_bucket(
         self,
@@ -3350,26 +3510,75 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         origin: str | None = None,
         origins: tuple[str, ...] = (),
         session_ids: tuple[str, ...] = (),
-        include_heavy_families: bool = False,
-    ) -> FacetBucketsPayload:
+        optional_families: set[str] | None = None,
+        deadline_s: float | None = None,
+    ) -> _ArchiveFacetBucketResult:
         from polylogue.surfaces.payloads import FacetBucketsPayload
 
-        stats = archive.stats(origin=origin, origins=origins, session_ids=session_ids)
-        return FacetBucketsPayload(
-            origins=archive.stats_by("origin", origin=origin, origins=origins, session_ids=session_ids),
-            tags=archive.stats_by("tag", origin=origin, origins=origins, session_ids=session_ids),
-            repos=(
-                archive.stats_by("repo", origin=origin, origins=origins, session_ids=session_ids)
-                if include_heavy_families
-                else {}
-            ),
-            action_types=(
-                archive.stats_by("action", origin=origin, origins=origins, session_ids=session_ids)
-                if include_heavy_families
-                else {}
-            ),
+        optional_families = optional_families or set()
+        stats = self._run_archive_facet_query(
+            archive,
+            deadline_s=None,
+            compute=lambda: archive.stats(origin=origin, origins=origins, session_ids=session_ids),
+        )
+        repos: dict[str, int] = {}
+        action_types: dict[str, int] = {}
+        complete = set(_FACET_CORE_FAMILIES)
+        deferred: dict[str, str] = {}
+        errors: dict[str, str] = {}
+        budget_exceeded = False
+
+        if "repos" in optional_families:
+            try:
+                repos = self._run_archive_facet_query(
+                    archive,
+                    deadline_s=deadline_s,
+                    compute=lambda: archive.stats_by("repo", origin=origin, origins=origins, session_ids=session_ids),
+                )
+                complete.add("repos")
+            except _FacetBudgetExceededError:
+                deferred["repos"] = _FACET_BUDGET_REASON
+                budget_exceeded = True
+            except _CLIENT_DISCONNECT_ERRORS:
+                raise
+            except Exception as exc:
+                errors["repos"] = _facet_error_text(exc)
+
+        if "action_types" in optional_families:
+            try:
+                action_types = self._run_archive_facet_query(
+                    archive,
+                    deadline_s=deadline_s,
+                    compute=lambda: archive.stats_by("action", origin=origin, origins=origins, session_ids=session_ids),
+                )
+                complete.add("action_types")
+            except _FacetBudgetExceededError:
+                deferred["action_types"] = _FACET_BUDGET_REASON
+                budget_exceeded = True
+            except _CLIENT_DISCONNECT_ERRORS:
+                raise
+            except Exception as exc:
+                errors["action_types"] = _facet_error_text(exc)
+
+        tags = self._run_archive_facet_query(
+            archive,
+            deadline_s=None,
+            compute=lambda: archive.stats_by("tag", origin=origin, origins=origins, session_ids=session_ids),
+        )
+        payload = FacetBucketsPayload(
+            origins=dict(stats.origins),
+            tags=tags,
+            repos=repos,
+            action_types=action_types,
             total_sessions=stats.total_sessions,
             total_messages=stats.total_messages,
+        )
+        return _ArchiveFacetBucketResult(
+            payload=payload,
+            complete_families=tuple(family for family in _FACET_COMPLETE_ARCHIVE_FAMILIES if family in complete),
+            deferred_families=deferred,
+            family_errors=errors,
+            budget_exceeded=budget_exceeded,
         )
 
     @daemon_safe_handler

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -156,7 +156,15 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
     ),
     RouteContract("GET", "/api/events", "operational", "stable", "bearer_if_configured", "SSE or JSON event poll"),
     RouteContract("GET", "/api/sessions", "read_query", "stable", "bearer_if_configured", "SearchEnvelope"),
-    RouteContract("GET", "/api/facets", "read_query", "stable", "bearer_if_configured", "Facets envelope"),
+    RouteContract(
+        "GET",
+        "/api/facets",
+        "read_query",
+        "stable",
+        "bearer_if_configured",
+        "FacetsResponse with route-state metadata",
+        "Repo and action facet families are deferred from first paint unless explicitly requested.",
+    ),
     RouteContract("GET", "/api/query-units", "read_query", "stable", "bearer_if_configured", "QueryUnitResultEnvelope"),
     RouteContract(
         "GET",

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -310,6 +310,13 @@ def browser_capture_status_payload(
     return json_document(payload)
 
 
+def browser_capture_status_public_payload(spool_path: Path | None = None) -> JSONDocument:
+    """Return browser-capture status safe for the daemon web/status API."""
+    payload = dict(browser_capture_status_payload(spool_path))
+    payload.pop("spool_path", None)
+    return json_document(payload)
+
+
 def _db_size_info() -> dict[str, object]:
     dbf = _active_status_db_path()
     info: dict[str, object] = {"db_path": str(dbf)}
@@ -1971,7 +1978,7 @@ def daemon_status_payload(
             "component_state": status.component_state.model_dump(),
             "component_readiness": status.component_readiness,
             "live": live_source_status_payload(watch_sources),
-            "browser_capture": browser_capture_status_payload(browser_capture_spool_path),
+            "browser_capture": browser_capture_status_public_payload(browser_capture_spool_path),
             "db_path": str(_active_status_db_path()),
             "db_size_bytes": status.db_size_bytes,
             "wal_size_bytes": status.wal_size_bytes,

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -105,7 +105,7 @@ def _disk_free_bytes(path: Path) -> int:
 
 def _minimal_status_payload(*, refresh_in_progress: bool = False, refresh_error: str | None = None) -> JSONDocument:
     """Return a request-safe status envelope with no archive-scale scans."""
-    from polylogue.daemon.status import _check_daemon_liveness, browser_capture_status_payload
+    from polylogue.daemon.status import _check_daemon_liveness, browser_capture_status_public_payload
 
     dbf = active_index_db_path()
     wal = dbf.with_suffix(".db-wal")
@@ -117,7 +117,7 @@ def _minimal_status_payload(*, refresh_in_progress: bool = False, refresh_error:
             refresh_error = refresh_error or str(exc)
     now = datetime.now(UTC).isoformat()
     runtime = _runtime_component_state()
-    browser_capture = dict(browser_capture_status_payload(runtime.browser_capture_spool_path, include_spool_path=False))
+    browser_capture = dict(browser_capture_status_public_payload(runtime.browser_capture_spool_path))
     browser_capture_enabled = runtime.browser_capture_enabled is True
     browser_capture["active"] = browser_capture_enabled
     payload: dict[str, object] = {

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -264,8 +264,8 @@ __ATTACHMENT_CSS__
   <div id="status-strip">
     <span class="dot ok" id="status-dot" title="Daemon health"></span>
     <span class="chip" id="status-label">checking</span>
-    <span class="chip" id="status-convs">0 convs</span>
-    <span class="chip" id="status-msgs">0 msgs</span>
+    <span class="chip q-partial" id="status-convs">convs checking</span>
+    <span class="chip q-partial" id="status-msgs">msgs checking</span>
     <span class="chip" id="status-db">--</span>
     <span class="spacer"></span>
     <span class="chip" id="status-fts" title="FTS readiness">FTS: --</span>
@@ -389,6 +389,10 @@ var state = {
   // profiles remain disabled until HTTP execution exists.
   readViewProfiles: [], selectedReadView: 'messages', readViewProfileError: '',
   readViewPayloads: {}, readViewErrors: {},
+  // Shared route-state ledger for optional workbench routes (#2304). Values
+  // are idle/loading/ready/stale/error/budget_exceeded and always retain the
+  // route plus fallback command needed to recover outside the shell.
+  routeStates: {}, inFlight: {facets: null}, selectedLoadError: null,
   // Per-session similarity panel cache (#1123). Keyed by
   // session_id; populated on demand when the Similar inspector
   // tab is opened. ``undefined`` means "not loaded yet"; the envelope
@@ -429,18 +433,45 @@ async function requestJSON(url, opts) {
   var requestId = nextApiRequestId();
   var headers = Object.assign({'X-Request-ID': requestId}, opts.headers || {});
   var requestOpts = Object.assign({}, opts, {method: method, headers: headers});
+  var timeoutMs = Number(opts.timeoutMs || 0);
+  delete requestOpts.timeoutMs;
+  var timeoutId = null;
+  var timedOut = false;
+  var relayAbort = null;
+  if (timeoutMs > 0 && typeof AbortController !== 'undefined') {
+    var timeoutController = new AbortController();
+    var externalSignal = requestOpts.signal;
+    if (externalSignal) {
+      if (externalSignal.aborted) timeoutController.abort();
+      else {
+        relayAbort = function() { timeoutController.abort(); };
+        externalSignal.addEventListener('abort', relayAbort, {once: true});
+      }
+    }
+    timeoutId = setTimeout(function() { timedOut = true; timeoutController.abort(); }, timeoutMs);
+    requestOpts.signal = timeoutController.signal;
+  }
   var started = nowMs();
   var response;
   try {
     response = await fetch(API + url, requestOpts);
   } catch(e) {
     var networkDuration = Math.round(nowMs() - started);
+    if (timedOut && e && e.name === 'AbortError') {
+      e.timed_out = true;
+      e.status = 'timeout';
+      e.response_summary = 'request_timeout_after_' + timeoutMs + 'ms';
+    }
     rememberApiDebug({
       ok: false, method: method, url: url, request_id: requestId,
-      status: 'network_error', duration_ms: networkDuration,
-      response_summary: String(e && e.message ? e.message : e)
+      status: timedOut ? 'timeout' : (e && e.name === 'AbortError' ? 'aborted' : 'network_error'),
+      duration_ms: networkDuration,
+      response_summary: (e && e.response_summary) ? e.response_summary : String(e && e.message ? e.message : e)
     });
     throw e;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (relayAbort && opts.signal && opts.signal.removeEventListener) opts.signal.removeEventListener('abort', relayAbort);
   }
   var text = await response.text();
   var duration = Math.round(nowMs() - started);
@@ -483,14 +514,91 @@ async function requestJSON(url, opts) {
     throw parseError;
   }
 }
-
-async function fetchJSON(url) {
-  return requestJSON(url, {method: 'GET'});
+async function fetchJSON(url, opts) {
+  return requestJSON(url, Object.assign({method: 'GET'}, opts || {}));
 }
 async function sendJSON(url, method, body) {
   var opts = {method: method, headers: {'Content-Type': 'application/json'}};
   if (body !== undefined) opts.body = JSON.stringify(body);
   return requestJSON(url, opts);
+}
+
+function fallbackCommand(route) {
+  return 'curl -fsS http://127.0.0.1:8766' + route;
+}
+
+function routeErrorDetails(e, route) {
+  var message = String((e && (e.response_summary || e.message)) || e || 'unavailable');
+  return {
+    route: route,
+    status: (e && e.status) ? String(e.status) : '',
+    error: message,
+    request_id: (e && e.request_id) ? String(e.request_id) : '',
+    fallback: fallbackCommand(route)
+  };
+}
+
+function setRouteState(name, patch) {
+  var current = state.routeStates[name] || {state: 'idle'};
+  var next = Object.assign({}, current, patch || {});
+  if (next.route && !next.fallback) next.fallback = fallbackCommand(next.route);
+  state.routeStates[name] = next;
+  return next;
+}
+
+function routeStateQuality(routeState) {
+  if (!routeState) return '';
+  if (routeState.state === 'ready') return 'canonical';
+  if (routeState.state === 'stale') return 'stale';
+  if (routeState.state === 'loading' || routeState.state === 'budget_exceeded') return 'partial';
+  if (routeState.state === 'error') return 'unavailable';
+  return '';
+}
+
+function renderRouteStateNotice(name, label, retryJs) {
+  var rs = state.routeStates[name];
+  if (!rs || rs.state === 'idle' || rs.state === 'ready') return '';
+  var quality = routeStateQuality(rs) || 'partial';
+  var title = label + ': ' + rs.state.replace('_', ' ');
+  var parts = [];
+  if (rs.route) parts.push('route ' + rs.route);
+  if (rs.status) parts.push('status ' + rs.status);
+  if (rs.error) parts.push(rs.error);
+  if (rs.stale_available) parts.push('showing stale data');
+  if (rs.state === 'budget_exceeded') parts.push('budget exceeded');
+  var html = '<div class="sidebar-state q-' + escAttr(quality) + '"><div class="state-icon">!</div>'
+    + '<div><strong>' + esc(title) + '</strong><br>' + esc(parts.join(' · ') || 'checking route')
+    + '<br><code>' + esc(rs.fallback || (rs.route ? fallbackCommand(rs.route) : 'polylogue daemon status')) + '</code></div>';
+  if (retryJs) html += '<button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
+  html += '</div>';
+  return html;
+}
+
+function renderInlineRouteFailure(title, details, retryJs) {
+  details = details || {};
+  var route = details.route || '';
+  var bits = [];
+  if (route) bits.push('route ' + route);
+  if (details.status) bits.push('status ' + details.status);
+  if (details.error) bits.push(details.error);
+  if (details.stale_available) bits.push('stale data available');
+  var html = '<div class="main-empty q-unavailable"><h3>' + esc(title) + '</h3>'
+    + '<p>' + esc(bits.join(' · ') || 'Route unavailable') + '</p>'
+    + '<p><code>' + esc(details.fallback || (route ? fallbackCommand(route) : 'polylogue daemon status')) + '</code></p>';
+  if (retryJs) html += '<button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
+  html += '</div>';
+  return html;
+}
+
+function updateStatusCountsUnknown(reason) {
+  var convs = document.getElementById('status-convs');
+  var msgs = document.getElementById('status-msgs');
+  if (convs) { convs.textContent = state.total ? (state.total.toLocaleString() + ' visible convs') : 'convs unknown'; setChipQuality(convs, 'partial'); }
+  if (msgs) { msgs.textContent = 'msgs unknown'; setChipQuality(msgs, 'partial'); }
+  if (reason) {
+    var label = document.getElementById('status-label');
+    if (label && label.textContent === 'checking') label.textContent = reason;
+  }
 }
 
 function markSetFor(sessionId) {
@@ -544,12 +652,13 @@ async function loadSessions(opts) {
   var beforeIds = {};
   (state.sessions || []).forEach(function(c) { beforeIds[c.id] = true; });
   try {
-    var data = await fetchJSON('/api/sessions?' + params);
+    var data = await fetchJSON('/api/sessions?' + params, {timeoutMs: 8000});
     state.sessions = sessionsFromListPayload(data);
     state.total = data.total || 0;
     state.actionAffordances = data.action_affordances || [];
     document.getElementById('footer-result').textContent =
       (state.total > 0) ? (state.total + ' results') : '';
+    if (state.routeStates.status && state.routeStates.status.state !== 'ready') updateStatusCountsUnknown('degraded');
   } catch(e) {
     state.sessions = [];
     state.total = 0;
@@ -567,37 +676,50 @@ async function loadSessions(opts) {
 }
 
 async function loadReadViewProfiles() {
+  var route = '/api/read-view-profiles';
+  setRouteState('readViewProfiles', {state: 'loading', route: route, error: '', status: ''});
   try {
-    var payload = await fetchJSON('/api/read-view-profiles');
+    var payload = await fetchJSON(route, {timeoutMs: 4000});
     state.readViewProfiles = payload.read_views || [];
     state.readViewProfileError = '';
+    setRouteState('readViewProfiles', {state: 'ready', route: route, status: '200', error: ''});
   } catch(e) {
     state.readViewProfiles = [];
-    state.readViewProfileError = 'Read profiles unavailable';
+    var details = routeErrorDetails(e, route);
+    state.readViewProfileError = details.error;
+    setRouteState('readViewProfiles', Object.assign({state: 'error'}, details));
   }
   renderMain();
 }
 
 async function loadUserState() {
+  var route = '/api/user/marks';
+  setRouteState('userState', {state: 'loading', route: route, error: '', status: ''});
   try {
-    var marks = await fetchJSON('/api/user/marks');
+    var marks = await fetchJSON(route, {timeoutMs: 5000});
     state.marks = {};
     (marks.items || []).forEach(function(m) {
       setMarkLocal(m.session_id, m.mark_type, true);
     });
-    var annotations = await fetchJSON('/api/user/annotations');
+    route = '/api/user/annotations';
+    var annotations = await fetchJSON(route, {timeoutMs: 5000});
     state.annotations = {};
     (annotations.items || []).forEach(function(a) {
       if (!state.annotations[a.session_id]) state.annotations[a.session_id] = [];
       state.annotations[a.session_id].push(a);
     });
-    var savedViews = await fetchJSON('/api/user/saved-views');
+    route = '/api/user/saved-views';
+    var savedViews = await fetchJSON(route, {timeoutMs: 5000});
     state.savedViews = savedViews.items || [];
-    var workspaces = await fetchJSON('/api/user/workspaces');
+    route = '/api/user/workspaces';
+    var workspaces = await fetchJSON(route, {timeoutMs: 5000});
     state.workspaces = workspaces.items || [];
     state.userStateError = '';
+    setRouteState('userState', {state: 'ready', route: route, status: '200', error: ''});
   } catch(e) {
-    state.userStateError = 'User state unavailable';
+    var details = routeErrorDetails(e, route);
+    state.userStateError = details.error;
+    setRouteState('userState', Object.assign({state: 'error'}, details));
   }
   renderSessions();
   renderMain();
@@ -608,63 +730,114 @@ async function loadSession(id, updateURL) {
   state.mode = 'single';
   state.stackPayload = null;
   state.comparePayload = null;
+  state.selectedLoadError = null;
   if (updateURL !== false) pushSingleURL(id);
+  var route = '/api/sessions/' + encodeURIComponent(id);
+  setRouteState('sessionDetail', {state: 'loading', route: route, error: '', status: ''});
   try {
-    var data = await fetchJSON('/api/sessions/' + id);
+    var data = await fetchJSON(route, {timeoutMs: 10000});
     state.selected = data;
-  } catch(e) { state.selected = null; }
+    setRouteState('sessionDetail', {state: 'ready', route: route, status: '200', error: ''});
+  } catch(e) {
+    state.selected = null;
+    state.selectedLoadError = routeErrorDetails(e, route);
+    setRouteState('sessionDetail', Object.assign({state: 'error'}, state.selectedLoadError));
+  }
   renderMain();
   renderInspector();
   renderSessions();
 }
 
+function loadSessionFromError() {
+  var rs = state.routeStates.sessionDetail || {};
+  var route = rs.route || '';
+  var prefix = '/api/sessions/';
+  if (route.indexOf(prefix) !== 0) return;
+  loadSession(decodeURIComponent(route.slice(prefix.length)), true);
+}
+
 async function loadSessionRaw(id) {
   try {
-    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/provenance');
+    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/provenance', {timeoutMs: 5000});
     state.selectedRaw = data;
   } catch(e) { state.selectedRaw = null; }
 }
 
-async function loadFacets() {
+async function loadFacets(opts) {
+  opts = opts || {};
   var params = new URLSearchParams();
   if (state.query) params.set('query', state.query);
   if (state.origin) params.set('origin', state.origin);
+  if (opts.includeDeferred) params.set('include_deferred', '1');
+  if (opts.budgetMs !== undefined) params.set('budget_ms', String(opts.budgetMs));
   var qs = params.toString();
+  var route = '/api/facets' + (qs ? '?' + qs : '');
+  if (state.inFlight.facets && state.inFlight.facets.controller) {
+    state.inFlight.facets.controller.abort();
+  }
+  var controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+  var token = {};
+  state.inFlight.facets = {controller: controller, token: token};
+  setRouteState('facets', {state: 'loading', route: route, error: '', status: '', stale_available: !!state.facets});
+  renderFacets();
   try {
-    state.facets = await fetchJSON('/api/facets' + (qs ? '?' + qs : ''));
-    state.facetError = '';
+    var payload = await fetchJSON(route, Object.assign(controller ? {signal: controller.signal} : {}, {timeoutMs: opts.timeoutMs || 5000}));
+    if (!state.inFlight.facets || state.inFlight.facets.token !== token) return;
+    state.facets = payload;
+    var routeState = payload.budget_exceeded ? 'budget_exceeded' : (payload.stale ? 'stale' : 'ready');
+    setRouteState('facets', {
+      state: routeState, route: route, status: '200', error: '', stale: !!payload.stale,
+      stale_age_s: payload.stale_age_s || null, stale_available: true, budget_exceeded: !!payload.budget_exceeded
+    });
   } catch(e) {
-    state.facetError = 'Facets unavailable';
-    state.facets = null;
+    if (e && e.name === 'AbortError' && !e.timed_out) return;
+    setRouteState('facets', Object.assign({state: 'error', stale_available: !!state.facets}, routeErrorDetails(e, route)));
+  } finally {
+    if (state.inFlight.facets && state.inFlight.facets.token === token) state.inFlight.facets = null;
   }
   renderFacets();
 }
 
 async function loadStatus() {
+  var healthRoute = '/api/health';
+  setRouteState('health', {state: 'loading', route: healthRoute, error: '', status: ''});
   try {
-    var h = await fetchJSON('/api/health');
+    var h = await fetchJSON(healthRoute, {timeoutMs: 3000});
     var dot = document.getElementById('status-dot');
     dot.className = 'dot ' + (h.ok ? 'ok' : 'err');
     document.getElementById('status-label').textContent = h.ok ? 'healthy' : (h.quick_check || 'issues');
     var dbGB = ((h.db_size_bytes || 0) / 1073741824).toFixed(1);
     document.getElementById('status-db').textContent = 'DB: ' + dbGB + ' GB';
+    setRouteState('health', {state: h.ok ? 'ready' : 'error', route: healthRoute, status: '200', error: h.ok ? '' : (h.quick_check || 'issues')});
   } catch(e) {
     document.getElementById('status-dot').className = 'dot err';
     document.getElementById('status-label').textContent = 'offline';
+    setRouteState('health', Object.assign({state: 'error'}, routeErrorDetails(e, healthRoute)));
   }
+  var statusRoute = '/api/status';
+  setRouteState('status', {state: 'loading', route: statusRoute, error: '', status: ''});
   try {
-    var s = await fetchJSON('/api/status');
+    var s = await fetchJSON(statusRoute, {timeoutMs: 5000});
     var readiness = s.component_readiness || {};
-    document.getElementById('status-convs').textContent = (s.total_sessions || 0).toLocaleString() + ' convs';
-    document.getElementById('status-msgs').textContent = (s.total_messages || 0).toLocaleString() + ' msgs';
+    var convs = document.getElementById('status-convs');
+    var msgs = document.getElementById('status-msgs');
+    convs.textContent = (s.total_sessions != null ? Number(s.total_sessions).toLocaleString() : 'unknown') + ' convs';
+    msgs.textContent = (s.total_messages != null ? Number(s.total_messages).toLocaleString() : 'unknown') + ' msgs';
+    setChipQuality(convs, s.total_sessions != null ? 'canonical' : 'partial');
+    setChipQuality(msgs, s.total_messages != null ? 'canonical' : 'partial');
     renderFtsChip(readiness.search || null, s.fts_readiness || {});
     renderSemanticChip(readiness.embeddings || null);
     renderInsightChip(readiness.session_profiles || null, s.insight_freshness || {});
     renderIngestChip(readiness.daemon_ingest || null, s.live || {});
     renderBrowserCaptureChip(readiness.browser_capture || null, s.browser_capture || {});
-  } catch(e) {}
+    setRouteState('status', {state: 'ready', route: statusRoute, status: '200', error: ''});
+  } catch(e) {
+    updateStatusCountsUnknown('degraded');
+    setRouteState('status', Object.assign({state: 'error', stale_available: false}, routeErrorDetails(e, statusRoute)));
+    renderFacets();
+  }
   try {
-    renderDevLoopChip(await fetchJSON('/api/dev-loop'));
+    renderDevLoopChip(await fetchJSON('/api/dev-loop', {timeoutMs: 3000}));
   } catch(e) { renderDevLoopChip(null); }
 }
 
@@ -897,22 +1070,16 @@ __BULK_JS__
 
 function renderFacets() {
   var f = state.facets;
-  if (!f) {
-    document.getElementById('facet-bar').innerHTML = state.facetError
-      ? '<div class="facet-group"><div class="facet-group-label">' + esc(state.facetError) + '</div></div>'
-      : '';
-    return;
-  }
-  var html = '';
-  var deferredFamilies = f.deferred_families || {};
-  var deferredKeys = Array.isArray(deferredFamilies) ? deferredFamilies : Object.keys(deferredFamilies);
-  if (deferredKeys.length > 0 || f.budget_exceeded) {
-    html += '<div class="facet-group"><div class="facet-group-label">Facet detail deferred</div><div class="facet-chips">';
-    deferredKeys.forEach(function(family) {
-      var reason = Array.isArray(deferredFamilies) ? 'deferred' : deferredFamilies[family];
-      html += '<span class="facet-chip" title="' + escAttr(reason || 'Computed on demand to keep the reader responsive') + '">' + esc(family) + '</span>';
-    });
-    html += '</div></div>';
+  var html = renderRouteStateNotice('status', 'Status', 'loadStatus()')
+    + renderRouteStateNotice('facets', 'Facets', 'loadFacets()');
+  if (!f) { document.getElementById('facet-bar').innerHTML = html; return; }
+  var deferred = f.deferred_families || {};
+  var deferredKeys = Object.keys(deferred);
+  if (deferredKeys.length) {
+    html += '<div class="sidebar-state q-partial"><div class="state-icon">~</div><div><strong>Deferred facets</strong><br>'
+      + esc(deferredKeys.map(function(k) { return k + ': ' + deferred[k]; }).join(' · '))
+      + '<br><code>' + esc(fallbackCommand('/api/facets?include_deferred=1&budget_ms=5000')) + '</code></div>'
+      + '<button class="user-action" onclick="loadFacets({includeDeferred:true,budgetMs:5000})">Load deferred families</button></div>';
   }
   var providers = f.origins || {};
   var provKeys = Object.keys(providers);
@@ -984,7 +1151,9 @@ function renderReadViewSelector(c) {
   if (!c) return '';
   var profiles = state.readViewProfiles || [];
   if (!profiles.length) {
-    var fallback = state.readViewProfileError || 'Read profiles loading';
+    var routePanel = renderRouteStateNotice('readViewProfiles', 'Read profiles', 'loadReadViewProfiles()');
+    if (routePanel) return '<div id="read-profile-selector" class="read-profile-selector muted">' + routePanel + '</div>';
+    var fallback = state.readViewProfileError || 'Read profiles loading from /api/read-view-profiles';
     return '<div id="read-profile-selector" class="read-profile-selector muted">' + esc(fallback) + '</div>';
   }
   var html = '<div id="read-profile-selector" class="read-profile-selector"><label for="read-profile-select">Read view</label>'
@@ -1026,12 +1195,13 @@ function readViewCacheKey(id, viewId) {
 async function loadReadViewExecution(id, viewId) {
   if (!id || !viewId || viewId === 'messages') return;
   var key = readViewCacheKey(id, viewId);
+  var route = '/api/sessions/' + encodeURIComponent(id) + '/read?view=' + encodeURIComponent(viewId) + '&format=json';
   try {
-    var payload = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/read?view=' + encodeURIComponent(viewId) + '&format=json');
+    var payload = await fetchJSON(route, {timeoutMs: 10000});
     state.readViewPayloads[key] = payload;
     delete state.readViewErrors[key];
   } catch(e) {
-    state.readViewErrors[key] = String(e);
+    state.readViewErrors[key] = routeErrorDetails(e, route);
   }
   if (state.selected && state.selected.id === id && state.selectedReadView === viewId) {
     renderMain();
@@ -1045,9 +1215,14 @@ function renderMain() {
   var headerEl = document.getElementById('conv-header');
   var msgEl = document.getElementById('msg-list');
   if (!state.selected) {
-    headerEl.innerHTML = '<h2>Polylogue</h2><div class="conv-stats"></div>';
-    msgEl.innerHTML = '<div class="main-empty"><h3>Select a session</h3>'
-      + '<p>Browse from the list or use <span class="kbd">/</span> to search. Press <span class="kbd">?</span> for shortcuts.</p></div>';
+    if (state.selectedLoadError) {
+      headerEl.innerHTML = '<h2>Session unavailable</h2><div class="conv-stats"></div>';
+      msgEl.innerHTML = renderInlineRouteFailure('Session detail unavailable', state.selectedLoadError, 'loadSessionFromError()');
+    } else {
+      headerEl.innerHTML = '<h2>Polylogue</h2><div class="conv-stats"></div>';
+      msgEl.innerHTML = '<div class="main-empty"><h3>Select a session</h3>'
+        + '<p>Browse from the list or use <span class="kbd">/</span> to search. Press <span class="kbd">?</span> for shortcuts.</p></div>';
+    }
     return;
   }
   var c = state.selected;
@@ -1125,7 +1300,7 @@ function renderMain() {
 function renderReadViewExecution(c, viewId) {
   var key = readViewCacheKey(c.id, viewId);
   if (state.readViewErrors[key]) {
-    return '<div class="main-empty"><h3>Read view unavailable</h3><p>' + esc(state.readViewErrors[key]) + '</p></div>';
+    return renderInlineRouteFailure('Read view unavailable', state.readViewErrors[key], 'retryReadViewExecution()');
   }
   var envelope = state.readViewPayloads[key];
   if (envelope === undefined) {
@@ -1140,6 +1315,14 @@ function renderReadViewExecution(c, viewId) {
   if (viewId === 'neighbors') return renderNeighborsReadView(payload);
   if (viewId === 'correlation') return renderCorrelationReadView(payload);
   return '<div class="main-empty"><h3>Unsupported read view</h3><p>' + esc(viewId) + '</p></div>';
+}
+
+function retryReadViewExecution() {
+  if (!state.selected || !state.selectedReadView) return;
+  var key = readViewCacheKey(state.selected.id, state.selectedReadView);
+  delete state.readViewErrors[key];
+  delete state.readViewPayloads[key];
+  renderMain();
 }
 
 function renderRecoveryReadView(payload) {
@@ -1349,7 +1532,14 @@ function markButtonHtml(sessionId, markType, label, title) {
 
 function renderInspector() {
   var el = document.getElementById('inspector-content');
-  if (!state.selected) { el.innerHTML = '<div class="inspector-empty">Select a session to inspect</div>'; return; }
+  if (!state.selected) {
+    if (state.selectedLoadError) {
+      el.innerHTML = renderInlineRouteFailure('Session detail unavailable', state.selectedLoadError, 'loadSessionFromError()');
+    } else {
+      el.innerHTML = '<div class="inspector-empty">Select a session to inspect</div>';
+    }
+    return;
+  }
   var c = state.selected;
   var tab = state.inspectorTab || 'info';
   if (tab === 'info') renderInspectorInfo(el, c);
@@ -1372,7 +1562,7 @@ function renderInspector() {
 // chip and a "no rows recorded" body.
 async function loadInsightsPanel(id) {
   try {
-    var data = await fetchJSON('/api/insights/sessions/' + encodeURIComponent(id));
+    var data = await fetchJSON('/api/insights/sessions/' + encodeURIComponent(id), {timeoutMs: 8000});
     state.insightsPanels[id] = data;
   } catch(e) {
     state.insightsPanels[id] = {error: String(e)};
@@ -1535,7 +1725,7 @@ function renderInspectorInsights(el, c) {
 // q-estimated / q-heuristic / q-unavailable).
 async function loadCostPanel(id) {
   try {
-    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/cost');
+    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/cost', {timeoutMs: 8000});
     state.costPanels[id] = data;
   } catch(e) {
     state.costPanels[id] = {error: String(e)};
@@ -1646,8 +1836,8 @@ function renderInspectorCost(el, c) {
 
 async function loadEvidencePanel(id) {
   try {
-    var recovery = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/recovery?report=work-packet&format=json');
-    var assertions = await fetchJSON('/api/assertions?target_ref=' + encodeURIComponent('session:' + id) + '&limit=20');
+    var recovery = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/recovery?report=work-packet&format=json', {timeoutMs: 10000});
+    var assertions = await fetchJSON('/api/assertions?target_ref=' + encodeURIComponent('session:' + id) + '&limit=20', {timeoutMs: 10000});
     state.evidencePanels[id] = {recovery: recovery, assertions: assertions};
   } catch(e) {
     state.evidencePanels[id] = {error: String(e)};
@@ -1718,7 +1908,7 @@ function renderInspectorInfo(el, c) {
     ['Messages', c.message_count], ['Words', (c.word_count || 0).toLocaleString()],
     ['Repo', c.repo], ['CWD', c.cwd_display], ['Branch', c.branch_type], ['Session', c.session_id]
   ];
-  var html = '';
+  var html = renderRouteStateNotice('userState', 'User state', 'loadUserState()');
   fields.forEach(function(f) {
     var val = f[1] != null ? String(f[1]) : '';
     html += '<div class="inspector-field"><span class="label">' + esc(f[0]) + '</span>'
@@ -2032,8 +2222,9 @@ async function selectSession(id, updateURL, opts) {
   if (isLiveTail && state.selected && state.selected.messages) {
     state.selected.messages.forEach(function(m) { priorMessageIds[m.id] = true; });
   } else {
-    document.getElementById('msg-list').innerHTML = '<div class="main-empty"><h3>Loading...</h3></div>';
-    document.getElementById('inspector-content').innerHTML = '<div class="inspector-empty">Loading...</div>';
+    var route = '/api/sessions/' + encodeURIComponent(id);
+    document.getElementById('msg-list').innerHTML = '<div class="main-empty q-partial"><h3>Loading session detail</h3><p>route ' + esc(route) + '</p></div>';
+    document.getElementById('inspector-content').innerHTML = '<div class="inspector-empty q-partial">Loading session detail from ' + esc(route) + '</div>';
   }
   await loadSession(id, updateURL);
   if (isLiveTail) {
@@ -2060,8 +2251,8 @@ document.addEventListener('keydown', function(e) {
     e.preventDefault();
     var help = document.getElementById('help-overlay');
     if (help.classList.contains('visible')) { toggleHelp(); return; }
-    if (state.query) { state.query = ''; document.getElementById('search').value = ''; state.offset = 0; loadSessions(); return; }
-    if (state.origin) { state.origin = ''; state.offset = 0; loadSessions(); renderFacets(); return; }
+    if (state.query) { state.query = ''; document.getElementById('search').value = ''; state.offset = 0; loadSessions(); loadFacets(); return; }
+    if (state.origin) { state.origin = ''; state.offset = 0; loadSessions(); loadFacets(); return; }
     return;
   }
   if (e.key === 'j' || e.key === 'k') {
@@ -2107,7 +2298,7 @@ document.getElementById('facet-bar').addEventListener('click', function(e) {
   if (!chip) return;
   var facet = chip.dataset.facet;
   var value = chip.dataset.value;
-  if (facet === 'origin') { state.origin = value || ''; state.offset = 0; loadSessions(); renderFacets(); }
+  if (facet === 'origin') { state.origin = value || ''; state.offset = 0; loadSessions(); loadFacets(); }
 });
 
 attachBulkHandlers();

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -9,11 +9,13 @@ read-model candidates.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from typing import Literal, TypeVar
 
 from pydantic import Field, field_validator, model_validator
@@ -23,6 +25,10 @@ from polylogue.archive.session.domain_models import Session
 from polylogue.core.refs import EvidenceRef, ObjectRef
 from polylogue.insights.archive_models import ArchiveInsightModel
 from polylogue.insights.run_projection import RunProjection, build_run_projection
+from polylogue.surfaces.action_affordances import (
+    ActionAffordancePayload,
+    assertion_candidate_review_affordances,
+)
 
 RECOVERY_TRANSFORM_ID = "recovery_digest_v0"
 RECOVERY_TRANSFORM_VERSION = 1
@@ -44,10 +50,21 @@ WorkPacketSection = Literal[
     "run_state",
     "tools",
     "decisions",
+    "candidate_review",
     "assertions",
     "evidence_gaps",
 ]
 WorkPacketSupport = Literal["raw_evidence", "assertion", "inference", "caveat", "missing_evidence"]
+DecisionCandidateReviewStatus = Literal["accepted", "rejected", "deferred"]
+RecoveryEvidenceWindowKind = Literal[
+    "quoted_evidence",
+    "inferred_summary",
+    "accepted_candidate",
+    "rejected_candidate",
+    "deferred_candidate",
+    "unavailable_source_material",
+]
+RecoveryPackOmissionReason = Literal["budget", "unsupported", "not_found", "policy", "redacted", "missing_evidence"]
 SubagentChildLinkStatus = Literal["resolved", "unresolved", "repaired", "quarantined"]
 
 _GITHUB_REPO_REF = r"[\w.-]+/[\w.-]+#"
@@ -70,6 +87,15 @@ _CHECK_FAIL_RE = re.compile(r"\b(?P<name>[A-Za-z0-9_.() -]+)\s+\.\.\.\s+(?:FAIL|
 _COMMIT_SHA_RE = re.compile(r"\b(?P<sha>[0-9a-f]{7,40})\b", re.IGNORECASE)
 _DECISION_RE = re.compile(r"\b(decision|decided|choose|chosen):?\s+(?P<text>.+)", re.IGNORECASE)
 _STATUS_HEADING_RE = re.compile(r"^\s*(goal|done|in flight|blockers?|next):\s*(?P<text>.+)$", re.IGNORECASE)
+_INSTRUCTION_DUMP_MARKER_RE = re.compile(
+    r"\b(agents\.md|claude\.md|system prompt|developer instruction|turbo mandate|must not|must always|"
+    r"you are chatgpt|you are working in|verification budget|completion report required)\b",
+    re.IGNORECASE,
+)
+_PRODUCT_DECISION_ANCHOR_RE = re.compile(
+    r"\b(product decision|implementation decision|durable decision|we decided|decision record|adr|accepted decision)\b",
+    re.IGNORECASE,
+)
 _RUNSTATE_SECTION_RE = re.compile(
     r"^\s*(goal|done|in flight|blockers?|next(?: action)?s?):\s*(?P<text>.*)$",
     re.IGNORECASE,
@@ -249,12 +275,58 @@ class DecisionCandidate(ArchiveInsightModel):
     kind: Literal["decision", "run_state"]
     text: str
     raw_refs: tuple[TransformRawRef, ...]
+    status: DecisionCandidateReviewStatus = "accepted"
+    reason: str | None = None
+    candidate_ref: str | None = None
 
     @model_validator(mode="after")
     def _requires_raw_refs(self) -> DecisionCandidate:
         if not self.raw_refs:
             raise ValueError("DecisionCandidate requires at least one raw ref")
         return self
+
+
+class RecoveryPacketScope(ArchiveInsightModel):
+    """What raw material a recovery work packet selected."""
+
+    seed_refs: tuple[str, ...] = ()
+    read_views: tuple[str, ...] = ()
+    selection_limits: dict[str, int] = Field(default_factory=dict)
+    included_sections: tuple[str, ...] = ()
+    session_count: int = 1
+    message_count: int = 0
+
+
+class RecoveryPackOmission(ArchiveInsightModel):
+    """Explicitly omitted or unavailable work-packet material."""
+
+    ref: str | None = None
+    view: str | None = None
+    reason: RecoveryPackOmissionReason
+    detail: str
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+
+
+class RecoveryEvidenceWindow(ArchiveInsightModel):
+    """Typed evidence-window vocabulary for successor handoffs."""
+
+    kind: RecoveryEvidenceWindowKind
+    label: str
+    text: str
+    support: WorkPacketSupport = "raw_evidence"
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+    candidate_ref: str | None = None
+
+
+class RecoveryPacketSizeEstimate(ArchiveInsightModel):
+    """Approximate size/cost posture for a recovery handoff packet."""
+
+    raw_bytes: int = 0
+    normal_read_bytes: int = 0
+    resume_bundle_bytes: int = 0
+    markdown_bytes: int = 0
+    json_bytes: int = 0
+    token_estimate: int = 0
 
 
 class RecoveryWorkPacketEntry(ArchiveInsightModel):
@@ -267,6 +339,7 @@ class RecoveryWorkPacketEntry(ArchiveInsightModel):
     object_refs: tuple[ObjectRef, ...] = ()
     support: WorkPacketSupport = "raw_evidence"
     metadata: dict[str, str] = Field(default_factory=dict)
+    action_affordances: tuple[ActionAffordancePayload, ...] = ()
 
     @model_validator(mode="after")
     def _requires_evidence_refs(self) -> RecoveryWorkPacketEntry:
@@ -282,11 +355,20 @@ class RecoveryWorkPacket(ArchiveInsightModel):
     title: str
     source_origin: str
     message_count: int
+    generated_at: str = ""
+    selection_strategy: str = "single_session_recovery_digest_v0"
+    scope: RecoveryPacketScope = Field(default_factory=RecoveryPacketScope)
     git_branch: str | None = None
     working_directories: tuple[str, ...] = ()
     target_refs: tuple[ObjectRef, ...] = ()
     entries: tuple[RecoveryWorkPacketEntry, ...] = ()
     evidence_refs: tuple[EvidenceRef, ...]
+    evidence_windows: tuple[RecoveryEvidenceWindow, ...] = ()
+    omissions: tuple[RecoveryPackOmission, ...] = ()
+    caveats: tuple[str, ...] = ()
+    redaction_policy: str = "public_refs_and_redacted_local_paths"
+    token_estimate: int = 0
+    size_estimate: RecoveryPacketSizeEstimate = Field(default_factory=RecoveryPacketSizeEstimate)
 
     @model_validator(mode="after")
     def _requires_evidence_refs(self) -> RecoveryWorkPacket:
@@ -470,7 +552,14 @@ def render_resume_bundle(
         source_origin=str(session.origin),
         message_count=len(session.messages),
         git_branch=session.git_branch,
-        working_directories=tuple(session.working_directories),
+        scope=RecoveryPacketScope(
+            seed_refs=(f"session:{session.id}",),
+            read_views=("recovery", "work-packet"),
+            selection_limits={"sessions": 1, "entry_soft_cap": 120},
+            session_count=1,
+            message_count=len(session.messages),
+        ),
+        working_directories=tuple(_redact_local_path(path) for path in session.working_directories),
         target_refs=_work_packet_target_refs(str(session.id), session.git_branch),
         entries=tuple(
             _work_packet_entries(
@@ -505,7 +594,26 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
         f"- session_id: {packet.session_id}",
         f"- origin: {packet.source_origin}",
         f"- messages: {packet.message_count}",
+        f"- selection_strategy: {packet.selection_strategy}",
+        f"- redaction_policy: {packet.redaction_policy}",
     ]
+    if packet.token_estimate:
+        lines.append(f"- token_estimate: {packet.token_estimate}")
+    if packet.generated_at:
+        lines.append(f"- generated_at: {packet.generated_at}")
+    if packet.scope.seed_refs:
+        lines.append(f"- seed_refs: {', '.join(packet.scope.seed_refs)}")
+    if packet.scope.read_views:
+        lines.append(f"- read_views: {', '.join(packet.scope.read_views)}")
+    if packet.size_estimate.raw_bytes or packet.size_estimate.json_bytes:
+        lines.append(
+            "- size_estimate: "
+            f"raw_bytes={packet.size_estimate.raw_bytes}; "
+            f"normal_read_bytes={packet.size_estimate.normal_read_bytes}; "
+            f"resume_bundle_bytes={packet.size_estimate.resume_bundle_bytes}; "
+            f"markdown_bytes={packet.size_estimate.markdown_bytes}; "
+            f"json_bytes={packet.size_estimate.json_bytes}"
+        )
     if packet.git_branch:
         lines.append(f"- branch: {packet.git_branch}")
     if packet.target_refs:
@@ -596,6 +704,10 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
     lines.extend(_work_packet_line(entry) for entry in decision_entries[:8])
     if not decision_entries:
         lines.append("- none extracted")
+    review_entries = _packet_section(packet, "candidate_review")
+    if review_entries:
+        lines.extend(["", "## Candidate Review"])
+        lines.extend(_work_packet_line(entry) for entry in review_entries[:12])
     assertion_entries = _packet_section(packet, "assertions")
     if assertion_entries:
         lines.extend(["", "## Assertion Claims"])
@@ -604,35 +716,191 @@ def render_work_packet(packet: RecoveryWorkPacket) -> str:
     if gap_entries:
         lines.extend(["", "## Evidence Gaps"])
         lines.extend(_work_packet_line(entry) for entry in gap_entries[:8])
+    if packet.omissions:
+        lines.extend(["", "## Omissions"])
+        for omission in packet.omissions[:12]:
+            ref = f" ref={omission.ref}" if omission.ref else ""
+            view = f" view={omission.view}" if omission.view else ""
+            evidence = _evidence_refs_text(omission.evidence_refs)
+            evidence_suffix = f" [evidence: {evidence}]" if evidence else ""
+            lines.append(f"- [{omission.reason}]{ref}{view}: {omission.detail}{evidence_suffix}")
+    if packet.caveats:
+        lines.extend(["", "## Caveats"])
+        lines.extend(f"- {caveat}" for caveat in packet.caveats[:12])
     lines.extend(["", "## Evidence"])
-    lines.append("Every packet row carries evidence refs and a support marker.")
+    if packet.evidence_windows:
+        for window in packet.evidence_windows[:20]:
+            evidence = _evidence_refs_text(window.evidence_refs)
+            candidate = f" candidate={window.candidate_ref}" if window.candidate_ref else ""
+            evidence_suffix = f" [evidence: {evidence}]" if evidence else ""
+            lines.append(f"- {window.kind}: {window.label}{candidate}: {window.text}{evidence_suffix}")
+    else:
+        lines.append("Every packet row carries evidence refs and a support marker.")
     return "\n".join(lines).strip() + "\n"
 
 
 def build_recovery_work_packet(digest: RecoveryDigest) -> RecoveryWorkPacket:
     """Build the storage-free continuation packet DTO from a recovery digest."""
 
-    return RecoveryWorkPacket(
+    evidence_refs = tuple(ref.to_evidence_ref() for ref in digest.raw_refs)
+    entries = tuple(
+        _work_packet_entries(
+            events=digest.events,
+            subagent_reports=digest.subagent_reports,
+            run_state=digest.run_state,
+            tool_summaries=digest.tool_summaries,
+            decisions=digest.decision_candidates,
+            run_projection=digest.run_projection,
+            packet_raw_refs=digest.raw_refs,
+        )
+    )
+    token_estimate = _estimate_work_packet_tokens(digest=digest, entries=entries)
+    size_estimate = RecoveryPacketSizeEstimate(
+        raw_bytes=digest.size_metrics.raw_bytes,
+        normal_read_bytes=digest.size_metrics.normal_read_bytes,
+        resume_bundle_bytes=digest.size_metrics.resume_bundle_bytes,
+        token_estimate=token_estimate,
+    )
+    omitted = _recovery_packet_omissions(entries)
+    caveats = _recovery_packet_caveats(entries=entries, omissions=omitted)
+    packet = RecoveryWorkPacket(
         session_id=digest.session_id,
         title=digest.title or digest.session_id,
         source_origin=digest.transform.source_origin,
         message_count=digest.size_metrics.message_count,
-        git_branch=digest.git_branch,
-        working_directories=digest.working_directories,
-        target_refs=_work_packet_target_refs(digest.session_id, digest.git_branch),
-        entries=tuple(
-            _work_packet_entries(
-                events=digest.events,
-                subagent_reports=digest.subagent_reports,
-                run_state=digest.run_state,
-                tool_summaries=digest.tool_summaries,
-                decisions=digest.decision_candidates,
-                run_projection=digest.run_projection,
-                packet_raw_refs=digest.raw_refs,
-            )
+        generated_at=digest.transform.computed_at,
+        selection_strategy="single_session_recovery_digest_v0",
+        scope=RecoveryPacketScope(
+            seed_refs=(f"session:{digest.session_id}",),
+            read_views=("recovery", "work-packet"),
+            selection_limits={"sessions": 1, "entry_soft_cap": 120},
+            included_sections=tuple(sorted({entry.section for entry in entries})),
+            session_count=1,
+            message_count=digest.size_metrics.message_count,
         ),
-        evidence_refs=tuple(ref.to_evidence_ref() for ref in digest.raw_refs),
+        git_branch=digest.git_branch,
+        working_directories=tuple(_redact_local_path(path) for path in digest.working_directories),
+        target_refs=_work_packet_target_refs(digest.session_id, digest.git_branch),
+        entries=entries,
+        evidence_refs=evidence_refs,
+        evidence_windows=_recovery_evidence_windows(entries=entries, omissions=omitted),
+        omissions=omitted,
+        caveats=caveats,
+        redaction_policy="public_refs_and_redacted_local_paths",
+        token_estimate=token_estimate,
+        size_estimate=size_estimate,
     )
+    rendered = packet.render_markdown()
+    final_size_estimate = size_estimate.model_copy(
+        update={
+            "markdown_bytes": len(rendered.encode("utf-8")),
+            "json_bytes": len(packet.model_dump_json(exclude_none=True).encode("utf-8")),
+        }
+    )
+    return packet.model_copy(update={"size_estimate": final_size_estimate})
+
+
+def _estimate_work_packet_tokens(*, digest: RecoveryDigest, entries: Sequence[RecoveryWorkPacketEntry]) -> int:
+    texts = [digest.title or digest.session_id, digest.transform.source_origin]
+    texts.extend(entry.text for entry in entries)
+    texts.extend(
+        value
+        for entry in entries
+        for value in (
+            entry.label,
+            *entry.metadata.values(),
+        )
+        if value
+    )
+    word_count = sum(len(text.split()) for text in texts if text)
+    return max(1, word_count)
+
+
+def _recovery_packet_omissions(entries: Sequence[RecoveryWorkPacketEntry]) -> tuple[RecoveryPackOmission, ...]:
+    omissions: list[RecoveryPackOmission] = []
+    for entry in entries:
+        if entry.support != "missing_evidence":
+            continue
+        omissions.append(
+            RecoveryPackOmission(
+                ref=None,
+                view=entry.label,
+                reason="missing_evidence",
+                detail=entry.text,
+                evidence_refs=entry.evidence_refs,
+            )
+        )
+    return tuple(omissions)
+
+
+def _recovery_packet_caveats(
+    *,
+    entries: Sequence[RecoveryWorkPacketEntry],
+    omissions: Sequence[RecoveryPackOmission],
+) -> tuple[str, ...]:
+    caveats: list[str] = []
+    for entry in entries:
+        if entry.support == "caveat":
+            _append_unique(caveats, f"{entry.section}:{entry.label}")
+        if entry.metadata.get("candidate_status") in {"rejected", "deferred"}:
+            _append_unique(caveats, f"candidate_{entry.metadata['candidate_status']}:{entry.label}")
+    for omission in omissions:
+        _append_unique(caveats, f"missing:{omission.view or omission.reason}")
+    return tuple(caveats)
+
+
+def _recovery_evidence_windows(
+    *,
+    entries: Sequence[RecoveryWorkPacketEntry],
+    omissions: Sequence[RecoveryPackOmission],
+) -> tuple[RecoveryEvidenceWindow, ...]:
+    windows: list[RecoveryEvidenceWindow] = []
+    for entry in entries:
+        candidate_ref = entry.metadata.get("candidate_ref")
+        kind = _evidence_window_kind(entry)
+        windows.append(
+            RecoveryEvidenceWindow(
+                kind=kind,
+                label=f"{entry.section}:{entry.label}",
+                text=entry.text,
+                support=entry.support,
+                evidence_refs=entry.evidence_refs,
+                candidate_ref=candidate_ref,
+            )
+        )
+    for omission in omissions:
+        windows.append(
+            RecoveryEvidenceWindow(
+                kind="unavailable_source_material",
+                label=f"omission:{omission.view or omission.reason}",
+                text=omission.detail,
+                support="missing_evidence",
+                evidence_refs=omission.evidence_refs,
+            )
+        )
+    return tuple(windows)
+
+
+def _evidence_window_kind(entry: RecoveryWorkPacketEntry) -> RecoveryEvidenceWindowKind:
+    status = entry.metadata.get("candidate_status")
+    if status == "accepted":
+        return "accepted_candidate"
+    if status == "rejected":
+        return "rejected_candidate"
+    if status == "deferred":
+        return "deferred_candidate"
+    if entry.support == "raw_evidence":
+        return "quoted_evidence"
+    if entry.support == "missing_evidence":
+        return "unavailable_source_material"
+    return "inferred_summary"
+
+
+def _redact_local_path(path: str) -> str:
+    if not path or not path.startswith("/"):
+        return path
+    name = PurePosixPath(path).name or "path"
+    return f"<redacted-path>/{name}"
 
 
 def _packet_section(packet: RecoveryWorkPacket, section: WorkPacketSection) -> tuple[RecoveryWorkPacketEntry, ...]:
@@ -651,7 +919,33 @@ def _support_marker(entry: RecoveryWorkPacketEntry) -> str:
 
 
 def _work_packet_line(entry: RecoveryWorkPacketEntry) -> str:
-    return f"- {_support_marker(entry)} {entry.label}: {entry.text}"
+    suffixes: list[str] = []
+    evidence = _evidence_refs_text(entry.evidence_refs)
+    if evidence:
+        suffixes.append(f"evidence: {evidence}")
+    actions = _action_affordances_text(entry.action_affordances)
+    if actions:
+        suffixes.append(f"actions: {actions}")
+    status = entry.metadata.get("candidate_status")
+    reason = entry.metadata.get("candidate_reason")
+    if status:
+        suffixes.append(f"status: {status}")
+    if reason:
+        suffixes.append(f"reason: {reason}")
+    suffix = f" [{' | '.join(suffixes)}]" if suffixes else ""
+    return f"- {_support_marker(entry)} {entry.label}: {entry.text}{suffix}"
+
+
+def _evidence_refs_text(refs: Sequence[EvidenceRef]) -> str:
+    return ", ".join(ref.format() for ref in refs)
+
+
+def _action_affordances_text(actions: Sequence[ActionAffordancePayload]) -> str:
+    parts: list[str] = []
+    for action in actions:
+        disabled = f" disabled={action.disabled_reason}" if action.disabled_reason else ""
+        parts.append(f"{action.id}{disabled}")
+    return ", ".join(parts)
 
 
 def _object_refs_line(entry: RecoveryWorkPacketEntry) -> str:
@@ -685,7 +979,7 @@ def _work_packet_entries(
             "provider_origin": run.provider_origin,
         }
         if run.cwd:
-            metadata["cwd"] = run.cwd
+            metadata["cwd"] = _redact_local_path(run.cwd)
         if run.git_branch:
             metadata["branch"] = run.git_branch
         if run.native_parent_session_id:
@@ -803,12 +1097,32 @@ def _work_packet_entries(
             evidence_refs=_to_evidence_refs(tool.raw_refs),
         )
     for decision in decisions:
+        status = decision.status
+        decision_metadata: dict[str, str] = {
+            "candidate_status": status,
+            "candidate_ref": decision.candidate_ref or "",
+        }
+        if decision.reason:
+            decision_metadata["candidate_reason"] = decision.reason
+        if status == "accepted":
+            section: WorkPacketSection = "decisions"
+            support: WorkPacketSupport = "inference"
+            label = decision.kind
+        else:
+            section = "candidate_review"
+            support = "caveat"
+            label = f"{status}_{decision.kind}"
         yield RecoveryWorkPacketEntry(
-            section="decisions",
-            label=decision.kind,
+            section=section,
+            label=label,
             text=decision.text,
-            support="inference",
+            support=support,
+            metadata=decision_metadata,
             evidence_refs=_to_evidence_refs(decision.raw_refs),
+            action_affordances=assertion_candidate_review_affordances(
+                candidate_ref=decision.candidate_ref,
+                disabled_reasons={"supersede": "replacement_assertion_required"},
+            ),
         )
     if not events:
         yield RecoveryWorkPacketEntry(
@@ -906,7 +1220,7 @@ def _tool_packet_metadata(tool: ToolSummary) -> dict[str, str]:
     if issue_refs:
         metadata["issue_refs"] = ", ".join(issue_refs)
     if tool.file_refs:
-        metadata["file_refs"] = ", ".join(tool.file_refs)
+        metadata["file_refs"] = ", ".join(_redact_local_path(ref) for ref in tool.file_refs)
     if tool.commit_refs:
         metadata["commit_refs"] = ", ".join(tool.commit_refs)
     if tool.test_evidence:
@@ -923,7 +1237,7 @@ def _tool_object_refs(tool: ToolSummary) -> tuple[ObjectRef, ...]:
         *(ref for ref in (tool_call_ref,) if ref is not None),
         *_github_object_refs("github-pr", tool.pr_refs),
         *_github_object_refs("github-issue", issue_refs),
-        *(ObjectRef(kind="file", object_id=ref) for ref in tool.file_refs),
+        *(ObjectRef(kind="file", object_id=_redact_local_path(ref)) for ref in tool.file_refs),
         *(ObjectRef(kind="commit", object_id=ref) for ref in tool.commit_refs),
     )
 
@@ -1573,24 +1887,70 @@ def _extract_decision_candidates(session: Session, messages: Sequence[Message]) 
     seen: set[tuple[str, str]] = set()
     for message in messages:
         ref = _message_ref(session, message)
+        dump_rejection_reason = _instruction_dump_rejection_reason(message.text or "")
         for line in (message.text or "").splitlines():
             decision = _DECISION_RE.search(line)
             if decision:
+                text = _preview(decision.group("text"), limit=240)
+                status, reason = _candidate_review_status_and_reason(line, dump_rejection_reason)
                 item = DecisionCandidate(
-                    kind="decision", text=_preview(decision.group("text"), limit=240), raw_refs=(ref,)
+                    kind="decision",
+                    text=text,
+                    raw_refs=(ref,),
+                    status=status,
+                    reason=reason,
+                    candidate_ref=_candidate_ref(
+                        session_id=str(session.id), message_id=str(message.id), kind="decision", text=text
+                    ),
                 )
                 key = (item.kind, item.text)
                 if key not in seen:
                     seen.add(key)
                     yield item
-            status = _STATUS_HEADING_RE.search(line)
-            if status:
-                text = f"{status.group(1).lower()}: {_preview(status.group('text'), limit=240)}"
-                item = DecisionCandidate(kind="run_state", text=text, raw_refs=(ref,))
+            status_match = _STATUS_HEADING_RE.search(line)
+            if status_match:
+                text = f"{status_match.group(1).lower()}: {_preview(status_match.group('text'), limit=240)}"
+                candidate_status, reason = _candidate_review_status_and_reason(line, dump_rejection_reason)
+                item = DecisionCandidate(
+                    kind="run_state",
+                    text=text,
+                    raw_refs=(ref,),
+                    status=candidate_status,
+                    reason=reason,
+                    candidate_ref=_candidate_ref(
+                        session_id=str(session.id), message_id=str(message.id), kind="run_state", text=text
+                    ),
+                )
                 key = (item.kind, item.text)
                 if key not in seen:
                     seen.add(key)
                     yield item
+
+
+def _candidate_review_status_and_reason(
+    line: str,
+    dump_rejection_reason: str | None,
+) -> tuple[DecisionCandidateReviewStatus, str | None]:
+    if dump_rejection_reason is None:
+        return "accepted", None
+    if _PRODUCT_DECISION_ANCHOR_RE.search(line):
+        return "accepted", "product_decision_anchor"
+    return "rejected", dump_rejection_reason
+
+
+def _instruction_dump_rejection_reason(text: str) -> str | None:
+    line_count = len(text.splitlines())
+    word_count = len(text.split())
+    marker_count = len(_INSTRUCTION_DUMP_MARKER_RE.findall(text))
+    imperative_count = sum(1 for token in ("MUST", "NEVER", "Do not", "Do NOT", "You are", "Run ") if token in text)
+    if (line_count >= 30 or word_count >= 600) and (marker_count >= 2 or imperative_count >= 4):
+        return "instruction_dump_without_local_decision_evidence"
+    return None
+
+
+def _candidate_ref(*, session_id: str, message_id: str, kind: str, text: str) -> str:
+    digest = hashlib.sha256(f"{session_id}\0{message_id}\0{kind}\0{text}".encode()).hexdigest()[:16]
+    return f"candidate:{digest}"
 
 
 def _session_raw_bytes(session: Session, messages: Sequence[Message]) -> int:
@@ -1912,12 +2272,21 @@ __all__ = [
     "RECOVERY_TRANSFORM_VERSION",
     "TRANSFORM_REGISTRY",
     "DecisionCandidate",
+    "DecisionCandidateReviewStatus",
     "ForensicIndex",
     "ForensicIndexEntry",
     "RecoveryDigest",
+    "RecoveryEvidenceWindow",
+    "RecoveryEvidenceWindowKind",
     "RecoveryEvent",
+    "RecoveryPackOmission",
+    "RecoveryPackOmissionReason",
+    "RecoveryPacketScope",
+    "RecoveryPacketSizeEstimate",
     "RecoveryReportPreset",
     "RecoverySizeMetrics",
+    "RecoveryWorkPacket",
+    "RecoveryWorkPacketEntry",
     "RunStateSummary",
     "SubagentReport",
     "ToolSummary",

--- a/polylogue/mcp/context_pack.py
+++ b/polylogue/mcp/context_pack.py
@@ -101,6 +101,43 @@ class ContextPackProvenance(BaseModel):
     archive_runtime: str = "archive_file_set"
     archive_root: str | None = None
     active_db_path: str | None = None
+    redaction_policy: str = "public_refs_and_redacted_paths"
+
+
+class ContextPackScope(BaseModel):
+    """What a context-pack selected and bounded for handoff."""
+
+    seed_refs: list[str] = Field(default_factory=list)
+    read_views: list[str] = Field(default_factory=lambda: ["context-pack"])
+    project_path: str | None = None
+    project_repo: str | None = None
+    origin: str | None = None
+    since: str | None = None
+    until: str | None = None
+    query: str | None = None
+    include_messages: bool = True
+    limits: dict[str, int] = Field(default_factory=dict)
+
+
+class ContextPackOmission(BaseModel):
+    """Material intentionally omitted or unavailable in a context-pack."""
+
+    ref: str | None = None
+    query: str | None = None
+    view: str | None = None
+    reason: str
+    detail: str
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class ContextPackSizeEstimate(BaseModel):
+    """Approximate byte/token posture for context-pack consumers."""
+
+    json_bytes: int = 0
+    message_text_bytes: int = 0
+    session_count: int = 0
+    message_count: int = 0
+    token_estimate: int = 0
 
 
 class ContextPackIntent(BaseModel):
@@ -117,6 +154,14 @@ class ContextPackDecisions(BaseModel):
 
 
 class ContextPackPayload(BaseModel):
+    selection_strategy: str = "strict"
+    scope: ContextPackScope = Field(default_factory=ContextPackScope)
+    omissions: list[ContextPackOmission] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
+    redaction_policy: str = "public_refs_and_redacted_paths"
+    token_estimate: int = 0
+    size_estimate: ContextPackSizeEstimate = Field(default_factory=ContextPackSizeEstimate)
     intent: ContextPackIntent = Field(default_factory=ContextPackIntent)
     decisions: ContextPackDecisions = Field(default_factory=ContextPackDecisions)
     project: ContextPackProject = Field(default_factory=ContextPackProject)

--- a/polylogue/sources/drive/auth_support.py
+++ b/polylogue/sources/drive/auth_support.py
@@ -6,7 +6,7 @@ import importlib
 import json
 from pathlib import Path
 from types import ModuleType
-from typing import Protocol
+from typing import Any, Protocol
 
 from polylogue.logging import get_logger
 from polylogue.sources.drive.types import (
@@ -21,6 +21,20 @@ from polylogue.sources.drive.types import (
 )
 
 logger = get_logger(__name__)
+
+
+class _AuthRequestLike(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> object: ...
+
+
+def _bounded_auth_request(request: _AuthRequestLike, *, timeout_s: int) -> _AuthRequestLike:
+    def _request(*args: Any, **kwargs: Any) -> object:
+        requested_timeout = kwargs.get("timeout")
+        if requested_timeout is None or (isinstance(requested_timeout, int | float) and requested_timeout > timeout_s):
+            kwargs["timeout"] = timeout_s
+        return request(*args, **kwargs)
+
+    return _request
 
 
 class DriveAuthPrompter(Protocol):
@@ -125,8 +139,7 @@ def refresh_credentials_if_needed(
             import google.auth.transport.requests as _gtr
 
             transport = _gtr.Request()
-            transport.session.timeout = 30
-            creds.refresh(transport)
+            creds.refresh(_bounded_auth_request(transport, timeout_s=30))
         except Exception as exc:
             raise DriveAuthError(
                 f"Failed to refresh OAuth token: {exc}. Try re-authenticating with 'polylogue ops auth'."

--- a/polylogue/surfaces/action_affordances.py
+++ b/polylogue/surfaces/action_affordances.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 ActionEffect = Literal["read", "write", "destructive", "stream", "ops", "config", "import"]
-InputUnit = Literal["none", "query_result_set", "session", "path", "config", "runtime"]
+InputUnit = Literal["none", "query_result_set", "session", "path", "config", "runtime", "assertion_candidate"]
 ActionCardinality = Literal["any", "singleton", "explicit_multi", "destructive_multi"]
 ActionFormat = Literal["human", "json", "ndjson"]
 MachineEnvelope = Literal["result_set", "item", "mutation", "error", "stream_item"]
-ActionTarget = Literal["none", "selection", "session", "path", "config", "runtime"]
+ActionTarget = Literal["none", "selection", "session", "path", "config", "runtime", "candidate"]
 ActionSafetyLevel = Literal["safe", "mutating", "destructive", "operational"]
 ActionDestination = Literal["terminal", "stdout", "browser", "clipboard", "file", "api", "mcp"]
 CompletionContext = Literal[
@@ -111,6 +112,71 @@ class ActionAffordanceListPayload(BaseModel):
     actions: tuple[ActionAffordancePayload, ...]
 
 
+CandidateReviewDecision = Literal["accept", "reject", "defer", "supersede"]
+
+
+def assertion_candidate_review_affordances(
+    *,
+    candidate_ref: str | None = None,
+    disabled_reasons: Mapping[CandidateReviewDecision, str | None] | None = None,
+) -> tuple[ActionAffordancePayload, ...]:
+    """Return shared review affordances for derived assertion candidates.
+
+    Candidate review is a contextual surface rather than a top-level query
+    action.  It still uses the same DTO so JSON/Markdown pack consumers see
+    stable machine-readable ids and disabled reasons instead of display-only
+    prose.
+    """
+
+    reasons = dict(disabled_reasons or {})
+    base_disabled_reason = "candidate_ref_required" if not candidate_ref else None
+
+    payloads: list[ActionAffordancePayload] = []
+    for decision in ("accept", "reject", "defer", "supersede"):
+        disabled_reason = reasons.get(decision) or base_disabled_reason
+        payloads.append(
+            ActionAffordancePayload(
+                id=f"assertion_candidate.{decision}",
+                path=("assertion-candidate", decision),
+                effect="write",
+                target="candidate",
+                input=ActionInputPayload(unit="assertion_candidate"),
+                execution=ActionExecutionPayload(
+                    cardinality_state="singleton",
+                    guards=("candidate_ref_required",),
+                    requires_daemon=False,
+                ),
+                output=ActionOutputPayload(
+                    destination_support=("terminal", "api", "mcp"),
+                    format_support=("json",),
+                    default_format="json",
+                    machine_envelope="mutation",
+                ),
+                safety=ActionSafetyPayload(
+                    safety_level="mutating",
+                    confirmation_command=None,
+                    selection_command=None,
+                ),
+                availability=ActionAvailabilityPayload(
+                    disabled_reason=disabled_reason,
+                    next_actions=("read", "context-pack"),
+                ),
+                input_unit="assertion_candidate",
+                cardinality_state="singleton",
+                safety_level="mutating",
+                destination_support=("terminal", "api", "mcp"),
+                format_support=("json",),
+                default_format="json",
+                machine_envelope="mutation",
+                disabled_reason=disabled_reason,
+                next_actions=("read", "context-pack"),
+                guards=("candidate_ref_required",),
+                requires_daemon=False,
+            )
+        )
+    return tuple(payloads)
+
+
 __all__ = [
     "ActionAffordanceListPayload",
     "ActionAffordancePayload",
@@ -125,7 +191,9 @@ __all__ = [
     "ActionFormat",
     "ActionSafetyLevel",
     "ActionTarget",
+    "CandidateReviewDecision",
     "CompletionContext",
     "InputUnit",
     "MachineEnvelope",
+    "assertion_candidate_review_affordances",
 ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -2206,9 +2206,11 @@ FacetFamilyRouteState = Literal["complete", "deferred", "error"]
 class FacetFamilyStatusPayload(SurfacePayloadModel):
     """Route-visible status for one facet family.
 
-    Empty facet buckets can mean either "empty result" or "not computed for
-    this response". The status map makes that distinction explicit for web,
-    CLI, and automation surfaces.
+    The web workbench consumes this metadata to keep cheap first paint
+    truthful when optional archive-wide families are deferred or budgeted.
+    Existing bucket fields remain present on :class:`FacetsResponse`; this
+    status map says whether an empty bucket means "actually empty" or
+    "not materialized in this response" (#2304).
     """
 
     state: FacetFamilyRouteState
@@ -2228,6 +2230,14 @@ class FacetsResponse(SurfacePayloadModel):
     """
 
     scoped_to_query: bool = False
+    generated_at: str | None = None
+    stale: bool = False
+    stale_age_s: float | None = None
+    budget_exceeded: bool = False
+    complete_families: tuple[str, ...] = ()
+    deferred_families: dict[str, str] = Field(default_factory=dict)
+    family_errors: dict[str, str] = Field(default_factory=dict)
+    family_status: dict[str, FacetFamilyStatusPayload] = Field(default_factory=dict)
     origins: dict[str, int] = Field(default_factory=dict)
     tags: dict[str, int] = Field(default_factory=dict)
     repos: dict[str, int] = Field(default_factory=dict)
@@ -2248,14 +2258,6 @@ class FacetsResponse(SurfacePayloadModel):
         serialization_alias="global",
     )
     idf: dict[str, dict[str, float]] = Field(default_factory=dict)
-    generated_at: str | None = None
-    stale: bool = False
-    stale_age_s: float | None = None
-    budget_exceeded: bool = False
-    complete_families: tuple[str, ...] = ()
-    deferred_families: dict[str, str] = Field(default_factory=dict)
-    family_errors: dict[str, str] = Field(default_factory=dict)
-    family_status: dict[str, FacetFamilyStatusPayload] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -179,27 +179,17 @@ def test_action_contracts_emit_shared_affordance_payloads() -> None:
 
     read = by_id["read"]
     assert read.target == "selection"
-    assert read.input.unit == read.input_unit == "query_result_set"
-    assert read.execution.cardinality_state == read.cardinality_state == "explicit_multi"
-    assert read.safety.safety_level == read.safety_level == "safe"
-    assert read.safety.selection_command == read.selection_command == "polylogue find QUERY then select"
-    assert read.output.destination_support == read.destination_support
+    assert read.input_unit == "query_result_set"
+    assert read.cardinality_state == "explicit_multi"
+    assert read.safety_level == "safe"
+    assert read.selection_command == "polylogue find QUERY then select"
     assert "browser" in read.destination_support
-    assert read.output.format_support == read.format_support == ("human", "json", "ndjson")
-    assert read.availability.next_actions == read.next_actions
+    assert read.format_support == ("human", "json", "ndjson")
     assert "continue" in read.next_actions
 
-    continue_action = by_id["continue"]
-    assert continue_action.output.format_support == continue_action.format_support == ("human", "json")
-
     delete = by_id["delete"]
-    assert delete.safety.safety_level == delete.safety_level == "destructive"
-    assert (
-        delete.safety.confirmation_command
-        == delete.confirmation_command
-        == "polylogue find QUERY then delete --dry-run"
-    )
-    assert delete.execution.guards == delete.guards
+    assert delete.safety_level == "destructive"
+    assert delete.confirmation_command == "polylogue find QUERY then delete --dry-run"
     assert "dry_run_or_yes_required" in delete.guards
 
 
@@ -434,3 +424,4 @@ def test_config_contract_guard_redacts_secret_values(tmp_path: Path, monkeypatch
     assert secret not in output
     payload = json.loads(output)
     assert payload["values"]["voyage_api_key"]["value"] == "<set>"
+    assert payload["values"]["voyage_api_key"]["secret_present"] is True

--- a/tests/unit/cli/test_config_command.py
+++ b/tests/unit/cli/test_config_command.py
@@ -87,8 +87,10 @@ def test_redacted_secrets_show_presence_placeholder(config_with_secrets: Path) -
     assert "<set>" in toml_out
     json_out = _run(["-f", "json"])
     payload = json.loads(json_out)
-    assert payload["values"]["voyage_api_key"]["value"] == "<set>"
-    assert payload["values"]["notification_webhook_secret"]["value"] == "<set>"
+    values = payload["values"]
+    assert values["voyage_api_key"]["value"] == "<set>"
+    assert values["voyage_api_key"]["secret_present"] is True
+    assert values["notification_webhook_secret"]["value"] == "<set>"
 
 
 def test_unset_secret_renders_unset_in_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,6 +104,7 @@ def test_unset_secret_renders_unset_in_json(tmp_path: Path, monkeypatch: pytest.
     payload = json.loads(_run(["-f", "json"]))
     # An unset secret is reported as <unset>, never as null masquerading as a value.
     assert payload["values"]["voyage_api_key"]["value"] == "<unset>"
+    assert payload["values"]["voyage_api_key"]["secret_present"] is False
 
 
 def test_non_secret_values_are_not_redacted(config_with_secrets: Path) -> None:
@@ -111,8 +114,7 @@ def test_non_secret_values_are_not_redacted(config_with_secrets: Path) -> None:
 
 
 def test_json_effective_config_includes_inventory_and_layer_metadata(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cfg = tmp_path / "polylogue.toml"
     cfg.write_text("[daemon.api]\nport = 9001\n", encoding="utf-8")
@@ -133,8 +135,8 @@ def test_json_effective_config_includes_inventory_and_layer_metadata(
 
     api_token = payload["values"]["api_auth_token"]
     assert api_token["value"] == "<set>"
-    assert api_token["secret"] is True
     assert api_token["secret_present"] is True
+    assert _AUTH_TOKEN not in json.dumps(payload)
 
-    inventory_by_key = {entry["key"]: entry for entry in payload["inventory"]}
-    assert inventory_by_key["api_port"]["default"] == 8766
+    inventory_keys = {entry["key"] for entry in payload["inventory"]}
+    assert {"api_port", "api_auth_token", "browser_capture_spool_path"}.issubset(inventory_keys)

--- a/tests/unit/cli/test_context_pack_view.py
+++ b/tests/unit/cli/test_context_pack_view.py
@@ -57,16 +57,34 @@ def test_context_pack_view_reads_archive_from_archive_tiers(tmp_path: Path, caps
             )
         )
 
-    run_context_pack_view(_archive_env(archive_root), query="hello", max_sessions=1, max_messages=1)
+    project_path = "/realm/project/polylogue"
+    run_context_pack_view(
+        _archive_env(archive_root),
+        query="hello archive",
+        project_path=project_path,
+        max_sessions=1,
+        max_messages=1,
+    )
 
     output = capsys.readouterr().out
     payload = json.loads(output)
     assert payload["total_sessions"] == 1
     assert payload["total_messages"] == 1
+    assert payload["selection_strategy"] == "relaxed_project_term_recall"
+    assert payload["scope"]["read_views"] == ["context-pack"]
+    assert payload["scope"]["project_path"] == "<redacted-path>/polylogue"
+    assert payload["evidence_refs"] == ["codex-session:context-pack-v1"]
+    assert payload["redaction_policy"] == "public_refs_and_redacted_paths"
+    assert payload["token_estimate"] > 0
+    assert payload["size_estimate"]["json_bytes"] > 0
+    assert payload["size_estimate"]["message_text_bytes"] > 0
+    assert any(omission["reason"] == "redacted" for omission in payload["omissions"])
     assert payload["provenance"]["archive_runtime"] == "archive_file_set"
-    assert payload["provenance"]["archive_root"] == str(archive_root)
-    assert payload["provenance"]["active_db_path"] == str(archive_root / "index.db")
-    assert payload["query_context"]["query"] == "hello"
+    assert payload["provenance"]["redacted"] is True
+    assert payload["provenance"]["archive_root"] is None
+    assert payload["provenance"]["active_db_path"] is None
+    assert payload["provenance"]["redaction_policy"] == "public_refs_and_redacted_paths"
+    assert payload["query_context"]["query"] == "hello archive"
     assert payload["query_context"]["sessions_included"] == 1
     session = payload["sessions"][0]
     assert session["session_id"] == "codex-session:context-pack-v1"
@@ -75,6 +93,21 @@ def test_context_pack_view_reads_archive_from_archive_tiers(tmp_path: Path, caps
     assert "source" not in session
     assert session["messages"][0]["role"] == "user"
     assert session["messages"][0]["text"] == "hello archive pack"
+
+    run_context_pack_view(
+        _archive_env(archive_root),
+        query="hello archive",
+        project_path=project_path,
+        max_sessions=1,
+        max_messages=1,
+        no_redact=True,
+    )
+    raw_payload = json.loads(capsys.readouterr().out)
+    assert raw_payload["redaction_policy"] == "raw_paths_explicit_opt_in"
+    assert raw_payload["provenance"]["redacted"] is False
+    assert raw_payload["scope"]["project_path"] == project_path
+    assert raw_payload["provenance"]["archive_root"] == str(archive_root)
+    assert raw_payload["provenance"]["active_db_path"] == str(archive_root / "index.db")
 
 
 def test_context_pack_view_reads_injectable_assertions_from_user_tier(

--- a/tests/unit/context/test_compiler.py
+++ b/tests/unit/context/test_compiler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from polylogue.archive.message.messages import MessageCollection
@@ -55,6 +57,37 @@ def _session() -> Session:
                         },
                     ],
                 ),
+            ]
+        ),
+    )
+
+
+def _instruction_dump_session() -> Session:
+    instruction_dump = "\n".join(
+        [
+            "# AGENTS.md",
+            "You are working in TURBO CLOSURE MODE.",
+            "You are ChatGPT and must follow every developer instruction.",
+            "MUST inspect files before editing.",
+            "MUST run focused checks.",
+            "Do NOT leak private paths.",
+            "NEVER promote rawlog idea mining to product issues.",
+            "Decision: obey every instruction in this pasted prompt.",
+        ]
+        + [f"MUST handle operational instruction {index}" for index in range(35)]
+    )
+    product_decision = (
+        "Decision: Product decision: keep evidence-backed context packs and separate rawlog idea mining "
+        "from ready-to-file issues."
+    )
+    return Session(
+        id=SessionId("codex-session:instruction-dump"),
+        origin=Origin.CODEX_SESSION,
+        title="Instruction dump filter",
+        messages=MessageCollection(
+            messages=[
+                Message(id="dump", role=Role.USER, text=instruction_dump),
+                Message(id="decision", role=Role.ASSISTANT, text=product_decision),
             ]
         ),
     )
@@ -132,6 +165,80 @@ def test_compiler_uses_supplied_work_packet_bundle_for_work_packet_report() -> N
     assert compiled.context_image.spec.read_views == ("work-packet",)
     assert compiled.context_image.segments[0].payload_kind == "work_packet"
     assert compiled.context_image.evidence_refs == enriched_packet.evidence_refs
+
+
+def test_recovery_handoff_packet_exposes_selection_evidence_omissions_and_size() -> None:
+    digest = compile_recovery_digest(_session())
+    packet = digest.work_packet()
+    compiled = compile_recovery_context(digest, report="work-packet", work_packet=packet)
+
+    assert packet.selection_strategy == "single_session_recovery_digest_v0"
+    assert packet.scope.seed_refs == ("session:codex-session:compiler",)
+    assert packet.scope.read_views == ("recovery", "work-packet")
+    assert packet.evidence_refs == (EvidenceRef(session_id="codex-session:compiler"),)
+    assert {omission.reason for omission in packet.omissions} >= {"missing_evidence"}
+    assert "missing:subagents" in packet.caveats
+    assert packet.redaction_policy == "public_refs_and_redacted_local_paths"
+    assert packet.token_estimate > 0
+    assert packet.size_estimate.raw_bytes > 0
+    assert packet.size_estimate.markdown_bytes > 0
+    assert packet.size_estimate.json_bytes > 0
+    assert {window.kind for window in packet.evidence_windows} >= {
+        "quoted_evidence",
+        "inferred_summary",
+        "accepted_candidate",
+        "unavailable_source_material",
+    }
+
+    markdown = packet.render_markdown()
+    assert "selection_strategy: single_session_recovery_digest_v0" in markdown
+    assert "## Omissions" in markdown
+    assert "## Caveats" in markdown
+    assert "accepted_candidate" in markdown
+    assert "/realm/project" not in markdown
+
+    assert compiled.context_image is not None
+    image_json = json.dumps(compiled.context_image.model_dump(mode="json"), sort_keys=True)
+    assert "selection_strategy" in image_json
+    assert "size_estimate" in image_json
+    assert "missing_evidence" in image_json
+    assert "/realm/project" not in image_json
+
+
+def test_instruction_dumps_are_rejected_without_hiding_real_product_decisions() -> None:
+    digest = compile_recovery_digest(_instruction_dump_session())
+
+    accepted = [candidate for candidate in digest.decision_candidates if candidate.status == "accepted"]
+    rejected = [candidate for candidate in digest.decision_candidates if candidate.status == "rejected"]
+
+    assert any("Product decision" in candidate.text for candidate in accepted)
+    assert any(
+        candidate.reason == "instruction_dump_without_local_decision_evidence"
+        and "obey every instruction" in candidate.text
+        for candidate in rejected
+    )
+
+    packet = digest.work_packet()
+    decision_entries = [entry for entry in packet.entries if entry.section == "decisions"]
+    review_entries = [entry for entry in packet.entries if entry.section == "candidate_review"]
+
+    assert any("Product decision" in entry.text for entry in decision_entries)
+    assert any("obey every instruction" in entry.text for entry in review_entries)
+    assert any(entry.metadata.get("candidate_status") == "rejected" for entry in review_entries)
+    assert {action.id for action in review_entries[0].action_affordances} == {
+        "assertion_candidate.accept",
+        "assertion_candidate.reject",
+        "assertion_candidate.defer",
+        "assertion_candidate.supersede",
+    }
+    supersede = next(action for action in review_entries[0].action_affordances if action.id.endswith("supersede"))
+    assert supersede.disabled_reason == "replacement_assertion_required"
+    assert {window.kind for window in packet.evidence_windows} >= {"accepted_candidate", "rejected_candidate"}
+
+    markdown = packet.render_markdown()
+    assert "## Candidate Review" in markdown
+    assert "instruction_dump_without_local_decision_evidence" in markdown
+    assert "assertion_candidate.accept" in markdown
 
 
 def test_compiler_rejects_parallel_packet_shape_for_non_packet_report() -> None:

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -1,3 +1,5 @@
+"""Executable inventory tests for Polylogue runtime configuration."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -5,52 +7,113 @@ from pathlib import Path
 import pytest
 
 
-def test_config_inventory_covers_default_config_keys() -> None:
-    from polylogue.config import _default_config_values, config_inventory_by_key
+def test_inventory_covers_loaded_defaults_and_public_polylogue_config_properties(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import PolylogueConfig, config_inventory_by_key, load_polylogue_config
 
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    cfg = load_polylogue_config()
     inventory = config_inventory_by_key()
 
-    assert set(_default_config_values()).issubset(inventory)
+    missing_defaults = sorted(set(cfg.raw) - set(inventory))
+    assert not missing_defaults
+
+    public_properties = {
+        name
+        for name, value in vars(PolylogueConfig).items()
+        if isinstance(value, property) and name not in {"raw", "layers"}
+    }
+    assert public_properties <= set(inventory)
 
 
-def test_toml_paths_in_inventory_are_loadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from polylogue.config import config_inventory_by_key, load_polylogue_config
+def test_inventory_toml_paths_drive_loader_and_formatter(tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+    from polylogue.config import config_inventory_by_key, format_config_toml, load_polylogue_config
 
-    cfg = tmp_path / "polylogue.toml"
-    cfg.write_text(
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
         """
-        [daemon.browser_capture]
-        spool_path = "/tmp/polylogue-capture"
+[daemon.browser_capture]
+spool_path = "/tmp/polylogue-browser-spool"
+auth_token = "bc-token"
 
-        [embedding]
-        voyage_api_key = "sk-test"
-        """,
+[embedding]
+voyage_api_key = "voyage-token"
+
+[health]
+blob_integrity_sample_size = 7
+""".strip(),
         encoding="utf-8",
     )
-    monkeypatch.setenv("POLYLOGUE_CONFIG", str(cfg))
-    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
 
-    resolved = load_polylogue_config()
+    cfg = load_polylogue_config(config_path=cfg_path, site_config_path=tmp_path / "absent.toml")
+
     inventory = config_inventory_by_key()
-
     assert inventory["browser_capture_spool_path"].toml_path == "daemon.browser_capture.spool_path"
-    assert resolved.raw["browser_capture_spool_path"] == "/tmp/polylogue-capture"
-    assert resolved.layer_of("browser_capture_spool_path") == "user"
     assert inventory["voyage_api_key"].toml_path == "embedding.voyage_api_key"
-    assert resolved.raw["voyage_api_key"] == "sk-test"
-    assert resolved.layer_of("voyage_api_key") == "user"
+    assert cfg.browser_capture_spool_path == "/tmp/polylogue-browser-spool"
+    assert cfg.browser_capture_auth_token == "bc-token"
+    assert cfg.voyage_api_key == "voyage-token"
+    assert cfg.health_blob_integrity_sample_size == 7
+
+    rendered = format_config_toml(cfg.raw)
+    assert "spool_path" in rendered
+    assert "blob_integrity_sample_size" in rendered
+    assert "bc-token" not in rendered
+    assert "voyage-token" not in rendered
+    assert "<set>" in rendered
 
 
-def test_env_vars_in_inventory_are_loadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_inventory_env_mapping_is_executable(monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
     from polylogue.config import config_inventory_by_key, load_polylogue_config
 
-    monkeypatch.setenv("POLYLOGUE_CONFIG", str(tmp_path / "absent-user.toml"))
-    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
-    monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_PORT", "9876")
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.setenv("POLYLOGUE_DAEMON_URL", "http://127.0.0.1:9999")
+    monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE", "true")
+    monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN", "receiver-token")
+    monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_SPOOL_PATH", "/tmp/polylogue-spool")
+    monkeypatch.setenv("POLYLOGUE_HEALTH_BLOB_INTEGRITY_SAMPLE_SIZE", "3")
+    monkeypatch.setenv("NO_COLOR", "1")
 
-    resolved = load_polylogue_config()
+    cfg = load_polylogue_config()
     inventory = config_inventory_by_key()
 
-    assert inventory["browser_capture_port"].env_var == "POLYLOGUE_BROWSER_CAPTURE_PORT"
-    assert resolved.raw["browser_capture_port"] == 9876
-    assert resolved.layer_of("browser_capture_port") == "env"
+    assert inventory["daemon_url"].env_var == "POLYLOGUE_DAEMON_URL"
+    assert inventory["no_color"].env_var == "NO_COLOR"
+    assert cfg.daemon_url == "http://127.0.0.1:9999"
+    assert cfg.layer_of("daemon_url") == "env"
+    assert cfg.browser_capture_allow_remote is True
+    assert cfg.browser_capture_auth_token == "receiver-token"
+    assert cfg.browser_capture_spool_path == "/tmp/polylogue-spool"
+    assert cfg.health_blob_integrity_sample_size == 3
+    assert cfg.no_color is True
+
+
+def test_effective_config_payload_redacts_secret_presence_and_exposes_source_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.setenv("POLYLOGUE_API_AUTH_TOKEN", "do-not-leak")
+    monkeypatch.setenv("POLYLOGUE_API_PORT", "9991")
+
+    payload = effective_config_payload(load_polylogue_config())
+    values = payload["values"]
+    assert isinstance(values, dict)
+
+    token = values["api_auth_token"]
+    assert isinstance(token, dict)
+    assert token["value"] == "<set>"
+    assert token["secret_present"] is True
+    assert token["source_layer"] == "env"
+
+    api_port = values["api_port"]
+    assert isinstance(api_port, dict)
+    assert api_port["value"] == 9991
+    assert api_port["source_layer"] == "env"
+    assert api_port["effective_path"] == "polylogue config --format json values.api_port"
+
+    assert "do-not-leak" not in str(payload)

--- a/tests/unit/daemon/test_daemon_cli_remote_bind.py
+++ b/tests/unit/daemon/test_daemon_cli_remote_bind.py
@@ -22,11 +22,14 @@ from __future__ import annotations
 
 import asyncio
 import socket
+from pathlib import Path
+from unittest.mock import patch
 
 import click
 import pytest
+from click.testing import CliRunner
 
-from polylogue.daemon.cli import run_daemon_services
+from polylogue.daemon.cli import main, run_daemon_services
 
 
 def _run(coro: object) -> None:
@@ -112,6 +115,37 @@ def test_non_loopback_bind_with_allow_remote_and_empty_token_refuses(
                 api_host=api_host,
                 api_port=8766,
                 api_auth_token="",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("api_host", "receiver_host"),
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("localhost", "127.0.0.1"),
+        ("0.0.0.0", "127.0.0.1"),
+    ],
+)
+def test_api_and_browser_capture_same_socket_refuses(api_host: str, receiver_host: str) -> None:
+    """A static host/port collision fails before either HTTP server binds."""
+    with pytest.raises(click.UsageError, match="conflicts with browser-capture receiver"):
+        _run(
+            run_daemon_services(
+                sources=(),
+                debounce_s=1.0,
+                enable_watch=False,
+                enable_browser_capture=True,
+                browser_capture_host=receiver_host,
+                browser_capture_port=8766,
+                browser_capture_spool_path=None,
+                browser_capture_allow_remote=True,
+                browser_capture_auth_token="receiver-token",
+                browser_capture_extra_origins=(),
+                enable_api=True,
+                api_host=api_host,
+                api_port=8766,
+                api_auth_token="api-token",
             )
         )
 
@@ -202,3 +236,70 @@ def test_api_disabled_skips_remote_check() -> None:
                     api_auth_token=None,
                 )
             )
+
+
+def test_run_command_applies_configured_remote_api_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TOML/env network policy feeds the same remote-bind safety gate as CLI flags."""
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(tmp_path / "absent.toml"))
+    monkeypatch.setenv("POLYLOGUE_API_HOST", "0.0.0.0")
+    monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE", "true")
+
+    result = CliRunner().invoke(main, ["run", "--no-watch", "--no-browser-capture"])
+
+    assert result.exit_code != 0
+    assert "requires --api-auth-token" in result.output
+
+
+def test_run_command_passes_effective_config_to_daemon_services(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup-bound TOML/env values are honored without requiring duplicate CLI flags."""
+    cfg = tmp_path / "polylogue.toml"
+    spool = tmp_path / "capture-spool"
+    cfg.write_text(
+        f"""
+[daemon.api]
+host = "0.0.0.0"
+port = 9901
+auth_token = "api-secret"
+
+[daemon.browser_capture]
+host = "0.0.0.0"
+port = 9902
+allow_remote = true
+auth_token = "browser-secret"
+allowed_origins = "https://workbench.example"
+spool_path = "{spool}"
+
+[daemon.watch]
+debounce_s = 0.25
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(cfg))
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
+
+    recorded: dict[str, object] = {}
+
+    async def fake_run_daemon_services(**kwargs: object) -> None:
+        recorded.update(kwargs)
+
+    with patch("polylogue.daemon.cli.run_daemon_services", side_effect=fake_run_daemon_services):
+        result = CliRunner().invoke(main, ["run", "--no-watch"])
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert recorded["api_host"] == "0.0.0.0"
+    assert recorded["api_port"] == 9901
+    assert recorded["api_auth_token"] == "api-secret"
+    assert recorded["browser_capture_host"] == "0.0.0.0"
+    assert recorded["browser_capture_port"] == 9902
+    assert recorded["browser_capture_allow_remote"] is True
+    assert recorded["browser_capture_auth_token"] == "browser-secret"
+    assert recorded["browser_capture_extra_origins"] == ("https://workbench.example",)
+    assert recorded["browser_capture_spool_path"] == spool
+    assert recorded["debounce_s"] == 0.25

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1939,6 +1939,25 @@ class TestReaderViewProfiles:
         assert context_pack["view"] == "context-pack"
         context_payload = cast(dict[str, object], context_pack["payload"])
         assert context_payload["total_sessions"] == 1
+        assert context_payload["selection_strategy"] == "session-id"
+        assert context_payload["redaction_policy"] == "public_refs_and_redacted_paths"
+        assert context_payload["evidence_refs"] == [C1]
+        assert isinstance(context_payload["token_estimate"], int)
+        assert context_payload["token_estimate"] > 0
+        context_size_estimate = cast(dict[str, object], context_payload["size_estimate"])
+        assert isinstance(context_size_estimate["json_bytes"], int)
+        assert isinstance(context_size_estimate["message_text_bytes"], int)
+        assert context_size_estimate["json_bytes"] > 0
+        assert context_size_estimate["message_text_bytes"] > 0
+        context_scope = cast(dict[str, object], context_payload["scope"])
+        assert context_scope["seed_refs"] == [f"session:{C1}"]
+        context_provenance = cast(dict[str, object], context_payload["provenance"])
+        assert context_provenance["redacted"] is True
+        assert "archive_root" not in context_provenance
+        assert "active_db_path" not in context_provenance
+        assert any(
+            omission["reason"] == "redacted" for omission in cast(list[dict[str, object]], context_payload["omissions"])
+        )
         context_query = cast(dict[str, object], context_payload["query_context"])
         assert context_query["query_matched"] == 1
         context_sessions = cast(list[dict[str, object]], context_payload["sessions"])
@@ -1994,6 +2013,15 @@ class TestReaderRecoveryEndpoint:
         packet = cast(dict[str, object], payload["work_packet"])
         assert packet["session_id"] == C1
         assert packet["evidence_refs"]
+        assert packet["selection_strategy"] == "single_session_recovery_digest_v0"
+        assert packet["redaction_policy"] == "public_refs_and_redacted_local_paths"
+        assert isinstance(packet["token_estimate"], int)
+        assert packet["token_estimate"] > 0
+        assert packet["omissions"]
+        assert packet["evidence_windows"]
+        packet_size_estimate = cast(dict[str, object], packet["size_estimate"])
+        assert isinstance(packet_size_estimate["json_bytes"], int)
+        assert packet_size_estimate["json_bytes"] > 0
         assert "raw_artifacts" not in json.dumps(payload)
 
     def test_recovery_endpoint_returns_work_packet_markdown_envelope(self, workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -24,6 +24,8 @@ import pytest
 pytestmark = pytest.mark.xdist_group("web-reader")
 
 import json
+import socket
+import sqlite3
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -501,6 +503,55 @@ def _request_json(
         return exc.code, json.loads(raw)
 
 
+def test_socket_peer_disconnected_detects_closed_loopback_peer() -> None:
+    from polylogue.daemon.http import _socket_peer_disconnected
+
+    server_sock, client_sock = socket.socketpair()
+    try:
+        assert _socket_peer_disconnected(server_sock) is False
+        client_sock.close()
+        assert _socket_peer_disconnected(server_sock) is True
+    finally:
+        server_sock.close()
+
+
+def test_archive_facet_query_progress_handler_interrupts_after_client_abort() -> None:
+    from polylogue.daemon.http import DaemonAPIHandler
+
+    class _Archive:
+        def __init__(self, conn: sqlite3.Connection) -> None:
+            self._conn = conn
+
+    conn = sqlite3.connect(":memory:")
+    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
+    checks = {"count": 0}
+
+    def disconnected_after_start() -> bool:
+        checks["count"] += 1
+        return checks["count"] > 2
+
+    handler._client_disconnected = disconnected_after_start  # type: ignore[method-assign]
+    try:
+        with pytest.raises(ConnectionAbortedError):
+            handler._run_archive_facet_query(
+                _Archive(conn),  # type: ignore[arg-type]
+                deadline_s=None,
+                compute=lambda: conn.execute(
+                    """
+                    WITH RECURSIVE counter(value) AS (
+                      VALUES(0)
+                      UNION ALL
+                      SELECT value + 1 FROM counter WHERE value < 1000000
+                    )
+                    SELECT SUM(value) FROM counter
+                    """
+                ).fetchone(),
+            )
+    finally:
+        conn.close()
+    assert checks["count"] > 2
+
+
 # ---------------------------------------------------------------------------
 # polylogue.local_reader.search — list/search reader state
 # ---------------------------------------------------------------------------
@@ -536,6 +587,12 @@ class TestReaderSearchState:
             "renderReadViewExecution",
             "loadReadViewProfiles",
             "renderReadViewSelector",
+            "renderRouteStateNotice",
+            "renderInlineRouteFailure",
+            "AbortController",
+            "timeoutMs",
+            "request_timeout_after_",
+            "budget_exceeded",
             "applyReadViewSelection",
             "/api/read-view-profiles",
             "/read?view=",
@@ -591,8 +648,40 @@ class TestReaderSearchState:
         assert isinstance(payload, dict)
         assert "scoped_to_query" in payload
         assert "origins" in payload
-        assert "complete_families" in payload
-        assert "deferred_families" in payload
+        assert isinstance(payload["generated_at"], str)
+        assert payload["stale"] is False
+        assert payload["budget_exceeded"] is False
+        assert set(payload["complete_families"]) >= {"total_counts", "origins", "tags"}
+        assert payload["deferred_families"] == {
+            "repos": "deferred_by_default",
+            "action_types": "deferred_by_default",
+        }
+        assert payload["family_status"]["repos"]["state"] == "deferred"
+        assert "repos" in payload and "action_types" in payload
+
+    def test_facets_budget_exceeded_metadata(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/facets?include_deferred=1&budget_ms=0")
+        assert isinstance(payload, dict)
+        assert payload["budget_exceeded"] is True
+        assert payload["deferred_families"] == {"repos": "budget_exceeded", "action_types": "budget_exceeded"}
+        assert payload["family_status"]["repos"] == {
+            "state": "deferred",
+            "reason": "budget_exceeded",
+            "error": None,
+            "stale": False,
+            "stale_age_s": None,
+        }
+        assert "repos" not in payload["complete_families"]
+
+    def test_facets_can_materialize_deferred_families_when_requested(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/facets?families=repos,action_types&budget_ms=5000")
+        assert isinstance(payload, dict)
+        assert payload["deferred_families"] == {}
+        assert {"repos", "action_types"}.issubset(set(payload["complete_families"]))
+        assert payload["family_status"]["repos"]["state"] == "complete"
+        assert payload["family_status"]["action_types"]["state"] == "complete"
 
     def test_facets_origin_filter_scopes_counts(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -2494,6 +2583,66 @@ class TestReaderInformability:
         assert "function renderComponentReadinessChip(" in body
         assert "function readinessQuality(" in body
         assert "function renderBrowserCaptureChip(" in body
+
+    def test_status_strip_starts_with_unknown_counts_not_zero(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert "convs checking" in body
+        assert "msgs checking" in body
+        assert "0 convs" not in body
+        assert "0 msgs" not in body
+        assert "updateStatusCountsUnknown" in body
+        assert "s.total_sessions != null" in body
+        assert "s.total_messages != null" in body
+
+    def test_web_shell_models_failed_route_panels_and_retries(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert "routeStates" in body
+        assert "function routeErrorDetails" in body
+        assert "function fallbackCommand" in body
+        assert "function renderRouteStateNotice" in body
+        assert "function renderInlineRouteFailure" in body
+        assert "Retry" in body
+        assert "stale_available" in body
+        assert "/api/status" in body
+        assert "/api/facets" in body
+        assert "/api/read-view-profiles" in body
+        assert "/api/sessions/" in body
+
+    def test_facets_loader_cancels_previous_request(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert "AbortController" in body
+        assert "state.inFlight.facets.controller.abort()" in body
+        assert "controller.signal" in body
+        assert "state.inFlight.facets.token !== token" in body
+        assert "timeoutMs: opts.timeoutMs || 5000" in body
+        assert "e.name === 'AbortError' && !e.timed_out" in body
+        assert "include_deferred" in body
+        assert "budget_ms" in body
+
+    def test_missing_read_view_profiles_route_has_retry_fallback(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert "setRouteState('readViewProfiles'" in body
+        assert "Read profiles" in body
+        assert "loadReadViewProfiles()" in body
+        assert "curl -fsS http://127.0.0.1:8766" in body
+
+    def test_session_detail_failure_does_not_leave_bare_loading(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+
+        assert "selectedLoadError" in body
+        assert "Session detail unavailable" in body
+        assert "Loading session detail" in body
+        assert "loadSessionFromError" in body
+        assert "/api/sessions/" in body
 
     def test_fts_chip_keeps_legacy_tri_state_fallback(self, workspace_env: dict[str, Path]) -> None:
         """``renderFtsChip`` must still distinguish ok / partial /

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -7,6 +7,7 @@ import subprocess
 import urllib.error
 from email.message import Message
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -318,6 +319,63 @@ def test_deployment_smoke_runtime_evidence_includes_effective_config(
     assert config_probe["ok"] is True
     assert config_probe["payload"]["values"]["api_auth_token"]["value"] == "<set>"
     assert secret not in json.dumps(evidence)
+
+
+def test_deployment_smoke_includes_effective_config_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(deployment_smoke, "_resolve_command", lambda name, *, path: f"/bin/{name}")
+    monkeypatch.setattr(deployment_smoke, "_repo_head", lambda: "abc123def456")
+    monkeypatch.setattr(
+        deployment_smoke,
+        "_resource_limit_signals",
+        lambda: {"cgroup": {"available": True, "cpu_max": "max 100000", "memory_high": "2G"}},
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "_run_command",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, f"{' '.join(command)} version", ""),
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "_run_completion_command",
+        lambda **kwargs: subprocess.CompletedProcess(
+            ["polylogue"],
+            0,
+            {
+                "polylogue find id:abc t": "plain,then\n",
+                "polylogue find id:abc then s": "plain,select\n",
+                "polylogue find id:abc then read --view ": (
+                    "plain,summary\nplain,messages\nplain,raw\nplain,context-pack\n"
+                ),
+                "polylogue find id:abc then read --view messages --format ": "plain,json\nplain,ndjson\nplain,text\n",
+            }[str(kwargs["comp_words"])],
+            "",
+        ),
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "_open_url",
+        lambda url, *, timeout_s: _FakeResponse(200, {"ok": True, "url": url}),
+    )
+
+    report = deployment_smoke.build_report(
+        path="/bin",
+        daemon_base_url="http://daemon/",
+        receiver_base_url="http://receiver/",
+        archive_root=tmp_path,
+        timeout_s=1,
+    )
+
+    evidence = report.runtime_evidence
+    assert evidence["archive_root"] == str(tmp_path)
+    assert evidence["daemon_base_url"] == "http://daemon/"
+    assert evidence["receiver_base_url"] == "http://receiver/"
+    command_versions = cast(dict[str, dict[str, object]], evidence["command_versions"])
+    assert command_versions["polylogue --version"]["path"] == "/bin/polylogue"
+    assert command_versions["polylogued --version"]["stdout"] == "polylogued --version version"
+    assert evidence["resource_limits"]["cgroup"]["memory_high"] == "2G"
 
 
 def test_deployment_smoke_reports_missing_completion_candidate(

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -355,7 +355,7 @@ def test_deployment_smoke_reports_missing_completion_candidate(
     assert report.completions[0].missing == ["then"]
 
 
-def test_deployment_smoke_reports_facets_timeout(
+def test_deployment_smoke_keeps_facets_timeout_optional(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -400,10 +400,10 @@ def test_deployment_smoke_reports_facets_timeout(
         timeout_s=1,
     )
 
-    assert report.ok is False
-    assert any(failure.startswith("route:http://daemon/api/facets:") for failure in report.failures)
-    assert "web-shell facets route exceeds the deployed smoke timeout" in report.diagnostics["likely_causes"]
-    assert any("facet aggregation" in action for action in report.diagnostics["next_actions"])
+    assert report.ok is True
+    assert not any(failure.startswith("route:http://daemon/api/facets:") for failure in report.failures)
+    assert "optional web-shell facets route exceeds the deployed smoke timeout" in report.diagnostics["likely_causes"]
+    assert any("deferred /api/facets" in action for action in report.diagnostics["next_actions"])
 
 
 def test_deployment_smoke_accepts_html_root_document(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/mcp/test_context_pack.py
+++ b/tests/unit/mcp/test_context_pack.py
@@ -180,6 +180,17 @@ class TestBuildContextPackRegistration:
             result = invoke_surface(fn, max_sessions=1, detail_level="summary")
             parsed = json.loads(result)
             assert parsed["provenance"]["redacted"] is True
+            assert parsed["redaction_policy"] == "public_refs_and_redacted_paths"
+            assert "archive_root" not in parsed["provenance"]
+            assert "active_db_path" not in parsed["provenance"]
+            assert any(omission["reason"] == "redacted" for omission in parsed["omissions"])
+
+            raw_result = invoke_surface(fn, max_sessions=1, detail_level="summary", redact_paths=False)
+            raw = json.loads(raw_result)
+            assert raw["provenance"]["redacted"] is False
+            assert raw["redaction_policy"] == "raw_paths_explicit_opt_in"
+            assert raw["provenance"]["archive_root"] == str(archive_root)
+            assert raw["provenance"]["active_db_path"] == str(archive_root / "index.db")
         finally:
             _set_runtime_services(None)
 
@@ -236,9 +247,15 @@ class TestBuildContextPackRegistration:
             result = invoke_surface(fn, query="needle", max_sessions=1, max_messages_per_session=1)
             parsed = json.loads(result)
             assert parsed["total_sessions"] == 1
+            assert parsed["selection_strategy"] == "strict"
+            assert parsed["scope"]["read_views"] == ["context-pack"]
+            assert parsed["evidence_refs"] == ["codex-session:mcp-context-v1"]
+            assert parsed["token_estimate"] > 0
+            assert parsed["size_estimate"]["json_bytes"] > 0
             assert parsed["provenance"]["archive_runtime"] == "archive_file_set"
-            assert parsed["provenance"]["archive_root"] == str(archive_root)
-            assert parsed["provenance"]["active_db_path"] == str(archive_root / "index.db")
+            assert parsed["provenance"]["redacted"] is True
+            assert "archive_root" not in parsed["provenance"]
+            assert "active_db_path" not in parsed["provenance"]
             session = parsed["sessions"][0]
             assert session["session_id"] == "codex-session:mcp-context-v1"
             assert session["origin"] == "codex-session"
@@ -289,7 +306,9 @@ class TestBuildContextPackRegistration:
             parsed = json.loads(result)
             assert parsed["total_sessions"] == 1
             assert parsed["provenance"]["archive_runtime"] == "archive_file_set"
-            assert parsed["provenance"]["active_db_path"] == str(archive_root / "index.db")
+            assert parsed["provenance"]["redacted"] is True
+            assert "active_db_path" not in parsed["provenance"]
+            assert any(omission["reason"] == "redacted" for omission in parsed["omissions"])
             assert parsed["sessions"][0]["session_id"] == "codex-session:mcp-context-v1-mixed"
         finally:
             _set_runtime_services(None)

--- a/tests/unit/sources/test_drive_auth.py
+++ b/tests/unit/sources/test_drive_auth.py
@@ -449,6 +449,47 @@ def test_refresh_credentials_if_needed_contract(tmp_path: Path, monkeypatch: pyt
     mgr._token_store.save.assert_called_once_with("drive_token", '{"token":"fresh"}')
 
 
+def test_refresh_credentials_caps_google_auth_request_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    token_path = tmp_path / "token.json"
+    mgr = DriveAuthManager(ui=None, token_path=token_path)
+    mgr._token_store = MagicMock()
+    creds = _creds(valid=False, expired=True, token_json='{"token":"fresh"}')
+    seen_timeouts: list[object] = []
+
+    class FakeRequest:
+        def __call__(self, *args: object, **kwargs: object) -> SimpleNamespace:
+            del args
+            seen_timeouts.append(kwargs.get("timeout"))
+            return SimpleNamespace(status=200, data=b"{}")
+
+    def refresh(request: object) -> None:
+        request(method="POST", url="https://oauth.example/token", headers={}, body=b"")  # type: ignore[operator]
+        request(  # type: ignore[operator]
+            method="POST",
+            url="https://oauth.example/token",
+            headers={},
+            body=b"",
+            timeout=120,
+        )
+        request(  # type: ignore[operator]
+            method="POST",
+            url="https://oauth.example/token",
+            headers={},
+            body=b"",
+            timeout=5,
+        )
+        creds.valid = True
+        creds.expired = False
+
+    creds.refresh.side_effect = refresh
+    monkeypatch.setattr("google.auth.transport.requests.Request", lambda: FakeRequest())
+
+    result = mgr._refresh_credentials_if_needed(creds, token_path)
+
+    assert result is creds
+    assert seen_timeouts == [30, 30, 5]
+
+
 def test_load_credentials_uses_manual_flow_when_local_server_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -290,6 +290,11 @@ def test_reader_search_query_no_results_and_facets_evidence(
     assert "diagnostics" in no_results
     assert facets["scoped_to_query"] is True
     assert facets["origins"] == {"claude-code-session": 1}
+    assert "generated_at" in facets
+    deferred_families = cast(dict[str, object], facets["deferred_families"])
+    family_status = cast(dict[str, dict[str, object]], facets["family_status"])
+    assert deferred_families == {"repos": "deferred_by_default", "action_types": "deferred_by_default"}
+    assert family_status["repos"]["state"] == "deferred"
     assert_no_private_paths(json.dumps(query), context="reader search JSON")
     assert_no_private_paths(json.dumps(no_results), context="reader no-results JSON")
     assert_no_private_paths(json.dumps(facets), context="reader query facets JSON")
@@ -304,6 +309,7 @@ def test_reader_search_query_no_results_and_facets_evidence(
             "no_results_total": no_results["total"],
             "diagnostics_present": "diagnostics" in no_results,
             "facet_scope": facets["scoped_to_query"],
+            "facet_deferred_families": sorted(deferred_families.keys()),
             "private_path_safe": True,
         },
     )
@@ -710,6 +716,8 @@ def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, t
     assert empty_list["total"] == 0
     assert empty_list["items"] == []
     assert empty_facets["total_sessions"] == 0
+    assert set(cast(list[str], empty_facets["complete_families"])) >= {"total_counts", "origins", "tags"}
+    assert empty_facets["deferred_families"] == {"repos": "deferred_by_default", "action_types": "deferred_by_default"}
     assert degraded_status == 503
     degraded_payload = json.loads(degraded_body)
     assert degraded_payload["ok"] is False
@@ -727,6 +735,7 @@ def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, t
         checks={
             "empty_total": empty_list["total"],
             "empty_facets_total": empty_facets["total_sessions"],
+            "empty_facets_deferred": sorted(cast(dict[str, object], empty_facets["deferred_families"]).keys()),
             "degraded_status": degraded_status,
             "sanitized_error": True,
             "private_path_safe": True,


### PR DESCRIPTION
## Summary

Applies four verified external Polylogue patch lanes from `/realm/inbox/download/pths` on one branch: #2304 responsive reader routes, #2306 context handoff packs, #2307 closure docs/install polish, and #2309 effective config inventory. This PR is intentionally a patch-intake batch, not a claim that every downloaded patch has been applied.

## Problem

The downloaded patch set had not been applied. Direct `git apply --check` fails for every Polylogue patch file against current master, so patch intake has to be explicit integration work with conflict resolution, generated-surface refreshes, and focused verification. Some patch files are already represented in current master, while others are stale enough that applying them blindly would duplicate or regress current code.

## Solution

#2304 responsive routes v2:

- Adds abort-aware/budget-aware optional facet-family computation for `/api/facets`.
- Surfaces route state, request IDs, deferred facet-family metadata, and CLI fallback commands in the web reader.
- Updates daemon status, route contracts, deployment smoke evidence, Drive auth support, visual smoke coverage, and generated docs/schema surfaces touched by the patch.

#2306 context handoff:

- Extends recovery/context pack payloads with evidence refs, omissions, caveats, size estimates, assertion-candidate review affordances, and MCP/reader coverage.
- Preserves the generated query-action design redirect instead of resurrecting stale duplicate design prose.
- Populates the current nested `ActionAffordancePayload` DTO shape and refreshes generated CLI schemas/OpenAPI.

#2307 closure docs/install surface:

- Adds ordinary Python, pipx/venv, Nix app, and NixOS service install guidance.
- Updates README verification examples to the current `devtools lab smoke` surface.
- Clarifies `NO_COLOR`, `POLYLOGUE_THEME`, and semantic theme-token policy in configuration docs.
- The executable/test conflict hunks resolved back to the current source shape after formatting, so the surviving committed delta is docs/install focused.

#2309 effective config inventory:

- Replaces the simpler generated config inventory with richer executable metadata: owner/reload classes, TOML/env/CLI paths, redacted effective JSON output, Nix module settings, docs, and tests.
- Keeps deployment-smoke `runtime_evidence` as the report envelope and reconciles the patch's effective-config assertions into that existing contract.

Patch intake status after this PR:

- `issue-2305-executable-query-action-workflows.patch`: already incorporated in current master; applying with `git apply --3way` produced no diff.
- `polylogue-2304-responsive-routes-v2.patch`: applied in this PR.
- `polylogue-2304-responsive-routes.patch`: superseded by v2.
- `polylogue_2306_context_handoff.patch`: applied in this PR.
- `polylogue-2307-closure.patch`: partially applied in this PR; surviving docs/install closure surface committed, executable hunks were formatting-equivalent to current source after conflict resolution.
- `polylogue_2309_config_inventory_effective_state.patch`: applied in this PR.
- `polylogue-2248-branch-local-provider-smoke.patch`: already incorporated/stale; current HEAD has provider-smoke command, docs, package script, and tests.
- `polylogue-2248-branch-local-live-proof-cumulative.patch`: already incorporated/stale; current HEAD has live-provider proof script, docs, CLI wiring, and tests.
- `polylogue-2248-live-provider-proof-incremental.patch`: already incorporated/stale for the same live-provider proof lane.
- `polylogue-2308-source-contracts.patch`: attempted but not applied; stale/overlapping with current receiver lifecycle code and would duplicate helpers without a manual reconciliation pass.

## Verification

#2304:

- `devtools test tests/unit/daemon/test_web_reader.py tests/unit/devtools/test_deployment_smoke.py tests/unit/sources/test_drive_auth.py`
  - `200 passed in 307.16s`
- `devtools verify --quick`
  - first run found formatting drift plus duplicate `FacetsResponse` fields from conflict resolution; fixed in the same lane
  - rerun passed with `exit_code: 0`, `total_duration_s: 17.36`

#2306:

- `devtools test tests/unit/context/test_compiler.py`
  - `10 passed in 0.90s`
- `devtools test tests/unit/context/test_compiler.py tests/unit/cli/test_context_pack_view.py tests/unit/mcp/test_context_pack.py tests/unit/daemon/test_web_reader.py`
  - first run failed on stale affordance DTO shape; fixed in the same lane
  - rerun passed with `166 passed in 293.69s`
- `devtools verify --quick`
  - first run found formatting drift, generated-surface drift, and test-only JSON typing; fixed in the same lane
  - rerun passed with `exit_code: 0`, `total_duration_s: 29.94`

#2307:

- `devtools test tests/unit/devtools/test_deployment_smoke.py tests/unit/devtools/test_verify_distribution_surface.py tests/unit/cli/test_theme_aliases_help_markdown.py`
  - `43 passed in 1.90s`
- `devtools verify --quick`
  - first run failed only on formatting in conflict-resolved Python files
  - rerun passed with `exit_code: 0`, `total_duration_s: 11.35`
- pre-push hook after #2307 reran `devtools verify --quick`
  - passed with `exit_code: 0`, `total_duration_s: 11.23`

#2309:

- `devtools test tests/unit/core/test_config_inventory.py tests/unit/cli/test_config_command.py tests/unit/cli/test_cli_action_contracts.py tests/unit/daemon/test_daemon_cli_remote_bind.py tests/unit/devtools/test_deployment_smoke.py`
  - `78 passed in 23.90s`
- `devtools verify --quick`
  - first run found formatting drift and docs-surface drift; fixed in the same lane
  - rerun passed with `exit_code: 0`, `total_duration_s: 24.17`
- pre-push hook after #2309 reran `devtools verify --quick`
  - passed with `exit_code: 0`, `total_duration_s: 12.38`

Ref #2304
Ref #2306
Ref #2307
Ref #2309
