### PR TITLE
fix(cli): point root status to ops status

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -21,6 +21,11 @@ Usage: polylogue [OPTIONS] COMMAND [ARGS]...
       `polylogue --diagnose <args>` to have the parser explain how it
       routed your invocation.
 
+  Product roles:
+      Setup/demo/proof:  config, init, import, demo, tutorial
+      Operations:        polylogue ops status, ops diagnostics, ops maintenance, ops backup
+      Query actions:     find QUERY then read|select|mark|analyze|delete|continue
+
   Query mode (default):
       polylogue find "search terms"
       polylogue --origin claude-ai-export --since "last week" find "search terms"

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -288,6 +288,12 @@ def cli(
         routed your invocation.
 
     \b
+    Product roles:
+        Setup/demo/proof:  config, init, import, demo, tutorial
+        Operations:        polylogue ops status, ops diagnostics, ops maintenance, ops backup
+        Query actions:     find QUERY then read|select|mark|analyze|delete|continue
+
+    \b
     Query mode (default):
         polylogue find "search terms"
         polylogue --origin claude-ai-export --since "last week" find "search terms"

--- a/polylogue/cli/machine_main.py
+++ b/polylogue/cli/machine_main.py
@@ -45,6 +45,12 @@ def actionable_hint_for_usage_error(message: str) -> str | None:
 
         match = re.search(r"No such command ['\"]([^'\"]+)['\"]", msg)
         bad = match.group(1) if match is not None else msg.split("No such command")[-1].strip().split()[0]
+        if bad == "status":
+            return (
+                "Hint: `status` is an operational command. "
+                "Run `polylogue ops status` for daemon/archive status, or "
+                "`polylogue find status` if you meant to search for the word."
+            )
         return (
             f"Hint: `{bad}` is not a registered subcommand. "
             f"Did you mean to search? Try `polylogue find {bad}` "

--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -116,6 +116,12 @@ def _bare_root_error_message(group: click.Group, query_terms: tuple[str, ...]) -
     if len(query_terms) == 1:
         token = query_terms[0].strip()
         if token:
+            if token == "status":
+                lines += [
+                    "",
+                    "Status is an operational command. Try:",
+                    "    polylogue ops status",
+                ]
             from polylogue.cli.parser_diagnostics import looks_like_subcommand_typo
 
             suggestions = looks_like_subcommand_typo(token, sorted(group.commands.keys()))

--- a/tests/unit/cli/test_diagnose_and_error_discipline.py
+++ b/tests/unit/cli/test_diagnose_and_error_discipline.py
@@ -66,6 +66,15 @@ class TestRootHelpDocumentsQueryFirst:
         # help reference.
         assert "<subcommand> --help" in result.output
 
+    def test_root_help_labels_product_roles(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Product roles:" in result.output
+        assert "Setup/demo/proof:" in result.output
+        assert "Operations:" in result.output
+        assert "Query actions:" in result.output
+        assert "polylogue ops status" in result.output
+
 
 # ---------------------------------------------------------------------------
 # Contract 2: --diagnose prints parser-decision banner on stderr
@@ -96,6 +105,14 @@ class TestDiagnoseBanner:
         assert "polylogue find invalid-xyz" in result.output
         assert "strict command floor will refuse it" in result.output
         assert "interpreting as search query" not in result.output
+
+    def test_status_strict_floor_points_to_ops_status(self, runner: CliRunner) -> None:
+        """The natural root status instinct should point at the real owner."""
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 2
+        assert "No such command 'status'." in result.output
+        assert "polylogue ops status" in result.output
+        assert "polylogue find status" in result.output
 
     def test_diagnose_banner_on_matched_subcommand(
         self,
@@ -174,6 +191,12 @@ class TestUsageErrorHints:
         assert hint is not None
         assert "polylogue find foo" in hint
         assert "polylogue --help" in hint
+
+    def test_actionable_hint_for_root_status(self) -> None:
+        hint = actionable_hint_for_usage_error("No such command 'status'.")
+        assert hint is not None
+        assert "polylogue ops status" in hint
+        assert "polylogue find status" in hint
 
     def test_actionable_hint_for_strict_floor_message_extracts_command_only(self) -> None:
         hint = actionable_hint_for_usage_error(


### PR DESCRIPTION
## Summary

Adds a targeted root `status` diagnostic and labels root help by product role, so `polylogue status` points to `polylogue ops status` instead of the generic search hint.

## Problem

Ref #2317. Root onboarding drift made status a natural operator instinct, but the root strict-floor error only suggested `polylogue find status`. Root help also mixed setup/operator/query-action surfaces without role labels.

## Solution

Treat bare root `status` specially in the strict-floor and UsageError hint paths, add product-role labels to root help, regenerate `docs/cli-reference.md`, and add focused tests.

Remaining #2317 scope: dashboard/tutorial behavior, mark ownership, facet canonicalization/noise control, facet JSON/degraded-state shape, and demo-backed verification for those surfaces.

## Verification

- `devtools test tests/unit/cli/test_diagnose_and_error_discipline.py::TestRootHelpDocumentsQueryFirst tests/unit/cli/test_diagnose_and_error_discipline.py::TestDiagnoseBanner::test_status_strict_floor_points_to_ops_status tests/unit/cli/test_diagnose_and_error_discipline.py::TestUsageErrorHints::test_actionable_hint_for_root_status tests/unit/cli/test_help_contract.py::TestRootHelpStructure` -> `8 passed`.
- `devtools render all --check` -> passed.
- `devtools verify --quick` -> pass (`20260623T124951Z-quick-3534319-011618e8`).
