### PR TITLE
test(browser-capture): pin native payload coalescing

### DIFF
--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -106,6 +106,41 @@ browser-capture payloads. Route metadata lives in
 `polylogue/browser_capture/route_contracts.py` so tests and future OpenAPI/web
 surfaces do not infer receiver DTO or auth semantics from handler branches.
 
+## Provider payloads and coalescing
+
+Browser capture is an acquisition path for the same provider sessions that
+GDPR/Takeout-style imports already store. It must not create a duplicate
+session merely because the evidence arrived through an extension.
+
+| Provider/path | Adapter or source | Stored payload | Parser path | Coalescing key |
+| --- | --- | --- | --- | --- |
+| ChatGPT authenticated page | `chatgpt-native-v1` | Full `/backend-api/conversation/<id>` JSON under `raw_provider_payload` | delegated to the normal ChatGPT parser | `chatgpt-export:<conversation_id or id>` |
+| ChatGPT authenticated page fallback | `chatgpt-dom-v1` | Visible turns in the browser-capture envelope | browser-capture DOM parser | `chatgpt-export:<url /c/<id>>` |
+| ChatGPT GDPR/export file | provider import | Export JSON `mapping` payload | normal ChatGPT parser | `chatgpt-export:<conversation_id or id>` |
+| ChatGPT shared-link helper | standalone public-share script | React Router share stream reduced to export-shaped messages | separate conversion input, not the extension payload | provider-native share conversation id when converted |
+| Claude.ai authenticated page | `claude-ai-dom-v1` today | Visible turns in the browser-capture envelope | browser-capture DOM parser | `claude-ai-export:<url /chat/<id>>` |
+| Claude.ai native/export payload | provider import or future adapter | `chat_messages` payload under provider import or `raw_provider_payload` | delegated to the normal Claude.ai parser | `claude-ai-export:<uuid>` |
+
+The ChatGPT content script hooks same-origin fetches for authenticated
+conversation JSON and keeps only a bounded recent window in page memory. On
+capture it sends that provider-native JSON as `raw_provider_payload`; the
+browser-capture parser then delegates to the same ChatGPT parser used by direct
+imports. This is the preferred path because it preserves branches, current
+node, message ids, timestamps, model metadata, attachments, and other fields the
+visible DOM cannot reliably expose.
+
+DOM extraction is a compatibility fallback for pages where no provider-native
+payload has been observed yet. It still uses the provider-native conversation id
+from the URL, so a later native capture or GDPR import for the same conversation
+updates the same archive session instead of creating a second visible session.
+Fallback DOM captures are therefore acceptable as temporary live evidence, but
+not as a reason to prefer DOM over a clean provider payload.
+
+The Claude.ai parser already accepts native `chat_messages` payloads through
+`raw_provider_payload`, and archive tests pin coalescing with direct Claude.ai
+imports. The shipped extension adapter is still DOM-only, so native Claude.ai
+fetch capture remains a fidelity residual rather than a parser/storage gap.
+
 ## Local auth and origin policy
 
 Default CORS is extension-only: `chrome-extension://*`. Remote web origins such

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -125,6 +125,56 @@ def test_browser_capture_prefers_raw_chatgpt_payload_when_present() -> None:
     assert session.messages[1].blocks[0].type.value == "code"
 
 
+def test_browser_capture_raw_chatgpt_payload_matches_direct_import_identity() -> None:
+    raw_payload = {
+        "conversation_id": "native-conv",
+        "title": "Native ChatGPT title",
+        "create_time": 1781442866.0,
+        "update_time": 1781442966.0,
+        "current_node": "assistant-node",
+        "mapping": {
+            "root": {"id": "root", "message": None, "parent": None, "children": ["user-node"]},
+            "user-node": {
+                "id": "user-node",
+                "parent": "root",
+                "children": ["assistant-node"],
+                "message": {
+                    "id": "native-u1",
+                    "author": {"role": "user"},
+                    "create_time": 1781442870.0,
+                    "content": {"content_type": "text", "parts": ["Native user text"]},
+                    "metadata": {},
+                },
+            },
+            "assistant-node": {
+                "id": "assistant-node",
+                "parent": "user-node",
+                "children": [],
+                "message": {
+                    "id": "native-a1",
+                    "author": {"role": "assistant"},
+                    "create_time": 1781442880.0,
+                    "content": {"content_type": "text", "parts": ["Native answer text"]},
+                    "metadata": {},
+                },
+            },
+        },
+    }
+    payload = _capture_payload()
+    payload["raw_provider_payload"] = raw_payload
+
+    direct_session = parse_payload(Provider.CHATGPT, raw_payload, "direct-fallback")[0]
+    captured_session = parse_payload(Provider.CHATGPT, payload, "capture-fallback")[0]
+
+    assert captured_session.provider_session_id == direct_session.provider_session_id == "native-conv"
+    assert captured_session.title == direct_session.title == "Native ChatGPT title"
+    assert (
+        [message.provider_message_id for message in captured_session.messages]
+        == [message.provider_message_id for message in direct_session.messages]
+        == ["native-u1", "native-a1"]
+    )
+
+
 def test_browser_capture_raw_chatgpt_without_id_uses_envelope_session_id() -> None:
     payload = _capture_payload()
     payload["raw_provider_payload"] = {


### PR DESCRIPTION
## Summary

Adds a narrow browser-capture regression test and documentation for how provider-native browser payloads coalesce with direct provider imports.

## Problem

Live browser capture currently depends on a precise but under-documented boundary: ChatGPT authenticated captures should use the backend conversation payload when available, and that payload must land on the same archive session identity as a direct ChatGPT export/import. Without this contract written down, DOM fallback, shared-link helper output, GDPR exports, and future Claude.ai native capture are easy to blur together.

## Solution

- Added a ChatGPT parser regression showing a browser-capture envelope with `raw_provider_payload.conversation_id` normalizes to the same `provider_session_id`, title, and message ids as direct ChatGPT parsing.
- Documented the provider payload/coalescing matrix for ChatGPT native capture, ChatGPT DOM fallback, ChatGPT GDPR/direct import, shared-link helper input, Claude.ai DOM capture, and Claude.ai native/export payloads.
- Called out the current Claude.ai adapter residual: parser/storage support native `chat_messages`, but the shipped extension adapter is still DOM-only.

Ref #2308.

## Verification

- `devtools test tests/unit/sources/test_browser_capture.py -k 'raw_chatgpt_payload_matches_direct_import_identity or raw_payload_coalesces_with_chatgpt_export or raw_payload_coalesces_with_claude_ai_export'` -> 3 passed, 17 deselected.
- `devtools verify --quick` -> passed, run `20260624T122223Z-quick-2523494-a767b741`.
- Push hook `devtools verify --quick` -> passed, run `20260624T122304Z-quick-2524563-3767dddc`.