### PR TITLE
perf(daemon): bound metrics route counting

### DIFF
--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -540,6 +540,12 @@ def _normalise_storage_route(value: object) -> str:
     return value if value in _KNOWN_STORAGE_ROUTES else "other"
 
 
+def _empty_storage_route_counts() -> dict[str, int]:
+    counts = dict.fromkeys(sorted(_KNOWN_STORAGE_ROUTES), 0)
+    counts["other"] = 0
+    return counts
+
+
 def _storage_route_counts(
     conn: sqlite3.Connection,
     *,
@@ -551,8 +557,7 @@ def _storage_route_counts(
         if ops_counts is not None:
             return ops_counts
 
-    counts = dict.fromkeys(sorted(_KNOWN_STORAGE_ROUTES), 0)
-    counts["other"] = 0
+    counts = _empty_storage_route_counts()
     if not _table_exists(conn, "live_ingest_attempt"):
         return counts
     columns = _columns(conn, "live_ingest_attempt")
@@ -576,32 +581,44 @@ def _ops_storage_route_counts(ops_db: Path) -> dict[str, int] | None:
         try:
             if not _table_exists(conn, "ingest_attempts"):
                 return None
-            attempt_rows = conn.execute("SELECT attempt_id FROM ingest_attempts").fetchall()
-            attempt_ids = [str(row[0]) for row in attempt_rows]
-            if not attempt_ids:
-                return None
-            counts = dict.fromkeys(sorted(_KNOWN_STORAGE_ROUTES), 0)
-            counts["other"] = 0
-            route_by_attempt: dict[str, str] = {}
-            if _table_exists(conn, "daemon_stage_events"):
-                placeholders = ",".join("?" for _ in attempt_ids)
+            counts = _empty_storage_route_counts()
+            attempt_columns = _columns(conn, "ingest_attempts")
+            if "storage_route" in attempt_columns:
                 rows = conn.execute(
-                    f"""
-                    SELECT attempt_id, payload_json
-                    FROM daemon_stage_events
-                    WHERE attempt_id IN ({placeholders})
-                    ORDER BY observed_at_ms DESC, rowid DESC
-                    """,
-                    tuple(attempt_ids),
+                    "SELECT storage_route, COUNT(*) FROM ingest_attempts GROUP BY storage_route"
                 ).fetchall()
                 for row in rows:
-                    attempt_id = str(row[0])
-                    if attempt_id in route_by_attempt:
-                        continue
-                    route_by_attempt[attempt_id] = _normalise_storage_route(_json_payload(row[1]).get("storage_route"))
-            for attempt_id in attempt_ids:
-                route = route_by_attempt.get(attempt_id, "unknown")
-                counts[route] = counts.get(route, 0) + 1
+                    route = _normalise_storage_route(row[0])
+                    counts[route] = counts.get(route, 0) + int(row[1] or 0)
+                return counts
+
+            total_attempts = _scalar_int(conn, "SELECT COUNT(*) FROM ingest_attempts")
+            if not _table_exists(conn, "daemon_stage_events"):
+                counts["unknown"] = total_attempts
+                return counts
+            index_names = {str(row[1]) for row in conn.execute("PRAGMA index_list('daemon_stage_events')")}
+            if "idx_daemon_stage_events_attempt_observed" not in index_names:
+                counts["unknown"] = total_attempts
+                return counts
+
+            rows = conn.execute(
+                """
+                SELECT (
+                    SELECT payload_json
+                    FROM daemon_stage_events AS e
+                    WHERE e.attempt_id = a.attempt_id
+                      AND e.payload_json LIKE '%"storage_route"%'
+                    ORDER BY e.observed_at_ms DESC, e.rowid DESC
+                    LIMIT 1
+                ) AS payload_json,
+                COUNT(*)
+                FROM ingest_attempts AS a
+                GROUP BY payload_json
+                """
+            ).fetchall()
+            for row in rows:
+                route = _normalise_storage_route(_json_payload(row[0]).get("storage_route"))
+                counts[route] = counts.get(route, 0) + int(row[1] or 0)
             return counts
         finally:
             conn.close()

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -175,6 +175,17 @@ def _archive_attempt_status(status: str) -> str:
     return "failed"
 
 
+def _storage_route_from_payload(payload: dict[str, object] | None) -> str | None:
+    if not payload:
+        return None
+    route = payload.get("storage_route")
+    return route if isinstance(route, str) and route else None
+
+
+def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(str(row[1]) == column for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
 def _convergence_debt_status(*, stage: str, error: str | None) -> str:
     if stage == "insights" and error == _INSIGHT_DEFERRED_UNTIL_QUIET:
         return "deferred"
@@ -504,34 +515,64 @@ class CursorStore:
         parsed_raw_count = succeeded_file_count if succeeded_file_count is not None else None
         if parsed_raw_count is None and failed_file_count is not None:
             parsed_raw_count = failed_file_count
+        storage_route = _storage_route_from_payload(stage_payload)
 
         def write() -> None:
             with self._connect_ops() as conn:
-                conn.execute(
-                    """
-                    UPDATE ingest_attempts
-                    SET heartbeat_at_ms = ?,
-                        status = ?,
-                        phase = ?,
-                        source_path = COALESCE(?, source_path),
-                        origin = COALESCE(?, origin),
-                        parsed_raw_count = COALESCE(?, parsed_raw_count),
-                        materialized_count = COALESCE(?, materialized_count),
-                        error_message = COALESCE(?, error_message)
-                    WHERE attempt_id = ?
-                    """,
-                    (
-                        now_ms,
-                        _archive_attempt_status(status),
-                        phase,
-                        str(current_path) if current_path is not None else None,
-                        _origin_value_for_source_name(current_source),
-                        parsed_raw_count,
-                        succeeded_file_count,
-                        error,
-                        attempt_id,
-                    ),
-                )
+                if _table_has_column(conn, "ingest_attempts", "storage_route"):
+                    conn.execute(
+                        """
+                        UPDATE ingest_attempts
+                        SET heartbeat_at_ms = ?,
+                            status = ?,
+                            phase = ?,
+                            storage_route = COALESCE(?, storage_route),
+                            source_path = COALESCE(?, source_path),
+                            origin = COALESCE(?, origin),
+                            parsed_raw_count = COALESCE(?, parsed_raw_count),
+                            materialized_count = COALESCE(?, materialized_count),
+                            error_message = COALESCE(?, error_message)
+                        WHERE attempt_id = ?
+                        """,
+                        (
+                            now_ms,
+                            _archive_attempt_status(status),
+                            phase,
+                            storage_route,
+                            str(current_path) if current_path is not None else None,
+                            _origin_value_for_source_name(current_source),
+                            parsed_raw_count,
+                            succeeded_file_count,
+                            error,
+                            attempt_id,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        UPDATE ingest_attempts
+                        SET heartbeat_at_ms = ?,
+                            status = ?,
+                            phase = ?,
+                            source_path = COALESCE(?, source_path),
+                            origin = COALESCE(?, origin),
+                            parsed_raw_count = COALESCE(?, parsed_raw_count),
+                            materialized_count = COALESCE(?, materialized_count),
+                            error_message = COALESCE(?, error_message)
+                        WHERE attempt_id = ?
+                        """,
+                        (
+                            now_ms,
+                            _archive_attempt_status(status),
+                            phase,
+                            str(current_path) if current_path is not None else None,
+                            _origin_value_for_source_name(current_source),
+                            parsed_raw_count,
+                            succeeded_file_count,
+                            error,
+                            attempt_id,
+                        ),
+                    )
                 payload: dict[str, object] = {
                     key: value
                     for key, value in {

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS ingest_attempts (
     origin                 TEXT CHECK ({check("origin", Origin)} OR origin IS NULL),
     status                 TEXT NOT NULL CHECK(status IN ('running', 'completed', 'failed', 'interrupted')),
     phase                  TEXT,
+    storage_route          TEXT,
     started_at_ms          INTEGER NOT NULL,
     heartbeat_at_ms        INTEGER,
     finished_at_ms         INTEGER,
@@ -48,6 +49,9 @@ CREATE TABLE IF NOT EXISTS ingest_attempts (
 
 CREATE INDEX IF NOT EXISTS idx_ingest_attempts_status
 ON ingest_attempts(status, heartbeat_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_attempts_storage_route
+ON ingest_attempts(storage_route);
 
 CREATE TABLE IF NOT EXISTS convergence_debt (
     debt_id        TEXT PRIMARY KEY,
@@ -91,6 +95,9 @@ CREATE TABLE IF NOT EXISTS daemon_stage_events (
     observed_at_ms INTEGER NOT NULL,
     payload_json   TEXT NOT NULL DEFAULT '{{}}'
 ) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_daemon_stage_events_attempt_observed
+ON daemon_stage_events(attempt_id, observed_at_ms DESC);
 
 CREATE TABLE IF NOT EXISTS daemon_events (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -184,19 +184,30 @@ def record_ingest_attempt(
     materialized_count: int = 0,
     error_message: str | None = None,
     source_paths_json: str = "[]",
+    storage_route: str | None = None,
     attempt_id: str | None = None,
 ) -> str:
     """Create or replace one ``ingest_attempts`` row and return its ``attempt_id``."""
     if attempt_id is None:
         attempt_id = str(uuid.uuid4())
+    has_storage_route = _table_has_column(conn, "ingest_attempts", "storage_route")
+    route_column = "storage_route,\n            " if has_storage_route else ""
+    route_value = "?, " if has_storage_route else ""
+    route_update = (
+        "storage_route = COALESCE(excluded.storage_route, ingest_attempts.storage_route),\n            "
+        if has_storage_route
+        else ""
+    )
+    route_params: tuple[object, ...] = (storage_route,) if has_storage_route else ()
     conn.execute(
-        """
+        f"""
         INSERT INTO ingest_attempts (
             attempt_id,
             source_path,
             origin,
             status,
             phase,
+            {route_column}
             started_at_ms,
             heartbeat_at_ms,
             finished_at_ms,
@@ -205,12 +216,13 @@ def record_ingest_attempt(
             error_message,
             source_paths_json
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, {route_value}?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (attempt_id) DO UPDATE SET
             source_path = excluded.source_path,
             origin = excluded.origin,
             status = excluded.status,
             phase = excluded.phase,
+            {route_update}
             started_at_ms = excluded.started_at_ms,
             heartbeat_at_ms = excluded.heartbeat_at_ms,
             finished_at_ms = excluded.finished_at_ms,
@@ -225,6 +237,7 @@ def record_ingest_attempt(
             _origin_value(origin),
             status,
             phase,
+            *route_params,
             started_at_ms,
             heartbeat_at_ms,
             finished_at_ms,
@@ -712,6 +725,10 @@ def _origin_value(origin: Origin | str | None) -> str | None:
     if isinstance(origin, Origin):
         return origin.value
     return origin
+
+
+def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(str(row[1]) == column for row in conn.execute(f"PRAGMA table_info({table})"))
 
 
 def _stage_event_from_row(row: sqlite3.Row | tuple[object, ...]) -> ArchiveDaemonStageEvent:

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -432,6 +432,7 @@ class TestFormatMetricsReadsArchiveState:
                 status="running",
                 started_at_ms=1_770_000_000_000,
                 heartbeat_at_ms=1_770_000_001_000,
+                storage_route="archive_full",
             )
             record_ingest_attempt(
                 conn,

--- a/tests/unit/storage/test_archive_tiers_ops_write.py
+++ b/tests/unit/storage/test_archive_tiers_ops_write.py
@@ -84,15 +84,21 @@ def test_record_ingest_attempt_records_one_row(tmp_path: Path) -> None:
         parsed_raw_count=7,
         materialized_count=3,
         source_paths_json='["/tmp/source-a.jsonl"]',
+        storage_route="archive_append",
     )
 
     row = conn.execute(
-        "SELECT status, phase, parsed_raw_count, source_paths_json FROM ingest_attempts WHERE attempt_id = ?",
+        """
+        SELECT status, phase, parsed_raw_count, source_paths_json, storage_route
+        FROM ingest_attempts
+        WHERE attempt_id = ?
+        """,
         (attempt_id,),
     ).fetchone()
     assert row is not None
     assert row[0] == "running"
     assert row[1] == "planning"
+    assert row[4] == "archive_append"
     assert row[2] == 7
     assert row[3] == '["/tmp/source-a.jsonl"]'
     assert conn.execute("SELECT COUNT(*) FROM ingest_attempts").fetchone()[0] == 1


### PR DESCRIPTION
## Summary

Metrics storage-route attribution now uses typed ops attempt state instead of reconstructing route counts from every daemon stage-event payload during each scrape.

## Problem

Live dogfooding on 2026-06-24 showed `/metrics` taking around 1.1s on repeated scrapes, with an earlier sample above 5s. Section timing against the production archive isolated the slow path to `_storage_route_counts`: it loaded all 33k ingest attempt ids and scanned 370k stage-event payloads to infer storage routes.

Ref #2308. Remaining #2308 scope continues in live/runtime trust and browser-capture work; this PR only removes this scrape-time reconstruction path.

## Solution

- Add backward-compatible `storage_route` telemetry to ops-tier `ingest_attempts` without changing the ops tier version.
- Add indexes for route grouping and legacy route-bearing event lookup.
- Make `record_ingest_attempt` and `CursorStore.update_ingest_attempt` populate `storage_route` when the column is available, while keeping old ops DBs usable.
- Make `/metrics` prefer `ingest_attempts.storage_route`; for old DBs it avoids an unindexed event-log scan and reports unknown rows rather than turning the scrape into an archive reconstruction job.

Production note: the live `ops.db` was compatibly altered/backfilled after source verification: `storage_route` column plus the two indexes were added, latest route-bearing stage events were backfilled, and `PRAGMA user_version` remains `1` for compatibility with the currently deployed daemon until this branch is deployed.

## Verification

- `devtools test tests/unit/daemon/test_metrics_endpoint.py tests/unit/storage/test_archive_tiers_ops_write.py -k 'live_ingest_metrics_prefer_archive_ops_when_present or record_ingest_attempt_records_one_row'`
  - `2 passed, 32 deselected`
- `devtools verify --quick`
  - exit code 0
- pre-push `devtools verify --quick`
  - exit code 0 after amended push
- Live source timing against `/home/sinity/.local/share/polylogue/index.db` after production ops backfill:
  - `_storage_route_counts`: `0.0033s`
  - `format_metrics`: `0.2508s`
- Still-deployed route remains around `1.14s`, as expected, until this PR is deployed.
