### PR TITLE
fix(devtools): align browser plan with Chromium smokes

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -1252,19 +1252,21 @@ def build_browser_plan(*, preflight: dict[str, Any]) -> dict[str, object]:
     web_shell_url = f"http://127.0.0.1:{api_port}/"
     receiver_token = os.environ.get("POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN", "")
 
-    chrome_command = [
-        "google-chrome-stable",
+    chromium_command = [
+        "chromium",
         f"--user-data-dir={profile_dir}",
+        "--enable-unsafe-extension-debugging",
         f"--unsafely-treat-insecure-origin-as-secure={receiver_url}",
         f"--disable-extensions-except={extension_root}",
         f"--load-extension={extension_root}",
         "--new-window",
         web_shell_url,
     ]
-    chromium_command = ["chromium", *chrome_command[1:]]
+    google_chrome_command = ["google-chrome-stable", *chromium_command[1:]]
     live_launch_command = [
-        "google-chrome-stable",
+        "chromium",
         f"--user-data-dir={live_profile_dir}",
+        "--enable-unsafe-extension-debugging",
         f"--unsafely-treat-insecure-origin-as-secure={receiver_url}",
         f"--disable-extensions-except={extension_root}",
         f"--load-extension={extension_root}",
@@ -1351,8 +1353,9 @@ def build_browser_plan(*, preflight: dict[str, Any]) -> dict[str, object]:
         "receiver_auth_configured": bool(receiver_token),
         "web_shell_url": web_shell_url,
         "commands": {
-            "chrome": chrome_command,
+            "preferred": chromium_command,
             "chromium": chromium_command,
+            "google_chrome": google_chrome_command,
         },
         "supported_probe_urls": {
             "chatgpt": "https://chatgpt.com/",
@@ -1429,14 +1432,16 @@ def build_browser_plan(*, preflight: dict[str, Any]) -> dict[str, object]:
             "",
             "## Launch",
             "",
-            "```bash",
-            shlex.join(chrome_command),
-            "```",
-            "",
-            "If your Chromium binary is named `chromium`:",
+            "Preferred automated browser:",
             "",
             "```bash",
             shlex.join(chromium_command),
+            "```",
+            "",
+            "Branded Chrome fallback for manual/visible runs:",
+            "",
+            "```bash",
+            shlex.join(google_chrome_command),
             "```",
             "",
             "## Configure",

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -494,8 +494,10 @@ The JSON and Markdown plans include:
 - the unpacked extension path (`browser-extension/`);
 - the branch-local receiver URL and whether a local receiver token is set;
 - the branch-local web-shell URL;
-- a `google-chrome-stable --user-data-dir=... --load-extension=...` command;
-- a `chromium` variant of the same command;
+- a preferred `chromium --user-data-dir=... --load-extension=...` command with
+  `--enable-unsafe-extension-debugging`;
+- a branded `google-chrome-stable` fallback command, for visible/manual use
+  when its unpacked-extension restrictions are acceptable;
 - supported real-page probe URLs for `chatgpt.com` and `claude.ai`;
 - screenshot/download artifact directories for the browser-control layer;
 - an operator-local copied-profile proof checklist and environment template.

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -412,10 +412,13 @@ def test_browser_plan_writes_local_extension_launch_artifacts(
     assert Path(plan["screenshot_dir"]).is_dir()
     assert Path(plan["downloads_dir"]).is_dir()
     assert Path(plan["extension_root"]).name == "browser-extension"
-    chrome = plan["commands"]["chrome"]
-    assert chrome[0] == "google-chrome-stable"
-    assert f"--load-extension={plan['extension_root']}" in chrome
-    assert f"--user-data-dir={plan['profile_dir']}" in chrome
+    preferred = plan["commands"]["preferred"]
+    assert preferred[0] == "chromium"
+    assert "--enable-unsafe-extension-debugging" in preferred
+    assert f"--load-extension={plan['extension_root']}" in preferred
+    assert f"--user-data-dir={plan['profile_dir']}" in preferred
+    google_chrome = plan["commands"]["google_chrome"]
+    assert google_chrome[0] == "google-chrome-stable"
     live_proof = plan["live_provider_proof"]
     assert live_proof["providers"] == ["chatgpt", "claude"]
     assert live_proof["suggested_profile_dir"].endswith("-chrome-user-data")


### PR DESCRIPTION
## Summary

Align the browser dev-loop plan with the extension-smoke browser policy that just landed: generated launch commands now prefer Chromium, include `--enable-unsafe-extension-debugging`, and keep branded Google Chrome as an explicit fallback rather than the primary command.

## Problem

Ref #2248. Ref #2308. After the extension smokes were fixed to prefer local Chromium, `devtools workspace dev-loop --browser-plan --json` still generated Google Chrome as the first copied-profile/browser command. That stale handoff would steer agents/operators back into the branded-Chrome partial-extension behavior the smoke repair avoids.

## Solution

The browser plan now emits `commands.preferred` and `commands.chromium` as the Chromium launch, plus `commands.google_chrome` as the branded fallback. The live copied-profile command also starts with Chromium and includes the unsafe extension debugging flag. The Markdown and docs describe the preferred/fallback split, and the unit test asserts the generated command shape.

## Verification

- `devtools test tests/unit/devtools/test_dev_loop.py -k browser_plan`
  - `2 passed, 19 deselected`
- `devtools workspace dev-loop --browser-plan --json > .agent/scratch/dev-loop-browser-plan-20260624-after-plan-fix.json`
  - generated `commands.preferred[0] == "chromium"`
  - generated live copied-profile command starts with `chromium --user-data-dir=... --enable-unsafe-extension-debugging`
- `devtools render all --check`
  - passed
- `devtools verify --quick`
  - passed locally and in the pre-push hook

Remaining #2248/#2308 scope: this only corrects the operator handoff; actual copied-profile live provider proof still needs a separate run.
