### PR TITLE
fix(daemon): preserve live stage telemetry payloads

### DIFF
--- a/polylogue/sources/live/batch_observability.py
+++ b/polylogue/sources/live/batch_observability.py
@@ -112,6 +112,7 @@ def record_attempt_progress(
         cgroup_memory_anon_mb=cgroup_stat_mb.get("anon"),
         cgroup_memory_file_mb=cgroup_stat_mb.get("file"),
         cgroup_memory_inactive_file_mb=cgroup_stat_mb.get("inactive_file"),
+        stage_payload=stage_payload,
         stage_timings_json=None
         if not stage_timings_s
         else json_dumps(stage_timings_s, sort_keys=True, separators=(",", ":")),

--- a/tests/unit/sources/test_live_batch_observability.py
+++ b/tests/unit/sources/test_live_batch_observability.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from polylogue.sources.live.batch_observability import record_attempt_progress
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.progress_kwargs: dict[str, Any] | None = None
+        self.event_kwargs: dict[str, Any] | None = None
+
+    def update_ingest_attempt(self, attempt_id: str, **kwargs: Any) -> bool:
+        self.progress_kwargs = {"attempt_id": attempt_id, **kwargs}
+        return True
+
+    def record_ingest_stage_event(self, attempt_id: str, **kwargs: Any) -> bool:
+        self.event_kwargs = {"attempt_id": attempt_id, **kwargs}
+        return True
+
+
+def test_record_attempt_progress_preserves_stage_payload_in_durable_event() -> None:
+    cursor = _RecordingCursor()
+
+    record_attempt_progress(
+        cursor,
+        "attempt-1",
+        phase="full_archive_write",
+        status="running",
+        queued_file_count=1,
+        needed_file_count=1,
+        succeeded_file_count=0,
+        failed_file_count=0,
+        input_bytes=128,
+        source_payload_read_bytes=64,
+        cursor_fingerprint_read_bytes=32,
+        archive_write_bytes_delta=16,
+        parse_time_s=1.25,
+        current_source="chatgpt",
+        current_path=Path("/archive/browser-capture/capture.json"),
+        stage_payload={
+            "storage_route": "archive_full",
+            "storage_write_tiers": "source,index",
+            "payload_available_file_count": 1,
+        },
+    )
+
+    assert cursor.progress_kwargs is not None
+    assert cursor.progress_kwargs["stage_payload"] == {
+        "storage_route": "archive_full",
+        "storage_write_tiers": "source,index",
+        "payload_available_file_count": 1,
+    }
+    assert cursor.event_kwargs is not None
+    assert cursor.event_kwargs["stage_payload"] == {
+        "storage_route": "archive_full",
+        "storage_write_tiers": "source,index",
+        "payload_available_file_count": 1,
+    }


### PR DESCRIPTION
## Summary

Preserves live-ingest `stage_payload` fields on the durable daemon-stage event path, so storage-route and write-tier telemetry survives into workload diagnostics instead of depending on only the progress update path.

## Problem

Ref #2308. The remaining live work depends on trustworthy daemon resource/backpressure evidence. `LiveBatchProcessor` already attaches route/write metadata such as `storage_route=archive_full` and `storage_write_tiers=source,index` to progress updates, but `record_attempt_progress()` dropped the same `stage_payload` when appending the secondary durable stage event. That made diagnostics fragile: route evidence could be missing or show as `unknown` even when the live batch path had the information.

## Solution

Forward `stage_payload` into `record_ingest_stage_event()` and add a focused regression around `record_attempt_progress()` proving storage-route payloads survive both durable progress paths.

Remaining #2308 scope: broader deployed dogfooding, source-preserving rebuild, and daemon backpressure work.

## Verification

- `devtools test tests/unit/sources/test_live_batch_observability.py tests/unit/devtools/test_daemon_workload_probe.py::test_daemon_workload_probe_reports_ops_tier_from_db_anchor` -> `2 passed`.
- `devtools verify --quick` -> pass (`20260623T124243Z-quick-3525970-2b91e19b`).
- pre-push `devtools verify --quick` -> pass (`20260623T124350Z-quick-3527178-23a4a830`).
