### PR TITLE
fix(cli): read exact refs as selected sessions

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -1355,6 +1355,21 @@ def _execute_query_verb(
     execute_query_request(env, request)
 
 
+def _spec_is_exact_session_ref(spec: object) -> bool:
+    return bool(
+        getattr(spec, "session_id", None)
+        and not any(
+            (
+                getattr(spec, "query_terms", ()),
+                getattr(spec, "contains_terms", ()),
+                getattr(spec, "exclude_text_terms", ()),
+                getattr(spec, "similar_text", None),
+                getattr(spec, "similar_session_id", None),
+            )
+        )
+    )
+
+
 def _resolve_target_session_id(request: RootModeRequest) -> str | None:
     """Verb-tree adapter for the shared latest-resolver helper (#1626, #1642)."""
     if request.query_terms:
@@ -1367,6 +1382,8 @@ def _resolve_target_session_id(request: RootModeRequest) -> str | None:
         if isinstance(explicit, str) and explicit:
             return explicit
         spec = request.query_spec()
+        if _spec_is_exact_session_ref(spec):
+            return cast("str", spec.session_id)
         if not spec.latest and not spec.has_filters():
             return None
         one_match_spec = replace(spec, limit=1)

--- a/polylogue/cli/read_views/standard.py
+++ b/polylogue/cli/read_views/standard.py
@@ -11,11 +11,34 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 
 
+def _is_exact_ref_read(request: RootModeRequest, invocation: ReadViewInvocation) -> bool:
+    if not invocation.session_id:
+        return False
+    spec = request.query_spec()
+    if not spec.session_id:
+        return False
+    return not any(
+        (
+            spec.query_terms,
+            spec.contains_terms,
+            spec.exclude_text_terms,
+            spec.similar_text,
+            spec.similar_session_id,
+        )
+    )
+
+
+def _request_for_standard_read(request: RootModeRequest, invocation: ReadViewInvocation) -> RootModeRequest:
+    if not _is_exact_ref_read(request, invocation):
+        return request
+    return request.with_param_updates(conv_id=invocation.session_id).with_query_terms(())
+
+
 def run_read_summary_or_transcript(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
     """Standard query/list renderer used by summary and transcript views."""
 
     fmt = invocation.output_format or "markdown"
-    updated = request.with_param_updates(output_format=fmt)
+    updated = _request_for_standard_read(request, invocation).with_param_updates(output_format=fmt)
     if invocation.destination in ("stdout", "terminal"):
         execute_query_request(env, updated)
     elif invocation.destination == "clipboard":

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -380,6 +380,43 @@ def test_read_verb_summary_dispatches_to_execute_query_verb() -> None:
     assert request.query_params()["origin"] == "chatgpt-export"
 
 
+def test_read_verb_summary_exact_ref_dispatches_direct_read() -> None:
+    """Exact session refs read the selected session instead of re-running search."""
+    _, child = _context_pair(query_terms=("session:codex-session:abc123",))
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.read_views.standard.execute_query_request") as execute:
+        wrapped(child, **_read_verb_kwargs(view="summary", output_format="json"))
+
+    execute.assert_called_once()
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_terms == ()
+    assert request.params["conv_id"] == "codex-session:abc123"
+    assert request.params["output_format"] == "json"
+
+
+def test_read_verb_summary_preserves_search_within_exact_ref() -> None:
+    """Exact refs combined with FTS terms still search within the session."""
+    _, child = _context_pair(query_terms=("session:codex-session:abc123", "needle"))
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with (
+        patch("polylogue.cli.query_verbs._resolve_target_session_id", return_value="codex-session:abc123"),
+        patch("polylogue.cli.read_views.standard.execute_query_request") as execute,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="summary", output_format="json"))
+
+    execute.assert_called_once()
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_terms == ("session:codex-session:abc123", "needle")
+    assert "conv_id" not in request.params
+    assert request.params["output_format"] == "json"
+
+
 def test_read_verb_all_non_summary_invokes_bulk_export_view() -> None:
     """read --all with a concrete non-summary view routes to bulk export."""
     _, child = _context_pair(params={"origin": "claude-code-session"}, query_terms=("alpha",))


### PR DESCRIPTION
## Summary

Exact `find ... then read` refs now resolve to the selected session payload instead of falling back into the search renderer. This covers `session:<id>` and `id:<id>` when they are used as exact refs with no accompanying FTS or similarity term.

## Problem

Live dogfooding showed that `polylogue find session:<id> then read --view summary --format json` could return a search envelope rather than the concrete session payload. The verb layer had enough information to identify the selected session, but the standard read-view handler kept the original query terms and re-entered normal query rendering.

## Solution

The read verb resolver now treats exact session refs as concrete targets without a summary-list round trip when there is no text/similarity search leg. The standard summary/transcript read handler then rewrites that selected target to a direct `conv_id` request while preserving mixed `session:<id> needle` behavior as search-within-session.

Ref #2317

Remaining #2317 scope: broader root onboarding/facet/action grammar polish is still separate from this exact-ref read path.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py -k read_verb_summary` -> 3 passed.
- `devtools verify --quick` -> all quick checks passed locally.
- Pre-push hook reran `devtools verify --quick` at `73d26b7bc7ee28568b6cf853794b1354361b7dad` -> all quick checks passed.
- Live source probe against `/home/sinity/.local/share/polylogue`: `polylogue --plain find "id:<current-codex-session>" then read --view summary --format json` returned `mode=session` and the expected `session_id`.
