### PR TITLE
fix(config): audit env-provided path diagnostics

### DIFF
--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -1405,7 +1405,7 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
         value = resolved.raw.get(entry.key)
         # Defaults may legitimately point at not-yet-created first-run paths.
         # Operator-provided paths must be explicit enough to audit.
-        if resolved.layer_of(entry.key) == "default":
+        if resolved.layer_of(entry.key) == "default" and not (entry.env_var and entry.env_var in os.environ):
             continue
         for raw_path in _iter_path_config_values(entry.key, value):
             path = _expand_config_path(raw_path)


### PR DESCRIPTION
## Summary

Keep configuration path diagnostics tied to the resolved configuration snapshot so environment-provided paths are audited even when the resolved layer reports the default fallback.

## Problem

The diagnostics code skipped every key whose resolved layer was `default`. That is correct for built-in first-run paths, but not for keys with an environment variable present whose invalid value failed coercion or otherwise fell back to the default layer. The result was a blind spot in `polylogue config --format json` diagnostics.

## Solution

Only skip default-layer path diagnostics when the corresponding environment variable is absent. This preserves the first-run default behavior while still surfacing operator-provided path debt.

## Verification

- `devtools test tests/unit/core/test_config_inventory.py tests/unit/cli/test_config_command.py` -> 19 passed
- `devtools verify --quick` -> exit_code 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path configuration validation to properly detect environment variable overrides, ensuring more accurate diagnostics and timely warnings for configuration issues. Path values are now validated more thoroughly, helping users identify missing or invalid source roots earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->