### PR TITLE
fix(cli): accept post-verb json output alias

### DIFF
--- a/polylogue/cli/query_group.py
+++ b/polylogue/cli/query_group.py
@@ -77,12 +77,13 @@ def _split_query_mode_args(group: click.Group, args: list[str]) -> tuple[list[st
                 query_terms.append(arg)
                 index += 1
                 continue
-            misplaced = _find_root_option_after_verb(group, arg, list(args[index + 1 :]))
+            remaining = _normalize_post_verb_output_aliases(group.commands.get(arg), list(args[index + 1 :]))
+            misplaced = _find_root_option_after_verb(group, arg, remaining)
             if misplaced is not None:
                 raise click.UsageError(
                     f"Query filters and root output flags must appear before the verb. Move {misplaced} before `{arg}`."
                 )
-            verb_args = option_args + [arg] + list(args[index + 1 :])
+            verb_args = option_args + [arg] + remaining
             return verb_args, tuple(query_terms), True, explicit_query
         query_terms.append(arg)
         index += 1
@@ -204,6 +205,23 @@ def _command_options_for_remaining(command: click.Command, remaining: list[str])
         current = current.get_command(ctx, next_token)
         index += 1
     return opts
+
+
+def _normalize_post_verb_output_aliases(command: click.Command | None, remaining: list[str]) -> list[str]:
+    """Normalize root output shorthands that users naturally place after a verb."""
+
+    if command is None or "--json" not in remaining:
+        return remaining
+    command_opts = _command_options_for_remaining(command, remaining)
+    if "--format" not in command_opts or "--json" in command_opts:
+        return remaining
+    normalized: list[str] = []
+    for arg in remaining:
+        if arg == "--json":
+            normalized.extend(["--format", "json"])
+        else:
+            normalized.append(arg)
+    return normalized
 
 
 def _detect_subcommand_and_verb(group: click.Group, args: list[str]) -> tuple[str | None, str | None]:

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -9,6 +9,7 @@ from typing import cast
 from unittest.mock import patch
 
 import click
+import pytest
 from click.testing import CliRunner
 from rich.console import Console
 
@@ -119,6 +120,25 @@ def test_virtual_find_counterpart_is_query_parser_keyword() -> None:
     assert query_terms == ("needle",)
     assert not has_subcommand
     assert explicit_query
+
+
+def test_post_verb_json_alias_normalizes_to_verb_format() -> None:
+    """`read REF --json` is accepted as the natural spelling of `read REF --format json`."""
+    click_args, query_terms, has_subcommand, explicit_query = _split_query_mode_args(
+        cli,
+        ["read", "chatgpt-export:conv-123", "--json"],
+    )
+
+    assert click_args == ["read", "chatgpt-export:conv-123", "--format", "json"]
+    assert query_terms == ()
+    assert has_subcommand
+    assert not explicit_query
+
+
+def test_post_verb_root_filters_remain_rejected() -> None:
+    """Output shorthands can be local aliases; source/query filters still precede the verb."""
+    with pytest.raises(click.UsageError, match="Move --origin before `read`"):
+        _split_query_mode_args(cli, ["read", "chatgpt-export:conv-123", "--origin", "chatgpt-export"])
 
 
 def test_every_declared_guard_has_behavior_coverage() -> None:


### PR DESCRIPTION
## Summary

Accepts `--json` after query/action verbs that already expose `--format json`, starting with the dogfooded `polylogue read <ref> --json` shape.

## Problem

A live find-then-read dogfood run succeeded until the natural `polylogue read <session> --json` spelling hit the query-first parser boundary. The command already supports JSON output as `read <session> --format json`, and root `--json read <session>` also works, but placing the output-format flag after the verb produced a usage error. That is unnecessary friction in the action grammar.

## Solution

The query-first parser now normalizes post-verb `--json` into `--format json` when the target verb exposes `--format`. Root query/source filters remain strict: `read <ref> --origin ...` still errors and tells the user to move the filter before `read`.

Ref #2006.
Ref #2317.

## Verification

- `devtools test tests/unit/cli/test_cli_action_contracts.py -k 'post_verb_json_alias_normalizes_to_verb_format or post_verb_root_filters_remain_rejected'` -> 2 passed, 28 deselected.
- `devtools verify --quick` -> passed, run `20260624T123714Z-quick-2560095-2cc8f0ca`.
- Push hook `devtools verify --quick` -> passed, run `20260624T123812Z-quick-2560868-7f8417fc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shorthand `--json` option after certain CLI verbs, automatically treating it as `--format json` where supported.
* **Bug Fixes**
  * Improved command parsing so misplaced root options after a verb are still flagged with a clear error message.
  * Made verb argument handling more consistent when normalizing output format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->