### PR TITLE
fix(dev-loop): prefer Chromium for extension smokes

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -84,17 +84,22 @@ receiver token, checks receiver status, and posts a deterministic capture
 envelope. Artifacts are written under `.cache/dev-loop/<run-id>/browser/`.
 This proves the extension service-worker HTTP path without using real
 ChatGPT/Claude.ai profile data. The provider page smoke then loads the unpacked
-extension into real headless Chrome/Chromium, serves deterministic ChatGPT and
+extension into real headless Chromium/Chrome, serves deterministic ChatGPT and
 Claude fixture pages behind a local CONNECT proxy on their normal origins, opens
-those pages through the extension worker's `chrome.tabs.create` API, triggers
-the content-script capture path through the same worker-visible tabs, and
-verifies provider/adapter identity, receiver request ids, and spool artifacts
-without copying browser profiles or writing raw turn text into the summary. If
-manifest content-script delivery is unavailable in the headless fixture browser,
-the smoke uses the same `chrome.scripting.executeScript` retry path as the popup
-and records the `injection_mode`. If Chrome creates the page target but the
-worker cannot see the corresponding tab, the summary records both the CDP page
-target and the worker-visible tab inventory.
+those pages through extension-owned tab APIs, triggers the content-script
+capture path through extension-visible tabs, and verifies provider/adapter
+identity, receiver request ids, and spool artifacts without copying browser
+profiles or writing raw turn text into the summary. Automated unpacked-extension
+proof prefers Chromium or Chrome for Testing, including the local Nix-store
+Chromium when it is not on `PATH`, because branded Google Chrome 137+ can expose
+a partial service-worker target while withholding content-script and extension
+page behavior from `--load-extension` automation. Set
+`POLYLOGUE_PROVIDER_SMOKE_CHROME=/path/to/browser` to override the binary. If
+manifest content-script delivery is unavailable in the fixture browser, the
+smoke uses the same `chrome.scripting.executeScript` retry path as the popup and
+records the `injection_mode`. If Chrome creates the page target but the
+extension cannot see the corresponding tab, the summary records both the CDP
+page target and the extension-visible tab inventory.
 
 For live authenticated ChatGPT/Claude.ai work, generate the operator-local plan
 and run the copied-profile proof from the repo instead of inventing a private
@@ -185,8 +190,8 @@ npm run test:watch    # watch mode
 npm run lint          # eslint
 npm run validate      # in-tree manifest validation
 npm run dev-loop-smoke # background worker -> local receiver smoke
-npm run dev-loop-browser-smoke # real Chrome service worker -> local receiver smoke
-npm run dev-loop-provider-smoke # real Chrome content scripts -> deterministic provider fixtures
+npm run dev-loop-browser-smoke # real Chromium/Chrome service worker -> local receiver smoke
+npm run dev-loop-provider-smoke # real Chromium/Chrome content scripts -> deterministic provider fixtures
 npm run dev-loop-live-provider-proof # visible copied-profile live provider proof
 npm run build         # build Chrome .zip + Firefox .xpi under dist/
 npm run screenshots   # capture store-submission screenshots (Playwright)

--- a/browser-extension/scripts/dev-loop-browser-smoke.mjs
+++ b/browser-extension/scripts/dev-loop-browser-smoke.mjs
@@ -4,7 +4,7 @@
 // service-worker origin. This intentionally has no npm dependencies.
 
 import { spawn, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -123,9 +123,40 @@ function serviceWorkerSuffix(manifest) {
   return `/${worker.replace(/^\/+/, "")}`;
 }
 
+function nixStoreChromiumCandidates() {
+  const storeRoot = "/nix/store";
+  if (!existsSync(storeRoot)) return [];
+  return readdirSync(storeRoot)
+    .map((entry) => {
+      const match = entry.match(/-chromium-(\d+(?:\.\d+)+)$/);
+      if (!match) return null;
+      const binary = path.join(storeRoot, entry, "bin", "chromium");
+      if (!existsSync(binary)) return null;
+      return {
+        binary,
+        version: match[1].split(".").map((part) => Number(part)),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const width = Math.max(left.version.length, right.version.length);
+      for (let index = 0; index < width; index += 1) {
+        const delta = (right.version[index] || 0) - (left.version[index] || 0);
+        if (delta !== 0) return delta;
+      }
+      return left.binary.localeCompare(right.binary);
+    })
+    .map((candidate) => candidate.binary);
+}
+
 function resolveChromeBinary() {
   if (process.env.POLYLOGUE_BROWSER_SMOKE_CHROME) return process.env.POLYLOGUE_BROWSER_SMOKE_CHROME;
-  for (const candidate of ["google-chrome-stable", "google-chrome", "chromium", "chromium-browser"]) {
+  for (const candidate of ["chromium", "chromium-browser", "chrome-for-testing"]) {
+    const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
+    if (found.status === 0 && found.stdout.trim()) return candidate;
+  }
+  for (const candidate of nixStoreChromiumCandidates()) return candidate;
+  for (const candidate of ["google-chrome-stable", "google-chrome"]) {
     const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
     if (found.status === 0 && found.stdout.trim()) return candidate;
   }
@@ -181,6 +212,7 @@ async function main() {
     `--remote-debugging-port=${debuggingPort}`,
     "--headless=new",
     "--no-sandbox",
+    "--enable-unsafe-extension-debugging",
     `--disable-extensions-except=${extensionRoot}`,
     `--load-extension=${extensionRoot}`,
     "about:blank",

--- a/browser-extension/scripts/dev-loop-live-provider-proof.mjs
+++ b/browser-extension/scripts/dev-loop-live-provider-proof.mjs
@@ -7,7 +7,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
@@ -161,9 +161,40 @@ function serviceWorkerSuffix(manifest) {
   return `/${worker.replace(/^\/+/, "")}`;
 }
 
+function nixStoreChromiumCandidates() {
+  const storeRoot = "/nix/store";
+  if (!existsSync(storeRoot)) return [];
+  return readdirSync(storeRoot)
+    .map((entry) => {
+      const match = entry.match(/-chromium-(\d+(?:\.\d+)+)$/);
+      if (!match) return null;
+      const binary = path.join(storeRoot, entry, "bin", "chromium");
+      if (!existsSync(binary)) return null;
+      return {
+        binary,
+        version: match[1].split(".").map((part) => Number(part)),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const width = Math.max(left.version.length, right.version.length);
+      for (let index = 0; index < width; index += 1) {
+        const delta = (right.version[index] || 0) - (left.version[index] || 0);
+        if (delta !== 0) return delta;
+      }
+      return left.binary.localeCompare(right.binary);
+    })
+    .map((candidate) => candidate.binary);
+}
+
 function resolveChromeBinary() {
   if (process.env.POLYLOGUE_LIVE_PROOF_CHROME) return process.env.POLYLOGUE_LIVE_PROOF_CHROME;
-  for (const candidate of ["google-chrome-stable", "google-chrome", "chromium", "chromium-browser"]) {
+  for (const candidate of ["chromium", "chromium-browser", "chrome-for-testing"]) {
+    const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
+    if (found.status === 0 && found.stdout.trim()) return candidate;
+  }
+  for (const candidate of nixStoreChromiumCandidates()) return candidate;
+  for (const candidate of ["google-chrome-stable", "google-chrome"]) {
     const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
     if (found.status === 0 && found.stdout.trim()) return candidate;
   }
@@ -437,6 +468,7 @@ async function main() {
     "--no-first-run",
     "--disable-default-apps",
     "--no-default-browser-check",
+    "--enable-unsafe-extension-debugging",
     `--unsafely-treat-insecure-origin-as-secure=${receiverBaseUrl}`,
     `--disable-extensions-except=${extensionRoot}`,
     `--load-extension=${extensionRoot}`,

--- a/browser-extension/scripts/dev-loop-provider-smoke.mjs
+++ b/browser-extension/scripts/dev-loop-provider-smoke.mjs
@@ -5,7 +5,7 @@
 // cookies or cloud browser state.
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
@@ -105,9 +105,41 @@ function serviceWorkerSuffix(manifest) {
   return `/${worker.replace(/^\/+/, "")}`;
 }
 
+function nixStoreChromiumCandidates() {
+  const storeRoot = "/nix/store";
+  if (!existsSync(storeRoot)) return [];
+  return readdirSync(storeRoot)
+    .map((entry) => {
+      const match = entry.match(/-chromium-(\d+(?:\.\d+)+)$/);
+      if (!match) return null;
+      const binary = path.join(storeRoot, entry, "bin", "chromium");
+      if (!existsSync(binary)) return null;
+      return {
+        binary,
+        version: match[1].split(".").map((part) => Number(part)),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const width = Math.max(left.version.length, right.version.length);
+      for (let index = 0; index < width; index += 1) {
+        const delta = (right.version[index] || 0) - (left.version[index] || 0);
+        if (delta !== 0) return delta;
+      }
+      return left.binary.localeCompare(right.binary);
+    })
+    .map((candidate) => candidate.binary);
+}
+
 function resolveChromeBinary() {
   if (process.env.POLYLOGUE_PROVIDER_SMOKE_CHROME) return process.env.POLYLOGUE_PROVIDER_SMOKE_CHROME;
-  for (const candidate of ["google-chrome-stable", "google-chrome", "chromium", "chromium-browser"]) {
+  const pathCandidates = ["chromium", "chromium-browser", "chrome-for-testing"];
+  for (const candidate of pathCandidates) {
+    const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
+    if (found.status === 0 && found.stdout.trim()) return candidate;
+  }
+  for (const candidate of nixStoreChromiumCandidates()) return candidate;
+  for (const candidate of ["google-chrome-stable", "google-chrome"]) {
     const found = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
     if (found.status === 0 && found.stdout.trim()) return candidate;
   }
@@ -299,12 +331,78 @@ async function waitForExtensionWorker(debuggingPort, expectedWorkerSuffix, expec
   );
 }
 
-async function openProviderTargetFromWorker(workerClient, debuggingPort, url) {
-  const createdTab = await evaluateJson(
+async function openExtensionController(workerClient, debuggingPort, extensionId) {
+  const controllerUrl = await evaluateJson(
+    workerClient,
+    `chrome.runtime.getURL("src/popup.html")`,
+  );
+  const created = await evaluateJson(
     workerClient,
     `(async () => {
       if (!globalThis.chrome?.tabs?.create) {
         throw new Error("extension service-worker CDP target does not expose chrome.tabs.create");
+      }
+      let tab;
+      try {
+        tab = await chrome.tabs.create({url: ${JSON.stringify(controllerUrl)}, active: false});
+      } catch (error) {
+        const message = String(error && error.message ? error.message : error);
+        if (!message.includes("No current window") || !globalThis.chrome?.windows?.create) {
+          throw error;
+        }
+        const createdWindow = await chrome.windows.create({url: ${JSON.stringify(controllerUrl)}, focused: false, type: "normal"});
+        tab = Array.isArray(createdWindow.tabs) && createdWindow.tabs.length ? createdWindow.tabs[0] : null;
+      }
+      if (!tab) throw new Error("extension API did not return a controller tab");
+      return {id: tab.id ?? null, url: tab.url ?? null, pendingUrl: tab.pendingUrl ?? null, title: tab.title ?? null};
+    })()`,
+  );
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const targets = await waitJson(`http://127.0.0.1:${debuggingPort}/json/list`, Math.min(2000, timeoutMs));
+    const target = targets.find((candidate) => candidate.url === controllerUrl);
+    if (target?.webSocketDebuggerUrl) {
+      const client = await connectCdp(target.webSocketDebuggerUrl);
+      await client.call("Runtime.enable");
+      await client.call("Page.enable");
+      await waitForReadyPage(client);
+      await waitForExtensionControllerApis(client);
+      return { target, client, tab: created };
+    }
+    await sleep(250);
+  }
+  throw new Error(`Polylogue extension controller page not found for ${controllerUrl}; tab=${JSON.stringify(created)}`);
+}
+
+async function waitForExtensionControllerApis(client) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await evaluateJson(
+      client,
+      `(() => ({
+        href: location.href,
+        readyState: document.readyState,
+        hasChrome: Boolean(globalThis.chrome),
+        hasRuntime: Boolean(globalThis.chrome?.runtime),
+        hasTabsCreate: Boolean(globalThis.chrome?.tabs?.create),
+        hasTabsQuery: Boolean(globalThis.chrome?.tabs?.query),
+        hasStorageLocal: Boolean(globalThis.chrome?.storage?.local),
+        hasScripting: Boolean(globalThis.chrome?.scripting?.executeScript)
+      }))()`,
+    ).catch((error) => ({ error: String(error.message || error) }));
+    if (last?.hasTabsCreate && last?.hasTabsQuery && last?.hasStorageLocal && last?.hasScripting) return last;
+    await sleep(100);
+  }
+  throw new Error(`extension controller missing required APIs: ${JSON.stringify(last)}`);
+}
+
+async function openProviderTargetFromExtension(extensionClient, debuggingPort, url) {
+  const createdTab = await evaluateJson(
+    extensionClient,
+    `(async () => {
+      if (!globalThis.chrome?.tabs?.create) {
+        throw new Error("extension controller CDP target does not expose chrome.tabs.create");
       }
       let tab;
       try {
@@ -361,9 +459,9 @@ async function providerPageDiagnostics(client) {
   );
 }
 
-async function configureExtension(workerClient) {
+async function configureExtension(extensionClient) {
   return evaluateJson(
-    workerClient,
+    extensionClient,
     `(async () => {
       if (!globalThis.chrome?.storage?.local) {
         if (${JSON.stringify(receiverBaseUrl)} === "http://127.0.0.1:8765" && !${JSON.stringify(receiverAuthToken)}) {
@@ -374,7 +472,7 @@ async function configureExtension(workerClient) {
             caveat: "chrome.storage.local unavailable in service-worker CDP context; using extension defaults"
           };
         }
-        throw new Error("extension service-worker CDP target does not expose chrome.storage.local");
+        throw new Error("extension controller CDP target does not expose chrome.storage.local");
       }
       await chrome.storage.local.set({
         receiverBaseUrl: ${JSON.stringify(receiverBaseUrl)},
@@ -385,12 +483,12 @@ async function configureExtension(workerClient) {
   );
 }
 
-async function captureProvider(workerClient, providerConfig) {
+async function captureProvider(extensionClient, providerConfig) {
   return evaluateJson(
-    workerClient,
+    extensionClient,
     `(async () => {
       if (!globalThis.chrome?.tabs?.query) {
-        throw new Error("extension service-worker CDP target does not expose chrome.tabs");
+        throw new Error("extension controller CDP target does not expose chrome.tabs");
       }
       async function sendCapture(tabId) {
         try {
@@ -419,10 +517,11 @@ async function captureProvider(workerClient, providerConfig) {
         const tabs = await chrome.tabs.query({});
         const tabInventory = summarizeTabs(tabs);
         const expectedTabId = ${JSON.stringify(providerConfig.expectedTabId ?? null)};
+        const openedUrl = ${JSON.stringify(providerConfig.openedTab?.url || providerConfig.openedTab?.pendingUrl || null)};
         const tab = tabs.find((candidate) => typeof expectedTabId === "number" && candidate.id === expectedTabId)
           || tabs.find((candidate) => {
             try {
-              return new URL(candidate.url || "about:blank").hostname === ${JSON.stringify(providerConfig.host)};
+              return new URL(candidate.url || candidate.pendingUrl || openedUrl || "about:blank").hostname === ${JSON.stringify(providerConfig.host)};
             } catch (_error) {
               return false;
             }
@@ -517,6 +616,7 @@ async function main() {
     `--remote-debugging-port=${debuggingPort}`,
     "--no-sandbox",
     "--disable-features=ExtensionsMenuAccessControl",
+    "--enable-unsafe-extension-debugging",
     "--ignore-certificate-errors",
     "--allow-insecure-localhost",
     `--proxy-server=http://127.0.0.1:${proxyServer.port}`,
@@ -539,6 +639,7 @@ async function main() {
 
   let workerClient = null;
   let browserClient = null;
+  let extensionControllerClient = null;
   const pageClients = [];
   try {
     const browserVersion = await waitJson(`http://127.0.0.1:${debuggingPort}/json/version`);
@@ -564,10 +665,20 @@ async function main() {
     const { worker, client } = await waitForExtensionWorker(debuggingPort, expectedWorkerSuffix, localManifest.name);
     workerClient = client;
     const extensionId = new URL(worker.url).host;
-    const configuredReceiver = await configureExtension(workerClient);
+    const { target: extensionController, client: controllerClient, tab: extensionControllerTab } = await openExtensionController(
+      workerClient,
+      debuggingPort,
+      extensionId,
+    );
+    extensionControllerClient = controllerClient;
+    const configuredReceiver = await configureExtension(extensionControllerClient);
 
     for (const config of providerConfigs) {
-      const { client, target, tab } = await openProviderTargetFromWorker(workerClient, debuggingPort, config.url);
+      const { client, target, tab } = await openProviderTargetFromExtension(
+        extensionControllerClient,
+        debuggingPort,
+        config.url,
+      );
       config.pageTarget = {
         id: target.id || null,
         type: target.type || null,
@@ -583,7 +694,7 @@ async function main() {
 
     const providers = {};
     for (const config of providerConfigs) {
-      const capturePayload = await captureProvider(workerClient, config);
+      const capturePayload = await captureProvider(extensionControllerClient, config);
       providers[config.key] = safeProviderSummary(config, capturePayload);
     }
 
@@ -615,6 +726,13 @@ async function main() {
       },
       spool_dir: spoolDir || null,
       service_worker_url: worker.url,
+      extension_controller: {
+        id: extensionController.id || null,
+        type: extensionController.type || null,
+        url: extensionController.url || null,
+        title: extensionController.title || null,
+        tab: extensionControllerTab || null,
+      },
       providers,
     };
     if (outputPath) writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
@@ -622,6 +740,7 @@ async function main() {
     if (!summary.ok) process.exitCode = 1;
   } finally {
     for (const client of pageClients) client.close();
+    if (extensionControllerClient) extensionControllerClient.close();
     if (workerClient) workerClient.close();
     if (browserClient) browserClient.close();
     await terminateProcess(chrome);

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -390,12 +390,13 @@ devtools workspace dev-loop --browser-smoke --json
 devtools workspace dev-loop --browser-plan --extension-smoke --browser-smoke --json
 ```
 
-This launches the first available Chrome-family binary from
-`google-chrome-stable`, `google-chrome`, `chromium`, and `chromium-browser` in
-headless mode with `--load-extension=browser-extension`, discovers the
-Polylogue MV3 service worker over Chrome DevTools Protocol, reads the extension
-manifest, starts a temporary branch-local receiver, then sends unauthenticated
-and authenticated receiver requests from the extension service-worker context.
+This launches the first usable Chrome-family binary, preferring
+Chromium/Chrome for Testing and then local Nix-store Chromium before falling
+back to branded Google Chrome, in headless mode with
+`--load-extension=browser-extension`, discovers the Polylogue MV3 service
+worker over Chrome DevTools Protocol, reads the extension manifest, starts a
+temporary branch-local receiver, then sends unauthenticated and authenticated
+receiver requests from the extension service-worker context.
 It writes
 `browser_smoke_requested` / `browser_smoke_finished` rows to
 `dev-loop.events.jsonl` plus:
@@ -436,15 +437,22 @@ artifacts. It appends `browser_provider_smoke_requested` /
 
 The provider smoke deliberately uses deterministic fixture pages and omits raw
 turn text from its summary. It closes the repo-owned real-browser
-content-script loop without using authenticated cookies or copied profiles. When
-manifest content-script delivery is unavailable in the headless fixture browser,
-the smoke uses the same `chrome.scripting.executeScript` retry path as the popup
-and records `injection_mode=scripted_retry`; `injection_mode=manifest` means the
-content script was already listening. Use `--browser-plan` for the
-visible/private browser handoff when screenshots, copied-profile cookies, or
-live provider pages are needed.
-If Chrome creates the fixture page target but the extension worker cannot see
-the tab, the result records both the CDP page target and the worker-visible tab
+content-script loop without using authenticated cookies or copied profiles.
+Automated unpacked-extension proof prefers Chromium or Chrome for Testing,
+including the local Nix-store Chromium when it is not on `PATH`, before falling
+back to branded Google Chrome. This is intentional: branded Chrome 137+ can
+expose a partial service-worker target for `--load-extension` while withholding
+content-script and extension page behavior that the smoke must prove. Set
+`POLYLOGUE_BROWSER_SMOKE_CHROME`, `POLYLOGUE_PROVIDER_SMOKE_CHROME`, or
+`POLYLOGUE_LIVE_PROOF_CHROME` to override the binary. When manifest
+content-script delivery is unavailable in the fixture browser, the smoke uses
+the same `chrome.scripting.executeScript` retry path as the popup and records
+`injection_mode=scripted_retry`; `injection_mode=manifest` means the content
+script was already listening. Use `--browser-plan` for the visible/private
+browser handoff when screenshots, copied-profile cookies, or live provider
+pages are needed.
+If Chrome creates the fixture page target but the extension cannot see the tab,
+the result records both the CDP page target and the extension-visible tab
 inventory so the failure points at browser/headless capability rather than an
 ambiguous content-script miss.
 


### PR DESCRIPTION
## Summary

Make browser-extension dev-loop smokes prefer Chromium/Chrome for Testing, including local Nix-store Chromium, before falling back to branded Google Chrome. The provider smoke now drives configuration and fallback injection from a real extension page controller so deterministic fixture captures exercise extension-visible tab APIs instead of a limited service-worker CDP context.

## Problem

Ref #2248. Ref #2308. Branded Google Chrome 149 exposed a partial MV3 service-worker target under `--load-extension`, but deterministic provider fixture pages did not receive content scripts, extension pages resolved to `chrome-error://chromewebdata/`, and `chrome.scripting` / `chrome.storage.local` were unavailable from the worker CDP context. This made the dev-loop proof fail in a way that looked like a Polylogue content-script bug while the same extension worked under local Nix-store Chromium.

## Solution

The browser smoke, provider smoke, and live-provider proof now resolve browser binaries in this order: explicit environment override, PATH Chromium/Chrome for Testing, local Nix-store Chromium, then branded Google Chrome fallback. The launchers include `--enable-unsafe-extension-debugging` for unpacked-extension debugging. Provider smoke records the extension controller page and still reports page target diagnostics, tab inventory, adapter identity, request ids, and `injection_mode`.

Docs now explain why automated unpacked-extension proof prefers non-branded Chromium and how to override the binary.

## Verification

- `cd browser-extension && npm run lint && npm run build && npm test -- tests/popup.test.js tests/build.test.js`
- `POLYLOGUE_PROVIDER_SMOKE_OUT=/realm/project/polylogue/.agent/scratch/provider-smoke-20260624-default-resolver.json npm run dev-loop-provider-smoke`
  - passed with `/nix/store/cyw9j7gm65p1768q6vhaax20jlkvpb27-chromium-149.0.7827.114/bin/chromium`
  - ChatGPT and Claude.ai both reported `injection_mode=manifest`
- `devtools workspace dev-loop --browser-smoke --browser-provider-smoke --json > .agent/scratch/dev-loop-browser-smokes-20260624.json`
  - `browser_smoke=True`, `browser_provider_smoke=True`
- `devtools verify --quick`
  - passed locally and in the pre-push hook

Remaining #2248/#2308 scope: live copied-profile provider proof and real provider native-payload fidelity still need separate operator-approved browser runs; this PR fixes the deterministic local dev-loop proof path.
