### PR TITLE
fix(dev-loop): preserve provider smoke browser evidence

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -85,10 +85,16 @@ envelope. Artifacts are written under `.cache/dev-loop/<run-id>/browser/`.
 This proves the extension service-worker HTTP path without using real
 ChatGPT/Claude.ai profile data. The provider page smoke then loads the unpacked
 extension into real headless Chrome/Chromium, serves deterministic ChatGPT and
-Claude fixture pages on their supported origins, triggers the content-script
-capture path, and verifies provider/adapter identity, receiver request ids, and
-spool artifacts without copying browser profiles or writing raw turn text into
-the summary.
+Claude fixture pages behind a local CONNECT proxy on their normal origins, opens
+those pages through the extension worker's `chrome.tabs.create` API, triggers
+the content-script capture path through the same worker-visible tabs, and
+verifies provider/adapter identity, receiver request ids, and spool artifacts
+without copying browser profiles or writing raw turn text into the summary. If
+manifest content-script delivery is unavailable in the headless fixture browser,
+the smoke uses the same `chrome.scripting.executeScript` retry path as the popup
+and records the `injection_mode`. If Chrome creates the page target but the
+worker cannot see the corresponding tab, the summary records both the CDP page
+target and the worker-visible tab inventory.
 
 For live authenticated ChatGPT/Claude.ai work, generate the operator-local plan
 and run the copied-profile proof from the repo instead of inventing a private
@@ -116,8 +122,11 @@ If headless Chromium cannot expose MV3 extension service workers, the browser
 smokes fail cleanly with `Polylogue extension service worker not found` in the
 stderr artifact. Set `POLYLOGUE_BROWSER_SMOKE_CHROME` or
 `POLYLOGUE_PROVIDER_SMOKE_CHROME` to a Chrome/Chromium binary with extension
-service-worker support, or use `--browser-live-proof` with a visible copied
-profile for operator-local live-page evidence.
+service-worker support. When Chrome exposes the service worker but does not
+deliver provider content scripts, the provider smoke records page diagnostics,
+tab inventory, and injection mode. Set `POLYLOGUE_PROVIDER_SMOKE_HEADLESS=0` to
+repeat the same isolated-profile proof visibly, or use `--browser-live-proof`
+with a visible copied profile for operator-local live-page evidence.
 
 ## Supported Sites
 

--- a/browser-extension/scripts/dev-loop-provider-smoke.mjs
+++ b/browser-extension/scripts/dev-loop-provider-smoke.mjs
@@ -6,6 +6,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
 import https from "node:https";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -20,6 +21,7 @@ const profileDir =
 const keepProfile = process.env.POLYLOGUE_PROVIDER_SMOKE_KEEP_PROFILE === "1";
 const timeoutMs = Number(process.env.POLYLOGUE_PROVIDER_SMOKE_TIMEOUT_MS || "10000");
 const spoolDir = process.env.POLYLOGUE_PROVIDER_SMOKE_SPOOL_DIR || "";
+const headless = process.env.POLYLOGUE_PROVIDER_SMOKE_HEADLESS !== "0";
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -190,10 +192,45 @@ async function startProviderFixtureServer(certDir) {
     port,
     server,
     urls: {
-      chatgpt: `https://chatgpt.com:${port}/c/polylogue-dev-loop-provider-smoke`,
-      claude: `https://claude.ai:${port}/chat/polylogue-dev-loop-provider-smoke`,
+      chatgpt: "https://chatgpt.com/c/polylogue-dev-loop-provider-smoke",
+      claude: "https://claude.ai/chat/polylogue-dev-loop-provider-smoke",
     },
   };
+}
+
+async function startProviderProxyServer(fixturePort) {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+    response.end("Polylogue provider smoke proxy only supports CONNECT\n");
+  });
+  server.on("connect", (request, clientSocket, head) => {
+    const [host, portText] = String(request.url || "").split(":");
+    const port = Number(portText || "443");
+    if (!["chatgpt.com", "claude.ai"].includes(host) || port !== 443) {
+      clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+      clientSocket.destroy();
+      return;
+    }
+    const upstream = net.connect(fixturePort, "127.0.0.1", () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length) upstream.write(head);
+      upstream.pipe(clientSocket);
+      clientSocket.pipe(upstream);
+    });
+    upstream.on("error", () => {
+      clientSocket.destroy();
+    });
+    clientSocket.on("error", () => {
+      upstream.destroy();
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return { port, server };
 }
 
 function closeServer(server) {
@@ -262,17 +299,38 @@ async function waitForExtensionWorker(debuggingPort, expectedWorkerSuffix, expec
   );
 }
 
-async function openProviderTarget(browserClient, debuggingPort, url) {
-  const created = await browserClient.call("Target.createTarget", { url });
-  const targetId = created.targetId;
+async function openProviderTargetFromWorker(workerClient, debuggingPort, url) {
+  const createdTab = await evaluateJson(
+    workerClient,
+    `(async () => {
+      if (!globalThis.chrome?.tabs?.create) {
+        throw new Error("extension service-worker CDP target does not expose chrome.tabs.create");
+      }
+      let tab;
+      try {
+        tab = await chrome.tabs.create({url: ${JSON.stringify(url)}, active: false});
+      } catch (error) {
+        const message = String(error && error.message ? error.message : error);
+        if (!message.includes("No current window") || !globalThis.chrome?.windows?.create) {
+          throw error;
+        }
+        const createdWindow = await chrome.windows.create({url: ${JSON.stringify(url)}, focused: false, type: "normal"});
+        tab = Array.isArray(createdWindow.tabs) && createdWindow.tabs.length ? createdWindow.tabs[0] : null;
+      }
+      if (!tab) throw new Error("extension API did not return a provider tab");
+      return {id: tab.id ?? null, url: tab.url ?? null, pendingUrl: tab.pendingUrl ?? null, title: tab.title ?? null};
+    })()`,
+  );
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const targets = await waitJson(`http://127.0.0.1:${debuggingPort}/json/list`, Math.min(2000, timeoutMs));
-    const target = targets.find((candidate) => candidate.id === targetId || candidate.url === url);
+    const target = targets.find((candidate) => candidate.url === url);
     if (target?.webSocketDebuggerUrl) {
       const client = await connectCdp(target.webSocketDebuggerUrl);
       await client.call("Runtime.enable");
-      return { target, client };
+      await client.call("Page.enable");
+      await client.call("Page.navigate", { url });
+      return { target, client, tab: createdTab };
     }
     await sleep(250);
   }
@@ -289,18 +347,40 @@ async function waitForReadyPage(client) {
   throw new Error("provider fixture page did not become ready");
 }
 
+async function providerPageDiagnostics(client) {
+  return evaluateJson(
+    client,
+    `(() => ({
+      href: location.href,
+      title: document.title || null,
+      readyState: document.readyState,
+      articleCount: document.querySelectorAll("article").length,
+      hasPolylogueCapture: Boolean(window.polylogueCapture),
+      bodyTextSample: (document.body?.innerText || document.body?.textContent || "").slice(0, 240)
+    }))()`,
+  );
+}
+
 async function configureExtension(workerClient) {
   return evaluateJson(
     workerClient,
     `(async () => {
       if (!globalThis.chrome?.storage?.local) {
+        if (${JSON.stringify(receiverBaseUrl)} === "http://127.0.0.1:8765" && !${JSON.stringify(receiverAuthToken)}) {
+          return {
+            receiverBaseUrl: "http://127.0.0.1:8765",
+            receiverAuthToken: "",
+            storageConfigured: false,
+            caveat: "chrome.storage.local unavailable in service-worker CDP context; using extension defaults"
+          };
+        }
         throw new Error("extension service-worker CDP target does not expose chrome.storage.local");
       }
       await chrome.storage.local.set({
         receiverBaseUrl: ${JSON.stringify(receiverBaseUrl)},
         receiverAuthToken: ${JSON.stringify(receiverAuthToken)}
       });
-      return await chrome.storage.local.get(["receiverBaseUrl", "receiverAuthToken"]);
+      return { ...(await chrome.storage.local.get(["receiverBaseUrl", "receiverAuthToken"])), storageConfigured: true };
     })()`,
   );
 }
@@ -312,27 +392,53 @@ async function captureProvider(workerClient, providerConfig) {
       if (!globalThis.chrome?.tabs?.query) {
         throw new Error("extension service-worker CDP target does not expose chrome.tabs");
       }
+      async function sendCapture(tabId) {
+        try {
+          const result = await chrome.tabs.sendMessage(tabId, {type: "polylogue.capturePage"});
+          return {ok: Boolean(result && result.ok), result, injection_mode: "manifest"};
+        } catch (error) {
+          const message = String(error && error.message ? error.message : error);
+          if (!message.includes("Receiving end does not exist") || !globalThis.chrome?.scripting?.executeScript) {
+            return {ok: false, error: message, injection_mode: "none"};
+          }
+          await chrome.scripting.executeScript({target: {tabId}, files: ["src/common.js"]});
+          await chrome.scripting.executeScript({target: {tabId}, files: [${JSON.stringify(providerConfig.contentScriptFile)}]});
+          const result = await chrome.tabs.sendMessage(tabId, {type: "polylogue.capturePage"});
+          return {ok: Boolean(result && result.ok), result, injection_mode: "scripted_retry"};
+        }
+      }
+      const summarizeTabs = (tabs) => tabs.map((tab) => ({
+        id: typeof tab.id === "number" ? tab.id : null,
+        url: tab.url || tab.pendingUrl || null,
+        title: tab.title || null,
+        active: Boolean(tab.active)
+      }));
       const deadline = Date.now() + ${JSON.stringify(timeoutMs)};
       let last = null;
       while (Date.now() < deadline) {
         const tabs = await chrome.tabs.query({});
-        const tab = tabs.find((candidate) => {
-          try {
-            return new URL(candidate.url || "about:blank").hostname === ${JSON.stringify(providerConfig.host)};
-          } catch (_error) {
-            return false;
-          }
-        });
+        const tabInventory = summarizeTabs(tabs);
+        const expectedTabId = ${JSON.stringify(providerConfig.expectedTabId ?? null)};
+        const tab = tabs.find((candidate) => typeof expectedTabId === "number" && candidate.id === expectedTabId)
+          || tabs.find((candidate) => {
+            try {
+              return new URL(candidate.url || "about:blank").hostname === ${JSON.stringify(providerConfig.host)};
+            } catch (_error) {
+              return false;
+            }
+          });
         if (tab && typeof tab.id === "number") {
-          try {
-            const result = await chrome.tabs.sendMessage(tab.id, {type: "polylogue.capturePage"});
-            last = {tab: {id: tab.id, url: tab.url, title: tab.title}, result};
-            if (result && result.ok) return {ok: true, ...last};
-          } catch (error) {
-            last = {tab: {id: tab.id, url: tab.url, title: tab.title}, error: String(error && error.message ? error.message : error)};
-          }
+          const capture = await sendCapture(tab.id);
+          last = {
+            tab: {id: tab.id, url: tab.url, title: tab.title},
+            tab_inventory: tabInventory,
+            injection_mode: capture.injection_mode,
+            result: capture.result,
+            error: capture.error
+          };
+          if (capture.ok) return {ok: true, ...last};
         } else {
-          last = {error: "tab_not_found"};
+          last = {error: "tab_not_found", expected_host: ${JSON.stringify(providerConfig.host)}, tab_inventory: tabInventory};
         }
         await new Promise((resolve) => setTimeout(resolve, 250));
       }
@@ -351,12 +457,13 @@ function safeProviderSummary(providerConfig, capturePayload) {
   const turns = Array.isArray(session.turns) ? session.turns : [];
   const artifactRef = typeof captureResult.artifact_ref === "string" ? captureResult.artifact_ref : null;
   const artifactPath = artifactRef && spoolDir ? path.join(spoolDir, artifactRef) : null;
+  const adapterName = typeof provenance.adapter_name === "string" ? provenance.adapter_name : null;
   const roles = turns.map((turn) => turn.role).filter(Boolean);
   const ok = Boolean(
     capturePayload?.ok &&
       result.ok === true &&
       session.provider === providerConfig.expectedProvider &&
-      provenance.adapter_name === providerConfig.expectedAdapter &&
+      providerConfig.expectedAdapters.includes(adapterName) &&
       turns.length >= 2 &&
       roles.includes("user") &&
       roles.includes("assistant") &&
@@ -368,12 +475,18 @@ function safeProviderSummary(providerConfig, capturePayload) {
   return {
     ok,
     url: providerConfig.url,
+    expected_host: providerConfig.host,
+    page_target: providerConfig.pageTarget || null,
+    page_diagnostics: providerConfig.pageDiagnostics || null,
+    opened_tab: providerConfig.openedTab || null,
     tab: capturePayload?.tab || null,
+    tab_inventory: capturePayload?.tab_inventory || null,
+    injection_mode: capturePayload?.injection_mode || null,
     expected_provider: providerConfig.expectedProvider,
     provider: session.provider || null,
     provider_session_id: session.provider_session_id || null,
-    expected_adapter: providerConfig.expectedAdapter,
-    adapter_name: provenance.adapter_name || null,
+    expected_adapters: providerConfig.expectedAdapters,
+    adapter_name: adapterName,
     turn_count: turns.length,
     roles,
     capture_result: {
@@ -398,19 +511,22 @@ async function main() {
   const chromeBinary = resolveChromeBinary();
   const debuggingPort = await freePort();
   const fixtureServer = await startProviderFixtureServer(profileDir);
+  const proxyServer = await startProviderProxyServer(fixtureServer.port);
   const chromeArgs = [
     `--user-data-dir=${profileDir}`,
     `--remote-debugging-port=${debuggingPort}`,
-    "--headless=new",
     "--no-sandbox",
+    "--disable-features=ExtensionsMenuAccessControl",
     "--ignore-certificate-errors",
     "--allow-insecure-localhost",
-    `--host-resolver-rules=MAP chatgpt.com 127.0.0.1,MAP claude.ai 127.0.0.1`,
+    `--proxy-server=http://127.0.0.1:${proxyServer.port}`,
+    "--proxy-bypass-list=127.0.0.1;localhost",
     `--unsafely-treat-insecure-origin-as-secure=${receiverBaseUrl}`,
     `--disable-extensions-except=${extensionRoot}`,
     `--load-extension=${extensionRoot}`,
     "about:blank",
   ];
+  if (headless) chromeArgs.splice(2, 0, "--headless=new");
   const chrome = spawn(chromeBinary, chromeArgs, { detached: true, stdio: ["ignore", "pipe", "pipe"] });
   let stdout = "";
   let stderr = "";
@@ -433,26 +549,37 @@ async function main() {
         host: "chatgpt.com",
         url: fixtureServer.urls.chatgpt,
         expectedProvider: "chatgpt",
-        expectedAdapter: "chatgpt-dom-v1",
+        expectedAdapters: ["chatgpt-native-v1", "chatgpt-dom-v1"],
+        contentScriptFile: "src/content/chatgpt.js",
       },
       {
         key: "claude",
         host: "claude.ai",
         url: fixtureServer.urls.claude,
         expectedProvider: "claude-ai",
-        expectedAdapter: "claude-ai-dom-v1",
+        expectedAdapters: ["claude-ai-native-v1", "claude-ai-dom-v1"],
+        contentScriptFile: "src/content/claude.js",
       },
     ];
-    for (const config of providerConfigs) {
-      const { client } = await openProviderTarget(browserClient, debuggingPort, config.url);
-      pageClients.push(client);
-      await waitForReadyPage(client);
-    }
-
     const { worker, client } = await waitForExtensionWorker(debuggingPort, expectedWorkerSuffix, localManifest.name);
     workerClient = client;
     const extensionId = new URL(worker.url).host;
     const configuredReceiver = await configureExtension(workerClient);
+
+    for (const config of providerConfigs) {
+      const { client, target, tab } = await openProviderTargetFromWorker(workerClient, debuggingPort, config.url);
+      config.pageTarget = {
+        id: target.id || null,
+        type: target.type || null,
+        url: target.url || null,
+        title: target.title || null,
+      };
+      config.openedTab = tab;
+      config.expectedTabId = typeof tab?.id === "number" ? tab.id : null;
+      pageClients.push(client);
+      await waitForReadyPage(client);
+      config.pageDiagnostics = await providerPageDiagnostics(client);
+    }
 
     const providers = {};
     for (const config of providerConfigs) {
@@ -464,13 +591,15 @@ async function main() {
       ok: Object.values(providers).every((provider) => provider.ok === true),
       chrome_binary: chromeBinary,
       chrome_args: chromeArgs,
+      headless,
       debugging_port: debuggingPort,
       extension_id: extensionId,
       extension_root: extensionRoot,
       fixture_server: {
         port: fixtureServer.port,
         urls: fixtureServer.urls,
-        host_resolver_rules: "MAP chatgpt.com 127.0.0.1,MAP claude.ai 127.0.0.1",
+        proxy_port: proxyServer.port,
+        proxy_mode: "CONNECT chatgpt.com:443 and claude.ai:443 to fixture server",
       },
       manifest: {
         name: localManifest.name,
@@ -496,6 +625,7 @@ async function main() {
     if (workerClient) workerClient.close();
     if (browserClient) browserClient.close();
     await terminateProcess(chrome);
+    await closeServer(proxyServer.server);
     await closeServer(fixtureServer.server);
     if (!keepProfile && !process.env.POLYLOGUE_PROVIDER_SMOKE_PROFILE_DIR) {
       rmSync(profileDir, { recursive: true, force: true });

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -416,10 +416,12 @@ devtools workspace dev-loop --browser-plan --extension-smoke --browser-smoke --b
 ```
 
 This starts a temporary branch-local receiver, starts a local HTTPS fixture
-server, maps `chatgpt.com` and `claude.ai` to loopback with Chrome host resolver
-rules, loads the unpacked extension into headless Chrome/Chromium, opens
-deterministic provider fixture pages on those supported origins, configures the
-extension receiver settings, and asks the content scripts to capture the page.
+server, starts a local CONNECT proxy that tunnels `chatgpt.com:443` and
+`claude.ai:443` to that fixture server, loads the unpacked extension into
+headless Chrome/Chromium, opens deterministic provider fixture pages on the
+normal provider origins through the extension worker's `chrome.tabs.create` API,
+configures the extension receiver settings, and asks the content scripts to
+capture the page through the same worker-visible tabs.
 The smoke verifies provider identity, adapter identity, user/assistant roles,
 receiver request ids, archive state request ids, and the written receiver spool
 artifacts. It appends `browser_provider_smoke_requested` /
@@ -434,16 +436,27 @@ artifacts. It appends `browser_provider_smoke_requested` /
 
 The provider smoke deliberately uses deterministic fixture pages and omits raw
 turn text from its summary. It closes the repo-owned real-browser
-content-script loop without using authenticated cookies or copied profiles. Use
-`--browser-plan` for the visible/private browser handoff when screenshots,
-copied-profile cookies, or live provider pages are needed.
+content-script loop without using authenticated cookies or copied profiles. When
+manifest content-script delivery is unavailable in the headless fixture browser,
+the smoke uses the same `chrome.scripting.executeScript` retry path as the popup
+and records `injection_mode=scripted_retry`; `injection_mode=manifest` means the
+content script was already listening. Use `--browser-plan` for the
+visible/private browser handoff when screenshots, copied-profile cookies, or
+live provider pages are needed.
+If Chrome creates the fixture page target but the extension worker cannot see
+the tab, the result records both the CDP page target and the worker-visible tab
+inventory so the failure points at browser/headless capability rather than an
+ambiguous content-script miss.
 
 If a distro Chromium headless build does not expose MV3 extension service
 workers, these smokes fail cleanly with `Polylogue extension service worker not
 found` in the smoke stderr artifact. Point `POLYLOGUE_BROWSER_SMOKE_CHROME` or
 `POLYLOGUE_PROVIDER_SMOKE_CHROME` at a Chrome/Chromium build with extension
-service-worker support, or use `--browser-plan` for the local visible-browser
-handoff.
+service-worker support. If Chrome exposes the service worker but does not
+deliver provider content scripts, the smoke records page diagnostics, tab
+inventory, and injection mode. `POLYLOGUE_PROVIDER_SMOKE_HEADLESS=0` can be used
+to repeat the same isolated-profile proof visibly, and `--browser-plan` remains
+the handoff for operator-approved live/copy-profile evidence.
 
 For GUI/browser inspection, generate a branch-local browser plan:
 


### PR DESCRIPTION
## Summary

Makes the branch-local provider smoke preserve actionable browser evidence when deterministic provider capture cannot complete. The smoke now keeps provider URLs on normal origins behind a local CONNECT proxy, opens tabs through extension APIs, explicitly navigates the matched CDP target, records page diagnostics/tab inventory/injection mode, and documents the remaining browser-control boundary.

## Problem

The provider smoke previously collapsed multiple distinct failures into vague `tab_not_found` or receiving-end errors. During live dogfooding, Chrome loaded the extension worker and fixture page targets, but agents could not tell whether the target had navigated, whether the extension could see tabs, whether manifest content scripts ran, or whether receiver delivery failed.

## Solution

The smoke now emits separate evidence for fixture networking, CDP page target state, page DOM readiness, worker-visible tabs, content-script injection mode, and receiver artifacts. It also supports `POLYLOGUE_PROVIDER_SMOKE_HEADLESS=0` for repeating the same isolated-profile proof visibly. The current local Chrome still does not deliver content scripts to these fixture pages, but the resulting JSON now proves the pages loaded and isolates the remaining failure to content-script delivery / extension API control rather than network or route setup.

Ref #2248
Ref #2308

## Verification

- `cd browser-extension && npm run lint && npm run build` — passed.
- `cd browser-extension && npm test -- tests/popup.test.js tests/build.test.js` — 6 tests passed.
- `devtools verify --quick` — passed locally and in the pre-push hook.
- `cd browser-extension && POLYLOGUE_PROVIDER_SMOKE_OUT=/realm/project/polylogue/.agent/scratch/provider-smoke-20260624-after-navigate.json npm run dev-loop-provider-smoke` — expected nonzero on this Chrome; JSON now shows fixture pages loaded (`articleCount=2`, expected titles and URLs) while `hasPolylogueCapture=false` and `chrome.tabs.sendMessage` reports no receiving end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded browser smoke-test instructions with clearer setup, troubleshooting, and recovery steps.
  * Added guidance for running the check in visible mode and capturing more useful diagnostics.

* **Bug Fixes**
  * Improved reliability of browser smoke checks when a page isn’t immediately reachable.
  * Added fallback handling that helps the extension recover when message delivery fails and records clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->