### PR TITLE
ci: reject issue-state keywords in PR text

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@ _What changed and why it matters (1-3 sentences)._
 
 _What the codebase needed. Why this work was necessary._
 
+Use neutral issue references such as `Ref #NNN`. Do not use GitHub
+issue-state keywords in PR text unless the operator explicitly requested that
+this PR change that exact issue state.
+
 ## Solution
 
 _What was done. Key modules, contracts, and boundaries touched._

--- a/.github/workflows/pr-state-guard.yml
+++ b/.github/workflows/pr-state-guard.yml
@@ -1,0 +1,71 @@
+name: PR State Guard
+
+on:
+  pull_request:
+    branches: [master]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  # Read repository metadata for this checkout-free PR workflow.
+  contents: read
+  # Read pull request metadata exposed through the event payload.
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  issue-state-keywords:
+    name: reject issue state keywords
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title and body
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          event_path = os.environ.get("GITHUB_EVENT_PATH")
+          if not event_path:
+              print("Error: GITHUB_EVENT_PATH is not set")
+              sys.exit(1)
+          try:
+              with open(event_path, encoding="utf-8") as handle:
+                  event = json.load(handle)
+          except FileNotFoundError:
+              print(f"Error: GitHub event payload not found: {event_path}")
+              sys.exit(1)
+          except json.JSONDecodeError as exc:
+              print(f"Error: GitHub event payload is not valid JSON: {exc}")
+              sys.exit(1)
+
+          pr = event.get("pull_request") or {}
+          fields = {
+              "title": pr.get("title") or "",
+              "body": pr.get("body") or "",
+          }
+          pattern = re.compile(
+              r"\b(?:close(?:s|d)?|fix(?:es|ed)?|resolve(?:s|d)?)\s*:?\s+"
+              r"(?:(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+\b|"
+              r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+\b)",
+              re.IGNORECASE,
+          )
+          hits = [(name, match.group(0)) for name, text in fields.items() for match in pattern.finditer(text)]
+          if hits:
+              print("PR title/body contains GitHub issue-state keywords next to issue refs.")
+              print("Use neutral references such as 'Ref #NNN' and describe remaining scope explicitly.")
+              for field, hit in hits:
+                  print(f"- {field}: {hit!r}")
+              sys.exit(1)
+
+          print("PR state guard: no issue-state keywords found")
+          PY


### PR DESCRIPTION
## Summary

Adds a fast PR policy check that rejects PR title/body text containing GitHub issue-state keywords next to issue references, and updates the PR template to steer authors toward neutral references.

## Problem

GitHub can change issue state from PR text when a linked PR is merged. That is too easy for agents to trigger accidentally, especially when a broad issue still has residual deployed/runtime work.

## Solution

The new `PR State Guard` workflow runs on PR metadata changes and scans the PR title/body directly from the event payload. It accepts neutral `Ref #NNN` wording and rejects state-changing keyword forms before merge. The PR template now reminds authors to keep issue references neutral unless the operator explicitly asks for that exact state change.

## Verification

- `devtools verify ci-workflows` -> 17 workflow files checked, no errors.
- Local regex smoke: neutral `Ref #2308` passed; state-changing same-repo and cross-repo keyword forms failed.
- Pre-push `devtools verify --quick` -> pass (`20260623T165120Z-quick-84113-aec841b3`).

## Changelog

Skipped; CI/project-process only.

## Risks and Follow-ups

The GitHub repository setting for auto-changing issue state on linked PR merge should still be disabled manually under repository settings when available. This PR adds an enforceable repository guard so the workflow does not depend only on agent memory or the GitHub UI setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced pull request submission guidelines with clearer issue referencing instructions.

* **Chores**
  * Added automated workflow to validate pull request formatting and issue references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->