### PR TITLE
fix(daemon): attribute append ingest storage route

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -116,6 +116,18 @@ _ARCHIVE_RUNTIME_TIERS = ",".join(spec.tier.value for spec in ARCHIVE_TIER_SPECS
 _ARCHIVE_NATIVE_WRITE_TIERS = "source,index"
 
 
+def _single_route_stage_payload(*, append_file_count: int, full_file_count: int) -> dict[str, object] | None:
+    if append_file_count > 0 and full_file_count == 0:
+        return {"storage_route": "archive_append"}
+    if full_file_count > 0 and append_file_count == 0:
+        return {
+            "storage_route": "archive_full",
+            "storage_tiers": _ARCHIVE_RUNTIME_TIERS,
+            "storage_write_tiers": _ARCHIVE_NATIVE_WRITE_TIERS,
+        }
+    return None
+
+
 def _iso_to_epoch_ms(value: str) -> int:
     return int(datetime.fromisoformat(value).timestamp() * 1000)
 
@@ -227,6 +239,7 @@ class LiveBatchProcessor:
                 parse_time_s=parse_time_s,
                 current_source=plans[0].source_name,
                 current_path=plans[0].path,
+                stage_payload={"storage_route": "archive_append"},
             )
             t0 = time.perf_counter()
             try:
@@ -256,6 +269,7 @@ class LiveBatchProcessor:
                 convergence_time_s=convergence_time_s,
                 current_source=plans[0].source_name,
                 current_path=plans[0].path,
+                stage_payload={"storage_route": "archive_append"},
             )
             _converged_paths, elapsed, timings, convergence_debt = await asyncio.to_thread(
                 self._converge_paths,
@@ -450,6 +464,10 @@ class LiveBatchProcessor:
                     len(full_result.succeeded) / max(parse_elapsed, 0.01),
                 )
 
+        summary_stage_payload = _single_route_stage_payload(
+            append_file_count=append_file_count,
+            full_file_count=len(full_paths),
+        )
         self._record_attempt_progress(
             attempt_id,
             phase="cursor_update",
@@ -460,6 +478,7 @@ class LiveBatchProcessor:
             parse_time_s=parse_time_s,
             convergence_time_s=convergence_time_s,
             stale_cursor_write_count=stale_cursor_write_count,
+            stage_payload=summary_stage_payload,
         )
 
         if succeeded_paths:
@@ -518,6 +537,7 @@ class LiveBatchProcessor:
             total_time_s=metrics.total_time_s,
             stage_timings_s=metrics.stage_timings_s,
             stale_cursor_write_count=stale_cursor_write_count,
+            stage_payload=summary_stage_payload,
         )
         self._cursor.finish_ingest_attempt(
             attempt_id,

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1211,3 +1211,24 @@ async def test_live_append_plans_flush_in_bounded_groups(
     assert groups == [paths[:2], paths[2:4], paths[4:]]
     assert metrics.append_file_count == 5
     assert metrics.full_file_count == 0
+    with sqlite3.connect(cursor._ops_db_path) as conn:
+        stage_payloads = [
+            (str(row[0]), json.loads(row[1]))
+            for row in conn.execute(
+                """
+                SELECT stage, payload_json
+                FROM daemon_stage_events
+                WHERE stage IN ('append_parse', 'convergence', 'cursor_update', 'completed')
+                ORDER BY observed_at_ms, rowid
+                """
+            ).fetchall()
+        ]
+    route_payloads = [(stage, payload) for stage, payload in stage_payloads if payload.get("storage_route")]
+    assert route_payloads
+    assert {payload["storage_route"] for _, payload in route_payloads} == {"archive_append"}
+    assert ("cursor_update", "archive_append") in [
+        (stage, str(payload.get("storage_route"))) for stage, payload in route_payloads
+    ]
+    assert ("completed", "archive_append") in [
+        (stage, str(payload.get("storage_route"))) for stage, payload in route_payloads
+    ]


### PR DESCRIPTION
## Summary

Append-only live ingest attempts now write `storage_route=archive_append` into durable stage-event payloads, including cursor-update and completed summaries when the batch uses a single storage route.

## Problem

Live workload diagnostics could report recent append-only daemon attempts as `storage_route=unknown` even though the append path was known and low-amplification. That made it harder to tell healthy live-ish sync from genuinely unclassified ingest behavior while investigating deployed-state trust.

## Solution

`polylogue/sources/live/batch.py` now annotates append parse/convergence progress with `archive_append`. Final summary progress receives a storage route only when the batch is single-route: append-only gets `archive_append`, full-only gets the existing archive tier metadata, and mixed batches stay unattributed at summary level rather than claiming one false route.

The regression test reads `ops.db.daemon_stage_events` for an append-only batch and asserts route-bearing payloads are attributed to `archive_append`, including the cursor-update and completed events consumed by diagnostics.

Ref #2308.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py::test_live_append_plans_flush_in_bounded_groups` -> 1 passed.
- `devtools test tests/unit/sources/test_live_batch_support.py tests/unit/devtools/test_daemon_workload_probe.py` -> 43 passed.
- `devtools render all --check` -> sync OK.
- `git diff --check` -> clean.
- `devtools verify --quick` -> exit_code 0.
- Pre-push `devtools verify --quick` -> exit_code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress events now include clearer storage-route details for batch processing, making it easier to see whether files were handled through append-based or full ingestion paths.
  * Batch completion and cursor updates now carry summarized storage information when applicable.

* **Bug Fixes**
  * Improved consistency in progress reporting across append parsing, convergence, cursor update, and completion stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->