### PR TITLE
test(cli): cover json alias across query actions

### DIFF
--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -135,6 +135,50 @@ def test_post_verb_json_alias_normalizes_to_verb_format() -> None:
     assert not explicit_query
 
 
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (
+            ["find", "needle", "then", "read", "--json"],
+            ["read", "--format", "json"],
+        ),
+        (
+            ["find", "needle", "then", "continue", "--json"],
+            ["continue", "--format", "json"],
+        ),
+        (
+            ["find", "needle", "then", "delete", "--dry-run", "--json"],
+            ["delete", "--dry-run", "--format", "json"],
+        ),
+        (
+            ["find", "needle", "then", "mark", "--tag-add", "reviewed", "--json"],
+            ["mark", "--tag-add", "reviewed", "--format", "json"],
+        ),
+        (
+            ["find", "needle", "then", "mark", "candidates", "list", "--json"],
+            ["mark", "candidates", "list", "--format", "json"],
+        ),
+        (
+            ["analyze", "usage", "--json"],
+            ["analyze", "usage", "--format", "json"],
+        ),
+        (
+            ["analyze", "insights", "profiles", "--json"],
+            ["analyze", "insights", "profiles", "--format", "json"],
+        ),
+    ],
+)
+def test_post_verb_json_alias_normalizes_for_all_format_actions(
+    argv: list[str],
+    expected: list[str],
+) -> None:
+    """Post-verb ``--json`` is a grammar alias for every action with ``--format json``."""
+    click_args, _, has_subcommand, _ = _split_query_mode_args(cli, argv)
+
+    assert click_args == expected
+    assert has_subcommand
+
+
 def test_post_verb_root_filters_remain_rejected() -> None:
     """Output shorthands can be local aliases; source/query filters still precede the verb."""
     with pytest.raises(click.UsageError, match="Move --origin before `read`"):


### PR DESCRIPTION
## Summary

Adds regression coverage proving the query-action parser treats post-verb `--json` as the natural alias for `--format json` across all query actions and nested action paths that expose JSON format output.

## Problem

The live dogfood fix for `polylogue read <session> --json` was implemented generically, but the regression test only covered direct `read` refs. That left the broader product grammar under-specified for `find QUERY then ACTION` workflows.

## Solution

Added a parametrized CLI contract test covering `read`, `continue`, `delete`, `mark`, `mark candidates list`, `analyze usage`, and `analyze insights profiles`. The existing test still proves root filters such as `--origin` remain rejected after the verb.

## Verification

- `devtools test tests/unit/cli/test_cli_action_contracts.py -k 'post_verb_json_alias'` -> 8 passed, 29 deselected.
- `devtools verify --quick` -> passed, run `20260624T125000Z-quick-2585034-420da621`.
- pre-push `devtools verify --quick` -> passed, run `20260624T125034Z-quick-2585547-2da69d3f`.

Ref #2006
Ref #2317
