### PR TITLE
fix(browser-capture): prefer native Claude payloads

### DIFF
--- a/browser-extension/scripts/dev-loop-live-provider-proof.mjs
+++ b/browser-extension/scripts/dev-loop-live-provider-proof.mjs
@@ -38,7 +38,7 @@ const providerCatalog = {
     host: "claude.ai",
     url: process.env.POLYLOGUE_LIVE_PROOF_CLAUDE_URL || "https://claude.ai/",
     expectedProvider: "claude-ai",
-    expectedAdapters: ["claude-ai-dom-v1"],
+    expectedAdapters: ["claude-ai-native-v1", "claude-ai-dom-v1"],
   },
 };
 

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -1,5 +1,84 @@
 (function () {
-  const adapterName = "claude-ai-dom-v1";
+  const domAdapterName = "claude-ai-dom-v1";
+  const nativeAdapterName = "claude-ai-native-v1";
+  const nativeCaptureMessage = "polylogue.claude.nativeCapture";
+  const nativeCaptures = [];
+
+  function conversationIdFromUrl(url = window.location.href) {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    return parts[0] === "chat" && parts[1] ? parts[1] : null;
+  }
+
+  function injectNativeCaptureBridge() {
+    const root = document.documentElement || document.head || document.body;
+    if (!root) {
+      window.setTimeout(injectNativeCaptureBridge, 0);
+      return;
+    }
+    const script = document.createElement("script");
+    script.textContent = `(() => {
+      const messageType = ${JSON.stringify(nativeCaptureMessage)};
+      const currentOrigin = window.location.origin;
+      window.__polylogueClaudeCapturedFetches = Array.isArray(window.__polylogueClaudeCapturedFetches)
+        ? window.__polylogueClaudeCapturedFetches
+        : [];
+      function post(capture) {
+        window.postMessage({ type: messageType, capture }, currentOrigin);
+      }
+      function remember(capture) {
+        window.__polylogueClaudeCapturedFetches.push(capture);
+        if (window.__polylogueClaudeCapturedFetches.length > 8) {
+          window.__polylogueClaudeCapturedFetches.splice(0, window.__polylogueClaudeCapturedFetches.length - 8);
+        }
+        post(capture);
+      }
+      const existingCaptures = window.__polylogueClaudeCapturedFetches.slice(-8);
+      window.__polylogueClaudeCapturedFetches = existingCaptures;
+      for (const capture of existingCaptures) post(capture);
+      if (window.__polylogueClaudeFetchHookInstalled) return;
+      window.__polylogueClaudeFetchHookInstalled = true;
+      const originalFetch = window.fetch;
+      window.fetch = async function polylogueClaudeFetch(input) {
+        const response = await originalFetch.apply(this, arguments);
+        try {
+          const url = typeof input === "string" ? input : input && input.url;
+          const absolute = new URL(url, window.location.href);
+          const isConversation = absolute.origin === currentOrigin
+            && /\\/api\\/organizations\\/[^/?#]+\\/chat_conversations\\/[^/?#]+/.test(absolute.pathname);
+          const contentType = response.headers.get("content-type") || "";
+          if (isConversation && contentType.includes("application/json")) {
+            const body = await response.clone().text();
+            if (body.includes('"chat_messages"')) {
+              remember({
+                url: absolute.href,
+                status: response.status,
+                ok: response.ok,
+                contentType,
+                body,
+                capturedAt: new Date().toISOString()
+              });
+            }
+          }
+        } catch (_error) {
+          // Capture must never perturb the Claude.ai page's own request path.
+        }
+        return response;
+      };
+    })();`;
+    root.appendChild(script);
+    script.remove();
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type !== nativeCaptureMessage || !data.capture) return;
+    nativeCaptures.push(data.capture);
+    if (nativeCaptures.length > 8) nativeCaptures.splice(0, nativeCaptures.length - 8);
+  });
+
+  injectNativeCaptureBridge();
 
   function roleFromNode(node, index) {
     const role = node.getAttribute("data-message-author-role") || node.getAttribute("data-testid") || "";
@@ -20,20 +99,127 @@
       .filter(Boolean);
   }
 
-  async function capture() {
-    const turns = collectTurns();
-    if (!turns.length) return { ok: false, error: "no_turns" };
-    const envelope = window.polylogueCapture.buildEnvelope({
+  function textFromMessage(message) {
+    if (!message || typeof message !== "object") return "";
+    if (typeof message.text === "string" && message.text) return message.text;
+    if (typeof message.content === "string" && message.content) return message.content;
+    if (Array.isArray(message.content)) {
+      return message.content
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (part && typeof part === "object" && typeof part.text === "string") return part.text;
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+    return "";
+  }
+
+  function roleFromNativeMessage(message) {
+    const raw = message && (message.sender || message.role || message.author);
+    if (raw === "human" || raw === "user") return "user";
+    if (raw === "assistant" || raw === "claude") return "assistant";
+    if (raw === "system" || raw === "tool") return raw;
+    return "unknown";
+  }
+
+  function collectNativeTurns(payload) {
+    const messages = payload && payload.chat_messages;
+    if (!Array.isArray(messages)) return [];
+    return messages
+      .map((message, index) => {
+        const text = textFromMessage(message);
+        if (!text) return null;
+        return {
+          provider_turn_id: String(message.uuid || message.id || `claude-message-${index}`),
+          role: roleFromNativeMessage(message),
+          text,
+          timestamp: message.created_at || message.updated_at || null,
+          parent_turn_id: message.parent_message_uuid || message.parent_uuid || null,
+          provider_meta: {
+            model: message.model || null,
+            sender: message.sender || message.role || null,
+            capture_source: "claude_chat_conversations_api"
+          }
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function parseNativeCapture(capture) {
+    if (!capture || !capture.ok || typeof capture.body !== "string") return null;
+    const currentConversationId = conversationIdFromUrl();
+    if (!currentConversationId || !String(capture.url || "").includes(`/chat_conversations/${currentConversationId}`)) {
+      return null;
+    }
+    try {
+      const payload = JSON.parse(capture.body);
+      if (!payload || typeof payload !== "object" || !Array.isArray(payload.chat_messages)) return null;
+      if (payload.uuid && String(payload.uuid) !== currentConversationId) return null;
+      return payload;
+    } catch {
+      return null;
+    }
+  }
+
+  function latestNativePayload() {
+    for (let index = nativeCaptures.length - 1; index >= 0; index -= 1) {
+      const payload = parseNativeCapture(nativeCaptures[index]);
+      if (payload) return payload;
+    }
+    return null;
+  }
+
+  function modelFromNativePayload(payload) {
+    const messages = payload && payload.chat_messages;
+    if (!Array.isArray(messages)) return null;
+    for (const message of messages) {
+      if (typeof message.model === "string" && message.model) return message.model;
+    }
+    return null;
+  }
+
+  function buildNativeEnvelope(payload) {
+    const turns = collectNativeTurns(payload);
+    if (!turns.length) return null;
+    return window.polylogueCapture.buildEnvelope({
       provider: "claude-ai",
-      adapterName,
-      turns
+      adapterName: nativeAdapterName,
+      turns,
+      providerSessionId: String(payload.uuid || conversationIdFromUrl()),
+      title: typeof payload.name === "string" && payload.name ? payload.name : null,
+      createdAt: payload.created_at || null,
+      updatedAt: payload.updated_at || null,
+      model: modelFromNativePayload(payload),
+      providerMeta: {
+        capture_source: "claude_chat_conversations_api",
+        message_count: Array.isArray(payload.chat_messages) ? payload.chat_messages.length : 0
+      },
+      rawProviderPayload: payload
     });
-    const captureResult = await window.polylogueCapture.sendCapture(envelope);
+  }
+
+  async function capture() {
+    const nativePayload = latestNativePayload();
+    const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
+    const fallbackEnvelope = () => {
+      const turns = collectTurns();
+      if (!turns.length) return null;
+      return window.polylogueCapture.buildEnvelope({
+        provider: "claude-ai",
+        adapterName: domAdapterName,
+        turns
+      });
+    };
+    const finalEnvelope = envelope || fallbackEnvelope();
+    if (!finalEnvelope) return { ok: false, error: "no_turns" };
+    const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope);
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "claude-ai",
-      envelope.session.provider_session_id
+      finalEnvelope.session.provider_session_id
     );
-    return { ok: true, envelope, captureResult, archiveState };
+    return { ok: true, envelope: finalEnvelope, captureResult, archiveState };
   }
 
   let timer = 0;

--- a/browser-extension/tests/content/claude.test.js
+++ b/browser-extension/tests/content/claude.test.js
@@ -26,6 +26,90 @@ function roleFromNode(node, index) {
   return index % 2 === 0 ? "user" : "assistant";
 }
 
+function conversationIdFromUrl(url) {
+  const parsed = new URL(url);
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  return parts[0] === "chat" && parts[1] ? parts[1] : null;
+}
+
+function textFromMessage(message) {
+  if (!message || typeof message !== "object") return "";
+  if (typeof message.text === "string" && message.text) return message.text;
+  if (typeof message.content === "string" && message.content) return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object" && typeof part.text === "string")
+          return part.text;
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function roleFromNativeMessage(message) {
+  const raw = message && (message.sender || message.role || message.author);
+  if (raw === "human" || raw === "user") return "user";
+  if (raw === "assistant" || raw === "claude") return "assistant";
+  if (raw === "system" || raw === "tool") return raw;
+  return "unknown";
+}
+
+function collectNativeTurns(payload) {
+  const messages = payload && payload.chat_messages;
+  if (!Array.isArray(messages)) return [];
+  return messages
+    .map((message, index) => {
+      const text = textFromMessage(message);
+      if (!text) return null;
+      return {
+        provider_turn_id: String(
+          message.uuid || message.id || `claude-message-${index}`,
+        ),
+        role: roleFromNativeMessage(message),
+        text,
+        timestamp: message.created_at || message.updated_at || null,
+        parent_turn_id: message.parent_message_uuid || message.parent_uuid || null,
+        provider_meta: {
+          model: message.model || null,
+          sender: message.sender || message.role || null,
+          capture_source: "claude_chat_conversations_api",
+        },
+      };
+    })
+    .filter(Boolean);
+}
+
+function parseNativeCapture(capture, pageUrl) {
+  if (!capture || !capture.ok || typeof capture.body !== "string") return null;
+  const currentConversationId = conversationIdFromUrl(pageUrl);
+  if (
+    !currentConversationId ||
+    !String(capture.url || "").includes(
+      `/chat_conversations/${currentConversationId}`,
+    )
+  ) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(capture.body);
+    if (
+      !payload ||
+      typeof payload !== "object" ||
+      !Array.isArray(payload.chat_messages)
+    )
+      return null;
+    if (payload.uuid && String(payload.uuid) !== currentConversationId)
+      return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -148,5 +232,87 @@ describe("claude roleFromNode — #622 gap (index-parity fallback)", () => {
     const node = makeNode({});
     expect(roleFromNode(node, 100)).toBe("user");
     expect(roleFromNode(node, 101)).toBe("assistant");
+  });
+});
+
+describe("claude native capture helpers", () => {
+  const pageUrl = "https://claude.ai/chat/conv-123";
+  const apiUrl =
+    "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True";
+
+  it("reads Claude conversation routes", () => {
+    expect(conversationIdFromUrl(pageUrl)).toBe("conv-123");
+    expect(conversationIdFromUrl("https://claude.ai/new")).toBe(null);
+  });
+
+  it("accepts only current chat_conversations payloads with messages", () => {
+    const payload = {
+      uuid: "conv-123",
+      name: "Native Claude title",
+      chat_messages: [{ uuid: "m1", sender: "human", text: "hello" }],
+    };
+    expect(
+      parseNativeCapture(
+        { ok: true, url: apiUrl, body: JSON.stringify(payload) },
+        pageUrl,
+      ),
+    ).toEqual(payload);
+    expect(
+      parseNativeCapture(
+        {
+          ok: true,
+          url: "https://claude.ai/api/organizations/org-1/chat_conversations/other",
+          body: JSON.stringify(payload),
+        },
+        pageUrl,
+      ),
+    ).toBe(null);
+    expect(
+      parseNativeCapture(
+        {
+          ok: true,
+          url: apiUrl,
+          body: JSON.stringify({ uuid: "other", chat_messages: [] }),
+        },
+        pageUrl,
+      ),
+    ).toBe(null);
+  });
+
+  it("extracts native Claude turns without DOM role parity fallback", () => {
+    const turns = collectNativeTurns({
+      chat_messages: [
+        {
+          uuid: "u1",
+          sender: "human",
+          text: "Native user",
+          created_at: "2026-06-24T00:00:00Z",
+        },
+        {
+          uuid: "a1",
+          sender: "assistant",
+          content: [{ text: "Native answer" }],
+          model: "claude-native",
+          parent_message_uuid: "u1",
+        },
+        { uuid: "empty", sender: "assistant", text: "" },
+      ],
+    });
+
+    expect(turns).toHaveLength(2);
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+    expect(turns.map((turn) => turn.text)).toEqual([
+      "Native user",
+      "Native answer",
+    ]);
+    expect(turns[1].parent_turn_id).toBe("u1");
+    expect(turns[1].provider_meta.capture_source).toBe(
+      "claude_chat_conversations_api",
+    );
+  });
+
+  it("keeps unknown native roles explicit", () => {
+    expect(roleFromNativeMessage({ sender: "system" })).toBe("system");
+    expect(roleFromNativeMessage({ sender: "unexpected" })).toBe("unknown");
   });
 });

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -118,8 +118,8 @@ session merely because the evidence arrived through an extension.
 | ChatGPT authenticated page fallback | `chatgpt-dom-v1` | Visible turns in the browser-capture envelope | browser-capture DOM parser | `chatgpt-export:<url /c/<id>>` |
 | ChatGPT GDPR/export file | provider import | Export JSON `mapping` payload | normal ChatGPT parser | `chatgpt-export:<conversation_id or id>` |
 | ChatGPT shared-link helper | standalone public-share script | React Router share stream reduced to export-shaped messages | separate conversion input, not the extension payload | provider-native share conversation id when converted |
-| Claude.ai authenticated page | `claude-ai-dom-v1` today | Visible turns in the browser-capture envelope | browser-capture DOM parser | `claude-ai-export:<url /chat/<id>>` |
-| Claude.ai native/export payload | provider import or future adapter | `chat_messages` payload under provider import or `raw_provider_payload` | delegated to the normal Claude.ai parser | `claude-ai-export:<uuid>` |
+| Claude.ai authenticated page | `claude-ai-native-v1` when the conversation API response is observed; `claude-ai-dom-v1` fallback | Full `/api/organizations/.../chat_conversations/<id>` JSON under `raw_provider_payload`; otherwise visible turns in the browser-capture envelope | delegated to the normal Claude.ai parser for native payloads; browser-capture DOM parser for fallback | `claude-ai-export:<uuid or url /chat/<id>>` |
+| Claude.ai GDPR/export file | provider import | `chat_messages` payload | normal Claude.ai parser | `claude-ai-export:<uuid>` |
 
 The ChatGPT content script hooks same-origin fetches for authenticated
 conversation JSON and keeps only a bounded recent window in page memory. On
@@ -136,10 +136,11 @@ updates the same archive session instead of creating a second visible session.
 Fallback DOM captures are therefore acceptable as temporary live evidence, but
 not as a reason to prefer DOM over a clean provider payload.
 
-The Claude.ai parser already accepts native `chat_messages` payloads through
-`raw_provider_payload`, and archive tests pin coalescing with direct Claude.ai
-imports. The shipped extension adapter is still DOM-only, so native Claude.ai
-fetch capture remains a fidelity residual rather than a parser/storage gap.
+The Claude.ai content script also hooks same-origin conversation fetches and
+uses native payloads when the response is the current
+`/chat_conversations/<id>` JSON shape with `chat_messages`. DOM extraction
+remains a fallback for pages where the provider response is not available to
+the content script.
 
 ## Local auth and origin policy
 


### PR DESCRIPTION
## Summary

Adds a Claude.ai native browser-capture path so authenticated Claude pages can archive provider conversation JSON when the content script observes the same-origin `chat_conversations` API response, falling back to DOM capture when native evidence is unavailable.

## Problem

ChatGPT browser capture already prefers provider-native backend payloads and sends `raw_provider_payload` into the normal ChatGPT parser. Claude.ai capture still relied only on visible DOM text, even though the browser-capture parser already delegates Claude.ai `raw_provider_payload` to the normal Claude.ai parser. That made Claude.ai capture less faithful than the available provider evidence.

## Solution

The Claude content script now installs a page-context fetch bridge for `/api/organizations/.../chat_conversations/<id>` JSON responses that contain `chat_messages`, keeps the latest matching captures, and emits `claude-ai-native-v1` envelopes with `raw_provider_payload`. DOM capture remains the fallback. The extension tests cover URL matching, payload filtering, native turn extraction, and explicit unknown role handling; the browser-capture docs now describe the native/fallback matrix. The copied-profile live proof now accepts `claude-ai-native-v1` as preferred while retaining `claude-ai-dom-v1` fallback.

Ref #2308
Ref #2248

## Verification

- `devtools test tests/unit/sources/test_browser_capture.py` → 20 passed
- `cd browser-extension && npm test -- tests/content/claude.test.js` → 17 passed
- `cd browser-extension && npm run lint && npm run build` → passed
- `devtools verify --quick` → exit_code 0
- pre-push `devtools verify --quick` → exit_code 0 after each pushed commit

## Local smoke note

I attempted `npm run dev-loop-provider-smoke` against the active loopback receiver. It exposed a separate harness issue: in this headless fixture setup, provider pages served on ephemeral `https://chatgpt.com:<port>` / `https://claude.ai:<port>` targets did not receive manifest content-script APIs, and worker-side tab discovery returned `tab_not_found`. I recorded this in `.agent`; it needs a separate dev-loop smoke repair rather than a partial change in this PR.