### PR TITLE
feat(archive): classify message material origin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1145,6 +1145,11 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 5 adds `messages.material_origin` plus authored-user
+  aggregate columns on `sessions`. Existing index tiers must be rebuilt from
+  source evidence so Claude Code `role=user` protocol/context/generated-pack
+  rows move out of authored-user accounting while provider-role counts remain
+  available.
 - Provider schemas (the parsing/validation surface, distinct from the
   storage schema) are still regenerated fresh via
   `devtools lab schema generate` and promoted via `devtools lab schema promote`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -73,9 +73,16 @@ Convenience properties resolve these:
 | `text` | `str?` | Flattened message text |
 | `timestamp` | `datetime?` | Message timestamp |
 | `message_type` | `MessageType` | `message`, `summary`, `tool_use`, `tool_result`, `thinking`, `context`, `protocol` |
+| `material_origin` | `MaterialOrigin` | Authoredness/material source, separate from provider role: `human_authored`, `assistant_authored`, `operator_command`, `runtime_protocol`, `runtime_context`, `tool_result`, `generated_context_pack`, `generated_analysis_pack`, `unknown` |
 | `provider` | `Provider?` | Provider-wire identity (parse-boundary only; prefer the session `origin`) |
 | `content_blocks` | `list[dict]` | Structured content blocks (text/thinking/tool_use/tool_result/image/code/document) |
 | `attachments` | `list[Attachment]` | File attachments referenced by the message |
+
+`role` preserves provider/display envelope truth. It must not be used as a
+proxy for human-authored prose: Claude Code, for example, carries command
+wrappers, task notifications, generated context packs, and tool-result
+protocol envelopes through `role=user`. Use `material_origin` for authoredness
+accounting and prose projection.
 | `parent_id` | `str?` | Parent message, for branching |
 | `branch_index` | `int` | Branch position among sibling variants |
 | `has_tool_use` / `has_thinking` / `has_paste` | `bool` | Precomputed content flags projected from storage |

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,6 +106,11 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 5 adds `messages.material_origin` plus authored-user
+  aggregate columns on `sessions`. Existing index tiers must be rebuilt from
+  source evidence so Claude Code `role=user` protocol/context/generated-pack
+  rows move out of authored-user accounting while provider-role counts remain
+  available.
 - Provider schemas (the parsing/validation surface, distinct from the
   storage schema) are still regenerated fresh via
   `devtools lab schema generate` and promoted via `devtools lab schema promote`.

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1650,6 +1650,10 @@ components:
         message_type:
           title: Message Type
           type: string
+        material_origin:
+          default: unknown
+          title: Material Origin
+          type: string
         position:
           title: Position
           type: integer

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -575,6 +575,11 @@
       "additionalProperties": false,
       "description": "Shared terminal-query row for archive messages.",
       "properties": {
+        "material_origin": {
+          "default": "unknown",
+          "title": "Material Origin",
+          "type": "string"
+        },
         "message_id": {
           "title": "Message Id",
           "type": "string"

--- a/docs/schemas/cli-output/session-message-row.schema.json
+++ b/docs/schemas/cli-output/session-message-row.schema.json
@@ -215,6 +215,11 @@
       "title": "Input Tokens",
       "type": "integer"
     },
+    "material_origin": {
+      "default": "unknown",
+      "title": "Material Origin",
+      "type": "string"
+    },
     "message_type": {
       "default": "message",
       "title": "Message Type",

--- a/docs/schemas/cli-output/session-messages-response.schema.json
+++ b/docs/schemas/cli-output/session-messages-response.schema.json
@@ -141,6 +141,11 @@
           "title": "Input Tokens",
           "type": "integer"
         },
+        "material_origin": {
+          "default": "unknown",
+          "title": "Material Origin",
+          "type": "string"
+        },
         "message_type": {
           "default": "message",
           "title": "Message Type",

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -23,7 +23,7 @@ from polylogue.archive.query.spec import normalize_action_sequence, normalize_ac
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session, SessionSummary
-from polylogue.core.enums import Origin, Provider
+from polylogue.core.enums import MaterialOrigin, Origin, Provider
 from polylogue.core.json import JSONDocument
 from polylogue.core.refs import EvidenceRef, ObjectRef, parse_public_ref
 from polylogue.core.sources import origin_from_provider, provider_from_origin
@@ -706,6 +706,7 @@ def _archive_message_to_domain(message: ArchiveMessageRow, *, provider: Provider
         provider=provider,
         blocks=content_blocks,
         message_type=MessageType.normalize(message.message_type),
+        material_origin=MaterialOrigin.normalize(message.material_origin),
         has_tool_use=message.has_tool_use,
         has_thinking=message.has_thinking,
         has_paste=message.has_paste,

--- a/polylogue/archive/message/artifacts.py
+++ b/polylogue/archive/message/artifacts.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 
 from polylogue.archive.message.types import MessageType
+from polylogue.core.enums import BlockType, MaterialOrigin, Role
 
 _SYSTEM_REMINDER_PATTERN = re.compile(r"<system-reminder>.*?</system-reminder>\s*", re.DOTALL)
 
@@ -49,6 +50,20 @@ _CLAUDE_CODE_PROTOCOL_START_MARKERS = (
 
 _CONTENTS_OF_LINE_RE = re.compile(r"^Contents of .+:", re.MULTILINE)
 _FILE_PATH_LINE_RE = re.compile(r"^<file path=", re.MULTILINE)
+_GENERATED_CONTEXT_PACK_START_MARKERS = (
+    "# Commit ",
+    "Generate all artifacts",
+)
+_GENERATED_ANALYSIS_PACK_START_MARKERS = (
+    "Generate a retrospective for:",
+    "Generate retrospective for:",
+)
+_OPERATOR_COMMAND_MARKERS = (
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "<bash-input>",
+)
 
 
 def strip_system_reminders(text: str) -> str:
@@ -97,7 +112,41 @@ def classify_text_message_type(text: str | None) -> MessageType | None:
     return None
 
 
+def classify_material_origin(
+    *,
+    role: Role,
+    message_type: MessageType,
+    text: str | None,
+    block_types: tuple[BlockType, ...] = (),
+) -> MaterialOrigin:
+    """Classify authoredness/material origin independently from provider role."""
+    normalized_role = role
+    normalized_type = MessageType.normalize(message_type)
+    stripped = strip_leading_system_reminders(text or "")
+
+    if normalized_role is Role.TOOL or normalized_type is MessageType.TOOL_RESULT:
+        return MaterialOrigin.TOOL_RESULT
+    if block_types and all(block_type is BlockType.TOOL_RESULT for block_type in block_types):
+        return MaterialOrigin.TOOL_RESULT
+    if stripped.startswith(_GENERATED_ANALYSIS_PACK_START_MARKERS):
+        return MaterialOrigin.GENERATED_ANALYSIS_PACK
+    if stripped.startswith(_GENERATED_CONTEXT_PACK_START_MARKERS):
+        return MaterialOrigin.GENERATED_CONTEXT_PACK
+    if normalized_type is MessageType.CONTEXT:
+        return MaterialOrigin.RUNTIME_CONTEXT
+    if normalized_type is MessageType.PROTOCOL:
+        if any(marker in stripped for marker in _OPERATOR_COMMAND_MARKERS):
+            return MaterialOrigin.OPERATOR_COMMAND
+        return MaterialOrigin.RUNTIME_PROTOCOL
+    if normalized_role is Role.USER and normalized_type is MessageType.MESSAGE:
+        return MaterialOrigin.HUMAN_AUTHORED
+    if normalized_role is Role.ASSISTANT and normalized_type is MessageType.MESSAGE:
+        return MaterialOrigin.ASSISTANT_AUTHORED
+    return MaterialOrigin.UNKNOWN
+
+
 __all__ = [
+    "classify_material_origin",
     "classify_text_message_type",
     "strip_leading_system_reminders",
     "strip_system_reminders",

--- a/polylogue/archive/message/model_runtime.py
+++ b/polylogue/archive/message/model_runtime.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
-from polylogue.core.enums import Provider
+from polylogue.core.enums import MaterialOrigin, Provider
 
 
 def _block_texts(blocks: Iterable[Mapping[str, object]], *, block_type: str) -> list[str]:
@@ -42,6 +42,7 @@ class MessageRuntimeMixin:
     attachments: list[Attachment]
     blocks: list[dict[str, object]]
     message_type: MessageType
+    material_origin: MaterialOrigin
     parent_id: str | None
     branch_index: int
 
@@ -52,6 +53,19 @@ class MessageRuntimeMixin:
     @property
     def is_user(self) -> bool:
         return self.role == Role.USER
+
+    @property
+    def is_human_authored(self) -> bool:
+        return MaterialOrigin.normalize(getattr(self, "material_origin", MaterialOrigin.UNKNOWN)) is (
+            MaterialOrigin.HUMAN_AUTHORED
+        )
+
+    @property
+    def is_authored_prose(self) -> bool:
+        return MaterialOrigin.normalize(getattr(self, "material_origin", MaterialOrigin.UNKNOWN)) in {
+            MaterialOrigin.HUMAN_AUTHORED,
+            MaterialOrigin.ASSISTANT_AUTHORED,
+        }
 
     @property
     def is_assistant(self) -> bool:

--- a/polylogue/archive/message/models.py
+++ b/polylogue/archive/message/models.py
@@ -10,7 +10,7 @@ from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.model_runtime import MessageRuntimeMixin
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
-from polylogue.core.enums import Provider
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider
 
 
 class Message(MessageRuntimeMixin, BaseModel):
@@ -22,6 +22,7 @@ class Message(MessageRuntimeMixin, BaseModel):
     attachments: list[Attachment] = Field(default_factory=list)
     blocks: list[dict[str, object]] = Field(default_factory=list)
     message_type: MessageType = MessageType.MESSAGE
+    material_origin: MaterialOrigin = MaterialOrigin.UNKNOWN
     parent_id: str | None = None
     branch_index: int = 0
     # Stats projected from the storage layer so reader surfaces can
@@ -60,6 +61,33 @@ class Message(MessageRuntimeMixin, BaseModel):
     @classmethod
     def coerce_message_type(cls, v: object) -> MessageType:
         return MessageType.normalize(v)
+
+    @field_validator("material_origin", mode="before")
+    @classmethod
+    def coerce_material_origin(cls, v: object) -> MaterialOrigin:
+        return MaterialOrigin.normalize(v)
+
+    @model_validator(mode="after")
+    def derive_material_origin(self) -> Message:
+        if self.material_origin is MaterialOrigin.UNKNOWN:
+            from polylogue.archive.message.artifacts import classify_material_origin
+
+            block_types: list[BlockType] = []
+            for block in self.blocks:
+                raw_type = block.get("type")
+                if raw_type is None:
+                    continue
+                try:
+                    block_types.append(BlockType.from_string(str(raw_type)))
+                except ValueError:
+                    continue
+            self.material_origin = classify_material_origin(
+                role=self.role,
+                message_type=self.message_type,
+                text=self.text,
+                block_types=tuple(block_types),
+            )
+        return self
 
 
 class DialoguePair(BaseModel):

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -19,7 +19,7 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.domain_models import Session, SessionSummary
-from polylogue.core.enums import Provider
+from polylogue.core.enums import MaterialOrigin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.types import SessionId
 
@@ -249,6 +249,7 @@ def _message_to_domain(message: ArchiveMessageRow, *, provider: Provider) -> Mes
         provider=provider,
         blocks=content_blocks,
         message_type=MessageType.normalize(message.message_type),
+        material_origin=MaterialOrigin.normalize(message.material_origin),
         has_tool_use=message.has_tool_use,
         has_thinking=message.has_thinking,
         has_paste=message.has_paste,

--- a/polylogue/archive/semantic/content_projection.py
+++ b/polylogue/archive/semantic/content_projection.py
@@ -234,6 +234,8 @@ def _segments_from_text(message: Message) -> list[_Segment]:
         return []
     if message.role == Role.TOOL or message.is_tool_use:
         return [_Segment(ContentKind.TOOL_OUTPUT, text)]
+    if not message.is_authored_prose:
+        return [_Segment(ContentKind.SYSTEM_NOISE, text)]
     if message.is_context_dump or message.is_protocol_artifact or message.is_system:
         return [_Segment(ContentKind.SYSTEM_NOISE, text)]
 

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -152,6 +152,37 @@ class MessageType(PolylogueStrEnum):
         raise ValueError(msg)
 
 
+class MaterialOrigin(PolylogueStrEnum):
+    """Archive-visible authoredness/material-origin axis for messages.
+
+    ``Role`` preserves provider/API envelope truth. Material origin answers
+    what kind of material the row represents for accounting, projections, and
+    user-facing prose filters.
+    """
+
+    HUMAN_AUTHORED = "human_authored"
+    ASSISTANT_AUTHORED = "assistant_authored"
+    OPERATOR_COMMAND = "operator_command"
+    RUNTIME_PROTOCOL = "runtime_protocol"
+    RUNTIME_CONTEXT = "runtime_context"
+    TOOL_RESULT = "tool_result"
+    GENERATED_CONTEXT_PACK = "generated_context_pack"
+    GENERATED_ANALYSIS_PACK = "generated_analysis_pack"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def normalize(cls, value: object) -> MaterialOrigin:
+        if isinstance(value, MaterialOrigin):
+            return value
+        candidate = (str(value) if value is not None else "").strip().lower().replace("-", "_")
+        if not candidate:
+            return cls.UNKNOWN
+        for item in cls:
+            if item.value == candidate:
+                return item
+        return cls.UNKNOWN
+
+
 class BlockType(PolylogueStrEnum):
     """Canonical stored and parsed block kinds.
 
@@ -358,6 +389,7 @@ __all__ = [
     "BlockType",
     "BranchType",
     "LinkType",
+    "MaterialOrigin",
     "MessageType",
     "Origin",
     "PasteBoundary",

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -896,6 +896,13 @@ def _message_type_value(message: object) -> str:
     return str(message_type)
 
 
+def _material_origin_value(message: object) -> str:
+    material_origin = getattr(message, "material_origin", "")
+    if hasattr(material_origin, "value"):
+        return str(material_origin.value)
+    return str(material_origin)
+
+
 def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator that discriminates PolylogueError types to HTTP status codes.
 
@@ -2177,6 +2184,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "actions": _dump_actions(reader_message_actions()),
                     "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
                     "message_type": _message_type_value(msg),
+                    "material_origin": _material_origin_value(msg),
                     "word_count": msg.word_count,
                     "has_tool_use": bool(msg.has_tool_use) if hasattr(msg, "has_tool_use") else False,
                     "has_thinking": bool(msg.has_thinking) if hasattr(msg, "has_thinking") else False,
@@ -2359,6 +2367,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             "actions": _dump_actions(reader_message_actions()),
             "timestamp": message.occurred_at,
             "message_type": message.message_type,
+            "material_origin": message.material_origin,
             "word_count": message.word_count,
             "has_tool_use": bool(message.has_tool_use),
             "has_thinking": bool(message.has_thinking),
@@ -3202,6 +3211,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "actions": _dump_actions(reader_message_actions()),
                     "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
                     "message_type": _message_type_value(msg),
+                    "material_origin": _material_origin_value(msg),
                     "word_count": msg.word_count,
                 }
                 for msg in messages

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1978,7 +1978,7 @@ def daemon_status_payload(
             "component_state": status.component_state.model_dump(),
             "component_readiness": status.component_readiness,
             "live": live_source_status_payload(watch_sources),
-            "browser_capture": browser_capture_status_public_payload(browser_capture_spool_path),
+            "browser_capture": browser_capture_status_payload(browser_capture_spool_path),
             "db_path": str(_active_status_db_path()),
             "db_size_bytes": status.db_size_bytes,
             "wal_size_bytes": status.wal_size_bytes,

--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -412,6 +412,7 @@ class ArchiveCoverageInsight(ArchiveInsightModel):
     logical_session_count: int = 0
     message_count: int = 0
     user_message_count: int = 0
+    authored_user_message_count: int = 0
     assistant_message_count: int = 0
     total_cost_usd: float = 0.0
     total_duration_ms: int = 0
@@ -420,6 +421,7 @@ class ArchiveCoverageInsight(ArchiveInsightModel):
     total_words: int = 0
     avg_messages_per_session: float = 0.0
     avg_user_words: float = 0.0
+    avg_authored_user_words: float = 0.0
     avg_assistant_words: float = 0.0
     tool_use_count: int = 0
     thinking_count: int = 0

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -106,6 +106,14 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _session_transform_timestamp(session: Session) -> str:
+    message_timestamps = [message.timestamp for message in session.messages if message.timestamp is not None]
+    timestamp = session.updated_at or session.created_at or (max(message_timestamps) if message_timestamps else None)
+    if timestamp is None:
+        return "1970-01-01T00:00:00+00:00"
+    return timestamp.astimezone(timezone.utc).isoformat()
+
+
 class TransformRawRef(ArchiveInsightModel):
     """Pointer back to the raw session evidence that produced a digest claim."""
 
@@ -506,6 +514,7 @@ def compile_recovery_digest(
             transform_version=RECOVERY_TRANSFORM_VERSION,
             input_session_id=str(session.id),
             source_origin=str(session.origin),
+            computed_at=_session_transform_timestamp(session),
             input_message_count=len(messages),
         ),
         size_metrics=RecoverySizeMetrics(

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -255,6 +255,7 @@ def archive_message_payload(message: ArchiveMessageRow, *, session_id: str) -> M
         anchor=reader_anchor("message", message.message_id),
         timestamp=_parse_archive_datetime(message.occurred_at),
         message_type=message.message_type,
+        material_origin=message.material_origin,
         content_blocks=content_blocks,
         branch_index=message.variant_index,
         has_paste=message.has_paste,

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -385,6 +385,9 @@ def _write_session_entry(
 
 
 def _delete_stale_sessions_for_raw_entries(conn: sqlite3.Connection, ready_entries: list[_SessionEntry]) -> None:
+    if not hasattr(conn, "execute"):
+        return
+
     expected_by_raw_id: dict[str, set[str]] = {}
     for raw_id, cdata in ready_entries:
         if raw_id:

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -42,20 +42,22 @@ INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson")
 
 def _log_ingest_metrics(prefix: str, metrics: LiveBatchMetrics) -> None:
     """Log actual live-ingest read work separately from candidate file size."""
-    read_amp = metrics.source_payload_read_bytes / metrics.input_bytes if metrics.input_bytes > 0 else 0.0
+    input_bytes = getattr(metrics, "input_bytes", 0)
+    source_payload_read_bytes = getattr(metrics, "source_payload_read_bytes", 0)
+    read_amp = source_payload_read_bytes / input_bytes if input_bytes > 0 else 0.0
     logger.info(
         "%s complete: read=%.1f MB input=%.1f MB read_amp=%.6fx append_files=%d full_files=%d "
         "succeeded=%d failed=%d parse_s=%.3f convergence_s=%.3f",
         prefix,
-        metrics.source_payload_read_bytes / 1e6,
-        metrics.input_bytes / 1e6,
+        source_payload_read_bytes / 1e6,
+        input_bytes / 1e6,
         read_amp,
-        metrics.append_file_count,
-        metrics.full_file_count,
-        metrics.succeeded_file_count,
-        metrics.failed_file_count,
-        metrics.parse_time_s,
-        metrics.convergence_time_s,
+        getattr(metrics, "append_file_count", 0),
+        getattr(metrics, "full_file_count", 0),
+        getattr(metrics, "succeeded_file_count", 0),
+        getattr(metrics, "failed_file_count", 0),
+        getattr(metrics, "parse_time_s", 0.0),
+        getattr(metrics, "convergence_time_s", 0.0),
     )
 
 

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -9,7 +9,7 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator, model_vali
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, Provider, TitleSource
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider, TitleSource
 from polylogue.core.security import sanitize_path as _sanitize_path_helper
 from polylogue.core.timestamps import parse_timestamp
 
@@ -60,6 +60,7 @@ class ParsedMessage(BaseModel):
     occurred_at_ms: int | None = None
     blocks: list[ParsedContentBlock] = Field(default_factory=list)
     message_type: MessageType = MessageType.MESSAGE
+    material_origin: MaterialOrigin = MaterialOrigin.UNKNOWN
     parent_message_provider_id: str | None = None
     position: int | None = None
     branch_index: int = 0
@@ -93,6 +94,11 @@ class ParsedMessage(BaseModel):
     def coerce_message_type(cls, v: object) -> MessageType:
         return MessageType.normalize(v)
 
+    @field_validator("material_origin", mode="before")
+    @classmethod
+    def coerce_material_origin(cls, v: object) -> MaterialOrigin:
+        return MaterialOrigin.normalize(v)
+
     @field_validator("occurred_at_ms", "position", "variant_index", "duration_ms")
     @classmethod
     def non_negative_optional_int(cls, value: int | None) -> int | None:
@@ -106,6 +112,15 @@ class ParsedMessage(BaseModel):
             parsed = parse_timestamp(self.timestamp)
             if parsed is not None:
                 self.occurred_at_ms = int(parsed.timestamp() * 1000)
+        if self.material_origin is MaterialOrigin.UNKNOWN:
+            from polylogue.archive.message.artifacts import classify_material_origin
+
+            self.material_origin = classify_material_origin(
+                role=self.role,
+                message_type=self.message_type,
+                text=self.text,
+                block_types=tuple(block.type for block in self.blocks),
+            )
         return self
 
 

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -6,11 +6,11 @@ import re
 from collections.abc import Iterable, Sequence
 from typing import TypeAlias
 
-from polylogue.archive.message.artifacts import classify_text_message_type
+from polylogue.archive.message.artifacts import classify_material_origin, classify_text_message_type
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, PasteBoundary, Provider
+from polylogue.core.enums import BlockType, MaterialOrigin, PasteBoundary, Provider
 from polylogue.logging import get_logger
 from polylogue.pipeline.semantic_capture import detect_context_compaction
 
@@ -251,6 +251,12 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
         msg_effort = _message_model_effort(message_payload) or _message_model_effort(item)
         msg_duration_ms = _message_duration_ms(item)
         resolved_role = reclassify_tool_result_envelope(envelope_role, content_blocks)
+        material_origin = classify_material_origin(
+            role=resolved_role,
+            message_type=message_type,
+            text=text,
+            block_types=tuple(block.type for block in content_blocks),
+        )
         # Paste markers only appear in user prompts; restricting detection to the
         # user role avoids false positives from assistant text that quotes a marker.
         paste_spans = _detect_paste_spans(text) if resolved_role == Role.USER else []
@@ -262,6 +268,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
                 timestamp=timestamp,
                 blocks=content_blocks,
                 message_type=message_type,
+                material_origin=material_origin,
                 parent_message_provider_id=_string_field(item, "parentUuid"),
                 position=message_position,
                 variant_index=0,
@@ -327,7 +334,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
 
     title = str(composed_session_id)
     for message in messages:
-        if message.role == "user" and message.text and len(message.text.strip()) > 3:
+        if message.material_origin is MaterialOrigin.HUMAN_AUTHORED and message.text and len(message.text.strip()) > 3:
             # Strip protocol artifacts before extracting title
             cleaned = _clean_title_text(message.text)
             if cleaned and len(cleaned) > 3:

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -124,6 +124,7 @@ def message_from_record(
         attachments=[attachment_from_record(a) for a in attachments],
         blocks=blocks,
         message_type=record.message_type,
+        material_origin=record.material_origin,
         parent_id=record.parent_message_id,
         branch_index=record.branch_index,
         has_tool_use=bool(record.has_tool_use),

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, Origin, SemanticBlockType
+from polylogue.core.enums import BlockType, MaterialOrigin, Origin, SemanticBlockType
 from polylogue.core.hashing import hash_text
 from polylogue.core.json import json_document
 from polylogue.core.security import sanitize_path as _sanitize_path_helper
@@ -139,6 +139,7 @@ class MessageRecord(BaseModel):
     duration_ms: int | None = None
     model_name: str | None = None
     message_type: MessageType = MessageType.MESSAGE
+    material_origin: MaterialOrigin = MaterialOrigin.UNKNOWN
     paste_boundary_state: str | None = None
 
     @field_validator("role", mode="before")
@@ -156,6 +157,11 @@ class MessageRecord(BaseModel):
     @classmethod
     def coerce_message_type(cls, v: object) -> MessageType:
         return MessageType.normalize(v)
+
+    @field_validator("material_origin", mode="before")
+    @classmethod
+    def coerce_material_origin(cls, v: object) -> MaterialOrigin:
+        return MaterialOrigin.normalize(v)
 
     @property
     def role_typed(self) -> Role:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -173,10 +173,12 @@ class ArchiveSessionSummary:
     thinking_count: int = 0
     paste_count: int = 0
     user_message_count: int = 0
+    authored_user_message_count: int = 0
     assistant_message_count: int = 0
     system_message_count: int = 0
     tool_message_count: int = 0
     user_word_count: int = 0
+    authored_user_word_count: int = 0
     assistant_word_count: int = 0
     working_directories: tuple[str, ...] = ()
     git_branch: str | None = None
@@ -207,6 +209,7 @@ class ArchiveMessageQueryRow:
     title: str | None
     role: str
     message_type: str
+    material_origin: str
     position: int
     word_count: int
     text: str
@@ -1220,8 +1223,10 @@ class ArchiveStore:
             SELECT s.session_id, s.native_id, s.origin, s.title, s.created_at_ms, s.updated_at_ms,
                    s.message_count, s.word_count, s.reported_duration_ms,
                    s.tool_use_count, s.thinking_count, s.paste_count,
-                   s.user_message_count, s.assistant_message_count, s.system_message_count,
-                   s.tool_message_count, s.user_word_count, s.assistant_word_count,
+                   s.user_message_count, s.authored_user_message_count,
+                   s.assistant_message_count, s.system_message_count,
+                   s.tool_message_count, s.user_word_count, s.authored_user_word_count,
+                   s.assistant_word_count,
                    s.git_branch, s.git_repository_url,
                    COALESCE(
                        (
@@ -1598,8 +1603,10 @@ class ArchiveStore:
                 COUNT(*) AS session_count,
                 SUM(s.message_count) AS message_count,
                 SUM(s.user_message_count) AS user_message_count,
+                SUM(s.authored_user_message_count) AS authored_user_message_count,
                 SUM(s.assistant_message_count) AS assistant_message_count,
                 SUM(s.user_word_count) AS user_word_sum,
+                SUM(s.authored_user_word_count) AS authored_user_word_sum,
                 SUM(s.assistant_word_count) AS assistant_word_sum,
                 SUM(s.tool_use_count) AS tool_use_count,
                 SUM(s.thinking_count) AS thinking_count,
@@ -2995,8 +3002,10 @@ class ArchiveStore:
             SELECT s.session_id, s.native_id, s.origin, s.title, s.created_at_ms, s.updated_at_ms,
                    s.message_count, s.word_count, s.reported_duration_ms,
                    s.tool_use_count, s.thinking_count, s.paste_count,
-                   s.user_message_count, s.assistant_message_count, s.system_message_count,
-                   s.tool_message_count, s.user_word_count, s.assistant_word_count,
+                   s.user_message_count, s.authored_user_message_count,
+                   s.assistant_message_count, s.system_message_count,
+                   s.tool_message_count, s.user_word_count, s.authored_user_word_count,
+                   s.assistant_word_count,
                    s.git_branch, s.git_repository_url,
                    COALESCE(
                        (
@@ -3409,6 +3418,7 @@ class ArchiveStore:
                 s.title,
                 m.role,
                 m.message_type,
+                m.material_origin,
                 m.position,
                 m.word_count,
                 COALESCE((
@@ -3438,6 +3448,7 @@ class ArchiveStore:
                 title=str(row["title"]) if row["title"] is not None else None,
                 role=str(row["role"]),
                 message_type=str(row["message_type"]),
+                material_origin=str(row["material_origin"]),
                 position=int(row["position"]),
                 word_count=int(row["word_count"]),
                 text=str(row["text"] or ""),
@@ -4089,10 +4100,12 @@ def _summary_from_row(row: sqlite3.Row) -> ArchiveSessionSummary:
         thinking_count=row_int("thinking_count"),
         paste_count=row_int("paste_count"),
         user_message_count=row_int("user_message_count"),
+        authored_user_message_count=row_int("authored_user_message_count"),
         assistant_message_count=row_int("assistant_message_count"),
         system_message_count=row_int("system_message_count"),
         tool_message_count=row_int("tool_message_count"),
         user_word_count=row_int("user_word_count"),
+        authored_user_word_count=row_int("authored_user_word_count"),
         assistant_word_count=row_int("assistant_word_count"),
         working_directories=working_directories,
         git_branch=str(row["git_branch"]) if row["git_branch"] is not None else None,
@@ -5972,8 +5985,10 @@ def _provider_coverage_from_archive_row(row: sqlite3.Row) -> ArchiveCoverageInsi
     session_count = int(row["session_count"] or 0)
     message_count = int(row["message_count"] or 0)
     user_message_count = int(row["user_message_count"] or 0)
+    authored_user_message_count = int(row["authored_user_message_count"] or 0)
     assistant_message_count = int(row["assistant_message_count"] or 0)
     user_word_sum = int(row["user_word_sum"] or 0)
+    authored_user_word_sum = int(row["authored_user_word_sum"] or 0)
     assistant_word_sum = int(row["assistant_word_sum"] or 0)
     sessions_with_tools = int(row["sessions_with_tools"] or 0)
     sessions_with_thinking = int(row["sessions_with_thinking"] or 0)
@@ -5985,9 +6000,13 @@ def _provider_coverage_from_archive_row(row: sqlite3.Row) -> ArchiveCoverageInsi
         session_count=session_count,
         message_count=message_count,
         user_message_count=user_message_count,
+        authored_user_message_count=authored_user_message_count,
         assistant_message_count=assistant_message_count,
         avg_messages_per_session=(message_count / session_count if session_count else 0.0),
         avg_user_words=(user_word_sum / user_message_count if user_message_count else 0.0),
+        avg_authored_user_words=(
+            authored_user_word_sum / authored_user_message_count if authored_user_message_count else 0.0
+        ),
         avg_assistant_words=(assistant_word_sum / assistant_message_count if assistant_message_count else 0.0),
         tool_use_count=int(row["tool_use_count"] or 0),
         thinking_count=int(row["thinking_count"] or 0),

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
-from polylogue.core.enums import BlockType, BranchType, LinkType, MessageType, Origin, PasteBoundary, Role
+from polylogue.core.enums import (
+    BlockType,
+    BranchType,
+    LinkType,
+    MaterialOrigin,
+    MessageType,
+    Origin,
+    PasteBoundary,
+    Role,
+)
 from polylogue.storage.sqlite.archive_tiers.common import CONTENT_HASH_CHECK, check, nullable_check
 
-INDEX_SCHEMA_VERSION = 4
+INDEX_SCHEMA_VERSION = 5
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -30,10 +39,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     thinking_count          INTEGER NOT NULL DEFAULT 0 CHECK(thinking_count >= 0),
     paste_count             INTEGER NOT NULL DEFAULT 0 CHECK(paste_count >= 0),
     user_message_count      INTEGER NOT NULL DEFAULT 0 CHECK(user_message_count >= 0),
+    authored_user_message_count INTEGER NOT NULL DEFAULT 0 CHECK(authored_user_message_count >= 0),
     assistant_message_count INTEGER NOT NULL DEFAULT 0 CHECK(assistant_message_count >= 0),
     system_message_count    INTEGER NOT NULL DEFAULT 0 CHECK(system_message_count >= 0),
     tool_message_count      INTEGER NOT NULL DEFAULT 0 CHECK(tool_message_count >= 0),
     user_word_count         INTEGER NOT NULL DEFAULT 0 CHECK(user_word_count >= 0),
+    authored_user_word_count INTEGER NOT NULL DEFAULT 0 CHECK(authored_user_word_count >= 0),
     assistant_word_count    INTEGER NOT NULL DEFAULT 0 CHECK(assistant_word_count >= 0),
     content_hash            BLOB NOT NULL {CONTENT_HASH_CHECK},
     created_at_ms           INTEGER,
@@ -67,6 +78,7 @@ CREATE TABLE IF NOT EXISTS messages (
     position            INTEGER NOT NULL CHECK(position >= 0),
     role                TEXT NOT NULL CHECK ({check("role", Role)}),
     message_type        TEXT NOT NULL DEFAULT 'message' CHECK ({check("message_type", MessageType)}),
+    material_origin     TEXT NOT NULL DEFAULT 'unknown' CHECK ({check("material_origin", MaterialOrigin)}),
     model_name          TEXT,
     model_effort        TEXT,
     has_tool_use        INTEGER NOT NULL DEFAULT 0 CHECK(has_tool_use IN (0, 1)),
@@ -96,6 +108,9 @@ WHERE parent_message_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_messages_session_role
 ON messages(session_id, role);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session_material_origin
+ON messages(session_id, material_origin);
 
 CREATE INDEX IF NOT EXISTS idx_messages_active_path
 ON messages(session_id, is_active_path, position)

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -68,6 +68,7 @@ class ArchiveMessageRow:
     is_active_leaf: bool
     blocks: tuple[ArchiveBlockRow, ...]
     message_type: str = "message"
+    material_origin: str = "unknown"
     word_count: int = 0
     has_tool_use: bool = False
     has_thinking: bool = False
@@ -210,10 +211,11 @@ def write_parsed_session_to_archive(
                 title, title_source, git_branch, git_repository_url, commit_hash,
                 instructions_text, reported_duration_ms,
                 message_count, word_count, tool_use_count, thinking_count,
-                paste_count, user_message_count, assistant_message_count, system_message_count,
-                tool_message_count, user_word_count, assistant_word_count,
+                paste_count, user_message_count, authored_user_message_count,
+                assistant_message_count, system_message_count,
+                tool_message_count, user_word_count, authored_user_word_count, assistant_word_count,
                 content_hash, created_at_ms, updated_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(origin, native_id) DO UPDATE SET
                 raw_id = excluded.raw_id,
                 branch_type = excluded.branch_type,
@@ -248,10 +250,16 @@ def write_parsed_session_to_archive(
                 sum(_has_block(message, BlockType.THINKING) for message in messages),
                 sum(_has_paste(message) for message in messages),
                 sum(1 for message in messages if _enum_value(message.role) == "user"),
+                sum(1 for message in messages if _enum_value(message.material_origin) == "human_authored"),
                 sum(1 for message in messages if _enum_value(message.role) == "assistant"),
                 sum(1 for message in messages if _enum_value(message.role) == "system"),
                 sum(1 for message in messages if _enum_value(message.role) == "tool"),
                 sum(_word_count(message.text) for message in messages if _enum_value(message.role) == "user"),
+                sum(
+                    _word_count(message.text)
+                    for message in messages
+                    if _enum_value(message.material_origin) == "human_authored"
+                ),
                 sum(_word_count(message.text) for message in messages if _enum_value(message.role) == "assistant"),
                 session_content_hash,
                 _timestamp_ms(session.created_at),
@@ -975,7 +983,7 @@ def read_archive_session_envelope(conn: sqlite3.Connection, session_id: str) -> 
     message_rows = conn.execute(
         """
         SELECT message_id, native_id, role, position, variant_index, is_active_path, is_active_leaf,
-               message_type, word_count, has_tool_use, has_thinking, has_paste, occurred_at_ms,
+               message_type, material_origin, word_count, has_tool_use, has_thinking, has_paste, occurred_at_ms,
                duration_ms, parent_message_id
         FROM messages
         WHERE session_id = ?
@@ -1019,6 +1027,7 @@ def read_archive_session_envelope(conn: sqlite3.Connection, session_id: str) -> 
                     for block in block_rows
                 ),
                 message_type=message["message_type"],
+                material_origin=message["material_origin"],
                 word_count=int(message["word_count"] or 0),
                 has_tool_use=bool(message["has_tool_use"]),
                 has_thinking=bool(message["has_thinking"]),
@@ -1131,6 +1140,7 @@ def _write_messages(
                 position,
                 _enum_value(message.role),
                 _enum_value(message.message_type),
+                _enum_value(message.material_origin),
                 _sqlite_text(message.model_name),
                 _sqlite_text(message.model_effort),
                 _has_block(message, BlockType.TOOL_USE),
@@ -1155,12 +1165,12 @@ def _write_messages(
     conn.executemany(
         """
         INSERT OR REPLACE INTO messages (
-            session_id, native_id, parent_message_id, position, role, message_type,
+            session_id, native_id, parent_message_id, position, role, message_type, material_origin,
             model_name, model_effort, has_tool_use, has_thinking, has_paste, paste_boundary,
             variant_index, is_active_path, is_active_leaf, word_count,
             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
             duration_ms, content_hash, occurred_at_ms
-        ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         rows(),
     )
@@ -1222,6 +1232,10 @@ def _refresh_session_counts(conn: sqlite3.Connection, session_id: str) -> None:
             user_message_count = (
                 SELECT COUNT(*) FROM messages WHERE session_id = sessions.session_id AND role = 'user'
             ),
+            authored_user_message_count = (
+                SELECT COUNT(*) FROM messages
+                WHERE session_id = sessions.session_id AND material_origin = 'human_authored'
+            ),
             assistant_message_count = (
                 SELECT COUNT(*) FROM messages WHERE session_id = sessions.session_id AND role = 'assistant'
             ),
@@ -1233,6 +1247,10 @@ def _refresh_session_counts(conn: sqlite3.Connection, session_id: str) -> None:
             ),
             user_word_count = COALESCE((
                 SELECT SUM(word_count) FROM messages WHERE session_id = sessions.session_id AND role = 'user'
+            ), 0),
+            authored_user_word_count = COALESCE((
+                SELECT SUM(word_count) FROM messages
+                WHERE session_id = sessions.session_id AND material_origin = 'human_authored'
             ), 0),
             assistant_word_count = COALESCE((
                 SELECT SUM(word_count) FROM messages WHERE session_id = sessions.session_id AND role = 'assistant'

--- a/polylogue/storage/sqlite/async_sqlite.py
+++ b/polylogue/storage/sqlite/async_sqlite.py
@@ -531,6 +531,7 @@ class SQLiteBackend(
         async with self._get_connection() as conn:
             if _is_initialized_archive_index(self._db_path):
                 from polylogue.archive.message.roles import Role
+                from polylogue.core.enums import MaterialOrigin
 
                 message_count = len(messages)
                 word_count = sum(message.word_count for message in messages)
@@ -538,10 +539,18 @@ class SQLiteBackend(
                 thinking_count = sum(1 for message in messages if message.has_thinking)
                 paste_count = sum(1 for message in messages if message.has_paste)
                 user_message_count = sum(1 for message in messages if message.role == Role.USER)
+                authored_user_message_count = sum(
+                    1 for message in messages if message.material_origin == MaterialOrigin.HUMAN_AUTHORED
+                )
                 assistant_message_count = sum(1 for message in messages if message.role == Role.ASSISTANT)
                 system_message_count = sum(1 for message in messages if message.role == Role.SYSTEM)
                 tool_message_count = sum(1 for message in messages if message.role == Role.TOOL)
                 user_word_count = sum(message.word_count for message in messages if message.role == Role.USER)
+                authored_user_word_count = sum(
+                    message.word_count
+                    for message in messages
+                    if message.material_origin == MaterialOrigin.HUMAN_AUTHORED
+                )
                 assistant_word_count = sum(message.word_count for message in messages if message.role == Role.ASSISTANT)
                 await conn.execute(
                     """
@@ -552,10 +561,12 @@ class SQLiteBackend(
                         thinking_count = ?,
                         paste_count = ?,
                         user_message_count = ?,
+                        authored_user_message_count = ?,
                         assistant_message_count = ?,
                         system_message_count = ?,
                         tool_message_count = ?,
                         user_word_count = ?,
+                        authored_user_word_count = ?,
                         assistant_word_count = ?
                     WHERE session_id = ? OR native_id = ?
                     """,
@@ -566,10 +577,12 @@ class SQLiteBackend(
                         thinking_count,
                         paste_count,
                         user_message_count,
+                        authored_user_message_count,
                         assistant_message_count,
                         system_message_count,
                         tool_message_count,
                         user_word_count,
+                        authored_user_word_count,
                         assistant_word_count,
                         session_id,
                         session_id,

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -11,6 +11,7 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import (
     ArtifactSupportStatus,
     BlockType,
+    MaterialOrigin,
     Origin,
     SemanticBlockType,
     ValidationMode,
@@ -85,6 +86,7 @@ def _row_to_message(row: sqlite3.Row) -> MessageRecord:
         cache_write_tokens=_row_int(row, "cache_write_tokens", 0) or 0,
         model_name=_row_text(row, "model_name"),
         message_type=MessageType.normalize(_row_text(row, "message_type") or "message"),
+        material_origin=MaterialOrigin.normalize(_row_text(row, "material_origin")),
     )
 
 

--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -36,6 +36,7 @@ _MESSAGE_RECORD_SELECT = """
     m.has_thinking,
     m.has_paste,
     m.message_type,
+    m.material_origin,
     m.model_name,
     m.input_tokens,
     m.output_tokens,

--- a/polylogue/storage/sqlite/queries/stats.py
+++ b/polylogue/storage/sqlite/queries/stats.py
@@ -39,8 +39,10 @@ class ProviderMetricsRow(TypedDict):
     session_count: int
     message_count: int
     user_message_count: int
+    authored_user_message_count: int
     assistant_message_count: int
     user_word_sum: int
+    authored_user_word_sum: int
     assistant_word_sum: int
     tool_use_count: int
     thinking_count: int
@@ -244,12 +246,15 @@ async def upsert_session_stats(
     thinking_count = sum(1 for m in messages if m.has_thinking)
     paste_count = sum(1 for m in messages if m.has_paste)
     from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import MaterialOrigin
 
     user_msg_count = sum(1 for m in messages if m.role == Role.USER)
+    authored_user_msg_count = sum(1 for m in messages if m.material_origin == MaterialOrigin.HUMAN_AUTHORED)
     assistant_msg_count = sum(1 for m in messages if m.role == Role.ASSISTANT)
     system_msg_count = sum(1 for m in messages if m.role == Role.SYSTEM)
     tool_msg_count = sum(1 for m in messages if m.role == Role.TOOL)
     user_word_count = sum(m.word_count for m in messages if m.role == Role.USER)
+    authored_user_word_count = sum(m.word_count for m in messages if m.material_origin == MaterialOrigin.HUMAN_AUTHORED)
     assistant_word_count = sum(m.word_count for m in messages if m.role == Role.ASSISTANT)
     await conn.execute(
         """
@@ -260,10 +265,12 @@ async def upsert_session_stats(
             thinking_count = ?,
             paste_count = ?,
             user_message_count = ?,
+            authored_user_message_count = ?,
             assistant_message_count = ?,
             system_message_count = ?,
             tool_message_count = ?,
             user_word_count = ?,
+            authored_user_word_count = ?,
             assistant_word_count = ?
         WHERE session_id = ?
         """,
@@ -274,10 +281,12 @@ async def upsert_session_stats(
             thinking_count,
             paste_count,
             user_msg_count,
+            authored_user_msg_count,
             assistant_msg_count,
             system_msg_count,
             tool_msg_count,
             user_word_count,
+            authored_user_word_count,
             assistant_word_count,
             session_id,
         ),
@@ -377,8 +386,10 @@ async def get_provider_metrics_rows(
             SUM(CASE WHEN tool_use_count > 0 THEN 1 ELSE 0 END) AS sessions_with_tools,
             SUM(CASE WHEN thinking_count > 0 THEN 1 ELSE 0 END) AS sessions_with_thinking,
             COALESCE(SUM(user_message_count), 0) AS user_message_count,
+            COALESCE(SUM(authored_user_message_count), 0) AS authored_user_message_count,
             COALESCE(SUM(assistant_message_count), 0) AS assistant_message_count,
             COALESCE(SUM(user_word_count), 0) AS user_word_sum,
+            COALESCE(SUM(authored_user_word_count), 0) AS authored_user_word_sum,
             COALESCE(SUM(assistant_word_count), 0) AS assistant_word_sum
         FROM sessions
         GROUP BY origin
@@ -391,8 +402,10 @@ async def get_provider_metrics_rows(
         provider = str(row["source_name"] or "unknown")
         role_split = {
             "user_message_count": int(row["user_message_count"] or 0),
+            "authored_user_message_count": int(row["authored_user_message_count"] or 0),
             "assistant_message_count": int(row["assistant_message_count"] or 0),
             "user_word_sum": int(row["user_word_sum"] or 0),
+            "authored_user_word_sum": int(row["authored_user_word_sum"] or 0),
             "assistant_word_sum": int(row["assistant_word_sum"] or 0),
         }
         merged.append(
@@ -401,8 +414,10 @@ async def get_provider_metrics_rows(
                 "session_count": int(row["session_count"] or 0),
                 "message_count": int(row["message_count"] or 0),
                 "user_message_count": role_split["user_message_count"],
+                "authored_user_message_count": role_split["authored_user_message_count"],
                 "assistant_message_count": role_split["assistant_message_count"],
                 "user_word_sum": role_split["user_word_sum"],
+                "authored_user_word_sum": role_split["authored_user_word_sum"],
                 "assistant_word_sum": role_split["assistant_word_sum"],
                 "tool_use_count": int(row["tool_use_count"] or 0),
                 "thinking_count": int(row["thinking_count"] or 0),

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -517,6 +517,7 @@ class SessionMessagePayload(SurfacePayloadModel):
     actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_message_actions)
     timestamp: datetime | None = None
     message_type: str = "message"
+    material_origin: str = "unknown"
     content_blocks: list[dict[str, object]] = Field(default_factory=list)
     parent_id: str | None = None
     # #1487 envelope: branch/lineage state.
@@ -569,6 +570,13 @@ class SessionMessagePayload(SurfacePayloadModel):
             message_type = str(raw_message_type.value)
         else:
             message_type = str(raw_message_type)
+        raw_material_origin = getattr(message, "material_origin", None)
+        if raw_material_origin is None:
+            material_origin = "unknown"
+        elif hasattr(raw_material_origin, "value"):
+            material_origin = str(raw_material_origin.value)
+        else:
+            material_origin = str(raw_material_origin)
         target_ref = (
             TargetRefPayload.message(session_id=session_id, message_id=message.id) if session_id is not None else None
         )
@@ -585,6 +593,7 @@ class SessionMessagePayload(SurfacePayloadModel):
             anchor=reader_anchor("message", message.id),
             timestamp=message.timestamp,
             message_type=message_type,
+            material_origin=material_origin,
             content_blocks=message.blocks,
             parent_id=message.parent_id,
             branch_index=int(getattr(message, "branch_index", 0) or 0),
@@ -1090,6 +1099,7 @@ class MessageQueryRowPayload(SurfacePayloadModel):
     title: str | None = None
     role: str
     message_type: str
+    material_origin: str = "unknown"
     position: int
     word_count: int
     text: str
@@ -1103,6 +1113,7 @@ class MessageQueryRowPayload(SurfacePayloadModel):
             title=row.title,
             role=row.role,
             message_type=row.message_type,
+            material_origin=row.material_origin,
             position=row.position,
             word_count=row.word_count,
             text=row.text,

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -9,7 +9,7 @@
   '''
   {
     "avg_messages_per_session": 5.0,
-    "db_size_bytes": 532480,
+    "db_size_bytes": 536576,
     "embedded_messages": 0,
     "embedded_sessions": 0,
     "embedding_coverage_percent": 0.0,
@@ -40,68 +40,6 @@
   '''
   {
     "scoped_to_query": false,
-    "origins": {
-      "chatgpt-export": 2
-    },
-    "tags": {},
-    "repos": {},
-    "cwd_prefixes": {},
-    "message_types": {
-      "message": 10
-    },
-    "action_types": {},
-    "has_flags": {
-      "has_tool_use": 0,
-      "has_thinking": 0,
-      "has_paste": 0
-    },
-    "time_range": null,
-    "total_sessions": 2,
-    "total_messages": 10,
-    "scoped": {
-      "origins": {
-        "chatgpt-export": 2
-      },
-      "tags": {},
-      "repos": {},
-      "message_types": {
-        "message": 10
-      },
-      "action_types": {},
-      "has_flags": {
-        "has_tool_use": 0,
-        "has_thinking": 0,
-        "has_paste": 0
-      },
-      "total_sessions": 2,
-      "total_messages": 10
-    },
-    "global": {
-      "origins": {
-        "chatgpt-export": 2
-      },
-      "tags": {},
-      "repos": {},
-      "message_types": {
-        "message": 10
-      },
-      "action_types": {},
-      "has_flags": {
-        "has_tool_use": 0,
-        "has_thinking": 0,
-        "has_paste": 0
-      },
-      "total_sessions": 2,
-      "total_messages": 10
-    },
-    "idf": {
-      "origins": {
-        "chatgpt-export": 0.0
-      },
-      "message_types": {
-        "message": -1.<HASH>
-      }
-    },
     "generated_at": "<TIMESTAMP>",
     "stale": false,
     "stale_age_s": null,
@@ -166,6 +104,68 @@
         "error": null,
         "stale": false,
         "stale_age_s": null
+      }
+    },
+    "origins": {
+      "chatgpt-export": 2
+    },
+    "tags": {},
+    "repos": {},
+    "cwd_prefixes": {},
+    "message_types": {
+      "message": 10
+    },
+    "action_types": {},
+    "has_flags": {
+      "has_tool_use": 0,
+      "has_thinking": 0,
+      "has_paste": 0
+    },
+    "time_range": null,
+    "total_sessions": 2,
+    "total_messages": 10,
+    "scoped": {
+      "origins": {
+        "chatgpt-export": 2
+      },
+      "tags": {},
+      "repos": {},
+      "message_types": {
+        "message": 10
+      },
+      "action_types": {},
+      "has_flags": {
+        "has_tool_use": 0,
+        "has_thinking": 0,
+        "has_paste": 0
+      },
+      "total_sessions": 2,
+      "total_messages": 10
+    },
+    "global": {
+      "origins": {
+        "chatgpt-export": 2
+      },
+      "tags": {},
+      "repos": {},
+      "message_types": {
+        "message": 10
+      },
+      "action_types": {},
+      "has_flags": {
+        "has_tool_use": 0,
+        "has_thinking": 0,
+        "has_paste": 0
+      },
+      "total_sessions": 2,
+      "total_messages": 10
+    },
+    "idf": {
+      "origins": {
+        "chatgpt-export": 0.0
+      },
+      "message_types": {
+        "message": -1.<HASH>
       }
     }
   }
@@ -280,9 +280,9 @@
       "index": {
         "path": "<PATH>",
         "exists": true,
-        "size_bytes": 532480,
-        "expected_user_version": 4,
-        "user_version": 4,
+        "size_bytes": 536576,
+        "expected_user_version": 5,
+        "user_version": 5,
         "version_status": "ok",
         "table_counts": {
           "sessions": 2,

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -703,7 +703,23 @@ def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(
         observed["parse_provider"] = provider
         observed["parse_schema_resolution"] = schema_resolution
         observed["parse_fallback_id"] = fallback_id
-        return []
+        return [
+            ParsedSession(
+                source_name=Provider.CHATGPT,
+                provider_session_id=fallback_id,
+                title="Test Session",
+                created_at="2023-11-14T22:13:20Z",
+                updated_at="2023-11-14T22:13:21Z",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="msg-1",
+                        role=Role.USER,
+                        text="hello",
+                    )
+                ],
+                attachments=[],
+            )
+        ]
 
     monkeypatch.setattr("polylogue.schemas.validator.SchemaValidator.for_payload", _fake_for_payload)
     monkeypatch.setattr("polylogue.sources.dispatch.parse_payload", _fake_parse_payload)

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from polylogue.archive.message.types import MessageType
+from polylogue.core.enums import MaterialOrigin, Role
 from polylogue.sources.parsers.claude import parse_code
 from polylogue.sources.parsers.claude.common import normalize_timestamp
 
@@ -24,9 +25,19 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
         },
         {
             "type": "user",
-            "uuid": "command-1",
+            "uuid": "stdout-1",
             "sessionId": "sess-1",
             "timestamp": 1704067201,
+            "message": {
+                "role": "user",
+                "content": "<local-command-stdout>pytest passed</local-command-stdout>",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "command-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067202,
             "message": {
                 "role": "user",
                 "content": "<command-name>status</command-name>\n<command-message>status</command-message>",
@@ -36,7 +47,7 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
             "type": "user",
             "uuid": "skill-1",
             "sessionId": "sess-1",
-            "timestamp": 1704067202,
+            "timestamp": 1704067203,
             "message": {
                 "role": "user",
                 "content": "Base directory for this skill: /tmp/skill\n\n# Skill Body",
@@ -44,9 +55,29 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
         },
         {
             "type": "user",
+            "uuid": "commit-pack-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067204,
+            "message": {
+                "role": "user",
+                "content": "# Commit N: Generate all artifacts\n\nlarge generated context",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "retro-pack-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067205,
+            "message": {
+                "role": "user",
+                "content": "Generate a retrospective for: long generated analysis bundle",
+            },
+        },
+        {
+            "type": "user",
             "uuid": "prompt-1",
             "sessionId": "sess-1",
-            "timestamp": 1704067203,
+            "timestamp": 1704067206,
             "message": {
                 "role": "user",
                 "content": "<system-reminder>model-only context</system-reminder>\n\nActual user prompt.",
@@ -57,11 +88,42 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
     result = parse_code(items, "fallback")
 
     by_id = {message.provider_message_id: message for message in result.messages}
-    assert len(result.messages) == len(by_id) == 4
+    assert len(result.messages) == len(by_id) == 7
     assert by_id["task-1"].message_type is MessageType.PROTOCOL
+    assert by_id["task-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
+    assert by_id["stdout-1"].message_type is MessageType.PROTOCOL
+    assert by_id["stdout-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
     assert by_id["command-1"].message_type is MessageType.PROTOCOL
+    assert by_id["command-1"].material_origin is MaterialOrigin.OPERATOR_COMMAND
     assert by_id["skill-1"].message_type is MessageType.CONTEXT
+    assert by_id["skill-1"].material_origin is MaterialOrigin.RUNTIME_CONTEXT
+    assert by_id["commit-pack-1"].message_type is MessageType.MESSAGE
+    assert by_id["commit-pack-1"].material_origin is MaterialOrigin.GENERATED_CONTEXT_PACK
+    assert by_id["retro-pack-1"].message_type is MessageType.MESSAGE
+    assert by_id["retro-pack-1"].material_origin is MaterialOrigin.GENERATED_ANALYSIS_PACK
     assert by_id["prompt-1"].message_type is MessageType.MESSAGE
+    assert by_id["prompt-1"].material_origin is MaterialOrigin.HUMAN_AUTHORED
+    assert result.title == "Actual user prompt."
+
+
+def test_parse_code_preserves_tool_result_reclassification_material_origin() -> None:
+    result = parse_code(
+        [
+            {
+                "type": "user",
+                "uuid": "tool-result-1",
+                "sessionId": "sess-tool",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "tool-1", "content": "ok"}],
+                },
+            }
+        ],
+        "fallback-tool",
+    )
+
+    assert result.messages[0].role is Role.TOOL
+    assert result.messages[0].material_origin is MaterialOrigin.TOOL_RESULT
 
 
 def test_parse_code_drops_progress_hook_records() -> None:

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, Provider, TitleSource
+from polylogue.core.enums import BlockType, MaterialOrigin, MessageType, Provider, TitleSource
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -109,9 +109,66 @@ def test_archive_tiers_writer_materializes_codex_session(tmp_path: Path) -> None
     ]
     assert envelope.messages[1].is_active_leaf is True
     assert [block.block_type for block in envelope.messages[1].blocks] == ["tool_use", "tool_result"]
+    assert [message.material_origin for message in envelope.messages] == ["human_authored", "assistant_authored"]
     action = conn.execute("SELECT tool_command, output_text FROM actions").fetchone()
     assert dict(action) == {"tool_command": "pytest -q", "output_text": "checks passed"}
     assert search_archive_blocks(conn, "focused") == ["codex-session:codex-session-1:u1:0"]
+
+
+def test_archive_tiers_writer_splits_provider_user_from_authored_user_counts(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="claude-code-authoredness",
+        title="authoredness",
+        messages=[
+            ParsedMessage(
+                provider_message_id="runtime-protocol",
+                role=Role.USER,
+                text="<task-notification>done</task-notification>",
+                message_type=MessageType.PROTOCOL,
+                material_origin=MaterialOrigin.RUNTIME_PROTOCOL,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="<task-notification>done</task-notification>")],
+            ),
+            ParsedMessage(
+                provider_message_id="generated-pack",
+                role=Role.USER,
+                text="# Commit N: Generate all artifacts\n\nnot typed by the operator",
+                material_origin=MaterialOrigin.GENERATED_CONTEXT_PACK,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text="# Commit N: Generate all artifacts\n\nnot typed by the operator",
+                    )
+                ],
+            ),
+            ParsedMessage(
+                provider_message_id="typed-prompt",
+                role=Role.USER,
+                text="Please inspect the failing parser.",
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="Please inspect the failing parser.")],
+            ),
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+    counts = conn.execute(
+        """
+        SELECT user_message_count, authored_user_message_count,
+               user_word_count, authored_user_word_count
+        FROM sessions
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+
+    assert dict(counts) == {
+        "user_message_count": 3,
+        "authored_user_message_count": 1,
+        "user_word_count": 17,
+        "authored_user_word_count": 5,
+    }
 
 
 def test_archive_store_connection_applies_canonical_profile(tmp_path: Path) -> None:

--- a/tests/unit/surfaces/test_message_render_envelope.py
+++ b/tests/unit/surfaces/test_message_render_envelope.py
@@ -42,6 +42,7 @@ _ENVELOPE_FIELDS: tuple[str, ...] = (
     "actions",
     "timestamp",
     "message_type",
+    "material_origin",
     "content_blocks",
     "parent_id",
     "branch_index",


### PR DESCRIPTION
## Summary

Adds a first-class `MaterialOrigin` axis to archive messages so provider-role `user` rows can be distinguished from actually human-authored prompts. This is the main substrate slice for #2318: Claude Code runtime protocol, command wrappers, generated context, generated analysis, and tool-result material no longer have to masquerade as authored user prose.

## Problem

Claude Code and adjacent agent runtimes can emit `role=user` rows for material the user did not author. Existing title extraction, prose-only rendering, and archive statistics treated those rows as authored user prompts because role was the only axis available. That polluted prompt counts and made runtime/context artifacts look like human intent.

## Solution

- Added `MaterialOrigin` as a separate message axis from provider `Role` and `MessageType`.
- Classified Claude Code parser output into human-authored, assistant-authored, operator-command, runtime-protocol, runtime-context, tool-result, generated-context-pack, generated-analysis-pack, and unknown material.
- Persisted `messages.material_origin` in index schema v5 and added authored-user aggregate counters on `sessions`, while preserving existing provider-role user counts.
- Switched title/prose-only behavior to authoredness where that is the actual product question.
- Exposed `material_origin` through CLI/API/MCP/daemon payloads and refreshed generated schemas/OpenAPI.
- Documented the schema-v5 fresh rebuild expectation.
- Made recovery work-packet timestamps deterministic for repeated calls on the same hydrated session; this fixed a broad-seed failure surfaced while verifying this branch.

This does not claim full #2318 closure. Remaining work: audit every downstream analytics/query/reporting surface that still interprets provider-role `user` as human intent and switch only the surfaces where authoredness is the right semantic question.

Ref #2318

## Verification

- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py tests/unit/storage/test_archive_tiers_write.py -k "material_origin or authoredness or runtime_artifacts or materializes_codex_session"` -> `3 passed, 31 deselected`
- `devtools test tests/unit/storage/test_archive_tiers_ddl.py tests/unit/mcp/test_tool_contracts.py tests/unit/daemon/test_web_reader.py tests/unit/cli/test_messages.py tests/unit/cli/test_query_fmt.py -k "message_type or messages or prose_only or archive_tiers_index_generates_ids_and_actions_view or get_messages"` -> `19 passed, 267 deselected`
- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py tests/unit/storage/test_archive_tiers_write.py tests/unit/cli/test_messages.py -k "material_origin or authoredness or runtime_artifacts or materializes_codex_session or json_is_single or ndjson"` -> `5 passed, 34 deselected`
- `devtools test tests/unit/pipeline/test_ingest_batch_resource_bounds.py::test_drain_ready_session_entries_drops_written_payload tests/unit/sources/test_live_catchup_planning.py::test_flush_pending_does_not_hot_requeue_backed_off_failure tests/unit/sources/test_live_catchup_planning.py::test_catch_up_does_not_immediately_requeue_failed_paths tests/unit/pipeline/test_resilience.py::test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk tests/unit/daemon/test_daemon_cli.py::test_polylogued_status_json_reports_daemon_components tests/unit/api/test_facade_contracts.py::test_recovery_report_renders_seeded_session_presets tests/unit/cli/test_plain_cli_snapshots.py::test_json_facets_snapshot tests/unit/cli/test_plain_cli_snapshots.py::test_json_analyze_snapshot tests/unit/cli/test_plain_cli_snapshots.py::test_json_status_snapshot tests/unit/daemon/test_daemon_status.py::test_daemon_status_uses_default_browser_capture_spool tests/unit/surfaces/test_message_render_envelope.py::test_envelope_field_set_is_exhaustive` -> `11 passed`
- `devtools verify --quick` -> green, run id `20260623T092919Z-quick-2717969-d4a94d74`
- `devtools verify --seed-testmon --skip-slow` -> `11740 passed, 9 warnings`, run id `20260623T093046Z-seed-testmon-2725758-702df44b`
- `devtools verify` -> `7 passed`, run id `20260623T093607Z-testmon-2743734-48a86261`
- pre-push `devtools verify --quick` on committed SHA -> green, run id `20260623T093733Z-quick-2745546-d11f46db`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `material_origin` field to messages to distinguish authorship source from display role.
  * New authored-user message and word count metrics in session and provider analytics.
  * Enhanced message classification to separate human-authored, assistant-authored, and system-generated content.

* **Documentation**
  * Updated API schemas and data model documentation to include the new `material_origin` field.

* **Chores**
  * Database schema upgraded to version 5 with new columns and indexes supporting material origin classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->