### PR TITLE
fix(devtools): recognize repeated browser captures

### DIFF
--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -64,6 +64,10 @@ BROWSER_EXECUTABLE_CANDIDATES = (
     "chromium-browser",
     "chrome",
 )
+BROWSER_CAPTURE_PROVIDER_ORIGINS = {
+    "chatgpt": "chatgpt-export",
+    "claude-ai": "claude-ai-export",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -469,6 +473,22 @@ def _probe_browser_capture_archive(*, archive_root: Path) -> BrowserCaptureArchi
                             """,
                             (str(latest), latest_suffix_pattern, str(latest)),
                         ).fetchone()
+                        if latest_row is None and latest_provider and latest_provider_session_id:
+                            latest_origin = BROWSER_CAPTURE_PROVIDER_ORIGINS.get(latest_provider)
+                            latest_native_id = legacy_browser_capture_native_id(
+                                latest_provider, latest_provider_session_id
+                            )
+                            if latest_origin and latest_native_id:
+                                latest_row = conn.execute(
+                                    """
+                                    SELECT raw_id, native_id, file_mtime_ms, source_path
+                                    FROM raw_sessions
+                                    WHERE origin = ? AND native_id = ?
+                                    ORDER BY COALESCE(file_mtime_ms, 0) DESC, rowid DESC
+                                    LIMIT 1
+                                    """,
+                                    (latest_origin, latest_native_id),
+                                ).fetchone()
                         if latest_row is not None:
                             latest_raw_id = str(latest_row[0]) if latest_row[0] is not None else None
                             latest_raw_native_id = str(latest_row[1]) if latest_row[1] is not None else None

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -843,6 +843,26 @@ def test_deployment_smoke_matches_latest_browser_capture_by_stable_suffix(tmp_pa
     assert probe.latest_indexed_message_count == 1
 
 
+def test_deployment_smoke_matches_repeated_browser_capture_by_identity(tmp_path: Path) -> None:
+    capture = _write_spooled_capture(tmp_path, provider_session_id="capture")
+    source_path = Path("/alternate/archive/browser-capture/chatgpt/chatgpt-capture-oldhash.json")
+    _create_browser_source_db(
+        tmp_path,
+        file_mtime_ms=int(capture.stat().st_mtime * 1000),
+        capture_path=source_path,
+        native_id="capture",
+    )
+    _create_browser_index_db(tmp_path, native_id="capture")
+
+    probe = deployment_smoke._probe_browser_capture_archive(archive_root=tmp_path)
+
+    assert probe.ok is True
+    assert probe.latest_spooled_path == str(capture)
+    assert probe.latest_raw_source_path == str(source_path)
+    assert probe.latest_indexed_native_id == "capture"
+    assert probe.latest_indexed_message_count == 1
+
+
 def test_deployment_smoke_escapes_latest_suffix_like_wildcards(tmp_path: Path) -> None:
     capture = _write_spooled_capture(tmp_path, provider_session_id="cap_100%")
     _create_browser_source_db(


### PR DESCRIPTION
## Summary

Updates deployment smoke so browser-capture archive probing accepts repeated captures that have already materialized by stable provider identity, even when the newest spool filename is not itself the source path stored on the raw row.

## Problem

Live dogfooding after Ref #2308 produced a false negative: `/v1/archive-state` reported the latest ChatGPT capture as `lifecycle=archived`, `raw_row_exists=true`, `indexed_session_exists=true`, and `indexed_message_count=37`, but `devtools workspace deployment-smoke --json` failed with `browser-capture-archive:latest_spooled_without_raw_row`. The direct probe required the newest spool artifact path to match a raw row, while the archive correctly deduplicated/materialized the stable ChatGPT session under an earlier artifact path.

## Solution

The browser-capture archive probe still prefers exact and stable-suffix source-path matching. If that fails, it now falls back to the provider origin plus normalized native id for the latest spooled capture. This keeps missing-capture failures intact while making repeated/idempotent captures observable as healthy.

## Verification

- `devtools test tests/unit/devtools/test_deployment_smoke.py -k "browser_capture_archive or repeated_browser_capture or latest_browser_capture"` passed: 4 passed, 26 deselected.
- `devtools workspace deployment-smoke --json` passed from source with `ok=true`, no failures, latest ChatGPT capture `indexed_message_count=37`.
- `devtools verify --quick` passed with run id `20260623T234300Z-quick-1176983-cff56e15`.
