### PR TITLE
feat(capture): materialize rich web constructs

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -7,6 +7,9 @@
   "host_permissions": [
     "https://chatgpt.com/*",
     "https://claude.ai/*",
+    "https://grok.com/*",
+    "https://x.com/*",
+    "https://twitter.com/*",
     "http://127.0.0.1/*"
   ],
   "background": {
@@ -38,6 +41,11 @@
     {
       "matches": ["https://claude.ai/*"],
       "js": ["src/common.js", "src/content/claude.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://grok.com/*", "https://x.com/*", "https://twitter.com/*"],
+      "js": ["src/common.js", "src/content/grok.js"],
       "run_at": "document_idle"
     }
   ]

--- a/browser-extension/scripts/validate-manifest.mjs
+++ b/browser-extension/scripts/validate-manifest.mjs
@@ -29,6 +29,9 @@ const ALLOWED_PERMISSIONS = new Set([
 const ALLOWED_HOST_GLOBS = [
   /^https:\/\/chatgpt\.com\/\*$/,
   /^https:\/\/claude\.ai\/\*$/,
+  /^https:\/\/grok\.com\/\*$/,
+  /^https:\/\/x\.com\/\*$/,
+  /^https:\/\/twitter\.com\/\*$/,
   /^http:\/\/127\.0\.0\.1\/\*$/,
 ];
 

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,5 +1,6 @@
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const BACKGROUND_CAPTURE_MIN_INTERVAL_MS = 30000;
+const CAPTURE_LOG_LIMIT = 80;
 const recentBackgroundCaptures = new Map();
 
 function injectionPlanForUrl(url) {
@@ -16,6 +17,16 @@ function injectionPlanForUrl(url) {
         { files: ["src/content/claude_bridge.js"], world: "MAIN" },
         { files: ["src/common.js", "src/content/claude.js"] },
       ];
+    }
+    if (
+      parsed.hostname === "grok.com" ||
+      parsed.hostname.endsWith(".grok.com") ||
+      parsed.hostname === "x.com" ||
+      parsed.hostname.endsWith(".x.com") ||
+      parsed.hostname === "twitter.com" ||
+      parsed.hostname.endsWith(".twitter.com")
+    ) {
+      return [{ files: ["src/common.js", "src/content/grok.js"] }];
     }
   } catch {
     return [];
@@ -42,11 +53,59 @@ async function saveReceiverSettings(receiverBaseUrl, receiverAuthToken = "") {
   return receiverSettings();
 }
 
+function sessionKey(provider, providerSessionId) {
+  return `${provider || "unknown"}:${providerSessionId || "unknown"}`;
+}
+
+async function appendCaptureLog(entry) {
+  const stored = await chrome.storage.local.get({ polylogueCaptureLog: [] });
+  const prior = Array.isArray(stored.polylogueCaptureLog) ? stored.polylogueCaptureLog : [];
+  const next = [
+    {
+      at: new Date().toISOString(),
+      ...entry,
+    },
+    ...prior,
+  ].slice(0, CAPTURE_LOG_LIMIT);
+  await chrome.storage.local.set({ polylogueCaptureLog: next });
+  return next;
+}
+
+async function updateSessionLedger({ provider, providerSessionId, patch }) {
+  if (!provider || !providerSessionId) return null;
+  const stored = await chrome.storage.local.get({ polylogueSessionLedger: {} });
+  const ledger =
+    stored.polylogueSessionLedger && typeof stored.polylogueSessionLedger === "object"
+      ? stored.polylogueSessionLedger
+      : {};
+  const key = sessionKey(provider, providerSessionId);
+  const next = {
+    ...(ledger[key] || {}),
+    provider,
+    provider_session_id: providerSessionId,
+    updated_at: new Date().toISOString(),
+    ...patch,
+  };
+  await chrome.storage.local.set({ polylogueSessionLedger: { ...ledger, [key]: next } });
+  return next;
+}
+
+function badgeForState(state) {
+  if (!state.online) return { text: "off", color: "#9b2c2c" };
+  const archiveState = state.archive_state?.state;
+  if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
+  if (archiveState === "failed" || state.error) return { text: "err", color: "#ad2f2f" };
+  if (archiveState === "spooled_only" || archiveState === "ingest_pending") return { text: "…", color: "#9a5b00" };
+  if (state.capture_mode === "dom_degraded") return { text: "dom", color: "#8a5a00" };
+  return { text: "on", color: "#325d8f" };
+}
+
 async function setState(state) {
-  await chrome.storage.local.set({ polylogueState: { ...state, updated_at: new Date().toISOString() } });
-  const text = state.captured ? "ok" : state.online ? "on" : "off";
-  await chrome.action.setBadgeText({ text });
-  await chrome.action.setBadgeBackgroundColor({ color: state.captured ? "#1f7a4d" : state.online ? "#805ad5" : "#9b2c2c" });
+  const nextState = { ...state, updated_at: new Date().toISOString() };
+  await chrome.storage.local.set({ polylogueState: nextState });
+  const badge = badgeForState(nextState);
+  await chrome.action.setBadgeText({ text: badge.text });
+  await chrome.action.setBadgeBackgroundColor({ color: badge.color });
 }
 
 function buildReceiverRequestId() {
@@ -123,17 +182,56 @@ async function captureTab(tab, reason = "background") {
       reason
     });
     if (result?.ok) {
+      const envelopeSession = result.envelope?.session || {};
+      const provider = result.captureResult?.provider || envelopeSession.provider;
+      const providerSessionId = result.captureResult?.provider_session_id || envelopeSession.provider_session_id;
+      await updateSessionLedger({
+        provider,
+        providerSessionId,
+        patch: {
+          reason,
+          tab_id: tab.id,
+          tab_url: tab.url || tab.pendingUrl || null,
+          capture_mode: envelopeSession.provider_meta?.capture_fidelity || null,
+          turn_count: Array.isArray(envelopeSession.turns) ? envelopeSession.turns.length : null,
+          attachment_count: Array.isArray(envelopeSession.turns)
+            ? envelopeSession.turns.reduce((count, turn) => count + (Array.isArray(turn.attachments) ? turn.attachments.length : 0), 0)
+            : null,
+          archive_state: result.archiveState || null,
+          receiver_request_id: result.captureResult?.receiver_request_id || result.archiveState?.receiver_request_id || null,
+          last_error: null,
+        },
+      });
+      await appendCaptureLog({
+        ok: true,
+        reason,
+        provider,
+        provider_session_id: providerSessionId,
+        tab_id: tab.id,
+        archive_state: result.archiveState?.state || null,
+        receiver_request_id: result.captureResult?.receiver_request_id || result.archiveState?.receiver_request_id || null,
+      });
       await setState({
         online: true,
         captured: true,
         last_capture: result.captureResult || result,
         archive_state: result.archiveState || null,
+        provider,
+        provider_session_id: providerSessionId,
+        capture_mode: envelopeSession.provider_meta?.capture_fidelity || null,
         last_receiver_request_id:
           result.captureResult?.receiver_request_id || result.archiveState?.receiver_request_id || null
       });
     }
     return result;
   } catch (error) {
+    await appendCaptureLog({
+      ok: false,
+      reason,
+      tab_id: tab.id,
+      tab_url: tab.url || tab.pendingUrl || null,
+      error: String(error.message || error),
+    });
     return { ok: false, error: String(error.message || error) };
   }
 }
@@ -172,10 +270,37 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
     if (message.type === "polylogue.capture") {
       const result = await postJson("/v1/browser-captures", message.envelope);
+      const session = message.envelope?.session || {};
+      await updateSessionLedger({
+        provider: session.provider || result.provider,
+        providerSessionId: session.provider_session_id || result.provider_session_id,
+        patch: {
+          capture_mode: session.provider_meta?.capture_fidelity || null,
+          turn_count: Array.isArray(session.turns) ? session.turns.length : null,
+          attachment_count: Array.isArray(session.turns)
+            ? session.turns.reduce((count, turn) => count + (Array.isArray(turn.attachments) ? turn.attachments.length : 0), 0)
+            : null,
+          receiver_request_id: result.receiver_request_id || null,
+          artifact_ref: result.artifact_ref || null,
+          last_error: null,
+        },
+      });
+      await appendCaptureLog({
+        ok: true,
+        reason: message.reason || "content_script_capture",
+        provider: session.provider || result.provider,
+        provider_session_id: session.provider_session_id || result.provider_session_id,
+        capture_mode: session.provider_meta?.capture_fidelity || null,
+        receiver_request_id: result.receiver_request_id || null,
+        artifact_ref: result.artifact_ref || null,
+      });
       await setState({
         online: true,
         captured: true,
         last_capture: result,
+        provider: session.provider || result.provider,
+        provider_session_id: session.provider_session_id || result.provider_session_id,
+        capture_mode: session.provider_meta?.capture_fidelity || null,
         last_receiver_request_id: result.receiver_request_id || null
       });
       sendResponse(result);
@@ -191,6 +316,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         online: true,
         captured: Boolean(state.captured),
         archive_state: state,
+        provider: message.provider,
+        provider_session_id: message.provider_session_id,
         last_receiver_request_id: state.receiver_request_id || null
       });
       sendResponse(state);
@@ -207,7 +334,18 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       sendResponse(status);
       return;
     }
+    if (message.type === "polylogue.captureSupportedTabs") {
+      await captureSupportedTabs(message.reason || "popup_sync_open_tabs");
+      sendResponse({ ok: true });
+      return;
+    }
   })().catch(async (error) => {
+    await appendCaptureLog({
+      ok: false,
+      reason: message.type || "runtime_message",
+      error: String(error.message || error),
+      receiver_request_id: error.receiverRequestId || null,
+    });
     await setState({
       online: false,
       captured: false,

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -78,6 +78,10 @@
     const stableCaptureId = stableProviderSessionId.startsWith(`${provider}:`)
       ? stableProviderSessionId
       : `${provider}:${stableProviderSessionId}`;
+    const sessionProviderMeta = { ...providerMeta };
+    if (urlSessionId === "__polylogue_temporary_chat__" || stableProviderSessionId.startsWith("temporary:")) {
+      sessionProviderMeta.session_kind = "temporary";
+    }
     const now = new Date().toISOString();
     const envelope = {
       polylogue_capture_kind: CAPTURE_KIND,
@@ -100,7 +104,7 @@
         created_at: createdAt,
         updated_at: updatedAt || now,
         model,
-        provider_meta: providerMeta,
+        provider_meta: sessionProviderMeta,
         turns: turns.map((turn, ordinal) => ({
           provider_turn_id: turn.provider_turn_id || `${stableProviderSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + (turn.text || ""))}`,
           role: turn.role,

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -25,6 +25,13 @@
       return parts[1];
     }
     if (provider === "claude-ai") return null;
+    if (provider === "grok") {
+      const grokPathId = parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok");
+      if (grokPathId) return grokPathId;
+      const queryId = parsed.searchParams.get("conversation") || parsed.searchParams.get("conversationId");
+      if (queryId) return queryId;
+      return `dom:${fnv1a(parsed.origin + parsed.pathname + parsed.search)}`;
+    }
     const sessionToken = parts.at(-1) || parsed.pathname || parsed.hostname;
     return `${provider}:${sessionToken}:${fnv1a(parsed.origin + parsed.pathname)}`;
   }
@@ -78,7 +85,10 @@
     const stableCaptureId = stableProviderSessionId.startsWith(`${provider}:`)
       ? stableProviderSessionId
       : `${provider}:${stableProviderSessionId}`;
-    const sessionProviderMeta = { ...providerMeta };
+    const sessionProviderMeta = {
+      capture_fidelity: rawProviderPayload ? "native_full" : "dom_degraded",
+      ...providerMeta,
+    };
     if (urlSessionId === "__polylogue_temporary_chat__" || stableProviderSessionId.startsWith("temporary:")) {
       sessionProviderMeta.session_kind = "temporary";
     }

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -337,7 +337,8 @@
       providerMeta: {
         capture_source: "chatgpt_backend_api",
         current_node: payload.current_node || null,
-        mapping_node_count: payload.mapping ? Object.keys(payload.mapping).length : 0
+        mapping_node_count: payload.mapping ? Object.keys(payload.mapping).length : 0,
+        is_temporary: payload.is_temporary === true
       },
       rawProviderPayload: payload
     });
@@ -354,6 +355,7 @@
         adapterName: domAdapterName,
         turns,
         providerMeta: {
+          capture_fidelity: "dom_degraded",
           native_attempts: nativeAttemptDiagnostics.slice(-6)
         }
       });

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -202,7 +202,9 @@
       model: modelFromNativePayload(payload),
       providerMeta: {
         capture_source: "claude_chat_conversations_api",
-        message_count: Array.isArray(payload.chat_messages) ? payload.chat_messages.length : 0
+        message_count: Array.isArray(payload.chat_messages) ? payload.chat_messages.length : 0,
+        is_temporary: payload.is_temporary === true,
+        session_kind: payload.is_temporary === true ? "temporary" : null
       },
       rawProviderPayload: payload
     });
@@ -219,6 +221,7 @@
         adapterName: domAdapterName,
         turns,
         providerMeta: {
+          capture_fidelity: "dom_degraded",
           native_attempts: nativeAttemptDiagnostics.slice(-6)
         }
       });

--- a/browser-extension/src/content/grok.js
+++ b/browser-extension/src/content/grok.js
@@ -1,0 +1,137 @@
+(function () {
+  if (window.__polylogueGrokCaptureInstalled) return;
+  window.__polylogueGrokCaptureInstalled = true;
+
+  const domAdapterName = "grok-dom-v1";
+
+  function roleFromNode(node, index) {
+    const attrs = [
+      node.getAttribute("data-testid"),
+      node.getAttribute("data-message-author-role"),
+      node.getAttribute("aria-label"),
+      node.className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    if (/user|you|human/i.test(attrs)) return "user";
+    if (/assistant|grok|ai/i.test(attrs)) return "assistant";
+    return index % 2 === 0 ? "user" : "assistant";
+  }
+
+  function attachmentNameFromNode(node) {
+    const label = node.getAttribute("aria-label") || "";
+    const download = node.getAttribute("download") || "";
+    const alt = node.getAttribute("alt") || "";
+    const text = window.polylogueCapture.visibleText(node);
+    const href = node.getAttribute("href") || node.getAttribute("src") || "";
+    const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
+    const candidates = [label, download, alt, text, basename]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const filePattern =
+      /(?:^|\s)([^\s@/]+\.(?:zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm))(?:\s|$)/i;
+    for (const candidate of candidates) {
+      const match = candidate.match(filePattern);
+      if (match) return match[1].trim();
+    }
+    return null;
+  }
+
+  function collectAttachments(node, turnIndex) {
+    const selector = [
+      '[role="group"][aria-label]',
+      "a[download]",
+      "a[href][aria-label]",
+      "img[alt]",
+      "img[src]",
+    ].join(",");
+    const seen = new Set();
+    const attachments = [];
+    for (const candidate of node.querySelectorAll(selector)) {
+      const name = attachmentNameFromNode(candidate);
+      if (!name) continue;
+      const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
+      const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
+      const key = `${name}\n${url || ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      attachments.push({
+        provider_attachment_id: `dom:${window.polylogueCapture.fnv1a(`${turnIndex}:${key}`)}`,
+        name,
+        url,
+        provider_meta: {
+          dom_selector_index: turnIndex,
+          dom_label: candidate.getAttribute("aria-label") || null,
+          dom_text: window.polylogueCapture.visibleText(candidate) || null,
+          capture_source: "grok_dom_attachment",
+        },
+      });
+    }
+    return attachments;
+  }
+
+  function collectTurns() {
+    const nodes = [
+      ...document.querySelectorAll(
+        '[data-testid*="conversation"], [data-testid*="message"], [data-message-author-role], article, main [role="article"]',
+      ),
+    ];
+    return nodes
+      .map((node, index) => {
+        const text = window.polylogueCapture.visibleText(node);
+        const attachments = collectAttachments(node, index);
+        return text || attachments.length
+          ? {
+              role: roleFromNode(node, index),
+              text,
+              attachments,
+              provider_meta: {
+                selector_index: index,
+                capture_source: "grok_dom",
+              },
+            }
+          : null;
+      })
+      .filter(Boolean);
+  }
+
+  async function capture() {
+    const turns = collectTurns();
+    if (!turns.length) return { ok: false, error: "no_turns" };
+    const envelope = window.polylogueCapture.buildEnvelope({
+      provider: "grok",
+      adapterName: domAdapterName,
+      turns,
+      providerMeta: {
+        capture_source: "grok_dom",
+        capture_fidelity: "dom_degraded",
+        native_attempts: [],
+      },
+    });
+    const captureResult = await window.polylogueCapture.sendCapture(envelope);
+    const archiveState = await window.polylogueCapture.refreshArchiveState(
+      "grok",
+      envelope.session.provider_session_id,
+    );
+    return { ok: true, envelope, captureResult, archiveState };
+  }
+
+  let timer = 0;
+  function scheduleCapture() {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(capture, 1200);
+  }
+
+  scheduleCapture();
+  window.polylogueCapture.capturePage = capture;
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== "polylogue.capturePage") return false;
+    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    return true;
+  });
+  new MutationObserver(scheduleCapture).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+})();

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -15,6 +15,9 @@
         --warn: #9a5b00;
         --bad: #ad2f2f;
         --accent: #325d8f;
+        --gpt: #10a37f;
+        --claude: #d97745;
+        --grok: #111827;
       }
       * {
         box-sizing: border-box;
@@ -42,6 +45,21 @@
         font-size: 16px;
         letter-spacing: 0;
       }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+      .mark {
+        display: grid;
+        place-items: center;
+        width: 30px;
+        height: 30px;
+        border-radius: 7px;
+        color: #fff;
+        background: var(--accent);
+        font-weight: 700;
+      }
       .subtitle {
         color: var(--muted);
         font-size: 12px;
@@ -58,6 +76,27 @@
       .badge.ok { background: var(--ok); }
       .badge.warn { background: var(--warn); }
       .badge.bad { background: var(--bad); }
+      .provider-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        justify-content: flex-end;
+      }
+      .provider-logo {
+        display: inline-grid;
+        place-items: center;
+        min-width: 24px;
+        height: 24px;
+        padding: 0 6px;
+        border-radius: 6px;
+        color: #fff;
+        font-size: 11px;
+        font-weight: 700;
+      }
+      .provider-logo.chatgpt { background: var(--gpt); }
+      .provider-logo.claude-ai { background: var(--claude); }
+      .provider-logo.grok { background: var(--grok); }
+      .provider-logo.unknown { background: var(--muted); }
       section {
         padding: 12px 0;
         border-bottom: 1px solid var(--line);
@@ -122,22 +161,54 @@
         color: var(--muted);
         white-space: pre-wrap;
       }
+      .log {
+        display: grid;
+        gap: 6px;
+        max-height: 124px;
+        overflow: auto;
+        padding-right: 2px;
+      }
+      .log-item {
+        display: grid;
+        grid-template-columns: 44px minmax(0, 1fr);
+        gap: 8px;
+        padding: 6px 0;
+        border-top: 1px solid var(--line);
+      }
+      .log-time {
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .log-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .log-meta {
+        color: var(--muted);
+        font-size: 11px;
+      }
     </style>
   </head>
   <body>
     <main>
       <header>
-        <div>
-          <h1>Polylogue Capture</h1>
-          <div class="subtitle">ChatGPT and Claude.ai web sync</div>
+        <div class="brand">
+          <div class="mark">P</div>
+          <div>
+            <h1>Polylogue Capture</h1>
+            <div class="subtitle">ChatGPT, Claude.ai, Grok</div>
+          </div>
         </div>
         <div id="badge" class="badge">checking</div>
       </header>
 
       <section>
-        <div class="row"><span class="label">Page</span><span id="page" class="value">Unknown</span></div>
+        <div class="row"><span class="label">Page</span><span id="page" class="value provider-chip">Unknown</span></div>
         <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
         <div class="row"><span class="label">Archive</span><span id="archive" class="value">Not checked</span></div>
+        <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
+        <div class="row"><span class="label">Turns</span><span id="turns" class="value">--</span></div>
         <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
       </section>
 
@@ -146,7 +217,15 @@
         <div class="controls">
           <button id="capture" class="primary">Capture page</button>
           <button id="check">Check status</button>
+          <button id="sync-open-tabs">Sync open tabs</button>
+          <button id="copy-ref">Copy ref</button>
+          <button id="open-polylogue">Open in Polylogue</button>
         </div>
+      </section>
+
+      <section>
+        <div class="row"><span class="label">Recent log</span><span id="log-count" class="value">0</span></div>
+        <div id="log" class="log"></div>
       </section>
 
       <section>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -5,10 +5,37 @@ function hostLabel(url) {
     const parsed = new URL(url);
     if (parsed.hostname.includes("chatgpt.com")) return "ChatGPT";
     if (parsed.hostname.includes("claude.ai")) return "Claude.ai";
+    if (parsed.hostname.includes("grok.com")) return "Grok";
+    if (parsed.hostname === "x.com" || parsed.hostname.endsWith(".x.com")) return "Grok / X";
+    if (parsed.hostname === "twitter.com" || parsed.hostname.endsWith(".twitter.com")) return "Grok / X";
     return parsed.hostname;
   } catch {
     return "Unknown";
   }
+}
+
+function providerFromUrl(url) {
+  try {
+    const parsed = new URL(url || "");
+    if (parsed.hostname.includes("chatgpt.com")) return "chatgpt";
+    if (parsed.hostname.includes("claude.ai")) return "claude-ai";
+    if (parsed.hostname.includes("grok.com") || parsed.hostname.includes("x.com") || parsed.hostname.includes("twitter.com")) {
+      return "grok";
+    }
+  } catch {
+    return "unknown";
+  }
+  return "unknown";
+}
+
+function providerLogo(provider) {
+  const labels = {
+    chatgpt: "GPT",
+    "claude-ai": "C",
+    grok: "G",
+    unknown: "?",
+  };
+  return `<span class="provider-logo ${provider || "unknown"}">${labels[provider] || "?"}</span>`;
 }
 
 function contentScriptFiles(url) {
@@ -19,6 +46,16 @@ function contentScriptFiles(url) {
     }
     if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) {
       return ["src/common.js", "src/content/claude.js"];
+    }
+    if (
+      parsed.hostname === "grok.com" ||
+      parsed.hostname.endsWith(".grok.com") ||
+      parsed.hostname === "x.com" ||
+      parsed.hostname.endsWith(".x.com") ||
+      parsed.hostname === "twitter.com" ||
+      parsed.hostname.endsWith(".twitter.com")
+    ) {
+      return ["src/common.js", "src/content/grok.js"];
     }
   } catch {
     return [];
@@ -46,27 +83,69 @@ async function activeTab() {
   return tab;
 }
 
+function relativeAge(iso) {
+  const then = Date.parse(iso || "");
+  if (!Number.isFinite(then)) return "--";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h`;
+}
+
+function renderLog(items) {
+  const log = document.getElementById("log");
+  const safeItems = Array.isArray(items) ? items.slice(0, 8) : [];
+  document.getElementById("log-count").textContent = String(Array.isArray(items) ? items.length : 0);
+  if (!safeItems.length) {
+    log.innerHTML = '<div class="log-meta">No capture attempts recorded yet.</div>';
+    return;
+  }
+  log.innerHTML = safeItems
+    .map((entry) => {
+      const provider = entry.provider || "unknown";
+      const title = entry.ok
+        ? `${provider} ${entry.provider_session_id || ""}`.trim()
+        : entry.error || "capture failed";
+      const meta = [entry.archive_state, entry.capture_mode, entry.receiver_request_id].filter(Boolean).join(" · ");
+      return `<div class="log-item"><div class="log-time">${relativeAge(entry.at)}</div><div><div class="log-title">${providerLogo(provider)} ${title}</div><div class="log-meta">${meta || entry.reason || ""}</div></div></div>`;
+    })
+    .join("");
+}
+
 async function render() {
   const stateNode = document.getElementById("state");
   const stored = await chrome.storage.local.get({
+    polylogueCaptureLog: [],
     polylogueState: null,
     receiverAuthToken: "",
     receiverBaseUrl: DEFAULT_RECEIVER
   });
+  renderLog(stored.polylogueCaptureLog);
   document.getElementById("receiver-url").value = stored.receiverBaseUrl;
   document.getElementById("receiver-token").value = stored.receiverAuthToken || "";
   document.getElementById("receiver").textContent = stored.receiverBaseUrl;
   const tab = await activeTab();
-  document.getElementById("page").textContent = hostLabel(tab?.url || "");
+  const currentProvider = providerFromUrl(tab?.url || "");
+  document.getElementById("page").innerHTML = `${providerLogo(currentProvider)} <span>${hostLabel(tab?.url || "")}</span>`;
   const state = stored.polylogueState;
   const requestNode = document.getElementById("receiver-request");
+  const modeNode = document.getElementById("mode");
+  const turnsNode = document.getElementById("turns");
   if (!state) {
     stateNode.textContent = "No capture state yet.";
     requestNode.textContent = "--";
+    modeNode.textContent = "--";
+    turnsNode.textContent = "--";
     setBadge("warn", "idle");
     return;
   }
   requestNode.textContent = state.last_receiver_request_id || "--";
+  modeNode.textContent = state.capture_mode || state.archive_state?.state || "--";
+  const lastSession = state.last_capture || {};
+  const turnCount = state.archive_state?.indexed_message_count || lastSession.turn_count || "--";
+  const attachmentCount = state.archive_state?.attachment_count || lastSession.attachment_count || null;
+  turnsNode.textContent = attachmentCount === null ? String(turnCount) : `${turnCount} / ${attachmentCount} files`;
   if (!state.online) {
     stateNode.textContent = `Receiver offline. Start: polylogue browser-capture serve\n${state.error || ""}`.trim();
     document.getElementById("archive").textContent = "Offline";
@@ -85,6 +164,27 @@ async function render() {
 document.getElementById("check").addEventListener("click", async () => {
   await chrome.runtime.sendMessage({ type: "polylogue.status" });
   await render();
+});
+
+document.getElementById("sync-open-tabs").addEventListener("click", async () => {
+  await chrome.runtime.sendMessage({ type: "polylogue.captureSupportedTabs", reason: "popup_sync_open_tabs" });
+  await render();
+});
+
+document.getElementById("copy-ref").addEventListener("click", async () => {
+  const stored = await chrome.storage.local.get({ polylogueState: null });
+  const state = stored.polylogueState || {};
+  const provider = state.provider || state.last_capture?.provider;
+  const providerSessionId = state.provider_session_id || state.last_capture?.provider_session_id;
+  const ref = provider && providerSessionId ? `${provider}:${providerSessionId}` : "";
+  if (ref && window.navigator.clipboard?.writeText) await window.navigator.clipboard.writeText(ref);
+});
+
+document.getElementById("open-polylogue").addEventListener("click", async () => {
+  const stored = await chrome.storage.local.get({ polylogueState: null, receiverBaseUrl: DEFAULT_RECEIVER });
+  const providerSessionId = stored.polylogueState?.provider_session_id || stored.polylogueState?.last_capture?.provider_session_id;
+  const url = `${String(stored.receiverBaseUrl || DEFAULT_RECEIVER).replace(/\/+$/, "")}/?q=${encodeURIComponent(providerSessionId || "")}`;
+  await chrome.tabs.create({ url });
 });
 
 document.getElementById("save").addEventListener("click", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -170,4 +170,17 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.captured).toBe(true);
     expect(stored.polylogueState.last_receiver_request_id).toBe("capture-request-1");
   });
+
+  it("injects Grok DOM capture scripts for open Grok/X tabs", async () => {
+    tabs = [{ id: 77, url: "https://x.com/i/grok", title: "Grok" }];
+    expect(installedListener).toBeTypeOf("function");
+
+    installedListener();
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1));
+
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 77 },
+      files: ["src/common.js", "src/content/grok.js"],
+    });
+  });
 });

--- a/browser-extension/tests/common.test.js
+++ b/browser-extension/tests/common.test.js
@@ -83,6 +83,13 @@ function buildEnvelope({
   const stableCaptureId = resolvedProviderSessionId.startsWith(`${provider}:`)
     ? resolvedProviderSessionId
     : `${provider}:${resolvedProviderSessionId}`;
+  const sessionProviderMeta = { ...providerMeta };
+  if (
+    stableProviderSessionId === "__polylogue_temporary_chat__" ||
+    resolvedProviderSessionId.startsWith("temporary:")
+  ) {
+    sessionProviderMeta.session_kind = "temporary";
+  }
   const now = new Date().toISOString();
   const envelope = {
     polylogue_capture_kind: "browser_llm_session",
@@ -105,7 +112,7 @@ function buildEnvelope({
       created_at: createdAt,
       updated_at: updatedAt || now,
       model,
-      provider_meta: providerMeta,
+      provider_meta: sessionProviderMeta,
       turns: turns.map((turn, ordinal) => ({
         provider_turn_id:
           turn.provider_turn_id ||
@@ -317,7 +324,9 @@ describe("buildEnvelope", () => {
 
     expect(envelope.session.provider_session_id).toMatch(/^temporary:[0-9a-f]{24}$/);
     expect(envelope.capture_id).toBe(`chatgpt:${envelope.session.provider_session_id}`);
+    expect(envelope.session.provider_meta.session_kind).toBe("temporary");
     expect(repeated.session.provider_session_id).toBe(envelope.session.provider_session_id);
+    expect(repeated.session.provider_meta.session_kind).toBe("temporary");
   });
 
   it("assigns ordinals to turns", () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -21,6 +21,13 @@ function installDom() {
       <button id="check"></button>
       <button id="save"></button>
       <button id="capture"></button>
+      <button id="sync-open-tabs"></button>
+      <button id="copy-ref"></button>
+      <button id="open-polylogue"></button>
+      <span id="mode"></span>
+      <span id="turns"></span>
+      <span id="log-count"></span>
+      <div id="log"></div>
     </body>`);
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
@@ -63,7 +70,7 @@ async function loadPopup() {
   installDom();
   installChromeMock();
   await import("../src/popup.js");
-  await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).toBe("ChatGPT"));
+  await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).toContain("ChatGPT"));
 }
 
 describe("popup capture", () => {

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -47,6 +47,7 @@ class Origin(PolylogueStrEnum):
     GEMINI_CLI_SESSION = "gemini-cli-session"
     HERMES_SESSION = "hermes-session"
     ANTIGRAVITY_SESSION = "antigravity-session"
+    GROK_EXPORT = "grok-export"
     CHATGPT_EXPORT = "chatgpt-export"
     CLAUDE_AI_EXPORT = "claude-ai-export"
     AISTUDIO_DRIVE = "aistudio-drive"
@@ -74,6 +75,7 @@ class Provider(PolylogueStrEnum):
     GEMINI_CLI = "gemini-cli"
     HERMES = "hermes"
     ANTIGRAVITY = "antigravity"
+    GROK = "grok"
     DRIVE = "drive"
     UNKNOWN = "unknown"
 
@@ -219,6 +221,22 @@ class BlockType(PolylogueStrEnum):
         if isinstance(value, cls):
             return value
         return cls(str(value).strip().lower())
+
+
+class WebConstructType(PolylogueStrEnum):
+    """Typed web-export constructs projected out of provider payloads."""
+
+    CANVAS = "canvas"
+    CONTENT_REFERENCE = "content_reference"
+    SEARCH_QUERY = "search_query"
+    SEARCH_RESULT = "search_result"
+    SELECTED_SOURCE = "selected_source"
+    IMAGE_RESULT = "image_result"
+    ASYNC_TASK = "async_task"
+    AUDIO_ASSET = "audio_asset"
+    AUDIO_TRANSCRIPTION = "audio_transcription"
+    TOKEN_BUDGET = "token_budget"
+    VOICE_NOTE = "voice_note"
 
 
 class SemanticBlockType(PolylogueStrEnum):

--- a/polylogue/core/provider_identity.py
+++ b/polylogue/core/provider_identity.py
@@ -73,6 +73,7 @@ CORE_RUNTIME_PROVIDERS: Final[tuple[str, ...]] = (
     "gemini-cli",
     "hermes",
     "antigravity",
+    "grok",
     "drive",
     "unknown",
 )
@@ -86,6 +87,7 @@ CORE_SCHEMA_PROVIDERS: Final[tuple[str, ...]] = (
     "gemini-cli",
     "hermes",
     "antigravity",
+    "grok",
 )
 
 _RUNTIME_PROVIDER_ALIASES: Final[dict[str, str]] = {
@@ -97,6 +99,9 @@ _RUNTIME_PROVIDER_ALIASES: Final[dict[str, str]] = {
     "aistudio": "gemini",
     "ai-studio": "gemini",
     "hermes-agent": "hermes",
+    "xai": "grok",
+    "x-ai": "grok",
+    "twitter-grok": "grok",
     "cursor": "codex",
 }
 

--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -122,6 +122,11 @@ _SOURCE_ANTIGRAVITY: Final[Source] = Source(
     runtime_root="~/.antigravity",
     originating_lab="google",
 )
+_SOURCE_GROK: Final[Source] = Source(
+    family="grok-export",
+    runtime_root=None,
+    originating_lab="xai",
+)
 _SOURCE_DRIVE: Final[Source] = Source(
     family="drive-takeout",
     runtime_root=None,  # acquired via Google Drive / Takeout APIs
@@ -144,6 +149,7 @@ _PROVIDER_TO_SOURCE: Final[dict[Provider, Source]] = {
     Provider.GEMINI_CLI: _SOURCE_GEMINI_CLI,
     Provider.HERMES: _SOURCE_HERMES,
     Provider.ANTIGRAVITY: _SOURCE_ANTIGRAVITY,
+    Provider.GROK: _SOURCE_GROK,
     Provider.DRIVE: _SOURCE_DRIVE,
     Provider.UNKNOWN: _SOURCE_UNKNOWN,
 }
@@ -220,6 +226,7 @@ _PROVIDER_TO_ORIGIN: Final[dict[Provider, Origin]] = {
     Provider.GEMINI_CLI: Origin.GEMINI_CLI_SESSION,
     Provider.HERMES: Origin.HERMES_SESSION,
     Provider.ANTIGRAVITY: Origin.ANTIGRAVITY_SESSION,
+    Provider.GROK: Origin.GROK_EXPORT,
     Provider.DRIVE: Origin.AISTUDIO_DRIVE,
     Provider.UNKNOWN: Origin.UNKNOWN_EXPORT,
 }
@@ -237,6 +244,7 @@ _ORIGIN_TO_LAB: Final[dict[Origin, Lab]] = {
     Origin.AISTUDIO_DRIVE: "google",
     Origin.ANTIGRAVITY_SESSION: "google",
     Origin.HERMES_SESSION: "nous",
+    Origin.GROK_EXPORT: "xai",
     Origin.UNKNOWN_EXPORT: "unknown",
 }
 
@@ -273,6 +281,7 @@ _ORIGIN_TO_PROVIDER: Final[dict[Origin, Provider]] = {
     Origin.GEMINI_CLI_SESSION: Provider.GEMINI_CLI,
     Origin.HERMES_SESSION: Provider.HERMES,
     Origin.ANTIGRAVITY_SESSION: Provider.ANTIGRAVITY,
+    Origin.GROK_EXPORT: Provider.GROK,
     Origin.CHATGPT_EXPORT: Provider.CHATGPT,
     Origin.CLAUDE_AI_EXPORT: Provider.CLAUDE_AI,
     Origin.AISTUDIO_DRIVE: Provider.GEMINI,

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -42,7 +42,10 @@ from polylogue.pipeline.services.process_pool import process_pool_executor
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.storage.sqlite.archive_tiers.write import (
+    upsert_parser_ingest_flag_tags,
+    write_parsed_session_to_archive,
+)
 from polylogue.storage.sqlite.connection import _load_sqlite_vec
 from polylogue.storage.sqlite.connection_profile import (
     DB_TIMEOUT,
@@ -237,6 +240,8 @@ def _write_session(
         delta, skipped_messages = _append_delta_payload(conn, payload)
         counts["skipped_messages"] = skipped_messages
         if delta is None:
+            if payload.parsed_session.ingest_flags:
+                upsert_parser_ingest_flag_tags(conn, payload.session_id, payload.parsed_session.ingest_flags)
             counts["skipped_sessions"] = 1
             counts["skipped_attachments"] = payload.attachment_count
             counts["skipped_session_events"] = len(payload.parsed_session.session_events)
@@ -247,6 +252,8 @@ def _write_session(
         merge_append = True
 
     if not force_write and content_unchanged:
+        if payload.parsed_session.ingest_flags:
+            upsert_parser_ingest_flag_tags(conn, payload.session_id, payload.parsed_session.ingest_flags)
         counts["skipped_sessions"] = 1
         counts["skipped_messages"] = payload.message_count
         counts["skipped_attachments"] = payload.attachment_count

--- a/polylogue/sources/parsers/base.py
+++ b/polylogue/sources/parsers/base.py
@@ -11,6 +11,7 @@ from .base_models import (
     ParsedPasteEvidence,
     ParsedSession,
     ParsedSessionEvent,
+    ParsedWebConstruct,
     RawSessionData,
 )
 from .base_support import (
@@ -24,6 +25,7 @@ __all__ = [
     "ParsedMessage",
     "ParsedAttachment",
     "ParsedPasteEvidence",
+    "ParsedWebConstruct",
     "ParsedSession",
     "ParsedSessionEvent",
     "RawSessionData",

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -9,9 +9,43 @@ from pydantic import AliasChoices, BaseModel, Field, field_validator, model_vali
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, MaterialOrigin, Provider, TitleSource
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider, TitleSource, WebConstructType
 from polylogue.core.security import sanitize_path as _sanitize_path_helper
 from polylogue.core.timestamps import parse_timestamp
+
+
+class ParsedWebConstruct(BaseModel):
+    """Typed construct projected from rich web UI/export payloads.
+
+    Raw provider JSON remains in source evidence. This model carries the
+    normalized fields that are useful for archive reads, search, and later
+    provider-specific projections without reintroducing provider_meta bags.
+    """
+
+    construct_type: WebConstructType
+    provider_key: str | None = None
+    title: str | None = None
+    url: str | None = None
+    text: str | None = None
+    source_id: str | None = None
+    group_id: str | None = None
+    group_title: str | None = None
+    query: str | None = None
+    asset_pointer: str | None = None
+    mime_type: str | None = None
+    status: str | None = None
+    task_id: str | None = None
+    task_type: str | None = None
+    rank: int | None = None
+    start_index: int | None = None
+    end_index: int | None = None
+
+    @field_validator("construct_type", mode="before")
+    @classmethod
+    def coerce_construct_type(cls, v: object) -> WebConstructType:
+        if isinstance(v, WebConstructType):
+            return v
+        return WebConstructType(str(v).strip().lower())
 
 
 class ParsedContentBlock(BaseModel):
@@ -34,6 +68,7 @@ class ParsedContentBlock(BaseModel):
     tool_input: Mapping[str, object] | None = None
     media_type: str | None = None
     metadata: dict[str, object] | None = None
+    web_constructs: list[ParsedWebConstruct] = Field(default_factory=list)
 
     @field_validator("type", mode="before")
     @classmethod
@@ -80,6 +115,11 @@ class ParsedMessage(BaseModel):
     model_name: str | None = None
     model_effort: str | None = None
     duration_ms: int | None = None
+    sender_name: str | None = None
+    recipient: str | None = None
+    delivery_status: str | None = None
+    end_turn: bool | None = None
+    user_context_text: str | None = None
     paste_spans: list[ParsedPasteEvidence] = Field(default_factory=list)
 
     @field_validator("role", mode="before")

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import BlockType
+from polylogue.core.enums import BlockType, WebConstructType
 from polylogue.core.hashing import hash_text
 
 from .base_models import (
     ParsedAttachment,
     ParsedContentBlock,
     ParsedMessage,
+    ParsedWebConstruct,
 )
 
 
@@ -75,6 +76,40 @@ def content_blocks_from_segments(content: object) -> list[ParsedContentBlock]:
                     metadata={k: v for k, v in seg.items() if k not in ("type", "media_type")},
                 )
             )
+        elif seg_type == "token_budget":
+            remaining = seg.get("remaining")
+            if remaining is not None:
+                blocks.append(
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text=f"[Claude token budget remaining: {remaining}]",
+                        web_constructs=[
+                            ParsedWebConstruct(
+                                construct_type=WebConstructType.TOKEN_BUDGET,
+                                provider_key="token_budget",
+                                text=str(remaining),
+                            )
+                        ],
+                    )
+                )
+        elif seg_type == "voice_note":
+            text = seg.get("text") or ""
+            title = seg.get("title")
+            if text or title:
+                blocks.append(
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text=str(text or title),
+                        web_constructs=[
+                            ParsedWebConstruct(
+                                construct_type=WebConstructType.VOICE_NOTE,
+                                provider_key="voice_note",
+                                title=str(title) if title else None,
+                                text=str(text) if text else None,
+                            )
+                        ],
+                    )
+                )
         elif seg_type == "code":
             text = seg.get("text") or seg.get("code") or ""
             if text:
@@ -97,24 +132,26 @@ def _make_attachment_id(seed: str) -> str:
 def attachment_from_meta(meta: object, message_id: str | None, index: int) -> ParsedAttachment | None:
     if not isinstance(meta, dict):
         return None
-    attachment_id = meta.get("id") or meta.get("file_id") or meta.get("fileId") or meta.get("uuid")
+    attachment_id = (
+        meta.get("id") or meta.get("file_id") or meta.get("fileId") or meta.get("uuid") or meta.get("file_uuid")
+    )
     name = meta.get("name") or meta.get("filename") or meta.get("file_name")
     if not attachment_id:
         if not name:
             return None
         seed = f"{message_id or 'msg'}:{name}:{index}"
         attachment_id = _make_attachment_id(seed)
-    size_raw = meta.get("size") or meta.get("size_bytes") or meta.get("sizeBytes")
+    size_raw = meta.get("size") or meta.get("size_bytes") or meta.get("sizeBytes") or meta.get("file_size")
     size_bytes = None
     if isinstance(size_raw, (int, str)):
         try:
             size_bytes = int(size_raw)
         except ValueError:
             size_bytes = None
-    mime_type = meta.get("mimeType") or meta.get("mime_type") or meta.get("content_type")
+    mime_type = meta.get("mimeType") or meta.get("mime_type") or meta.get("content_type") or meta.get("file_type")
     # #1252: promote native identifiers when present. claude-code/codex
     # attachments arrive via OAuth-authenticated session/export.
-    file_id_raw = meta.get("file_id") or meta.get("fileId")
+    file_id_raw = meta.get("file_id") or meta.get("fileId") or meta.get("file_uuid")
     drive_id_raw = meta.get("drive_id") or meta.get("driveId")
     return ParsedAttachment(
         provider_attachment_id=str(attachment_id),

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -10,6 +10,8 @@ from polylogue.browser_capture.models import BrowserCaptureEnvelope, looks_like_
 from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base_models import ParsedAttachment, ParsedMessage, ParsedSession
 
+TEMPORARY_CHAT_INGEST_FLAG = "capture:temporary-chat"
+
 
 def _legacy_native_id(provider: Provider, provider_session_id: str | None) -> str | None:
     return legacy_browser_capture_native_id(provider, provider_session_id)
@@ -26,6 +28,13 @@ def _has_chatgpt_native_payload(payload: object) -> TypeGuard[Mapping[str, objec
 
 def _has_claude_ai_native_payload(payload: object) -> TypeGuard[Mapping[str, object]]:
     return isinstance(payload, dict) and isinstance(payload.get("chat_messages"), list)
+
+
+def _ingest_flags_for_browser_capture(envelope: BrowserCaptureEnvelope, provider_session_id: str) -> list[str]:
+    session_kind = envelope.session.provider_meta.get("session_kind")
+    if session_kind == "temporary" or provider_session_id.startswith("temporary:"):
+        return [TEMPORARY_CHAT_INGEST_FLAG]
+    return []
 
 
 def parse(payload: object, fallback_id: str) -> ParsedSession:
@@ -111,7 +120,8 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
         attachments=attachments,
+        ingest_flags=_ingest_flags_for_browser_capture(envelope, provider_session_id),
     )
 
 
-__all__ = ["looks_like", "parse"]
+__all__ = ["TEMPORARY_CHAT_INGEST_FLAG", "looks_like", "parse"]

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import BlockType, Provider
+from polylogue.core.enums import BlockType, Provider, WebConstructType
 from polylogue.core.timestamps import parse_timestamp
 
-from .base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession
+from .base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession, ParsedWebConstruct
+
+SHARED_CONVERSATION_INDEX_INGEST_FLAG = "capture:chatgpt-shared-index-shell"
 
 
 def _coerce_float(value: object) -> float | None:
@@ -24,6 +26,176 @@ def _coerce_float(value: object) -> float | None:
         if parsed is not None:
             return parsed.timestamp()
     return None
+
+
+def _string_value(payload: Mapping[str, object], *keys: str) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+    return None
+
+
+def _int_value(payload: Mapping[str, object], *keys: str) -> int | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, str):
+            try:
+                return int(value)
+            except ValueError:
+                continue
+    return None
+
+
+def _iter_mapping_items(value: object) -> list[Mapping[str, object]]:
+    if isinstance(value, Mapping):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _construct_from_reference(
+    item: Mapping[str, object],
+    *,
+    construct_type: WebConstructType,
+    provider_key: str,
+    rank: int | None = None,
+    group_id: str | None = None,
+    group_title: str | None = None,
+) -> ParsedWebConstruct:
+    return ParsedWebConstruct(
+        construct_type=construct_type,
+        provider_key=provider_key,
+        title=_string_value(item, "title", "name", "source_name"),
+        url=_string_value(item, "url", "link", "source_url"),
+        text=_string_value(item, "snippet", "text", "content", "description"),
+        source_id=_string_value(item, "id", "source_id", "ref_id", "attribution_id", "textdoc_id"),
+        group_id=group_id,
+        group_title=group_title,
+        asset_pointer=_string_value(item, "asset_pointer"),
+        mime_type=_string_value(item, "mime_type", "media_type"),
+        rank=rank if rank is not None else _int_value(item, "rank", "index"),
+        start_index=_int_value(item, "start_index", "start_idx", "start_ix", "start"),
+        end_index=_int_value(item, "end_index", "end_idx", "end_ix", "end"),
+    )
+
+
+def _constructs_from_chatgpt_metadata(msg_metadata: object) -> list[ParsedWebConstruct]:
+    if not isinstance(msg_metadata, Mapping):
+        return []
+    constructs: list[ParsedWebConstruct] = []
+    for item in _iter_mapping_items(msg_metadata.get("canvas")):
+        constructs.append(
+            ParsedWebConstruct(
+                construct_type=WebConstructType.CANVAS,
+                provider_key="canvas",
+                title=_string_value(item, "title", "name"),
+                text=_string_value(item, "text", "content"),
+                source_id=_string_value(item, "id", "canvas_id", "textdoc_id"),
+                status=_string_value(item, "status"),
+            )
+        )
+    for provider_key in ("content_references", "citations", "_cite_metadata"):
+        value = msg_metadata.get(provider_key)
+        for rank, item in enumerate(_iter_mapping_items(value)):
+            constructs.append(
+                _construct_from_reference(
+                    item,
+                    construct_type=WebConstructType.CONTENT_REFERENCE,
+                    provider_key=provider_key,
+                    rank=rank,
+                )
+            )
+    search_queries = msg_metadata.get("search_queries")
+    if isinstance(search_queries, list):
+        for rank, item in enumerate(search_queries):
+            if isinstance(item, str) and item:
+                constructs.append(
+                    ParsedWebConstruct(
+                        construct_type=WebConstructType.SEARCH_QUERY,
+                        provider_key="search_queries",
+                        query=item,
+                        rank=rank,
+                    )
+                )
+            elif isinstance(item, Mapping):
+                constructs.append(
+                    ParsedWebConstruct(
+                        construct_type=WebConstructType.SEARCH_QUERY,
+                        provider_key="search_queries",
+                        query=_string_value(item, "query", "text"),
+                        title=_string_value(item, "title"),
+                        rank=rank,
+                    )
+                )
+    for group_rank, group in enumerate(_iter_mapping_items(msg_metadata.get("search_result_groups"))):
+        group_id = _string_value(group, "id", "group_id") or str(group_rank)
+        group_title = _string_value(group, "title", "name", "query")
+        candidates = (
+            group.get("results") or group.get("items") or group.get("search_results") or group.get("sources") or []
+        )
+        for rank, item in enumerate(_iter_mapping_items(candidates)):
+            constructs.append(
+                _construct_from_reference(
+                    item,
+                    construct_type=WebConstructType.SEARCH_RESULT,
+                    provider_key="search_result_groups",
+                    rank=rank,
+                    group_id=group_id,
+                    group_title=group_title,
+                )
+            )
+    for rank, item in enumerate(_iter_mapping_items(msg_metadata.get("selected_sources"))):
+        constructs.append(
+            _construct_from_reference(
+                item,
+                construct_type=WebConstructType.SELECTED_SOURCE,
+                provider_key="selected_sources",
+                rank=rank,
+            )
+        )
+    for rank, item in enumerate(_iter_mapping_items(msg_metadata.get("image_results"))):
+        constructs.append(
+            _construct_from_reference(
+                item,
+                construct_type=WebConstructType.IMAGE_RESULT,
+                provider_key="image_results",
+                rank=rank,
+            )
+        )
+    async_task_type = _string_value(msg_metadata, "async_task_type")
+    async_task_id = _string_value(msg_metadata, "async_task_id")
+    async_task_title = _string_value(msg_metadata, "async_task_title")
+    if async_task_type or async_task_id or async_task_title:
+        constructs.append(
+            ParsedWebConstruct(
+                construct_type=WebConstructType.ASYNC_TASK,
+                provider_key="async_task",
+                title=async_task_title,
+                task_id=async_task_id,
+                task_type=async_task_type,
+            )
+        )
+    for item in _iter_mapping_items(msg_metadata.get("aggregate_result")):
+        constructs.append(
+            ParsedWebConstruct(
+                construct_type=WebConstructType.ASYNC_TASK,
+                provider_key="aggregate_result",
+                title=_string_value(item, "title"),
+                text=_string_value(item, "output", "text", "stdout", "stderr"),
+                status=_string_value(item, "status", "exit_code"),
+            )
+        )
+    return constructs
 
 
 def _active_path_node_ids(mapping: Mapping[str, object], current_node: str | None) -> list[str]:
@@ -229,44 +401,45 @@ def extract_messages_from_mapping(
                             metadata={"asset_pointer": str(part.get("asset_pointer", ""))},
                         )
                     )
+                elif isinstance(part, dict) and part.get("content_type") in {
+                    "audio_asset_pointer",
+                    "audio_transcription",
+                    "real_time_user_audio_video_asset_pointer",
+                }:
+                    part_text = part.get("text")
+                    content_type = str(part.get("content_type"))
+                    content_blocks.append(
+                        ParsedContentBlock(
+                            type=BlockType.DOCUMENT,
+                            text=part_text if isinstance(part_text, str) and part_text else None,
+                            media_type=_string_value(part, "mime_type", "media_type"),
+                            web_constructs=[
+                                ParsedWebConstruct(
+                                    construct_type=(
+                                        WebConstructType.AUDIO_TRANSCRIPTION
+                                        if content_type == "audio_transcription"
+                                        else WebConstructType.AUDIO_ASSET
+                                    ),
+                                    provider_key=content_type,
+                                    text=part_text if isinstance(part_text, str) and part_text else None,
+                                    asset_pointer=_string_value(part, "asset_pointer"),
+                                    mime_type=_string_value(part, "mime_type", "media_type"),
+                                )
+                            ],
+                        )
+                    )
 
-        # Promote message-level metadata into content_block metadata so it
-        # survives parsing → materialization → storage → hydration. These
-        # are prefixed with chatgpt_ to distinguish provider-specific facts
-        # from canonical block semantics.
-        _chatgpt_block_meta: dict[str, object] = {}
-        if isinstance(msg_metadata, dict):
-            model_slug_val = msg_metadata.get("model_slug")
-            if model_slug_val:
-                _chatgpt_block_meta["chatgpt_model"] = model_slug_val
-            citations_val = msg_metadata.get("citations") or msg_metadata.get("_cite_metadata")
-            if isinstance(citations_val, (list, dict)) and citations_val:
-                _chatgpt_block_meta["chatgpt_citations"] = citations_val
-            aggregate_result_val = msg_metadata.get("aggregate_result")
-            if isinstance(aggregate_result_val, dict) and aggregate_result_val:
-                _chatgpt_block_meta["chatgpt_code_execution"] = aggregate_result_val
-            user_context_val = msg_metadata.get("user_context_message_data")
-            if isinstance(user_context_val, dict) and user_context_val:
-                _chatgpt_block_meta["chatgpt_user_context"] = user_context_val
-        if isinstance(author, dict):
-            author_name = author.get("name")
-            if isinstance(author_name, str) and author_name:
-                _chatgpt_block_meta["chatgpt_author_name"] = author_name
+        web_constructs = _constructs_from_chatgpt_metadata(msg_metadata)
+        if web_constructs:
+            if not content_blocks:
+                content_blocks.append(ParsedContentBlock(type=BlockType.TEXT))
+            first_block = content_blocks[0]
+            first_block.web_constructs.extend(web_constructs)
+
         recipient_val = msg.get("recipient")
-        if isinstance(recipient_val, str) and recipient_val and recipient_val != "all":
-            _chatgpt_block_meta["chatgpt_recipient"] = recipient_val
         status_val = msg.get("status")
-        if isinstance(status_val, str) and status_val:
-            _chatgpt_block_meta["chatgpt_status"] = status_val
         end_turn_val = msg.get("end_turn")
-        if isinstance(end_turn_val, bool):
-            _chatgpt_block_meta["chatgpt_end_turn"] = end_turn_val
-
-        if _chatgpt_block_meta:
-            for block in content_blocks:
-                if block.metadata is None:
-                    block.metadata = {}
-                block.metadata.update(_chatgpt_block_meta)
+        user_context_val = msg_metadata.get("user_context_message_data") if isinstance(msg_metadata, Mapping) else None
 
         parsed = ParsedMessage(
             provider_message_id=str(msg_id),
@@ -281,6 +454,17 @@ def extract_messages_from_mapping(
             is_active_path=node_id in active_path_id_set if active_path_ids else None,
             model_name=model_name,
             duration_ms=duration_ms,
+            sender_name=_string_value(author, "name") if isinstance(author, Mapping) else None,
+            recipient=recipient_val
+            if isinstance(recipient_val, str) and recipient_val and recipient_val != "all"
+            else None,
+            delivery_status=status_val if isinstance(status_val, str) and status_val else None,
+            end_turn=end_turn_val if isinstance(end_turn_val, bool) else None,
+            user_context_text=(
+                _string_value(user_context_val, "about_user_message", "text", "content")
+                if isinstance(user_context_val, Mapping)
+                else None
+            ),
         )
         emitted_by_node_id[node_id] = parsed.provider_message_id
         entries.append((_coerce_float(timestamp), idx, parsed))
@@ -317,6 +501,11 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
     messages, attachments = extract_messages_from_mapping(mapping, current_node)
     title = payload.get("title") or payload.get("name") or fallback_id
     conv_id = payload.get("id") or payload.get("uuid") or payload.get("conversation_id")
+    ingest_flags: list[str] = []
+    if not messages and payload.get("conversation_id") and payload.get("id") and "mapping" not in payload:
+        ingest_flags.append(SHARED_CONVERSATION_INDEX_INGEST_FLAG)
+    if payload.get("is_temporary") is True:
+        ingest_flags.append("capture:temporary-chat")
 
     return ParsedSession(
         source_name=Provider.CHATGPT,
@@ -330,4 +519,5 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
             None,
         ),
         attachments=attachments,
+        ingest_flags=ingest_flags,
     )

--- a/polylogue/sources/parsers/claude/ai_parser.py
+++ b/polylogue/sources/parsers/claude/ai_parser.py
@@ -6,13 +6,15 @@ from collections.abc import Mapping
 
 from pydantic import ValidationError
 
-from polylogue.core.enums import BlockType, Provider
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider, WebConstructType
 from polylogue.sources.providers.claude_ai import ClaudeAISession
 
 from ..base import (
     ParsedContentBlock,
     ParsedMessage,
     ParsedSession,
+    ParsedWebConstruct,
     attachment_from_meta,
     content_blocks_from_segments,
 )
@@ -24,12 +26,135 @@ from .common import (
     normalize_timestamp,
 )
 
+CLAUDE_DESIGN_CHAT_INGEST_FLAG = "capture:claude-design-chat"
+CLAUDE_TEMPORARY_CHAT_INGEST_FLAG = "capture:temporary-chat"
+
 
 def looks_like_ai(payload: object) -> bool:
-    return isinstance(payload, dict) and isinstance(payload.get("chat_messages"), list)
+    return isinstance(payload, dict) and (
+        isinstance(payload.get("chat_messages"), list) or _looks_like_design_chat(payload)
+    )
+
+
+def _looks_like_design_chat(payload: object) -> bool:
+    return (
+        isinstance(payload, dict)
+        and isinstance(payload.get("messages"), list)
+        and ("project" in payload or "design_chats" in str(payload.get("source_path", "")))
+        and not isinstance(payload.get("chat_messages"), list)
+    )
+
+
+def _session_ingest_flags(payload: Mapping[str, object], *, design_chat: bool = False) -> list[str]:
+    flags: list[str] = []
+    if design_chat:
+        flags.append(CLAUDE_DESIGN_CHAT_INGEST_FLAG)
+    if payload.get("is_temporary") is True:
+        flags.append(CLAUDE_TEMPORARY_CHAT_INGEST_FLAG)
+    return flags
+
+
+def _design_content_payload(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    nested = value.get("content")
+    if isinstance(nested, Mapping):
+        return nested
+    return value
+
+
+def _design_project_title(value: object) -> str | None:
+    if isinstance(value, Mapping):
+        name = value.get("name")
+        return str(name) if name is not None else None
+    return str(value) if value is not None else None
+
+
+def _design_project_id(value: object) -> str | None:
+    if isinstance(value, Mapping):
+        project_id = value.get("uuid") or value.get("id")
+        return str(project_id) if project_id is not None else None
+    return None
+
+
+def _parse_design_chat(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
+    messages: list[ParsedMessage] = []
+    attachments = []
+    raw_messages = payload.get("messages")
+    design_messages = raw_messages if isinstance(raw_messages, list) else []
+    for position, raw_message in enumerate(design_messages):
+        if not isinstance(raw_message, Mapping):
+            continue
+        content_payload = _design_content_payload(raw_message.get("content"))
+        text = content_payload.get("content") or content_payload.get("text") or raw_message.get("text")
+        if not isinstance(text, str) or not text:
+            continue
+        message_id = (
+            raw_message.get("uuid") or content_payload.get("id") or raw_message.get("id") or f"design-{position}"
+        )
+        raw_role = raw_message.get("role") or content_payload.get("role")
+        messages.append(
+            ParsedMessage(
+                provider_message_id=str(message_id),
+                role=Role.normalize(str(raw_role or "unknown")),
+                text=text,
+                timestamp=str(content_payload.get("timestamp") or raw_message.get("created_at"))
+                if content_payload.get("timestamp") or raw_message.get("created_at")
+                else None,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text=text,
+                        web_constructs=[
+                            ParsedWebConstruct(
+                                construct_type=WebConstructType.CANVAS,
+                                provider_key="claude_design_chat",
+                                title=_design_project_title(payload.get("project")),
+                                source_id=(
+                                    str(content_payload.get("id"))
+                                    if content_payload.get("id") is not None
+                                    else _design_project_id(payload.get("project"))
+                                ),
+                            )
+                        ],
+                    )
+                ],
+                position=position,
+                variant_index=0,
+                is_active_path=True,
+            )
+        )
+        raw_attachments = content_payload.get("attachments")
+        design_attachments = raw_attachments if isinstance(raw_attachments, list) else []
+        for att_idx, meta in enumerate(design_attachments, start=1):
+            attachment = attachment_from_meta(meta, str(message_id), att_idx)
+            if attachment:
+                attachments.append(attachment)
+    active_leaf_message_provider_id = messages[-1].provider_message_id if messages else None
+    if active_leaf_message_provider_id is not None:
+        messages = [
+            message.model_copy(
+                update={"is_active_leaf": message.provider_message_id == active_leaf_message_provider_id}
+            )
+            for message in messages
+        ]
+    return ParsedSession(
+        source_name=Provider.CLAUDE_AI,
+        provider_session_id=str(payload.get("uuid") or payload.get("id") or fallback_id),
+        title=str(payload.get("title") or payload.get("name") or fallback_id),
+        created_at=str(payload.get("created_at")) if payload.get("created_at") else None,
+        updated_at=str(payload.get("updated_at")) if payload.get("updated_at") else None,
+        messages=messages,
+        active_leaf_message_provider_id=active_leaf_message_provider_id,
+        attachments=attachments,
+        ingest_flags=_session_ingest_flags(payload, design_chat=True),
+    )
 
 
 def parse_ai(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
+    if _looks_like_design_chat(payload):
+        return _parse_design_chat(payload, fallback_id)
+
     try:
         conv = ClaudeAISession.model_validate(payload)
     except ValidationError:
@@ -51,6 +176,7 @@ def parse_ai(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
                 None,
             ),
             attachments=attachments,
+            ingest_flags=_session_ingest_flags(payload),
         )
 
     messages = []
@@ -102,7 +228,13 @@ def parse_ai(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
         attachments=attachments,
+        ingest_flags=_session_ingest_flags(payload),
     )
 
 
-__all__ = ["looks_like_ai", "parse_ai"]
+__all__ = [
+    "CLAUDE_DESIGN_CHAT_INGEST_FLAG",
+    "CLAUDE_TEMPORARY_CHAT_INGEST_FLAG",
+    "looks_like_ai",
+    "parse_ai",
+]

--- a/polylogue/sources/parsers/claude/common.py
+++ b/polylogue/sources/parsers/claude/common.py
@@ -196,7 +196,14 @@ def extract_messages_from_chat_messages(
                 )
             )
             message_position += 1
-        for att_idx, meta in enumerate(item.get("attachments") or item.get("files") or [], start=1):
+        raw_attachments: list[object] = []
+        attachments_value = item.get("attachments")
+        files_value = item.get("files")
+        if isinstance(attachments_value, list):
+            raw_attachments.extend(attachments_value)
+        if isinstance(files_value, list):
+            raw_attachments.extend(files_value)
+        for att_idx, meta in enumerate(raw_attachments, start=1):
             attachment = attachment_from_meta(meta, message_id, att_idx)
             if attachment:
                 attachments.append(attachment)

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -11,6 +11,7 @@ from polylogue.core.enums import (
     Origin,
     PasteBoundary,
     Role,
+    WebConstructType,
 )
 from polylogue.storage.sqlite.archive_tiers.common import (
     CONTENT_HASH_CHECK,
@@ -19,7 +20,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
     nullable_check,
 )
 
-INDEX_SCHEMA_VERSION = 7
+INDEX_SCHEMA_VERSION = 8
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -86,6 +87,11 @@ CREATE TABLE IF NOT EXISTS messages (
     material_origin     TEXT NOT NULL DEFAULT 'unknown' CHECK ({check("material_origin", MaterialOrigin)}),
     model_name          TEXT,
     model_effort        TEXT,
+    sender_name         TEXT,
+    recipient           TEXT,
+    delivery_status     TEXT,
+    end_turn            INTEGER CHECK(end_turn IN (0, 1) OR end_turn IS NULL),
+    user_context_text   TEXT,
     has_tool_use        INTEGER NOT NULL DEFAULT 0 CHECK(has_tool_use IN (0, 1)),
     has_thinking        INTEGER NOT NULL DEFAULT 0 CHECK(has_thinking IN (0, 1)),
     has_paste           INTEGER NOT NULL DEFAULT 0 CHECK(has_paste IN (0, 1)),
@@ -163,6 +169,44 @@ ON blocks(block_type);
 CREATE INDEX IF NOT EXISTS idx_blocks_tool_id
 ON blocks(tool_id)
 WHERE tool_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS web_content_constructs (
+    construct_id    TEXT GENERATED ALWAYS AS (block_id || ':' || position) STORED UNIQUE,
+    session_id      TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+    message_id      TEXT NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+    block_id        TEXT NOT NULL REFERENCES blocks(block_id) ON DELETE CASCADE,
+    position        INTEGER NOT NULL CHECK(position >= 0),
+    provider        TEXT NOT NULL,
+    construct_type  TEXT NOT NULL CHECK ({check("construct_type", WebConstructType)}),
+    provider_key    TEXT,
+    title           TEXT,
+    url             TEXT,
+    text            TEXT,
+    source_id       TEXT,
+    group_id        TEXT,
+    group_title     TEXT,
+    query           TEXT,
+    asset_pointer   TEXT,
+    mime_type       TEXT,
+    status          TEXT,
+    task_id         TEXT,
+    task_type       TEXT,
+    rank            INTEGER,
+    start_index     INTEGER,
+    end_index       INTEGER,
+    PRIMARY KEY(block_id, position)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_web_constructs_session_type
+ON web_content_constructs(session_id, construct_type);
+
+CREATE INDEX IF NOT EXISTS idx_web_constructs_url
+ON web_content_constructs(url)
+WHERE url IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_web_constructs_query
+ON web_content_constructs(query)
+WHERE query IS NOT NULL;
 
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     block_id UNINDEXED,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -52,6 +52,33 @@ class ArchiveBlockRow:
 
 
 @dataclass(frozen=True, slots=True)
+class ArchiveWebConstructRow:
+    construct_id: str
+    session_id: str
+    message_id: str
+    block_id: str
+    position: int
+    provider: str
+    construct_type: str
+    provider_key: str | None = None
+    title: str | None = None
+    url: str | None = None
+    text: str | None = None
+    source_id: str | None = None
+    group_id: str | None = None
+    group_title: str | None = None
+    query: str | None = None
+    asset_pointer: str | None = None
+    mime_type: str | None = None
+    status: str | None = None
+    task_id: str | None = None
+    task_type: str | None = None
+    rank: int | None = None
+    start_index: int | None = None
+    end_index: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ArchiveAttachmentRow:
     attachment_id: str
     message_id: str | None
@@ -294,8 +321,7 @@ def write_parsed_session_to_archive(
         else:
             _replace_full_session_messages_and_blocks(
                 conn,
-                session_id,
-                messages,
+                session,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
         if merge_append:
@@ -312,6 +338,13 @@ def write_parsed_session_to_archive(
                 messages,
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
+            )
+            _write_web_constructs(
+                conn,
+                session,
+                position_offset=position_offset,
+                duplicate_native_ids=duplicate_message_native_ids,
+                replace_session=False,
             )
         _write_attachments(
             conn,
@@ -378,6 +411,11 @@ def _write_ingest_flag_tags(conn: sqlite3.Connection, session_id: str, flags: li
             """,
             (session_id, normalized),
         )
+
+
+def upsert_parser_ingest_flag_tags(conn: sqlite3.Connection, session_id: str, flags: list[str]) -> None:
+    """Upsert parser-owned ingest flag tags for an already-materialized session."""
+    _write_ingest_flag_tags(conn, session_id, flags)
 
 
 def _clear_session_projection_rows(conn: sqlite3.Connection, session_id: str) -> None:
@@ -1157,6 +1195,11 @@ def _write_messages(
                 _enum_value(message.material_origin),
                 _sqlite_text(message.model_name),
                 _sqlite_text(message.model_effort),
+                _sqlite_text(message.sender_name),
+                _sqlite_text(message.recipient),
+                _sqlite_text(message.delivery_status),
+                None if message.end_turn is None else int(message.end_turn),
+                _sqlite_text(message.user_context_text),
                 _has_block(message, BlockType.TOOL_USE),
                 _has_block(message, BlockType.THINKING),
                 _has_paste(message),
@@ -1180,11 +1223,12 @@ def _write_messages(
         """
         INSERT OR REPLACE INTO messages (
             session_id, native_id, parent_message_id, position, role, message_type, material_origin,
-            model_name, model_effort, has_tool_use, has_thinking, has_paste, paste_boundary,
+            model_name, model_effort, sender_name, recipient, delivery_status, end_turn, user_context_text,
+            has_tool_use, has_thinking, has_paste, paste_boundary,
             variant_index, is_active_path, is_active_leaf, word_count,
             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
             duration_ms, content_hash, occurred_at_ms
-        ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         rows(),
     )
@@ -1234,13 +1278,87 @@ def _write_blocks(
     )
 
 
+def _write_web_constructs(
+    conn: sqlite3.Connection,
+    session: ParsedSession,
+    *,
+    position_offset: int = 0,
+    duplicate_native_ids: frozenset[str] = frozenset(),
+    replace_session: bool = True,
+) -> None:
+    origin = origin_from_provider(session.source_name)
+    session_id = archive_session_id(origin.value, session.provider_session_id)
+    provider = _enum_value(session.source_name)
+    rows: list[tuple[object, ...]] = []
+    block_ids: list[str] = []
+    for fallback_position, message in enumerate(session.messages):
+        message_id = _message_id(
+            session_id,
+            message,
+            fallback_position,
+            position_offset=position_offset,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+        blocks = _message_blocks(message)
+        for block_position, block in enumerate(blocks):
+            block_id = f"{message_id}:{block_position}"
+            block_ids.append(block_id)
+            for construct_position, construct in enumerate(block.web_constructs):
+                rows.append(
+                    (
+                        session_id,
+                        message_id,
+                        block_id,
+                        construct_position,
+                        provider,
+                        _enum_value(construct.construct_type),
+                        _sqlite_text(construct.provider_key),
+                        _sqlite_text(construct.title),
+                        _sqlite_text(construct.url),
+                        _sqlite_text(construct.text),
+                        _sqlite_text(construct.source_id),
+                        _sqlite_text(construct.group_id),
+                        _sqlite_text(construct.group_title),
+                        _sqlite_text(construct.query),
+                        _sqlite_text(construct.asset_pointer),
+                        _sqlite_text(construct.mime_type),
+                        _sqlite_text(construct.status),
+                        _sqlite_text(construct.task_id),
+                        _sqlite_text(construct.task_type),
+                        construct.rank,
+                        construct.start_index,
+                        construct.end_index,
+                    )
+                )
+
+    if replace_session:
+        conn.execute("DELETE FROM web_content_constructs WHERE session_id = ?", (session_id,))
+    else:
+        conn.executemany(
+            "DELETE FROM web_content_constructs WHERE block_id = ?", ((block_id,) for block_id in block_ids)
+        )
+
+    conn.executemany(
+        """
+        INSERT OR REPLACE INTO web_content_constructs (
+            session_id, message_id, block_id, position, provider, construct_type,
+            provider_key, title, url, text, source_id, group_id, group_title,
+            query, asset_pointer, mime_type, status, task_id, task_type,
+            rank, start_index, end_index
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+
+
 def _replace_full_session_messages_and_blocks(
     conn: sqlite3.Connection,
-    session_id: str,
-    messages: list[ParsedMessage],
+    session: ParsedSession,
     *,
     duplicate_native_ids: frozenset[str],
 ) -> None:
+    origin = origin_from_provider(session.source_name)
+    session_id = archive_session_id(origin.value, session.provider_session_id)
     use_scoped_fts_rebuild = message_fts_triggers_present_sync(conn)
     if use_scoped_fts_rebuild:
         conn.execute(delete_session_rows_sql(1), (session_id,))
@@ -1251,13 +1369,18 @@ def _replace_full_session_messages_and_blocks(
         _write_messages(
             conn,
             session_id,
-            messages,
+            session.messages,
             duplicate_native_ids=duplicate_native_ids,
         )
         _write_blocks(
             conn,
             session_id,
-            messages,
+            session.messages,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+        _write_web_constructs(
+            conn,
+            session,
             duplicate_native_ids=duplicate_native_ids,
         )
         if use_scoped_fts_rebuild:
@@ -2539,6 +2662,7 @@ __all__ = [
     "apply_insight_materialization",
     "upsert_insight_materialization",
     "upsert_session_phase",
+    "upsert_parser_ingest_flag_tags",
     "upsert_session_tag",
     "upsert_session_work_event",
     "read_archive_session_envelope",

--- a/tests/unit/core/test_sources.py
+++ b/tests/unit/core/test_sources.py
@@ -114,6 +114,7 @@ def test_originating_lab_attribution() -> None:
         Provider.ANTIGRAVITY: "google",
         Provider.DRIVE: "google",
         Provider.HERMES: "nous",
+        Provider.GROK: "xai",
         Provider.UNKNOWN: "unknown",
     }
     for provider, lab in expected_labs.items():

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -140,6 +140,7 @@ def _session_data(
     stats_tuple: object | None = None,
     attachment_tuples: list[ParsedAttachment] | None = None,
     attachment_ref_tuples: list[AttachmentRefSpec] | None = None,
+    ingest_flags: list[str] | None = None,
     append_only: bool = False,
 ) -> SessionWritePayload:
     del stats_tuple
@@ -169,6 +170,7 @@ def _session_data(
         messages=messages,
         attachments=attachments,
         session_events=list(action_tuples or []),
+        ingest_flags=list(ingest_flags or []),
     )
     return SessionWritePayload(
         session_id=session_id,
@@ -577,6 +579,59 @@ def test_write_session_force_write_updates_message_time(tmp_path: Path) -> None:
         assert rows[0]["native_id"] == "msg-1"
         assert rows[0]["role"] == "user"
         assert rows[0]["occurred_at_ms"] == 1777636800000
+
+
+def test_write_session_upserts_ingest_flags_when_content_is_unchanged(tmp_path: Path) -> None:
+    """Parser-owned auto-tags still converge when the content hash is unchanged."""
+    with open_connection(tmp_path / "index.db") as conn:
+        first = _session_data(
+            "codex-session:unchanged-tags",
+            content_hash="same-hash",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex-session:unchanged-tags",
+                    role="user",
+                    text="hello",
+                    content_hash="msg-hash",
+                    sort_key=1777636800.0,
+                )
+            ],
+        )
+        changed, _ = _write_session(conn, first)
+        assert changed is True
+
+        recapture = _session_data(
+            "codex-session:unchanged-tags",
+            content_hash="same-hash",
+            ingest_flags=["capture:temporary-chat"],
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex-session:unchanged-tags",
+                    role="user",
+                    text="hello",
+                    content_hash="msg-hash",
+                    sort_key=1777636800.0,
+                )
+            ],
+        )
+        unchanged, counts = _write_session(conn, recapture)
+        conn.commit()
+
+        tags = conn.execute(
+            """
+            SELECT tag, tag_source, method
+            FROM session_tags
+            WHERE session_id = ?
+            """,
+            ("codex-session:unchanged-tags",),
+        ).fetchall()
+        assert unchanged is False
+        assert counts["skipped_sessions"] == 1
+        assert [(row["tag"], row["tag_source"], row["method"]) for row in tags] == [
+            ("capture:temporary-chat", "auto", "parser")
+        ]
 
 
 def test_write_session_skips_shorter_duplicate_raw_source(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -11,6 +11,7 @@ from polylogue.browser_capture.receiver import write_capture_envelope
 from polylogue.config import Source, get_config
 from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import detect_provider, parse_payload
+from polylogue.sources.parsers.browser_capture import TEMPORARY_CHAT_INGEST_FLAG
 from tests.infra.archive_scenarios import open_index_db
 
 
@@ -234,6 +235,19 @@ def test_browser_capture_non_native_raw_payload_keeps_envelope_turns() -> None:
     assert session.provider_session_id == "temporary:abc123"
     assert [message.provider_message_id for message in session.messages] == ["u1", "a1"]
     assert [message.text for message in session.messages] == ["Draft the plan", "Here is the plan"]
+    assert session.ingest_flags == [TEMPORARY_CHAT_INGEST_FLAG]
+
+
+def test_browser_capture_session_kind_marks_temporary_chat() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    session_payload["provider_meta"] = {"session_kind": "temporary"}
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "file-fallback")
+
+    assert parsed[0].provider_session_id == "conv-123"
+    assert parsed[0].ingest_flags == [TEMPORARY_CHAT_INGEST_FLAG]
 
 
 def test_browser_capture_raw_chatgpt_normalizes_legacy_synthetic_fallback_id() -> None:

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -10,7 +10,11 @@ import pytest
 
 from polylogue.scenarios import CorpusSpec
 from polylogue.sources.parsers.base import ParsedSession
-from polylogue.sources.parsers.chatgpt import _coerce_float, extract_messages_from_mapping
+from polylogue.sources.parsers.chatgpt import (
+    SHARED_CONVERSATION_INDEX_INGEST_FLAG,
+    _coerce_float,
+    extract_messages_from_mapping,
+)
 from polylogue.sources.parsers.chatgpt import looks_like as chatgpt_looks_like
 from polylogue.sources.parsers.chatgpt import parse as chatgpt_parse
 from polylogue.sources.parsers.claude import looks_like_ai, looks_like_code
@@ -61,6 +65,66 @@ def test_provider_format_detection(data: object, expected: bool, check_fn: Provi
     """Unified format detection across all providers."""
     result = check_fn(data)
     assert result == expected, f"Failed {desc}"
+
+
+def test_chatgpt_rich_web_metadata_is_promoted_to_typed_constructs() -> None:
+    messages, _ = extract_messages_from_mapping(
+        {
+            "node-1": {
+                "id": "node-1",
+                "message": {
+                    "id": "msg-1",
+                    "author": {"role": "assistant", "name": "research_kickoff_tool.start_research_task"},
+                    "recipient": "canmore.update_textdoc",
+                    "create_time": 1,
+                    "content": {"content_type": "text", "parts": ["Research answer"]},
+                    "metadata": {
+                        "canvas": {"textdoc_id": "canvas-1"},
+                        "content_references": [{"url": "https://example.test/ref"}],
+                        "search_result_groups": [{"query": "polylogue"}],
+                        "search_queries": ["polylogue browser capture"],
+                        "selected_sources": [{"title": "Source"}],
+                        "async_task_type": "deep_research",
+                        "async_task_id": "task-1",
+                        "citations": [{"start_ix": 0, "end_ix": 8}],
+                    },
+                },
+            }
+        }
+    )
+
+    constructs = messages[0].blocks[0].web_constructs
+    assert [construct.construct_type.value for construct in constructs] == [
+        "canvas",
+        "content_reference",
+        "content_reference",
+        "search_query",
+        "selected_source",
+        "async_task",
+    ]
+    assert constructs[0].source_id == "canvas-1"
+    assert constructs[1].url == "https://example.test/ref"
+    assert constructs[2].start_index == 0
+    assert constructs[3].query == "polylogue browser capture"
+    assert constructs[4].title == "Source"
+    assert constructs[5].task_type == "deep_research"
+    assert constructs[5].task_id == "task-1"
+    assert messages[0].blocks[0].metadata is None
+
+
+def test_chatgpt_shared_conversation_index_shell_is_tagged() -> None:
+    session = chatgpt_parse(
+        {
+            "conversation_id": "shared-conv",
+            "id": "share-row",
+            "is_anonymous": True,
+            "title": "Shared title only",
+        },
+        "fallback",
+    )
+
+    assert session.messages == []
+    assert SHARED_CONVERSATION_INDEX_INGEST_FLAG in session.ingest_flags
 
 
 # COERCE FLOAT - MERGED WITH FORMAT DETECTION ABOVE
@@ -413,12 +477,7 @@ def test_chatgpt_parse_synthetic_branching() -> None:
 
 
 def test_chatgpt_metadata_extracted_into_content_blocks() -> None:
-    """ChatGPT message-level metadata is extracted into content-block metadata.
-
-    Proves the parser lifts ChatGPT message metadata (model, author_name,
-    recipient, status, end_turn, citations, code_execution, user_context) onto
-    ``ParsedContentBlock.metadata`` rather than an opaque provider_meta blob.
-    """
+    """ChatGPT message metadata is extracted into typed parser fields."""
     # Build a ChatGPT mapping payload with rich message-level metadata.
     payload: dict[str, object] = {
         "title": "Metadata Roundtrip Test",
@@ -462,29 +521,25 @@ def test_chatgpt_metadata_extracted_into_content_blocks() -> None:
     parsed = chatgpt_parse(payload, "roundtrip-test")
     assert parsed.source_name == "chatgpt"
 
-    # The assistant message should have content_blocks with chatgpt_ metadata.
     assistant_msg = next(m for m in parsed.messages if m.role == "assistant")
     assert len(assistant_msg.blocks) >= 1
-    block_meta = assistant_msg.blocks[0].metadata
-    assert block_meta is not None, "content_block metadata should be set"
-    assert block_meta.get("chatgpt_model") == "gpt-4"
-    assert block_meta.get("chatgpt_author_name") == "dalle"
-    assert block_meta.get("chatgpt_recipient") == "dalle.text2im"
-    assert block_meta.get("chatgpt_status") == "finished_successfully"
-    assert block_meta.get("chatgpt_end_turn") is True
-    assert isinstance(block_meta.get("chatgpt_citations"), list)
-    assert isinstance(block_meta.get("chatgpt_code_execution"), dict)
-    assert isinstance(block_meta.get("chatgpt_user_context"), dict)
+    assert assistant_msg.model_name == "gpt-4"
+    assert assistant_msg.sender_name == "dalle"
+    assert assistant_msg.recipient == "dalle.text2im"
+    assert assistant_msg.delivery_status == "finished_successfully"
+    assert assistant_msg.end_turn is True
+    assert assistant_msg.user_context_text == "I like cats"
+    constructs = assistant_msg.blocks[0].web_constructs
+    assert any(construct.construct_type.value == "content_reference" for construct in constructs)
+    assert any(construct.construct_type.value == "async_task" for construct in constructs)
+    assert assistant_msg.blocks[0].metadata is None
 
-    # The user message should also have model metadata.
     user_msg = next(m for m in parsed.messages if m.role == "user")
     assert len(user_msg.blocks) >= 1
-    user_block_meta = user_msg.blocks[0].metadata
-    assert user_block_meta is not None
-    assert user_block_meta.get("chatgpt_model") == "gpt-4"
-    # User message should NOT have tool-specific metadata.
-    assert "chatgpt_author_name" not in user_block_meta
-    assert "chatgpt_recipient" not in user_block_meta
+    assert user_msg.model_name == "gpt-4"
+    assert user_msg.sender_name is None
+    assert user_msg.recipient is None
+    assert user_msg.blocks[0].metadata is None
 
 
 # =============================================================================
@@ -650,8 +705,8 @@ def test_chatgpt_metadata_permutation_extracted_by_parser(
     desc: str,
     expected_fields: dict[str, object],
 ) -> None:
-    """Catalog-driven: each metadata field permutation is extracted by the parser
-    onto the first content block's metadata."""
+    """Catalog-driven: each metadata field lands in a typed parser field."""
+    _ = expected_fields
     payload = _build_chatgpt_message_metadata_payload(meta_spec)
 
     parsed = chatgpt_parse(payload, "permutation-test")
@@ -660,20 +715,30 @@ def test_chatgpt_metadata_permutation_extracted_by_parser(
 
     blocks = parsed.messages[0].blocks
     assert len(blocks) >= 1
-    meta = blocks[0].metadata
-    assert isinstance(meta, dict), f"Expected dict metadata, got {type(meta)}: {desc}"
+    message = parsed.messages[0]
+    constructs = blocks[0].web_constructs
+    assert blocks[0].metadata is None
 
-    for field_name, expected_value in expected_fields.items():
-        actual = meta.get(field_name)
-        if isinstance(expected_value, dict):
-            assert isinstance(actual, dict), f"[{desc}] Expected dict for {field_name}, got {type(actual)}"
-            for k, v in expected_value.items():
-                assert actual.get(k) == v, f"[{desc}] {field_name}.{k}: expected {v!r}, got {actual.get(k)!r}"
-        elif isinstance(expected_value, list):
-            assert isinstance(actual, list), f"[{desc}] Expected list for {field_name}, got {type(actual)}"
-            assert actual == expected_value, f"[{desc}] {field_name}: expected {expected_value!r}, got {actual!r}"
-        else:
-            assert actual == expected_value, f"[{desc}] {field_name}: expected {expected_value!r}, got {actual!r}"
+    if "model_slug" in meta_spec:
+        assert message.model_name == meta_spec["model_slug"], desc
+    if meta_spec.get("is_tool_message"):
+        assert message.sender_name == "dalle", desc
+        assert message.recipient == "dalle.text2im", desc
+    else:
+        assert message.sender_name is None, desc
+        assert message.recipient is None, desc
+    if "message_status" in meta_spec:
+        assert message.delivery_status == meta_spec["message_status"], desc
+    if "end_turn" in meta_spec:
+        assert message.end_turn is meta_spec["end_turn"], desc
+    if "citations" in meta_spec:
+        reference = next(construct for construct in constructs if construct.construct_type.value == "content_reference")
+        assert reference.title == "Ref" or reference.title == "A", desc
+    if "aggregate_result" in meta_spec:
+        task = next(construct for construct in constructs if construct.construct_type.value == "async_task")
+        assert task.text in {"ok", "done"}, desc
+    if "user_context_message_data" in meta_spec:
+        assert message.user_context_text in {"likes cats", "needs help"}, desc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sources/test_parsers_claude_ai_catalog.py
+++ b/tests/unit/sources/test_parsers_claude_ai_catalog.py
@@ -28,6 +28,7 @@ from typing import Any, TypeAlias
 import pytest
 
 from polylogue.sources.parsers.claude import looks_like_ai, parse_ai
+from polylogue.sources.parsers.claude.ai_parser import CLAUDE_DESIGN_CHAT_INGEST_FLAG, CLAUDE_TEMPORARY_CHAT_INGEST_FLAG
 from polylogue.storage.sqlite.connection import open_connection
 from tests.infra.pipeline_roundtrip import (
     parse_payload_roundtrip,
@@ -116,6 +117,97 @@ def _payload(
     if model is not None:
         payload["model"] = model
     return payload
+
+
+def test_claude_design_chat_shape_is_parsed_as_session() -> None:
+    payload = {
+        "uuid": "design-1",
+        "title": "Design system",
+        "project": {"uuid": "project-1", "name": "Polylogue"},
+        "created_at": "2026-06-01T00:00:00Z",
+        "updated_at": "2026-06-01T00:01:00Z",
+        "messages": [
+            {
+                "uuid": "m1",
+                "role": "user",
+                "content": {
+                    "role": "user",
+                    "content": "Create a design system.",
+                    "attachments": [
+                        {
+                            "id": "att-1",
+                            "name": "brief.md",
+                            "type": "text/markdown",
+                            "content": "# brief",
+                        }
+                    ],
+                    "timestamp": "2026-06-01T00:00:01Z",
+                },
+            }
+        ],
+    }
+
+    assert looks_like_ai(payload)
+    session = parse_ai(payload, "fallback")
+
+    assert session.provider_session_id == "design-1"
+    assert session.title == "Design system"
+    assert [message.text for message in session.messages] == ["Create a design system."]
+    design_constructs = session.messages[0].blocks[0].web_constructs
+    assert len(design_constructs) == 1
+    assert design_constructs[0].construct_type.value == "canvas"
+    assert design_constructs[0].provider_key == "claude_design_chat"
+    assert design_constructs[0].title == "Polylogue"
+    assert session.attachments[0].provider_attachment_id == "att-1"
+    assert CLAUDE_DESIGN_CHAT_INGEST_FLAG in session.ingest_flags
+
+
+def test_claude_rich_segments_and_attachment_fields_are_preserved() -> None:
+    payload = {
+        "uuid": "claude-1",
+        "name": "Claude rich",
+        "is_temporary": True,
+        "chat_messages": [
+            {
+                "uuid": "m1",
+                "sender": "assistant",
+                "text": "answer\nremaining",
+                "created_at": "2026-06-01T00:00:01Z",
+                "updated_at": "2026-06-01T00:00:02Z",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "answer",
+                        "citations": [{"url": "https://example.test"}],
+                        "start_timestamp": "2026-06-01T00:00:01Z",
+                    },
+                    {"type": "token_budget", "remaining": 1234},
+                ],
+                "attachments": [
+                    {
+                        "file_name": "report.pdf",
+                        "file_size": 42,
+                        "file_type": "application/pdf",
+                        "extracted_content": "report text",
+                    }
+                ],
+                "files": [{"file_uuid": "file-1", "file_name": "source.py"}],
+            }
+        ],
+    }
+
+    session = parse_ai(payload, "fallback")
+
+    assert CLAUDE_TEMPORARY_CHAT_INGEST_FLAG in session.ingest_flags
+    assert session.messages[0].blocks[0].metadata is None
+    token_budget_constructs = session.messages[0].blocks[1].web_constructs
+    assert len(token_budget_constructs) == 1
+    assert token_budget_constructs[0].construct_type.value == "token_budget"
+    assert token_budget_constructs[0].text == "1234"
+    assert session.attachments[0].name == "report.pdf"
+    assert session.attachments[0].size_bytes == 42
+    assert session.attachments[0].mime_type == "application/pdf"
+    assert session.attachments[1].provider_attachment_id == "file-1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, MaterialOrigin, MessageType, Provider, TitleSource
+from polylogue.core.enums import BlockType, MaterialOrigin, MessageType, Provider, TitleSource, WebConstructType
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -14,6 +14,7 @@ from polylogue.sources.parsers.base import (
     ParsedPasteEvidence,
     ParsedSession,
     ParsedSessionEvent,
+    ParsedWebConstruct,
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -45,6 +46,63 @@ def _connect(path: Path) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys = ON")
     initialize_archive_tier(conn, ArchiveTier.INDEX)
     return conn
+
+
+def test_archive_tiers_writer_materializes_typed_web_constructs(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id="construct-session",
+        title="Construct session",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                text="answer with source",
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text="answer with source",
+                        web_constructs=[
+                            ParsedWebConstruct(
+                                construct_type=WebConstructType.CONTENT_REFERENCE,
+                                provider_key="content_references",
+                                title="Source",
+                                url="https://example.test/source",
+                                rank=0,
+                            ),
+                            ParsedWebConstruct(
+                                construct_type=WebConstructType.CANVAS,
+                                provider_key="canvas",
+                                source_id="canvas-1",
+                            ),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    rows = conn.execute(
+        """
+        SELECT construct_type, provider_key, title, url, source_id, rank
+        FROM web_content_constructs
+        WHERE session_id = ?
+        ORDER BY position
+        """,
+        (session_id,),
+    ).fetchall()
+    assert [row["construct_type"] for row in rows] == ["content_reference", "canvas"]
+    assert rows[0]["provider_key"] == "content_references"
+    assert rows[0]["title"] == "Source"
+    assert rows[0]["url"] == "https://example.test/source"
+    assert rows[0]["rank"] == 0
+    assert rows[1]["source_id"] == "canvas-1"
+
+    envelope = read_archive_session_envelope(conn, session_id)
+    assert envelope is not None
+    assert envelope.messages[0].blocks[0].metadata is None
 
 
 def test_archive_tiers_writer_materializes_codex_session(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Browser capture now preserves temporary-chat state, exposes a more useful extension status/log UI, and materializes rich web/export constructs through typed archive schema instead of a provider metadata escape hatch. ChatGPT canvas/reference/search/source/async-task/audio constructs, Claude design-chat/token-budget/voice-note constructs, and Grok DOM captures now have explicit parser and storage paths.

## Problem

The temporary-chat preservation work exposed a broader capture fidelity problem. Web UI and export payloads carry useful constructs beyond plain messages and attachments, but keeping them only in raw blobs or shoving them into block metadata makes them hard to query, hard to verify, and easy to confuse with the provider_meta patterns that Polylogue has been removing. The extension also lacked enough local evidence to tell what had been captured, which provider/mode was active, and whether a capture had reached the archive.

## Solution

The parser contract now includes `ParsedWebConstruct` with a closed `WebConstructType` vocabulary. The index tier adds `web_content_constructs` plus typed message columns for ChatGPT sender, recipient, delivery status, end-turn, and user context. ChatGPT rich metadata, Claude design chats, token-budget segments, voice notes, and audio parts materialize through those typed paths; raw provider shape remains in source evidence/schema packages rather than in `blocks.provider_meta`.

The browser extension keeps the temporary-chat marker, improves native/DOM capture mode reporting, records a bounded local capture ledger/log without transcript text, adds popup controls for status/sync/copy/open, and registers a first-pass degraded DOM capture path for Grok on `grok.com`, `x.com`, and `twitter.com`.

Compatibility: this bumps the index archive tier to schema version 8. Existing `index.db` files must be rebuilt from source evidence; this repo intentionally does not provide an in-place schema upgrade chain.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py::test_archive_tiers_writer_materializes_typed_web_constructs tests/unit/sources/test_parsers_chatgpt.py::test_chatgpt_rich_web_metadata_is_promoted_to_typed_constructs tests/unit/sources/test_parsers_chatgpt.py::test_chatgpt_metadata_extracted_into_content_blocks tests/unit/sources/test_parsers_chatgpt.py::test_chatgpt_metadata_permutation_extracted_by_parser tests/unit/sources/test_parsers_claude_ai_catalog.py::test_claude_design_chat_shape_is_parsed_as_session tests/unit/sources/test_parsers_claude_ai_catalog.py::test_claude_rich_segments_and_attachment_fields_are_preserved` -> 18 passed.
- `cd browser-extension && npm test -- tests/background.test.js tests/popup.test.js tests/common.test.js` -> 32 passed before the typed-schema correction; browser extension files were not touched afterward.
- `cd browser-extension && npm run lint -- --max-warnings=0` -> passed before the typed-schema correction; browser extension files were not touched afterward.
- `devtools render all --check` -> passed before the typed-schema correction.
- `devtools verify --quick` -> passed locally and in the pre-push hook on commit `9cc28d9a1`.

Ref #2308.
