### PR TITLE
fix(cli): defer expensive facet families by default

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -218,6 +218,8 @@ Options:
                                   Projection method for --cost-outlook.
   --no-idf                        With --facets, skip inverse-document-
                                   frequency weighting
+  --include-deferred              With --facets, compute expensive families
+                                  that are deferred by default.
   -f, --format [markdown|json|ndjson|html|obsidian|org|yaml|plaintext|csv]
                                   Output format (ndjson = one JSON document
                                   per row, streaming-friendly)

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -102,15 +102,20 @@ if TYPE_CHECKING:
     )
 
 
-_FACET_COMPLETE_FAMILIES = (
+_FACET_CORE_FAMILIES = (
     "total_counts",
     "origins",
     "tags",
+)
+
+_FACET_DEFERRED_FAMILIES = (
     "repos",
     "message_types",
     "action_types",
     "has_flags",
 )
+
+_FACET_COMPLETE_FAMILIES = _FACET_CORE_FAMILIES + _FACET_DEFERRED_FAMILIES
 
 _NOISY_REPO_LABELS = {
     "",
@@ -336,7 +341,12 @@ def _archive_count_sessions_for_spec(archive: Any, spec: SessionQuerySpec) -> in
     return int(archive.count_sessions(**query_kwargs))
 
 
-def _archive_facet_buckets(archive: Any, spec: SessionQuerySpec | None) -> Any:
+def _archive_facet_buckets(
+    archive: Any,
+    spec: SessionQuerySpec | None,
+    *,
+    include_deferred: bool = True,
+) -> Any:
     from polylogue.archive.query.facets import FacetBuckets
 
     if spec is None:
@@ -347,15 +357,29 @@ def _archive_facet_buckets(archive: Any, spec: SessionQuerySpec | None) -> Any:
     tags: dict[str, int] = {}
     total_messages = 0
     session_ids: list[str] = []
+    seen_session_ids: set[str] = set()
     for summary in summaries:
+        if summary.session_id in seen_session_ids:
+            continue
+        seen_session_ids.add(summary.session_id)
         session_ids.append(summary.session_id)
         total_messages += summary.message_count
         origins[summary.origin] = origins.get(summary.origin, 0) + 1
         for tag in set(summary.tags):
             tags[tag] = tags.get(tag, 0) + 1
-    sql_buckets = _archive_aggregate_facet_families(
-        archive._conn,
-        session_ids=session_ids if spec is not None else None,
+    sql_buckets = (
+        _archive_aggregate_facet_families(
+            archive._conn,
+            session_ids=session_ids if spec is not None else None,
+        )
+        if include_deferred
+        else {
+            "repos": {},
+            "message_types": {},
+            "action_types": {},
+            "has_flags": {},
+            "omitted": {},
+        }
     )
     return FacetBuckets(
         providers=origins,
@@ -365,7 +389,7 @@ def _archive_facet_buckets(archive: Any, spec: SessionQuerySpec | None) -> Any:
         action_types=sql_buckets["action_types"],
         has_flags=sql_buckets["has_flags"],
         omitted=sql_buckets["omitted"],
-        total_sessions=len(summaries),
+        total_sessions=len(session_ids),
         total_messages=total_messages,
     )
 
@@ -2972,6 +2996,7 @@ class PolylogueArchiveMixin:
         spec: SessionQuerySpec | None = None,
         *,
         include_idf: bool = True,
+        include_deferred: bool = True,
     ) -> FacetsResponse:
         """Compute scoped + global facet aggregates over the archive.
 
@@ -3010,10 +3035,16 @@ class PolylogueArchiveMixin:
 
         scoped_to_query = spec is not None and spec.has_filters()
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
-            global_buckets = _archive_facet_buckets(archive, None)
-            scoped_buckets = _archive_facet_buckets(archive, spec) if scoped_to_query else global_buckets
+            global_buckets = _archive_facet_buckets(archive, None, include_deferred=include_deferred)
+            scoped_buckets = (
+                _archive_facet_buckets(archive, spec, include_deferred=include_deferred)
+                if scoped_to_query
+                else global_buckets
+            )
         idf_map = compute_idf(global_buckets) if include_idf else {}
         active = scoped_buckets if scoped_to_query else global_buckets
+        complete_families = _FACET_COMPLETE_FAMILIES if include_deferred else _FACET_CORE_FAMILIES
+        deferred_families = {} if include_deferred else dict.fromkeys(_FACET_DEFERRED_FAMILIES, "deferred_by_default")
         return FacetsResponse.model_validate(
             {
                 "scoped_to_query": scoped_to_query,
@@ -3021,10 +3052,16 @@ class PolylogueArchiveMixin:
                 "stale": False,
                 "stale_age_s": None,
                 "budget_exceeded": False,
-                "complete_families": _FACET_COMPLETE_FAMILIES,
-                "deferred_families": {},
+                "complete_families": complete_families,
+                "deferred_families": deferred_families,
                 "family_errors": {},
-                "family_status": {family: {"state": "complete", "stale": False} for family in _FACET_COMPLETE_FAMILIES},
+                "family_status": {
+                    **{family: {"state": "complete", "stale": False} for family in complete_families},
+                    **{
+                        family: {"state": "deferred", "reason": reason, "stale": False}
+                        for family, reason in deferred_families.items()
+                    },
+                },
                 "origins": dict(active.providers),
                 "tags": dict(active.tags),
                 "repos": dict(active.repos),

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -1119,6 +1119,12 @@ def _emit_candidate_judgment(
     help="With --facets, skip inverse-document-frequency weighting",
 )
 @click.option(
+    "--include-deferred",
+    is_flag=True,
+    default=False,
+    help="With --facets, compute expensive families that are deferred by default.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -1137,6 +1143,7 @@ def analyze_verb(
     plan_name: str | None = None,
     method: str = "linear",
     no_idf: bool = False,
+    include_deferred: bool = False,
     output_format: str | None = None,
     limit: int | None = None,
 ) -> None:
@@ -1166,6 +1173,7 @@ def analyze_verb(
                 plan_name is not None,
                 method != "linear",
                 no_idf,
+                include_deferred,
                 output_format is not None,
                 limit is not None,
             )
@@ -1192,6 +1200,7 @@ def analyze_verb(
         count=count_only,
         by=stats_by,
         facets=show_facets,
+        include_deferred=include_deferred,
         cost_outlook=cost_outlook,
         format=output_format or request.params.get("output_format") or "default",
         limit=limit,
@@ -1225,7 +1234,9 @@ def analyze_verb(
             raise click.UsageError("`analyze --facets` only supports terminal text or --format json")
         # Delegate to the Polylogue facets API using the request's query spec.
         spec = request.query_spec()
-        response = run_coroutine_sync(env.polylogue.facets(spec, include_idf=not no_idf))
+        response = run_coroutine_sync(
+            env.polylogue.facets(spec, include_idf=not no_idf, include_deferred=include_deferred)
+        )
         if output_format == "json":
             click.echo(_json.dumps(response.model_dump(mode="json", by_alias=True), indent=2))
             return
@@ -1246,6 +1257,10 @@ def analyze_verb(
                 click.echo(f"    [{family}]")
                 for value, weight in sorted(values.items(), key=lambda kv: -kv[1]):
                     click.echo(f"      {value}: {weight:.3f}")
+        if response.deferred_families:
+            click.echo("  Deferred families:")
+            for family, reason in sorted(response.deferred_families.items()):
+                click.echo(f"    {family}: {reason} (use --include-deferred)")
         return
 
     if cost_outlook:

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -670,6 +670,38 @@ async def test_facets_returns_typed_envelope_on_empty_archive(tmp_path: Path) ->
         await archive.close()
 
 
+def test_archive_facet_buckets_count_unique_sessions_for_duplicate_hits() -> None:
+    """Facet buckets count sessions, not duplicate per-message search hits."""
+    from types import SimpleNamespace
+
+    from polylogue.api.archive import _archive_facet_buckets
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary
+
+    summary = ArchiveSessionSummary(
+        session_id="claude-ai-export:conv-alpha",
+        native_id="conv-alpha",
+        origin="claude-ai-export",
+        provider=Provider.CLAUDE_AI,
+        title="Alpha",
+        created_at=None,
+        updated_at=None,
+        message_count=2,
+        word_count=4,
+        tags=("work",),
+    )
+    archive = SimpleNamespace(
+        list_summaries=lambda limit: [summary, summary],
+        _conn=None,
+    )
+
+    result = _archive_facet_buckets(archive, None, include_deferred=False)
+
+    assert result.total_sessions == 1
+    assert result.total_messages == 2
+    assert result.providers == {"claude-ai-export": 1}
+    assert result.tags == {"work": 1}
+
+
 # ---------------------------------------------------------------------------
 # 5. Happy path on a seeded archive
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -58,13 +58,14 @@
     "complete_families": [
       "total_counts",
       "origins",
-      "tags",
-      "repos",
-      "message_types",
-      "action_types",
-      "has_flags"
+      "tags"
     ],
-    "deferred_families": {},
+    "deferred_families": {
+      "repos": "deferred_by_default",
+      "message_types": "deferred_by_default",
+      "action_types": "deferred_by_default",
+      "has_flags": "deferred_by_default"
+    },
     "family_errors": {},
     "family_status": {
       "total_counts": {
@@ -89,29 +90,29 @@
         "stale_age_s": null
       },
       "repos": {
-        "state": "complete",
-        "reason": null,
+        "state": "deferred",
+        "reason": "deferred_by_default",
         "error": null,
         "stale": false,
         "stale_age_s": null
       },
       "message_types": {
-        "state": "complete",
-        "reason": null,
+        "state": "deferred",
+        "reason": "deferred_by_default",
         "error": null,
         "stale": false,
         "stale_age_s": null
       },
       "action_types": {
-        "state": "complete",
-        "reason": null,
+        "state": "deferred",
+        "reason": "deferred_by_default",
         "error": null,
         "stale": false,
         "stale_age_s": null
       },
       "has_flags": {
-        "state": "complete",
-        "reason": null,
+        "state": "deferred",
+        "reason": "deferred_by_default",
         "error": null,
         "stale": false,
         "stale_age_s": null
@@ -124,16 +125,10 @@
     "repos": {},
     "cwd_prefixes": {},
     "role_counts": {},
-    "message_types": {
-      "message": 10
-    },
+    "message_types": {},
     "material_origins": {},
     "action_types": {},
-    "has_flags": {
-      "has_tool_use": 0,
-      "has_thinking": 0,
-      "has_paste": 0
-    },
+    "has_flags": {},
     "omitted_facet_counts": {},
     "time_range": null,
     "total_sessions": 2,
@@ -145,16 +140,10 @@
       "tags": {},
       "repos": {},
       "role_counts": {},
-      "message_types": {
-        "message": 10
-      },
+      "message_types": {},
       "material_origins": {},
       "action_types": {},
-      "has_flags": {
-        "has_tool_use": 0,
-        "has_thinking": 0,
-        "has_paste": 0
-      },
+      "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
       "total_messages": 10
@@ -166,16 +155,10 @@
       "tags": {},
       "repos": {},
       "role_counts": {},
-      "message_types": {
-        "message": 10
-      },
+      "message_types": {},
       "material_origins": {},
       "action_types": {},
-      "has_flags": {
-        "has_tool_use": 0,
-        "has_thinking": 0,
-        "has_paste": 0
-      },
+      "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
       "total_messages": 10
@@ -183,9 +166,6 @@
     "idf": {
       "origins": {
         "chatgpt-export": 0.0
-      },
-      "message_types": {
-        "message": -1.<HASH>
       }
     }
   }

--- a/tests/unit/cli/test_plain_cli_snapshots.py
+++ b/tests/unit/cli/test_plain_cli_snapshots.py
@@ -188,6 +188,27 @@ def test_analyze_facets_no_idf_omits_idf(runner: CliRunner, seeded_db_env: Path)
     assert not payload.get("idf")  # no IDF weights when --no-idf is set
 
 
+def test_analyze_facets_include_deferred_materializes_expensive_families(
+    runner: CliRunner,
+    seeded_db_env: Path,
+) -> None:
+    """`--include-deferred` opts into the full facet families."""
+    import json as _json
+
+    result = runner.invoke(
+        cli,
+        ["--plain", "analyze", "--facets", "--include-deferred", "--format", "json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+
+    assert payload["deferred_families"] == {}
+    assert {"repos", "message_types", "action_types", "has_flags"}.issubset(set(payload["complete_families"]))
+    assert payload["family_status"]["message_types"]["state"] == "complete"
+    assert payload["message_types"] == {"message": 10}
+
+
 def test_json_status_snapshot(
     runner: CliRunner,
     seeded_db_env: Path,


### PR DESCRIPTION
## Summary

`polylogue analyze --facets` now mirrors the reader route contract: cheap families are computed by default, expensive families are reported as deferred, and `--include-deferred` opts into the full facet set. Facet bucket totals now count unique session ids instead of duplicate search-hit rows.

## Problem

Live dogfooding on the production archive showed that `polylogue analyze --facets --format json` and broad scoped facet queries could sit silent long enough to be unusable. A scoped `find pytest then analyze --facets --format json` probe also exposed misleading cardinality: duplicate FTS hit rows were counted as sessions.

## Solution

The archive facets API accepts `include_deferred`; default API behavior remains full-family for existing callers, while CLI `analyze --facets` passes `include_deferred=False` unless the operator supplies `--include-deferred`. The JSON envelope now advertises deferred expensive families and complete cheap families, and terminal output names deferred families with the opt-in flag. Bucket aggregation deduplicates by `session_id` before counting sessions, origins, tags, and messages.

Ref #2317

Remaining #2317 scope: tutorial/dashboard behavior, mark ownership, broader facet UX/canonicalization, and root help/product grammar remain separate product-surface work.

## Verification

- `devtools test tests/unit/cli/test_plain_cli_snapshots.py -k facets tests/unit/api/test_facade_contracts.py -k facets` -> 5 passed.
- `devtools render all` -> rendered CLI reference/docs/schemas/site/agents.
- `devtools verify --quick` -> all quick checks passed.
- Pre-push quick gate at `b957c887abf78e2af2f19c743d15c585516c7678` -> all quick checks passed.
- Live production archive probes:
  - global `analyze --facets --format json` returned cheap complete families plus deferred expensive families.
  - scoped `find pytest then analyze --facets --format json` returned `sessions=1476`, `global_sessions=3273`, and deferred expensive families.
