### PR TITLE
feat(cli): expose json aliases on action commands

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -242,6 +242,7 @@ Options:
   --include-deferred              With --facets, compute deferred detail
                                   families: repos, roles, material origins,
                                   message types, actions, flags.
+  --json                          Shortcut for --format json.
   -f, --format [markdown|json|ndjson|html|obsidian|org|yaml|plaintext|csv]
                                   Output format (ndjson = one JSON document
                                   per row, streaming-friendly)
@@ -295,6 +296,7 @@ Options:
                                   [default: summary]
   --to [terminal|stdout|browser|clipboard|file]
                                   Output destination.  [default: terminal]
+  --json                          Shortcut for --format json.
   -f, --format [csv|html|json|markdown|ndjson|obsidian|org|plaintext|text|yaml]
                                   Output format (where applicable).
   --out PATH                      File path for --to file.
@@ -387,6 +389,7 @@ Options:
   --dry-run        Preview what would be deleted without deleting
   --yes            Confirm the deletion (required for actual deletion)
   --all            Delete all matched sessions (required when multiple match)
+  --json           Shortcut for --format json.
   --format [json]  Output format. JSON emits a MutationResultPayload.
   --help           Show this message and exit.
 ```
@@ -428,6 +431,7 @@ Options:
   --note TEXT       Add or update a note annotation
   --all             Apply to all matched sessions (default: singleton only)
   --first           Apply to the first matched session only
+  --json            Shortcut for --format json.
   --format [json]   Output format. JSON emits a MutationResultPayload.
   --help            Show this message and exit.
 
@@ -486,6 +490,7 @@ Options:
                                   Repeatable.
   --limit INTEGER                 Maximum continuation candidates to return.
                                   [default: 10]
+  --json                          Shortcut for --format json.
   -f, --format [json]             Output format. JSON emits the shared
                                   ContextImage payload.
   --help                          Show this message and exit.

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -225,6 +225,13 @@ async def _turns(env: AppEnv, session_id: str, limit: int) -> None:
     help="Max diagnostic session IDs to include per sample family.",
 )
 @click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",

--- a/polylogue/cli/commands/insights.py
+++ b/polylogue/cli/commands/insights.py
@@ -91,6 +91,14 @@ def _build_click_params(pt: InsightType) -> list[click.Parameter]:
     )
     params.append(
         click.Option(
+            ("--json", "output_format"),
+            flag_value="json",
+            default=None,
+            help="Shortcut for --format json.",
+        )
+    )
+    params.append(
+        click.Option(
             ("--format", "-f", "output_format"),
             type=click.Choice(["json"]),
             default=None,
@@ -262,6 +270,7 @@ def _render_export_plain(result: InsightExportBundleResult) -> None:
 @click.option("--origin", "-o", default=None, help="Limit origin coverage details to one origin.")
 @click.option("--since", default=None, help="Limit coverage details to rows at/after this timestamp or date.")
 @click.option("--until", default=None, help="Limit coverage details to rows at/before this timestamp or date.")
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
 @click.pass_context
 def insights_status_command(
@@ -309,6 +318,7 @@ def insights_status_command(
 @click.option("--since", default=None, help="Limit supported insights to rows at/after this timestamp or date.")
 @click.option("--until", default=None, help="Limit supported insights to rows at/before this timestamp or date.")
 @click.option("--bundle-format", type=click.Choice(["jsonl"]), default="jsonl", show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
 @click.option(
     "--overwrite", is_flag=True, help="Replace an existing bundle directory after writing a complete new one."
@@ -412,6 +422,13 @@ def _render_audit_plain(report: InsightRigorAuditReport) -> None:
     help="Maximum rows per product to sample for the rigor profile.",
 )
 @click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -448,6 +465,13 @@ def insights_audit_command(
 
 @analyze_insights_command.command("timeline")
 @click.argument("session_id")
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
 @click.option(
     "--format",
     "-f",

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -419,6 +419,13 @@ def select_verb(ctx: click.Context, limit: int, print_field: str, json_output: b
     help="Output destination.",
 )
 @click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -737,6 +744,13 @@ def read_verb(
     help="Maximum continuation candidates to return.",
 )
 @click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -846,6 +860,13 @@ def continue_verb(
 @click.option("--yes", "yes_flag", is_flag=True, help="Confirm the deletion (required for actual deletion)")
 @click.option("--all", "all_flag", is_flag=True, help="Delete all matched sessions (required when multiple match)")
 @click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
+@click.option(
     "--format",
     "output_format",
     type=click.Choice(["json"]),
@@ -940,6 +961,13 @@ def delete_verb(
 @click.option("--note", "note_text", default=None, metavar="TEXT", help="Add or update a note annotation")
 @click.option("--all", "apply_all", is_flag=True, help="Apply to all matched sessions (default: singleton only)")
 @click.option("--first", "first_only", is_flag=True, help="Apply to the first matched session only")
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
+)
 @click.option(
     "--format",
     "output_format",
@@ -1100,6 +1128,7 @@ def mark_candidates_group() -> None:
 @mark_candidates_group.command("list")
 @click.option("--target-ref", default=None, help="Limit candidates to one target object ref.")
 @click.option("--limit", "-l", type=int, default=50, show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def list_mark_candidates_command(env: AppEnv, target_ref: str | None, limit: int, output_format: str | None) -> None:
@@ -1122,6 +1151,7 @@ def list_mark_candidates_command(env: AppEnv, target_ref: str | None, limit: int
 @mark_candidates_group.command("review")
 @click.option("--target-ref", default=None, help="Limit candidate review rows to one target object ref.")
 @click.option("--limit", "-l", type=int, default=50, show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def review_mark_candidates_command(env: AppEnv, target_ref: str | None, limit: int, output_format: str | None) -> None:
@@ -1161,6 +1191,7 @@ def review_mark_candidates_command(env: AppEnv, target_ref: str | None, limit: i
 @click.argument("candidate_ref")
 @click.option("--reason", default=None)
 @click.option("--actor-ref", default="user:local", show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def accept_mark_candidate_command(
@@ -1185,6 +1216,7 @@ def accept_mark_candidate_command(
 @click.argument("candidate_ref")
 @click.option("--reason", required=True)
 @click.option("--actor-ref", default="user:local", show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def reject_mark_candidate_command(
@@ -1209,6 +1241,7 @@ def reject_mark_candidate_command(
 @click.argument("candidate_ref")
 @click.option("--reason", default=None)
 @click.option("--actor-ref", default="user:local", show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def defer_mark_candidate_command(
@@ -1235,6 +1268,7 @@ def defer_mark_candidate_command(
 @click.option("--body", "replacement_body_text", required=True, help="Body text for the replacement assertion.")
 @click.option("--reason", default=None)
 @click.option("--actor-ref", default="user:local", show_default=True)
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
 @click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_obj
 def supersede_mark_candidate_command(
@@ -1326,6 +1360,13 @@ def _emit_candidate_judgment(
     is_flag=True,
     default=False,
     help="With --facets, compute deferred detail families: repos, roles, material origins, message types, actions, flags.",
+)
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Shortcut for --format json.",
 )
 @click.option(
     "--format",

--- a/tests/unit/cli/test_cli_action_contracts.py
+++ b/tests/unit/cli/test_cli_action_contracts.py
@@ -122,14 +122,14 @@ def test_virtual_find_counterpart_is_query_parser_keyword() -> None:
     assert explicit_query
 
 
-def test_post_verb_json_alias_normalizes_to_verb_format() -> None:
-    """`read REF --json` is accepted as the natural spelling of `read REF --format json`."""
+def test_post_verb_json_alias_is_owned_by_verb_format_option() -> None:
+    """`read REF --json` is accepted as a verb-local output alias."""
     click_args, query_terms, has_subcommand, explicit_query = _split_query_mode_args(
         cli,
         ["read", "chatgpt-export:conv-123", "--json"],
     )
 
-    assert click_args == ["read", "chatgpt-export:conv-123", "--format", "json"]
+    assert click_args == ["read", "chatgpt-export:conv-123", "--json"]
     assert query_terms == ()
     assert has_subcommand
     assert not explicit_query
@@ -140,39 +140,39 @@ def test_post_verb_json_alias_normalizes_to_verb_format() -> None:
     [
         (
             ["find", "needle", "then", "read", "--json"],
-            ["read", "--format", "json"],
+            ["read", "--json"],
         ),
         (
             ["find", "needle", "then", "continue", "--json"],
-            ["continue", "--format", "json"],
+            ["continue", "--json"],
         ),
         (
             ["find", "needle", "then", "delete", "--dry-run", "--json"],
-            ["delete", "--dry-run", "--format", "json"],
+            ["delete", "--dry-run", "--json"],
         ),
         (
             ["find", "needle", "then", "mark", "--tag-add", "reviewed", "--json"],
-            ["mark", "--tag-add", "reviewed", "--format", "json"],
+            ["mark", "--tag-add", "reviewed", "--json"],
         ),
         (
             ["find", "needle", "then", "mark", "candidates", "list", "--json"],
-            ["mark", "candidates", "list", "--format", "json"],
+            ["mark", "candidates", "list", "--json"],
         ),
         (
             ["analyze", "usage", "--json"],
-            ["analyze", "usage", "--format", "json"],
+            ["analyze", "usage", "--json"],
         ),
         (
             ["analyze", "insights", "profiles", "--json"],
-            ["analyze", "insights", "profiles", "--format", "json"],
+            ["analyze", "insights", "profiles", "--json"],
         ),
     ],
 )
-def test_post_verb_json_alias_normalizes_for_all_format_actions(
+def test_post_verb_json_alias_is_local_for_all_format_actions(
     argv: list[str],
     expected: list[str],
 ) -> None:
-    """Post-verb ``--json`` is a grammar alias for every action with ``--format json``."""
+    """Post-verb ``--json`` is a local alias for every action with ``--format json``."""
     click_args, _, has_subcommand, _ = _split_query_mode_args(cli, argv)
 
     assert click_args == expected

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -704,6 +704,38 @@ def test_query_action_mutating_guard_completion_per_shell(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
+@pytest.mark.parametrize(
+    "cwords",
+    [
+        ["find", "id:abc", "then", "read"],
+        ["find", "id:abc", "then", "continue"],
+        ["find", "id:abc", "then", "delete"],
+        ["find", "id:abc", "then", "mark"],
+        ["find", "id:abc", "then", "mark", "candidates", "list"],
+        ["analyze", "usage"],
+        ["analyze", "insights", "profiles"],
+    ],
+)
+def test_query_action_json_alias_completion_per_shell(
+    shell: str,
+    comp_cls: type[ShellComplete],
+    cwords: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Actions that own ``--format`` also advertise the accepted ``--json`` alias."""
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    items = dict(_run_completion_for_partial(shell, comp_cls, cwords, "--"))
+
+    assert "--format" in items
+    assert items["--json"] == "Shortcut for --format json."
+
+
+@pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
 def test_query_action_mark_candidates_completion_per_shell(
     shell: str,
     comp_cls: type[ShellComplete],


### PR DESCRIPTION
## Summary

Promotes `--json` from a parser-only convenience into a local Click option on the action and analysis commands that already own `--format json`, and updates shell-completion coverage plus the generated CLI reference.

## Problem

`polylogue read <session> --json` was accepted after the previous dogfood fix, but completions and command help still advertised only `--format` for many verbs. That made the accepted grammar less discoverable and kept the completion surface behind parser behavior.

## Solution

Added local `--json` aliases backed by the existing `output_format` parameter for query actions, candidate assertion review commands, provider usage diagnostics, and insight analysis commands. The parser tests now assert the alias is owned locally rather than rewritten before Click dispatch. Completion tests verify bash, zsh, and fish expose `--json` alongside `--format` for the covered action paths.

## Verification

- `devtools test tests/unit/cli/test_cli_action_contracts.py -k 'post_verb_json_alias'` -> 8 passed, 29 deselected.
- `devtools test tests/unit/cli/test_completion_matrix.py -k 'json_alias_completion or mutating_guard_completion'` -> 24 passed, 148 deselected.
- `devtools verify --quick` -> passed, run `20260624T130051Z-quick-2590871-05f3c605`.
- pre-push `devtools verify --quick` -> passed, run `20260624T130135Z-quick-2591533-8ce195c6`.

Ref #1844
Ref #2006
Ref #2317
