### PR TITLE
perf(watcher): skip tail reads for stat-stable cursors

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -471,6 +471,8 @@ class LiveWatcher:
             # catch-up skip path. Device/inode churn across bind mounts,
             # restored homes, or filesystem rebuilds must not force a full
             # content rehash of every historical session file.
+            if _cursor_stat_matches(cursor, stat):
+                return False
             if cursor.tail_hash is None:
                 return False
             try:
@@ -730,6 +732,12 @@ def _parse_retry_at(next_retry_at: str | None) -> datetime | None:
     if retry_at.tzinfo is None:
         retry_at = retry_at.replace(tzinfo=UTC)
     return retry_at
+
+
+def _cursor_stat_matches(cursor: CursorRecord, stat: os.stat_result) -> bool:
+    """Return True when the cursor was written for this exact file state."""
+
+    return cursor.st_dev == stat.st_dev and cursor.st_ino == stat.st_ino and cursor.mtime_ns == stat.st_mtime_ns
 
 
 __all__ = ["LiveWatcher", "WatchSource", "default_sources"]

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -820,7 +820,11 @@ def test_unchanged_file_uses_stat_fast_path_without_fingerprint_read(
     def fail_fingerprint(path: Path) -> tuple[str, int]:
         raise AssertionError(f"unchanged file should not be fingerprinted: {path}")
 
+    def fail_tail_hash(path: Path, size: int) -> tuple[str, int]:
+        raise AssertionError(f"stat-stable unchanged file should not read tail hash: {path} ({size})")
+
     monkeypatch.setattr(live_watcher, "fingerprint_file", fail_fingerprint)
+    monkeypatch.setattr(live_watcher, "tail_hash_from_path", fail_tail_hash)
 
     assert watcher._needs_work(f) is False
 


### PR DESCRIPTION
## Summary

Reduce daemon restart catch-up I/O by letting live watcher cursor rows prove that an unchanged source file needs no tail-hash read when the stored `(dev, inode, mtime_ns)` tuple still matches the current file stat.

## Problem

Live evidence from the deployed daemon on 2026-06-24 showed every restart scanning 13,136 watched files before returning to normal watching. The active append file handling was correct, but stable historical files could still be opened for bounded tail-hash checks even when the cursor row described the exact current file state. On short live runs this showed up as 1.2-1.4 GB memory peaks and 1.6-2.4 GB disk reads around startup/catch-up.

Ref #2308.

## Solution

`LiveWatcher._needs_work_from_state` now treats same-size, same-parser cursor rows with a content fingerprint and a matching stat tuple as complete no-work evidence. The existing tail-hash path remains active for copied, restored, touched, or otherwise stat-changed files, preserving same-size rewrite detection without full-file hashing.

A focused unit test now fails if a stat-stable unchanged file attempts either full fingerprinting or bounded tail-hash reads.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k 'unchanged_file_uses_stat_fast_path or same_size_rewrite_uses_tail_hash or legacy_same_size_cursor_without_tail_hash'` -> `1 passed, 70 deselected`
- `devtools test tests/integration/test_live_read_amplification.py -k 'MtimeDriftCatchUp or RestartedCursorReconcile or CatchUpDoesNotRehash'` -> `2 passed, 4 deselected`
- `devtools verify --quick` -> passed, run `20260624T121248Z-quick-2507200-67c47a17`
- pre-push `devtools verify --quick` -> passed, run `20260624T121334Z-quick-2508320-98983283`
