### PR TITLE
fix(storage): distrust FTS freshness without triggers

### DIFF
--- a/polylogue/storage/fts/freshness.py
+++ b/polylogue/storage/fts/freshness.py
@@ -13,6 +13,7 @@ READY = "ready"
 STALE = "stale"
 UNKNOWN = "unknown"
 MESSAGE_SURFACE = "messages_fts"
+_MESSAGE_FTS_TRIGGER_NAMES = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
 
 _CREATE_TABLE_SQL = f"""
     CREATE TABLE IF NOT EXISTS {FRESHNESS_TABLE} (
@@ -132,11 +133,31 @@ def _message_fts_source_has_rows_sync(conn: sqlite3.Connection) -> bool | None:
     return row is not None
 
 
+def _message_fts_triggers_present_sync(conn: sqlite3.Connection) -> bool:
+    placeholders = ", ".join("?" for _ in _MESSAGE_FTS_TRIGGER_NAMES)
+    row = conn.execute(
+        f"SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
+        _MESSAGE_FTS_TRIGGER_NAMES,
+    ).fetchone()
+    return row is not None and int(row[0] or 0) == len(_MESSAGE_FTS_TRIGGER_NAMES)
+
+
 async def _message_fts_source_has_rows_async(conn: aiosqlite.Connection) -> bool | None:
     if not await _named_table_exists_async(conn, "blocks"):
         return None
     row = await (await conn.execute("SELECT 1 FROM blocks WHERE search_text != '' LIMIT 1")).fetchone()
     return row is not None
+
+
+async def _message_fts_triggers_present_async(conn: aiosqlite.Connection) -> bool:
+    placeholders = ", ".join("?" for _ in _MESSAGE_FTS_TRIGGER_NAMES)
+    row = await (
+        await conn.execute(
+            f"SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
+            _MESSAGE_FTS_TRIGGER_NAMES,
+        )
+    ).fetchone()
+    return row is not None and int(row[0] or 0) == len(_MESSAGE_FTS_TRIGGER_NAMES)
 
 
 def ensure_fts_freshness_table_sync(conn: sqlite3.Connection) -> None:
@@ -326,6 +347,8 @@ def message_fts_recorded_ready_trusted_sync(conn: sqlite3.Connection) -> bool:
     if row is None:
         return False
     record = dict(zip(selected, row, strict=True))
+    if not _message_fts_triggers_present_sync(conn):
+        return False
     return freshness_ready_record_trusted(
         state=str(record["state"]),
         source_rows=_int_or_zero(record.get("source_rows")),
@@ -359,6 +382,8 @@ async def message_fts_recorded_ready_trusted_async(conn: aiosqlite.Connection) -
     record = dict(zip(selected, row, strict=True))
     source_rows = _int_or_zero(record.get("source_rows"))
     indexed_rows = _int_or_zero(record.get("indexed_rows"))
+    if not await _message_fts_triggers_present_async(conn):
+        return False
     return freshness_ready_record_trusted(
         state=str(record["state"]),
         source_rows=source_rows,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -5929,15 +5929,11 @@ def _ensure_messages_fts_ready(conn: sqlite3.Connection) -> None:
     "Search index" response instead of surfacing a raw ``no such table`` /
     empty-result 200.
     """
-    from polylogue.errors import DatabaseError
+    from polylogue.maintenance.targets import build_maintenance_target_catalog
+    from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_search_readiness_sync
 
-    repair_hint = "Run `polylogue ops doctor --repair` to rebuild the search index."
-    if not _table_exists(conn, "messages_fts"):
-        raise DatabaseError(f"Search index not built. {repair_hint}")
-    text_blocks = _count_scalar(conn, "SELECT COUNT(*) FROM blocks WHERE search_text != ''")
-    fts_rows = _count_scalar(conn, "SELECT COUNT(*) FROM messages_fts")
-    if fts_rows < text_blocks:
-        raise DatabaseError(f"Search index is incomplete. {repair_hint}")
+    repair_hint = build_maintenance_target_catalog().repair_hint(("dangling_fts",), include_run_all=True)
+    check_fts_readiness(message_fts_search_readiness_sync(conn), repair_hint)
 
 
 def _epoch_ms_from_iso(value: object) -> int | None:

--- a/tests/unit/storage/test_archive_tiers_search_guard.py
+++ b/tests/unit/storage/test_archive_tiers_search_guard.py
@@ -9,10 +9,13 @@ column operator.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 
+from polylogue.errors import DatabaseError
+from polylogue.storage.fts.freshness import record_fts_surface_state_sync
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from tests.infra.storage_records import SessionBuilder, db_setup
 
@@ -44,6 +47,34 @@ def test_hyphenated_token_does_not_raise(workspace_env: dict[str, Path]) -> None
         # And the count path stays consistent.
         assert archive.count_search_sessions("drive-file-1") >= 0
         assert isinstance(hits, list)
+
+
+def test_search_rejects_ready_freshness_row_when_triggers_missing(workspace_env: dict[str, Path]) -> None:
+    archive_root = _seed(workspace_env)
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        source_rows = int(conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0] or 0)
+        indexed_rows = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
+        record_fts_surface_state_sync(
+            conn,
+            surface="messages_fts",
+            state="ready",
+            source_rows=source_rows,
+            indexed_rows=indexed_rows,
+            missing_rows=0,
+            excess_rows=0,
+            duplicate_rows=0,
+        )
+        conn.executescript(
+            """
+            DROP TRIGGER IF EXISTS messages_fts_ai;
+            DROP TRIGGER IF EXISTS messages_fts_ad;
+            DROP TRIGGER IF EXISTS messages_fts_au;
+            """
+        )
+
+    with ArchiveStore.open_existing(archive_root) as archive:
+        with pytest.raises(DatabaseError, match="Search index is incomplete"):
+            archive.search_summaries("drive-file-1")
 
 
 @pytest.mark.parametrize("query", ["*", "AND", "NOT", '"unterminated', "col:val"])

--- a/tests/unit/storage/test_dangling_fts_derived_surfaces.py
+++ b/tests/unit/storage/test_dangling_fts_derived_surfaces.py
@@ -141,6 +141,52 @@ def test_search_readiness_rejects_poisoned_zero_count_ready_marker(tmp_path: Pat
     assert recorded == (1, 0, "exact message readiness failed")
 
 
+def test_search_readiness_rejects_ready_marker_when_triggers_are_missing(tmp_path: Path) -> None:
+    db = tmp_path / "archive.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE blocks (
+                block_id TEXT, message_id TEXT, session_id TEXT, block_type TEXT, text TEXT, search_text TEXT
+            );
+            CREATE VIRTUAL TABLE messages_fts USING fts5(
+                block_id UNINDEXED, message_id UNINDEXED, session_id UNINDEXED, block_type UNINDEXED, text,
+                content='', contentless_delete=1
+            );
+            CREATE TABLE fts_freshness_state (
+                surface TEXT PRIMARY KEY, state TEXT NOT NULL, checked_at TEXT NOT NULL,
+                source_rows INTEGER NOT NULL DEFAULT 0, indexed_rows INTEGER NOT NULL DEFAULT 0,
+                missing_rows INTEGER NOT NULL DEFAULT 0, excess_rows INTEGER NOT NULL DEFAULT 0,
+                duplicate_rows INTEGER NOT NULL DEFAULT 0, detail TEXT
+            );
+            INSERT INTO blocks VALUES ('block-1', 'msg-1', 'conv-1', 'text', 'needle freshness', 'needle freshness');
+            INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
+            SELECT rowid, block_id, message_id, session_id, block_type, search_text FROM blocks;
+            INSERT INTO fts_freshness_state (
+                surface, state, checked_at, source_rows, indexed_rows,
+                missing_rows, excess_rows, duplicate_rows, detail
+            )
+            VALUES ('messages_fts', 'ready', 'now', 1, 1, 0, 0, 0, NULL);
+            """
+        )
+
+        readiness = message_fts_search_readiness_sync(conn)
+        state = message_fts_recorded_state_sync(conn)
+        recorded = conn.execute(
+            "SELECT state, source_rows, indexed_rows, detail FROM fts_freshness_state WHERE surface='messages_fts'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert readiness["ready"] is False
+    assert readiness["triggers_present"] is False
+    assert readiness["total_rows"] == 1
+    assert readiness["indexed_rows"] == 1
+    assert state == "stale"
+    assert recorded == ("stale", 1, 1, "exact message readiness failed")
+
+
 def test_search_readiness_uses_blocks_as_zero_count_trust_source(tmp_path: Path) -> None:
     """A ready|0|0 ledger is untrusted when the actual FTS source has rows."""
     db = tmp_path / "archive.db"


### PR DESCRIPTION
## Summary

Hardens message FTS readiness so search no longer trusts a recorded `messages_fts` ready row after the FTS sync triggers disappear.

## Problem

Search correctness depends on `messages_fts` being pristine. The freshness ledger already records exact row counts, but the `ready` fast path did not require the current trigger set to still exist. If triggers were dropped after readiness was recorded, retrieval could treat the index as fresh until another exact probe ran.

## Solution

Require the three `messages_fts` triggers before trusting a recorded ready freshness row, for both sync and async readers. The native `ArchiveStore` search guard now uses the shared `message_fts_search_readiness_sync` and `check_fts_readiness` path instead of a weaker count-only check, so stale/missing-trigger FTS state fails closed with the normal repair hint.

## Verification

- `devtools test tests/unit/storage/test_dangling_fts_derived_surfaces.py tests/unit/storage/test_archive_tiers_search_guard.py` -> `15 passed`.
- `devtools verify --quick` -> pass (`20260623T130103Z-quick-3559783-c36a34dd`).
- pre-push `devtools verify --quick` -> pass (`20260623T130146Z-quick-3561801-511a8f85`).
