### PR TITLE
fix(usage): expose codex zero-token projection debt

### DIFF
--- a/docs/schemas/cli-output/archive-debt-list.schema.json
+++ b/docs/schemas/cli-output/archive-debt-list.schema.json
@@ -98,6 +98,7 @@
             "convergence",
             "embedding",
             "fts",
+            "provider-usage",
             "raw-materialization"
           ],
           "title": "Kind",

--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -54,6 +54,8 @@ def archive_debt_list(
         rows.extend(_assertion_candidate_rows(archive_root / "user.db"))
     if _include("raw-materialization", selected_kinds):
         rows.extend(_raw_materialization_rows(archive_root))
+    if _include("provider-usage", selected_kinds):
+        rows.extend(_provider_usage_rows(index_db))
     if _include("convergence", selected_kinds):
         rows.extend(_convergence_rows(index_db))
     if _include("embedding", selected_kinds):
@@ -497,6 +499,85 @@ def _source_family(subject_type: str, subject_id: str) -> str:
     from polylogue.daemon.convergence_debt_alert import source_family_for_subject
 
     return source_family_for_subject(subject_type, subject_id)
+
+
+def _provider_usage_rows(index_db: Path) -> list[ArchiveDebtRowPayload]:
+    if not index_db.exists():
+        return []
+    try:
+        conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error:
+        return []
+    try:
+        if not _table_exists(conn, "sessions") or not _table_exists(conn, "session_model_usage"):
+            return []
+        rows = list(
+            conn.execute(
+                """
+                SELECT
+                    s.origin AS origin,
+                    COUNT(DISTINCT s.session_id) AS session_count,
+                    COUNT(*) AS model_row_count,
+                    COUNT(DISTINCT smu.model_name) AS model_count
+                FROM sessions AS s
+                JOIN session_model_usage AS smu ON smu.session_id = s.session_id
+                WHERE s.origin = 'codex-session'
+                GROUP BY s.origin
+                HAVING COALESCE(SUM(smu.input_tokens), 0) = 0
+                   AND COALESCE(SUM(smu.output_tokens), 0) = 0
+                   AND COALESCE(SUM(smu.cache_read_tokens), 0) = 0
+                   AND COALESCE(SUM(smu.cache_write_tokens), 0) = 0
+                """
+            )
+        )
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+
+    debt_rows: list[ArchiveDebtRowPayload] = []
+    for row in rows:
+        origin = str(row["origin"])
+        session_count = _int_value(row["session_count"]) or 0
+        model_row_count = _int_value(row["model_row_count"]) or 0
+        model_count = _int_value(row["model_count"]) or 0
+        if session_count <= 0 or model_row_count <= 0:
+            continue
+        debt_rows.append(
+            ArchiveDebtRowPayload(
+                debt_ref=f"debt:provider-usage:{origin}:zero-token-projection",
+                kind="provider-usage",
+                stage="usage-projection",
+                subject_ref=f"raw-origin:{origin}",
+                severity="warning",
+                status="open",
+                owner="archive",
+                summary=f"{session_count} {origin} session(s) have model rows but no projected token usage",
+                details=(
+                    f"{model_row_count} session_model_usage row(s) across {model_count} model(s) contain only zero "
+                    "token counters. Codex token_count events are parser-visible but are not yet materialized into "
+                    "a provider-usage ledger or rollup."
+                ),
+                source_family=origin,
+                evidence_refs=(f"archive-tier:{index_db}", "table:session_model_usage"),
+                caveats=(
+                    "Zero projected tokens are usage-coverage debt, not evidence that the sessions consumed no tokens.",
+                ),
+            )
+        )
+    return debt_rows
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ? LIMIT 1",
+            (table,),
+        ).fetchone()
+    except sqlite3.Error:
+        return False
+    return row is not None
 
 
 def _embedding_rows(index_db: Path) -> list[ArchiveDebtRowPayload]:

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -147,6 +147,24 @@ def _optional_int_field(record: dict[str, object], *keys: str) -> int | None:
     return None
 
 
+def _codex_token_usage_payload(record: dict[str, object] | None) -> dict[str, int]:
+    if not record:
+        return {}
+    usage: dict[str, int] = {}
+    field_aliases = {
+        "input_tokens": ("input_tokens", "inputTokenCount"),
+        "cached_input_tokens": ("cached_input_tokens", "cache_read_input_tokens", "cached_tokens"),
+        "output_tokens": ("output_tokens", "outputTokenCount"),
+        "reasoning_output_tokens": ("reasoning_output_tokens", "reasoning_tokens"),
+        "total_tokens": ("total_tokens", "totalTokenCount"),
+    }
+    for public_key, aliases in field_aliases.items():
+        value = _optional_int_field(record, *aliases)
+        if value is not None:
+            usage[public_key] = value
+    return usage
+
+
 def _turn_context_payload(payload: dict[str, object]) -> dict[str, object]:
     nested = payload.get("turn_context")
     if isinstance(nested, dict):
@@ -239,6 +257,23 @@ def _compact_response_payload(payload: dict[str, object], *, index: int) -> dict
     cwd = _extract_cwd(payload)
     if cwd:
         compact["cwd"] = cwd
+    if compact.get("type") == "token_count":
+        info = _dict_record(payload.get("info")) or {}
+        last_usage = _codex_token_usage_payload(_dict_record(info.get("last_token_usage")))
+        total_usage = _codex_token_usage_payload(_dict_record(info.get("total_token_usage")))
+        if not last_usage:
+            last_usage = _codex_token_usage_payload(_dict_record(payload.get("last_token_usage")) or payload)
+        if not total_usage:
+            total_usage = _codex_token_usage_payload(_dict_record(payload.get("total_token_usage")))
+        if last_usage:
+            compact["last_token_usage"] = last_usage
+        if total_usage:
+            compact["total_token_usage"] = total_usage
+        context_window = _optional_int_field(info, "model_context_window") or _optional_int_field(
+            payload, "model_context_window"
+        )
+        if context_window is not None:
+            compact["model_context_window"] = context_window
     return compact
 
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -293,6 +293,7 @@ ArchiveDebtKind = Literal[
     "convergence",
     "embedding",
     "fts",
+    "provider-usage",
     "raw-materialization",
 ]
 ArchiveDebtSeverity = Literal["info", "warning", "critical"]

--- a/tests/unit/operations/test_archive_debt.py
+++ b/tests/unit/operations/test_archive_debt.py
@@ -316,6 +316,76 @@ def test_archive_debt_reports_raw_materialization_debt(tmp_path: Path) -> None:
     assert "passed=1" in (parsed_gap.details or "")
 
 
+def test_archive_debt_reports_codex_zero_token_projection_debt(tmp_path: Path) -> None:
+    _write_current_tier_files(tmp_path)
+    index_db = tmp_path / "index.db"
+    with sqlite3.connect(index_db) as conn:
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY, origin TEXT NOT NULL)")
+        conn.execute(
+            """
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL,
+                model_name TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute("INSERT INTO sessions (session_id, origin) VALUES ('codex-session:s1', 'codex-session')")
+        conn.execute(
+            """
+            INSERT INTO session_model_usage (
+                session_id, model_name, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
+            ) VALUES ('codex-session:s1', 'gpt-5-codex', 0, 0, 0, 0)
+            """
+        )
+
+    payload = archive_debt_list(archive_root=tmp_path, kinds=("provider-usage",))
+
+    assert payload.totals.total == 1
+    row = payload.rows[0]
+    assert row.debt_ref == "debt:provider-usage:codex-session:zero-token-projection"
+    assert row.kind == "provider-usage"
+    assert row.stage == "usage-projection"
+    assert row.severity == "warning"
+    assert row.status == "open"
+    assert "no projected token usage" in row.summary
+    assert "not evidence that the sessions consumed no tokens" in row.caveats[0]
+
+
+def test_archive_debt_ignores_codex_usage_rows_with_nonzero_tokens(tmp_path: Path) -> None:
+    _write_current_tier_files(tmp_path)
+    index_db = tmp_path / "index.db"
+    with sqlite3.connect(index_db) as conn:
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY, origin TEXT NOT NULL)")
+        conn.execute(
+            """
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL,
+                model_name TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute("INSERT INTO sessions (session_id, origin) VALUES ('codex-session:s1', 'codex-session')")
+        conn.execute(
+            """
+            INSERT INTO session_model_usage (
+                session_id, model_name, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
+            ) VALUES ('codex-session:s1', 'gpt-5-codex', 10, 0, 0, 0)
+            """
+        )
+
+    payload = archive_debt_list(archive_root=tmp_path, kinds=("provider-usage",))
+
+    assert payload.rows == ()
+
+
 def test_archive_debt_raw_materialization_ignores_materialized_rows(tmp_path: Path) -> None:
     source_db, index_db, _source_file = _init_raw_materialization_fixture(tmp_path)
     with sqlite3.connect(index_db) as conn:

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -739,3 +739,53 @@ class TestEdgeCases:
         assert result.messages[0].blocks[0].tool_name == "exec_command"
         assert result.messages[0].blocks[0].tool_input == {"cmd": "git status"}
         assert result.messages[1].blocks[0].type == "tool_result"
+
+    def test_token_count_event_preserves_nested_usage_counters(self) -> None:
+        payload = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 111,
+                            "cached_input_tokens": 22,
+                            "output_tokens": 33,
+                            "reasoning_output_tokens": 4,
+                            "total_tokens": 170,
+                        },
+                        "total_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 9000,
+                            "output_tokens": 300,
+                            "reasoning_output_tokens": 40,
+                            "total_tokens": 10340,
+                        },
+                        "model_context_window": 200000,
+                    },
+                },
+            },
+        ]
+
+        result = parse(payload, "fallback")
+
+        assert [event.event_type for event in result.session_events] == ["token_count"]
+        assert result.session_events[0].payload == {
+            "source_index": 1,
+            "type": "token_count",
+            "last_token_usage": {
+                "input_tokens": 111,
+                "cached_input_tokens": 22,
+                "output_tokens": 33,
+                "reasoning_output_tokens": 4,
+                "total_tokens": 170,
+            },
+            "total_token_usage": {
+                "input_tokens": 1000,
+                "cached_input_tokens": 9000,
+                "output_tokens": 300,
+                "reasoning_output_tokens": 40,
+                "total_tokens": 10340,
+            },
+            "model_context_window": 200000,
+        }


### PR DESCRIPTION
## Summary

Preserves structured Codex `token_count` usage details in parsed session events and exposes the current durable gap as `provider-usage` archive debt when Codex `session_model_usage` rows contain only zero token counters.

## Problem

Ref #2316 documents that Codex raw/session streams contain `token_count` events, but current durable rollups can still show Codex model rows with all token counters at zero. That makes missing provider-usage projection look like no usage, which is misleading for archive status, diagnostics, and future usage analysis work.

## Solution

The Codex parser now compacts nested `info.last_token_usage`, `info.total_token_usage`, and `model_context_window` into bounded `token_count` event payloads instead of dropping those counters at the parser boundary. The shared archive-debt payload vocabulary adds `provider-usage`, and `archive_debt_list(..., kinds=("provider-usage",))` reports Codex zero-token model rows as usage-coverage debt with an explicit caveat that zero projection is not evidence of zero provider usage. The generated CLI output schema was refreshed for the new debt kind.

This is intentionally a first slice, not full #2316 closure. It does not add the final usage-event storage table or cross-provider rollups yet; it makes the existing gap visible and preserves parser-level evidence for that next step.

## Verification

- `devtools test tests/unit/sources/test_parsers_codex.py tests/unit/operations/test_archive_debt.py` -> 54 passed
- `devtools verify --quick` -> pass `20260623T133220Z-quick-3666771-0ef384e3`
- pre-push `devtools verify --quick` -> pass `20260623T133336Z-quick-3668127-f7d63714`

## Risks

No storage schema bump. The new archive-debt row is a diagnostic signal only; it does not claim the underlying usage ledger is complete.