### PR TITLE
fix(browser-capture): recapture existing provider tabs

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,4 +1,27 @@
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
+const BACKGROUND_CAPTURE_MIN_INTERVAL_MS = 30000;
+const recentBackgroundCaptures = new Map();
+
+function injectionPlanForUrl(url) {
+  try {
+    const parsed = new URL(url || "");
+    if (parsed.hostname === "chatgpt.com" || parsed.hostname.endsWith(".chatgpt.com")) {
+      return [
+        { files: ["src/content/chatgpt_bridge.js"], world: "MAIN" },
+        { files: ["src/common.js", "src/content/chatgpt.js"] },
+      ];
+    }
+    if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) {
+      return [
+        { files: ["src/content/claude_bridge.js"], world: "MAIN" },
+        { files: ["src/common.js", "src/content/claude.js"] },
+      ];
+    }
+  } catch {
+    return [];
+  }
+  return [];
+}
 
 async function receiverSettings() {
   const stored = await chrome.storage.local.get({
@@ -73,6 +96,72 @@ async function getJson(path) {
   }
   return { ...body, receiver_request_id: receiverRequestId };
 }
+
+async function ensureCaptureScripts(tab) {
+  const plan = injectionPlanForUrl(tab?.url || tab?.pendingUrl || "");
+  if (!tab?.id || !plan.length || !chrome.scripting?.executeScript) return false;
+  for (const step of plan) {
+    const details = { target: { tabId: tab.id }, files: step.files };
+    if (step.world) details.world = step.world;
+    await chrome.scripting.executeScript(details);
+  }
+  return true;
+}
+
+async function captureTab(tab, reason = "background") {
+  if (!tab?.id || !injectionPlanForUrl(tab.url || tab.pendingUrl || "").length) return null;
+  const now = Date.now();
+  const lastCaptureAt = recentBackgroundCaptures.get(tab.id) || 0;
+  if (reason !== "extension_installed_or_updated" && now - lastCaptureAt < BACKGROUND_CAPTURE_MIN_INTERVAL_MS) {
+    return { ok: false, skipped: true, reason: "background_capture_throttled" };
+  }
+  recentBackgroundCaptures.set(tab.id, now);
+  await ensureCaptureScripts(tab);
+  try {
+    const result = await chrome.tabs.sendMessage(tab.id, {
+      type: "polylogue.capturePage",
+      reason
+    });
+    if (result?.ok) {
+      await setState({
+        online: true,
+        captured: true,
+        last_capture: result.captureResult || result,
+        archive_state: result.archiveState || null,
+        last_receiver_request_id:
+          result.captureResult?.receiver_request_id || result.archiveState?.receiver_request_id || null
+      });
+    }
+    return result;
+  } catch (error) {
+    return { ok: false, error: String(error.message || error) };
+  }
+}
+
+async function captureSupportedTabs(reason) {
+  if (!chrome.tabs?.query) return;
+  const tabs = await chrome.tabs.query({});
+  await Promise.allSettled(tabs.map((tab) => captureTab(tab, reason)));
+}
+
+chrome.runtime.onInstalled?.addListener(() => {
+  void captureSupportedTabs("extension_installed_or_updated");
+});
+
+chrome.runtime.onStartup?.addListener(() => {
+  void captureSupportedTabs("browser_started");
+});
+
+chrome.tabs?.onUpdated?.addListener((_tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete") {
+    void captureTab(tab, "tab_updated");
+  }
+});
+
+chrome.tabs?.onActivated?.addListener(async ({ tabId }) => {
+  const tab = await chrome.tabs.get(tabId).catch(() => null);
+  if (tab) void captureTab(tab, "tab_activated");
+});
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   (async () => {

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -1,6 +1,7 @@
 (function () {
   const SCHEMA_VERSION = 1;
   const CAPTURE_KIND = "browser_llm_session";
+  const TEMPORARY_CHAT_ID_KEY = "polylogue:chatgpt-temporary-session-id";
 
   function fnv1a(text) {
     let hash = 0x811c9dc5;
@@ -32,6 +33,27 @@
     return (node?.innerText || node?.textContent || "").replace(/\s+\n/g, "\n").trim();
   }
 
+  function randomHex(length) {
+    const bytes = new Uint8Array(Math.ceil(length / 2));
+    if (globalThis.crypto?.getRandomValues) {
+      globalThis.crypto.getRandomValues(bytes);
+      return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("").slice(0, length);
+    }
+    return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`.slice(0, length).padEnd(length, "0");
+  }
+
+  function temporarySessionId() {
+    try {
+      const existing = window.sessionStorage.getItem(TEMPORARY_CHAT_ID_KEY);
+      if (existing && /^temporary:[0-9a-f]{24}$/.test(existing)) return existing;
+      const created = `temporary:${randomHex(24)}`;
+      window.sessionStorage.setItem(TEMPORARY_CHAT_ID_KEY, created);
+      return created;
+    } catch {
+      return `temporary:${randomHex(24)}`;
+    }
+  }
+
   function buildEnvelope({
     provider,
     adapterName,
@@ -48,7 +70,7 @@
     const urlSessionId = providerSessionId || sessionIdFromUrl(provider, sourceUrl);
     const stableProviderSessionId =
       urlSessionId === "__polylogue_temporary_chat__"
-      ? `temporary:${fnv1a(`${sourceUrl}:${turns.map((turn) => `${turn.role}:${turn.text || ""}`).join("\n")}`)}`
+      ? temporarySessionId()
         : urlSessionId;
     if (!stableProviderSessionId) {
       throw new Error(`cannot capture ${provider} page without a provider-native conversation id`);
@@ -110,13 +132,16 @@
     });
   }
 
+  const existingCapture = window.polylogueCapture || {};
   window.polylogueCapture = {
+    ...existingCapture,
     buildEnvelope,
     sessionIdFromUrl,
-    capturePage: null,
+    capturePage: existingCapture.capturePage || null,
     fnv1a,
     refreshArchiveState,
     sendCapture,
+    temporarySessionId,
     visibleText
   };
 })();

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -1,4 +1,7 @@
 (function () {
+  if (window.__polylogueChatgptCaptureInstalled) return;
+  window.__polylogueChatgptCaptureInstalled = true;
+
   const domAdapterName = "chatgpt-dom-v1";
   const nativeAdapterName = "chatgpt-native-v1";
   const nativeCaptureMessage = "polylogue.chatgpt.nativeCapture";

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -1,4 +1,7 @@
 (function () {
+  if (window.__polylogueClaudeCaptureInstalled) return;
+  window.__polylogueClaudeCaptureInstalled = true;
+
   const domAdapterName = "claude-ai-dom-v1";
   const nativeAdapterName = "claude-ai-native-v1";
   const nativeCaptureMessage = "polylogue.claude.nativeCapture";

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let messageListener;
+let installedListener;
 let stored;
 let fetchCalls;
+let tabs;
 
 function installChromeMock() {
   stored = {
@@ -10,18 +12,31 @@ function installChromeMock() {
     receiverBaseUrl: "http://127.0.0.1:8875",
   };
   messageListener = null;
+  installedListener = null;
   fetchCalls = [];
+  tabs = [{ id: 42, url: "https://chatgpt.com/?temporary-chat=true", title: "ChatGPT" }];
   globalThis.chrome = {
     action: {
       setBadgeBackgroundColor: vi.fn(async () => undefined),
       setBadgeText: vi.fn(async () => undefined),
     },
     runtime: {
+      onInstalled: {
+        addListener: vi.fn((fn) => {
+          installedListener = fn;
+        }),
+      },
+      onStartup: {
+        addListener: vi.fn(),
+      },
       onMessage: {
         addListener: vi.fn((fn) => {
           messageListener = fn;
         }),
       },
+    },
+    scripting: {
+      executeScript: vi.fn(async () => undefined),
     },
     storage: {
       local: {
@@ -30,6 +45,28 @@ function installChromeMock() {
           stored = { ...stored, ...patch };
         }),
       },
+    },
+    tabs: {
+      get: vi.fn(async (tabId) => tabs.find((tab) => tab.id === tabId)),
+      onActivated: {
+        addListener: vi.fn(),
+      },
+      onUpdated: {
+        addListener: vi.fn(),
+      },
+      query: vi.fn(async () => tabs),
+      sendMessage: vi.fn(async () => ({
+        ok: true,
+        captureResult: {
+          receiver_request_id: "capture-request-1",
+          provider: "chatgpt",
+          provider_session_id: "temporary:abc",
+        },
+        archiveState: {
+          receiver_request_id: "state-request-1",
+          captured: true,
+        },
+      })),
     },
   };
 }
@@ -108,5 +145,29 @@ describe("background receiver diagnostics", () => {
     });
     expect(stored.polylogueState.online).toBe(false);
     expect(stored.polylogueState.last_receiver_request_id).toBe("reject-42");
+  });
+
+  it("injects capture scripts into existing provider tabs after extension update", async () => {
+    expect(installedListener).toBeTypeOf("function");
+
+    installedListener();
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1));
+
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 42 },
+      files: ["src/content/chatgpt_bridge.js"],
+      world: "MAIN",
+    });
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 42 },
+      files: ["src/common.js", "src/content/chatgpt.js"],
+    });
+    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      type: "polylogue.capturePage",
+      reason: "extension_installed_or_updated",
+    });
+    expect(stored.polylogueState.online).toBe(true);
+    expect(stored.polylogueState.captured).toBe(true);
+    expect(stored.polylogueState.last_receiver_request_id).toBe("capture-request-1");
   });
 });

--- a/browser-extension/tests/common.test.js
+++ b/browser-extension/tests/common.test.js
@@ -44,6 +44,19 @@ function visibleText(node) {
     .trim();
 }
 
+function randomHex(length) {
+  return "a".repeat(length);
+}
+
+function temporarySessionId(storage = new Map()) {
+  const key = "polylogue:chatgpt-temporary-session-id";
+  const existing = storage.get(key);
+  if (existing && /^temporary:[0-9a-f]{24}$/.test(existing)) return existing;
+  const created = `temporary:${randomHex(24)}`;
+  storage.set(key, created);
+  return created;
+}
+
 function buildEnvelope({
   provider,
   adapterName,
@@ -56,12 +69,13 @@ function buildEnvelope({
   providerMeta = {},
   rawProviderPayload = null,
   sourceUrl = "https://chatgpt.com/c/test-conv",
+  temporaryIdStorage = new Map(),
 }) {
   const stableProviderSessionId =
     providerSessionId || sessionIdFromUrl(provider, sourceUrl);
   const resolvedProviderSessionId =
     stableProviderSessionId === "__polylogue_temporary_chat__"
-      ? `temporary:${fnv1a(`${sourceUrl}:${turns.map((turn) => `${turn.role}:${turn.text || ""}`).join("\n")}`)}`
+      ? temporarySessionId(temporaryIdStorage)
       : stableProviderSessionId;
   if (!resolvedProviderSessionId) {
     throw new Error(`cannot capture ${provider} page without a provider-native conversation id`);
@@ -277,11 +291,13 @@ describe("buildEnvelope", () => {
     })).toThrow("cannot capture chatgpt page without a provider-native conversation id");
   });
 
-  it("assigns deterministic local ids for ChatGPT temporary chats", () => {
+  it("assigns stable local ids for ChatGPT temporary chats", () => {
+    const temporaryIdStorage = new Map();
     const envelope = buildEnvelope({
       provider: "chatgpt",
       adapterName: "chatgpt-dom-v1",
       sourceUrl: "https://chatgpt.com/?temporary-chat=true",
+      temporaryIdStorage,
       turns: [
         { role: "user", text: "Important temporary prompt" },
         { role: "assistant", text: "Important temporary answer" },
@@ -291,13 +307,15 @@ describe("buildEnvelope", () => {
       provider: "chatgpt",
       adapterName: "chatgpt-dom-v1",
       sourceUrl: "https://chatgpt.com/?temporary-chat=true",
+      temporaryIdStorage,
       turns: [
         { role: "user", text: "Important temporary prompt" },
         { role: "assistant", text: "Important temporary answer" },
+        { role: "assistant", text: "Later streamed answer" },
       ],
     });
 
-    expect(envelope.session.provider_session_id).toMatch(/^temporary:[0-9a-f]{8}$/);
+    expect(envelope.session.provider_session_id).toMatch(/^temporary:[0-9a-f]{24}$/);
     expect(envelope.capture_id).toBe(`chatgpt:${envelope.session.provider_session_id}`);
     expect(repeated.session.provider_session_id).toBe(envelope.session.provider_session_id);
   });


### PR DESCRIPTION
## Summary

This makes browser capture recover already-open ChatGPT and Claude tabs after extension install/update/startup/navigation, and stabilizes ChatGPT temporary-chat ids across later turns.

## Problem

The temporary ChatGPT tab that was preserved earlier did not live-update after later assistant responses. Live inspection showed `window.polylogueCapture` was absent in that already-open tab, so no mutation observer was running. This can happen when the extension is installed or rebuilt while tabs are already open: manifest content scripts inject at page load, not retroactively. There was also a second temporary-chat bug: local temporary ids were derived from all turn text, so later responses could produce a different `temporary:<hash>` instead of updating the same archive session.

Ref #2308.

## Solution

- Add background install/startup/tab-update/tab-activation hooks that inject the provider bridge and content scripts into supported tabs, then request `polylogue.capturePage`.
- Add a per-tab background capture throttle so activation recovery does not spam captures.
- Make ChatGPT and Claude content scripts idempotent under reinjection.
- Make `common.js` preserve an existing `capturePage` handler across reinjection.
- Store ChatGPT temporary ids in `sessionStorage` as `temporary:<24 hex>` so new turns update the same temporary session.

## Verification

- `npm run validate && npm run lint && npm run build && npm test -- tests/common.test.js tests/background.test.js tests/content/chatgpt.test.js tests/content/claude.test.js tests/build.test.js` — passed, 75 tests.
- `devtools verify --quick` — passed, run id `20260624T161347Z-quick-2878947-37adf59a`.
- `git push` pre-push quick gate — passed, run id `20260624T161423Z-quick-2879477-41865bb5`.
