### PR TITLE
docs(devtools): name verification-lab in verify help

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1177,7 +1177,8 @@ def main(argv: list[str] | None = None) -> int:
         "--lab",
         action="store_true",
         help=(
-            "Run the default pytest-testmon baseline plus lab scenario and verify-slos checks; does not imply --all."
+            "Run the default pytest-testmon baseline plus verification-lab "
+            "scenario and verify-slos checks; does not imply --all."
         ),
     )
     parser.add_argument("--history", action="store_true", help="Print last 10 verify runs and exit.")


### PR DESCRIPTION
## Summary

Updates `devtools verify --lab` help text to name the durable verification-lab surface instead of saying only "lab scenario".

## Problem

The latest Downloads patch intake replayed the active patch batch against current `master`. Most patch bodies were stale or already represented; the only surviving source delta was that the `--lab` help string still used vague terminology while surrounding docs/devtools surfaces consistently call this the verification-lab.

## Solution

Changed the `devtools verify --lab` help text to say "verification-lab scenario". During intake, #2248, #2304, #2309, and #2317 patches were replayed in an isolated worktree and reduced to current source or older/stale behavior; #1883 still failed with stale context even after correcting its export path strip level.

Ref #2196
Ref #2248
Ref #2304
Ref #2309
Ref #2317
Ref #1883

## Verification

- `devtools verify --quick` → exit_code 0
- pre-push `devtools verify --quick` → exit_code 0