### PR TITLE
fix(devtools): treat completed browser artifacts as smoke success

### DIFF
--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -838,6 +838,11 @@ def _probe_browser_render(
             dom_bytes = len(stdout.encode())
             screenshot_bytes = screenshot_path.stat().st_size if screenshot_path.exists() else None
             if dom_bytes > 0 and screenshot_bytes:
+                # Chrome can leave background services alive after the
+                # one-shot --dump-dom/--screenshot artifacts are complete
+                # (observed with Chrome 149 and GCM registration retries).
+                # The smoke contract is first-paint evidence, not browser
+                # process lifetime, so artifact completion is a clean pass.
                 return BrowserRenderProbe(
                     url=url,
                     executable=resolved,
@@ -846,7 +851,6 @@ def _probe_browser_render(
                     dom_bytes=dom_bytes,
                     screenshot_bytes=screenshot_bytes,
                     stderr_tail=stderr[-2000:],
-                    caveats=("browser_timeout_after_capture",),
                 )
             return BrowserRenderProbe(
                 url=url,

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -587,7 +587,7 @@ def test_deployment_smoke_browser_render_probe_reports_timeout(monkeypatch: pyte
     assert "still loading" in probe.stderr_tail
 
 
-def test_deployment_smoke_browser_render_accepts_timeout_after_capture(
+def test_deployment_smoke_browser_render_accepts_completed_artifacts_after_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -625,7 +625,7 @@ def test_deployment_smoke_browser_render_accepts_timeout_after_capture(
     assert probe.dom_bytes == len("<html>Polylogue</html>")
     assert probe.screenshot_bytes == 3
     assert probe.error is None
-    assert probe.caveats == ("browser_timeout_after_capture",)
+    assert probe.caveats == ()
 
 
 def test_deployment_smoke_report_includes_browser_render_failure(


### PR DESCRIPTION
## Summary

Make the deployment browser smoke treat completed DOM plus screenshot artifacts as a clean first-paint pass, even when Chrome remains alive until the timeout after writing those artifacts.

## Problem

The deployed browser smoke reported a residual `browser_timeout_after_capture` caveat after the live capture work. Reproduction with an isolated headless Chrome profile showed Chrome 149 wrote both `--dump-dom` and `--screenshot` outputs quickly, then stayed resident until the outer timeout killed it while background GCM registration retries appeared in stderr. That made successful first-paint evidence look degraded.

## Solution

`devtools/deployment_smoke.py` now makes the smoke contract explicit: DOM bytes plus screenshot bytes prove the browser-render path. If the process times out after those artifacts exist, the probe returns `ok=true` with no caveat. A timeout before complete artifacts still reports `browser_timeout`.

Updated the browser-render unit test to assert that the completed-artifact timeout path is a clean pass.

Ref #2308

## Verification

- `devtools test tests/unit/devtools/test_deployment_smoke.py -k browser_render` -> 5 passed.
- `python -m devtools.deployment_smoke --json --browser --browser-executable /etc/profiles/per-user/sinity/bin/google-chrome` -> `ok=true`, `failures=[]`, `browser_render.caveats=[]`, browser-capture archive `ok=true`.
- `devtools verify --quick` -> passed, run `20260624T022646Z-quick-1428970-8b3895e5`.
- Push hook `devtools verify --quick` -> passed, run `20260624T022737Z-quick-1430908-e520c82c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated browser rendering timeout handling in deployment smoke tests to correctly classify successful artifact capture scenarios, removing unnecessary timeout flags when artifacts are successfully obtained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->