### PR TITLE
fix(devtools): use block rows for FTS gap plans

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -1904,17 +1904,17 @@ def _query_plans(conn: sqlite3.Connection, *, db: Path) -> dict[str, Any]:
                 "hazards": [item for item in plan if "SCAN c" in item],
                 "storage_route": "archive_file_set",
             }
-    if _table_exists(conn, "messages") and _table_exists(conn, "messages_fts_docsize"):
-        conv_row = conn.execute("SELECT session_id FROM messages LIMIT 1").fetchone()
+    if _table_exists(conn, "blocks") and _table_exists(conn, "messages_fts_docsize"):
+        conv_row = conn.execute("SELECT session_id FROM blocks LIMIT 1").fetchone()
         if conv_row is not None:
             plan = _explain(
                 conn,
                 """
                 SELECT COUNT(*)
-                FROM messages AS m
-                LEFT JOIN messages_fts_docsize AS d ON d.id = m.rowid
-                WHERE m.text IS NOT NULL
-                  AND m.session_id IN (?)
+                FROM blocks AS b
+                LEFT JOIN messages_fts_docsize AS d ON d.id = b.rowid
+                WHERE b.search_text != ''
+                  AND b.session_id IN (?)
                   AND d.id IS NULL
                 """,
                 (conv_row[0],),

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -125,6 +125,10 @@ def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -
     source_plan = payload["query_plans"]["source_path_lookup"]
     assert source_plan["hazards"] == []
     assert any("idx_raw_sessions_source_path" in item for item in source_plan["plan"])
+    fts_plan = payload["query_plans"]["message_fts_gap_probe"]
+    assert fts_plan["hazards"] == []
+    assert not any(item.startswith("unavailable:") for item in fts_plan["plan"])
+    assert any("blocks" in item for item in fts_plan["plan"])
 
 
 def test_daemon_workload_probe_defaults_to_estimated_table_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Workload diagnostics now explain the FTS gap probe against the current FTS contract: `blocks.search_text` indexed into `messages_fts`/`messages_fts_docsize` by `blocks.rowid`.

## Problem

Live dogfooding on 2026-06-24 showed `polylogue ops diagnostics workload --json` reporting `query_plans.message_fts_gap_probe.plan` as `unavailable: no such column: m.text`. That was stale diagnostics SQL: the archive no longer has `messages.text`; FTS indexes block `search_text` rows.

Ref #2308. Remaining #2308 scope is unchanged: broader live/browser-capture/runtime trust work continues separately.

## Solution

`devtools/daemon_workload_probe.py` now uses `blocks` plus `messages_fts_docsize` for the cheap EXPLAIN probe. The unit regression asserts the plan is available and references `blocks`, so stale message-text probes cannot silently return an unavailable plan again.

## Verification

- `devtools test tests/unit/devtools/test_daemon_workload_probe.py -k 'plan_shape or stable_top_level_shape'`
  - `2 passed, 16 deselected`
- Live production archive check:
  - `message_fts_gap_probe` now reports `hazards=[]`
  - plan: `SEARCH b USING INDEX idx_blocks_session_position (session_id=?)`, `SEARCH d USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the message search gap probe so it now checks the right data source and produces a more accurate query plan.
  * Reduced false alerts by avoiding missing-plan warnings for this check.

* **Tests**
  * Expanded coverage to verify the updated query plan includes the expected table and reports no hazards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->