### PR TITLE
fix(config): report effective configuration debt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,13 @@ Secrets are never printed in cleartext. Set secrets show as `<set>` and unset or
 empty secrets show as `<unset>`, while `secret_present` preserves the useful bit
 for diagnostics.
 
+The JSON form also includes a `diagnostics` array. Each item has stable
+`code`, `severity`, `key`, `toml_path`, `env_var`, `message`, and
+`next_action` fields so deployment smoke, agents, and shell scripts can tell
+configuration debt from daemon/runtime failures. Current diagnostics cover
+operator-supplied path-layout problems and `embedding.enabled = true` without
+a configured Voyage key.
+
 ### State classes
 
 | Class | Where it lives | Examples | Reload behavior |

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -21,6 +21,7 @@ from .paths import (
     GEMINI_DRIVE_FOLDER,
     archive_root,
     config_home,
+    data_home,
     drive_cache_path,
     drive_credentials_path,
     drive_token_path,
@@ -983,14 +984,12 @@ def _user_config_path() -> Path | None:
 def _default_config_values() -> dict[str, object]:
     """Built-in defaults (layer 1).
 
-    Pure function — does not touch the filesystem, env, or CLI state.
-    The one exception is ``archive_root``, which derives from XDG paths
-    via :func:`archive_root`; that resolution is itself env-driven but
-    represents the documented built-in default for an unconfigured
-    install.
+    The ``archive_root`` default follows the XDG data root, but the explicit
+    ``POLYLOGUE_ARCHIVE_ROOT`` override is applied only by the env layer below
+    so layer provenance remains accurate.
     """
     return {
-        "archive_root": str(archive_root()),
+        "archive_root": str(data_home()),
         "daemon_url": "http://127.0.0.1:8766",
         "daemon_host": "127.0.0.1",
         "daemon_port": 8766,
@@ -1406,7 +1405,7 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
         value = resolved.raw.get(entry.key)
         # Defaults may legitimately point at not-yet-created first-run paths.
         # Operator-provided paths must be explicit enough to audit.
-        if resolved.layer_of(entry.key) == "default" and not (entry.env_var and entry.env_var in os.environ):
+        if resolved.layer_of(entry.key) == "default":
             continue
         for raw_path in _iter_path_config_values(entry.key, value):
             path = _expand_config_path(raw_path)

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -1359,6 +1359,98 @@ def config_inventory_payload() -> list[dict[str, object]]:
     return [_inventory_entry_payload(entry, default=defaults.get(entry.key, _MISSING)) for entry in _CONFIG_INVENTORY]
 
 
+def _config_diagnostic(
+    *,
+    code: str,
+    severity: str,
+    key: str,
+    message: str,
+    next_action: str,
+) -> dict[str, object]:
+    entry = _CONFIG_INVENTORY_BY_KEY.get(key)
+    return {
+        "code": code,
+        "severity": severity,
+        "key": key,
+        "toml_path": entry.toml_path if entry is not None else None,
+        "env_var": entry.env_var if entry is not None else None,
+        "message": message,
+        "next_action": next_action,
+    }
+
+
+def _iter_path_config_values(key: str, value: object) -> list[str]:
+    if value in (None, "", ()):
+        return []
+    if key == "source_roots":
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (tuple, list)):
+            return [str(item) for item in value if str(item)]
+        return [str(value)]
+    return [str(value)]
+
+
+def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object]]:
+    diagnostics: list[dict[str, object]] = []
+    for entry in _CONFIG_INVENTORY:
+        if entry.owner_class != "path-layout":
+            continue
+        value = resolved.raw.get(entry.key)
+        # Defaults may legitimately point at not-yet-created first-run paths.
+        # Operator-provided paths must be explicit enough to audit.
+        if resolved.layer_of(entry.key) == "default":
+            continue
+        for raw_path in _iter_path_config_values(entry.key, value):
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                diagnostics.append(
+                    _config_diagnostic(
+                        code="config_path_not_absolute",
+                        severity="error",
+                        key=entry.key,
+                        message=f"{entry.key} resolves to a relative path: {raw_path!r}.",
+                        next_action=(
+                            f"Set {entry.toml_path or entry.key} to an absolute path"
+                            + (f" or override {entry.env_var}" if entry.env_var else "")
+                            + "."
+                        ),
+                    )
+                )
+                continue
+            if entry.key == "source_roots" and not path.exists():
+                diagnostics.append(
+                    _config_diagnostic(
+                        code="configured_source_root_missing",
+                        severity="warning",
+                        key=entry.key,
+                        message=f"Configured source root does not exist: {raw_path}.",
+                        next_action="Remove the stale source root or create/mount it before running the daemon.",
+                    )
+                )
+    return diagnostics
+
+
+def config_diagnostics(cfg: PolylogueConfig | None = None) -> list[dict[str, object]]:
+    """Return typed diagnostics for the resolved effective configuration."""
+    resolved = cfg if cfg is not None else load_polylogue_config()
+    diagnostics = _config_path_diagnostics(resolved)
+    if resolved.embedding_enabled and not resolved.voyage_api_key:
+        diagnostics.append(
+            _config_diagnostic(
+                code="embedding_enabled_without_voyage_key",
+                severity="error",
+                key="voyage_api_key",
+                message="Embedding convergence is enabled but no Voyage API key is configured.",
+                next_action=(
+                    "Set VOYAGE_API_KEY, run `polylogue ops embed enable --voyage-api-key ...`, "
+                    "or disable embedding convergence."
+                ),
+            )
+        )
+    return diagnostics
+
+
 def effective_config_payload(
     cfg: PolylogueConfig | None = None,
     *,
@@ -1411,6 +1503,7 @@ def effective_config_payload(
             "cli": "CLI overrides (per-invocation)",
         },
         "values": values,
+        "diagnostics": config_diagnostics(resolved),
     }
     if include_inventory:
         payload["inventory"] = config_inventory_payload()
@@ -1466,6 +1559,7 @@ __all__ = [
     "SECRET_UNSET_PLACEHOLDER",
     "Source",
     "config_display_value",
+    "config_diagnostics",
     "config_inventory",
     "config_inventory_by_key",
     "config_inventory_payload",

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -1391,6 +1391,13 @@ def _iter_path_config_values(key: str, value: object) -> list[str]:
     return [str(value)]
 
 
+def _expand_config_path(raw_path: str) -> Path | None:
+    try:
+        return Path(raw_path).expanduser()
+    except RuntimeError:
+        return None
+
+
 def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object]]:
     diagnostics: list[dict[str, object]] = []
     for entry in _CONFIG_INVENTORY:
@@ -1399,10 +1406,25 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
         value = resolved.raw.get(entry.key)
         # Defaults may legitimately point at not-yet-created first-run paths.
         # Operator-provided paths must be explicit enough to audit.
-        if resolved.layer_of(entry.key) == "default":
+        if resolved.layer_of(entry.key) == "default" and not (entry.env_var and entry.env_var in os.environ):
             continue
         for raw_path in _iter_path_config_values(entry.key, value):
-            path = Path(raw_path).expanduser()
+            path = _expand_config_path(raw_path)
+            if path is None:
+                diagnostics.append(
+                    _config_diagnostic(
+                        code="config_path_invalid",
+                        severity="error",
+                        key=entry.key,
+                        message=f"{entry.key} resolves to an invalid path: {raw_path!r}.",
+                        next_action=(
+                            f"Set {entry.toml_path or entry.key} to an absolute path with a valid home expansion"
+                            + (f" or override {entry.env_var}" if entry.env_var else "")
+                            + "."
+                        ),
+                    )
+                )
+                continue
             if not path.is_absolute():
                 diagnostics.append(
                     _config_diagnostic(

--- a/tests/unit/cli/test_config_command.py
+++ b/tests/unit/cli/test_config_command.py
@@ -140,3 +140,21 @@ def test_json_effective_config_includes_inventory_and_layer_metadata(
 
     inventory_keys = {entry["key"] for entry in payload["inventory"]}
     assert {"api_port", "api_auth_token", "browser_capture_spool_path"}.issubset(inventory_keys)
+    assert "diagnostics" in payload
+
+
+def test_json_effective_config_includes_typed_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "polylogue.toml"
+    cfg.write_text("[embedding]\nenabled = true\n", encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(cfg))
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(tmp_path / "absent-site.toml"))
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+    payload = json.loads(_run(["-f", "json"]))
+
+    assert any(
+        diag["code"] == "embedding_enabled_without_voyage_key"
+        and diag["key"] == "voyage_api_key"
+        and diag["env_var"] == "VOYAGE_API_KEY"
+        for diag in payload["diagnostics"]
+    )

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -117,3 +117,62 @@ def test_effective_config_payload_redacts_secret_presence_and_exposes_source_lay
     assert api_port["effective_path"] == "polylogue config --format json values.api_port"
 
     assert "do-not-leak" not in str(payload)
+
+
+def test_effective_config_payload_reports_configured_source_root_debt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    missing_root = tmp_path / "missing-source-root"
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
+        f"""
+[sources]
+roots = ["{missing_root}"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert {
+        "code": "configured_source_root_missing",
+        "severity": "warning",
+        "key": "source_roots",
+        "toml_path": "sources.roots",
+        "env_var": None,
+        "message": f"Configured source root does not exist: {missing_root}.",
+        "next_action": "Remove the stale source root or create/mount it before running the daemon.",
+    } in diagnostics
+
+
+def test_effective_config_payload_reports_embedding_enabled_without_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text("[embedding]\nenabled = true\n", encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert any(
+        diag.get("code") == "embedding_enabled_without_voyage_key"
+        and diag.get("severity") == "error"
+        and diag.get("key") == "voyage_api_key"
+        and diag.get("env_var") == "VOYAGE_API_KEY"
+        for diag in diagnostics
+        if isinstance(diag, dict)
+    )

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -152,6 +152,61 @@ roots = ["{missing_root}"]
     } in diagnostics
 
 
+def test_effective_config_payload_reports_invalid_home_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    cfg_path = tmp_path / "polylogue.toml"
+    raw_root = "~polylogue-user-that-should-not-exist/source"
+    cfg_path.write_text(
+        f"""
+[sources]
+roots = ["{raw_root}"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert any(
+        diag.get("code") == "config_path_invalid"
+        and diag.get("severity") == "error"
+        and diag.get("key") == "source_roots"
+        and raw_root in str(diag.get("message"))
+        for diag in diagnostics
+        if isinstance(diag, dict)
+    )
+
+
+def test_effective_config_payload_reports_env_relative_archive_root(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", "relative-archive")
+
+    payload = effective_config_payload(load_polylogue_config())
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert any(
+        diag.get("code") == "config_path_not_absolute"
+        and diag.get("severity") == "error"
+        and diag.get("key") == "archive_root"
+        and diag.get("env_var") == "POLYLOGUE_ARCHIVE_ROOT"
+        for diag in diagnostics
+        if isinstance(diag, dict)
+    )
+
+
 def test_effective_config_payload_reports_embedding_enabled_without_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -207,6 +207,30 @@ def test_effective_config_payload_reports_env_relative_archive_root(
     )
 
 
+def test_config_diagnostics_use_resolved_snapshot_not_ambient_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", "relative-archive")
+    cfg = load_polylogue_config()
+    monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT")
+
+    payload = effective_config_payload(cfg)
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert any(
+        diag.get("code") == "config_path_not_absolute"
+        and diag.get("key") == "archive_root"
+        and diag.get("env_var") == "POLYLOGUE_ARCHIVE_ROOT"
+        for diag in diagnostics
+        if isinstance(diag, dict)
+    )
+
+
 def test_effective_config_payload_reports_embedding_enabled_without_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Adds typed diagnostics to `polylogue config --format json` so effective configuration output reports common broken states directly instead of requiring downstream commands or deployment-smoke to infer them.

## Problem

Ref #2309. The effective config inventory already exposes values, owners, reload behavior, and redacted provenance, but it still treats obviously broken operator state as ordinary values. Missing configured source roots and `embedding.enabled = true` without a Voyage key can be misread as daemon, provider, or deployment failures.

## Solution

`polylogue.config.effective_config_payload` now includes a `diagnostics` array with stable `code`, `severity`, `key`, `toml_path`, `env_var`, `message`, and `next_action` fields. The first diagnostics cover operator-supplied path-layout debt and embedding convergence enabled without a provider key. The JSON CLI surface, core inventory tests, and configuration docs now cover the contract.

Remaining #2309 scope: deeper Sinnix wrapper/deployed overlay evidence and any broader runtime-state consolidation not proven by this PR.

## Verification

- `devtools test tests/unit/core/test_config_inventory.py tests/unit/cli/test_config_command.py` -> `16 passed`
- `devtools verify --quick` -> pass `20260623T130733Z-quick-3577969-bc345640`
- pre-push `devtools verify --quick` -> pass `20260623T130813Z-quick-3578642-4cc5f61c`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration output now includes a `diagnostics` array with structured error and warning information, including codes, severity levels, configuration keys, and actionable guidance.
  * Diagnostics validate path configurations and embedding settings.

* **Documentation**
  * Updated configuration documentation to document the diagnostics field in JSON format output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
