### PR TITLE
feat(usage): materialize provider token events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1145,7 +1145,12 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
-- Index schema version 5 adds `messages.material_origin` plus authored-user
+- Index schema version 6 adds `session_provider_usage_events` for
+  provider-reported token usage events and single-model rollup repair from
+  those events. Existing index tiers must be rebuilt from source evidence so
+  Codex `token_count` records materialize into durable provider usage rows
+  instead of disappearing after parse.
+- Index schema version 5 added `messages.material_origin` plus authored-user
   aggregate columns on `sessions`. Existing index tiers must be rebuilt from
   source evidence so Claude Code `role=user` protocol/context/generated-pack
   rows move out of authored-user accounting while provider-role counts remain

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,7 +106,12 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
-- Index schema version 5 adds `messages.material_origin` plus authored-user
+- Index schema version 6 adds `session_provider_usage_events` for
+  provider-reported token usage events and single-model rollup repair from
+  those events. Existing index tiers must be rebuilt from source evidence so
+  Codex `token_count` records materialize into durable provider usage rows
+  instead of disappearing after parse.
+- Index schema version 5 added `messages.material_origin` plus authored-user
   aggregate columns on `sessions`. Existing index tiers must be rebuilt from
   source evidence so Claude Code `role=user` protocol/context/generated-pack
   rows move out of authored-user accounting while provider-role counts remain

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ over the `CREATE TABLE` statement.
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 1` |
-| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 4` |
+| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 6` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 1` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 3` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -14,7 +14,7 @@ from polylogue.core.enums import (
 )
 from polylogue.storage.sqlite.archive_tiers.common import CONTENT_HASH_CHECK, check, nullable_check
 
-INDEX_SCHEMA_VERSION = 5
+INDEX_SCHEMA_VERSION = 6
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -461,6 +461,32 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     cost_provenance         TEXT CHECK(cost_provenance IN ('origin_reported', 'priced', 'estimated') OR cost_provenance IS NULL),
     PRIMARY KEY(session_id, model_name)
 ) STRICT;
+
+CREATE TABLE IF NOT EXISTS session_provider_usage_events (
+    usage_event_id                 TEXT GENERATED ALWAYS AS (session_id || ':usage:' || position) STORED UNIQUE,
+    session_id                     TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+    source_message_id              TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
+    position                       INTEGER NOT NULL CHECK(position >= 0),
+    provider_event_type            TEXT NOT NULL CHECK(provider_event_type IN ('token_count')),
+    model_name                     TEXT,
+    last_input_tokens              INTEGER NOT NULL DEFAULT 0 CHECK(last_input_tokens >= 0),
+    last_output_tokens             INTEGER NOT NULL DEFAULT 0 CHECK(last_output_tokens >= 0),
+    last_cached_input_tokens       INTEGER NOT NULL DEFAULT 0 CHECK(last_cached_input_tokens >= 0),
+    last_reasoning_output_tokens   INTEGER NOT NULL DEFAULT 0 CHECK(last_reasoning_output_tokens >= 0),
+    last_total_tokens              INTEGER NOT NULL DEFAULT 0 CHECK(last_total_tokens >= 0),
+    total_input_tokens             INTEGER NOT NULL DEFAULT 0 CHECK(total_input_tokens >= 0),
+    total_output_tokens            INTEGER NOT NULL DEFAULT 0 CHECK(total_output_tokens >= 0),
+    total_cached_input_tokens      INTEGER NOT NULL DEFAULT 0 CHECK(total_cached_input_tokens >= 0),
+    total_reasoning_output_tokens  INTEGER NOT NULL DEFAULT 0 CHECK(total_reasoning_output_tokens >= 0),
+    total_tokens                   INTEGER NOT NULL DEFAULT 0 CHECK(total_tokens >= 0),
+    model_context_window           INTEGER CHECK(model_context_window IS NULL OR model_context_window >= 0),
+    payload_json                   TEXT NOT NULL DEFAULT '{{}}',
+    occurred_at_ms                 INTEGER,
+    PRIMARY KEY(session_id, position)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_session_provider_usage_events_session
+ON session_provider_usage_events(session_id, position);
 
 CREATE TABLE IF NOT EXISTS session_tags (
     session_id    TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,

--- a/polylogue/storage/sqlite/archive_tiers/self_verify.py
+++ b/polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -23,6 +23,11 @@ def build_archive_session_self_verify_envelope(
             "messages": len(envelope.messages),
             "blocks": sum(len(message.blocks) for message in envelope.messages),
             "session_events": _count(conn, "SELECT COUNT(*) FROM session_events WHERE session_id = ?", session_id),
+            "provider_usage_events": _count(
+                conn,
+                "SELECT COUNT(*) FROM session_provider_usage_events WHERE session_id = ?",
+                session_id,
+            ),
             "session_links_outbound": _count(
                 conn,
                 "SELECT COUNT(*) FROM session_links WHERE src_session_id = ?",

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -331,6 +331,7 @@ def write_parsed_session_to_archive(
             messages,
             session.session_events,
             position_offset=position_offset,
+            event_position_offset=_next_session_event_position(conn, session_id),
             duplicate_native_ids=duplicate_message_native_ids,
         )
         _write_working_dirs(conn, session_id, session.working_directories)
@@ -1659,6 +1660,23 @@ def _root_ids(conn: sqlite3.Connection, session_ids: set[str]) -> set[str]:
     return root_ids
 
 
+def _next_session_event_position(conn: sqlite3.Connection, session_id: str) -> int:
+    row = conn.execute(
+        """
+        SELECT MAX(position) + 1
+        FROM (
+            SELECT position FROM session_events WHERE session_id = ?
+            UNION ALL
+            SELECT position FROM session_agent_policies WHERE session_id = ?
+            UNION ALL
+            SELECT position FROM session_provider_usage_events WHERE session_id = ?
+        )
+        """,
+        (session_id, session_id, session_id),
+    ).fetchone()
+    return int(row[0] or 0) if row is not None else 0
+
+
 def _write_session_events(
     conn: sqlite3.Connection,
     session_id: str,
@@ -1666,6 +1684,7 @@ def _write_session_events(
     events: Iterable[ParsedSessionEvent],
     *,
     position_offset: int = 0,
+    event_position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
 ) -> None:
     by_native_id = {
@@ -1679,7 +1698,7 @@ def _write_session_events(
         for fallback_position, message in enumerate(messages)
         if message.provider_message_id and message.provider_message_id not in duplicate_native_ids
     }
-    position = 0
+    position = event_position_offset
     for event in events:
         if event.event_type == "compaction":
             conn.execute(
@@ -1817,7 +1836,10 @@ def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session
             output_tokens      = excluded.output_tokens,
             cache_read_tokens  = excluded.cache_read_tokens,
             cache_write_tokens = excluded.cache_write_tokens,
-            cost_provenance    = excluded.cost_provenance
+            cost_provenance    = excluded.cost_provenance,
+            cost_usd           = NULL,
+            priced_with        = NULL,
+            priced_at_ms       = NULL
         """,
         (
             session_id,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -336,6 +336,7 @@ def write_parsed_session_to_archive(
         _write_working_dirs(conn, session_id, session.working_directories)
         _write_repo_edges(conn, session_id, session)
         _write_reported_costs(conn, session_id, session)
+        _aggregate_provider_usage_into_model_usage(conn, session_id)
         _refresh_session_counts(conn, session_id)
         _resolve_session_graph(conn, session_id, native_id, origin.value)
         if session.ingest_flags:
@@ -385,6 +386,7 @@ def _clear_session_projection_rows(conn: sqlite3.Connection, session_id: str) ->
         "attachment_refs",
         "paste_spans",
         "session_events",
+        "session_provider_usage_events",
         "session_agent_policies",
         "session_working_dirs",
         "session_repos",
@@ -1715,6 +1717,116 @@ def _write_session_events(
                 ),
             )
             position += 1
+        elif event.event_type == "token_count":
+            _write_provider_usage_event(
+                conn,
+                session_id,
+                by_native_id.get(event.source_message_provider_id or ""),
+                position,
+                event,
+            )
+            position += 1
+
+
+def _write_provider_usage_event(
+    conn: sqlite3.Connection,
+    session_id: str,
+    source_message_id: str | None,
+    position: int,
+    event: ParsedSessionEvent,
+) -> None:
+    last_usage = _payload_mapping(event.payload, "last_token_usage")
+    total_usage = _payload_mapping(event.payload, "total_token_usage")
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO session_provider_usage_events (
+            session_id, source_message_id, position, provider_event_type, model_name,
+            last_input_tokens, last_output_tokens, last_cached_input_tokens,
+            last_reasoning_output_tokens, last_total_tokens,
+            total_input_tokens, total_output_tokens, total_cached_input_tokens,
+            total_reasoning_output_tokens, total_tokens, model_context_window,
+            payload_json, occurred_at_ms
+        ) VALUES (?, ?, ?, 'token_count', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            source_message_id,
+            position,
+            _sqlite_text(_payload_string(event.payload, "model", "model_name")),
+            _payload_int(last_usage, "input_tokens"),
+            _payload_int(last_usage, "output_tokens"),
+            _payload_int(last_usage, "cached_input_tokens"),
+            _payload_int(last_usage, "reasoning_output_tokens"),
+            _payload_int(last_usage, "total_tokens"),
+            _payload_int(total_usage, "input_tokens"),
+            _payload_int(total_usage, "output_tokens"),
+            _payload_int(total_usage, "cached_input_tokens"),
+            _payload_int(total_usage, "reasoning_output_tokens"),
+            _payload_int(total_usage, "total_tokens"),
+            _payload_optional_int(event.payload, "model_context_window"),
+            _json_dumps(event.payload),
+            _timestamp_ms(event.timestamp),
+        ),
+    )
+
+
+def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session_id: str) -> None:
+    """Fold provider-reported total usage into model usage for single-model sessions."""
+
+    usage_row = conn.execute(
+        """
+        SELECT model_name, total_input_tokens, total_output_tokens,
+               total_cached_input_tokens, total_reasoning_output_tokens
+        FROM session_provider_usage_events
+        WHERE session_id = ?
+          AND provider_event_type = 'token_count'
+          AND (
+            total_input_tokens > 0 OR total_output_tokens > 0 OR
+            total_cached_input_tokens > 0 OR total_reasoning_output_tokens > 0 OR
+            total_tokens > 0
+          )
+        ORDER BY position DESC
+        LIMIT 1
+        """,
+        (session_id,),
+    ).fetchone()
+    if usage_row is None:
+        return
+
+    model_name = str(usage_row[0]).strip() if usage_row[0] else ""
+    if not model_name:
+        model_rows = conn.execute(
+            "SELECT model_name FROM session_model_usage WHERE session_id = ? ORDER BY model_name",
+            (session_id,),
+        ).fetchall()
+        if len(model_rows) != 1:
+            return
+        model_name = str(model_rows[0][0]).strip()
+    if not model_name:
+        return
+
+    conn.execute(
+        """
+        INSERT INTO session_model_usage (
+            session_id, model_name,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+            cost_provenance
+        ) VALUES (?, ?, ?, ?, ?, 0, 'origin_reported')
+        ON CONFLICT(session_id, model_name) DO UPDATE SET
+            input_tokens       = excluded.input_tokens,
+            output_tokens      = excluded.output_tokens,
+            cache_read_tokens  = excluded.cache_read_tokens,
+            cache_write_tokens = excluded.cache_write_tokens,
+            cost_provenance    = excluded.cost_provenance
+        """,
+        (
+            session_id,
+            model_name,
+            int(usage_row[1] or 0),
+            int(usage_row[2] or 0) + int(usage_row[4] or 0),
+            int(usage_row[3] or 0),
+        ),
+    )
 
 
 def _write_working_dirs(conn: sqlite3.Connection, session_id: str, working_directories: Iterable[str]) -> None:
@@ -2081,6 +2193,31 @@ def _payload_string(payload: Mapping[str, object], *keys: str) -> str | None:
         value = payload.get(key)
         if value is not None:
             return str(value)
+    return None
+
+
+def _payload_mapping(payload: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = payload.get(key)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _payload_int(payload: Mapping[str, object], key: str) -> int:
+    return _payload_optional_int(payload, key) or 0
+
+
+def _payload_optional_int(payload: Mapping[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str) and value.strip():
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return None
     return None
 
 

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -304,7 +304,13 @@ def test_archive_tiers_cost_price_basis_has_typed_tables(tmp_path: Path) -> None
         ).fetchall()
     }
 
-    assert {"price_catalogs", "model_prices", "session_reported_costs", "session_model_usage"} <= tables
+    assert {
+        "price_catalogs",
+        "model_prices",
+        "session_reported_costs",
+        "session_model_usage",
+        "session_provider_usage_events",
+    } <= tables
 
 
 def test_archive_tier_specs_capture_file_and_backup_policy() -> None:

--- a/tests/unit/storage/test_archive_tiers_self_verify.py
+++ b/tests/unit/storage/test_archive_tiers_self_verify.py
@@ -117,6 +117,7 @@ def test_archive_tiers_archive_self_verify_envelope_is_stable(tmp_path: Path) ->
             "messages": 2,
             "blocks": 2,
             "session_events": 1,
+            "provider_usage_events": 0,
             "session_links_outbound": 0,
             "attachments": 1,
             "attachment_refs": 1,

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -954,6 +954,132 @@ def test_provider_usage_events_repair_single_model_usage_rollup(tmp_path: Path) 
     }
 
 
+def test_provider_usage_events_append_preserves_prior_history(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m1",
+                payload={
+                    "type": "token_count",
+                    "total_token_usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            )
+        ],
+    )
+    second = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="second answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m2",
+                payload={
+                    "type": "token_count",
+                    "total_token_usage": {"input_tokens": 30, "output_tokens": 15},
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    write_parsed_session_to_archive(conn, second, merge_append=True)
+
+    rows = conn.execute(
+        """
+        SELECT usage_event_id, source_message_id, position, total_input_tokens, total_output_tokens
+        FROM session_provider_usage_events
+        WHERE session_id = ?
+        ORDER BY position
+        """,
+        (session_id,),
+    ).fetchall()
+    assert [dict(row) for row in rows] == [
+        {
+            "usage_event_id": f"{session_id}:usage:0",
+            "source_message_id": f"{session_id}:m1",
+            "position": 0,
+            "total_input_tokens": 10,
+            "total_output_tokens": 5,
+        },
+        {
+            "usage_event_id": f"{session_id}:usage:1",
+            "source_message_id": f"{session_id}:m2",
+            "position": 1,
+            "total_input_tokens": 30,
+            "total_output_tokens": 15,
+        },
+    ]
+
+
+def test_provider_usage_rollup_clears_stale_message_pricing(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-priced-repair",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-4o",
+                input_tokens=10,
+                output_tokens=5,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="priced answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-4o",
+                    "total_token_usage": {"input_tokens": 1_000, "output_tokens": 500},
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    row = conn.execute(
+        """
+        SELECT model_name, input_tokens, output_tokens, cost_provenance,
+               cost_usd, priced_with, priced_at_ms
+        FROM session_model_usage
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    assert dict(row) == {
+        "model_name": "gpt-4o",
+        "input_tokens": 1_000,
+        "output_tokens": 500,
+        "cost_provenance": "origin_reported",
+        "cost_usd": None,
+        "priced_with": None,
+        "priced_at_ms": None,
+    }
+
+
 def test_archive_tiers_writer_records_unresolved_parent_session_link(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -829,6 +829,131 @@ def test_archive_tiers_writer_materializes_supported_session_events(tmp_path: Pa
     ]
 
 
+def test_archive_tiers_writer_materializes_provider_usage_events(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-1",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m1",
+                timestamp="2026-01-01T00:00:03+00:00",
+                payload={
+                    "type": "token_count",
+                    "last_token_usage": {
+                        "input_tokens": 11,
+                        "cached_input_tokens": 2,
+                        "output_tokens": 3,
+                        "reasoning_output_tokens": 4,
+                        "total_tokens": 20,
+                    },
+                    "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 30,
+                        "reasoning_output_tokens": 40,
+                        "total_tokens": 190,
+                    },
+                    "model_context_window": 200000,
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    usage = conn.execute(
+        """
+        SELECT usage_event_id, source_message_id, position, provider_event_type,
+               last_input_tokens, last_output_tokens, last_cached_input_tokens,
+               last_reasoning_output_tokens, last_total_tokens,
+               total_input_tokens, total_output_tokens, total_cached_input_tokens,
+               total_reasoning_output_tokens, total_tokens, model_context_window,
+               occurred_at_ms
+        FROM session_provider_usage_events
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    assert dict(usage) == {
+        "usage_event_id": f"{session_id}:usage:0",
+        "source_message_id": f"{session_id}:m1",
+        "position": 0,
+        "provider_event_type": "token_count",
+        "last_input_tokens": 11,
+        "last_output_tokens": 3,
+        "last_cached_input_tokens": 2,
+        "last_reasoning_output_tokens": 4,
+        "last_total_tokens": 20,
+        "total_input_tokens": 100,
+        "total_output_tokens": 30,
+        "total_cached_input_tokens": 20,
+        "total_reasoning_output_tokens": 40,
+        "total_tokens": 190,
+        "model_context_window": 200000,
+        "occurred_at_ms": 1_767_225_603_000,
+    }
+
+
+def test_provider_usage_events_repair_single_model_usage_rollup(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-rollup-1",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 30,
+                        "reasoning_output_tokens": 40,
+                    },
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    usage = conn.execute(
+        """
+        SELECT model_name, input_tokens, output_tokens, cache_read_tokens,
+               cache_write_tokens, cost_provenance
+        FROM session_model_usage
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    assert dict(usage) == {
+        "model_name": "gpt-5-codex",
+        "input_tokens": 100,
+        "output_tokens": 70,
+        "cache_read_tokens": 20,
+        "cache_write_tokens": 0,
+        "cost_provenance": "origin_reported",
+    }
+
+
 def test_archive_tiers_writer_records_unresolved_parent_session_link(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(


### PR DESCRIPTION
## Summary

This PR adds a durable provider-usage event ledger for Codex `token_count` records and folds provider totals into `session_model_usage` for single-model sessions. It is the next #2316 slice after #2336 exposed the zero-token projection debt.

## Problem

Ref #2316. Codex `token_count` records were parser-visible, but the index tier only persisted compaction session events and message-derived model usage. A session could therefore have provider-reported token usage in the raw transcript while the durable archive only showed zero-token `session_model_usage` rows, which made usage/cost surfaces look authoritative when they were really missing provider evidence.

## Solution

Bumped the index tier schema to v6 and added `session_provider_usage_events` for provider token-count records. The archive writer now persists parsed `token_count` payloads, clears those rows on replacement writes, and folds the latest provider total usage into `session_model_usage` when a session has exactly one known model. Multi-model or unknown-model cases keep the provider event durable but do not fabricate attribution.

Review follow-up tightened the write path further: append writes now offset event positions across all session-event tables so appended provider usage history is preserved, and provider-total rollups clear stale message-derived pricing fields instead of showing old costs next to new token totals.

Updated self-verify counts, DDL contract tests, schema docs, and `AGENTS.md`/internals documentation for the fresh-first re-ingest expectation.

Schema/re-ingest plan: because this changes the canonical index-tier DDL, existing `index.db` files at v5 must be rebuilt from source evidence. The intended operator path is to recreate/re-ingest the index tier rather than applying an in-place migration chain.

Remaining #2316 scope: broader cross-provider usage reconciliation, durable query/read surfaces for provider usage events, richer cost/pricing provenance, and multi-model attribution policy.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py::test_archive_tiers_writer_materializes_provider_usage_events tests/unit/storage/test_archive_tiers_write.py::test_provider_usage_events_repair_single_model_usage_rollup tests/unit/storage/test_archive_tiers_write.py::test_archive_tiers_writer_materializes_supported_session_events tests/unit/storage/test_archive_tiers_self_verify.py tests/unit/storage/test_archive_tiers_ddl.py::test_archive_tiers_cost_price_basis_has_typed_tables tests/unit/operations/test_archive_debt.py::test_archive_debt_reports_codex_zero_token_projection_debt tests/unit/operations/test_archive_debt.py::test_archive_debt_ignores_codex_usage_rows_with_nonzero_tokens` -> `7 passed`.
- `devtools verify --quick` -> pass, run `20260623T135108Z-quick-3716406-7156c96a`.
- pre-push `devtools verify --quick` -> pass, run `20260623T135358Z-quick-3718698-a1969204`.
- review follow-up `devtools test tests/unit/storage/test_archive_tiers_write.py::test_archive_tiers_writer_materializes_provider_usage_events tests/unit/storage/test_archive_tiers_write.py::test_provider_usage_events_repair_single_model_usage_rollup tests/unit/storage/test_archive_tiers_write.py::test_provider_usage_events_append_preserves_prior_history tests/unit/storage/test_archive_tiers_write.py::test_provider_usage_rollup_clears_stale_message_pricing` -> `4 passed`.
- review follow-up `devtools verify --quick` -> pass, run `20260623T141239Z-quick-3764915-da2b4a4f`.
- review follow-up pre-push `devtools verify --quick` -> pass, run `20260623T141312Z-quick-3766521-f5eb619a`.
