### PR TITLE
fix(insights): keep runtime user rows out of authored analysis

### DIFF
--- a/polylogue/archive/semantic/timing.py
+++ b/polylogue/archive/semantic/timing.py
@@ -279,15 +279,19 @@ def _message_response_latencies(messages: Sequence[Message]) -> tuple[list[int],
     timestamped = [message for message in messages if message.timestamp is not None]
     for index, message in enumerate(timestamped):
         next_message = next(
-            (candidate for candidate in timestamped[index + 1 :] if candidate.is_user or candidate.is_assistant),
+            (
+                candidate
+                for candidate in timestamped[index + 1 :]
+                if candidate.is_human_authored or candidate.is_assistant
+            ),
             None,
         )
         if next_message is None or next_message.timestamp is None or message.timestamp is None:
             continue
         delta_ms = max(int((next_message.timestamp - message.timestamp).total_seconds() * 1000), 0)
-        if message.is_user and next_message.is_assistant:
+        if message.is_human_authored and next_message.is_assistant:
             agent_response_ms.append(delta_ms)
-        elif message.is_assistant and next_message.is_user and delta_ms <= 1_800_000:
+        elif message.is_assistant and next_message.is_human_authored and delta_ms <= 1_800_000:
             user_response_ms.append(delta_ms)
     return agent_response_ms, user_response_ms
 

--- a/polylogue/archive/session/attribution.py
+++ b/polylogue/archive/session/attribution.py
@@ -249,10 +249,12 @@ def extract_attribution(
     file_paths = set(base.file_paths_touched)
     languages = set(base.languages_detected)
 
-    # Dialogue text can mention transcript-store or persisted-output paths that are not
-    # evidence of the repos actually worked on. Keep only low-risk language hints here.
+    # Authored dialogue text can mention transcript-store or persisted-output
+    # paths that are not evidence of the repos actually worked on. Keep only
+    # low-risk language hints here and ignore runtime/protocol provider-user
+    # rows such as command stdout.
     for message in semantic_facts.message_facts:
-        if not message.is_dialogue or not message.text:
+        if not (message.is_human_authored or message.is_assistant) or message.is_noise or not message.text:
             continue
         text_lower = message.text.lower()
         for lang_name, pattern in _DIALOGUE_LANGUAGE_HINT_PATTERNS.items():

--- a/polylogue/archive/session/extraction.py
+++ b/polylogue/archive/session/extraction.py
@@ -24,7 +24,7 @@ from polylogue.core.payload_coercion import (
     string_sequence,
 )
 
-# Strip XML-like protocol artifacts from user messages before summarizing.
+# Strip XML-like protocol artifacts from authored prompt messages before summarizing.
 # Claude Code sessions contain <command-name>, <task-notification>,
 # <local-command-caveat>, <system-reminder> etc. which are tool protocol
 # noise, not human-readable content.
@@ -274,7 +274,7 @@ def _collect_range_signals(
     text_signal_name: str | None = None
 
     for message in message_range.iter_messages(messages):
-        if message.is_user and message.text and not message.is_noise:
+        if message.is_human_authored and message.text and not message.is_noise:
             lowered_text: str | None = None
             if normalized_user_text_len < _SIGNAL_TEXT_PREVIEW_MAX_LEN:
                 lowered_text = message.text.lower()
@@ -423,7 +423,7 @@ def _build_range_summary(
     summary_parts: list[str] = []
     summary_length = 0
     for message in message_range.iter_messages(messages):
-        if not message.is_user or not message.text:
+        if not message.is_human_authored or not message.text:
             continue
         cleaned_text = _clean_summary_text(message.text)
         if not cleaned_text:

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -23,9 +23,10 @@ from polylogue.archive.semantic.pricing import harmonize_session_cost
 from polylogue.archive.semantic.timing import compute_session_latency_profile
 from polylogue.archive.session import extraction as work_event_extraction
 from polylogue.archive.session import runtime as session_profile_runtime
+from polylogue.archive.session.attribution import extract_attribution
 from polylogue.archive.session.events import SessionEvent
 from polylogue.archive.session.session_profile import build_session_profile
-from polylogue.core.enums import Origin, Provider
+from polylogue.core.enums import MaterialOrigin, Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.archive_views import SessionRenderProjection
 from polylogue.types import SessionEventId, SessionId
@@ -102,6 +103,7 @@ def _protocol_summary_session() -> SessionModel:
                     text="<system-reminder>skip this</system-reminder>\n"
                     + (f"Please inspect {README_PATH} and summarize the findings clearly. " * 3),
                     timestamp=datetime(2026, 3, 23, 10, 0, tzinfo=timezone.utc),
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
                 ),
                 make_msg(
                     id="a1",
@@ -128,6 +130,7 @@ def _protocol_summary_session() -> SessionModel:
                         "It repeats a bit so we hit the summary truncation boundary."
                     ),
                     timestamp=datetime(2026, 3, 23, 10, 2, tzinfo=timezone.utc),
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
                 ),
                 make_msg(
                     id="u3",
@@ -135,6 +138,7 @@ def _protocol_summary_session() -> SessionModel:
                     origin="claude-code",
                     text="This trailing note should be truncated away once the summary is already full.",
                     timestamp=datetime(2026, 3, 23, 10, 3, tzinfo=timezone.utc),
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
                 ),
             ]
         ),
@@ -303,9 +307,23 @@ def test_compute_session_latency_profile_aggregates_tool_and_turn_latencies() ->
         origin=Provider.CODEX,
         title="Latency profile",
         messages=[
-            make_msg(id="u1", role="user", origin=Provider.CODEX, text="Run", timestamp=start),
+            make_msg(
+                id="u1",
+                role="user",
+                origin=Provider.CODEX,
+                text="Run",
+                timestamp=start,
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+            ),
             make_msg(id="a1", role="assistant", origin=Provider.CODEX, text="Done", timestamp=agent),
-            make_msg(id="u2", role="user", origin=Provider.CODEX, text="Follow up", timestamp=followup),
+            make_msg(
+                id="u2",
+                role="user",
+                origin=Provider.CODEX,
+                text="Follow up",
+                timestamp=followup,
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+            ),
         ],
         updated_at=datetime(2026, 5, 24, 10, 12, tzinfo=timezone.utc),
         session_events=(
@@ -354,6 +372,65 @@ def test_compute_session_latency_profile_aggregates_tool_and_turn_latencies() ->
     assert facts.median_agent_response_ms == 60_000
     assert facts.median_user_response_ms == 120_000
     assert facts.tool_call_count_by_category == {"shell": 2}
+
+
+def test_compute_session_latency_profile_ignores_provider_user_runtime_protocol_turns() -> None:
+    start = datetime(2026, 5, 24, 11, 0, tzinfo=timezone.utc)
+    runtime_after_user = datetime(2026, 5, 24, 11, 0, 10, tzinfo=timezone.utc)
+    assistant = datetime(2026, 5, 24, 11, 1, tzinfo=timezone.utc)
+    runtime_after_assistant = datetime(2026, 5, 24, 11, 1, 15, tzinfo=timezone.utc)
+    followup = datetime(2026, 5, 24, 11, 3, tzinfo=timezone.utc)
+    session = make_conv(
+        id="conv-latency-runtime-user",
+        origin=Provider.CLAUDE_CODE,
+        title="Latency profile runtime user",
+        messages=[
+            make_msg(
+                id="u1",
+                role="user",
+                origin=Provider.CLAUDE_CODE,
+                text="Run the release checks.",
+                timestamp=start,
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+            ),
+            make_msg(
+                id="u-runtime-1",
+                role="user",
+                origin=Provider.CLAUDE_CODE,
+                text="<local-command-stdout>pytest output</local-command-stdout>",
+                timestamp=runtime_after_user,
+                material_origin=MaterialOrigin.RUNTIME_PROTOCOL,
+            ),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CLAUDE_CODE,
+                text="Checks finished.",
+                timestamp=assistant,
+            ),
+            make_msg(
+                id="u-runtime-2",
+                role="user",
+                origin=Provider.CLAUDE_CODE,
+                text="<task-notification>background status</task-notification>",
+                timestamp=runtime_after_assistant,
+                material_origin=MaterialOrigin.RUNTIME_PROTOCOL,
+            ),
+            make_msg(
+                id="u2",
+                role="user",
+                origin=Provider.CLAUDE_CODE,
+                text="Prepare the final evidence note.",
+                timestamp=followup,
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+            ),
+        ],
+    )
+
+    facts = compute_session_latency_profile(list(session.messages), session.session_events)
+
+    assert facts.median_agent_response_ms == 60_000
+    assert facts.median_user_response_ms == 120_000
 
 
 def test_build_session_profile_classifies_workflow_shape_from_observable_features() -> None:
@@ -658,6 +735,74 @@ def test_extract_work_events_strips_protocol_noise_and_respects_summary_cap() ->
     assert f"Please inspect {README_PATH}" in summary
     assert "This trailing note should be truncated away" not in summary
     assert len(summary) <= 200
+
+
+def test_extract_work_events_ignores_provider_user_runtime_protocol_text() -> None:
+    session = make_conv(
+        id="conv-work-event-runtime-user",
+        origin="claude-code",
+        title="Work Event Runtime User",
+        created_at=datetime(2026, 3, 23, 11, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 23, 11, 5, tzinfo=timezone.utc),
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="u-runtime",
+                    role="user",
+                    origin="claude-code",
+                    text="<local-command-stdout>pytest failed with traceback</local-command-stdout>",
+                    timestamp=datetime(2026, 3, 23, 11, 0, tzinfo=timezone.utc),
+                    material_origin=MaterialOrigin.RUNTIME_PROTOCOL,
+                ),
+                make_msg(
+                    id="u-authored",
+                    role="user",
+                    origin="claude-code",
+                    text="Plan the release evidence package.",
+                    timestamp=datetime(2026, 3, 23, 11, 1, tzinfo=timezone.utc),
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                ),
+            ]
+        ),
+    )
+
+    events = work_event_extraction.extract_work_events(session)
+
+    assert events
+    assert events[0].heuristic_label == work_event_extraction.WorkEventHeuristicLabel.PLANNING
+    assert events[0].summary == "Plan the release evidence package."
+    assert "pytest failed" not in events[0].summary
+
+
+def test_extract_attribution_ignores_runtime_protocol_language_hints() -> None:
+    session = make_conv(
+        id="conv-attribution-runtime-user",
+        origin="claude-code",
+        title="Attribution Runtime User",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="u-runtime",
+                    role="user",
+                    origin="claude-code",
+                    text="<local-command-stdout>python traceback from generated output</local-command-stdout>",
+                    material_origin=MaterialOrigin.RUNTIME_PROTOCOL,
+                ),
+                make_msg(
+                    id="u-authored",
+                    role="user",
+                    origin="claude-code",
+                    text="Please review the rust parser path.",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                ),
+            ]
+        ),
+    )
+
+    attribution = extract_attribution(session)
+
+    assert "rust" in attribution.languages_detected
+    assert "python" not in attribution.languages_detected
 
 
 def test_build_session_semantic_facts_uses_canonical_db_content_blocks() -> None:


### PR DESCRIPTION
## Summary

Finishes another downstream #2318 audit slice by keeping provider-role runtime `user` rows out of authored-prompt analysis surfaces: work-event labels/summaries, response-latency medians, and dialogue-derived language hints.

## Problem

After #2324/#2325, the public query/read/facet surfaces distinguish provider-role `user` from `material_origin=human_authored`. A final source audit still found analysis helpers using provider-role `is_user` where the semantic question was operator-authored prompt material. That let Claude Code runtime/protocol rows such as command stdout influence work-event classification, event summaries, response timing, and language attribution.

## Solution

- Switch work-event range text signals and summaries from provider-role `is_user` to semantic `is_human_authored`.
- Pair assistant/user response latency only across authored human prompts and assistant messages, skipping runtime/protocol provider-user rows.
- Restrict dialogue-derived language hints to authored human or assistant non-noise text.
- Add regression fixtures where runtime/protocol `role=user` rows contain tempting text (`pytest`, `python`, command output) but authored analysis follows the real prompt text.

Live accounting evidence from the production schema-v5 archive:

```text
Claude Code provider-role user split:
- message / human_authored: 125,922 messages / 22,249,098 words
- protocol / runtime_protocol: 11,655 messages / 2,710,671 words
- context / runtime_context: 1,842 messages / 3,392,052 words

provider_user_messages: 139,419
provider_user_words: 28,351,821
authored_user_messages: 125,922
authored_user_words: 22,249,098
moved_out_messages: 13,497
moved_out_words: 6,102,723
sessions_with_moved_out: 1,270
```

## Verification

- `devtools test tests/unit/core/test_semantic_facts.py` -> pass (`30 passed`)
- `devtools verify --quick` -> pass (`20260623T121019Z-quick-3431435-df982a1b`)
- pre-push `devtools verify --quick` -> pass (`20260623T121058Z-quick-3436558-4e026c1d`)

Ref #2318