### PR TITLE
fix(ops): restore runtime materialization trust

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -33,6 +33,108 @@ _RECEIVER_SMOKE_TOKEN = "polylogue-dev-loop-token"
 _SENSITIVE_ENV_NAME_RE = re.compile(r"(TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL|AUTH)", re.IGNORECASE)
 _LOG = logging.getLogger(__name__)
 
+_DEV_LOOP_AUTHORITIES: dict[str, dict[str, object]] = {
+    "preflight": {
+        "label": "source-only-preflight",
+        "description": "Inspect checkout, branch-local paths, deployed service state, and selected ports without starting browsers or using live profiles.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "launch_daemon": {
+        "label": "source-only-branch-daemon",
+        "description": "Start polylogued from this checkout with explicit branch-local archive, ports, run id, and log directory.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "capture_cli": {
+        "label": "source-only-cli-capture",
+        "description": "Run a CLI command with branch-local POLYLOGUE_* environment and persisted stdout/stderr/transcript artifacts.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "receiver_smoke": {
+        "label": "source-only-deterministic-receiver-smoke",
+        "description": "Run an in-process loopback receiver auth/spool smoke with synthetic capture payloads only.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "extension_smoke": {
+        "label": "source-only-deterministic-extension-smoke",
+        "description": "Exercise the extension background worker against a temporary receiver with a Chrome API mock and synthetic payloads.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "browser_smoke": {
+        "label": "local-browser-deterministic-extension-smoke",
+        "description": "Load the unpacked extension in headless Chrome/Chromium against a temporary receiver without live cookies.",
+        "source_safe": True,
+        "cloud_safe": False,
+        "requires_browser": True,
+        "requires_copied_profile": False,
+        "local_only": True,
+    },
+    "browser_provider_smoke": {
+        "label": "local-browser-deterministic-provider-smoke",
+        "description": "Load deterministic ChatGPT/Claude fixture pages in headless Chrome/Chromium and verify content-script capture without live cookies.",
+        "source_safe": True,
+        "cloud_safe": False,
+        "requires_browser": True,
+        "requires_copied_profile": False,
+        "local_only": True,
+    },
+    "browser_plan": {
+        "label": "local-browser-control-handoff-plan",
+        "description": "Write exact local browser launch/configuration artifacts without claiming to control or certify the operator browser.",
+        "source_safe": True,
+        "cloud_safe": False,
+        "requires_browser": True,
+        "requires_copied_profile": False,
+        "local_only": True,
+    },
+    "browser_live_proof": {
+        "label": "operator-local-copied-profile-live-proof",
+        "description": "Visible local Chrome/Chromium proof using an operator-approved copied profile; never CI/cloud evidence and never a source-only claim.",
+        "source_safe": False,
+        "cloud_safe": False,
+        "requires_browser": True,
+        "requires_copied_profile": True,
+        "local_only": True,
+    },
+    "tui_plan": {
+        "label": "source-owned-local-terminal-plan",
+        "description": "Write branch-local terminal/TUI recording commands and artifact paths; terminal control remains local.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+    "inspect_run": {
+        "label": "source-only-run-artifact-inspection",
+        "description": "Summarize persisted run-local artifacts and report missing or failed surfaces without rerunning browser/profile proofs.",
+        "source_safe": True,
+        "cloud_safe": True,
+        "requires_browser": False,
+        "requires_copied_profile": False,
+        "local_only": False,
+    },
+}
+
 
 @dataclass(frozen=True, slots=True)
 class CommandResult:
@@ -391,6 +493,7 @@ def run_receiver_smoke(*, spool_path: Path) -> dict[str, object]:
         and accepted_status == 202
         and artifact_path is not None
         and artifact_path.exists(),
+        "authority": _authority("receiver_smoke"),
         "host": str(host),
         "port": int(port),
         "spool_path": str(spool_path),
@@ -503,6 +606,7 @@ def run_extension_smoke(*, preflight: dict[str, Any]) -> dict[str, object]:
     ok = exit_code == 0 and artifact_path is not None and artifact_path.exists()
     payload: dict[str, object] = {
         "ok": ok,
+        "authority": _authority("extension_smoke"),
         "exit_code": exit_code,
         "duration_ms": duration_ms,
         "extension_root": str(extension_root),
@@ -637,6 +741,7 @@ def run_browser_smoke(*, preflight: dict[str, Any]) -> dict[str, object]:
     ok = exit_code == 0 and artifact_path is not None and artifact_path.exists()
     payload: dict[str, object] = {
         "ok": ok,
+        "authority": _authority("browser_smoke"),
         "exit_code": exit_code,
         "duration_ms": duration_ms,
         "extension_id": extension_id,
@@ -838,6 +943,7 @@ def run_browser_provider_smoke(*, preflight: dict[str, Any]) -> dict[str, object
     )
     payload: dict[str, object] = {
         "ok": ok,
+        "authority": _authority("browser_provider_smoke"),
         "exit_code": exit_code,
         "duration_ms": duration_ms,
         "extension_id": extension_id,
@@ -1008,6 +1114,7 @@ def run_browser_live_proof(
     )
     payload: dict[str, object] = {
         "ok": ok,
+        "authority": _authority("browser_live_proof"),
         "exit_code": exit_code,
         "duration_ms": duration_ms,
         "extension_id": extension_id,
@@ -1989,6 +2096,354 @@ def _dev_loop_run_id(*, branch: str | None, commit: str | None, api_port: int, b
     return f"{branch_part}-{commit_part}-api{api_port}-capture{browser_capture_port}"
 
 
+def _authority(name: str) -> dict[str, object]:
+    authority = _DEV_LOOP_AUTHORITIES[name]
+    return dict(authority)
+
+
+def _dev_loop_cli_args(
+    *,
+    api_port: int,
+    browser_capture_port: int,
+    archive: Path,
+    logs: Path,
+    extra_args: list[str],
+) -> list[str]:
+    return [
+        "devtools",
+        "workspace",
+        "dev-loop",
+        "--api-port",
+        str(api_port),
+        "--browser-capture-port",
+        str(browser_capture_port),
+        "--archive-root",
+        str(archive),
+        "--log-dir",
+        str(logs),
+        *extra_args,
+    ]
+
+
+def _artifact_state(
+    path: Path,
+    *,
+    kind: str,
+    expected_after: str,
+    required_now: bool = False,
+) -> dict[str, object]:
+    exists = path.exists()
+    state = "present" if exists else "degraded" if required_now else "planned"
+    return {
+        "path": str(path),
+        "kind": kind,
+        "exists": exists,
+        "state": state,
+        "expected_after": expected_after,
+    }
+
+
+def _dev_loop_artifact_status(
+    *,
+    archive: Path,
+    logs: Path,
+    run_log_dir: Path,
+    daemon_log: Path,
+    browser_artifact_dir: Path,
+    terminal_artifact_dir: Path,
+    tui_artifact_dir: Path,
+    preflight_json: Path,
+    dev_events: Path,
+    prepare: bool,
+) -> dict[str, dict[str, object]]:
+    return {
+        "archive_root": _artifact_state(
+            archive,
+            kind="directory",
+            expected_after="--prepare",
+            required_now=prepare,
+        ),
+        "log_dir": _artifact_state(logs, kind="directory", expected_after="--prepare", required_now=prepare),
+        "run_log_dir": _artifact_state(
+            run_log_dir,
+            kind="directory",
+            expected_after="--prepare or any event-producing dev-loop action",
+            required_now=prepare,
+        ),
+        "browser_dir": _artifact_state(
+            browser_artifact_dir,
+            kind="directory",
+            expected_after="--prepare, --browser-plan, or any browser smoke/proof",
+            required_now=prepare,
+        ),
+        "terminal_dir": _artifact_state(
+            terminal_artifact_dir,
+            kind="directory",
+            expected_after="--prepare or --capture-cli",
+            required_now=prepare,
+        ),
+        "tui_dir": _artifact_state(
+            tui_artifact_dir,
+            kind="directory",
+            expected_after="--prepare or --tui-plan",
+            required_now=prepare,
+        ),
+        "preflight_json": _artifact_state(
+            preflight_json,
+            kind="file",
+            expected_after="--prepare",
+            required_now=prepare,
+        ),
+        "dev_events": _artifact_state(
+            dev_events,
+            kind="jsonl",
+            expected_after="--launch-daemon, --capture-cli, --browser-plan, --tui-plan, or a smoke/proof action",
+        ),
+        "daemon_log": _artifact_state(daemon_log, kind="log", expected_after="--launch-daemon"),
+    }
+
+
+def _dev_loop_action(
+    *,
+    name: str,
+    purpose: str,
+    command: list[str],
+    artifact_dir: Path,
+    authority_name: str,
+    writes: list[Path] | None = None,
+) -> dict[str, object]:
+    authority = _authority(authority_name)
+    return {
+        "name": name,
+        "purpose": purpose,
+        "command": command,
+        "command_text": shlex.join(command),
+        "artifact_dir": str(artifact_dir),
+        "writes": [str(path) for path in writes or []],
+        "authority": authority,
+    }
+
+
+def _build_operator_plan(
+    *,
+    root: Path,
+    archive: Path,
+    logs: Path,
+    run_id: str,
+    run_log_dir: Path,
+    daemon_log: Path,
+    browser_artifact_dir: Path,
+    terminal_artifact_dir: Path,
+    tui_artifact_dir: Path,
+    preflight_json: Path,
+    dev_events: Path,
+    api_port: int,
+    browser_capture_port: int,
+    prepared: bool,
+) -> dict[str, object]:
+    browser_plan_json = browser_artifact_dir / "browser-plan.json"
+    tui_plan_json = tui_artifact_dir / "tui-plan.json"
+    live_profile_dir = root / ".local" / "browser-profiles" / f"{run_id}-chrome-user-data"
+    prepare_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--prepare"],
+    )
+    launch_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--launch-daemon", "--json"],
+    )
+    receiver_smoke_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--receiver-smoke", "--json"],
+    )
+    extension_smoke_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--extension-smoke", "--json"],
+    )
+    browser_smoke_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--browser-smoke", "--json"],
+    )
+    browser_provider_smoke_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--browser-provider-smoke", "--json"],
+    )
+    browser_plan_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--browser-plan", "--json"],
+    )
+    live_proof_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=[
+            "--browser-live-proof",
+            "--browser-live-profile-dir",
+            str(live_profile_dir),
+            "--browser-live-chatgpt-url",
+            "https://chatgpt.com/c/<conversation-id>",
+            "--browser-live-claude-url",
+            "https://claude.ai/chat/<conversation-id>",
+            "--json",
+        ],
+    )
+    tui_plan_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--tui-plan", "--json"],
+    )
+    inspect_command = ["devtools", "workspace", "dev-loop", "--inspect-run", str(run_log_dir), "--json"]
+    capture_cli_command = _dev_loop_cli_args(
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        archive=archive,
+        logs=logs,
+        extra_args=["--capture-cli", "--", "polylogue", "ops", "status"],
+    )
+
+    actions = [
+        _dev_loop_action(
+            name="prepare",
+            purpose="create the branch-local archive/run artifact directories and write preflight.json",
+            command=prepare_command,
+            artifact_dir=run_log_dir,
+            authority_name="preflight",
+            writes=[preflight_json, browser_artifact_dir, terminal_artifact_dir, tui_artifact_dir],
+        ),
+        _dev_loop_action(
+            name="launch_daemon",
+            purpose="start the branch-local daemon from source with selected ports/archive/logs",
+            command=launch_command,
+            artifact_dir=run_log_dir,
+            authority_name="launch_daemon",
+            writes=[daemon_log, run_log_dir / "polylogued.launch.json", run_log_dir / "polylogued.pid", dev_events],
+        ),
+        _dev_loop_action(
+            name="receiver_smoke",
+            purpose="prove receiver auth rejection and synthetic capture spool acceptance without browser/profile state",
+            command=receiver_smoke_command,
+            artifact_dir=run_log_dir / "receiver-smoke-spool",
+            authority_name="receiver_smoke",
+        ),
+        _dev_loop_action(
+            name="extension_smoke",
+            purpose="exercise the extension background-worker receiver path with deterministic synthetic data",
+            command=extension_smoke_command,
+            artifact_dir=browser_artifact_dir,
+            authority_name="extension_smoke",
+            writes=[browser_artifact_dir / "extension-smoke.json", dev_events],
+        ),
+        _dev_loop_action(
+            name="browser_smoke",
+            purpose="load the unpacked extension in local headless Chrome/Chromium against a temporary receiver",
+            command=browser_smoke_command,
+            artifact_dir=browser_artifact_dir,
+            authority_name="browser_smoke",
+            writes=[browser_artifact_dir / "browser-smoke.json", dev_events],
+        ),
+        _dev_loop_action(
+            name="browser_provider_smoke",
+            purpose="verify deterministic provider fixture content-script capture in local headless Chrome/Chromium",
+            command=browser_provider_smoke_command,
+            artifact_dir=browser_artifact_dir,
+            authority_name="browser_provider_smoke",
+            writes=[browser_artifact_dir / "browser-provider-smoke.json", dev_events],
+        ),
+        _dev_loop_action(
+            name="browser_plan",
+            purpose="write local browser-control handoff commands, profile dirs, and copied-profile checklist",
+            command=browser_plan_command,
+            artifact_dir=browser_artifact_dir,
+            authority_name="browser_plan",
+            writes=[browser_plan_json, browser_artifact_dir / "browser-plan.md", dev_events],
+        ),
+        _dev_loop_action(
+            name="browser_live_proof",
+            purpose="operator-local visible copied-profile proof against live provider pages; never source-only/cloud evidence",
+            command=live_proof_command,
+            artifact_dir=browser_artifact_dir,
+            authority_name="browser_live_proof",
+            writes=[browser_artifact_dir / "browser-live-proof.json", dev_events],
+        ),
+        _dev_loop_action(
+            name="capture_cli_status",
+            purpose="record a branch-local CLI transcript with stdout/stderr/env/summary artifacts",
+            command=capture_cli_command,
+            artifact_dir=terminal_artifact_dir,
+            authority_name="capture_cli",
+            writes=[terminal_artifact_dir],
+        ),
+        _dev_loop_action(
+            name="tui_plan",
+            purpose="write local terminal/TUI recording commands and artifact paths",
+            command=tui_plan_command,
+            artifact_dir=tui_artifact_dir,
+            authority_name="tui_plan",
+            writes=[tui_plan_json, tui_artifact_dir / "tui-plan.md", dev_events],
+        ),
+        _dev_loop_action(
+            name="inspect_run",
+            purpose="summarize the run-local artifacts after any daemon/CLI/browser action",
+            command=inspect_command,
+            artifact_dir=run_log_dir,
+            authority_name="inspect_run",
+        ),
+    ]
+    checks = {
+        str(action["name"]): action
+        for action in actions
+        if action["name"]
+        in {
+            "receiver_smoke",
+            "extension_smoke",
+            "browser_smoke",
+            "browser_provider_smoke",
+            "browser_live_proof",
+        }
+    }
+    next_action = actions[1] if prepared else actions[0]
+    return {
+        "run_id": run_id,
+        "artifact_dir": str(run_log_dir),
+        "next_command_name": next_action["name"],
+        "next_command": next_action["command_text"],
+        "next_artifact_dir": next_action["artifact_dir"],
+        "ports": {"api": api_port, "browser_capture": browser_capture_port},
+        "urls": {
+            "api_url": f"http://127.0.0.1:{api_port}",
+            "web_url": f"http://127.0.0.1:{api_port}/",
+            "receiver_url": f"http://127.0.0.1:{browser_capture_port}",
+        },
+        "actions": actions,
+        "checks": checks,
+        "authority_levels": {name: _authority(name) for name in sorted(_DEV_LOOP_AUTHORITIES)},
+    }
+
+
 def build_dev_loop_status(
     *,
     repo_root: Path | None = None,
@@ -2035,6 +2490,79 @@ def build_dev_loop_status(
         if int(status.get("owner_count") or 0) > 0:
             warnings.append(f"{name} port {status['port']} already has a listener")
 
+    api_url = f"http://127.0.0.1:{api_port}"
+    web_url = f"{api_url}/"
+    receiver_url = f"http://127.0.0.1:{browser_capture_port}"
+    artifact_status = _dev_loop_artifact_status(
+        archive=archive,
+        logs=logs,
+        run_log_dir=run_log_dir,
+        daemon_log=daemon_log,
+        browser_artifact_dir=browser_artifact_dir,
+        terminal_artifact_dir=terminal_artifact_dir,
+        tui_artifact_dir=tui_artifact_dir,
+        preflight_json=preflight_json,
+        dev_events=dev_events,
+        prepare=prepare,
+    )
+    if prepare:
+        artifact_status["preflight_json"]["exists"] = True
+        artifact_status["preflight_json"]["state"] = "present"
+    operator_plan = _build_operator_plan(
+        root=root,
+        archive=archive,
+        logs=logs,
+        run_id=run_id,
+        run_log_dir=run_log_dir,
+        daemon_log=daemon_log,
+        browser_artifact_dir=browser_artifact_dir,
+        terminal_artifact_dir=terminal_artifact_dir,
+        tui_artifact_dir=tui_artifact_dir,
+        preflight_json=preflight_json,
+        dev_events=dev_events,
+        api_port=api_port,
+        browser_capture_port=browser_capture_port,
+        prepared=prepare,
+    )
+    plan_actions = {str(action["name"]): action for action in cast(list[dict[str, object]], operator_plan["actions"])}
+    plan_checks = cast(dict[str, dict[str, object]], operator_plan["checks"])
+    commands = {
+        "stop_system_service": "systemctl --user stop polylogued.service",
+        "prepare": str(plan_actions["prepare"]["command_text"]),
+        "prepare_isolated": "devtools workspace dev-loop --isolated-ports --prepare",
+        "save_preflight": (
+            f"mkdir -p {run_log_dir} && devtools workspace dev-loop --api-port {api_port} "
+            f"--browser-capture-port {browser_capture_port} --json > {preflight_json}"
+        ),
+        "launch_daemon": str(plan_actions["launch_daemon"]["command_text"]),
+        "receiver_smoke": str(plan_checks["receiver_smoke"]["command_text"]),
+        "extension_smoke": str(plan_checks["extension_smoke"]["command_text"]),
+        "browser_smoke": str(plan_checks["browser_smoke"]["command_text"]),
+        "browser_provider_smoke": str(plan_checks["browser_provider_smoke"]["command_text"]),
+        "browser_plan": str(plan_actions["browser_plan"]["command_text"]),
+        "browser_live_proof": str(plan_checks["browser_live_proof"]["command_text"]),
+        "tui_plan": str(plan_actions["tui_plan"]["command_text"]),
+        "inspect_run": str(plan_actions["inspect_run"]["command_text"]),
+        "run_daemon": (
+            f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
+            f"POLYLOGUE_API_PORT={api_port} "
+            f"POLYLOGUE_BROWSER_CAPTURE_PORT={browser_capture_port} "
+            f"POLYLOGUE_DEV_LOOP_RUN_ID={run_id} "
+            f"POLYLOGUE_DEV_LOOP_LOG_DIR={run_log_dir} "
+            f"PYTHONPATH={root}${{PYTHONPATH:+:${{PYTHONPATH}}}} "
+            f"{shlex.quote(sys.executable)} -c 'from polylogue.daemon.cli import main; main()' "
+            f"run --api-port {api_port} --port {browser_capture_port} 2>&1 | tee {daemon_log}"
+        ),
+        "open_web_shell": web_url,
+        "receiver_status": f"curl -sf {receiver_url}/v1/status",
+        "capture_cli_status": (
+            "script -q -c "
+            f"'env POLYLOGUE_ARCHIVE_ROOT={archive} polylogue ops status' "
+            f"{terminal_artifact_dir / 'polylogue-ops-status.typescript'}"
+        ),
+        "terminal_tui_plan": str(plan_actions["tui_plan"]["command_text"]),
+    }
+
     payload = {
         "repo_root": str(root),
         "branch": branch,
@@ -2046,6 +2574,10 @@ def build_dev_loop_status(
         "dev_archive_root": str(archive),
         "log_dir": str(logs),
         "run_log_dir": str(run_log_dir),
+        "artifact_dir": str(run_log_dir),
+        "api_url": api_url,
+        "web_url": web_url,
+        "receiver_url": receiver_url,
         "artifacts": {
             "daemon_log": str(daemon_log),
             "browser_dir": str(browser_artifact_dir),
@@ -2066,54 +2598,9 @@ def build_dev_loop_status(
             "POLYLOGUE_DEV_LOOP_RUN_ID": run_id,
             "POLYLOGUE_DEV_LOOP_LOG_DIR": str(run_log_dir),
         },
-        "commands": {
-            "stop_system_service": "systemctl --user stop polylogued.service",
-            "prepare": (
-                f"devtools workspace dev-loop --api-port {api_port} "
-                f"--browser-capture-port {browser_capture_port} --prepare"
-            ),
-            "prepare_isolated": "devtools workspace dev-loop --isolated-ports --prepare",
-            "save_preflight": (
-                f"mkdir -p {run_log_dir} && devtools workspace dev-loop --api-port {api_port} "
-                f"--browser-capture-port {browser_capture_port} --json > {preflight_json}"
-            ),
-            "receiver_smoke": (
-                f"devtools workspace dev-loop --api-port {api_port} "
-                f"--browser-capture-port {browser_capture_port} --receiver-smoke --json"
-            ),
-            "browser_plan": (
-                f"devtools workspace dev-loop --api-port {api_port} "
-                f"--browser-capture-port {browser_capture_port} --browser-plan"
-            ),
-            "browser_live_proof": (
-                f"devtools workspace dev-loop --api-port {api_port} "
-                f"--browser-capture-port {browser_capture_port} --browser-live-proof "
-                f"--browser-live-profile-dir {archive.parent / 'browser-profiles' / (run_id + '-chrome-user-data')} "
-                "--browser-live-chatgpt-url https://chatgpt.com/c/<conversation-id> "
-                "--browser-live-claude-url https://claude.ai/chat/<conversation-id>"
-            ),
-            "run_daemon": (
-                f"env POLYLOGUE_ARCHIVE_ROOT={archive} "
-                f"POLYLOGUE_API_PORT={api_port} "
-                f"POLYLOGUE_BROWSER_CAPTURE_PORT={browser_capture_port} "
-                f"POLYLOGUE_DEV_LOOP_RUN_ID={run_id} "
-                f"POLYLOGUE_DEV_LOOP_LOG_DIR={run_log_dir} "
-                f"PYTHONPATH={root}${{PYTHONPATH:+:${{PYTHONPATH}}}} "
-                f"{shlex.quote(sys.executable)} -c 'from polylogue.daemon.cli import main; main()' "
-                f"run --api-port {api_port} --port {browser_capture_port} 2>&1 | tee {daemon_log}"
-            ),
-            "open_web_shell": f"http://127.0.0.1:{api_port}/",
-            "receiver_status": f"curl -sf http://127.0.0.1:{browser_capture_port}/v1/status",
-            "capture_cli_status": (
-                "script -q -c "
-                f"'env POLYLOGUE_ARCHIVE_ROOT={archive} polylogue ops status' "
-                f"{terminal_artifact_dir / 'polylogue-ops-status.typescript'}"
-            ),
-            "capture_tui_placeholder": (
-                "Record branch-local TUI/terminal runs into "
-                f"{tui_artifact_dir}; use the local terminal-control surface or VHS when visual playback is needed"
-            ),
-        },
+        "commands": commands,
+        "artifact_status": artifact_status,
+        "plan": operator_plan,
         "warnings": warnings,
     }
     if prepare:
@@ -2130,6 +2617,13 @@ def _print_human(payload: dict[str, Any]) -> None:
     print(f"  archive: {payload['dev_archive_root']}")
     print(f"  logs:    {payload['log_dir']}")
     print(f"  run log: {payload['run_log_dir']}")
+    print(f"  artifacts: {payload.get('artifact_dir', payload['run_log_dir'])}")
+    if payload.get("api_url"):
+        print(f"  api:     {payload['api_url']}")
+    if payload.get("web_url"):
+        print(f"  web:     {payload['web_url']}")
+    if payload.get("receiver_url"):
+        print(f"  receiver:{payload['receiver_url']}")
     service = payload["system_service"]
     assert isinstance(service, dict)
     print(
@@ -2147,6 +2641,29 @@ def _print_human(payload: dict[str, Any]) -> None:
         print("  warnings:")
         for warning in warnings:
             print(f"    - {warning}")
+    plan = payload.get("plan")
+    if isinstance(plan, dict):
+        print("\nPlan:")
+        print(f"  next:      {plan.get('next_command_name')}")
+        print(f"  command:   {plan.get('next_command')}")
+        print(f"  artifacts: {plan.get('next_artifact_dir')}")
+        checks = plan.get("checks")
+        if isinstance(checks, dict):
+            print("  checks:")
+            for name in (
+                "receiver_smoke",
+                "extension_smoke",
+                "browser_smoke",
+                "browser_provider_smoke",
+                "browser_live_proof",
+            ):
+                check = checks.get(name)
+                if not isinstance(check, dict):
+                    continue
+                authority = check.get("authority")
+                label = authority.get("label") if isinstance(authority, dict) else "unknown"
+                cloud_safe = authority.get("cloud_safe") if isinstance(authority, dict) else "unknown"
+                print(f"    - {name}: {label} cloud_safe={cloud_safe} artifacts={check.get('artifact_dir')}")
     commands = payload["commands"]
     assert isinstance(commands, dict)
     print("\nCommands:")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,9 +151,13 @@ for diagnostics.
 The JSON form also includes a `diagnostics` array. Each item has stable
 `code`, `severity`, `key`, `toml_path`, `env_var`, `message`, and
 `next_action` fields so deployment smoke, agents, and shell scripts can tell
-configuration debt from daemon/runtime failures. Current diagnostics cover
-operator-supplied path-layout problems and `embedding.enabled = true` without
-a configured Voyage key.
+configuration debt from daemon/runtime failures. Diagnostics also include the
+redacted effective `value`, `source_layer`, `secret`, and `secret_present` when
+the source can be determined, plus `related_keys` for multi-key contradictions.
+Current diagnostics cover operator-supplied path-layout problems, unsafe
+network/auth combinations, API/browser-capture port conflicts, web-origin
+browser capture without bearer auth, and `embedding.enabled = true` without a
+configured Voyage key.
 
 ### State classes
 
@@ -273,12 +277,16 @@ auth_token = "..."
 
 [daemon.browser_capture]
 allow_remote = true
+auth_token = "..."
 ```
 
-Browser-capture web origins fail closed without a browser-capture auth token.
-Extension origins such as `chrome-extension://*` are allowed by default for the
-local receiver; ordinary web origins such as `https://workbench.example` require
-`daemon.browser_capture.auth_token` or `POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN`.
+Browser-capture remote opt-in and web origins fail closed without a
+browser-capture auth token. Extension origins such as `chrome-extension://*` are
+allowed by default for the local receiver; ordinary web origins such as
+`https://workbench.example` require `daemon.browser_capture.auth_token` or
+`POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN`. The config diagnostics payload reports
+these failures before daemon startup, including whether the missing token would
+come from the default, TOML, env, or CLI layer.
 
 Embeddings are provider-cost work. `VOYAGE_API_KEY` alone supplies a credential
 but does not enable daemon embedding convergence. Set `embedding.enabled = true`

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -26,6 +26,40 @@ It reports:
   path to use;
 - a concrete `polylogued run` command with branch-local environment variables.
 
+`--json` is intended to be enough for a source-only agent to choose the next
+step without reading `devtools/dev_loop.py`. In addition to the legacy `commands`
+map it includes stable top-level aliases:
+
+```text
+run_id
+artifact_dir
+api_url
+web_url
+receiver_url
+plan.next_command
+plan.next_artifact_dir
+```
+
+`plan.actions[]` records exact argv lists and shell-rendered command text for
+preparation, daemon launch, receiver/extension/browser smokes, browser/TUI
+plans, copied-profile live proof, CLI capture, and run inspection. The
+`plan.checks` entries carry an authority label and booleans for `source_safe`,
+`cloud_safe`, `requires_browser`, and `requires_copied_profile`, so a cloud
+source checkout can distinguish deterministic smokes from local browser or
+operator-profile evidence. `artifact_status` reports each core path as
+`present`, `planned`, or `degraded` instead of making agents infer whether a
+missing file is expected before a daemon/browser action has run.
+
+Authority summary:
+
+| Surface | Authority label | Cloud-safe | Profile/cookie state |
+| --- | --- | --- | --- |
+| `--receiver-smoke` | `source-only-deterministic-receiver-smoke` | yes | none |
+| `--extension-smoke` | `source-only-deterministic-extension-smoke` | yes | none |
+| `--browser-smoke` | `local-browser-deterministic-extension-smoke` | no | none |
+| `--browser-provider-smoke` | `local-browser-deterministic-provider-smoke` | no | none |
+| `--browser-live-proof` | `operator-local-copied-profile-live-proof` | no | operator-approved copied profile only |
+
 The default branch-local paths are:
 
 ```text

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -6,94 +6,125 @@ and PR discussion own scope; this file names the order that minimizes rework.
 
 ## Current Backlog Shape
 
-As of this plan, the active public backlog is intentionally small but no longer
-only substrate-shaped. Live deployed probing on 2026-06-21/22 added a product
-and operations layer over the older query/route/workbench spine:
+As of the 2026-06-24 issue export, the active public backlog is a residual map
+around #1807 rather than a single linear implementation queue. Closed campaign
+issues are baseline contracts; open issues below own the remaining execution
+lanes.
 
-| Issue | Scope | Primary owner surface |
+| Issue | Residual scope | Primary owner surface |
 | --- | --- | --- |
-| #1807 | Present Polylogue as a local AI-work evidence cockpit. | Epic / product integration |
-| #2006 | Finish the full query DSL substrate. | `polylogue/archive/query/`, storage lowerers, CLI/API/MCP/web query routes |
-| #1847 | Stabilize daemon/web API DTOs and local auth boundary. | `polylogue/daemon/`, `polylogue/surfaces/`, API/MCP parity |
-| #1846 | Build the web workbench over archive contracts. | `polylogue/daemon/web_shell.py`, visual/daemon tests |
-| #2304 | Keep the web workbench truthful and responsive when routes are slow, missing, or stale. | `polylogue/daemon/http.py`, `polylogue/daemon/web_shell.py`, facet/read models, browser smoke |
-| #2305 | Define and verify executable `find QUERY then ACTION` workflows. | CLI verbs, JSON envelopes, completions, HTTP/MCP affordances, web action rendering |
-| #2306 | Make recovery/context/evidence packs trustworthy handoff artifacts. | read views, evidence windows, assertion/candidate review, context/recovery renderers |
-| #2307 | Polish docs, theming, packaging, release proof, and local control-plane probes. | README/docs, renderers, Nix package/runtime proof, dev-loop/browser diagnostics |
-| #2308 | Make deployed state trustworthy and browser captures queryable. | deployment smoke, browser-capture receiver/archive flow, daemon status/resource behavior |
-| #2309 | Make runtime and deployment configuration intentional. | `polylogue/config.py`, config docs, HM/NixOS module options, runtime/user/ops state boundaries |
+| #1807 | Integrate the remaining work into a truthful local AI-work evidence cockpit story. | Epic / product integration |
+| #2006 | Finish the full query DSL substrate on the existing parser, typed AST, query-unit metadata, lowerers, pipeline stages, docs, and cross-surface parity. | `polylogue/archive/query/`, storage lowerers, CLI/API/MCP/web query routes |
+| #1844 | Build completion, fuzzy selection, and query-builder metadata from shared query grammar/action/read-view registries. | `polylogue/archive/query/metadata.py`, `polylogue/cli/shell_completion_values.py`, completion tests |
+| #1883 | Finish assertion lifecycle and policy over the landed assertion-backed user-overlay substrate. | `polylogue/storage/sqlite/archive_tiers/user.py`, assertion read/write/review surfaces |
+| #2177 | Make shared contracts own surfaces and delete remaining parallel dispatch/facade/string-vocabulary copies. | CLI/MCP/API/daemon/read-view/action contract metadata and generated-surface inputs |
+| #2196 | Replace showcase-era QA with demo-driven CLI, DOM, visual, and ordinary behavior tests. | `demo/`, `tests/infra/`, visual tests, validation-lane/devtools cleanup |
+| #2246 | Extend archive schema/read-path hygiene only where landed evidence-cockpit surfaces prove a storage need. | `polylogue/storage/sqlite/archive_tiers/`, schema docs, self-verification |
+| #2248 | Make daemon, web-shell, browser-capture, and extension debugging branch-local and isolated from deployed state. | `devtools/dev_loop.py`, `docs/dev-loop.md`, `browser-extension/`, daemon/browser-capture docs |
+| #2304 | Keep the web workbench truthful and responsive when routes are slow, missing, stale, or expensive. | `polylogue/daemon/http.py`, `polylogue/daemon/web_shell.py`, facet/read models, DOM/browser smoke |
+| #2307 | Polish docs, theming, package proof, and local control-plane probes that support shipped workflows. | README/docs map, renderers, Nix/package checks, dev-loop/browser diagnostics |
+| #2308 | Make deployed state trustworthy and browser captures queryable from archive rows, not only receiver spool files. | deployment smoke, browser-capture receiver/archive flow, daemon status/resource behavior |
+| #2309 | Make runtime and deployment configuration intentional and inspectable. | `polylogue/config.py`, config docs, HM/NixOS options, runtime/user/ops state boundaries |
+| #2316 | Make provider usage accounting complete, auditable, and explicit about coverage and cache semantics. | parser usage events, usage ledger/rollups, diagnostics, CLI/API/MCP usage surfaces |
+| #2317 | Rationalize root onboarding, reader/dashboard promises, status discoverability, mark ownership, and facet usefulness. | root CLI/help/tutorial/dashboard/facet surfaces and demo-backed tests |
 
-Closed design or campaign notes should not live here as dispatch truth. If an
-old plan is still useful, fold the relevant decision into the owning issue body
-or current reference docs.
+Closed issues that this plan can reference as baseline but should not present as
+active execution lanes: #1846 web workbench contract, #1847 daemon/API DTO and
+auth boundary, #2182 candidate assertion promotion, #2183 OTLP projection,
+#2253 ops/product command placement, #2305 query-action workflows, and #2306
+recovery/context/evidence handoff packs. Reopen those only when new source
+evidence shows their contracts regressed; otherwise route follow-up through the
+open residual owner above.
 
 #2126, the devtools command-sprawl cleanup, is closed. Treat it as maintenance
 history, not as a queued implementation lane. Reopen command-surface work only
 when a concrete command has the wrong owner, generated docs are stale, or a
 workflow/hook points at a removed command.
 
+## Residual Map
+
+| Residual class | Current owner | Where it belongs | Locality / agent posture |
+| --- | --- | --- | --- |
+| Live/deployment local-only | #2308 | Deployment smoke, installed `polylogue`/`polylogued` version checks, browser-capture receiver/archive consistency, daemon status/resource probes. | Requires the operator's live deployment, archive, browser-capture spool, and Sinnix/NixOS wrapper state for closeout. Cloud agents may patch source probes and docs, but cannot certify deployed truth. |
+| Live/deployment local-only | #2248 | Branch-local daemon/web/receiver/extension loop, dev archive roots, isolated ports, run logs, copied-profile safety boundary. | Local-only for copied profiles, real browser control, screenshots, extension service workers, and production-service coexistence. Cloud-safe work is limited to deterministic synthetic smoke, docs, and helper-source changes. |
+| Source-only implementation | #2006, #1844, #2177 | Shared query grammar/metadata/lowerers, completion metadata, normalized request/scope DTOs, read-view/action metadata, generated-surface inputs. | Cloud-safe when backed by unit/integration fixtures and generated docs/schema checks. Do not fork parser, completion, or route vocabularies to work around local data. |
+| Source-only implementation | #2316 | Provider usage extraction, `session_provider_usage_events`, rollups, coverage diagnostics, and usage-facing command/API/MCP payloads. | Initial Codex token-count preservation and usage-event storage exist in source; residual work is coverage semantics, rollups, provider matrix, docs, and rebuild guidance. Local archive probes are evidence, not a substitute for fixtures. |
+| Product/UX design | #2304, #2317, #1883 | Web degraded states, first-paint budget, root help/onboarding/dashboard/status behavior, facet canonicalization, assertion lifecycle/review policy. | Design decisions must land as observable contracts, help text, payload states, DOM/CLI tests, and docs. Avoid unverified tutorial/dashboard claims or decorative registries. |
+| Schema/runtime migration | #2246, #1883, #2316 | Fresh-first tier DDL, assertion indexes and lifecycle, usage ledger/rollups, self-verify, schema docs, explicit rebuild/reset paths. | Source changes are cloud-safe; closeout needs fresh-archive/rebuild evidence. `ops.db` may keep documented disposable compatibility helpers; durable tiers should not grow chained migrations. |
+| Docs/navigation | #2196, #2307, #2248 | Docs index, execution plan, dev-loop/browser-capture docs, generated docs surface, demo/visual verification docs. | Safe docs cleanup should point at shipped workflows and current architecture pages. Remove showcase-era or closed-campaign language rather than adding absence memorials. |
+| Stale or misframed | #1807 and any docs/issue references to closed #1846/#1847/#2182/#2183/#2253/#2305/#2306 as active lanes | Issue bodies, execution docs, generated docs descriptions, release/readiness notes. | Treat those closed issues as baseline contracts. Patch repo docs immediately; use issue comment/body drafts only when the stale surface is GitHub issue text rather than repository docs. |
+
 ## Execution Order
 
 1. **Keep deployed-state trust green while product work continues (#2308).**
    - Do not let the live service drift back to an unprovable state while
      feature work proceeds.
-   - Deployment smoke is now the installed-artifact witness for versions,
+   - Deployment smoke is the installed-artifact witness for versions,
      completions, core daemon routes, browser-capture spool/raw/index
      materialization, receiver archive-state, and optional browser first paint.
+   - Source patches can improve smoke payloads and receiver/archive diagnostics,
+     but closeout requires the operator's live deployment and archive.
    - Evidence: `devtools workspace deployment-smoke --json` passes against the
      systemwide deployment; `polylogue` and `polylogued` versions match the
      intended build; the latest browser capture is queryable from archive rows,
      not only present in the receiver spool.
 
-2. **Finish query substrate (#2006) together with query-action UX (#2305).**
+2. **Finish query substrate and discovery on shared metadata (#2006/#1844/#2177).**
    - The grammar is already Lark-backed; do not describe a separate floor
      grammar or compatibility compiler.
-   - Expand only through real lowerers, typed errors, explain metadata, and
-     cross-surface tests.
-   - Treat `find QUERY then ACTION` as the product contract over the query
-     substrate: selection envelope, cardinality, exactness, action
-     affordances, rendering, completions, and JSON/HTTP/MCP/web parity.
+   - Expand only through real lowerers, typed errors, explain metadata,
+     shared query-unit descriptors, and cross-surface tests.
+   - Completion, fuzzy selection, and query-builder help should introspect the
+     same query/action/read-view registries rather than carrying parallel field
+     lists.
    - Evidence: CLI, daemon, API, MCP, completion, and web query routes share the
      same parser/AST behavior; unsupported fields fail closed instead of
-     broadening results; exact refs do not degrade into broad FTS; query-result
-     envelopes expose the same action affordance DTO across surfaces.
+     broadening results; exact refs do not degrade into broad FTS; generated
+     docs come from the same contract inputs as runtime surfaces.
 
-3. **Stabilize route and DTO boundaries (#1847) through the new product
-   surfaces (#2304/#2305/#2306).**
-   - Promote stable daemon routes only when they have typed payloads, auth
-     posture, generated docs/schema where appropriate, and parity tests.
-   - Keep shell-supported routes honest when they are intentionally local
-     workbench internals.
-   - Slow or partial routes need typed degraded responses, not silent UI
-     failure. Facets/status/read-view profiles and context/recovery routes must
-     advertise completeness, staleness, omissions, and fallback actions when
-     applicable.
-   - Evidence: route contracts, OpenAPI/docs decisions, auth/redaction tests,
-     API/MCP parity where the route advertises shared behavior, and smoke/DOM
-     tests for degraded web states.
+3. **Make product-facing entrypoints and facets coherent (#2317, with #2305 as baseline).**
+   - Treat the query-action workflow contract as baseline, not as an active
+     issue lane. Follow-up belongs in root help, onboarding, dashboard/reader,
+     status discoverability, mark ownership, and facet usefulness.
+   - `dashboard`, `tutorial`, `status`, root query-action verbs, and `mark`
+     should either have explicit product ownership or be moved/renamed/deleted
+     with behavior tests.
+   - Facets should be canonical, bounded, and useful; path fragments, agent ids,
+     archive folders, and one-off scratch names must not masquerade as top repo
+     facets.
+   - Evidence: root help groups commands by role; `polylogue status` has an
+     intentional behavior or targeted `polylogue ops status` diagnostic;
+     tutorial/dashboard output proves what happened; facet JSON reports family,
+     canonicalization, omission/noise, freshness, and budget/degraded state.
 
-4. **Complete the web workbench verticals (#1846/#2304).**
-   - Build on the existing daemon shell, not a separate app or marketing page.
-   - Use shared query/read/recovery/assertion/ref DTOs; do not invent browser
-     vocabularies.
+4. **Keep the web workbench truthful under degradation (#2304, with #1846/#1847 as baseline).**
+   - The daemon web shell and local HTTP/auth DTO baseline already exists; do not
+     reopen closed web/API contract issues unless source evidence shows a
+     regression.
    - First paint must not depend on expensive optional route families. Results
      should remain visible when facets, status, read-view profiles, or session
      detail routes degrade.
-   - Evidence: fixture/demo-backed flow for search -> open -> read/recovery ->
-     assertions/evidence -> explicit raw drilldown; live browser smoke produces
-     DOM and screenshot artifacts; degraded-route tests prevent populated data
-     coexisting with unexplained zero counters or permanent `Loading...`.
+   - Slow or partial routes need typed degraded responses, visible retry/fallback
+     actions, and DOM/browser smoke coverage rather than silent UI failure.
+   - Evidence: populated lists cannot coexist with unexplained zero counters or
+     permanent `Loading...`; degraded-route tests cover timed-out facets,
+     missing read-view profiles, failed session detail, stale data, retry, and
+     fallback command rendering.
 
-5. **Make context/evidence packs usable for real handoff (#2306).**
-   - Recovery/context packs must state selection strategy, evidence refs,
-     omissions, redaction policy, caveats, and token/size estimates.
-   - Candidate extraction must avoid treating large instruction dumps as
-     durable decisions unless evidence supports the claim.
-   - Evidence: demo/live fixtures with instruction dumps and real decisions;
-     JSON and Markdown handoff outputs distinguish quoted evidence, inferred
-     summary, accepted/rejected/deferred candidates, unavailable source
-     material, and disabled review actions with reasons. Default handoffs redact
-     raw absolute paths unless an explicit raw/no-redact path is requested.
+5. **Finish assertion, schema, and usage runtime semantics (#1883/#2246/#2316).**
+   - User-overlay storage is already assertion-backed in the source tree; the
+     residual is lifecycle/read policy, index/read hardening, export/reset
+     semantics, and review surfaces, not a second overlay store.
+   - Schema work should follow fresh-first tier DDL and add durable tables only
+     when landed read/query/ref/usage surfaces prove they need identity,
+     freshness, or performance.
+   - Provider usage has an initial event substrate in source; finish provider
+     coverage semantics, rollups, coverage states, current-vs-cumulative token
+     handling, cache/pricing labels, diagnostics, and rebuild guidance.
+   - Evidence: schema docs match tier DDL; self-verify covers cheap high-value
+     invariants; usage surfaces distinguish exact provider telemetry, text
+     estimates, unsupported/missing data, acquired-not-materialized rows, and
+     stale rollups.
 
 6. **Make configuration explicit before adding more knobs (#2309).**
    - Classify settings as startup config, deployment policy, mutable user
@@ -106,20 +137,26 @@ workflow/hook points at a removed command.
      ops state, redaction/security tests, deployment smoke effective-config
      evidence, and Sinnix module checks where Nix options are touched.
 
-7. **Keep repo/package/dev-loop polish tied to shipped workflows (#2307/#2248).**
-   - Docs, theming, release proof, and private-browser/dev-loop probes should
+7. **Keep demo/docs/dev-loop polish tied to shipped workflows (#2196/#2307/#2248).**
+   - Replace showcase-era verification with demo-backed CLI/DOM/visual tests and
+     generated docs that describe current behavior.
+   - Docs, theming, package proof, and private-browser/dev-loop probes should
      make real workflows easier to run and verify; avoid decorative evidence layers and
      absence memorials.
-   - Evidence: README/install commands match shipped behavior; package checks
-     prove runtime dependency closure; rendering respects plain/no-color modes;
-     branch-local daemon/web/receiver runs expose ports, archive roots, logs,
-     browser executable paths, and capture artifacts.
+   - Branch-local daemon/web/receiver runs must expose ports, archive roots,
+     logs, browser executable paths, and capture artifacts without depending on
+     systemwide deployment or committed browser profile state.
+   - Evidence: docs index links the current architecture/execution/dev-loop
+     pages; rendering respects plain/no-color modes; branch-local synthetic
+     receiver/extension smokes pass; live browser/copied-profile proof remains a
+     local operator-only lane.
 
-8. **Close the epic (#1807) only after the product story is truthful.**
+8. **Treat #1807 as ready for final review only after the product story is truthful.**
    - The README, CLI help, docs site, daemon shell, and release gate must
      describe what exists now.
-   - Claims about query, web, recovery, assertions, and work packets must be
-     backed by executable routes/tests or explicitly scoped out.
+   - Claims about query, web, recovery, assertions, usage accounting, work
+     packets, browser capture, and deployment trust must be backed by executable
+     routes/tests or explicitly scoped out.
 
 ## Rawlog Coverage Map
 
@@ -129,15 +166,16 @@ body before implementing from chat context.
 
 | Rawlog theme | Durable owner | Implementation posture |
 | --- | --- | --- |
-| `find QUERY then ACTION` UX, CLI vs interactive vs web/TUI, JSON automation, exact refs, affordances | #2305 | Product contract first, then CLI/HTTP/MCP/web parity and golden paths. |
-| Markdown/format/rendering aesthetics, pleasant terminal output, no-color/plain modes, pywal/theme responsiveness | #2307 | Renderer/theme tokens and docs/release proof; do not hard-code a one-off palette. |
-| Web UI rethink, route failures, slow facets, first-paint truthfulness | #2304 | Bounded route contracts, degraded UI states, lazy/stale facets, DOM/browser smoke. |
+| `find QUERY then ACTION` UX, CLI vs interactive vs web/TUI, JSON automation, exact refs, affordances | #2006 and #2317; #2305 is the baseline contract | Keep query/action semantics on shared substrate, then repair root/help/onboarding/facet UX where the product surface still misleads. |
+| Markdown/format/rendering aesthetics, pleasant terminal output, no-color/plain modes, pywal/theme responsiveness | #2307 plus #2196 | Renderer/theme tokens and demo-backed visual tests; do not hard-code a one-off palette or keep showcase-era proof vocabulary. |
+| Web UI rethink, route failures, slow facets, first-paint truthfulness | #2304; #1846/#1847 are baseline contracts | Bounded route contracts, degraded UI states, lazy/stale facets, DOM/browser smoke. |
 | Browser capture fully functional, provider-native payloads, realtime/live-session state, archive-state lifecycle | #2308 for deployed correctness; #2248 for branch-local extension/dev loop | Keep current capture queryable first; widen to fidelity/lifecycle/sync once the deployed invariant is stable. |
-| Recovery/context packs for feeding stronger agents and avoiding missing context | #2306 | Evidence-backed bundles with omissions, caveats, redaction, and candidate-review affordances. |
+| Recovery/context packs for feeding stronger agents and avoiding missing context | #1883 and #2246 for residual assertion/schema policy; #2306 is the handoff baseline | Treat packs as evidence-backed outputs with omissions, caveats, redaction, and candidate-review affordances; add storage only when read/query/ref surfaces need it. |
 | Configurability without pointless knobs, Nix/NixOS/runtime config clarity | #2309 | Classify each setting before adding it; distinguish startup config, deployment policy, mutable user state, presentation preferences, provider spend, and disposable ops state. |
-| Codebase incoherence, stale names, schema/concept review | #2177 plus #2307 | Cleanup belongs with contract ownership or repo-polish work, not standalone rename ceremony. |
+| Provider usage, pricing, cache semantics, and provider UI reconciliation | #2316 | Preserve provider-reported usage as evidence, roll it up with coverage states, and keep text-volume estimates separate from billable/provider counters. |
+| Codebase incoherence, stale names, schema/concept review | #2177 plus #2246/#2307 | Cleanup belongs with contract ownership, schema doctrine, or repo-polish work, not standalone rename ceremony. |
 | Agent/process/desktop/browser control and ambient capabilities | #2248, with Polylogue only owning branch-local URLs/logs/receiver config | Do not make Polylogue a general desktop automation framework; expose inspectable control points for existing local tools. |
-| OTLP/observability relevance | #2183 for projection, #2248/#2308 for local daemon/dev-loop resource evidence | OTel-style export is a projection, not internal authority. |
+| OTLP/observability relevance | #2183 is the projection baseline; #2248/#2308 own local daemon/dev-loop resource evidence | OTel-style export is a projection, not internal authority. |
 
 ## Verification Policy
 

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -818,6 +818,61 @@ components:
           title: Inspect Path
       title: ReaderActionAvailabilityPayload
       type: object
+    RouteReadinessPayload:
+      additionalProperties: false
+      description: 'Route-visible readiness state for a web reader panel.
+
+
+        ``total=0`` can mean an empty archive, a scoped no-result query, or a
+
+        degraded backend that cannot compute results. This payload lets browserless
+
+        tests and the web shell distinguish those states without guessing from
+
+        counters alone (#2304).'
+      properties:
+        state:
+          enum:
+          - ready
+          - loading
+          - empty
+          - no_results
+          - stale
+          - degraded
+          - failed
+          - budget_exceeded
+          title: State
+          type: string
+        route:
+          title: Route
+          type: string
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Reason
+        component:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Component
+        generated_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Generated At
+        stale_available:
+          default: false
+          title: Stale Available
+          type: boolean
+      required:
+      - state
+      - route
+      title: RouteReadinessPayload
+      type: object
     SessionSearchHitPayload:
       additionalProperties: false
       description: Search-hit payload with summary identity and match evidence.
@@ -1106,6 +1161,11 @@ components:
         diagnostics:
           anyOf:
           - $ref: '#/components/schemas/QueryMissDiagnosticsPayload'
+          - type: 'null'
+          default: null
+        route_state:
+          anyOf:
+          - $ref: '#/components/schemas/RouteReadinessPayload'
           - type: 'null'
           default: null
       required:
@@ -2438,7 +2498,7 @@ x-polylogue-route-contracts:
   kind: read_query
   stability: stable
   auth_policy: bearer_if_configured
-  response_contract: SearchEnvelope
+  response_contract: SearchEnvelope / SessionListResponse with route_state
 - method: GET
   pattern: /api/facets
   kind: read_query

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -461,6 +461,77 @@
       "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },
+    "RouteReadinessPayload": {
+      "additionalProperties": false,
+      "description": "Route-visible readiness state for a web reader panel.\n\n``total=0`` can mean an empty archive, a scoped no-result query, or a\ndegraded backend that cannot compute results. This payload lets browserless\ntests and the web shell distinguish those states without guessing from\ncounters alone (#2304).",
+      "properties": {
+        "component": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Component"
+        },
+        "generated_at": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Generated At"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reason"
+        },
+        "route": {
+          "title": "Route",
+          "type": "string"
+        },
+        "stale_available": {
+          "default": false,
+          "title": "Stale Available",
+          "type": "boolean"
+        },
+        "state": {
+          "enum": [
+            "ready",
+            "loading",
+            "empty",
+            "no_results",
+            "stale",
+            "degraded",
+            "failed",
+            "budget_exceeded"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "state",
+        "route"
+      ],
+      "title": "RouteReadinessPayload",
+      "type": "object"
+    },
     "SessionSearchHitPayload": {
       "additionalProperties": false,
       "description": "Search-hit payload with summary identity and match evidence.",
@@ -875,6 +946,17 @@
     "retrieval_lane": {
       "title": "Retrieval Lane",
       "type": "string"
+    },
+    "route_state": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RouteReadinessPayload"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "sort": {
       "anyOf": [

--- a/docs/web-route-readiness-states.md
+++ b/docs/web-route-readiness-states.md
@@ -1,0 +1,36 @@
+# Web route readiness states
+
+The local web reader uses explicit route readiness payloads for panels where a
+zero count is not enough evidence. A route can be ready with results, ready but
+empty, ready with no scoped matches, or degraded because an underlying archive
+component could not answer.
+
+## `/api/sessions`
+
+`GET /api/sessions` returns either the list envelope (`items`) or the ranked
+search envelope (`hits`) and includes `route_state`:
+
+- `ready`: the route completed and returned at least one session or hit.
+- `empty`: the unfiltered archive list completed and the archive contains no
+  sessions.
+- `no_results`: the route completed but an active query or filter matched no
+  sessions.
+- `degraded`: the route could not compute search results because the message
+  search index was unavailable. In this case `hits` is empty, `total` is `null`,
+  `route_state.component` is `message_fts`, and `diagnostics.reasons` includes
+  `search_index_degraded`.
+
+The web shell consumes this field before rendering the sidebar empty state. A
+failed or degraded sessions route renders a route-state notice with DOM markers
+(`data-route-state-name="sessionList"` and `data-route-state="..."`) instead of
+falling through to “No sessions in archive.” Empty and no-result states keep the
+regular sidebar empty DOM marker (`data-sidebar-state="empty"` or
+`data-sidebar-state="noresults"`).
+
+## Facets first paint
+
+`GET /api/facets` carries per-family readiness through `family_status` plus the
+summary fields `complete_families`, `deferred_families`, `stale`, and
+`budget_exceeded`. Deferred facet families are not rendered as failed or empty;
+they remain explicit so the first paint can show cheap counts while the shell or
+a caller can request expensive families separately.

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import tomllib
 
+from .core.loopback import bind_hosts_overlap, is_loopback_host
 from .errors import PolylogueError
 from .paths import (
     GEMINI_DRIVE_FOLDER,
@@ -1365,9 +1366,12 @@ def _config_diagnostic(
     key: str,
     message: str,
     next_action: str,
+    cfg: PolylogueConfig | None = None,
+    value_key: str | None = None,
+    related_keys: tuple[str, ...] = (),
 ) -> dict[str, object]:
     entry = _CONFIG_INVENTORY_BY_KEY.get(key)
-    return {
+    payload: dict[str, object] = {
         "code": code,
         "severity": severity,
         "key": key,
@@ -1376,6 +1380,21 @@ def _config_diagnostic(
         "message": message,
         "next_action": next_action,
     }
+    if cfg is not None:
+        display_key = value_key or key
+        value = cfg.raw.get(display_key)
+        secret = is_secret_config_key(display_key)
+        payload.update(
+            {
+                "source_layer": cfg.layer_of(display_key),
+                "value": config_display_value(display_key, value),
+                "secret": secret,
+                "secret_present": bool(secret and redact_secret_value(value) == SECRET_SET_PLACEHOLDER),
+            }
+        )
+    if related_keys:
+        payload["related_keys"] = list(related_keys)
+    return payload
 
 
 def _iter_path_config_values(key: str, value: object) -> list[str]:
@@ -1421,6 +1440,7 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
                             + (f" or override {entry.env_var}" if entry.env_var else "")
                             + "."
                         ),
+                        cfg=resolved,
                     )
                 )
                 continue
@@ -1436,6 +1456,7 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
                             + (f" or override {entry.env_var}" if entry.env_var else "")
                             + "."
                         ),
+                        cfg=resolved,
                     )
                 )
                 continue
@@ -1447,8 +1468,134 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
                         key=entry.key,
                         message=f"Configured source root does not exist: {raw_path}.",
                         next_action="Remove the stale source root or create/mount it before running the daemon.",
+                        cfg=resolved,
                     )
                 )
+    return diagnostics
+
+
+def _configured_browser_capture_origins(resolved: PolylogueConfig) -> tuple[str, ...]:
+    return tuple(origin.strip() for origin in resolved.browser_capture_allowed_origins.split(",") if origin.strip())
+
+
+def _is_browser_extension_origin_pattern(origin: str) -> bool:
+    return origin == "chrome-extension://*" or origin.startswith("chrome-extension://")
+
+
+def _config_network_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object]]:
+    diagnostics: list[dict[str, object]] = []
+    api_is_remote = not is_loopback_host(resolved.api_host)
+    browser_capture_is_remote = not is_loopback_host(resolved.browser_capture_host)
+
+    if api_is_remote and not resolved.browser_capture_allow_remote:
+        diagnostics.append(
+            _config_diagnostic(
+                code="api_remote_bind_requires_allow_remote",
+                severity="error",
+                key="api_host",
+                message=f"Daemon API host {resolved.api_host!r} is not loopback but remote binding is not enabled.",
+                next_action=(
+                    "Set daemon.browser_capture.allow_remote = true / POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE=true "
+                    "only with an API auth token, or bind daemon.api.host to 127.0.0.1."
+                ),
+                cfg=resolved,
+                related_keys=("browser_capture_allow_remote", "api_auth_token"),
+            )
+        )
+    if api_is_remote and resolved.browser_capture_allow_remote and not resolved.api_auth_token:
+        diagnostics.append(
+            _config_diagnostic(
+                code="api_remote_bind_requires_auth_token",
+                severity="error",
+                key="api_auth_token",
+                message=f"Daemon API host {resolved.api_host!r} is remote-enabled without an API bearer token.",
+                next_action=(
+                    "Set daemon.api.auth_token / POLYLOGUE_API_AUTH_TOKEN or bind daemon.api.host to a loopback address."
+                ),
+                cfg=resolved,
+                related_keys=("api_host", "browser_capture_allow_remote"),
+            )
+        )
+
+    if browser_capture_is_remote and not resolved.browser_capture_allow_remote:
+        diagnostics.append(
+            _config_diagnostic(
+                code="browser_capture_remote_bind_requires_allow_remote",
+                severity="error",
+                key="browser_capture_host",
+                message=(
+                    f"Browser-capture host {resolved.browser_capture_host!r} is not loopback "
+                    "but remote binding is not enabled."
+                ),
+                next_action=(
+                    "Set daemon.browser_capture.allow_remote = true / POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE=true "
+                    "only with a browser-capture auth token, or bind daemon.browser_capture.host to 127.0.0.1."
+                ),
+                cfg=resolved,
+                related_keys=("browser_capture_allow_remote", "browser_capture_auth_token"),
+            )
+        )
+    if resolved.browser_capture_allow_remote and not resolved.browser_capture_auth_token:
+        diagnostics.append(
+            _config_diagnostic(
+                code="browser_capture_remote_requires_auth_token",
+                severity="error",
+                key="browser_capture_auth_token",
+                message="Remote browser-capture opt-in is set without a browser-capture bearer token.",
+                next_action=(
+                    "Set daemon.browser_capture.auth_token / POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN, "
+                    "or disable daemon.browser_capture.allow_remote."
+                ),
+                cfg=resolved,
+                related_keys=("browser_capture_allow_remote", "browser_capture_host"),
+            )
+        )
+
+    web_origins = tuple(
+        origin
+        for origin in _configured_browser_capture_origins(resolved)
+        if not _is_browser_extension_origin_pattern(origin)
+    )
+    if web_origins and not resolved.browser_capture_auth_token:
+        diagnostics.append(
+            _config_diagnostic(
+                code="browser_capture_web_origin_requires_auth_token",
+                severity="error",
+                key="browser_capture_auth_token",
+                message=(
+                    "Browser-capture web origins require a bearer token; "
+                    f"{len(web_origins)} non-extension origin(s) are configured."
+                ),
+                next_action=(
+                    "Set daemon.browser_capture.auth_token / POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN, "
+                    "or remove non-extension origins from daemon.browser_capture.allowed_origins."
+                ),
+                cfg=resolved,
+                related_keys=("browser_capture_allowed_origins",),
+            )
+        )
+
+    if resolved.api_port == resolved.browser_capture_port and bind_hosts_overlap(
+        resolved.api_host, resolved.browser_capture_host
+    ):
+        diagnostics.append(
+            _config_diagnostic(
+                code="daemon_api_browser_capture_port_conflict",
+                severity="error",
+                key="api_port",
+                message=(
+                    f"Daemon API {resolved.api_host}:{resolved.api_port} conflicts with browser-capture "
+                    f"receiver {resolved.browser_capture_host}:{resolved.browser_capture_port}."
+                ),
+                next_action=(
+                    "Set distinct daemon.api.port and daemon.browser_capture.port values, "
+                    "or bind one component to a non-overlapping host."
+                ),
+                cfg=resolved,
+                related_keys=("browser_capture_port", "api_host", "browser_capture_host"),
+            )
+        )
+
     return diagnostics
 
 
@@ -1456,6 +1603,7 @@ def config_diagnostics(cfg: PolylogueConfig | None = None) -> list[dict[str, obj
     """Return typed diagnostics for the resolved effective configuration."""
     resolved = cfg if cfg is not None else load_polylogue_config()
     diagnostics = _config_path_diagnostics(resolved)
+    diagnostics.extend(_config_network_diagnostics(resolved))
     if resolved.embedding_enabled and not resolved.voyage_api_key:
         diagnostics.append(
             _config_diagnostic(
@@ -1467,6 +1615,7 @@ def config_diagnostics(cfg: PolylogueConfig | None = None) -> list[dict[str, obj
                     "Set VOYAGE_API_KEY, run `polylogue ops embed enable --voyage-api-key ...`, "
                     "or disable embedding convergence."
                 ),
+                cfg=resolved,
             )
         )
     return diagnostics

--- a/polylogue/core/loopback.py
+++ b/polylogue/core/loopback.py
@@ -38,6 +38,23 @@ LOOPBACK_ORIGIN_PREFIXES: tuple[str, ...] = (
 )
 
 
+def bind_hosts_overlap(left: str, right: str) -> bool:
+    """Return True when two bind host strings can claim the same socket.
+
+    Wildcard binds (``0.0.0.0``/``::``/empty) overlap everything on the same
+    port. Distinct concrete loopback strings also overlap because the browser
+    shell and daemon API treat the loopback family as one local trust boundary.
+    """
+    left_norm = left.strip().lower()
+    right_norm = right.strip().lower()
+    wildcard_hosts = {"", "0.0.0.0", "::"}
+    if left_norm == right_norm:
+        return True
+    if left_norm in wildcard_hosts or right_norm in wildcard_hosts:
+        return True
+    return is_loopback_host(left_norm) and is_loopback_host(right_norm)
+
+
 def is_loopback_origin(origin: str) -> bool:
     """Return True if a browser ``Origin`` header points at a loopback host.
 
@@ -70,4 +87,10 @@ def is_loopback_origin(origin: str) -> bool:
     return False
 
 
-__all__ = ["LOOPBACK_HOST_NAMES", "LOOPBACK_ORIGIN_PREFIXES", "is_loopback_host", "is_loopback_origin"]
+__all__ = [
+    "LOOPBACK_HOST_NAMES",
+    "LOOPBACK_ORIGIN_PREFIXES",
+    "bind_hosts_overlap",
+    "is_loopback_host",
+    "is_loopback_origin",
+]

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -12,6 +12,7 @@ defragmented copy. Falls back to a file copy with WAL checkpoint first.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sqlite3
 import tempfile
@@ -410,6 +411,22 @@ def _verify_backup_result(result: BackupResult) -> None:
         result.error = str(verification.get("error") or "backup verification failed")
 
 
+def _backup_verification_scratch_parent(path: Path) -> Path | None:
+    """Choose scratch placement near the backup to avoid root ``/tmp`` I/O."""
+    env_tmpdir = os.environ.get("POLYLOGUE_BACKUP_VERIFY_TMPDIR")
+    candidates = (path.parent, Path(env_tmpdir) if env_tmpdir else None, Path("/realm/tmp"))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _copy_backup_artifact_to_scratch(source: Path, scratch_root: Path) -> Path:
     restore_root = scratch_root / "restore"
     if source.is_dir():
@@ -421,7 +438,8 @@ def _copy_backup_artifact_to_scratch(source: Path, scratch_root: Path) -> Path:
 
 
 def _verify_archive_file_set_backup(path: Path) -> dict[str, object]:
-    with tempfile.TemporaryDirectory(prefix="polylogue-backup-verify-") as raw_tmp:
+    scratch_parent = _backup_verification_scratch_parent(path)
+    with tempfile.TemporaryDirectory(prefix="polylogue-backup-verify-", dir=scratch_parent) as raw_tmp:
         restored = _copy_backup_artifact_to_scratch(path, Path(raw_tmp))
         if not restored.is_dir():
             return {"ok": False, "mode": "archive_file_set", "error": "backup output is not a directory"}
@@ -454,6 +472,7 @@ def _verify_archive_file_set_backup(path: Path) -> dict[str, object]:
             "manifest_blob_count": blob_count,
             "restored_blob_count": restored_blob_count,
             "scratch_restore": "temporary",
+            "scratch_parent": str(Path(raw_tmp).parent),
         }
 
 

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -36,6 +36,7 @@ BACKUP_PROFILES: tuple[BackupProfile, ...] = (
     "rebuildable_cache_exclude",
     "diagnostics_bundle",
 )
+_MISSING_BLOB_WARNING_SAMPLE_LIMIT = 10
 
 
 class BackupResult(BaseModel):
@@ -225,16 +226,25 @@ def _copy_referenced_blobs(*, source_db: Path, backup_root: Path, warnings: list
     blob_dst_root = backup_root / "blob"
     count = 0
     size = 0
+    missing_count = 0
+    missing_samples: list[str] = []
     for hash_hex in sorted(hashes):
         src = store.blob_path(hash_hex)
         if not src.exists():
-            warnings.append(f"referenced blob missing: {hash_hex}")
+            missing_count += 1
+            if len(missing_samples) < _MISSING_BLOB_WARNING_SAMPLE_LIMIT:
+                missing_samples.append(hash_hex)
             continue
         dst = blob_dst_root / hash_hex[:2] / hash_hex[2:]
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         count += 1
         size += dst.stat().st_size
+    if missing_count:
+        warnings.append(
+            "referenced blobs missing: "
+            f"{missing_count} total" + (f" (sample: {', '.join(missing_samples)})" if missing_samples else "")
+        )
     return count, size
 
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -22,7 +22,7 @@ from polylogue.api import Polylogue
 from polylogue.browser_capture.server import BrowserCaptureHTTPServer, make_server
 from polylogue.core.degraded import DegradedReason, set_degraded
 from polylogue.core.json import dumps
-from polylogue.core.loopback import is_loopback_host
+from polylogue.core.loopback import bind_hosts_overlap, is_loopback_host
 from polylogue.daemon.browser_capture import browser_capture_command
 
 # FTS startup readiness extracted to ``polylogue.daemon.fts_startup`` (#1614).
@@ -55,18 +55,6 @@ _DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS = 3600
 
 # Track the pidfile path for atexit cleanup.
 _pidfile_path: Path | None = None
-
-
-def _bind_hosts_overlap(left: str, right: str) -> bool:
-    """Return True when two bind hosts can occupy the same socket address space."""
-    left_norm = left.strip().lower()
-    right_norm = right.strip().lower()
-    wildcard_hosts = {"", "0.0.0.0", "::"}
-    if left_norm == right_norm:
-        return True
-    if left_norm in wildcard_hosts or right_norm in wildcard_hosts:
-        return True
-    return is_loopback_host(left_norm) and is_loopback_host(right_norm)
 
 
 def _cleanup_pidfile() -> None:
@@ -723,7 +711,7 @@ async def run_daemon_services(
         enable_api
         and enable_browser_capture
         and api_port == browser_capture_port
-        and _bind_hosts_overlap(api_host, browser_capture_host)
+        and bind_hosts_overlap(api_host, browser_capture_host)
     ):
         raise click.UsageError(
             f"Daemon API {api_host}:{api_port} conflicts with browser-capture "

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -44,14 +44,17 @@ from polylogue.daemon.web_shell_paste import (
     render_paste_browser_page,
     snippet_for_paste,
 )
-from polylogue.errors import PolylogueError
+from polylogue.errors import DatabaseError, PolylogueError
 from polylogue.logging import get_logger
 from polylogue.surfaces.payloads import (
     AssertionClaimListPayload,
     MutationResultPayload,
     QueryErrorPayload,
     QueryMissDiagnosticsPayload,
+    QueryMissReasonPayload,
     ReaderActionAvailabilityPayload,
+    RouteReadinessPayload,
+    RouteReadinessState,
     SessionReadViewEnvelope,
     TargetRefPayload,
     _build_flags_from_session,
@@ -439,6 +442,47 @@ def _archive_origin_filter(params: dict[str, list[str]]) -> tuple[str | None, tu
 
 def _utc_timestamp_json() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _public_route_from_request_path(raw_path: str) -> str:
+    parsed = urlparse(raw_path)
+    route = parsed.path or "/"
+    if parsed.query:
+        route = f"{route}?{parsed.query}"
+    return route
+
+
+def _route_readiness_payload(
+    state: RouteReadinessState,
+    route: str,
+    *,
+    reason: str | None = None,
+    component: str | None = None,
+    stale_available: bool = False,
+) -> dict[str, object]:
+    return RouteReadinessPayload(
+        state=state,
+        route=route,
+        reason=reason,
+        component=component,
+        generated_at=_utc_timestamp_json(),
+        stale_available=stale_available,
+    ).model_dump(mode="json")
+
+
+def _session_list_state(total: int, *, filtered: bool) -> tuple[RouteReadinessState, str | None]:
+    if total > 0:
+        return "ready", None
+    if filtered:
+        return "no_results", "No sessions matched the active query or filters."
+    return "empty", "Archive contains no sessions."
+
+
+def _search_index_degraded_reason(exc: BaseException) -> str | None:
+    text = str(exc).lower()
+    if "search index" in text or "messages_fts" in text or "fts" in text:
+        return "Search index unavailable: message FTS table is missing or degraded."
+    return None
 
 
 def _truthy_query_param(params: dict[str, list[str]], key: str) -> bool:
@@ -1718,6 +1762,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         from polylogue.archive.query.spec import clamp_query_limit
 
         query_params = _build_query_spec_params(params, self)
+        route = _public_route_from_request_path(self.path)
         # Clamp to the shared MAX_QUERY_LIMIT ceiling so the daemon honors the
         # same page-size cap as MCP instead of an arbitrary ?limit=99999999
         # (#1749). The default stays 50; clamp_query_limit only caps the top.
@@ -1730,7 +1775,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         archive_root = _web_reader_archive_root()
         if archive_root is not None:
-            self._send_json(HTTPStatus.OK, self._do_archive_list_sessions(archive_root, params, limit, offset))
+            self._send_json(HTTPStatus.OK, self._do_archive_list_sessions(archive_root, params, limit, offset, route))
             return
 
         async def _list(poly: Polylogue) -> object:
@@ -1860,6 +1905,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         params: dict[str, list[str]],
         limit: int,
         offset: int,
+        route: str = "/api/sessions",
     ) -> object:
         from polylogue.archive.query.expression import compile_expression
         from polylogue.archive.query.search_hits import search_query_text
@@ -1983,6 +2029,35 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             "since_ms": since_ms,
             "until_ms": until_ms,
         }
+        filtered = bool(
+            fts_query
+            or spec_session_id
+            or origin
+            or origins
+            or excluded_origins
+            or tags
+            or excluded_tags
+            or repo_names
+            or has_types
+            or tool_terms
+            or excluded_tool_terms
+            or action_terms
+            or excluded_action_terms
+            or action_sequence
+            or action_text_terms
+            or referenced_paths
+            or cwd_prefix
+            or title
+            or min_messages is not None
+            or max_messages is not None
+            or min_words is not None
+            or max_words is not None
+            or since_dt is not None
+            or until_dt is not None
+            or has_paste
+            or has_tool_use
+            or has_thinking
+        )
 
         with ArchiveStore.open_existing(archive_root) as archive:
             # Resolve an ``id:`` clause once, up front, so both branches share one
@@ -1999,6 +2074,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     if fts_query:
                         from polylogue.operations.action_contracts import query_result_action_affordance_payloads
 
+                        reason = "No session matched the id filter."
                         return {
                             "query": fts_query,
                             "retrieval_lane": "dialogue",
@@ -2008,27 +2084,76 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                             "total": 0,
                             "limit": limit,
                             "offset": offset,
+                            "route_state": _route_readiness_payload("no_results", route, reason=reason),
                             "action_affordances": [
                                 action.model_dump(mode="json") for action in query_result_action_affordance_payloads()
                             ],
                         }
-                    return {"items": [], "total": 0, "limit": limit, "offset": offset}
+                    reason = "No session matched the id filter."
+                    return {
+                        "items": [],
+                        "total": 0,
+                        "limit": limit,
+                        "offset": offset,
+                        "route_state": _route_readiness_payload("no_results", route, reason=reason),
+                    }
                 except ValueError as exc:
                     raise QuerySpecError("id", spec_session_id) from exc
             if fts_query:
                 from polylogue.operations.action_contracts import query_result_action_affordance_payloads
 
-                hits = self._run_archive_bounded_query(
-                    archive,
-                    deadline_s=None,
-                    compute=lambda: archive.search_summaries(
-                        fts_query,
-                        limit=limit,
-                        offset=offset,
-                        session_id=resolved_session_id,
-                        **_filter_kw,  # type: ignore[arg-type]
-                    ),
-                )
+                try:
+                    hits = self._run_archive_bounded_query(
+                        archive,
+                        deadline_s=None,
+                        compute=lambda: archive.search_summaries(
+                            fts_query,
+                            limit=limit,
+                            offset=offset,
+                            session_id=resolved_session_id,
+                            **_filter_kw,  # type: ignore[arg-type]
+                        ),
+                    )
+                except (DatabaseError, sqlite3.Error) as exc:
+                    degraded_reason = _search_index_degraded_reason(exc)
+                    if degraded_reason is None:
+                        raise
+                    diagnostics = QueryMissDiagnosticsPayload(
+                        message=degraded_reason,
+                        filters=(f"query={fts_query!r}",),
+                        reasons=(
+                            QueryMissReasonPayload(
+                                code="search_index_degraded",
+                                severity="warning",
+                                summary=degraded_reason,
+                                detail="The sessions route returned an explicit degraded state instead of a zero-hit "
+                                "result because the archive search index could not be read.",
+                            ),
+                        ),
+                        archive_session_count=None,
+                    ).model_dump(mode="json", by_alias=True)
+                    return {
+                        "query": fts_query,
+                        "retrieval_lane": "dialogue",
+                        "ranking_policy": "mixed-bm25-rrf-vector",
+                        "ranking_policy_version": "1",
+                        "hits": [],
+                        "total": None,
+                        "limit": limit,
+                        "offset": offset,
+                        "diagnostics": diagnostics,
+                        "route_state": _route_readiness_payload(
+                            "degraded",
+                            route,
+                            reason=degraded_reason,
+                            component="message_fts",
+                            stale_available=False,
+                        ),
+                        "action_affordances": [
+                            action.model_dump(mode="json") for action in query_result_action_affordance_payloads()
+                        ],
+                    }
+                route_state_name, route_state_reason = _session_list_state(len(hits), filtered=True)
                 payload: dict[str, object] = {
                     "query": fts_query,
                     "retrieval_lane": "dialogue",
@@ -2038,6 +2163,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "total": len(hits),
                     "limit": limit,
                     "offset": offset,
+                    "route_state": _route_readiness_payload(route_state_name, route, reason=route_state_reason),
                     "action_affordances": [
                         action.model_dump(mode="json") for action in query_result_action_affordance_payloads()
                     ],
@@ -2046,8 +2172,6 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     # Zero-result query: attach a diagnostics envelope (matching
                     # the archive reader contract) so the surface can explain the
                     # miss instead of rendering a bare empty list.
-                    from polylogue.surfaces.payloads import QueryMissDiagnosticsPayload
-
                     archive_count = self._run_archive_bounded_query(
                         archive,
                         deadline_s=None,
@@ -2092,11 +2216,13 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     compute=lambda: archive.count_sessions(**_filter_kw),  # type: ignore[arg-type]
                 )
             )
+            route_state_name, route_state_reason = _session_list_state(total, filtered=filtered)
             return {
                 "items": [self._archive_summary_payload(summary) for summary in summaries],
                 "total": total,
                 "limit": limit,
                 "offset": offset,
+                "route_state": _route_readiness_payload(route_state_name, route, reason=route_state_reason),
             }
 
     def _archive_summary_payload(self, summary: ArchiveSessionSummary) -> dict[str, object]:

--- a/polylogue/daemon/route_contracts.py
+++ b/polylogue/daemon/route_contracts.py
@@ -155,7 +155,14 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "Branch-local launcher metadata for the web shell; allowlisted fields only, no raw environment dump.",
     ),
     RouteContract("GET", "/api/events", "operational", "stable", "bearer_if_configured", "SSE or JSON event poll"),
-    RouteContract("GET", "/api/sessions", "read_query", "stable", "bearer_if_configured", "SearchEnvelope"),
+    RouteContract(
+        "GET",
+        "/api/sessions",
+        "read_query",
+        "stable",
+        "bearer_if_configured",
+        "SearchEnvelope / SessionListResponse with route_state",
+    ),
     RouteContract(
         "GET",
         "/api/facets",

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -390,8 +390,9 @@ var state = {
   readViewProfiles: [], selectedReadView: 'messages', readViewProfileError: '',
   readViewPayloads: {}, readViewErrors: {},
   // Shared route-state ledger for optional workbench routes (#2304). Values
-  // are idle/loading/ready/stale/error/budget_exceeded and always retain the
-  // route plus fallback command needed to recover outside the shell.
+  // carry route readiness such as loading/ready/empty/no_results/stale/
+  // degraded/failed/budget_exceeded and always retain the route plus fallback
+  // command needed to recover outside the shell.
   routeStates: {}, inFlight: {facets: null}, selectedLoadError: null,
   // Per-session similarity panel cache (#1123). Keyed by
   // session_id; populated on demand when the Similar inspector
@@ -548,10 +549,10 @@ function setRouteState(name, patch) {
 
 function routeStateQuality(routeState) {
   if (!routeState) return '';
-  if (routeState.state === 'ready') return 'canonical';
+  if (routeState.state === 'ready' || routeState.state === 'empty' || routeState.state === 'no_results') return 'canonical';
   if (routeState.state === 'stale') return 'stale';
-  if (routeState.state === 'loading' || routeState.state === 'budget_exceeded') return 'partial';
-  if (routeState.state === 'error') return 'unavailable';
+  if (routeState.state === 'loading' || routeState.state === 'degraded' || routeState.state === 'budget_exceeded') return 'partial';
+  if (routeState.state === 'error' || routeState.state === 'failed') return 'unavailable';
   return '';
 }
 
@@ -566,7 +567,8 @@ function renderRouteStateNotice(name, label, retryJs) {
   if (rs.error) parts.push(rs.error);
   if (rs.stale_available) parts.push('showing stale data');
   if (rs.state === 'budget_exceeded') parts.push('budget exceeded');
-  var html = '<div class="sidebar-state q-' + escAttr(quality) + '"><div class="state-icon">!</div>'
+  var html = '<div class="sidebar-state q-' + escAttr(quality) + '" data-route-state-name="' + escAttr(name)
+    + '" data-route-state="' + escAttr(rs.state || '') + '"><div class="state-icon">!</div>'
     + '<div><strong>' + esc(title) + '</strong><br>' + esc(parts.join(' · ') || 'checking route')
     + '<br><code>' + esc(rs.fallback || (rs.route ? fallbackCommand(rs.route) : 'polylogue daemon status')) + '</code></div>';
   if (retryJs) html += '<button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
@@ -648,21 +650,38 @@ async function loadSessions(opts) {
   params.set('offset', String(state.offset));
   if (state.origin) params.set('origin', state.origin);
   if (state.query) params.set('query', state.query);
+  var route = '/api/sessions?' + params;
   // Capture pre-load id set so we can animate newly-arrived rows after render.
   var beforeIds = {};
   (state.sessions || []).forEach(function(c) { beforeIds[c.id] = true; });
+  setRouteState('sessionList', {
+    state: 'loading', route: route, error: '', status: '', stale_available: !!(state.sessions && state.sessions.length)
+  });
+  renderSessions();
   try {
-    var data = await fetchJSON('/api/sessions?' + params, {timeoutMs: 8000});
+    var data = await fetchJSON(route, {timeoutMs: 8000});
     state.sessions = sessionsFromListPayload(data);
-    state.total = data.total || 0;
+    state.total = (data.total === null || data.total === undefined) ? null : Number(data.total || 0);
     state.actionAffordances = data.action_affordances || [];
     document.getElementById('footer-result').textContent =
       (state.total > 0) ? (state.total + ' results') : '';
+    var routePayload = data.route_state || {};
+    var inferredState = (state.total === 0)
+      ? ((state.query || state.origin) ? 'no_results' : 'empty')
+      : (state.total === null ? 'degraded' : 'ready');
+    setRouteState('sessionList', {
+      state: routePayload.state || inferredState,
+      route: routePayload.route || route,
+      status: '200',
+      error: routePayload.reason || '',
+      component: routePayload.component || '',
+      stale_available: !!routePayload.stale_available
+    });
     if (state.routeStates.status && state.routeStates.status.state !== 'ready') updateStatusCountsUnknown('degraded');
   } catch(e) {
     state.sessions = [];
-    state.total = 0;
-    renderSidebarState('error', 'Failed to load sessions');
+    state.total = null;
+    setRouteState('sessionList', Object.assign({state: 'failed', stale_available: false}, routeErrorDetails(e, route)));
   }
   renderSessions();
   // After render, animate rows that are newly present (either flagged by
@@ -1009,13 +1028,23 @@ function renderApiDebugChip() {
 function renderSidebarState(kind, msg) {
   var icons = {empty: '\u25a1', noresults: '\u25a2', error: '\u2715', loading: '\u2014'};
   document.getElementById('conv-list').innerHTML =
-    '<div class="sidebar-state"><div class="state-icon">' + (icons[kind] || '') + '</div>' + esc(msg) + '</div>';
+    '<div class="sidebar-state" data-sidebar-state="' + escAttr(kind) + '"><div class="state-icon">'
+    + (icons[kind] || '') + '</div>' + esc(msg) + '</div>';
 }
 
 function renderSessions() {
   var el = document.getElementById('conv-list');
   var items = state.sessions;
   if (!items || !items.length) {
+    var listRouteState = state.routeStates.sessionList || {};
+    if (listRouteState.state === 'loading') {
+      renderSidebarState('loading', 'Loading sessions from ' + (listRouteState.route || '/api/sessions'));
+      return;
+    }
+    if (listRouteState.state === 'degraded' || listRouteState.state === 'failed' || listRouteState.state === 'error') {
+      el.innerHTML = renderRouteStateNotice('sessionList', 'Sessions', 'loadSessions()');
+      return;
+    }
     // Distinguish empty archive from filtered-no-results so the operator
     // knows whether to ingest or to clear filters. Preserve filter context
     // in the empty-state message per MK3 state matrix.

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -32,6 +32,13 @@ from polylogue.storage.message_type_backfill import (
 logger = get_logger(__name__)
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
+_SESSION_INSIGHT_MATERIALIZATION_TYPES = (
+    "session_profile",
+    "latency",
+    "work_events",
+    "phases",
+    "thread",
+)
 
 
 def _open_archive_index_connection() -> sqlite3.Connection:
@@ -81,6 +88,102 @@ def _resolve_convergence_debt(
             target_id=target_id,
             error=str(exc),
         )
+
+
+def _session_insight_materializer_version() -> int:
+    from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
+
+    return SESSION_INSIGHT_MATERIALIZER_VERSION
+
+
+def _session_insight_requires_archive_wide_rebuild(status: object) -> bool:
+    return any(
+        int(getattr(status, attr, 0) or 0) > 0
+        for attr in (
+            "orphan_profile_row_count",
+            "orphan_latency_profile_row_count",
+            "orphan_work_event_inference_count",
+            "orphan_phase_inference_count",
+            "orphan_thread_count",
+            "stale_tag_rollup_count",
+            "stale_day_summary_count",
+        )
+    )
+
+
+def _targeted_session_insight_rebuild_ids(
+    conn: sqlite3.Connection | None,
+    status: object,
+) -> tuple[str, ...] | None:
+    if conn is None or _session_insight_requires_archive_wide_rebuild(status):
+        return None
+
+    materialization_selects = "\nUNION\n".join(
+        """
+        SELECT s.session_id
+        FROM sessions AS s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM insight_materialization AS m
+            WHERE m.insight_type = ?
+              AND m.session_id = s.session_id
+        )
+        """
+        for _insight_type in _SESSION_INSIGHT_MATERIALIZATION_TYPES
+    )
+    materializer_version = _session_insight_materializer_version()
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT session_id
+        FROM (
+            SELECT s.session_id
+            FROM sessions AS s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM session_profiles AS p WHERE p.session_id = s.session_id
+            )
+            UNION
+            SELECT s.session_id
+            FROM sessions AS s
+            JOIN session_profiles AS p ON p.session_id = s.session_id
+            WHERE p.materializer_version != ?
+               OR ABS(COALESCE(p.source_sort_key, 0.0) - COALESCE(CAST(s.sort_key_ms AS REAL)/1000.0, 0.0)) > 0.000001
+            UNION
+            SELECT p.session_id
+            FROM session_profiles AS p
+            JOIN sessions AS s ON s.session_id = p.session_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM session_latency_profiles AS lp WHERE lp.session_id = p.session_id
+            )
+            UNION
+            SELECT lp.session_id
+            FROM session_latency_profiles AS lp
+            JOIN sessions AS s ON s.session_id = lp.session_id
+            WHERE lp.materializer_version != ?
+               OR ABS(COALESCE(lp.source_sort_key, 0.0) - COALESCE(CAST(s.sort_key_ms AS REAL)/1000.0, 0.0)) > 0.000001
+            UNION
+            SELECT p.session_id
+            FROM session_profiles AS p
+            WHERE p.work_event_count != (
+                SELECT COUNT(*) FROM session_work_events AS e WHERE e.session_id = p.session_id
+            )
+            UNION
+            SELECT p.session_id
+            FROM session_profiles AS p
+            WHERE p.phase_count != (
+                SELECT COUNT(*) FROM session_phases AS ph WHERE ph.session_id = p.session_id
+            )
+            UNION
+            {materialization_selects}
+        )
+        ORDER BY session_id
+        """,
+        (
+            materializer_version,
+            materializer_version,
+            *_SESSION_INSIGHT_MATERIALIZATION_TYPES,
+        ),
+    ).fetchall()
+    return tuple(str(row["session_id"] if isinstance(row, sqlite3.Row) else row[0]) for row in rows)
 
 
 def _archive_index_present(config: Config) -> bool:
@@ -775,16 +878,44 @@ def repair_session_insights(
         with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
             status = archive.session_insight_status()
             assessment = assess_session_insight_repairs(status)
+            targeted_session_ids = (
+                None
+                if session_ids is not None or assessment.row_debt == 0
+                else _targeted_session_insight_rebuild_ids(getattr(archive, "_conn", None), status)
+            )
 
             if dry_run:
-                pending = min(assessment.row_debt, len(session_ids)) if session_ids is not None else assessment.row_debt
+                if session_ids is not None:
+                    pending = min(assessment.row_debt, len(session_ids))
+                    detail = (
+                        "Would: session insights already ready"
+                        if pending == 0
+                        else f"Would: rebuild session insights for {pending:,} scoped session(s)"
+                    )
+                elif targeted_session_ids is not None:
+                    pending = len(targeted_session_ids)
+                    detail = (
+                        "Would: session insights already ready"
+                        if pending == 0
+                        else (
+                            "Would: rebuild session insights for "
+                            f"{pending:,} candidate session(s) to repair {assessment.row_debt:,} debt row(s)"
+                        )
+                    )
+                elif assessment.row_debt == 0:
+                    pending = 0
+                    detail = "Would: session insights already ready"
+                else:
+                    pending = status.total_sessions
+                    detail = (
+                        "Would: rebuild archive-wide session insights "
+                        f"for {pending:,} session(s) to repair {assessment.row_debt:,} debt row(s)"
+                    )
                 return _repair_result(
                     "session_insights",
                     repaired_count=pending,
                     success=True,
-                    detail="Would: session insights already ready"
-                    if pending == 0
-                    else f"Would: rebuild session insights ({pending:,} pending items)",
+                    detail=detail,
                 )
 
             if session_ids is None and assessment.row_debt == 0:
@@ -795,9 +926,10 @@ def repair_session_insights(
                     detail="Session insights already ready",
                 )
 
+            rebuild_session_ids = session_ids if session_ids is not None else targeted_session_ids
             rebuilt = _rebuild_archive_session_insights(
                 archive,
-                session_ids=session_ids,
+                session_ids=rebuild_session_ids,
                 progress_callback=progress_callback,
             )
             rebuilt_count = rebuilt.total()

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -929,6 +929,35 @@ class SessionNeighborCandidatePayload(SurfacePayloadModel):
 # ---------------------------------------------------------------------------
 
 
+RouteReadinessState: TypeAlias = Literal[
+    "ready",
+    "loading",
+    "empty",
+    "no_results",
+    "stale",
+    "degraded",
+    "failed",
+    "budget_exceeded",
+]
+
+
+class RouteReadinessPayload(SurfacePayloadModel):
+    """Route-visible readiness state for a web reader panel.
+
+    ``total=0`` can mean an empty archive, a scoped no-result query, or a
+    degraded backend that cannot compute results. This payload lets browserless
+    tests and the web shell distinguish those states without guessing from
+    counters alone (#2304).
+    """
+
+    state: RouteReadinessState
+    route: str
+    reason: str | None = None
+    component: str | None = None
+    generated_at: str | None = None
+    stale_available: bool = False
+
+
 class QueryErrorPayload(SurfacePayloadModel):
     """Shared error payload for daemon HTTP, MCP, and other surfaces.
 
@@ -994,6 +1023,7 @@ class SessionListResponse(SurfacePayloadModel):
     offset: int
     query_description: list[str] = Field(default_factory=list)
     diagnostics: QueryMissDiagnosticsPayload | None = None
+    route_state: RouteReadinessPayload | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1075,6 +1105,7 @@ class SearchEnvelope(SurfacePayloadModel):
     ranking_policy_version: str = RANKING_POLICY_VERSION
     action_affordances: tuple[ActionAffordancePayload, ...] = ()
     diagnostics: QueryMissDiagnosticsPayload | None = None
+    route_state: RouteReadinessPayload | None = None
 
 
 QueryUnitKind: TypeAlias = Literal[
@@ -2549,6 +2580,8 @@ __all__ = [
     "RunQueryRowPayload",
     "QueryMissDiagnosticsPayload",
     "QueryMissReasonPayload",
+    "RouteReadinessPayload",
+    "RouteReadinessState",
     "ContextSnapshotQueryRowPayload",
     "ObservedEventQueryRowPayload",
     "OtelLogRecordPayload",

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -141,15 +141,19 @@ roots = ["{missing_root}"]
 
     diagnostics = payload["diagnostics"]
     assert isinstance(diagnostics, list)
-    assert {
-        "code": "configured_source_root_missing",
-        "severity": "warning",
-        "key": "source_roots",
-        "toml_path": "sources.roots",
-        "env_var": None,
-        "message": f"Configured source root does not exist: {missing_root}.",
-        "next_action": "Remove the stale source root or create/mount it before running the daemon.",
-    } in diagnostics
+    matches = [
+        diag for diag in diagnostics if isinstance(diag, dict) and diag.get("code") == "configured_source_root_missing"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["severity"] == "warning"
+    assert diag["key"] == "source_roots"
+    assert diag["toml_path"] == "sources.roots"
+    assert diag["env_var"] is None
+    assert diag["source_layer"] == "user"
+    assert diag["value"] == [str(missing_root)]
+    assert diag["message"] == f"Configured source root does not exist: {missing_root}."
+    assert diag["next_action"] == "Remove the stale source root or create/mount it before running the daemon."
 
 
 def test_effective_config_payload_reports_invalid_home_expansion(
@@ -197,14 +201,16 @@ def test_effective_config_payload_reports_env_relative_archive_root(
 
     diagnostics = payload["diagnostics"]
     assert isinstance(diagnostics, list)
-    assert any(
-        diag.get("code") == "config_path_not_absolute"
-        and diag.get("severity") == "error"
-        and diag.get("key") == "archive_root"
-        and diag.get("env_var") == "POLYLOGUE_ARCHIVE_ROOT"
-        for diag in diagnostics
-        if isinstance(diag, dict)
-    )
+    matches = [
+        diag for diag in diagnostics if isinstance(diag, dict) and diag.get("code") == "config_path_not_absolute"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["severity"] == "error"
+    assert diag["key"] == "archive_root"
+    assert diag["env_var"] == "POLYLOGUE_ARCHIVE_ROOT"
+    assert diag["source_layer"] == "env"
+    assert diag["value"] == "relative-archive"
 
 
 def test_config_diagnostics_use_resolved_snapshot_not_ambient_environment(
@@ -229,6 +235,125 @@ def test_config_diagnostics_use_resolved_snapshot_not_ambient_environment(
         for diag in diagnostics
         if isinstance(diag, dict)
     )
+
+
+def test_effective_config_payload_reports_remote_api_without_auth_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
+        """
+[daemon.api]
+host = "0.0.0.0"
+
+[daemon.browser_capture]
+allow_remote = true
+auth_token = "browser-token"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.delenv("POLYLOGUE_API_AUTH_TOKEN", raising=False)
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    matches = [
+        diag
+        for diag in diagnostics
+        if isinstance(diag, dict) and diag.get("code") == "api_remote_bind_requires_auth_token"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["key"] == "api_auth_token"
+    assert diag["toml_path"] == "daemon.api.auth_token"
+    assert diag["env_var"] == "POLYLOGUE_API_AUTH_TOKEN"
+    assert diag["source_layer"] == "default"
+    assert diag["value"] == "<unset>"
+    assert diag["secret"] is True
+    assert diag["secret_present"] is False
+    assert diag["related_keys"] == ["api_host", "browser_capture_allow_remote"]
+    assert "browser-token" not in str(payload)
+
+
+def test_effective_config_payload_reports_browser_capture_web_origin_without_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
+        """
+[daemon.browser_capture]
+allowed_origins = "chrome-extension://*,https://workbench.example"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    monkeypatch.delenv("POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN", raising=False)
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    matches = [
+        diag
+        for diag in diagnostics
+        if isinstance(diag, dict) and diag.get("code") == "browser_capture_web_origin_requires_auth_token"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["key"] == "browser_capture_auth_token"
+    assert diag["source_layer"] == "default"
+    assert diag["value"] == "<unset>"
+    assert diag["secret_present"] is False
+    assert diag["related_keys"] == ["browser_capture_allowed_origins"]
+    assert "1 non-extension origin" in str(diag["message"])
+    assert "https://workbench.example" not in str(diag["message"])
+
+
+def test_effective_config_payload_reports_api_browser_capture_port_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
+        """
+[daemon.api]
+port = 9999
+
+[daemon.browser_capture]
+port = 9999
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    matches = [
+        diag
+        for diag in diagnostics
+        if isinstance(diag, dict) and diag.get("code") == "daemon_api_browser_capture_port_conflict"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["key"] == "api_port"
+    assert diag["source_layer"] == "user"
+    assert diag["value"] == 9999
+    assert diag["related_keys"] == ["browser_capture_port", "api_host", "browser_capture_host"]
 
 
 def test_effective_config_payload_reports_embedding_enabled_without_key(

--- a/tests/unit/core/test_loopback.py
+++ b/tests/unit/core/test_loopback.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from polylogue.core.loopback import is_loopback_host, is_loopback_origin
+from polylogue.core.loopback import bind_hosts_overlap, is_loopback_host, is_loopback_origin
 
 
 class TestIsLoopbackHost:
@@ -46,6 +46,32 @@ class TestIsLoopbackHost:
     )
     def test_non_loopback_rejected(self, host: str) -> None:
         assert is_loopback_host(host) is False
+
+
+class TestBindHostsOverlap:
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            ("127.0.0.1", "127.0.0.1"),
+            ("127.0.0.1", "localhost"),
+            ("0.0.0.0", "127.0.0.1"),
+            ("::", "127.0.0.1"),
+            ("", "192.168.1.10"),
+        ],
+    )
+    def test_overlapping_bind_hosts(self, left: str, right: str) -> None:
+        assert bind_hosts_overlap(left, right) is True
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            ("127.0.0.1", "192.168.1.10"),
+            ("10.0.0.1", "192.168.1.10"),
+            ("::1", "192.168.1.10"),
+        ],
+    )
+    def test_non_overlapping_bind_hosts(self, left: str, right: str) -> None:
+        assert bind_hosts_overlap(left, right) is False
 
 
 class TestIsLoopbackOrigin:

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.daemon import backup as backup_mod
 from polylogue.daemon.backup import backup_archive
 from polylogue.storage.blob_store import BlobStore
 from tests.infra.storage_records import SessionBuilder, db_setup
@@ -324,6 +325,30 @@ def test_backup_result_formats_non_default_omissions_neutrally() -> None:
 
     assert "  Omitted by profile: source.db" in lines
     assert all("rebuildable/disposable" not in line for line in lines)
+
+
+def test_backup_missing_blob_warnings_are_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hashes = tuple(f"{idx:064x}" for idx in range(25))
+    monkeypatch.setattr(backup_mod, "_source_blob_hashes", lambda _source_db: hashes)
+    monkeypatch.setattr(backup_mod, "blob_store_root", lambda: tmp_path / "blob-store")
+
+    warnings: list[str] = []
+    count, size = backup_mod._copy_referenced_blobs(
+        source_db=tmp_path / "source.db",
+        backup_root=tmp_path / "backup",
+        warnings=warnings,
+    )
+
+    assert count == 0
+    assert size == 0
+    assert len(warnings) == 1
+    assert "25 total" in warnings[0]
+    assert hashes[0] in warnings[0]
+    assert hashes[9] in warnings[0]
+    assert hashes[10] not in warnings[0]
 
 
 def test_backup_archive_requires_precious_tiers(workspace_env: dict[str, Path], tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -299,6 +299,22 @@ def test_backup_archive_diagnostics_profile_copies_only_ops_tier(
     assert manifest["omitted_tiers"] == ["source.db", "index.db", "embeddings.db", "user.db"]
 
 
+def test_backup_verification_scratch_stays_near_backup_output(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    db_setup(workspace_env)
+    backup_parent = tmp_path / "backups"
+
+    result = backup_archive(output_dir=backup_parent, profile="user_overlays", verify=True)
+
+    assert result.ok
+    assert result.verified is True
+    scratch_parent = Path(str(result.verification["scratch_parent"]))
+    assert scratch_parent == backup_parent
+    assert not str(scratch_parent).startswith("/tmp/")
+
+
 def test_backup_result_formats_non_default_omissions_neutrally() -> None:
     from polylogue.daemon.backup import BackupResult, format_backup_result
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -185,6 +185,16 @@ def _seed_empty_schema(workspace: dict[str, Path]) -> None:
     ArchiveStore(workspace["archive_root"]).close()
 
 
+def _degrade_message_fts(workspace: dict[str, Path]) -> None:
+    """Drop the message search index so /api/sessions?query=... can report degraded route readiness."""
+
+    with sqlite3.connect(workspace["archive_root"] / "index.db") as conn:
+        for trigger in ("messages_fts_ai", "messages_fts_ad", "messages_fts_au"):
+            conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+        conn.execute("DROP TABLE IF EXISTS messages_fts")
+        conn.commit()
+
+
 def _seed_test_db(workspace: dict[str, Path]) -> None:
     """Seed a archive with three single-message sessions."""
     from polylogue.archive.message.roles import Role
@@ -611,6 +621,10 @@ class TestReaderSearchState:
             "renderReadViewSelector",
             "renderRouteStateNotice",
             "renderInlineRouteFailure",
+            "sessionList",
+            "data-route-state-name",
+            "data-route-state",
+            "data-sidebar-state",
             "AbortController",
             "timeoutMs",
             "request_timeout_after_",
@@ -663,6 +677,8 @@ class TestReaderSearchState:
         assert row["actions"]["open"]["enabled"] is True
         assert row["actions"]["annotate"]["enabled"] is True
         assert row["actions"]["annotate"]["state"] == "enabled"
+        assert payload["route_state"]["state"] == "ready"
+        assert payload["route_state"]["route"] == "/api/sessions"
 
     def test_facets_envelope_includes_scoped_flag(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
@@ -1611,6 +1627,8 @@ class TestReaderDegradedStates:
         assert isinstance(payload, dict)
         assert payload["total"] == 0
         assert payload["items"] == []
+        assert payload["route_state"]["state"] == "empty"
+        assert payload["route_state"]["reason"] == "Archive contains no sessions."
 
     def test_empty_archive_facets_returns_no_origins(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env, seeded=False) as (_, base_url):
@@ -1625,6 +1643,27 @@ class TestReaderDegradedStates:
         assert isinstance(payload, dict)
         # Archive non-empty (3 convs seeded) but query matches none.
         assert payload["total"] == 0
+        assert payload["route_state"]["state"] == "no_results"
+        assert payload["route_state"]["reason"] == "No sessions matched the active query or filters."
+        assert payload["diagnostics"]["message"] == "No sessions matched 'nonexistent_term_xyz'."
+
+    def test_degraded_search_index_returns_route_state_not_zero_results(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _degrade_message_fts(workspace_env)
+            status, payload = _get_json_ex(base_url, "/api/sessions?query=Hello")
+        assert status == 200
+        assert payload["total"] is None
+        assert payload["hits"] == []
+        route_state = cast(dict[str, object], payload["route_state"])
+        diagnostics = cast(dict[str, object], payload["diagnostics"])
+        reasons = cast(list[dict[str, object]], diagnostics["reasons"])
+        assert route_state["state"] == "degraded"
+        assert route_state["component"] == "message_fts"
+        assert "Search index" in str(route_state["reason"])
+        assert reasons[0]["code"] == "search_index_degraded"
 
 
 class TestReaderQueryCompletions:
@@ -2372,14 +2411,18 @@ class TestSharedQueryPayloads:
         assert d["archive_session_count"] == 42
 
     def test_session_list_response_shape(self) -> None:
-        from polylogue.surfaces.payloads import SessionListResponse
+        from polylogue.surfaces.payloads import RouteReadinessPayload, SessionListResponse
 
-        r = SessionListResponse(items=(), total=0, limit=50, offset=0)
+        route_state = RouteReadinessPayload(
+            state="empty", route="/api/sessions", reason="Archive contains no sessions."
+        )
+        r = SessionListResponse(items=(), total=0, limit=50, offset=0, route_state=route_state)
         d = r.model_dump(mode="json")
         assert d["items"] == []
         assert d["total"] == 0
         assert d["limit"] == 50
         assert d["offset"] == 0
+        assert d["route_state"]["state"] == "empty"
 
     def test_reader_target_ref_and_action_payloads_roundtrip(self) -> None:
         from polylogue.surfaces.payloads import (
@@ -2440,6 +2483,7 @@ class TestSharedQueryPayloads:
         d = r.model_dump(mode="json")
         assert d["diagnostics"] is not None
         assert d["diagnostics"]["message"] == "No results."
+        assert d["route_state"] is None
 
     def test_facets_response_shape(self) -> None:
         from polylogue.surfaces.payloads import FacetFamilyStatusPayload, FacetsResponse, FacetTimeRange
@@ -2724,6 +2768,8 @@ class TestReaderInformability:
         assert "function fallbackCommand" in body
         assert "function renderRouteStateNotice" in body
         assert "function renderInlineRouteFailure" in body
+        assert "setRouteState('sessionList'" in body
+        assert "renderRouteStateNotice('sessionList'" in body
         assert "Retry" in body
         assert "stale_available" in body
         assert "/api/status" in body

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -104,6 +105,10 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert Path(str(payload["dev_archive_root"])).is_dir()
     assert Path(str(payload["log_dir"])).is_dir()
     assert payload["run_log_dir"] == str(repo / ".cache" / "dev-loop" / "feature-dev-loop-abc1234-api9999-capture9998")
+    assert payload["artifact_dir"] == payload["run_log_dir"]
+    assert payload["api_url"] == "http://127.0.0.1:9999"
+    assert payload["web_url"] == "http://127.0.0.1:9999/"
+    assert payload["receiver_url"] == "http://127.0.0.1:9998"
     assert Path(str(payload["run_log_dir"])).is_dir()
     assert Path(str(payload["artifacts"]["browser_dir"])).is_dir()
     assert Path(str(payload["artifacts"]["terminal_dir"])).is_dir()
@@ -120,11 +125,37 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert "run --api-port 9999 --port 9998" in payload["commands"]["run_daemon"]
     assert "polylogue ops status" in payload["commands"]["capture_cli_status"]
     assert payload["commands"]["capture_cli_status"].endswith("terminal/polylogue-ops-status.typescript")
-    assert payload["commands"]["capture_tui_placeholder"].endswith(
-        "tui; use the local terminal-control surface or VHS when visual playback is needed"
-    )
+    assert payload["commands"]["terminal_tui_plan"].endswith("--tui-plan --json")
+    assert payload["commands"]["launch_daemon"].startswith("devtools workspace dev-loop")
+    assert "--archive-root" in payload["commands"]["launch_daemon"]
+    assert "--log-dir" in payload["commands"]["launch_daemon"]
     assert payload["suggested_env"]["POLYLOGUE_ARCHIVE_ROOT"] == str(repo / ".local" / "dev-archive")
     assert payload["suggested_env"]["POLYLOGUE_DEV_LOOP_RUN_ID"] == payload["run_id"]
+    artifact_status = payload["artifact_status"]
+    assert artifact_status["run_log_dir"]["state"] == "present"
+    assert artifact_status["preflight_json"]["state"] == "present"
+    assert artifact_status["daemon_log"]["state"] == "planned"
+    plan = payload["plan"]
+    assert plan["run_id"] == payload["run_id"]
+    assert plan["artifact_dir"] == payload["run_log_dir"]
+    assert plan["next_command_name"] == "launch_daemon"
+    assert plan["next_artifact_dir"] == payload["run_log_dir"]
+    assert "--launch-daemon" in plan["next_command"]
+    assert plan["urls"] == {
+        "api_url": "http://127.0.0.1:9999",
+        "web_url": "http://127.0.0.1:9999/",
+        "receiver_url": "http://127.0.0.1:9998",
+    }
+    receiver_smoke = plan["checks"]["receiver_smoke"]
+    assert receiver_smoke["artifact_dir"].endswith("receiver-smoke-spool")
+    assert receiver_smoke["authority"]["label"] == "source-only-deterministic-receiver-smoke"
+    assert receiver_smoke["authority"]["cloud_safe"] is True
+    extension_smoke = plan["checks"]["extension_smoke"]
+    assert extension_smoke["artifact_dir"] == payload["artifacts"]["browser_dir"]
+    live_proof = plan["checks"]["browser_live_proof"]
+    assert live_proof["authority"]["label"] == "operator-local-copied-profile-live-proof"
+    assert live_proof["authority"]["cloud_safe"] is False
+    assert live_proof["authority"]["requires_copied_profile"] is True
     assert payload["warnings"] == [
         "systemwide polylogued.service is active; stop it or use isolated ports before branch-local runs",
         "api port 9999 already has a listener",
@@ -172,9 +203,16 @@ def test_build_dev_loop_status_marks_isolated_ports_without_service_warning(
     assert payload["warnings"] == []
     assert payload["suggested_env"]["POLYLOGUE_API_PORT"] == "9911"
     assert payload["suggested_env"]["POLYLOGUE_BROWSER_CAPTURE_PORT"] == "9912"
-    assert "--api-port 9911 --browser-capture-port 9912 --prepare" in payload["commands"]["prepare"]
+    prepare_command = payload["commands"]["prepare"]
+    assert "--api-port 9911" in prepare_command
+    assert "--browser-capture-port 9912" in prepare_command
+    assert "--archive-root" in prepare_command
+    assert "--log-dir" in prepare_command
+    assert prepare_command.endswith("--prepare")
     assert payload["commands"]["prepare_isolated"] == "devtools workspace dev-loop --isolated-ports --prepare"
     assert "--api-port 9911 --browser-capture-port 9912 --json" in payload["commands"]["save_preflight"]
+    assert payload["plan"]["next_command_name"] == "launch_daemon"
+    assert payload["plan"]["authority_levels"]["browser_live_proof"]["cloud_safe"] is False
 
 
 def test_main_isolated_ports_allocates_free_ports(
@@ -254,6 +292,9 @@ def test_receiver_smoke_proves_auth_rejection_and_acceptance(tmp_path: Path) -> 
     assert payload["unauthenticated_error"] == "unauthorized"
     assert payload["authenticated_status"] == 202
     assert payload["artifact_ref"] == "chatgpt/dev-loop-smoke-e368c8af2a6b.json"
+    authority = cast(dict[str, object], payload["authority"])
+    assert authority["label"] == "source-only-deterministic-receiver-smoke"
+    assert authority["cloud_safe"] is True
     assert Path(str(payload["artifact_path"])).is_file()
 
 

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -150,6 +150,186 @@ def test_repair_session_insights_noops_when_ready(monkeypatch: pytest.MonkeyPatc
     assert result.detail == "Session insights already ready"
 
 
+def test_repair_session_insights_dry_run_reports_archive_wide_rebuild(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeArchive:
+        def session_insight_status(self) -> SessionInsightStatusSnapshot:
+            return SessionInsightStatusSnapshot(
+                total_sessions=16_358,
+                profile_rows_ready=False,
+                latency_profile_rows_ready=True,
+                work_event_inference_rows_ready=True,
+                work_event_inference_fts_ready=True,
+                phase_inference_rows_ready=True,
+                threads_ready=True,
+                threads_fts_ready=True,
+                tag_rollups_ready=True,
+                missing_profile_row_count=103,
+            )
+
+        def __enter__(self) -> FakeArchive:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.archive_tiers.archive.ArchiveStore.open_existing",
+        lambda _archive_root, read_only=False: FakeArchive(),
+    )
+
+    result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=True)
+
+    assert result.success is True
+    assert result.repaired_count == 16_358
+    assert result.detail == (
+        "Would: rebuild archive-wide session insights for 16,358 session(s) to repair 103 debt row(s)"
+    )
+
+
+def test_repair_session_insights_dry_run_reports_scoped_rebuild(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeArchive:
+        def session_insight_status(self) -> SessionInsightStatusSnapshot:
+            return SessionInsightStatusSnapshot(
+                total_sessions=16_358,
+                profile_rows_ready=False,
+                latency_profile_rows_ready=True,
+                work_event_inference_rows_ready=True,
+                work_event_inference_fts_ready=True,
+                phase_inference_rows_ready=True,
+                threads_ready=True,
+                threads_fts_ready=True,
+                tag_rollups_ready=True,
+                missing_profile_row_count=103,
+            )
+
+        def __enter__(self) -> FakeArchive:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.archive_tiers.archive.ArchiveStore.open_existing",
+        lambda _archive_root, read_only=False: FakeArchive(),
+    )
+
+    result = repair_mod.repair_session_insights(
+        _config(tmp_path),
+        dry_run=True,
+        session_ids=("a", "b", "c"),
+    )
+
+    assert result.success is True
+    assert result.repaired_count == 3
+    assert result.detail == "Would: rebuild session insights for 3 scoped session(s)"
+
+
+def test_repair_session_insights_uses_candidate_session_ids(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE sessions (session_id TEXT PRIMARY KEY, sort_key_ms REAL);
+        CREATE TABLE session_profiles (
+            session_id TEXT PRIMARY KEY,
+            materializer_version INTEGER,
+            source_sort_key REAL,
+            work_event_count INTEGER,
+            phase_count INTEGER
+        );
+        CREATE TABLE session_latency_profiles (
+            session_id TEXT PRIMARY KEY,
+            materializer_version INTEGER,
+            source_sort_key REAL
+        );
+        CREATE TABLE session_work_events (session_id TEXT);
+        CREATE TABLE session_phases (session_id TEXT);
+        CREATE TABLE insight_materialization (insight_type TEXT, session_id TEXT);
+        """
+    )
+    conn.executemany(
+        "INSERT INTO sessions(session_id, sort_key_ms) VALUES (?, ?)",
+        (("ready", 1_000.0), ("missing", 2_000.0)),
+    )
+    conn.execute(
+        """
+        INSERT INTO session_profiles(
+            session_id, materializer_version, source_sort_key, work_event_count, phase_count
+        )
+        VALUES ('ready', ?, 1.0, 0, 0)
+        """,
+        (repair_mod._session_insight_materializer_version(),),
+    )
+    conn.execute(
+        """
+        INSERT INTO session_latency_profiles(session_id, materializer_version, source_sort_key)
+        VALUES ('ready', ?, 1.0)
+        """,
+        (repair_mod._session_insight_materializer_version(),),
+    )
+    conn.executemany(
+        "INSERT INTO insight_materialization(insight_type, session_id) VALUES (?, 'ready')",
+        (
+            ("session_profile",),
+            ("latency",),
+            ("work_events",),
+            ("phases",),
+            ("thread",),
+        ),
+    )
+
+    calls: list[tuple[str, ...] | None] = []
+
+    class FakeArchive:
+        _conn = conn
+
+        def session_insight_status(self) -> SessionInsightStatusSnapshot:
+            return next(statuses)
+
+        def __enter__(self) -> FakeArchive:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    stale_status = SessionInsightStatusSnapshot(
+        total_sessions=2,
+        profile_rows_ready=False,
+        latency_profile_rows_ready=True,
+        work_event_inference_rows_ready=True,
+        work_event_inference_fts_ready=True,
+        phase_inference_rows_ready=True,
+        threads_ready=True,
+        threads_fts_ready=True,
+        tag_rollups_ready=True,
+        missing_profile_row_count=1,
+    )
+    statuses = iter((stale_status, _ready_session_insight_status()))
+
+    def fake_rebuild(_archive: FakeArchive, *, session_ids: tuple[str, ...] | None, **_kwargs: object) -> Any:
+        calls.append(session_ids)
+        return SessionInsightCounts(profiles=1)
+
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.archive_tiers.archive.ArchiveStore.open_existing",
+        lambda _archive_root, read_only=False: FakeArchive(),
+    )
+    monkeypatch.setattr(
+        "polylogue.api.archive._rebuild_archive_session_insights",
+        fake_rebuild,
+    )
+
+    result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
+
+    assert result.success is True
+    assert result.repaired_count == 1
+    assert calls == [("missing",)]
+
+
 def test_repair_session_insights_uses_stale_profile_candidates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: list[tuple[str, tuple[str, ...] | None]] = []
 

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -376,7 +376,7 @@ def seed_reader_assertion_claims(workspace: ReaderWorkspace) -> None:
 
 def _degrade_message_fts(workspace: ReaderWorkspace) -> None:
     """Drop the native message FTS virtual table and its sync triggers so a real
-    query degrades to a sanitized 503 "Search index" response, mirroring an
+    query degrades to an explicit "Search index" route-state response, mirroring an
     interrupted bulk import that never rebuilt the search index."""
     db = index_db_path(workspace)
     conn = sqlite3.connect(str(db))

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -709,20 +709,29 @@ def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, t
     with running_reader_server(reader_workspace, sessions=False) as (_, base_url):
         empty_list = cast(dict[str, object], get_json(base_url, "/api/sessions"))
         empty_facets = cast(dict[str, object], get_json(base_url, "/api/facets"))
+        empty_shell_status, _, empty_shell = get_text(base_url, "/")
 
     with running_reader_server(reader_workspace, sessions=True, message_fts=False) as (_, base_url):
         degraded_status, _, degraded_body = get_text(base_url, "/api/sessions?query=Hello")
 
     assert empty_list["total"] == 0
     assert empty_list["items"] == []
+    assert cast(dict[str, object], empty_list["route_state"])["state"] == "empty"
+    assert empty_shell_status == 200
+    assert "sessionList" in empty_shell
+    assert "data-sidebar-state" in empty_shell
+    assert "data-route-state-name" in empty_shell
     assert empty_facets["total_sessions"] == 0
     assert set(cast(list[str], empty_facets["complete_families"])) >= {"total_counts", "origins", "tags"}
     assert empty_facets["deferred_families"] == {"repos": "deferred_by_default", "action_types": "deferred_by_default"}
-    assert degraded_status == 503
+    assert degraded_status == 200
     degraded_payload = json.loads(degraded_body)
-    assert degraded_payload["ok"] is False
-    assert degraded_payload["error"] == "DatabaseError"
-    assert "Search index" in degraded_payload["detail"]
+    assert degraded_payload["total"] is None
+    assert degraded_payload["hits"] == []
+    assert degraded_payload["route_state"]["state"] == "degraded"
+    assert degraded_payload["route_state"]["component"] == "message_fts"
+    assert "Search index" in degraded_payload["route_state"]["reason"]
+    assert degraded_payload["diagnostics"]["reasons"][0]["code"] == "search_index_degraded"
     assert "Traceback" not in degraded_body
     assert_no_private_paths(json.dumps(empty_list), context="reader empty list JSON")
     assert_no_private_paths(degraded_body, context="reader degraded JSON")
@@ -734,10 +743,12 @@ def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, t
         fixture_id="reader-visual-synthetic-empty-and-degraded-v1",
         checks={
             "empty_total": empty_list["total"],
+            "empty_route_state": cast(dict[str, object], empty_list["route_state"])["state"],
             "empty_facets_total": empty_facets["total_sessions"],
             "empty_facets_deferred": sorted(cast(dict[str, object], empty_facets["deferred_families"]).keys()),
             "degraded_status": degraded_status,
-            "sanitized_error": True,
+            "degraded_route_state": degraded_payload["route_state"]["state"],
+            "sanitized_degraded_payload": True,
             "private_path_safe": True,
         },
     )


### PR DESCRIPTION
## Summary

Repairs the live archive/runtime path enough to dogfood the source daemon again, then integrates the audited non-live patch intake for runtime config diagnostics, route readiness, dev-loop authority metadata, and the residual execution map.

## Problem

The production archive had been left in a confusing state after manual database recovery: session insights needed targeted repair, backup verification restored into root `/tmp`, the deployed/source distinction was hard to prove, and browser-capture/materialization status could be misread from naive raw/index joins. Separately, the cloud patch intake for config, web route readiness, branch-local dev-loop ergonomics, and the residual map existed outside the live-tested branch.

## Solution

- Keep backup verification scratch restores next to the backup output, with `/realm/tmp` fallback and an explicit `POLYLOGUE_BACKUP_VERIFY_TMPDIR` override.
- Make `session_insights` repair target only missing/stale sessions where possible instead of defaulting to archive-wide rebuilds.
- Add effective config diagnostics with source layer, redaction state, network bind checks, auth-token caveats, and API/capture port conflict detection.
- Add route readiness payloads for daemon search/session routes and web rendering so degraded search-index states do not masquerade as empty results.
- Expand `devtools workspace dev-loop` payloads with authority metadata, branch-local artifact states, explicit commands, browser/terminal handoff plans, and no stale placeholder command key.
- Refresh `docs/execution-plan.md` with the current residual map and add route-readiness documentation.

Ref #2308. Ref #2309. Ref #2304. Ref #2248. Ref #1807.

## Verification

- `devtools test tests/unit/daemon/test_backup.py -k 'backup'`: passed before the backup-verification commit.
- `devtools test tests/unit/storage/test_repair.py -k 'session_insights'`: `5 passed, 5 deselected`.
- `devtools test tests/unit/core/test_config_inventory.py tests/unit/core/test_loopback.py tests/unit/daemon/test_web_reader.py tests/unit/devtools/test_dev_loop.py -k 'config or loopback or route_state or degraded_search_index or dev_loop or terminal_tui_plan'`: `78 passed, 141 deselected`.
- `devtools test tests/unit/core/test_config_inventory.py`: `12 passed` after removing configured-origin URL echoing from diagnostics.
- `devtools test tests/unit/daemon/test_backup.py -k 'backup_missing_blob_warnings_are_bounded or backup_verification_scratch'`: `2 passed, 10 deselected`.
- `devtools render all --check`: passed.
- `devtools verify --quick`: passed at `219eb726` via pre-push after the CodeQL URL-redaction and bounded-backup-warning fixes.
- `devtools verify`: refused because this worktree did not have a testmon seed.
- `devtools verify --seed-testmon --skip-slow`: static checks passed, pytest seed expanded into a broad long run and was intentionally aborted at about 6% to preserve wall-clock velocity.
- Source daemon, run from worktree imports against `/home/sinity/.local/share/polylogue`, returned 200 for `/api/status`, `/api/sessions?limit=1`, `/api/facets`, and `/api/sessions?query=polylogue&limit=3`.
- `polylogue ops debt list --kind raw-materialization --format json`: raw-materialization totals all zero.
- `polylogue ops status --json`: FTS readiness ready with trusted freshness and equal indexed/indexable message counts.
- `devtools workspace deployment-smoke --daemon-url http://127.0.0.1:8766 --receiver-url http://127.0.0.1:8765 --browser --browser-executable /etc/profiles/per-user/sinity/bin/google-chrome --json`: `ok: true`, no failures, DOM rendered and screenshot produced.

## Residuals

- The final systemwide deployment still needs Sinnix lock/update/switch after this branch is reviewed and merged.
- The live source-daemon proof used `--no-watch`; watcher-mode realtime sync and idle CPU/RSS sampling remain to be exercised.
- Full backup `--verify` completed against the large production archive with `Verification: OK` at `/home/sinity/.local/share/polylogue/archive-db-backups/polylogue-archive-20260624T071857Z`. It also exposed a pre-existing high-volume missing-blob warning stream, now capped/summarized by this PR; the underlying missing blob references remain archive debt to inspect separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route readiness status to session and search responses, giving clearer states like ready, empty, degraded, and no results.
  * Improved dev-loop status output with a structured plan, command preview, and artifact health details.

* **Bug Fixes**
  * Session listing now reports degraded search-index issues gracefully instead of returning a generic failure.
  * Browser capture and API configuration checks now catch more port, host, and auth conflicts before startup.
  * Backup verification now uses a nearby writable scratch location instead of `/tmp/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->