### PR TITLE
fix(browser): harden capture status evidence

### DIFF
--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -923,6 +923,18 @@ def _diagnose(
     if browser_capture_receiver_archive_state.error == "receiver_archive_state_absolute_artifact_path":
         likely_causes.append("deployed browser-capture receiver archive-state DTO leaks absolute artifact paths")
         next_actions.append("restart a deployed receiver built from the current relative artifact-ref contract")
+    elif browser_capture_receiver_archive_state.error in {
+        "receiver_archive_state_missing_lifecycle",
+        "receiver_archive_state_captured_without_archived_state",
+        "receiver_archive_state_not_archived",
+        "receiver_archive_state_missing_raw_row_evidence",
+        "receiver_archive_state_missing_index_evidence",
+        "receiver_archive_state_missing_index_messages",
+    }:
+        likely_causes.append("deployed browser-capture receiver archive-state DTO does not prove query visibility")
+        next_actions.append(
+            "restart a receiver built from the lifecycle archive-state contract and verify source/index rows for the latest capture"
+        )
     if repo_head is not None and deployed_commit is not None and not repo_head.startswith(deployed_commit):
         likely_causes.append("systemwide polylogue commit differs from the current checkout")
         next_actions.append("compare the deployed package input with the checkout before trusting live UI probes")

--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -927,6 +927,7 @@ def _diagnose(
         "receiver_archive_state_missing_lifecycle",
         "receiver_archive_state_captured_without_archived_state",
         "receiver_archive_state_not_archived",
+        "receiver_archive_state_not_captured",
         "receiver_archive_state_missing_raw_row_evidence",
         "receiver_archive_state_missing_index_evidence",
         "receiver_archive_state_missing_index_messages",

--- a/polylogue/daemon/browser_capture.py
+++ b/polylogue/daemon/browser_capture.py
@@ -21,7 +21,7 @@ def browser_capture_command() -> None:
 @click.option("--format", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
 def status_command(spool_path: Path | None, output_format: str | None) -> None:
     """Show receiver configuration and capture-spool target."""
-    payload = browser_capture_status_payload(spool_path)
+    payload = browser_capture_status_payload(spool_path, include_spool_path=True)
     if output_format == "json":
         click.echo(dumps(payload))
         return

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1198,10 +1198,16 @@ def status_command(spool_path: Path | None, output_format: str | None) -> None:
     configure_logging()
     if output_format == "json":
         with redirect_stdout(sys.stderr):
-            payload = daemon_status_payload(browser_capture_spool_path=spool_path)
+            payload = daemon_status_payload(
+                browser_capture_spool_path=spool_path,
+                include_browser_capture_spool_path=spool_path is not None,
+            )
         click.echo(dumps(payload))
         return
-    payload = daemon_status_payload(browser_capture_spool_path=spool_path)
+    payload = daemon_status_payload(
+        browser_capture_spool_path=spool_path,
+        include_browser_capture_spool_path=spool_path is not None,
+    )
     for line in format_daemon_status_lines(payload):
         click.echo(line)
 

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1943,6 +1943,7 @@ def daemon_status_payload(
     sources: tuple[WatchSource, ...] | None = None,
     browser_capture_enabled: bool | None = None,
     browser_capture_spool_path: Path | None = None,
+    include_browser_capture_spool_path: bool = False,
 ) -> JSONDocument:
     """Return the local daemon component status payload (backward-compat dict)."""
     watch_sources = sources if sources is not None else default_sources()
@@ -1976,7 +1977,10 @@ def daemon_status_payload(
             "component_state": status.component_state.model_dump(),
             "component_readiness": status.component_readiness,
             "live": live_source_status_payload(watch_sources),
-            "browser_capture": browser_capture_status_payload(browser_capture_spool_path),
+            "browser_capture": browser_capture_status_payload(
+                browser_capture_spool_path,
+                include_spool_path=include_browser_capture_spool_path,
+            ),
             "db_path": str(_active_status_db_path()),
             "db_size_bytes": status.db_size_bytes,
             "wal_size_bytes": status.wal_size_bytes,

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -290,9 +290,9 @@ def live_source_status_payload(sources: tuple[WatchSource, ...]) -> JSONDocument
 def browser_capture_status_payload(
     spool_path: Path | None = None,
     *,
-    include_spool_path: bool = True,
+    include_spool_path: bool = False,
 ) -> JSONDocument:
-    """Return status for the browser-capture receiver component."""
+    """Return safe status for the browser-capture receiver component."""
     cfg_default = BrowserCaptureReceiverConfig.default()
     if spool_path is not None:
         config = BrowserCaptureReceiverConfig(
@@ -312,9 +312,7 @@ def browser_capture_status_payload(
 
 def browser_capture_status_public_payload(spool_path: Path | None = None) -> JSONDocument:
     """Return browser-capture status safe for the daemon web/status API."""
-    payload = dict(browser_capture_status_payload(spool_path))
-    payload.pop("spool_path", None)
-    return json_document(payload)
+    return browser_capture_status_payload(spool_path, include_spool_path=False)
 
 
 def _db_size_info() -> dict[str, object]:

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -13,6 +13,7 @@ from polylogue.core.json import JSONDocument
 from polylogue.daemon import status as status_module
 from polylogue.daemon.status import (
     _insight_freshness_info,
+    browser_capture_status_payload,
     build_daemon_status,
     daemon_status_payload,
     format_daemon_status_lines,
@@ -194,7 +195,7 @@ def test_build_daemon_status_reports_failed_live_cursor_files(tmp_path: Path) ->
     assert status.live_cursor.failing_files[0].next_retry_at is not None
 
 
-def test_daemon_status_uses_default_browser_capture_spool(
+def test_daemon_status_redacts_default_browser_capture_spool(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -210,10 +211,27 @@ def test_daemon_status_uses_default_browser_capture_spool(
     assert payload["browser_capture_active"] is True
     browser_capture = payload["browser_capture"]
     assert isinstance(browser_capture, dict)
-    assert browser_capture["spool_path"] == str(expected_spool)
+    assert browser_capture["spool_ready"] is True
+    assert "spool_path" not in browser_capture
     component_state = payload["component_state"]
     assert isinstance(component_state, dict)
     assert component_state["browser_capture"] == "running"
+
+
+def test_browser_capture_status_payload_can_include_spool_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    expected_spool = tmp_path / "browser-capture"
+    monkeypatch.setattr(
+        BrowserCaptureReceiverConfig,
+        "default",
+        classmethod(lambda cls: BrowserCaptureReceiverConfig(spool_path=expected_spool)),
+    )
+
+    payload = browser_capture_status_payload(include_spool_path=True)
+
+    assert payload["spool_path"] == str(expected_spool)
 
 
 def test_daemon_status_honors_explicit_disabled_browser_capture(

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -1020,7 +1020,16 @@ def test_deployment_smoke_rejects_receiver_archive_state_without_index_evidence(
     assert probe.error == "receiver_archive_state_missing_index_evidence"
 
 
-def test_deployment_smoke_diagnoses_receiver_archive_state_without_index_evidence() -> None:
+@pytest.mark.parametrize(
+    "receiver_error",
+    [
+        "receiver_archive_state_missing_index_evidence",
+        "receiver_archive_state_not_captured",
+    ],
+)
+def test_deployment_smoke_diagnoses_receiver_archive_state_without_query_visibility(
+    receiver_error: str,
+) -> None:
     diagnostics = deployment_smoke._diagnose(
         commands=[
             deployment_smoke.CommandProbe(
@@ -1068,7 +1077,7 @@ def test_deployment_smoke_diagnoses_receiver_archive_state_without_index_evidenc
                 "indexed_session_exists": False,
             },
             ok=False,
-            error="receiver_archive_state_missing_index_evidence",
+            error=receiver_error,
         ),
     )
 

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -1018,3 +1018,62 @@ def test_deployment_smoke_rejects_receiver_archive_state_without_index_evidence(
 
     assert probe.ok is False
     assert probe.error == "receiver_archive_state_missing_index_evidence"
+
+
+def test_deployment_smoke_diagnoses_receiver_archive_state_without_index_evidence() -> None:
+    diagnostics = deployment_smoke._diagnose(
+        commands=[
+            deployment_smoke.CommandProbe(
+                name="polylogue --version",
+                path="/bin/polylogue",
+                exit_code=0,
+                ok=True,
+                stdout="polylogue, version 0.1.0+abc123",
+                stderr="",
+            ),
+            deployment_smoke.CommandProbe(
+                name="polylogued --version",
+                path="/bin/polylogued",
+                exit_code=0,
+                ok=True,
+                stdout="polylogued, version 0.1.0+abc123",
+                stderr="",
+            ),
+        ],
+        routes=[],
+        repo_head="abc123def456",
+        browser_render=None,
+        browser_executable_resolution={},
+        browser_capture_archive=deployment_smoke.BrowserCaptureArchiveProbe(
+            spool_path="/tmp/browser-capture",
+            source_db_path="/tmp/source.db",
+            spooled_count=1,
+            latest_spooled_path="/tmp/browser-capture/chatgpt/capture-no-index.json",
+            latest_spooled_mtime=1.0,
+            latest_spooled_mtime_ms=1000,
+            raw_rows=1,
+            latest_raw_file_mtime_ms=1000,
+            ok=True,
+        ),
+        browser_capture_receiver_archive_state=deployment_smoke.BrowserCaptureReceiverArchiveStateProbe(
+            url="http://receiver/v1/archive-state",
+            provider="chatgpt",
+            provider_session_id="capture-no-index",
+            status=200,
+            payload={
+                "state": "archived",
+                "captured": True,
+                "artifact_ref": "chatgpt/capture-no-index.json",
+                "raw_row_exists": True,
+                "indexed_session_exists": False,
+            },
+            ok=False,
+            error="receiver_archive_state_missing_index_evidence",
+        ),
+    )
+
+    assert (
+        "deployed browser-capture receiver archive-state DTO does not prove query visibility"
+        in diagnostics["likely_causes"]
+    )
+    assert any("verify source/index rows" in action for action in diagnostics["next_actions"])


### PR DESCRIPTION

## Summary

Closes two residuals from the #2308 patch-intake audit: browser-capture daemon
status no longer exposes the absolute spool path by default, and
deployment-smoke now diagnoses receiver archive-state payloads that do not prove
query visibility.

## Problem

The browser-capture archive-state contract already reports relative
`artifact_ref` values and rejects absolute artifact path leaks, but
`browser_capture_status_payload()` still exposed `spool_path` by default. That
left daemon status less strict than the source-contract posture from #2308.
Deployment-smoke also rejected missing lifecycle/raw/index evidence but only
explained absolute path leaks in its likely-cause output.

## Solution

- Change `browser_capture_status_payload()` to omit `spool_path` unless
  `include_spool_path=True`.
- Keep `browser_capture_status_public_payload()` as the safe public helper.
- Update `polylogued browser-capture status` to explicitly request the
  path-bearing operator payload.
- Add daemon-status tests for the redacted default and explicit opt-in helper.
- Add deployment-smoke diagnostics for receiver archive-state lifecycle/raw/index
  evidence failures.

## Verification

- `devtools test tests/unit/daemon/test_daemon_status.py -k browser_capture` -> pass
- `devtools test tests/unit/devtools/test_deployment_smoke.py -k "receiver_archive_state_without_index_evidence or diagnoses_receiver_archive_state"` -> pass
- `ruff format --check polylogue/daemon/status.py polylogue/daemon/browser_capture.py tests/unit/daemon/test_daemon_status.py` -> pass
- `ruff check devtools/deployment_smoke.py tests/unit/devtools/test_deployment_smoke.py polylogue/daemon/status.py polylogue/daemon/browser_capture.py tests/unit/daemon/test_daemon_status.py` -> pass
- `devtools verify --quick` -> pass (`20260623T110824Z-quick-3165209-40d583b3`)

Ref #2308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced diagnostic messages for receiver archive state errors, providing clearer guidance on troubleshooting and verification steps.

* **Changes**
  * Modified `browser-capture status` command to exclude spool path details from output by default. Use explicit options to include path information when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->