### PR TITLE
fix(browser): inject scripts from popup capture

### DIFF
--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -11,6 +11,30 @@ function hostLabel(url) {
   }
 }
 
+function contentScriptFiles(url) {
+  try {
+    const parsed = new URL(url || "");
+    if (parsed.hostname === "chatgpt.com" || parsed.hostname.endsWith(".chatgpt.com")) {
+      return ["src/common.js", "src/content/chatgpt.js"];
+    }
+    if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) {
+      return ["src/common.js", "src/content/claude.js"];
+    }
+  } catch {
+    return [];
+  }
+  return [];
+}
+
+async function ensureCaptureScripts(tab) {
+  const files = contentScriptFiles(tab?.url || "");
+  if (!tab?.id || !files.length) return false;
+  for (const file of files) {
+    await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: [file] });
+  }
+  return true;
+}
+
 function setBadge(kind, text) {
   const badge = document.getElementById("badge");
   badge.className = `badge ${kind}`;
@@ -73,10 +97,16 @@ document.getElementById("save").addEventListener("click", async () => {
 document.getElementById("capture").addEventListener("click", async () => {
   const tab = await activeTab();
   if (!tab?.id) return;
-  const result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.capturePage" }).catch((error) => ({
+  let result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.capturePage" }).catch((error) => ({
     ok: false,
     error: String(error.message || error)
   }));
+  if (!result?.ok && (await ensureCaptureScripts(tab))) {
+    result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.capturePage" }).catch((error) => ({
+      ok: false,
+      error: String(error.message || error)
+    }));
+  }
   if (!result?.ok) {
     await chrome.storage.local.set({
       polylogueState: {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -1,0 +1,95 @@
+import { JSDOM } from "jsdom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const CHATGPT_TAB = {
+  id: 42,
+  title: "ChatGPT conversation",
+  url: "https://chatgpt.com/c/test-conversation",
+};
+
+function installDom() {
+  const dom = new JSDOM(`<!doctype html>
+    <body>
+      <span id="badge"></span>
+      <span id="state"></span>
+      <span id="receiver-request"></span>
+      <span id="receiver"></span>
+      <span id="page"></span>
+      <span id="archive"></span>
+      <input id="receiver-url" />
+      <input id="receiver-token" />
+      <button id="check"></button>
+      <button id="save"></button>
+      <button id="capture"></button>
+    </body>`);
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+}
+
+function installChromeMock() {
+  let captureAttempts = 0;
+  globalThis.chrome = {
+    runtime: {
+      sendMessage: vi.fn(async () => ({ ok: true })),
+    },
+    scripting: {
+      executeScript: vi.fn(async () => undefined),
+    },
+    storage: {
+      local: {
+        get: vi.fn(async (defaults) => ({ ...defaults })),
+        set: vi.fn(async () => undefined),
+      },
+    },
+    tabs: {
+      query: vi.fn(async () => [CHATGPT_TAB]),
+      sendMessage: vi.fn(async () => {
+        captureAttempts += 1;
+        if (captureAttempts === 1) {
+          throw new Error("Could not establish connection. Receiving end does not exist.");
+        }
+        return {
+          ok: true,
+          captureResult: { ok: true },
+          archiveState: { captured: true },
+        };
+      }),
+    },
+  };
+}
+
+async function loadPopup() {
+  vi.resetModules();
+  installDom();
+  installChromeMock();
+  await import("../src/popup.js");
+  await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).toBe("ChatGPT"));
+}
+
+describe("popup capture", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("injects provider content scripts before retrying an already-open tab capture", async () => {
+    await loadPopup();
+
+    globalThis.document.getElementById("capture").click();
+
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(2));
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledTimes(2);
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenNthCalledWith(1, {
+      target: { tabId: CHATGPT_TAB.id },
+      files: ["src/common.js"],
+    });
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenNthCalledWith(2, {
+      target: { tabId: CHATGPT_TAB.id },
+      files: ["src/content/chatgpt.js"],
+    });
+    expect(globalThis.chrome.storage.local.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        polylogueState: expect.objectContaining({ online: false }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Makes the browser extension popup recover when a supported ChatGPT or Claude tab was already open before the extension content scripts were present.

## Problem

The live-extension proof showed that the extension/background/receiver/archive path works, but already-open tabs may not have the `polylogue.capturePage` listener. The previous workaround was to inject scripts through DevTools before sending the message. That should be normal popup behavior, not an operator workaround.

## Solution

The popup now maps supported ChatGPT and Claude hosts to the extension content scripts. When the first `chrome.tabs.sendMessage(... polylogue.capturePage ...)` attempt fails, it injects `src/common.js` plus the provider content script with `chrome.scripting.executeScript`, then retries the normal capture message. Unsupported pages still report the existing unsupported-page state.

## Verification

- `npm --prefix browser-extension test -- --run` passed: 58 tests.
- `npm --prefix browser-extension run lint` passed.
- `npm --prefix browser-extension run validate && npm --prefix browser-extension run build` passed.
- `devtools verify --quick` passed with run id `20260624T011435Z-quick-1280425-77be9e42`.

Live context: before this patch, the extension was loaded into live Chrome and proved against ChatGPT using the same `chrome.scripting.executeScript` + `chrome.tabs.sendMessage` APIs from the extension page; this patch moves that path into the visible popup capture action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved page capture compatibility and reliability on supported platforms.

* **Bug Fixes**
  * Enhanced capture mechanism with automatic script injection and retry logic to handle initial connection failures.

* **Tests**
  * Added test coverage for the popup's capture functionality, including script injection and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->