### PR TITLE
fix(cli): require explicit delete confirmation

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -1239,13 +1239,6 @@ def _emit_delete(
     dry_run = bool(params.get("dry_run"))
     force = bool(params.get("force"))
     count = len(session_ids)
-    if count == 0:
-        click.echo(
-            MutationResultPayload(status="ok", operation="delete", session_count=0, affected_count=0).to_json(
-                exclude_none=True
-            )
-        )
-        return
     if dry_run:
         # ``session_count`` = matched, ``affected_count`` = deleted (0 in a
         # preview); ``session_ids`` enumerates the sessions that would be deleted.
@@ -1257,6 +1250,13 @@ def _emit_delete(
                 affected_count=0,
                 session_ids=tuple(session_ids),
             ).to_json(exclude_none=True)
+        )
+        return
+    if count == 0:
+        click.echo(
+            MutationResultPayload(status="ok", operation="delete", session_count=0, affected_count=0).to_json(
+                exclude_none=True
+            )
         )
         return
     if not force:

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -793,6 +793,8 @@ def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: boo
         session_ids = resolve_session_ids_for_verb(env, request)
         execute_delete_by_session_ids(env, session_ids, force=True, dry_run=True)
         return
+    if not yes_flag:
+        raise click.UsageError("delete requires --yes for actual deletion; use --dry-run to preview.")
 
     # Enforce cardinality before any destructive action.
     session_ids = resolve_session_ids_for_verb(env, request)

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -240,30 +240,32 @@ def test_delete_contract_guard_refuses_plain_forceless_delete(workspace_env: dic
     _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
 
     runner = CliRunner()
-    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=["session-1"]):
+    with (
+        patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb") as resolve,
+        patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as execute_delete,
+    ):
         result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete"])
 
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["operation"] == "delete"
-    assert payload["status"] == "aborted"
-    assert payload["detail"] == "confirmation_required"
-    assert payload["affected_count"] == 0
+    assert result.exit_code != 0
+    assert "--yes" in result.output
+    assert "--dry-run" in result.output
+    resolve.assert_not_called()
+    execute_delete.assert_not_called()
 
 
-def test_delete_contract_aborted_payload_matches_mutation_schema(workspace_env: dict[str, Path]) -> None:
-    """The destructive-action guard emits the declared mutation envelope."""
-    import jsonschema
-
+def test_delete_contract_plain_forceless_delete_does_not_emit_mutation(
+    workspace_env: dict[str, Path],
+) -> None:
+    """The destructive-action guard rejects before mutation envelope execution."""
     _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
-    schema = _load_cli_output_schema("mutation-result")
 
     runner = CliRunner()
-    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=["session-1"]):
+    with patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as execute_delete:
         result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete"])
 
-    assert result.exit_code == 0, result.output
-    jsonschema.validate(instance=json.loads(result.output), schema=schema)
+    assert result.exit_code != 0
+    assert "confirmation_required" not in result.output
+    execute_delete.assert_not_called()
 
 
 def test_delete_contract_guard_allows_dry_run_preview(workspace_env: dict[str, Path]) -> None:
@@ -282,6 +284,23 @@ def test_delete_contract_guard_allows_dry_run_preview(workspace_env: dict[str, P
     assert payload["session_count"] == len(session_ids)
     assert payload["affected_count"] == 0
     assert payload["session_ids"] == session_ids
+
+
+def test_delete_contract_dry_run_empty_preview_is_explicit(workspace_env: dict[str, Path]) -> None:
+    """An empty dry-run is a preview envelope, not a completed deletion."""
+    _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
+
+    runner = CliRunner()
+    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=[]):
+        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["operation"] == "delete"
+    assert payload["status"] == "preview"
+    assert payload["session_count"] == 0
+    assert payload["affected_count"] == 0
+    assert payload["session_ids"] == []
 
 
 def test_delete_contract_preview_payload_matches_mutation_schema(workspace_env: dict[str, Path]) -> None:


### PR DESCRIPTION
## Summary

Makes query-action delete honor its confirmation contract consistently: actual deletion now requires `--yes` at the public verb boundary, and dry-run previews stay structured even when no sessions match.

## Problem

The action contract and help text said actual deletion requires `--yes`, but the query-action path could still pass through to the lower interactive prompt when `--yes` was omitted. Empty dry-run previews also returned an `ok` no-op envelope instead of an explicit preview shape.

## Solution

`find QUERY then delete` now rejects actual deletion before resolution or execution unless `--yes` is supplied. `--dry-run` continues to resolve and preview the full matched set. Empty dry-runs now emit the same mutation preview envelope as non-empty dry-runs, with `session_count: 0`, `affected_count: 0`, and `session_ids: []`.

Ref #2317. Ref #2006.

## Verification

- `devtools test tests/unit/cli/test_cli_action_contracts.py tests/unit/cli/test_query_verbs_runtime.py -k 'delete_contract or delete_verb_updates_confirmation'` passed with 7 selected tests.\n- `POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue timeout 20s ./.venv/bin/polylogue --plain find 'id:codex-session:019eeb52-2a15-7140-8811-143101d0a0dc' then delete` rejected with a usage error before deletion.\n- The same exact ref with `then delete --dry-run` returned a preview envelope naming the session id and `affected_count: 0`.\n- `devtools verify --quick` passed locally.\n