### PR TITLE
fix(browser-capture): preserve temporary chats and attachments

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -31,6 +31,12 @@
     },
     {
       "matches": ["https://claude.ai/*"],
+      "js": ["src/content/claude_bridge.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
       "js": ["src/common.js", "src/content/claude.js"],
       "run_at": "document_idle"
     }

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -17,6 +17,7 @@
     if (provider === "chatgpt") {
       const marker = parts.indexOf("c");
       if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
+      if (parsed.searchParams.get("temporary-chat") === "true") return "__polylogue_temporary_chat__";
       return null;
     }
     if (provider === "claude-ai" && parts[0] === "chat" && parts[1]) {
@@ -44,7 +45,11 @@
     rawProviderPayload = null
   }) {
     const sourceUrl = window.location.href;
-    const stableProviderSessionId = providerSessionId || sessionIdFromUrl(provider, sourceUrl);
+    const urlSessionId = providerSessionId || sessionIdFromUrl(provider, sourceUrl);
+    const stableProviderSessionId =
+      urlSessionId === "__polylogue_temporary_chat__"
+      ? `temporary:${fnv1a(`${sourceUrl}:${turns.map((turn) => `${turn.role}:${turn.text || ""}`).join("\n")}`)}`
+        : urlSessionId;
     if (!stableProviderSessionId) {
       throw new Error(`cannot capture ${provider} page without a provider-native conversation id`);
     }
@@ -75,12 +80,13 @@
         model,
         provider_meta: providerMeta,
         turns: turns.map((turn, ordinal) => ({
-          provider_turn_id: turn.provider_turn_id || `${stableProviderSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + turn.text)}`,
+          provider_turn_id: turn.provider_turn_id || `${stableProviderSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + (turn.text || ""))}`,
           role: turn.role,
-          text: turn.text,
+          text: turn.text || null,
           timestamp: turn.timestamp || null,
           ordinal,
           parent_turn_id: turn.parent_turn_id || null,
+          attachments: Array.isArray(turn.attachments) ? turn.attachments : [],
           provider_meta: turn.provider_meta || {}
         }))
       }

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -53,6 +53,59 @@
     return index % 2 === 0 ? "user" : "assistant";
   }
 
+  function attachmentNameFromNode(node) {
+    const label = node.getAttribute("aria-label") || "";
+    const download = node.getAttribute("download") || "";
+    const alt = node.getAttribute("alt") || "";
+    const text = window.polylogueCapture.visibleText(node);
+    const href = node.getAttribute("href") || node.getAttribute("src") || "";
+    const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
+    const candidates = [label, download, alt, text, basename]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const extensionPattern =
+      "zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm";
+    const filePattern = new RegExp(`(?:^|\\s)([^\\s@/]+\\.(?:${extensionPattern}))(?:\\s|$)`, "i");
+    for (const candidate of candidates) {
+      const fileNameMatch = candidate.match(filePattern);
+      if (fileNameMatch) return fileNameMatch[1].trim();
+    }
+    return null;
+  }
+
+  function collectAttachments(node, turnIndex) {
+    const selector = [
+      '[role="group"][aria-label]',
+      "a[download]",
+      "a[href][aria-label]",
+      "img[alt]",
+      "img[src]"
+    ].join(",");
+    const seen = new Set();
+    const attachments = [];
+    for (const candidate of node.querySelectorAll(selector)) {
+      const name = attachmentNameFromNode(candidate);
+      if (!name) continue;
+      const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
+      const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
+      const key = `${name}\n${url || ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      attachments.push({
+        provider_attachment_id: `dom:${window.polylogueCapture.fnv1a(`${turnIndex}:${key}`)}`,
+        name,
+        url,
+        provider_meta: {
+          dom_selector_index: turnIndex,
+          dom_label: candidate.getAttribute("aria-label") || null,
+          dom_text: window.polylogueCapture.visibleText(candidate) || null,
+          capture_source: "chatgpt_dom_attachment"
+        }
+      });
+    }
+    return attachments;
+  }
+
   function collectTurns() {
     const nodes = [
       ...document.querySelectorAll('[data-testid^="conversation-turn-"], article, [data-message-author-role]')
@@ -62,7 +115,10 @@
         const explicitRole = node.getAttribute("data-message-author-role");
         const role = explicitRole || roleFromNode(node, index);
         const text = window.polylogueCapture.visibleText(node);
-        return text ? { role, text, provider_meta: { selector_index: index } } : null;
+        const attachments = collectAttachments(node, index);
+        return text || attachments.length
+          ? { role, text, attachments, provider_meta: { selector_index: index } }
+          : null;
       })
       .filter(Boolean);
   }

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -2,72 +2,26 @@
   const domAdapterName = "claude-ai-dom-v1";
   const nativeAdapterName = "claude-ai-native-v1";
   const nativeCaptureMessage = "polylogue.claude.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.claude.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.claude.nativeFetchResponse";
   const nativeCaptures = [];
+  const nativeFetchResponses = new Map();
+  const nativeAttemptDiagnostics = [];
+
+  function rememberNativeAttempt(diagnostic) {
+    nativeAttemptDiagnostics.push({
+      attempted_at: new Date().toISOString(),
+      ...diagnostic
+    });
+    if (nativeAttemptDiagnostics.length > 6) {
+      nativeAttemptDiagnostics.splice(0, nativeAttemptDiagnostics.length - 6);
+    }
+  }
 
   function conversationIdFromUrl(url = window.location.href) {
     const parsed = new URL(url);
     const parts = parsed.pathname.split("/").filter(Boolean);
     return parts[0] === "chat" && parts[1] ? parts[1] : null;
-  }
-
-  function injectNativeCaptureBridge() {
-    const root = document.documentElement || document.head || document.body;
-    if (!root) {
-      window.setTimeout(injectNativeCaptureBridge, 0);
-      return;
-    }
-    const script = document.createElement("script");
-    script.textContent = `(() => {
-      const messageType = ${JSON.stringify(nativeCaptureMessage)};
-      const currentOrigin = window.location.origin;
-      window.__polylogueClaudeCapturedFetches = Array.isArray(window.__polylogueClaudeCapturedFetches)
-        ? window.__polylogueClaudeCapturedFetches
-        : [];
-      function post(capture) {
-        window.postMessage({ type: messageType, capture }, currentOrigin);
-      }
-      function remember(capture) {
-        window.__polylogueClaudeCapturedFetches.push(capture);
-        if (window.__polylogueClaudeCapturedFetches.length > 8) {
-          window.__polylogueClaudeCapturedFetches.splice(0, window.__polylogueClaudeCapturedFetches.length - 8);
-        }
-        post(capture);
-      }
-      const existingCaptures = window.__polylogueClaudeCapturedFetches.slice(-8);
-      window.__polylogueClaudeCapturedFetches = existingCaptures;
-      for (const capture of existingCaptures) post(capture);
-      if (window.__polylogueClaudeFetchHookInstalled) return;
-      window.__polylogueClaudeFetchHookInstalled = true;
-      const originalFetch = window.fetch;
-      window.fetch = async function polylogueClaudeFetch(input) {
-        const response = await originalFetch.apply(this, arguments);
-        try {
-          const url = typeof input === "string" ? input : input && input.url;
-          const absolute = new URL(url, window.location.href);
-          const isConversation = absolute.origin === currentOrigin
-            && /\\/api\\/organizations\\/[^/?#]+\\/chat_conversations\\/[^/?#]+/.test(absolute.pathname);
-          const contentType = response.headers.get("content-type") || "";
-          if (isConversation && contentType.includes("application/json")) {
-            const body = await response.clone().text();
-            if (body.includes('"chat_messages"')) {
-              remember({
-                url: absolute.href,
-                status: response.status,
-                ok: response.ok,
-                contentType,
-                body,
-                capturedAt: new Date().toISOString()
-              });
-            }
-          }
-        } catch (_error) {
-          // Capture must never perturb the Claude.ai page's own request path.
-        }
-        return response;
-      };
-    })();`;
-    root.appendChild(script);
-    script.remove();
   }
 
   window.addEventListener("message", (event) => {
@@ -78,7 +32,15 @@
     if (nativeCaptures.length > 8) nativeCaptures.splice(0, nativeCaptures.length - 8);
   });
 
-  injectNativeCaptureBridge();
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type !== nativeFetchResponseMessage || !data.requestId) return;
+    const pending = nativeFetchResponses.get(data.requestId);
+    if (!pending) return;
+    nativeFetchResponses.delete(data.requestId);
+    pending.resolve({ capture: data.capture || null, error: data.error || null });
+  });
 
   function roleFromNode(node, index) {
     const role = node.getAttribute("data-message-author-role") || node.getAttribute("data-testid") || "";
@@ -171,6 +133,49 @@
     return null;
   }
 
+  async function requestNativeCaptureFromPage(conversationId) {
+    const requestId = `polylogue-claude-native-fetch-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responsePromise = new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        nativeFetchResponses.delete(requestId);
+        resolve({ capture: null, error: "timeout" });
+      }, 10000);
+      nativeFetchResponses.set(requestId, {
+        resolve(value) {
+          window.clearTimeout(timeout);
+          resolve(value);
+        }
+      });
+    });
+    window.postMessage(
+      {
+        type: nativeFetchRequestMessage,
+        requestId,
+        conversationId
+      },
+      window.location.origin
+    );
+    return responsePromise;
+  }
+
+  async function fetchNativePayloadOnDemand() {
+    const conversationId = conversationIdFromUrl();
+    if (!conversationId) return null;
+    const pageResult = await requestNativeCaptureFromPage(conversationId);
+    const pageCapture = pageResult && pageResult.capture;
+    const pagePayload = parseNativeCapture(pageCapture);
+    rememberNativeAttempt({
+      stage: "page_bridge_fetch",
+      ok: pageCapture?.ok ?? null,
+      status: pageCapture?.status ?? null,
+      content_type: pageCapture?.contentType || null,
+      body_bytes: typeof pageCapture?.body === "string" ? pageCapture.body.length : 0,
+      accepted: Boolean(pagePayload),
+      error: pageResult?.error || pageCapture?.error || null
+    });
+    return pagePayload;
+  }
+
   function modelFromNativePayload(payload) {
     const messages = payload && payload.chat_messages;
     if (!Array.isArray(messages)) return null;
@@ -201,7 +206,7 @@
   }
 
   async function capture() {
-    const nativePayload = latestNativePayload();
+    const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
     const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
     const fallbackEnvelope = () => {
       const turns = collectTurns();
@@ -209,7 +214,10 @@
       return window.polylogueCapture.buildEnvelope({
         provider: "claude-ai",
         adapterName: domAdapterName,
-        turns
+        turns,
+        providerMeta: {
+          native_attempts: nativeAttemptDiagnostics.slice(-6)
+        }
       });
     };
     const finalEnvelope = envelope || fallbackEnvelope();

--- a/browser-extension/src/content/claude_bridge.js
+++ b/browser-extension/src/content/claude_bridge.js
@@ -1,0 +1,167 @@
+(function () {
+  const nativeCaptureMessage = "polylogue.claude.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.claude.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.claude.nativeFetchResponse";
+  const currentOrigin = window.location.origin;
+
+  window.__polylogueClaudeCapturedFetches = Array.isArray(window.__polylogueClaudeCapturedFetches)
+    ? window.__polylogueClaudeCapturedFetches
+    : [];
+
+  function post(capture) {
+    window.postMessage({ type: nativeCaptureMessage, capture }, currentOrigin);
+  }
+
+  function remember(capture) {
+    window.__polylogueClaudeCapturedFetches.push(capture);
+    if (window.__polylogueClaudeCapturedFetches.length > 8) {
+      window.__polylogueClaudeCapturedFetches.splice(0, window.__polylogueClaudeCapturedFetches.length - 8);
+    }
+    post(capture);
+  }
+
+  const existingCaptures = window.__polylogueClaudeCapturedFetches.slice(-8);
+  window.__polylogueClaudeCapturedFetches = existingCaptures;
+  for (const capture of existingCaptures) post(capture);
+
+  if (window.__polylogueClaudeFetchHookInstalled) return;
+  window.__polylogueClaudeFetchHookInstalled = true;
+
+  const originalFetch = window.fetch;
+
+  function resourceUrls() {
+    return window.performance.getEntriesByType("resource").map((entry) => entry.name);
+  }
+
+  function organizationIdFromLocalStorage() {
+    const uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+    const patterns = [
+      new RegExp(`^claude-mcp-has-connectors:(${uuidPattern})$`, "i"),
+      new RegExp(`^LSS-model-selector-thinking:(${uuidPattern}):`, "i")
+    ];
+    for (const key of Object.keys(window.localStorage)) {
+      for (const pattern of patterns) {
+        const match = key.match(pattern);
+        if (match) return match[1];
+      }
+    }
+    return null;
+  }
+
+  function conversationApiUrlFromResources(conversationId, urls = resourceUrls()) {
+    const escapedId = String(conversationId);
+    const observed = urls.find((url) => {
+      try {
+        const parsed = new URL(url, currentOrigin);
+        return (
+          parsed.origin === currentOrigin &&
+          parsed.pathname.includes(`/chat_conversations/${escapedId}`) &&
+          /\/api\/organizations\/[^/]+\/chat_conversations\/[^/]+/.test(parsed.pathname)
+        );
+      } catch {
+        return false;
+      }
+    });
+    if (observed) return observed;
+
+    for (const url of urls) {
+      try {
+        const parsed = new URL(url, currentOrigin);
+        const match = parsed.pathname.match(/\/api\/bootstrap\/([^/]+)\/current_user_access/);
+        if (parsed.origin === currentOrigin && match) {
+          return new URL(
+            `/api/organizations/${encodeURIComponent(match[1])}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+            currentOrigin
+          ).href;
+        }
+      } catch {
+        // Ignore malformed resource entries.
+      }
+    }
+    const localStorageOrgId = organizationIdFromLocalStorage();
+    if (localStorageOrgId) {
+      return new URL(
+        `/api/organizations/${encodeURIComponent(localStorageOrgId)}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+        currentOrigin
+      ).href;
+    }
+    return null;
+  }
+
+  async function fetchConversation(conversationId) {
+    const url = conversationApiUrlFromResources(conversationId);
+    if (!url) {
+      return {
+        url: "",
+        status: 0,
+        ok: false,
+        contentType: "",
+        body: "",
+        capturedAt: new Date().toISOString(),
+        error: "conversation_api_url_not_found"
+      };
+    }
+    const response = await originalFetch.call(window, url, {
+      credentials: "include",
+      cache: "no-store"
+    });
+    const contentType = response.headers.get("content-type") || "";
+    const body = contentType.includes("application/json") ? await response.clone().text() : "";
+    return {
+      url,
+      status: response.status,
+      ok: response.ok,
+      contentType,
+      body,
+      capturedAt: new Date().toISOString()
+    };
+  }
+
+  window.addEventListener("message", async (event) => {
+    if (event.source !== window || event.origin !== currentOrigin) return;
+    const data = event.data || {};
+    if (data.type !== nativeFetchRequestMessage || !data.requestId || !data.conversationId) return;
+    try {
+      const capture = await fetchConversation(data.conversationId);
+      if (capture.ok && capture.body) remember(capture);
+      window.postMessage({ type: nativeFetchResponseMessage, requestId: data.requestId, capture }, currentOrigin);
+    } catch (error) {
+      window.postMessage(
+        {
+          type: nativeFetchResponseMessage,
+          requestId: data.requestId,
+          error: String(error && error.message ? error.message : error)
+        },
+        currentOrigin
+      );
+    }
+  });
+
+  window.fetch = async function polylogueClaudeFetch(input) {
+    const response = await originalFetch.apply(this, arguments);
+    try {
+      const url = typeof input === "string" ? input : input && input.url;
+      const absolute = new URL(url, window.location.href);
+      const isConversation =
+        absolute.origin === currentOrigin &&
+        /\/api\/organizations\/[^/?#]+\/chat_conversations\/[^/?#]+/.test(absolute.pathname);
+      const contentType = response.headers.get("content-type") || "";
+      if (isConversation && contentType.includes("application/json")) {
+        const body = await response.clone().text();
+        if (body.includes('"chat_messages"')) {
+          remember({
+            url: absolute.href,
+            status: response.status,
+            ok: response.ok,
+            contentType,
+            body,
+            capturedAt: new Date().toISOString()
+          });
+        }
+      }
+    } catch {
+      // Capture must never perturb the Claude.ai page's own request path.
+    }
+    return response;
+  };
+})();

--- a/browser-extension/tests/common.test.js
+++ b/browser-extension/tests/common.test.js
@@ -26,6 +26,7 @@ function sessionIdFromUrl(provider, url) {
   if (provider === "chatgpt") {
     const marker = parts.indexOf("c");
     if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
+    if (parsed.searchParams.get("temporary-chat") === "true") return "__polylogue_temporary_chat__";
     return null;
   }
   if (provider === "claude-ai" && parts[0] === "chat" && parts[1]) {
@@ -58,12 +59,16 @@ function buildEnvelope({
 }) {
   const stableProviderSessionId =
     providerSessionId || sessionIdFromUrl(provider, sourceUrl);
-  if (!stableProviderSessionId) {
+  const resolvedProviderSessionId =
+    stableProviderSessionId === "__polylogue_temporary_chat__"
+      ? `temporary:${fnv1a(`${sourceUrl}:${turns.map((turn) => `${turn.role}:${turn.text || ""}`).join("\n")}`)}`
+      : stableProviderSessionId;
+  if (!resolvedProviderSessionId) {
     throw new Error(`cannot capture ${provider} page without a provider-native conversation id`);
   }
-  const stableCaptureId = stableProviderSessionId.startsWith(`${provider}:`)
-    ? stableProviderSessionId
-    : `${provider}:${stableProviderSessionId}`;
+  const stableCaptureId = resolvedProviderSessionId.startsWith(`${provider}:`)
+    ? resolvedProviderSessionId
+    : `${provider}:${resolvedProviderSessionId}`;
   const now = new Date().toISOString();
   const envelope = {
     polylogue_capture_kind: "browser_llm_session",
@@ -81,7 +86,7 @@ function buildEnvelope({
     },
     session: {
       provider,
-      provider_session_id: stableProviderSessionId,
+      provider_session_id: resolvedProviderSessionId,
       title: title || "Test Page",
       created_at: createdAt,
       updated_at: updatedAt || now,
@@ -90,12 +95,13 @@ function buildEnvelope({
       turns: turns.map((turn, ordinal) => ({
         provider_turn_id:
           turn.provider_turn_id ||
-          `${stableProviderSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + turn.text)}`,
+          `${resolvedProviderSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + (turn.text || ""))}`,
         role: turn.role,
-        text: turn.text,
+        text: turn.text || null,
         timestamp: turn.timestamp || null,
         ordinal,
         parent_turn_id: turn.parent_turn_id || null,
+        attachments: Array.isArray(turn.attachments) ? turn.attachments : [],
         provider_meta: turn.provider_meta || {},
       })),
     },
@@ -174,6 +180,14 @@ describe("sessionIdFromUrl", () => {
       "https://chatgpt.com/",
     );
     expect(id).toBeNull();
+  });
+
+  it("marks ChatGPT temporary-chat routes for local identity assignment", () => {
+    const id = sessionIdFromUrl(
+      "chatgpt",
+      "https://chatgpt.com/?temporary-chat=true",
+    );
+    expect(id).toBe("__polylogue_temporary_chat__");
   });
 
   it("does not invent Claude ids for non-conversation routes", () => {
@@ -263,6 +277,31 @@ describe("buildEnvelope", () => {
     })).toThrow("cannot capture chatgpt page without a provider-native conversation id");
   });
 
+  it("assigns deterministic local ids for ChatGPT temporary chats", () => {
+    const envelope = buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-dom-v1",
+      sourceUrl: "https://chatgpt.com/?temporary-chat=true",
+      turns: [
+        { role: "user", text: "Important temporary prompt" },
+        { role: "assistant", text: "Important temporary answer" },
+      ],
+    });
+    const repeated = buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-dom-v1",
+      sourceUrl: "https://chatgpt.com/?temporary-chat=true",
+      turns: [
+        { role: "user", text: "Important temporary prompt" },
+        { role: "assistant", text: "Important temporary answer" },
+      ],
+    });
+
+    expect(envelope.session.provider_session_id).toMatch(/^temporary:[0-9a-f]{8}$/);
+    expect(envelope.capture_id).toBe(`chatgpt:${envelope.session.provider_session_id}`);
+    expect(repeated.session.provider_session_id).toBe(envelope.session.provider_session_id);
+  });
+
   it("assigns ordinals to turns", () => {
     const envelope = buildEnvelope({
       provider: "chatgpt",
@@ -314,6 +353,34 @@ describe("buildEnvelope", () => {
     expect(envelope.session.turns[0].provider_meta).toEqual({
       selector_index: 0,
     });
+  });
+
+  it("passes through browser-observed turn attachments", () => {
+    const envelope = buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-dom-v1",
+      turns: [
+        {
+          role: "user",
+          text: "See attached",
+          attachments: [
+            {
+              provider_attachment_id: "dom:abc123",
+              name: "polylogue-all.tar.gz",
+              provider_meta: { capture_source: "chatgpt_dom_attachment" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(envelope.session.turns[0].attachments).toEqual([
+      {
+        provider_attachment_id: "dom:abc123",
+        name: "polylogue-all.tar.gz",
+        provider_meta: { capture_source: "chatgpt_dom_attachment" },
+      },
+    ]);
   });
 
   it("accepts null model", () => {

--- a/browser-extension/tests/content/chatgpt.test.js
+++ b/browser-extension/tests/content/chatgpt.test.js
@@ -26,6 +26,72 @@ function roleFromNode(node, index) {
   return index % 2 === 0 ? "user" : "assistant";
 }
 
+function fnv1a(text) {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function visibleText(node) {
+  return (node?.innerText || node?.textContent || "").replace(/\s+\n/g, "\n").trim();
+}
+
+function attachmentNameFromNode(node) {
+  const label = node.getAttribute("aria-label") || "";
+  const download = node.getAttribute("download") || "";
+  const alt = node.getAttribute("alt") || "";
+  const text = visibleText(node);
+  const href = node.getAttribute("href") || node.getAttribute("src") || "";
+  const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
+  const candidates = [label, download, alt, text, basename]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  const extensionPattern =
+    "zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm";
+  const filePattern = new RegExp(`(?:^|\\s)([^\\s@/]+\\.(?:${extensionPattern}))(?:\\s|$)`, "i");
+  for (const candidate of candidates) {
+    const fileNameMatch = candidate.match(filePattern);
+    if (fileNameMatch) return fileNameMatch[1].trim();
+  }
+  return null;
+}
+
+function collectAttachments(node, turnIndex) {
+  const selector = [
+    '[role="group"][aria-label]',
+    "a[download]",
+    "a[href][aria-label]",
+    "img[alt]",
+    "img[src]",
+  ].join(",");
+  const seen = new Set();
+  const attachments = [];
+  for (const candidate of node.querySelectorAll(selector)) {
+    const name = attachmentNameFromNode(candidate);
+    if (!name) continue;
+    const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
+    const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
+    const key = `${name}\n${url || ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    attachments.push({
+      provider_attachment_id: `dom:${fnv1a(`${turnIndex}:${key}`)}`,
+      name,
+      url,
+      provider_meta: {
+        dom_selector_index: turnIndex,
+        dom_label: candidate.getAttribute("aria-label") || null,
+        dom_text: visibleText(candidate) || null,
+        capture_source: "chatgpt_dom_attachment",
+      },
+    });
+  }
+  return attachments;
+}
+
 function conversationIdFromUrl(url) {
   const parsed = new URL(url);
   const parts = parsed.pathname.split("/").filter(Boolean);
@@ -212,6 +278,47 @@ describe("chatgpt conversationIdFromUrl", () => {
 
   it("returns null outside conversation routes", () => {
     expect(conversationIdFromUrl("https://chatgpt.com/g/g-p-abc")).toBe(null);
+  });
+});
+
+describe("chatgpt collectAttachments", () => {
+  it("captures ChatGPT file tiles by aria-label", () => {
+    const dom = new JSDOM(
+      '<!DOCTYPE html><article><div role="group" aria-label="polylogue-all.tar.gz"><span>polylogue-all.tar.gz</span></div></article>',
+    );
+    const article = dom.window.document.querySelector("article");
+
+    expect(collectAttachments(article, 3)).toEqual([
+      {
+        provider_attachment_id: `dom:${fnv1a("3:polylogue-all.tar.gz\n")}`,
+        name: "polylogue-all.tar.gz",
+        url: null,
+        provider_meta: {
+          dom_selector_index: 3,
+          dom_label: "polylogue-all.tar.gz",
+          dom_text: "polylogue-all.tar.gz",
+          capture_source: "chatgpt_dom_attachment",
+        },
+      },
+    ]);
+  });
+
+  it("deduplicates repeated labels within a turn", () => {
+    const dom = new JSDOM(
+      '<!DOCTYPE html><article><div role="group" aria-label="career.md"></div><div role="group" aria-label="career.md"></div></article>',
+    );
+    const article = dom.window.document.querySelector("article");
+
+    expect(collectAttachments(article, 0)).toHaveLength(1);
+  });
+
+  it("does not treat domains, emails, or version prose as file uploads", () => {
+    const dom = new JSDOM(
+      '<!DOCTYPE html><article><a aria-label="dbreunig.com" href="https://dbreunig.com">dbreunig.com</a><a aria-label="recruiting@nousresearch.com" href="mailto:recruiting@nousresearch.com">recruiting@nousresearch.com</a><div role="group" aria-label="After Opus 4.5">After Opus 4.5</div></article>',
+    );
+    const article = dom.window.document.querySelector("article");
+
+    expect(collectAttachments(article, 0)).toEqual([]);
   });
 });
 

--- a/browser-extension/tests/content/claude.test.js
+++ b/browser-extension/tests/content/claude.test.js
@@ -32,6 +32,71 @@ function conversationIdFromUrl(url) {
   return parts[0] === "chat" && parts[1] ? parts[1] : null;
 }
 
+function organizationIdFromStorageKeys(keys) {
+  const uuidPattern =
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+  const patterns = [
+    new RegExp(`^claude-mcp-has-connectors:(${uuidPattern})$`, "i"),
+    new RegExp(`^LSS-model-selector-thinking:(${uuidPattern}):`, "i"),
+  ];
+  for (const key of keys) {
+    for (const pattern of patterns) {
+      const match = key.match(pattern);
+      if (match) return match[1];
+    }
+  }
+  return null;
+}
+
+function conversationApiUrlFromResources(
+  conversationId,
+  urls,
+  origin = "https://claude.ai",
+  storageKeys = [],
+) {
+  const escapedId = String(conversationId);
+  const observed = urls.find((url) => {
+    try {
+      const parsed = new URL(url, origin);
+      return (
+        parsed.origin === origin &&
+        parsed.pathname.includes(`/chat_conversations/${escapedId}`) &&
+        /\/api\/organizations\/[^/]+\/chat_conversations\/[^/]+/.test(
+          parsed.pathname,
+        )
+      );
+    } catch {
+      return false;
+    }
+  });
+  if (observed) return observed;
+
+  for (const url of urls) {
+    try {
+      const parsed = new URL(url, origin);
+      const match = parsed.pathname.match(
+        /\/api\/bootstrap\/([^/]+)\/current_user_access/,
+      );
+      if (parsed.origin === origin && match) {
+        return new URL(
+          `/api/organizations/${encodeURIComponent(match[1])}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+          origin,
+        ).href;
+      }
+    } catch {
+      // Ignore malformed resource entries.
+    }
+  }
+  const localStorageOrgId = organizationIdFromStorageKeys(storageKeys);
+  if (localStorageOrgId) {
+    return new URL(
+      `/api/organizations/${encodeURIComponent(localStorageOrgId)}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+      origin,
+    ).href;
+  }
+  return null;
+}
+
 function textFromMessage(message) {
   if (!message || typeof message !== "object") return "";
   if (typeof message.text === "string" && message.text) return message.text;
@@ -314,5 +379,54 @@ describe("claude native capture helpers", () => {
   it("keeps unknown native roles explicit", () => {
     expect(roleFromNativeMessage({ sender: "system" })).toBe("system");
     expect(roleFromNativeMessage({ sender: "unexpected" })).toBe("unknown");
+  });
+});
+
+describe("claude conversationApiUrlFromResources", () => {
+  it("prefers the observed full chat_conversations resource URL", () => {
+    const observed =
+      "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True&rendering_mode=messages";
+    expect(
+      conversationApiUrlFromResources("conv-123", [
+        "https://claude.ai/api/bootstrap/org-2/current_user_access",
+        observed,
+      ]),
+    ).toBe(observed);
+  });
+
+  it("derives the conversation URL from the bootstrap organization when needed", () => {
+    expect(
+      conversationApiUrlFromResources("conv-123", [
+        "https://claude.ai/api/bootstrap/org-1/current_user_access",
+      ]),
+    ).toBe(
+      "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong",
+    );
+  });
+
+  it("ignores other origins and malformed resource entries", () => {
+    expect(
+      conversationApiUrlFromResources("conv-123", [
+        "not a url at all",
+        "https://example.com/api/bootstrap/org-1/current_user_access",
+        "https://example.com/api/organizations/org-1/chat_conversations/conv-123",
+      ]),
+    ).toBe(null);
+  });
+
+  it("derives the organization from stable Claude localStorage keys", () => {
+    const orgId = "d83be663-5e28-4dfc-8a54-1c34bdbb8c44";
+    expect(
+      conversationApiUrlFromResources("conv-123", [], "https://claude.ai", [
+        `claude-mcp-has-connectors:${orgId}`,
+      ]),
+    ).toBe(
+      `https://claude.ai/api/organizations/${orgId}/chat_conversations/conv-123?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+    );
+    expect(
+      organizationIdFromStorageKeys([
+        `LSS-model-selector-thinking:${orgId}:chat:claude-opus-4-8`,
+      ]),
+    ).toBe(orgId);
   });
 });

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import TypeGuard
+
 from polylogue.browser_capture.identity import legacy_browser_capture_native_id
 from polylogue.browser_capture.models import BrowserCaptureEnvelope, looks_like_browser_capture
 from polylogue.core.enums import Provider
@@ -17,19 +20,28 @@ def looks_like(payload: object) -> bool:
     return looks_like_browser_capture(payload)
 
 
+def _has_chatgpt_native_payload(payload: object) -> TypeGuard[Mapping[str, object]]:
+    return isinstance(payload, dict) and isinstance(payload.get("mapping"), dict)
+
+
+def _has_claude_ai_native_payload(payload: object) -> TypeGuard[Mapping[str, object]]:
+    return isinstance(payload, dict) and isinstance(payload.get("chat_messages"), list)
+
+
 def parse(payload: object, fallback_id: str) -> ParsedSession:
     """Parse a browser-capture envelope into the canonical parser contract."""
     envelope = BrowserCaptureEnvelope.model_validate(payload)
     provider = envelope.session.provider if envelope.session.provider is not Provider.UNKNOWN else Provider.UNKNOWN
     provider_session_id = _legacy_native_id(provider, envelope.session.provider_session_id) or fallback_id
-    if envelope.session.provider is Provider.CHATGPT and envelope.raw_provider_payload:
+    raw_provider_payload = envelope.raw_provider_payload
+    if envelope.session.provider is Provider.CHATGPT and _has_chatgpt_native_payload(raw_provider_payload):
         from polylogue.sources.parsers.chatgpt import parse as parse_chatgpt
 
-        return parse_chatgpt(envelope.raw_provider_payload, provider_session_id)
-    if envelope.session.provider is Provider.CLAUDE_AI and envelope.raw_provider_payload:
+        return parse_chatgpt(raw_provider_payload, provider_session_id)
+    if envelope.session.provider is Provider.CLAUDE_AI and _has_claude_ai_native_payload(raw_provider_payload):
         from polylogue.sources.parsers.claude.ai_parser import parse_ai as parse_claude_ai
 
-        return parse_claude_ai(envelope.raw_provider_payload, provider_session_id)
+        return parse_claude_ai(raw_provider_payload, provider_session_id)
 
     seen_turns: set[str] = set()
     messages: list[ParsedMessage] = []

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -215,6 +215,27 @@ def test_browser_capture_raw_chatgpt_without_id_uses_envelope_session_id() -> No
     assert [message.provider_message_id for message in session.messages] == ["native-u1", "native-a1"]
 
 
+def test_browser_capture_non_native_raw_payload_keeps_envelope_turns() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    session_payload["provider_session_id"] = "temporary:abc123"
+    payload["raw_provider_payload"] = {
+        "dom_transcript": {
+            "turn_count": 2,
+            "note": "preservation metadata, not a ChatGPT native mapping payload",
+        }
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "file-fallback")
+
+    assert len(parsed) == 1
+    session = parsed[0]
+    assert session.provider_session_id == "temporary:abc123"
+    assert [message.provider_message_id for message in session.messages] == ["u1", "a1"]
+    assert [message.text for message in session.messages] == ["Draft the plan", "Here is the plan"]
+
+
 def test_browser_capture_raw_chatgpt_normalizes_legacy_synthetic_fallback_id() -> None:
     payload = _capture_payload()
     session = payload["session"]


### PR DESCRIPTION
## Summary

This updates browser capture so ChatGPT temporary chats without `/c/<id>` routes get deterministic local ids, browser-observed turn attachments survive through the shared envelope, and non-native preservation payloads no longer get misparsed as empty native ChatGPT sessions. It also adds the Claude.ai main-world native capture bridge that was live-proven locally.

## Problem

A live ChatGPT temporary tab at `https://chatgpt.com/?temporary-chat=true` was important enough to preserve immediately, but temporary chats do not expose the normal provider-native conversation id. The first emergency envelope also showed a parser bug: a non-native `raw_provider_payload` wrapper was sent through the ChatGPT native parser and materialized a zero-message session. Separately, browser DOM fallback had an attachment model downstream but the extension dropped `turn.attachments` before storage could see them.

Ref #2308.

## Solution

- Assign deterministic `temporary:<hash>` ids for ChatGPT temporary-chat URLs.
- Preserve `turn.attachments` through `browser-extension/src/common.js`.
- Extract ChatGPT DOM file-tile-style attachments from labelled groups/downloads/images while rejecting domain/email/version-text false positives.
- Use native raw parsers only when raw payloads have the expected provider shape: ChatGPT `mapping`, Claude.ai `chat_messages`.
- Add the Claude.ai main-world bridge and on-demand content-script request path.
- Add focused browser-extension and parser regression coverage.

Live preservation proof for the urgent tab:

- Preserved session id: `chatgpt-export:temporary:867d1acac2bf4997857fa0a7`.
- Emergency preservation dir: `/realm/inbox/chatgpt-temporary-preserve-20260624-165817`.
- Archive-state: `state=archived`, `raw_row_exists=true`, `indexed_session_exists=true`, `indexed_message_count=25`.
- Attachment refs: 11 observed upload names; four have matched local byte counts.

## Verification

- `npm run validate && npm run lint && npm run build && npm test -- tests/common.test.js tests/content/chatgpt.test.js tests/content/claude.test.js tests/build.test.js` — passed, 72 tests.
- `devtools test tests/unit/sources/test_browser_capture.py -k 'non_native_raw_payload_keeps_envelope_turns or parses_session_metadata_and_deduplicates_turns'` — passed, 2 selected.
- `devtools verify --quick` — passed, run id `20260624T151252Z-quick-2819319-6a00faa2`.
- `git push` pre-push quick gate — passed, run id `20260624T151412Z-quick-2821092-f9098ead`.

## Residuals

Seven observed temporary-chat attachment names were preserved without local bytes because matching local files were not found under the checked download/snapshot roots. The archive stores their names and message refs; the preservation directory records the unmatched set for later recovery if the original upload files are found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing attachments in browser conversations.
  * Improved handling of temporary ChatGPT chats with stable, repeatable identifiers.
  * Expanded Claude capture support to retrieve conversation data through a page bridge.

* **Bug Fixes**
  * Improved native payload detection so only valid provider-specific data is parsed.
  * Preserved existing conversation turns when captured native data doesn’t match the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->