### PR TITLE
fix(cli): require singleton continue actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -646,17 +646,15 @@ need the host clock (timing benchmarks, fuzz harnesses, the
 `frozen_clock` self-tests) add their path to the allowlist with a
 one-line rationale; everything else migrates to the fixture.
 
-## Scenario Exercises
+## Demo Verification
 
 ```bash
-# Seeded (fast, no real data)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --only exercises --tier 0
+# Seed and verify the deterministic local demo archive
+polylogue demo seed --force --with-overlays
+polylogue demo verify --require-overlays
 
-# Schema audit (instant)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --only audit
-
-# Live (against real DB)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --live --only exercises --tier 0
+# Daemon-backed demo convergence
+polylogue import --demo --wait --timeout 30 --with-overlays
 ```
 
 ## Mutation Testing
@@ -1656,7 +1654,7 @@ repo verification checks and evidence records, not end-user archive workflows.
 | `devtools lab policy schema-versioning` | Enforce the policy boundary documented in docs/internals.md § 'Schema Versioning Model'. Polylogue intentionally has no in-place storage schema upgrade chain; archive-shape changes edit the canonical DDL and require a fresh rebuild from source. |
 | `devtools lab provider completeness` | Inspect detector, parser, fixture, schema, docs, ImportExplain, and caveat coverage before claiming a provider/importer mode is product-ready. |
 | `devtools lab probe capture-regression` | Turn a live or probe failure JSON summary into a replayable local regression artifact. |
-| `devtools lab probe pipeline` | Exercise real pipeline stages and optionally capture emitted summaries as regression cases. |
+| `devtools lab probe pipeline` | Run real pipeline stages and optionally capture emitted summaries as regression cases. |
 | `devtools lab probe turso` | Collect executable evidence before changing production storage backends: Python binding availability, generated-column support, FTS compatibility, MVCC, CDC, vector functions, ATTACH, and WAL pragma behavior. |
 | `devtools lab projections` | Inspect the unified projection inventory that feeds runtime coverage, generated docs, and control-plane maps. |
 | `devtools lab smoke` | Run direct archive and reader smoke sets outside the archive CLI. |

--- a/TESTING.md
+++ b/TESTING.md
@@ -222,17 +222,15 @@ need the host clock (timing benchmarks, fuzz harnesses, the
 `frozen_clock` self-tests) add their path to the allowlist with a
 one-line rationale; everything else migrates to the fixture.
 
-## Scenario Exercises
+## Demo Verification
 
 ```bash
-# Seeded (fast, no real data)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --only exercises --tier 0
+# Seed and verify the deterministic local demo archive
+polylogue demo seed --force --with-overlays
+polylogue demo verify --require-overlays
 
-# Schema audit (instant)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --only audit
-
-# Live (against real DB)
-POLYLOGUE_FORCE_PLAIN=1 polylogue audit --live --only exercises --tier 0
+# Daemon-backed demo convergence
+polylogue import --demo --wait --timeout 30 --with-overlays
 ```
 
 ## Mutation Testing

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -530,7 +530,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "verification lab",
         "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",
         "devtools.pipeline_probe",
-        use_when="Exercise real pipeline stages and optionally capture emitted summaries as regression cases.",
+        use_when="Run real pipeline stages and optionally capture emitted summaries as regression cases.",
         examples=(
             "devtools lab probe pipeline --provider chatgpt --stage parse",
             "devtools lab probe pipeline --input-mode archive-subset --capture-regression live-parse-drift",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -50,7 +50,7 @@ repo verification checks and evidence records, not end-user archive workflows.
 | `devtools lab policy schema-versioning` | Enforce the policy boundary documented in docs/internals.md § 'Schema Versioning Model'. Polylogue intentionally has no in-place storage schema upgrade chain; archive-shape changes edit the canonical DDL and require a fresh rebuild from source. |
 | `devtools lab provider completeness` | Inspect detector, parser, fixture, schema, docs, ImportExplain, and caveat coverage before claiming a provider/importer mode is product-ready. |
 | `devtools lab probe capture-regression` | Turn a live or probe failure JSON summary into a replayable local regression artifact. |
-| `devtools lab probe pipeline` | Exercise real pipeline stages and optionally capture emitted summaries as regression cases. |
+| `devtools lab probe pipeline` | Run real pipeline stages and optionally capture emitted summaries as regression cases. |
 | `devtools lab probe turso` | Collect executable evidence before changing production storage backends: Python binding availability, generated-column support, FTS compatibility, MVCC, CDC, vector functions, ATTACH, and WAL pragma behavior. |
 | `devtools lab projections` | Inspect the unified projection inventory that feeds runtime coverage, generated docs, and control-plane maps. |
 | `devtools lab smoke` | Run direct archive and reader smoke sets outside the archive CLI. |

--- a/docs/plans/docs-media-coverage.yaml
+++ b/docs/plans/docs-media-coverage.yaml
@@ -106,7 +106,7 @@ surfaces:
   testing_docs:
     path: TESTING.md
     notes: >
-      Test suite layout, patterns, scenario exercises, mutation testing
+      Test suite layout, patterns, demo verification, mutation testing
       policy. Root-level, manually maintained.
 
   agent_guide:

--- a/docs/plans/scenario-coverage.yaml
+++ b/docs/plans/scenario-coverage.yaml
@@ -1,7 +1,7 @@
 # Scenario-coverage manifest.
 #
 # Declares verification scenario families and their subject coverage.
-# Each family groups scenarios that exercise a common surface or
+# Each family groups scenarios that verify a common surface or
 # concern. Verification closure comes from executable scenarios and
 # coverage gaps, not maturity self-declarations.
 #
@@ -14,17 +14,17 @@ description: >
 
 families:
   - name: cli_surfaces
-    description: CLI command surface exercises
+    description: CLI command surface checks
     subject: cli_surface
     scenario_count: dynamic
     location: polylogue/scenarios/cli_surfaces.py
     notes: >
-      Generates CLI-surface exercises and variants (live, memory
+      Generates CLI-surface checks and variants (live, memory
       budget) from CliSurfaceFamily definitions. Covers all CLI
       commands via help-output and exit-code assertions.
 
   - name: insight_surfaces
-    description: Insight command surface exercises
+    description: Insight command surface checks
     subject: cli_surface
     scenario_count: dynamic
     location: polylogue/scenarios/insight_surfaces.py
@@ -33,7 +33,7 @@ families:
       rendering contracts. Includes live and contract variants.
 
   - name: operational_surfaces
-    description: Operational surface exercises
+    description: Operational surface checks
     subject: operational_resilience
     scenario_count: dynamic
     location: polylogue/scenarios/operational_surfaces.py

--- a/docs/plans/test-coverage-domains.yaml
+++ b/docs/plans/test-coverage-domains.yaml
@@ -178,7 +178,7 @@ domains:
       - tests/unit/storage/test_session_insight_mapper_fallbacks.py
       - tests/unit/scenarios/test_insight_surfaces.py
     notes: >
-      partial — mapper fallbacks and surface exercises covered; rebuild
+      partial — mapper fallbacks and surface checks covered; rebuild
       correctness not directly tested
 
   # -- Surfaces -----------------------------------------------------------

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -551,7 +551,7 @@ def read_verb(
         )
         return
 
-    session_id = _resolve_read_session_id(env, request, first_only=first_only)
+    session_id = _resolve_query_action_session_id(env, request, operation="read", first_only=first_only)
     effective_format = _effective_read_output_format(request, view=view, output_format=output_format)
     explicit_options = _explicit_read_view_options(ctx)
     if destination == "browser":
@@ -702,7 +702,7 @@ def continue_verb(
         raise click.UsageError("--repo, --cwd, and --recent are only valid with continue --candidates.")
     if candidate_limit != _CONTINUE_CANDIDATE_DEFAULT_LIMIT:
         raise click.UsageError("--limit is only valid with continue --candidates.")
-    session_id = _resolve_target_session_id(request)
+    session_id = _resolve_query_action_session_id(env, request, operation="continue")
     if session_id is None:
         raise click.UsageError("continue requires one matched session (use --id, --latest, or a narrowing query).")
     root_format = request.params.get("output_format")
@@ -1467,8 +1467,14 @@ def _resolve_target_session_id(request: RootModeRequest) -> str | None:
     return resolve_session_id_from_root_params(dict(request.params))
 
 
-def _resolve_read_session_id(env: AppEnv, request: RootModeRequest, *, first_only: bool) -> str | None:
-    """Resolve the singleton session for ``read`` with explicit cardinality."""
+def _resolve_query_action_session_id(
+    env: AppEnv,
+    request: RootModeRequest,
+    *,
+    operation: str,
+    first_only: bool = False,
+) -> str | None:
+    """Resolve one query-action session with explicit ranked-result cardinality."""
     if request.query_terms:
         from dataclasses import replace
 
@@ -1483,16 +1489,31 @@ def _resolve_read_session_id(env: AppEnv, request: RootModeRequest, *, first_onl
         if not spec.latest and not spec.has_filters():
             return None
 
-        read_limit = 1 if first_only else 2
-        bounded_spec = replace(spec, limit=read_limit)
+        resolve_limit = 1 if first_only else 2
+        bounded_spec = replace(spec, limit=resolve_limit)
 
         async def _resolve() -> list[str]:
             summaries = await bounded_spec.list_summaries(env.config)
             return [str(summary.id) for summary in summaries]
 
         session_ids = run_coroutine_sync(_resolve())
+        multi_match_hint = "Narrow the query to one session or run select first." if operation == "continue" else None
         try:
-            check_cardinality(len(session_ids), allow_all=False, first_only=first_only, operation="read")
+            if multi_match_hint is not None:
+                check_cardinality(
+                    len(session_ids),
+                    allow_all=False,
+                    first_only=first_only,
+                    operation=operation,
+                    multi_match_hint=multi_match_hint,
+                )
+            else:
+                check_cardinality(
+                    len(session_ids),
+                    allow_all=False,
+                    first_only=first_only,
+                    operation=operation,
+                )
         except CardinalityError as exc:
             raise click.UsageError(str(exc)) from exc
         return session_ids[0] if session_ids else None

--- a/polylogue/cli/verb_cardinality.py
+++ b/polylogue/cli/verb_cardinality.py
@@ -37,6 +37,7 @@ def check_cardinality(
     allow_all: bool,
     first_only: bool,
     operation: str = "operate on sessions",
+    multi_match_hint: str | None = None,
 ) -> None:
     """Enforce the singleton / ``--all`` / ``--first`` cardinality contract.
 
@@ -53,6 +54,8 @@ def check_cardinality(
         allow_all: ``True`` when ``--all`` was supplied by the user.
         first_only: ``True`` when ``--first`` was supplied by the user.
         operation: human-readable verb label used in the error message.
+        multi_match_hint: optional guidance for verbs that do not expose both
+            ``--first`` and ``--all``.
 
     Raises:
         CardinalityError: when the cardinality constraint is not satisfied.
@@ -63,9 +66,8 @@ def check_cardinality(
         return
     if allow_all or first_only:
         return
-    raise CardinalityError(
-        f"'{operation}' matched {count} sessions. Use --first to act on the first match only, or --all to act on all."
-    )
+    hint = multi_match_hint or "Use --first to act on the first match only, or --all to act on all."
+    raise CardinalityError(f"'{operation}' matched {count} sessions. {hint}")
 
 
 def resolve_session_ids_for_verb(env: AppEnv, request: RootModeRequest) -> list[str]:

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -557,17 +557,29 @@ def test_read_verb_recovery_report_selector_rejects_unknown() -> None:
         option.type.convert("incident", option, click.Context(query_verbs.read_verb))
 
 
+def _continue_verb_kwargs(**overrides: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "destination": "terminal",
+        "out_path": None,
+        "candidates": False,
+        "repo_path": None,
+        "cwd": None,
+        "recent_files": (),
+        "candidate_limit": 10,
+        "output_format": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
 def test_continue_verb_renders_recovery_continue_report() -> None:
     """``find QUERY then continue`` reuses the recovery continue report surface."""
     _, child = _context_pair(query_terms=("id:codex-session:abc123",))
     wrapped = getattr(query_verbs.continue_verb.callback, "__wrapped__", None)
     assert callable(wrapped)
 
-    with (
-        patch("polylogue.cli.query_verbs._resolve_target_session_id", return_value="codex-session:abc123"),
-        patch("polylogue.cli.query_verbs.run_read_view") as run_read_view,
-    ):
-        wrapped(child, "clipboard", None, False, None, None, (), 10, None)
+    with patch("polylogue.cli.query_verbs.run_read_view") as run_read_view:
+        wrapped(child, **_continue_verb_kwargs(destination="clipboard"))
 
     invocation = run_read_view.call_args.args[2]
     assert invocation == ReadViewInvocation(
@@ -578,6 +590,24 @@ def test_continue_verb_renders_recovery_continue_report() -> None:
         out_path=None,
         options=read_view_handlers.ReadViewRecoveryOptions(report="continue"),
     )
+
+
+def test_continue_verb_rejects_ambiguous_ranked_results() -> None:
+    """``find QUERY then continue`` requires a singleton query result."""
+    _, child = _context_pair(query_terms=("needle",))
+    child.obj = SimpleNamespace(config=SimpleNamespace())
+    wrapped = getattr(query_verbs.continue_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    def _close_and_return(coro: object) -> list[str]:
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        return ["session-1", "session-2"]
+
+    with patch("polylogue.cli.query_verbs.run_coroutine_sync", side_effect=_close_and_return):
+        with pytest.raises(click.UsageError, match="Narrow the query to one session"):
+            wrapped(child, **_continue_verb_kwargs())
 
 
 def test_continue_verb_json_emits_context_image(capsys: pytest.CaptureFixture[str]) -> None:
@@ -611,8 +641,7 @@ def test_continue_verb_json_emits_context_image(capsys: pytest.CaptureFixture[st
     wrapped = getattr(query_verbs.continue_verb.callback, "__wrapped__", None)
     assert callable(wrapped)
 
-    with patch("polylogue.cli.query_verbs._resolve_target_session_id", return_value="codex-session:abc123"):
-        wrapped(child, "terminal", None, False, None, None, (), 10, "json")
+    wrapped(child, **_continue_verb_kwargs(output_format="json"))
 
     emitted = json.loads(capsys.readouterr().out)
     assert emitted["spec"]["purpose"] == "continue"
@@ -637,14 +666,14 @@ def test_continue_candidates_ranks_context_without_session_resolution() -> None:
     ):
         wrapped(
             child,
-            "terminal",
-            None,
-            True,
-            "/workspace/polylogue",
-            "/workspace/polylogue",
-            ("polylogue/cli/query_verbs.py",),
-            3,
-            "json",
+            **_continue_verb_kwargs(
+                candidates=True,
+                repo_path="/workspace/polylogue",
+                cwd="/workspace/polylogue",
+                recent_files=("polylogue/cli/query_verbs.py",),
+                candidate_limit=3,
+                output_format="json",
+            ),
         )
 
     resolve_target.assert_not_called()
@@ -665,7 +694,7 @@ def test_continue_candidate_options_require_candidate_mode() -> None:
     assert callable(wrapped)
 
     with pytest.raises(click.UsageError, match="only valid with continue --candidates"):
-        wrapped(child, "terminal", None, False, "/workspace/polylogue", None, (), 10, None)
+        wrapped(child, **_continue_verb_kwargs(repo_path="/workspace/polylogue"))
 
 
 def test_resolve_target_session_id_uses_query_terms(workspace_env: dict[str, Path]) -> None:


### PR DESCRIPTION
## Summary

Tightens the query-action continuation contract and refreshes stale verification wording. `find QUERY then continue` now rejects ambiguous ranked results instead of continuing from an implicit first match, while the docs/manifests move old exercise/showcase phrasing to current demo verification language.

## Problem

Continuation output is a successor handoff for one session, but the CLI reused the generic target resolver and could proceed from the first ranked result for a broad query. Separately, some verification docs still described old exercise/audit flows even though the current operator path is demo seed/verify and import-demo verification.

## Solution

Read and continue now share a bounded query-action resolver that inspects one or two ranked matches. `continue` uses the shared cardinality guard without a first-match escape and reports continue-specific guidance when a broad query is ambiguous. Runtime tests cover exact refs, ambiguous ranked results, JSON context output, and candidate mode. The docs/verifiability slice updates current generated docs and manifests away from stale exercise wording.

Ref #2317. Ref #2006. Ref #2196. Ref #2307.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py tests/unit/cli/test_verb_cardinality.py -k 'continue_verb or resolve_target_session_id or ReadVerbCardinality or TestCheckCardinality'` passed with 20 selected tests.\n- `POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue timeout 20s ./.venv/bin/polylogue find polylogue then continue --format json` rejected with `invalid_arguments` and continue-specific narrowing guidance.\n- `POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue timeout 90s ./.venv/bin/polylogue find 'id:codex-session:019eeb52-2a15-7140-8811-143101d0a0dc' then continue --format json` produced a context image with purpose `continue`, the expected seed ref, and one segment.\n- `devtools render all --check` passed.\n- `devtools verify --quick` passed locally and again in the pre-push hook on commit `aae050d89`.\n