### PR TITLE
fix(cli): reject ambiguous plain select

### DIFF
--- a/polylogue/cli/select.py
+++ b/polylogue/cli/select.py
@@ -129,8 +129,10 @@ def choose_select_row(env: AppEnv, rows: list[SelectSessionRow]) -> SelectSessio
     """Choose one row, using fzf/prompt only when the terminal can support it."""
     if not rows:
         return None
-    if env.ui.plain or not sys.stdin.isatty() or not sys.stdout.isatty():
+    if len(rows) == 1:
         return rows[0]
+    if env.ui.plain or not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
 
     fzf_row = _choose_with_fzf(rows)
     if fzf_row is not None:
@@ -203,7 +205,10 @@ async def async_run_select(
     selected = choose_select_row(env, rows)
     if selected is None:
         if rows:
-            click.echo("Selection cancelled.", err=True)
+            click.echo(
+                "Selection required for multiple sessions; narrow the query or run in an interactive terminal.",
+                err=True,
+            )
             raise SystemExit(1)
         click.echo("No sessions matched.", err=True)
         raise SystemExit(2)

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -359,6 +359,7 @@ def _read_verb_kwargs(**overrides: object) -> dict[str, object]:
         "no_file_reads": False,
         "prose_only": False,
         "fields": None,
+        "first_only": False,
         "show_views": False,
     }
     defaults.update(overrides)

--- a/tests/unit/cli/test_select.py
+++ b/tests/unit/cli/test_select.py
@@ -77,7 +77,7 @@ def test_render_select_row_outputs_requested_field() -> None:
         (True, True, True),
     ],
 )
-def test_choose_select_row_returns_first_when_not_interactive(
+def test_choose_select_row_rejects_ambiguous_non_interactive(
     plain: bool,
     stdin_tty: bool,
     stdout_tty: bool,
@@ -90,8 +90,17 @@ def test_choose_select_row_returns_first_when_not_interactive(
         patch("sys.stdin.isatty", return_value=stdin_tty),
         patch("sys.stdout.isatty", return_value=stdout_tty),
     ):
-        assert choose_select_row(env, [_row(1), _row(2)]) == _row(1)
+        assert choose_select_row(env, [_row(1), _row(2)]) is None
         ui.choose.assert_not_called()
+
+
+def test_choose_select_row_returns_singleton_when_not_interactive() -> None:
+    ui = MagicMock()
+    ui.plain = True
+    env = cast(AppEnv, SimpleNamespace(ui=ui))
+
+    assert choose_select_row(env, [_row(1)]) == _row(1)
+    ui.choose.assert_not_called()
 
 
 def test_choose_select_row_prefers_fzf_then_falls_back_to_ui() -> None:
@@ -184,7 +193,7 @@ async def test_async_run_select_distinguishes_empty_results_from_cancel(capsys: 
         with pytest.raises(SystemExit) as exc_info:
             await async_run_select(env, request, limit=10, print_field="id")
     assert exc_info.value.code == 1
-    assert "Selection cancelled." in capsys.readouterr().err
+    assert "Selection required for multiple sessions" in capsys.readouterr().err
 
     with patch("polylogue.cli.select.select_session_rows", AsyncMock(return_value=[])):
         with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## Summary

Stops plain/non-TTY `find QUERY then select` from silently selecting the first ranked row when multiple sessions match.

## Problem

`select` is the explicit selector action, but in plain or redirected contexts it returned row 0 automatically. That made a ranked result-set look like an intentional selected item.

## Solution

Non-interactive `select` now auto-returns only when exactly one row is available. Multiple rows produce a selection-required error that asks the operator to narrow the query or use an interactive terminal. Exact one-row selections continue to render normally.

Ref #2317. Ref #2006.

## Verification

- `devtools test tests/unit/cli/test_select.py tests/unit/cli/test_query_verbs_runtime.py -k select` passed with 18 selected tests.
- `POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue timeout 20s ./.venv/bin/polylogue --plain find polylogue then select --json` rejected with selection-required guidance.
- Exact-ref `select --json` against the production archive still returned a selected-row JSON object.
- `devtools verify --quick` passed locally.
