### PR TITLE
fix(daemon): report live ingest read amplification

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -40,6 +40,25 @@ _CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
 INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson")
 
 
+def _log_ingest_metrics(prefix: str, metrics: LiveBatchMetrics) -> None:
+    """Log actual live-ingest read work separately from candidate file size."""
+    read_amp = metrics.source_payload_read_bytes / metrics.input_bytes if metrics.input_bytes > 0 else 0.0
+    logger.info(
+        "%s complete: read=%.1f MB input=%.1f MB read_amp=%.6fx append_files=%d full_files=%d "
+        "succeeded=%d failed=%d parse_s=%.3f convergence_s=%.3f",
+        prefix,
+        metrics.source_payload_read_bytes / 1e6,
+        metrics.input_bytes / 1e6,
+        read_amp,
+        metrics.append_file_count,
+        metrics.full_file_count,
+        metrics.succeeded_file_count,
+        metrics.failed_file_count,
+        metrics.parse_time_s,
+        metrics.convergence_time_s,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class WatchSource:
     """A directory to watch for live session files."""
@@ -196,11 +215,13 @@ class LiveWatcher:
                     len(chunk),
                     chunk_bytes / 1e6,
                 )
-                await self._ingest_files(
+                metrics = await self._ingest_files(
                     list(chunk),
                     queued_file_count=len(plan.candidates) if index == 1 else len(chunk),
                     skipped_file_count=plan.skipped_file_count if index == 1 else 0,
                 )
+                if metrics is not None:
+                    _log_ingest_metrics(f"live.watcher: catch-up chunk {index}/{len(chunks)}", metrics)
             self._schedule_failed_retry_scan()
 
     def _scan_catch_up_candidates(self, roots: list[Path]) -> tuple[CandidateSourceFile, ...]:
@@ -394,11 +415,13 @@ class LiveWatcher:
                 return bool(paths)
 
             logger.info("live.watcher: batching %d changed file(s)", len(needed))
-            await self._ingest_files(
+            metrics = await self._ingest_files(
                 needed,
                 queued_file_count=len(paths),
                 skipped_file_count=len(paths) - len(needed),
             )
+            if metrics is not None:
+                _log_ingest_metrics("live.watcher: changed-file batch", metrics)
             self._schedule_failed_retry_scan()
         except sqlite3.OperationalError as exc:
             if not _is_database_locked(exc):

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -31,6 +31,7 @@ from polylogue.sources.live.batch import (
     last_complete_newline_from_tail,
 )
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
+from polylogue.sources.live.metrics import LiveBatchMetrics
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawSessionRecord
 from tests.infra.frozen_clock import FrozenClock
@@ -82,6 +83,46 @@ class _FailingSecondPathConverger:
                 {"fake": 0.001},
             )
         return ({path: SimpleNamespace(converged=True) for path in paths}, {"fake": 0.001})
+
+
+def test_live_ingest_metrics_log_separates_read_bytes_from_candidate_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = MagicMock()
+    monkeypatch.setattr(live_watcher, "logger", logger)
+    metrics = LiveBatchMetrics(
+        queued_file_count=2,
+        needed_file_count=2,
+        skipped_file_count=0,
+        succeeded_file_count=2,
+        failed_file_count=0,
+        source_group_count=1,
+        input_bytes=400_000_000,
+        source_payload_read_bytes=40_000,
+        cursor_fingerprint_read_bytes=0,
+        ingest_worker_count_max=1,
+        append_file_count=2,
+        full_file_count=0,
+        archive_bytes_before=0,
+        archive_bytes_after=0,
+        archive_write_bytes_delta=0,
+        parse_time_s=0.5,
+        convergence_time_s=0.25,
+        total_time_s=1.0,
+    )
+
+    live_watcher._log_ingest_metrics("live.watcher: changed-file batch", metrics)
+
+    message, *args = logger.info.call_args.args
+    assert "read=%.1f MB input=%.1f MB read_amp=%.6fx" in message
+    assert args[:6] == [
+        "live.watcher: changed-file batch",
+        0.04,
+        400.0,
+        0.0001,
+        2,
+        0,
+    ]
 
 
 # --- CursorStore ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds operator-facing live-ingest completion logs that separate total candidate input size from the actual source bytes read by the daemon. This makes bounded append behavior visible during restart catch-up and debounced changed-file batches.

## Problem

After deploying #2322, live #2308 resource evidence showed the old failure shape is mostly gone: no running attempts, no convergence debt, FTS ready, current daemon memory around 300 MiB, and recent append attempts completing quickly. However the journal still printed messages like `catch-up ingesting 2 file(s) (401.4 MB)` even when the recorded attempt only read tens of KiB from those large Codex JSONL files. That log makes the bounded append path look like a full reread and keeps resource/backpressure diagnosis ambiguous.

Live evidence from `/realm/tmp/polylogue-workload-after-2322.json`:

- recent attempt input bytes around `401,743,775`
- `source_payload_read_bytes=17,282`
- `read_amplification=0.0`
- source paths were the two large active Codex session files

## Solution

- Adds `_log_ingest_metrics()` in `polylogue/sources/live/watcher.py` to log actual read MB, candidate input MB, read amplification, append/full file counts, success/failure counts, and parse/convergence timings.
- Calls it after catch-up chunks and debounced changed-file batches once `LiveBatchMetrics` are available.
- Keeps the existing pre-ingest candidate-size logs, but now the journal also shows the post-ingest actual work.
- Tolerates existing tests that stub `_ingest_files` without returning metrics.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py::test_catch_up_uses_bulk_cursor_records tests/unit/sources/test_live_watcher.py::test_live_ingest_metrics_log_separates_read_bytes_from_candidate_size`
  - `2 passed in 2.36s`
- `devtools test tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py`
  - `94 passed in 147.59s`
- `devtools verify --quick`
  - `exit_code: 0`, `total_duration_s: 38.65`
- pre-push `devtools verify --quick`
  - `exit_code: 0`, `total_duration_s: 11.29`

Ref #2308
