### PR TITLE
test(sources): cover Claude Code runtime stderr fixtures

### DIFF
--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -35,6 +35,36 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
         },
         {
             "type": "user",
+            "uuid": "stderr-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067201.1,
+            "message": {
+                "role": "user",
+                "content": "<local-command-stderr>warning: generated runtime stderr</local-command-stderr>",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "bash-stdout-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067201.2,
+            "message": {
+                "role": "user",
+                "content": "<bash-stdout>cargo test passed</bash-stdout>",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "bash-stderr-1",
+            "sessionId": "sess-1",
+            "timestamp": 1704067201.3,
+            "message": {
+                "role": "user",
+                "content": "<bash-stderr>traceback from shell wrapper</bash-stderr>",
+            },
+        },
+        {
+            "type": "user",
             "uuid": "command-1",
             "sessionId": "sess-1",
             "timestamp": 1704067202,
@@ -88,11 +118,20 @@ def test_parse_code_classifies_runtime_artifacts() -> None:
     result = parse_code(items, "fallback")
 
     by_id = {message.provider_message_id: message for message in result.messages}
-    assert len(result.messages) == len(by_id) == 7
+    assert len(result.messages) == len(by_id) == 10
     assert by_id["task-1"].message_type is MessageType.PROTOCOL
     assert by_id["task-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
     assert by_id["stdout-1"].message_type is MessageType.PROTOCOL
     assert by_id["stdout-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
+    assert by_id["stderr-1"].role is Role.USER
+    assert by_id["stderr-1"].message_type is MessageType.PROTOCOL
+    assert by_id["stderr-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
+    assert by_id["bash-stdout-1"].role is Role.USER
+    assert by_id["bash-stdout-1"].message_type is MessageType.PROTOCOL
+    assert by_id["bash-stdout-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
+    assert by_id["bash-stderr-1"].role is Role.USER
+    assert by_id["bash-stderr-1"].message_type is MessageType.PROTOCOL
+    assert by_id["bash-stderr-1"].material_origin is MaterialOrigin.RUNTIME_PROTOCOL
     assert by_id["command-1"].message_type is MessageType.PROTOCOL
     assert by_id["command-1"].material_origin is MaterialOrigin.OPERATOR_COMMAND
     assert by_id["skill-1"].message_type is MessageType.CONTEXT


### PR DESCRIPTION
## Summary

Adds the remaining Claude Code runtime-output fixture cases for #2318: local command stderr plus bash stdout/stderr wrappers. These rows remain provider-role user messages, but the parser classifies them as runtime protocol material rather than human-authored prompts.

## Problem

The authoredness implementation and live archive audit separated human-authored text from provider-role runtime/protocol material, but the parser fixture set still only covered local command stdout. #2318 explicitly asked for parser fixtures covering local command stdout/stderr and bash stdout/stderr so future parser changes cannot regress these boundaries silently.

## Solution

- Extend `tests/unit/sources/test_parsers_claude_code_artifacts.py` with `<local-command-stderr>`, `<bash-stdout>`, and `<bash-stderr>` rows.
- Assert the rows keep `Role.USER` while carrying `MessageType.PROTOCOL` and `MaterialOrigin.RUNTIME_PROTOCOL`.
- Leave implementation unchanged because the classifier already recognizes these wrappers; the gap was fixture coverage.

This is not a mechanical application of any downloaded patch file. It is a small test patch from the #2318 AC audit.

## Verification

- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py` -> pass (`4 passed`)
- `devtools verify --quick` -> pass (`20260623T122052Z-quick-3462406-95227ff7`)
- pre-push hook -> skipped by verified HEAD cache for `14380282`

Ref #2318
