### PR TITLE
fix(browser-capture): fetch ChatGPT native payloads

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -20,6 +20,12 @@
   "content_scripts": [
     {
       "matches": ["https://chatgpt.com/*"],
+      "js": ["src/content/chatgpt_bridge.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://chatgpt.com/*"],
       "js": ["src/common.js", "src/content/chatgpt.js"],
       "run_at": "document_start"
     },

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -2,72 +2,27 @@
   const domAdapterName = "chatgpt-dom-v1";
   const nativeAdapterName = "chatgpt-native-v1";
   const nativeCaptureMessage = "polylogue.chatgpt.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.chatgpt.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.chatgpt.nativeFetchResponse";
   const nativeCaptures = [];
+  const nativeFetchResponses = new Map();
+  const nativeAttemptDiagnostics = [];
+
+  function rememberNativeAttempt(diagnostic) {
+    nativeAttemptDiagnostics.push({
+      attempted_at: new Date().toISOString(),
+      ...diagnostic
+    });
+    if (nativeAttemptDiagnostics.length > 6) {
+      nativeAttemptDiagnostics.splice(0, nativeAttemptDiagnostics.length - 6);
+    }
+  }
 
   function conversationIdFromUrl(url = window.location.href) {
     const parsed = new URL(url);
     const parts = parsed.pathname.split("/").filter(Boolean);
     const marker = parts.indexOf("c");
     return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
-  }
-
-  function injectNativeCaptureBridge() {
-    const root = document.documentElement || document.head || document.body;
-    if (!root) {
-      window.setTimeout(injectNativeCaptureBridge, 0);
-      return;
-    }
-    const script = document.createElement("script");
-    script.textContent = `(() => {
-      const messageType = ${JSON.stringify(nativeCaptureMessage)};
-      const currentOrigin = window.location.origin;
-      window.__polylogueCapturedFetches = Array.isArray(window.__polylogueCapturedFetches)
-        ? window.__polylogueCapturedFetches
-        : [];
-      function post(capture) {
-        window.postMessage({ type: messageType, capture }, currentOrigin);
-      }
-      function remember(capture) {
-        window.__polylogueCapturedFetches.push(capture);
-        if (window.__polylogueCapturedFetches.length > 8) {
-          window.__polylogueCapturedFetches.splice(0, window.__polylogueCapturedFetches.length - 8);
-        }
-        post(capture);
-      }
-      const existingCaptures = window.__polylogueCapturedFetches.slice(-8);
-      window.__polylogueCapturedFetches = existingCaptures;
-      for (const capture of existingCaptures) post(capture);
-      if (window.__polylogueFetchHookInstalled) return;
-      window.__polylogueFetchHookInstalled = true;
-      const originalFetch = window.fetch;
-      window.fetch = async function polylogueFetch(input) {
-        const response = await originalFetch.apply(this, arguments);
-        try {
-          const url = typeof input === "string" ? input : input && input.url;
-          const absolute = new URL(url, window.location.href);
-          const isConversation = absolute.origin === currentOrigin
-            && /\\/backend-api\\/conversation\\/[^/?#]+/.test(absolute.pathname)
-            && !absolute.pathname.endsWith("/init");
-          const contentType = response.headers.get("content-type") || "";
-          if (isConversation && contentType.includes("application/json")) {
-            const body = await response.clone().text();
-            remember({
-              url: absolute.href,
-              status: response.status,
-              ok: response.ok,
-              contentType,
-              body,
-              capturedAt: new Date().toISOString()
-            });
-          }
-        } catch (_error) {
-          // Capture must never perturb the ChatGPT page's own request path.
-        }
-        return response;
-      };
-    })();`;
-    root.appendChild(script);
-    script.remove();
   }
 
   window.addEventListener("message", (event) => {
@@ -78,7 +33,15 @@
     if (nativeCaptures.length > 8) nativeCaptures.splice(0, nativeCaptures.length - 8);
   });
 
-  injectNativeCaptureBridge();
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type !== nativeFetchResponseMessage || !data.requestId) return;
+    const pending = nativeFetchResponses.get(data.requestId);
+    if (!pending) return;
+    nativeFetchResponses.delete(data.requestId);
+    pending.resolve({ capture: data.capture || null, error: data.error || null });
+  });
 
   function roleFromNode(node, index) {
     const testId = node.getAttribute("data-testid") || "";
@@ -185,6 +148,109 @@
     return null;
   }
 
+  async function requestNativeCaptureFromPage(conversationId) {
+    const requestId = `polylogue-native-fetch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responsePromise = new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        nativeFetchResponses.delete(requestId);
+        resolve({ capture: null, error: "timeout" });
+      }, 10000);
+      nativeFetchResponses.set(requestId, {
+        resolve(value) {
+          window.clearTimeout(timeout);
+          resolve(value);
+        }
+      });
+    });
+    window.postMessage(
+      {
+        type: nativeFetchRequestMessage,
+        requestId,
+        conversationId
+      },
+      window.location.origin
+    );
+    return responsePromise;
+  }
+
+  async function fetchNativePayloadFromContentScript(conversationId) {
+    try {
+      const response = await fetch(`/backend-api/conversation/${encodeURIComponent(conversationId)}`, {
+        credentials: "include",
+        cache: "no-store"
+      });
+      const contentType = response.headers.get("content-type") || "";
+      if (!response.ok || !contentType.includes("application/json")) {
+        rememberNativeAttempt({
+          stage: "content_script_fetch",
+          ok: response.ok,
+          status: response.status,
+          content_type: contentType,
+          accepted: false
+        });
+        return null;
+      }
+      const payload = await response.clone().json();
+      if (!payload || typeof payload !== "object" || !payload.mapping) {
+        rememberNativeAttempt({
+          stage: "content_script_fetch",
+          ok: response.ok,
+          status: response.status,
+          content_type: contentType,
+          accepted: false,
+          reason: "missing_mapping"
+        });
+        return null;
+      }
+      const payloadConversationId = payload.conversation_id || payload.id;
+      if (payloadConversationId && String(payloadConversationId) !== conversationId) {
+        rememberNativeAttempt({
+          stage: "content_script_fetch",
+          ok: response.ok,
+          status: response.status,
+          content_type: contentType,
+          accepted: false,
+          reason: "conversation_id_mismatch"
+        });
+        return null;
+      }
+      rememberNativeAttempt({
+        stage: "content_script_fetch",
+        ok: response.ok,
+        status: response.status,
+        content_type: contentType,
+        accepted: true
+      });
+      return payload;
+    } catch (error) {
+      rememberNativeAttempt({
+        stage: "content_script_fetch",
+        accepted: false,
+        error: String(error && error.message ? error.message : error)
+      });
+      return null;
+    }
+  }
+
+  async function fetchNativePayloadOnDemand() {
+    const conversationId = conversationIdFromUrl();
+    if (!conversationId) return null;
+    const pageResult = await requestNativeCaptureFromPage(conversationId);
+    const pageCapture = pageResult && pageResult.capture;
+    const pagePayload = parseNativeCapture(pageCapture);
+    rememberNativeAttempt({
+      stage: "page_bridge_fetch",
+      ok: pageCapture?.ok ?? null,
+      status: pageCapture?.status ?? null,
+      content_type: pageCapture?.contentType || null,
+      body_bytes: typeof pageCapture?.body === "string" ? pageCapture.body.length : 0,
+      accepted: Boolean(pagePayload),
+      error: pageResult?.error || null
+    });
+    if (pagePayload) return pagePayload;
+    return fetchNativePayloadFromContentScript(conversationId);
+  }
+
   function modelFromNativePayload(payload) {
     const mapping = payload && payload.mapping;
     if (!mapping || typeof mapping !== "object") return null;
@@ -219,7 +285,7 @@
   }
 
   async function capture() {
-    const nativePayload = latestNativePayload();
+    const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
     const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
     const fallbackEnvelope = () => {
       const turns = collectTurns();
@@ -227,7 +293,10 @@
       return window.polylogueCapture.buildEnvelope({
         provider: "chatgpt",
         adapterName: domAdapterName,
-        turns
+        turns,
+        providerMeta: {
+          native_attempts: nativeAttemptDiagnostics.slice(-6)
+        }
       });
     };
     const finalEnvelope = envelope || fallbackEnvelope();

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -1,0 +1,118 @@
+(function () {
+  const nativeCaptureMessage = "polylogue.chatgpt.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.chatgpt.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.chatgpt.nativeFetchResponse";
+  const currentOrigin = window.location.origin;
+
+  window.__polylogueCapturedFetches = Array.isArray(window.__polylogueCapturedFetches)
+    ? window.__polylogueCapturedFetches
+    : [];
+
+  function post(capture) {
+    window.postMessage({ type: nativeCaptureMessage, capture }, currentOrigin);
+  }
+
+  function remember(capture) {
+    window.__polylogueCapturedFetches.push(capture);
+    if (window.__polylogueCapturedFetches.length > 8) {
+      window.__polylogueCapturedFetches.splice(0, window.__polylogueCapturedFetches.length - 8);
+    }
+    post(capture);
+  }
+
+  const existingCaptures = window.__polylogueCapturedFetches.slice(-8);
+  window.__polylogueCapturedFetches = existingCaptures;
+  for (const capture of existingCaptures) post(capture);
+
+  if (window.__polylogueFetchHookInstalled) return;
+  window.__polylogueFetchHookInstalled = true;
+
+  const originalFetch = window.fetch;
+
+  function bootstrapAccessToken() {
+    try {
+      const raw = document.getElementById("client-bootstrap")?.textContent;
+      if (!raw) return null;
+      const bootstrap = JSON.parse(raw);
+      const token = bootstrap?.session?.accessToken;
+      return typeof token === "string" && token ? token : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function authHeaders() {
+    const token = bootstrapAccessToken();
+    return token ? { authorization: `Bearer ${token}` } : {};
+  }
+
+  function conversationUrl(conversationId) {
+    return new URL(`/backend-api/conversation/${encodeURIComponent(String(conversationId))}`, currentOrigin);
+  }
+
+  async function fetchConversation(conversationId) {
+    const url = conversationUrl(conversationId);
+    const response = await originalFetch.call(window, url.href, {
+      credentials: "include",
+      cache: "no-store",
+      headers: authHeaders()
+    });
+    const contentType = response.headers.get("content-type") || "";
+    const body = contentType.includes("application/json") ? await response.clone().text() : "";
+    return {
+      url: url.href,
+      status: response.status,
+      ok: response.ok,
+      contentType,
+      body,
+      capturedAt: new Date().toISOString()
+    };
+  }
+
+  window.addEventListener("message", async (event) => {
+    if (event.source !== window || event.origin !== currentOrigin) return;
+    const data = event.data || {};
+    if (data.type !== nativeFetchRequestMessage || !data.requestId || !data.conversationId) return;
+    try {
+      const capture = await fetchConversation(data.conversationId);
+      if (capture.ok && capture.body) remember(capture);
+      window.postMessage({ type: nativeFetchResponseMessage, requestId: data.requestId, capture }, currentOrigin);
+    } catch (error) {
+      window.postMessage(
+        {
+          type: nativeFetchResponseMessage,
+          requestId: data.requestId,
+          error: String(error && error.message ? error.message : error)
+        },
+        currentOrigin
+      );
+    }
+  });
+
+  window.fetch = async function polylogueFetch(input) {
+    const response = await originalFetch.apply(this, arguments);
+    try {
+      const url = typeof input === "string" ? input : input && input.url;
+      const absolute = new URL(url, window.location.href);
+      const isConversation =
+        absolute.origin === currentOrigin &&
+        /\/backend-api\/conversation\/[^/?#]+/.test(absolute.pathname) &&
+        !absolute.pathname.endsWith("/init");
+      const contentType = response.headers.get("content-type") || "";
+      if (isConversation && contentType.includes("application/json")) {
+        const body = await response.clone().text();
+        remember({
+          url: absolute.href,
+          status: response.status,
+          ok: response.ok,
+          contentType,
+          body,
+          capturedAt: new Date().toISOString()
+        });
+      }
+    } catch {
+      // Capture must never perturb the ChatGPT page's own request path.
+    }
+    return response;
+  };
+})();

--- a/browser-extension/tests/content/chatgpt.test.js
+++ b/browser-extension/tests/content/chatgpt.test.js
@@ -33,6 +33,54 @@ function conversationIdFromUrl(url) {
   return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
 }
 
+async function fetchNativePayloadOnDemand(pageUrl, fetchImpl) {
+  const conversationId = conversationIdFromUrl(pageUrl);
+  if (!conversationId) return null;
+  try {
+    const response = await fetchImpl(
+      `/backend-api/conversation/${encodeURIComponent(conversationId)}`,
+      {
+        credentials: "include",
+        cache: "no-store",
+      },
+    );
+    const contentType = response.headers.get("content-type") || "";
+    if (!response.ok || !contentType.includes("application/json")) return null;
+    const payload = await response.clone().json();
+    if (!payload || typeof payload !== "object" || !payload.mapping) return null;
+    const payloadConversationId = payload.conversation_id || payload.id;
+    if (payloadConversationId && String(payloadConversationId) !== conversationId)
+      return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+function makeFetchResponse(payload, options = {}) {
+  const {
+    ok = true,
+    contentType = "application/json",
+    throws = false,
+  } = options;
+  return {
+    ok,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === "content-type" ? contentType : null;
+      },
+    },
+    clone() {
+      return {
+        async json() {
+          if (throws) throw new Error("bad json");
+          return payload;
+        },
+      };
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -164,5 +212,84 @@ describe("chatgpt conversationIdFromUrl", () => {
 
   it("returns null outside conversation routes", () => {
     expect(conversationIdFromUrl("https://chatgpt.com/g/g-p-abc")).toBe(null);
+  });
+});
+
+describe("chatgpt fetchNativePayloadOnDemand", () => {
+  it("fetches the current conversation JSON with credentials", async () => {
+    const payload = {
+      conversation_id: "conv-123",
+      title: "Native ChatGPT title",
+      mapping: { node: { message: { content: { parts: ["hello"] } } } },
+    };
+    const calls = [];
+    const fetchImpl = async (...args) => {
+      calls.push(args);
+      return makeFetchResponse(payload);
+    };
+
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", fetchImpl),
+    ).resolves.toEqual(payload);
+    expect(calls).toEqual([
+      [
+        "/backend-api/conversation/conv-123",
+        { credentials: "include", cache: "no-store" },
+      ],
+    ]);
+  });
+
+  it("supports custom GPT conversation routes", async () => {
+    const payload = { id: "conv-123", mapping: { node: {} } };
+    const calls = [];
+    const fetchImpl = async (...args) => {
+      calls.push(args);
+      return makeFetchResponse(payload);
+    };
+
+    await expect(
+      fetchNativePayloadOnDemand(
+        "https://chatgpt.com/g/g-p-abc/c/conv-123",
+        fetchImpl,
+      ),
+    ).resolves.toEqual(payload);
+    expect(calls[0][0]).toBe("/backend-api/conversation/conv-123");
+  });
+
+  it("rejects mismatched, non-json, failed, malformed, and off-route payloads", async () => {
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
+        makeFetchResponse({ conversation_id: "other", mapping: {} }),
+      ),
+    ).resolves.toBe(null);
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
+        makeFetchResponse({ conversation_id: "conv-123", mapping: {} }, {
+          contentType: "text/html",
+        }),
+      ),
+    ).resolves.toBe(null);
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
+        makeFetchResponse({ conversation_id: "conv-123", mapping: {} }, {
+          ok: false,
+        }),
+      ),
+    ).resolves.toBe(null);
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
+        makeFetchResponse({ conversation_id: "conv-123" }),
+      ),
+    ).resolves.toBe(null);
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
+        makeFetchResponse(null, { throws: true }),
+      ),
+    ).resolves.toBe(null);
+    await expect(
+      fetchNativePayloadOnDemand("https://chatgpt.com/", async () =>
+        makeFetchResponse({ mapping: {} }),
+      ),
+    ).resolves.toBe(null);
   });
 });


### PR DESCRIPTION
## Summary

ChatGPT browser capture now uses a Manifest V3 main-world bridge to fetch the provider-native conversation payload for the current page before falling back to DOM extraction.

## Problem

Ref #2308. Copied-profile live proof was green at the extension/page level but still reported `chatgpt-dom-v1`. The old ChatGPT native path depended on brittle inline page-script injection and passive fetch observation. Live diagnostics showed the inline bridge did not reliably respond, while cookie-only requests to `/backend-api/conversation/<id>` returned `conversation_inaccessible` even inside an authenticated ChatGPT tab.

A live CDP probe against the same authenticated page showed that the endpoint returns the complete conversation when called with `Authorization: Bearer <client-bootstrap session.accessToken>`.

## Solution

- Add `src/content/chatgpt_bridge.js` as a ChatGPT `world: "MAIN"` content script.
- Have the bridge read the bearer token from `#client-bootstrap`, request `/backend-api/conversation/<id>` with credentials plus bearer auth, and forward the native payload to the isolated capture adapter via `postMessage`.
- Keep passive app-fetch capture in the main-world bridge.
- Keep bounded native-attempt diagnostics on DOM fallback without storing auth tokens in diagnostics.
- Add focused content tests for on-demand payload acceptance/rejection.

Remaining #2308 scope: Claude live capture still falls back to `claude-ai-dom-v1`; it likely needs an analogous main-world/on-demand path plus org-ID discovery.

## Verification

- `cd browser-extension && npm run validate && npm run lint && npm run build && npm test -- tests/content/chatgpt.test.js tests/build.test.js`
- Copied-profile live proof from this branch: `.agent/scratch/live-chatgpt-native-proof-20260624.json`
  - `browser_live_proof.ok = true`
  - ChatGPT `adapter_name = chatgpt-native-v1`
  - `turn_count = 86`
  - captured artifact size `2254140` bytes
  - session provider metadata includes `capture_source=chatgpt_backend_api` and `mapping_node_count=125`
- `devtools verify --quick`
- pre-push hook reran `devtools verify --quick` at `e609e52763c13e9062a5a61a33cc5afc5888c491`
