### PR TITLE
fix(cli): bound delete dry-run previews

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -361,7 +361,7 @@ Usage: polylogue delete [OPTIONS]
   Examples:
       polylogue find id:abc then delete --dry-run
       polylogue find id:abc then delete --yes
-      polylogue find 'repo:polylogue since:7d' then delete --dry-run
+      polylogue find 'repo:polylogue since:7d' then delete --dry-run --all
       polylogue find 'repo:polylogue since:7d' then delete --yes --all
 
 Options:

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -766,10 +766,15 @@ def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: boo
     Examples:
         polylogue find id:abc then delete --dry-run
         polylogue find id:abc then delete --yes
-        polylogue find 'repo:polylogue since:7d' then delete --dry-run
+        polylogue find 'repo:polylogue since:7d' then delete --dry-run --all
         polylogue find 'repo:polylogue since:7d' then delete --yes --all
     """
-    from polylogue.cli.verb_cardinality import CardinalityError, check_cardinality, resolve_session_ids_for_verb
+    from polylogue.cli.verb_cardinality import (
+        CardinalityError,
+        check_cardinality,
+        probe_session_ids_for_verb,
+        resolve_session_ids_for_verb,
+    )
 
     env: AppEnv = ctx.obj
     request = _parent_request(ctx)
@@ -784,12 +789,18 @@ def delete_verb(ctx: click.Context, dry_run: bool, yes_flag: bool, all_flag: boo
 
     from polylogue.cli.archive_query import execute_delete_by_session_ids
 
-    # dry-run: skip the cardinality guard and just show a preview. Resolve the
-    # SAME full ID set the real delete uses (via resolve_session_ids_for_verb)
-    # rather than re-running the query through _execute_query_verb, which caps at
-    # the default limit of 20 and would preview fewer sessions than --yes --all
-    # actually deletes (#1873). The previewed set must equal the deleted set.
+    # dry-run: require explicit multi-target scope before materializing a broad
+    # preview. Once --all is supplied, resolve the SAME full ID set the real
+    # delete uses rather than re-running the query through _execute_query_verb,
+    # which caps at the default limit of 20 and would preview fewer sessions
+    # than --yes --all actually deletes (#1873).
     if dry_run:
+        probe_ids = probe_session_ids_for_verb(env, request, limit=2)
+        if len(probe_ids) > 1 and not all_flag:
+            raise click.UsageError(
+                "'delete dry-run' matched multiple sessions. "
+                "Use --all to preview every matched session, or narrow the query."
+            )
         session_ids = resolve_session_ids_for_verb(env, request)
         execute_delete_by_session_ids(env, session_ids, force=True, dry_run=True)
         return

--- a/polylogue/cli/verb_cardinality.py
+++ b/polylogue/cli/verb_cardinality.py
@@ -11,9 +11,10 @@ cardinality contracts before performing mutations:
 verbs import it so tests can verify the shared path without repeating
 assertions.
 
-:func:`resolve_session_ids_for_verb` uses the same filter-chain infrastructure
-as the ``read`` and ``export`` paths so the resolved set is always consistent
-with what the user would see from ``find QUERY``.
+:func:`probe_session_ids_for_verb` and :func:`resolve_session_ids_for_verb` use
+the same filter-chain infrastructure as the ``read`` and ``export`` paths so
+guards and resolved sets are always consistent with what the user would see
+from ``find QUERY``.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING
 import click
 
 if TYPE_CHECKING:
+    from polylogue.archive.filter.filters import SessionFilter
     from polylogue.cli.root_request import RootModeRequest
     from polylogue.cli.shared.types import AppEnv
 
@@ -70,6 +72,30 @@ def check_cardinality(
     raise CardinalityError(f"'{operation}' matched {count} sessions. {hint}")
 
 
+def _reject_sample_for_mutating_verb(request: RootModeRequest) -> None:
+    # ``--sample`` is a display-window operation (random subset applied during
+    # result windowing); verb guard/resolution paths deliberately inspect the
+    # COMPLETE matched set so cardinality checks and mutations act on the same
+    # rows. Honoring ``--sample`` here would mean a destructive verb silently
+    # operated on the full match while the operator believed the blast radius was
+    # capped at N, so reject the combination instead of ignoring it.
+    if request.query_spec().sample is not None:
+        raise click.UsageError(
+            "Root query does not combine --sample with a mutating verb "
+            "(delete/mark): these operate on the complete matched set, so "
+            "--sample would be silently ignored. Narrow the query (e.g. an "
+            "id:/since: filter) to scope the blast radius explicitly."
+        )
+
+
+def probe_session_ids_for_verb(env: AppEnv, request: RootModeRequest, *, limit: int) -> list[str]:
+    """Resolve a bounded ID prefix for cheap zero/one/many verb guards."""
+    from polylogue.api.sync.bridge import run_coroutine_sync
+
+    _reject_sample_for_mutating_verb(request)
+    return run_coroutine_sync(_async_probe_ids(env, request, limit=limit))
+
+
 def resolve_session_ids_for_verb(env: AppEnv, request: RootModeRequest) -> list[str]:
     """Resolve session IDs for a verb that needs to inspect the matched set.
 
@@ -82,30 +108,11 @@ def resolve_session_ids_for_verb(env: AppEnv, request: RootModeRequest) -> list[
     """
     from polylogue.api.sync.bridge import run_coroutine_sync
 
-    # ``--sample`` is a display-window operation (random subset applied during
-    # result windowing); the verb resolution path deliberately resolves the
-    # COMPLETE matched set so the cardinality guard and the mutation act on the
-    # same rows. Honoring ``--sample`` here would mean a destructive verb
-    # silently operated on the full match while the operator believed the blast
-    # radius was capped at N — so reject the combination instead of ignoring it.
-    if request.query_spec().sample is not None:
-        raise click.UsageError(
-            "Root query does not combine --sample with a mutating verb "
-            "(delete/mark): these operate on the complete matched set, so "
-            "--sample would be silently ignored. Narrow the query (e.g. an "
-            "id:/since: filter) to scope the blast radius explicitly."
-        )
-
+    _reject_sample_for_mutating_verb(request)
     return run_coroutine_sync(_async_resolve_ids(env, request))
 
 
-async def _async_resolve_ids(env: AppEnv, request: RootModeRequest) -> list[str]:
-    """Async implementation of session-ID resolution for verb cardinality.
-
-    Uses the compiled DSL spec (``request.query_spec()``) so that field clauses
-    such as ``repo:polylogue`` or ``since:7d`` are resolved to structured filters
-    rather than being passed as literal FTS text.
-    """
+def _filter_chain_for_request(env: AppEnv, request: RootModeRequest) -> SessionFilter:
     from polylogue.cli.query import _create_query_vector_provider
     from polylogue.paths._roots import archive_file_set_root_for_paths
 
@@ -116,7 +123,27 @@ async def _async_resolve_ids(env: AppEnv, request: RootModeRequest) -> list[str]
         db_anchor=config.db_path,
     )
     vector_provider = _create_query_vector_provider(config, db_path=archive_root / "embeddings.db")
-    filter_chain = spec.build_filter(config, vector_provider=vector_provider)
+    return spec.build_filter(config, vector_provider=vector_provider)
+
+
+async def _async_probe_ids(env: AppEnv, request: RootModeRequest, *, limit: int) -> list[str]:
+    bounded = request.with_param_updates(limit=limit)
+    filter_chain = _filter_chain_for_request(env, bounded)
+    if filter_chain.can_use_summaries():
+        summaries = await filter_chain.list_summaries()
+        return [str(s.id) for s in summaries[:limit]]
+    sessions = await filter_chain.list()
+    return [str(s.id) for s in sessions[:limit]]
+
+
+async def _async_resolve_ids(env: AppEnv, request: RootModeRequest) -> list[str]:
+    """Async implementation of session-ID resolution for verb cardinality.
+
+    Uses the compiled DSL spec (``request.query_spec()``) so that field clauses
+    such as ``repo:polylogue`` or ``since:7d`` are resolved to structured filters
+    rather than being passed as literal FTS text.
+    """
+    filter_chain = _filter_chain_for_request(env, request)
     # Resolve the COMPLETE matched set, not a single page: this list drives the
     # cardinality guard and the actual delete/mark, so a paged list_summaries()
     # (default limit 50) would let ``delete --yes --all`` silently skip every
@@ -131,5 +158,6 @@ async def _async_resolve_ids(env: AppEnv, request: RootModeRequest) -> list[str]
 __all__ = [
     "CardinalityError",
     "check_cardinality",
+    "probe_session_ids_for_verb",
     "resolve_session_ids_for_verb",
 ]

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -274,8 +274,11 @@ def test_delete_contract_guard_allows_dry_run_preview(workspace_env: dict[str, P
 
     session_ids = ["session-1", "session-2"]
     runner = CliRunner()
-    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=session_ids):
-        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run"])
+    with (
+        patch("polylogue.cli.verb_cardinality.probe_session_ids_for_verb", return_value=session_ids[:2]),
+        patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=session_ids),
+    ):
+        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run", "--all"])
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
@@ -291,7 +294,10 @@ def test_delete_contract_dry_run_empty_preview_is_explicit(workspace_env: dict[s
     _assert_contract_declares_guard(("delete",), "dry_run_or_yes_required")
 
     runner = CliRunner()
-    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=[]):
+    with (
+        patch("polylogue.cli.verb_cardinality.probe_session_ids_for_verb", return_value=[]),
+        patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=[]),
+    ):
         result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run"])
 
     assert result.exit_code == 0, result.output
@@ -312,8 +318,11 @@ def test_delete_contract_preview_payload_matches_mutation_schema(workspace_env: 
 
     session_ids = ["session-1", "session-2"]
     runner = CliRunner()
-    with patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=session_ids):
-        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run"])
+    with (
+        patch("polylogue.cli.verb_cardinality.probe_session_ids_for_verb", return_value=session_ids[:2]),
+        patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb", return_value=session_ids),
+    ):
+        result = runner.invoke(cli, ["--plain", "find", "needle", "then", "delete", "--dry-run", "--all"])
 
     assert result.exit_code == 0, result.output
     jsonschema.validate(instance=json.loads(result.output), schema=schema)

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -955,6 +955,10 @@ def test_delete_verb_updates_confirmation_and_dry_run_flags() -> None:
     # uses force=True internally so it never triggers an interactive prompt.
     with (
         patch(
+            "polylogue.cli.verb_cardinality.probe_session_ids_for_verb",
+            return_value=["alpha-id"],
+        ) as probe_ids,
+        patch(
             "polylogue.cli.verb_cardinality.resolve_session_ids_for_verb",
             return_value=["alpha-id"],
         ) as resolve,
@@ -964,6 +968,7 @@ def test_delete_verb_updates_confirmation_and_dry_run_flags() -> None:
         wrapped(child, True, False, False)
 
     legacy.assert_not_called()
+    probe_ids.assert_called_once()
     resolve.assert_called_once()
     args, kwargs = execute.call_args
     assert list(args[1]) == ["alpha-id"]

--- a/tests/unit/cli/test_verb_cardinality.py
+++ b/tests/unit/cli/test_verb_cardinality.py
@@ -391,27 +391,45 @@ class TestDeleteVerbCardinality:
         cb = self._delete_callback()
         cb(child, dry_run, yes_flag, all_flag)  # type: ignore[operator]
 
-    def test_dry_run_skips_cardinality_check(self) -> None:
+    def test_dry_run_probes_before_resolving_ids(self) -> None:
         _, child = _context_pair()
         child.obj = SimpleNamespace(config=MagicMock())
 
         with (
             patch(
+                "polylogue.cli.verb_cardinality.probe_session_ids_for_verb",
+                return_value=["id1"],
+            ) as mock_probe,
+            patch(
                 "polylogue.cli.verb_cardinality.resolve_session_ids_for_verb",
-                return_value=["id1", "id2", "id3"],
+                return_value=["id1"],
             ),
             patch("polylogue.cli.verb_cardinality.check_cardinality") as mock_card,
             patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as mock_exec,
         ):
             self._call_delete(child, dry_run=True)
 
-        # The cardinality guard must NOT run for a dry-run (it is a preview, not a
-        # destructive action), but the preview must still go through the real
-        # full-set delete path.
+        mock_probe.assert_called_once()
+        assert mock_probe.call_args.kwargs == {"limit": 2}
         mock_card.assert_not_called()
         mock_exec.assert_called_once()
 
-    def test_dry_run_previews_full_resolved_set_not_truncated_query(self) -> None:
+    def test_multi_match_dry_run_requires_all_before_resolving_ids(self) -> None:
+        _, child = _context_pair()
+        child.obj = SimpleNamespace(config=MagicMock())
+
+        with (
+            patch("polylogue.cli.verb_cardinality.probe_session_ids_for_verb", return_value=["id1", "id2"]),
+            patch("polylogue.cli.verb_cardinality.resolve_session_ids_for_verb") as mock_resolve,
+            patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as mock_exec,
+            pytest.raises(click.UsageError, match="Use --all to preview every matched session"),
+        ):
+            self._call_delete(child, dry_run=True)
+
+        mock_resolve.assert_not_called()
+        mock_exec.assert_not_called()
+
+    def test_dry_run_all_previews_full_resolved_set_not_truncated_query(self) -> None:
         """Dry-run previews the full pre-resolved ID set.
 
         Regression for the #1873 truncation: dry-run must NOT re-run the query
@@ -425,6 +443,7 @@ class TestDeleteVerbCardinality:
 
         resolved = [f"id{i}" for i in range(60)]
         with (
+            patch("polylogue.cli.verb_cardinality.probe_session_ids_for_verb", return_value=resolved[:2]),
             patch(
                 "polylogue.cli.verb_cardinality.resolve_session_ids_for_verb",
                 return_value=resolved,
@@ -432,7 +451,7 @@ class TestDeleteVerbCardinality:
             patch("polylogue.cli.query_verbs._execute_query_verb") as mock_query,
             patch("polylogue.cli.archive_query.execute_delete_by_session_ids") as mock_exec,
         ):
-            self._call_delete(child, dry_run=True)
+            self._call_delete(child, dry_run=True, all_flag=True)
 
         mock_query.assert_not_called()
         args, kwargs = mock_exec.call_args
@@ -833,7 +852,10 @@ class TestDeleteCardinalityLargeNonMocked:
 
         # 2. Dry-run preview set: must equal the guard set (the #1873 bug previewed
         #    only the first page while --yes --all deleted everything).
-        preview = self._invoke_delete(env, dry_run=True, yes_flag=False, all_flag=False)
+        with pytest.raises(click.UsageError, match="Use --all to preview every matched session"):
+            self._invoke_delete(env, dry_run=True, yes_flag=False, all_flag=False)
+
+        preview = self._invoke_delete(env, dry_run=True, yes_flag=False, all_flag=True)
         assert preview["status"] == "preview"
         assert preview["session_count"] == self.COUNT
         assert preview["affected_count"] == 0


### PR DESCRIPTION
## Summary

Bound `find QUERY then delete --dry-run` so broad previews fail fast unless the operator explicitly supplies `--all`. Singleton and zero-match dry-runs still return preview payloads, while `--dry-run --all` continues to materialize the same full ID set as `--yes --all`.

## Problem

Live dogfood against the production archive showed `find polylogue --format json then delete --dry-run` could spend more than a minute resolving the full match set before producing any preview. That made the safe destructive-action preview path feel unsafe: an accidental broad query did expensive work before asking for explicit multi-target scope.

## Solution

`verb_cardinality` now exposes a bounded `probe_session_ids_for_verb(..., limit=2)` helper that uses the same query/filter path as full mutation resolution but only asks for enough rows to distinguish zero, one, and many. `delete` uses that probe before resolving the full preview set: zero and one proceed, many require `--all`, and explicit `--all` still uses `resolve_session_ids_for_verb` so preview and actual multi-delete remain aligned. The CLI reference was regenerated for the updated multi-target dry-run example.

Ref #2317. Ref #2006.

## Verification

- `devtools test tests/unit/cli/test_query_verbs_runtime.py::test_delete_verb_updates_confirmation_and_dry_run_flags tests/unit/cli/test_verb_cardinality.py::TestDeleteVerbCardinality tests/unit/cli/test_verb_cardinality.py::TestDeleteCardinalityLargeNonMocked tests/unit/cli/test_cli_action_contracts.py -k 'delete_contract or DeleteVerbCardinality or DeleteCardinalityLargeNonMocked or delete_verb_updates'` -> `16 passed, 22 deselected`.
- `devtools render all --check` -> all generated surfaces in sync.
- `devtools verify --quick` -> pass, run `20260624T091912Z-quick-2183296-fb033f2c`.
- Pre-push `devtools verify --quick` -> pass, run `20260624T092015Z-quick-2184848-d82ae4e6`.
- Live branch dogfood: `timeout 20 ./.venv/bin/polylogue --plain find polylogue then delete --dry-run` returned exit `2` quickly with `Use --all to preview every matched session`.
- Live branch dogfood: `timeout 20 ./.venv/bin/polylogue --plain find definitelynomatchpolyloguedeleteguard then delete --dry-run` returned preview JSON with `session_count: 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `delete` previews now handle large matches more safely by requiring `--all` when multiple sessions would be affected.
  * Dry-run behavior now shows a complete preview of matched sessions instead of relying on a partial result.
  * Using `--sample` with mutating actions now returns a clear error instead of being ignored.

* **Documentation**
  * Updated command examples to show the recommended `--dry-run --all` and `--yes --all` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->