### PR TITLE
test(config): pin effective inventory contract

### DIFF
--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -799,6 +799,68 @@ class TestDescribeConfigLayers:
         assert report["site"] == {"path": None, "exists": False}
 
 
+class TestConfigInventoryPayload:
+    """The public config inventory must stay executable, not decorative."""
+
+    def _disable_site(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    def test_inventory_payload_has_unique_keys_and_env_vars(self) -> None:
+        from polylogue.config import config_inventory_payload
+
+        rows = config_inventory_payload()
+        keys = [str(row["key"]) for row in rows]
+        env_vars = [str(row["env_var"]) for row in rows if row.get("env_var")]
+
+        assert len(keys) == len(set(keys))
+        assert len(env_vars) == len(set(env_vars))
+        assert all(row.get("owner_class") for row in rows)
+        assert all(row.get("reload_behavior") for row in rows)
+        assert all(row.get("effective_path") for row in rows)
+
+    def test_effective_payload_redacts_secret_and_reports_env_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import effective_config_payload, load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        monkeypatch.setenv("POLYLOGUE_API_AUTH_TOKEN", "secret-do-not-leak")
+        cfg = load_polylogue_config()
+        payload = effective_config_payload(cfg)
+
+        values = payload["values"]
+        assert isinstance(values, dict)
+        token = values["api_auth_token"]
+        assert isinstance(token, dict)
+        assert token["value"] == "<set>"
+        assert token["secret"] is True
+        assert token["secret_present"] is True
+        assert token["source_layer"] == "env"
+        assert "secret-do-not-leak" not in str(payload)
+
+    def test_effective_payload_uses_inventory_env_mapping_for_typed_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import effective_config_payload, load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_PORT", "9987")
+        cfg = load_polylogue_config()
+        payload = effective_config_payload(cfg)
+
+        values = payload["values"]
+        assert isinstance(values, dict)
+        port = values["browser_capture_port"]
+        assert isinstance(port, dict)
+        assert port["value"] == 9987
+        assert port["source_layer"] == "env"
+        assert port["env_var"] == "POLYLOGUE_BROWSER_CAPTURE_PORT"
+
+
 # =============================================================================
 # Merged from test_logging.py (2024-03-15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds focused tests that make the #2309 effective-configuration inventory contract executable: unique inventory keys/env vars, required metadata, redacted env-sourced secrets, and typed env values flowing through `effective_config_payload`.

## Problem

The downloaded #2309 patch is stale against current `master`; the main effective-config surfaces already exist (`polylogue config --format json`, configuration docs, and deployment-smoke runtime evidence). The remaining risk is that the inventory becomes decorative metadata: future config keys could drift from env mapping, source-layer reporting, or secret redaction without a direct test failing.

## Solution

- Assert every inventory row has a unique key and env var plus owner class, reload behavior, and effective inspection path.
- Assert an env-sourced `POLYLOGUE_API_AUTH_TOKEN` appears only as `<set>`, reports `secret_present`, and preserves `source_layer=env` without leaking the real secret.
- Assert a typed env value from the inventory (`POLYLOGUE_BROWSER_CAPTURE_PORT`) reaches `effective_config_payload` with the right value, env var, and source layer.

The patch file `/realm/inbox/download/pths/polylogue_2309_config_inventory_effective_state.patch` was not mechanically applied. Its major code/docs intent is already present on `master`; this PR hardens the missing contract coverage around that landed surface.

## Verification

- `devtools test tests/unit/core/test_config.py::TestConfigInventoryPayload tests/unit/devtools/test_deployment_smoke.py::test_deployment_smoke_runtime_evidence_includes_effective_config tests/unit/devtools/test_deployment_smoke.py::test_deployment_smoke_includes_effective_config_evidence` -> pass (`5 passed`)
- `devtools verify --quick` -> pass (`20260623T121441Z-quick-3443684-3ebc9195`)
- pre-push `devtools verify --quick` -> pass (`20260623T121534Z-quick-3445534-f57a4d77`)

Ref #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for configuration payload validation, including verification of unique configuration keys, environment variable sourcing, and proper handling of sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->