### PR TITLE
fix: make raw materialization replay auditable

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -549,13 +549,14 @@ Options:
                                   maintenance repairs
   --cleanup                       Run destructive archive cleanup for orphaned
                                   or empty persisted data
-  --target [session_insights|dangling_fts|message_type_backfill|message_embeddings|wal_checkpoint|orphaned_messages|empty_sessions|orphaned_attachments|orphaned_blobs|superseded_raw_snapshots]
+  --target [session_insights|dangling_fts|message_type_backfill|raw_materialization|message_embeddings|wal_checkpoint|orphaned_messages|empty_sessions|orphaned_attachments|orphaned_blobs|superseded_raw_snapshots]
                                   Limit maintenance to named targets such as
                                   session_insights, dangling_fts,
-                                  message_type_backfill, message_embeddings,
-                                  wal_checkpoint, orphaned_messages,
-                                  empty_sessions, orphaned_attachments,
-                                  orphaned_blobs, or superseded_raw_snapshots
+                                  message_type_backfill, raw_materialization,
+                                  message_embeddings, wal_checkpoint,
+                                  orphaned_messages, empty_sessions,
+                                  orphaned_attachments, orphaned_blobs, or
+                                  superseded_raw_snapshots
   --preview                       Preview maintenance without executing
                                   (requires --repair or --cleanup)
   --vacuum                        Reclaim unused space after maintenance

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -32,7 +32,7 @@ Current registry snapshot:
 - uncovered runtime paths: `thread-query-loop`, `tool-usage-query-loop`
 - uncovered runtime artifacts: `thread_results`, `tool_usage_results`
 - uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
-- uncovered maintenance targets: `empty_sessions`, `message_embeddings`, `message_type_backfill`, `orphaned_attachments`, `orphaned_messages`, `superseded_raw_snapshots`, `wal_checkpoint`
+- uncovered maintenance targets: `empty_sessions`, `message_embeddings`, `message_type_backfill`, `orphaned_attachments`, `orphaned_messages`, `raw_materialization`, `superseded_raw_snapshots`, `wal_checkpoint`
 - uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-remove-tag`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
 
 Inspect the full authored map with:

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -70,6 +70,7 @@ from polylogue.storage.repair import (
     repair_orphaned_attachments,
     repair_orphaned_blobs,
     repair_orphaned_messages,
+    repair_raw_materialization,
     repair_session_insights,
     repair_wal_checkpoint,
 )
@@ -115,6 +116,7 @@ _REPLAY_DISPATCH: Final[dict[str, _RepairFn]] = {
     "session_insights": repair_session_insights,
     "dangling_fts": repair_dangling_fts,
     "message_type_backfill": repair_message_type_backfill,
+    "raw_materialization": repair_raw_materialization,
     "wal_checkpoint": repair_wal_checkpoint,
     "orphaned_messages": repair_orphaned_messages,
     "empty_sessions": repair_empty_sessions,

--- a/polylogue/maintenance/targets.py
+++ b/polylogue/maintenance/targets.py
@@ -193,6 +193,17 @@ MAINTENANCE_TARGET_SPECS: tuple[MaintenanceTargetSpec, ...] = (
         doctor_repair_operation="backfill-message-type",
     ),
     MaintenanceTargetSpec(
+        name="raw_materialization",
+        mode=MaintenanceTargetMode.REPAIR,
+        category=MaintenanceCategory.DERIVED_REPAIR,
+        destructive=False,
+        description="Replay acquired raw evidence into the index tier when source.db is ahead of index.db.",
+        include_preview_when_ready=True,
+        doctor_readiness_operation="raw-materialization-readiness",
+        doctor_repair_operation="materialize-raw-evidence",
+        invalidation_keys=("raw_sessions", "sessions", "messages", "messages_fts"),
+    ),
+    MaintenanceTargetSpec(
         name="message_embeddings",
         mode=MaintenanceTargetMode.REPAIR,
         category=MaintenanceCategory.DERIVED_REPAIR,

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -17,6 +17,7 @@ import sqlite3
 import time
 from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, wait
+from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -268,7 +269,7 @@ def _write_session(
         and existing_raw_id
         and payload.raw_id
         and existing_raw_id != payload.raw_id
-        and payload.message_count < _stored_message_count(conn, payload.session_id)
+        and payload.message_count <= _stored_message_count(conn, payload.session_id)
     ):
         counts["skipped_sessions"] = 1
         counts["skipped_messages"] = payload.message_count
@@ -458,14 +459,17 @@ def _drain_ready_session_entries(
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
     force_write: bool = False,
-) -> None:
+) -> int:
     _delete_stale_sessions_for_raw_entries(conn, ready_entries)
+    written_count = 0
     for raw_id, cdata in _topo_sort_session_entries(ready_entries):
         wrote = _write_session_entry(conn, raw_id, cdata, summary=summary, force_write=force_write)
         discard_session_data_payload(cdata)
         if not wrote:
             continue
+        written_count += 1
         materialized_ids.add(cdata.session_id)
+    return written_count
 
 
 def _run_ingest_record(
@@ -672,13 +676,15 @@ def _drain_ingest_result(
         return
 
     drain_started = time.perf_counter()
-    _drain_ready_session_entries(
+    written_count = _drain_ready_session_entries(
         conn,
         [(ir.raw_id, cdata) for cdata in ir.sessions],
         summary=summary,
         materialized_ids=materialized_ids,
         force_write=force_write,
     )
+    if written_count == 0:
+        summary.skipped_raw_ids.add(ir.raw_id)
     summary.drain_elapsed_s += time.perf_counter() - drain_started
     _observe_current_rss(summary)
 
@@ -695,6 +701,7 @@ def _consume_ingest_results(
     progress: _WorkerProgress | None = None,
     ingest_result_chunk_size: int = 0,
     suspend_fts_triggers: bool = False,
+    mark_fts_stale_on_suspend: bool = False,
     force_process_pool: bool = False,
 ) -> bool:
     result_iterator = iter(
@@ -726,7 +733,7 @@ def _consume_ingest_results(
                 if suspend_fts_triggers:
                     from polylogue.storage.fts.fts_lifecycle import suspend_fts_triggers_sync
 
-                    suspend_fts_triggers_sync(conn, mark_stale=False)
+                    suspend_fts_triggers_sync(conn, mark_stale=mark_fts_stale_on_suspend)
                 transaction_started = True
             _drain_ingest_result(
                 conn,
@@ -826,6 +833,7 @@ def _process_ingest_batch_sync(
             progress=progress,
             ingest_result_chunk_size=ingest_result_chunk_size,
             suspend_fts_triggers=suspend_fts_triggers,
+            mark_fts_stale_on_suspend=suspend_fts_triggers and not repair_message_fts,
             force_process_pool=force_process_pool,
         )
         _flush_ingest_results(
@@ -849,7 +857,7 @@ def _process_ingest_batch_sync(
                 conn,
                 db_path=db_path,
                 changed_session_ids=tuple(fts_repair_ids),
-                repair_message_fts=repair_message_fts or suspend_fts_triggers,
+                repair_message_fts=repair_message_fts,
             )
             summary.commit_elapsed_s = time.perf_counter() - commit_started
             from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_wal
@@ -915,6 +923,7 @@ async def process_ingest_batch(
     progress_callback: ProgressCallback | None,
     *,
     force_write: bool = False,
+    repair_message_fts: bool = True,
     ingest_result_chunk_size: int = 0,
     suspend_fts_triggers: bool = False,
 ) -> ParseBatchObservation | None:
@@ -953,6 +962,7 @@ async def process_ingest_batch(
         ingest_workers=service.ingest_workers,
         measure_ingest_result_size=service.measure_ingest_result_size,
         force_write=force_write,
+        repair_message_fts=repair_message_fts,
         ingest_result_chunk_size=ingest_result_chunk_size,
         suspend_fts_triggers=suspend_fts_triggers,
     )
@@ -1047,6 +1057,22 @@ def _successful_raw_state_update(
     )
 
 
+def _skipped_raw_state_update(
+    *,
+    outcome: _RawIngestOutcome | None,
+    parsed_at: str,
+    validation_mode: str,
+) -> RawSessionStateUpdate:
+    return RawSessionStateUpdate(
+        parsed_at=parsed_at,
+        parse_error=None,
+        payload_provider=outcome.payload_provider if outcome is not None else None,
+        validation_status="skipped",
+        validation_error="parsed raw payload produced no new materialized sessions",
+        validation_mode=validation_mode,
+    )
+
+
 def _failed_raw_state_update(
     *,
     outcome: _RawIngestOutcome | None,
@@ -1080,8 +1106,13 @@ async def _persist_batch_raw_state_updates(
 ) -> float:
     now_iso = datetime.now(timezone.utc).isoformat()
     raw_state_update_started = time.perf_counter()
-    async with backend.bulk_connection():
+    source_backend = getattr(service.repository, "_source_backend", None)
+    async with AsyncExitStack() as stack:
+        raw_state_backend = source_backend if source_backend is not None else backend
+        await stack.enter_async_context(raw_state_backend.bulk_connection())
         for rid in succeeded_raw_ids:
+            if rid in skipped_raw_ids:
+                continue
             await service.repository.update_raw_state(
                 rid,
                 state=_successful_raw_state_update(
@@ -1091,11 +1122,11 @@ async def _persist_batch_raw_state_updates(
                 ),
             )
         for rid in skipped_raw_ids:
-            if rid in failed_raw_ids or rid in succeeded_raw_ids:
+            if rid in failed_raw_ids:
                 continue
             await service.repository.update_raw_state(
                 rid,
-                state=_successful_raw_state_update(
+                state=_skipped_raw_state_update(
                     outcome=outcomes.get(rid),
                     parsed_at=now_iso,
                     validation_mode=validation_mode,

--- a/polylogue/pipeline/services/parsing.py
+++ b/polylogue/pipeline/services/parsing.py
@@ -115,6 +115,7 @@ class ParsingService:
         provider: str | None = None,
         progress_callback: ProgressCallback | None = None,
         force_write: bool = False,
+        repair_message_fts: bool = True,
     ) -> ParseResult:
         return await parse_from_raw(
             self,
@@ -122,6 +123,7 @@ class ParsingService:
             provider=provider,
             progress_callback=progress_callback,
             force_write=force_write,
+            repair_message_fts=repair_message_fts,
         )
 
 

--- a/polylogue/pipeline/services/parsing_workflow.py
+++ b/polylogue/pipeline/services/parsing_workflow.py
@@ -9,7 +9,7 @@ already decoded for parsing anyway).
 from __future__ import annotations
 
 import time
-from collections.abc import AsyncIterator, Iterable, Iterator
+from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING
 
 from polylogue.logging import get_logger
@@ -57,34 +57,6 @@ def _iter_raw_id_batches(
 
 def _raw_batch_bytes(headers_by_raw_id: dict[str, int], batch_ids: Iterable[str]) -> int:
     return sum(max(int(headers_by_raw_id.get(raw_id, 0)), 0) for raw_id in batch_ids)
-
-
-async def _iter_raw_id_batches_async(
-    headers: AsyncIterator[tuple[str, int]],
-    *,
-    max_records: int,
-    max_blob_bytes: int,
-) -> AsyncIterator[list[str]]:
-    batch_ids: list[str] = []
-    batch_blob_bytes = 0
-
-    async for raw_id, blob_size in headers:
-        record_blob_bytes = max(int(blob_size), 0)
-        if batch_ids and (len(batch_ids) >= max_records or batch_blob_bytes + record_blob_bytes > max_blob_bytes):
-            yield batch_ids
-            batch_ids = []
-            batch_blob_bytes = 0
-
-        batch_ids.append(raw_id)
-        batch_blob_bytes += record_blob_bytes
-
-        if len(batch_ids) >= max_records or batch_blob_bytes >= max_blob_bytes:
-            yield batch_ids
-            batch_ids = []
-            batch_blob_bytes = 0
-
-    if batch_ids:
-        yield batch_ids
 
 
 def _append_unique_raw_ids(
@@ -297,6 +269,7 @@ async def parse_from_raw(
     provider: str | None = None,
     progress_callback: ProgressCallback | None = None,
     force_write: bool = False,
+    repair_message_fts: bool = True,
 ) -> ParseResult:
     """Parse raw_sessions from DB into sessions.
 
@@ -331,6 +304,7 @@ async def parse_from_raw(
                 result,
                 progress_callback,
                 force_write=force_write,
+                repair_message_fts=repair_message_fts,
                 suspend_fts_triggers=_raw_batch_bytes(raw_blob_sizes, batch_ids) >= _BULK_FTS_RAW_BATCH_BYTES,
             )
             batches_processed += 1
@@ -356,12 +330,16 @@ async def parse_from_raw(
     else:
         if progress_callback is not None:
             progress_callback(0, desc="Ingesting")
-        total_raw = 0
-        async for batch_ids in _iter_raw_id_batches_async(
-            service.repository.iter_raw_headers(source_name=provider),
+        raw_headers = [header async for header in service.repository.iter_raw_headers(source_name=provider)]
+        raw_blob_sizes = dict(raw_headers)
+        total = len(raw_headers)
+        processed_so_far = 0
+        for batch_ids in _iter_raw_id_batches(
+            raw_headers,
             max_records=service.raw_batch_size,
             max_blob_bytes=service.raw_batch_blob_limit_bytes,
         ):
+            t_batch = time.perf_counter()
             batch_observation = await process_ingest_batch(
                 service,
                 backend,
@@ -369,19 +347,29 @@ async def parse_from_raw(
                 result,
                 progress_callback,
                 force_write=force_write,
+                repair_message_fts=repair_message_fts,
+                suspend_fts_triggers=_raw_batch_bytes(raw_blob_sizes, batch_ids) >= _BULK_FTS_RAW_BATCH_BYTES,
             )
             batches_processed += 1
-            total_raw += len(batch_ids)
+            processed_so_far += len(batch_ids)
             if batch_observation is not None:
                 batch_observation["batch"] = batches_processed
-                batch_observation["processed_raw"] = total_raw
+                batch_observation["processed_raw"] = processed_so_far
                 result.batch_observations.append(batch_observation)
             if progress_callback is not None:
                 progress_callback(
                     0,
-                    desc=f"Ingesting ({total_raw:,} raw, batch {batches_processed})",
+                    desc=f"Ingesting ({processed_so_far:,}/{total:,} raw, batch {batches_processed})",
                 )
-        total = total_raw
+            batch_elapsed = time.perf_counter() - t_batch
+            if batch_elapsed > 2.0:
+                logger.info(
+                    "slow_batch",
+                    batch=batches_processed,
+                    size=len(batch_ids),
+                    elapsed_s=round(batch_elapsed, 2),
+                    rate=round(len(batch_ids) / batch_elapsed, 1) if batch_elapsed > 0 else 0,
+                )
 
     elapsed = time.perf_counter() - t_start
     logger.info(

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import re
 import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -20,6 +22,7 @@ from polylogue.maintenance.targets import (
 )
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.insights.session.repair_assessment import (
     assess_session_insight_repairs,
 )
@@ -39,6 +42,93 @@ _SESSION_INSIGHT_MATERIALIZATION_TYPES = (
     "phases",
     "thread",
 )
+
+
+def _raw_materialization_candidate_ids(config: Config) -> tuple[list[str], int]:
+    """Return replayable raw ids plus missing-blob debt count.
+
+    Raw evidence is the durable source of truth, but a raw row whose
+    content-addressed blob is absent cannot be reparsed without outside
+    evidence. Keep those rows as debt instead of mutating or deleting them.
+    """
+    source_db = config.archive_root / "source.db"
+    index_db = config.archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        return [], 0
+    blob_store = BlobStore(config.archive_root / "blob")
+    raw_ids: list[str] = []
+    missing_blobs = 0
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
+        rows = conn.execute(
+            """
+            SELECT r.raw_id, r.origin, r.native_id, r.source_path, r.blob_hash
+            FROM raw_sessions AS r
+            LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
+            LEFT JOIN index_tier.sessions AS s_by_native
+              ON r.native_id IS NOT NULL
+             AND s_by_native.origin = r.origin
+             AND s_by_native.native_id = r.native_id
+            WHERE s_by_raw.session_id IS NULL
+              AND s_by_native.session_id IS NULL
+              AND r.parse_error IS NULL
+              AND NOT (
+                r.validation_status = 'skipped'
+                AND r.parsed_at_ms IS NOT NULL
+                AND r.parse_error IS NULL
+              )
+            ORDER BY r.acquired_at_ms DESC, r.raw_id ASC
+            """
+        ).fetchall()
+        for row in rows:
+            if _raw_materialized_by_source_path_native(conn, row):
+                continue
+            blob_hash = row["blob_hash"].hex() if isinstance(row["blob_hash"], bytes) else str(row["blob_hash"])
+            if blob_store.exists(blob_hash):
+                raw_ids.append(str(row["raw_id"]))
+            else:
+                missing_blobs += 1
+    return raw_ids, missing_blobs
+
+
+def _raw_materialized_by_source_path_native(conn: sqlite3.Connection, row: sqlite3.Row) -> bool:
+    origin = str(row["origin"] or "")
+    if not origin:
+        return False
+    for native_id in _source_path_native_id_candidates(str(row["source_path"] or "")):
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM index_tier.sessions
+            WHERE origin = ?
+              AND native_id = ?
+            LIMIT 1
+            """,
+            (origin, native_id),
+        ).fetchone()
+        if existing is not None:
+            return True
+    return False
+
+
+def _source_path_native_id_candidates(source_path: str) -> tuple[str, ...]:
+    if not source_path:
+        return ()
+    name = Path(source_path).name
+    candidates: list[str] = []
+    current = name
+    for _ in range(4):
+        stem = Path(current).stem
+        if stem == current:
+            break
+        current = stem
+        if current and current not in candidates:
+            candidates.append(current)
+        unsplit = re.sub(r"_\d+$", "", current)
+        if unsplit and unsplit != current and unsplit not in candidates:
+            candidates.append(unsplit)
+    return tuple(candidates)
 
 
 def _open_archive_index_connection() -> sqlite3.Connection:
@@ -1032,6 +1122,65 @@ def preview_dangling_fts(*, count: int) -> RepairResult:
     )
 
 
+def repair_raw_materialization(config: Config, dry_run: bool = False) -> RepairResult:
+    """Materialize replayable raw evidence into the index tier."""
+    raw_ids, missing_blobs = _raw_materialization_candidate_ids(config)
+    if dry_run:
+        detail = f"Would: replay {len(raw_ids):,} raw rows into index.db"
+        if missing_blobs:
+            detail += f"; {missing_blobs:,} raw rows blocked by missing blobs"
+        return _repair_result(
+            "raw_materialization",
+            repaired_count=len(raw_ids),
+            success=True,
+            detail=detail,
+        )
+    if not raw_ids:
+        detail = "Raw materialization ready"
+        if missing_blobs:
+            detail += f"; {missing_blobs:,} raw rows remain blocked by missing blobs"
+        return _repair_result(
+            "raw_materialization",
+            repaired_count=0,
+            success=missing_blobs == 0,
+            detail=detail,
+        )
+
+    async def _run() -> int:
+        from polylogue.pipeline.services.parsing import ParsingService
+        from polylogue.storage.repository import SessionRepository
+        from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+
+        backend = SQLiteBackend(db_path=config.archive_root / "index.db")
+        repository = SessionRepository(backend=backend, archive_root=config.archive_root)
+        try:
+            service = ParsingService(repository=repository, archive_root=config.archive_root, config=config)
+            result = await service.parse_from_raw(raw_ids=raw_ids, force_write=False, repair_message_fts=False)
+            return len(result.processed_ids)
+        finally:
+            await repository.close()
+
+    try:
+        processed = asyncio.run(_run())
+    except Exception as exc:
+        return _repair_result(
+            "raw_materialization",
+            repaired_count=0,
+            success=False,
+            detail=f"Failed to materialize raw evidence: {exc}",
+        )
+    fts_result = repair_dangling_fts(config, dry_run=False)
+    detail = f"Replayed {len(raw_ids):,} raw rows; {processed:,} sessions changed; {fts_result.detail}"
+    if missing_blobs:
+        detail += f"; {missing_blobs:,} raw rows remain blocked by missing blobs"
+    return _repair_result(
+        "raw_materialization",
+        repaired_count=processed,
+        success=missing_blobs == 0 and fts_result.success,
+        detail=detail,
+    )
+
+
 def repair_wal_checkpoint(config: Config, dry_run: bool = False) -> RepairResult:
     from polylogue.paths import active_index_db_path
 
@@ -1285,6 +1434,7 @@ __all__ = [
     "repair_message_type_backfill",
     "repair_orphaned_attachments",
     "repair_orphaned_blobs",
+    "repair_raw_materialization",
     "repair_superseded_raw_snapshots",
     "repair_orphaned_messages",
     "repair_session_insights",

--- a/polylogue/storage/repository/__init__.py
+++ b/polylogue/storage/repository/__init__.py
@@ -83,6 +83,9 @@ class SessionRepository(
         active_backend = backend if backend is not None else SQLiteBackend(db_path=db_path)
         self._backend: SQLiteBackend = active_backend
         self._archive_root: Path | None = archive_root
+        self._source_backend: SQLiteBackend | None = (
+            SQLiteBackend(db_path=archive_root / "source.db") if archive_root is not None else None
+        )
         self.queries = active_backend.queries
 
     async def __aenter__(self) -> SessionRepository:
@@ -101,6 +104,8 @@ class SessionRepository(
     async def close(self) -> None:
         """Close database connections and release resources."""
         await self._backend.close()
+        if self._source_backend is not None:
+            await self._source_backend.close()
 
 
 __all__ = ["SessionRepository"]

--- a/polylogue/storage/repository/raw/repository_raw.py
+++ b/polylogue/storage/repository/raw/repository_raw.py
@@ -48,12 +48,14 @@ class RepositoryRawMixin:
         state: RawSessionStateUpdate,
     ) -> None:
         """Apply a typed raw-state mutation."""
-        async with self._backend.connection() as conn:
+        source_backend = getattr(self, "_source_backend", None)
+        backend = source_backend if source_backend is not None else self._backend
+        async with backend.connection() as conn:
             await raw_queries.apply_raw_state_update(
                 conn,
                 raw_id,
                 state=state,
-                transaction_depth=self._backend.transaction_depth,
+                transaction_depth=backend.transaction_depth,
             )
 
     async def mark_raw_parsed(

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -139,7 +139,9 @@ def initialize_archive_database(path: Path, tier: ArchiveTier) -> None:
     try:
         current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
         expected_version = archive_tier_spec(tier).version
-        if current_version not in (0, expected_version):
+        if current_version == expected_version:
+            return
+        if current_version != 0:
             raise RuntimeError(
                 f"{path.name} schema version {current_version} is not the current {tier.value} tier version "
                 f"{expected_version}; move it aside and rebuild the archive root"

--- a/tests/unit/core/test_maintenance_targets.py
+++ b/tests/unit/core/test_maintenance_targets.py
@@ -36,10 +36,11 @@ def test_maintenance_target_catalog_reports_preview_and_help_semantics() -> None
         "session_insights",
         "dangling_fts",
         "message_type_backfill",
+        "raw_materialization",
     )
     assert catalog.help_text() == (
         "Limit maintenance to named targets such as session_insights, dangling_fts, "
-        "message_type_backfill, message_embeddings, wal_checkpoint, orphaned_messages, "
+        "message_type_backfill, raw_materialization, message_embeddings, wal_checkpoint, orphaned_messages, "
         "empty_sessions, orphaned_attachments, orphaned_blobs, or superseded_raw_snapshots"
     )
 

--- a/tests/unit/maintenance/test_idempotency.py
+++ b/tests/unit/maintenance/test_idempotency.py
@@ -220,6 +220,7 @@ def test_supported_targets_cover_ac_required_set() -> None:
     supported = set(supported_replay_targets())
     required = {
         "session_insights",
+        "raw_materialization",
         "message_type_backfill",
         "dangling_fts",
         "orphaned_blobs",

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -702,6 +702,82 @@ def test_write_session_skips_shorter_duplicate_raw_source(tmp_path: Path) -> Non
         assert raw_id == "raw-full"
 
 
+def test_write_session_skips_equal_count_duplicate_raw_source(tmp_path: Path) -> None:
+    with open_connection(tmp_path / "index.db") as conn:
+        existing = _session_data(
+            "codex-session:duplicate-equal",
+            content_hash="hash-existing",
+            raw_id="raw-existing",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex-session:duplicate-equal",
+                    role="user",
+                    text="first",
+                    content_hash="msg-1",
+                    sort_key=1.0,
+                ),
+                _message_tuple(
+                    "msg-2",
+                    "codex-session:duplicate-equal",
+                    role="assistant",
+                    text="second",
+                    content_hash="msg-2",
+                    sort_key=2.0,
+                ),
+            ],
+        )
+        duplicate = _session_data(
+            "codex-session:duplicate-equal",
+            content_hash="hash-duplicate-title-or-raw",
+            raw_id="raw-duplicate",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "codex-session:duplicate-equal",
+                    role="user",
+                    text="first duplicate",
+                    content_hash="msg-1-duplicate",
+                    sort_key=1.0,
+                ),
+                _message_tuple(
+                    "msg-2",
+                    "codex-session:duplicate-equal",
+                    role="assistant",
+                    text="second duplicate",
+                    content_hash="msg-2-duplicate",
+                    sort_key=2.0,
+                ),
+            ],
+        )
+
+        changed_existing, _counts_existing = _write_session(conn, existing)
+        changed_duplicate, counts_duplicate = _write_session(conn, duplicate)
+        conn.commit()
+
+        messages = conn.execute(
+            """
+            SELECT b.text
+            FROM messages m
+            JOIN blocks b ON b.message_id = m.message_id
+            WHERE m.session_id = ? AND b.block_type = 'text'
+            ORDER BY m.position, b.position
+            """,
+            ("codex-session:duplicate-equal",),
+        ).fetchall()
+        raw_id = conn.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = ?",
+            ("codex-session:duplicate-equal",),
+        ).fetchone()["raw_id"]
+
+        assert changed_existing is True
+        assert changed_duplicate is False
+        assert counts_duplicate["skipped_sessions"] == 1
+        assert counts_duplicate["skipped_messages"] == 2
+        assert [row["text"] for row in messages] == ["first", "second"]
+        assert raw_id == "raw-existing"
+
+
 def test_write_session_skips_new_with_zero_messages(tmp_path: Path) -> None:
     """A new session with zero messages is skipped, not left as a manifest-only row."""
     with open_connection(tmp_path / "index.db") as conn:
@@ -1541,6 +1617,50 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
     assert failed_call.args == ("raw-failed",)
     assert failed_call.kwargs["state"].parse_error == "parse failed"
     assert failed_call.kwargs["state"].validation_error == "bad schema"
+
+
+@pytest.mark.asyncio
+async def test_persist_batch_raw_state_updates_marks_skipped_raw_before_success() -> None:
+    update_raw_state = AsyncMock()
+    service = _FakeParsingService(update_raw_state)
+
+    @asynccontextmanager
+    async def _bulk_connection() -> AsyncIterator[None]:
+        yield
+
+    backend = _FakeBulkBackend(_bulk_connection)
+    outcomes = {
+        "raw-duplicate": _RawIngestOutcome(
+            raw_id="raw-duplicate",
+            payload_provider="chatgpt",
+            validation_status="passed",
+            validation_error=None,
+            parse_error=None,
+            error=None,
+            had_sessions=True,
+        ),
+    }
+
+    elapsed_s = await _persist_batch_raw_state_updates(
+        service,
+        backend,
+        outcomes=outcomes,
+        succeeded_raw_ids={"raw-duplicate"},
+        skipped_raw_ids={"raw-duplicate"},
+        failed_raw_ids={},
+        validation_mode="advisory",
+    )
+
+    assert elapsed_s >= 0.0
+    update_raw_state.assert_awaited_once()
+    call = update_raw_state.await_args
+    assert call is not None
+    assert call.args == ("raw-duplicate",)
+    state = call.kwargs["state"]
+    assert state.validation_status == "skipped"
+    assert state.validation_error == "parsed raw payload produced no new materialized sessions"
+    assert state.parse_error is None
+    assert state.parsed_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -508,6 +508,33 @@ class TestParsingServiceStreaming:
         assert mock_process.await_args_list[0].args[2] == ["raw-1"]
         assert mock_process.await_args_list[1].args[2] == ["raw-2", "raw-3"]
 
+    async def test_parse_from_raw_closes_header_stream_before_writing_batches(self, tmp_path: Path) -> None:
+        backend = MagicMock()
+        events: list[str] = []
+
+        async def raw_headers() -> AsyncGenerator[tuple[str, int], None]:
+            events.append("headers-open")
+            yield ("raw-1", 1)
+            yield ("raw-2", 1)
+            events.append("headers-closed")
+
+        repository = MagicMock()
+        repository.backend = backend
+        repository.iter_raw_headers = MagicMock(return_value=raw_headers())
+        config = Config(archive_root=tmp_path / "archive", render_root=tmp_path / "render", sources=[])
+        service = ParsingService(repository=repository, archive_root=config.archive_root, config=config)
+
+        async def _process(*_args: object, **_kwargs: object) -> None:
+            events.append("batch-write")
+
+        with patch(
+            "polylogue.pipeline.services.ingest_batch.process_ingest_batch",
+            new=AsyncMock(side_effect=_process),
+        ):
+            await service.parse_from_raw(provider="chatgpt")
+
+        assert events == ["headers-open", "headers-closed", "batch-write"]
+
 
 # =====================================================================
 # Merged from test_planning_service.py (service tests)

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -345,3 +345,39 @@ def test_archive_tiers_database_bootstrap_creates_parent_directory(tmp_path: Pat
 
     conn = _connect(path)
     assert conn.execute("PRAGMA user_version").fetchone()[0] == ARCHIVE_TIER_SPECS[ArchiveTier.USER].version
+
+
+def test_archive_tiers_database_bootstrap_leaves_current_tier_unchanged(tmp_path: Path) -> None:
+    path = tmp_path / "user.db"
+    initialize_archive_database(path, ArchiveTier.USER)
+    conn = _connect(path)
+    conn.execute(
+        """
+        INSERT INTO assertions (
+            assertion_id, target_ref, kind, value_json, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "assertion:test",
+            "session:test",
+            "tag",
+            '{"tag":"kept"}',
+            1_767_225_600_000,
+            1_767_225_600_000,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    initialize_archive_database(path, ArchiveTier.USER)
+
+    conn = _connect(path)
+    rows = conn.execute("SELECT assertion_id, target_ref, kind, value_json FROM assertions").fetchall()
+    assert [dict(row) for row in rows] == [
+        {
+            "assertion_id": "assertion:test",
+            "target_ref": "session:test",
+            "kind": "tag",
+            "value_json": '{"tag":"kept"}',
+        }
+    ]

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -14,7 +14,11 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.storage.raw.models import RawSessionStateUpdate
+from polylogue.storage.repository import SessionRepository
 from polylogue.storage.runtime import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from tests.infra.storage_records import make_raw_session, make_session, save_session_to_archive
 
@@ -47,6 +51,52 @@ class TestRawSessionStorage:
         result = await backend.save_raw_session(record)
 
         assert result is True
+
+    async def test_repository_update_raw_state_uses_source_tier(self, tmp_path: Path) -> None:
+        initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+        initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+        source_backend = SQLiteBackend(db_path=tmp_path / "source.db")
+        try:
+            await source_backend.save_raw_session(
+                make_raw_session(
+                    raw_id="raw-split",
+                    source_name="chatgpt-export",
+                    source_path="/tmp/export.json",
+                    source_index=0,
+                    blob_size=2,
+                    acquired_at="2026-02-02T12:00:00+00:00",
+                )
+            )
+        finally:
+            await source_backend.close()
+
+        repo = SessionRepository(
+            backend=SQLiteBackend(db_path=tmp_path / "index.db"),
+            archive_root=tmp_path,
+        )
+        try:
+            await repo.update_raw_state(
+                "raw-split",
+                state=RawSessionStateUpdate(
+                    parsed_at="2026-02-03T12:00:00+00:00",
+                    parse_error=None,
+                    validation_status="skipped",
+                    validation_error="duplicate materialization",
+                    validation_mode="advisory",
+                ),
+            )
+        finally:
+            await repo.close()
+
+        verifier = SQLiteBackend(db_path=tmp_path / "source.db")
+        try:
+            record = await verifier.get_raw_session("raw-split")
+        finally:
+            await verifier.close()
+
+        assert record is not None
+        assert record.validation_status == "skipped"
+        assert record.validation_error == "duplicate materialization"
 
     async def test_save_raw_session_duplicate(self, backend: SQLiteBackend) -> None:
         """Saving a duplicate raw_id returns False (INSERT OR IGNORE)."""

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -11,8 +11,11 @@ import pytest
 from polylogue.config import Config
 from polylogue.maintenance.models import DerivedModelStatus
 from polylogue.storage import repair as repair_mod
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.fts.dangling_repair import DanglingFtsRepairOutcome
 from polylogue.storage.insights.session.runtime import SessionInsightCounts, SessionInsightStatusSnapshot
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 
 def _config(tmp_path: Path) -> Config:
@@ -110,6 +113,143 @@ def test_probe_only_archive_debt_skips_large_message_scans(monkeypatch: pytest.M
     assert debt["empty_sessions"].skipped is True
     assert debt["message_type_backfill"].skipped is True
     assert debt["orphaned_attachments"].skipped is False
+
+
+def test_raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    replayable_raw_id, replayable_size = blob_store.write_from_bytes(b'{"mapping":{}}')
+    materialized_raw_id, materialized_size = blob_store.write_from_bytes(b'{"mapping":{"done":{}}}')
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                replayable_raw_id,
+                "chatgpt-export",
+                "native-replay",
+                "replay.json",
+                0,
+                bytes.fromhex(replayable_raw_id),
+                replayable_size,
+                1,
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "missing-raw",
+                "chatgpt-export",
+                "native-missing",
+                "missing.json",
+                0,
+                bytes.fromhex("f" * 64),
+                9,
+                2,
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                materialized_raw_id,
+                "chatgpt-export",
+                "native-done",
+                "done.json",
+                0,
+                bytes.fromhex(materialized_raw_id),
+                materialized_size,
+                3,
+            ),
+        )
+        source_conn.commit()
+
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        index_conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, raw_id, title, content_hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("native-done", "chatgpt-export", materialized_raw_id, "done", bytes(32)),
+        )
+        index_conn.commit()
+
+    result = repair_mod.repair_raw_materialization(config, dry_run=True)
+
+    assert result.repaired_count == 1
+    assert result.success is True
+    assert "1 raw rows blocked by missing blobs" in result.detail
+
+
+def test_raw_materialization_defers_batch_fts_then_repairs_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    calls: dict[str, object] = {}
+
+    class FakeBackend:
+        def __init__(self, *, db_path: Path) -> None:
+            calls["db_path"] = db_path
+
+    class FakeRepository:
+        def __init__(self, *, backend: FakeBackend, archive_root: Path) -> None:
+            calls["archive_root"] = archive_root
+
+        async def close(self) -> None:
+            calls["closed"] = True
+
+    class FakeParseResult:
+        processed_ids = {"session-1", "session-2"}
+
+    class FakeParsingService:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def parse_from_raw(self, **kwargs: object) -> FakeParseResult:
+            calls["parse_kwargs"] = kwargs
+            return FakeParseResult()
+
+    def fake_repair_dangling_fts(_config: Config, *, dry_run: bool = False) -> repair_mod.RepairResult:
+        calls["fts_dry_run"] = dry_run
+        return repair_mod._repair_result(
+            "dangling_fts",
+            repaired_count=7,
+            success=True,
+            detail="repaired 7 FTS rows",
+        )
+
+    monkeypatch.setattr(repair_mod, "_raw_materialization_candidate_ids", lambda _config: (["raw-1"], 0))
+    monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", FakeParsingService)
+    monkeypatch.setattr("polylogue.storage.repository.SessionRepository", FakeRepository)
+    monkeypatch.setattr("polylogue.storage.sqlite.async_sqlite.SQLiteBackend", FakeBackend)
+    monkeypatch.setattr(repair_mod, "repair_dangling_fts", fake_repair_dangling_fts)
+
+    result = repair_mod.repair_raw_materialization(config, dry_run=False)
+
+    assert result.success is True
+    assert result.repaired_count == 2
+    assert "repaired 7 FTS rows" in result.detail
+    assert calls["parse_kwargs"] == {
+        "raw_ids": ["raw-1"],
+        "force_write": False,
+        "repair_message_fts": False,
+    }
+    assert calls["fts_dry_run"] is False
+    assert calls["closed"] is True
 
 
 def _ready_session_insight_status() -> SessionInsightStatusSnapshot:


### PR DESCRIPTION
## Summary

Make raw acquisition, parsed duplicate handling, index materialization, and FTS freshness converge as one auditable maintenance path. This adds a `raw_materialization` repair target, fixes duplicate raw replay behavior, and routes split-tier raw-state updates to `source.db`.

## Problem

Production v8 replay exposed raw evidence rows that were acquired and parse-clean but absent from `index.db.sessions`. The old behavior could replay duplicate ChatGPT export fragments forever, force-rewrite already-materialized sessions, and report stale raw-materialization debt even after replay. Split archive raw-state updates also went through the index backend instead of the source tier.

## Solution

- Add a non-destructive `raw_materialization` maintenance target that replays available raw blobs and leaves missing blobs as blocked evidence.
- Let raw-materialization replay defer per-batch FTS repair and run the existing FTS repair once afterward.
- Treat duplicate raw sources with an existing session and at least the same message count as skipped rather than rewriting the existing session.
- Mark parsed raw records that produce no new materialized sessions as skipped raw evidence.
- Route `SessionRepository.update_raw_state` through `source.db` when using split archive tiers.
- Refresh generated CLI/test-quality docs for the new maintenance target.

## Verification

- `devtools test tests/unit/storage/test_repair.py::test_raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs tests/unit/storage/test_repair.py::test_raw_materialization_defers_batch_fts_then_repairs_once tests/unit/storage/test_raw.py::TestRawSessionStorage::test_repository_update_raw_state_uses_source_tier tests/unit/pipeline/test_ingest_batch.py::test_write_session_skips_shorter_duplicate_raw_source tests/unit/pipeline/test_ingest_batch.py::test_write_session_skips_equal_count_duplicate_raw_source tests/unit/pipeline/test_ingest_batch.py::test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw tests/unit/pipeline/test_ingest_batch.py::test_persist_batch_raw_state_updates_marks_skipped_raw_before_success tests/unit/pipeline/test_ingest_batch.py::test_persist_batch_raw_state_updates_preserves_validation_only_failure_without_quarantine tests/unit/pipeline/test_parsing_service.py::TestParsingServiceStreaming tests/unit/storage/test_archive_tiers_ddl.py::test_archive_tiers_database_bootstrap_leaves_current_tier_unchanged tests/unit/maintenance/test_idempotency.py::test_supported_targets_cover_ac_required_set tests/unit/core/test_maintenance_targets.py` — 19 passed.
- `devtools verify --quick` — passed locally and in pre-push hook.
- Production replay evidence: `raw_materialization` preview now reports `replay 0` with `315` missing-blob rows blocked and preserved; `dangling_fts` reports in sync; diagnostics report ok with FTS triggers present and empty convergence debt.

Ref #2308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new maintenance repair target, `raw_materialization`, including CLI/documentation visibility and replay support.
  * Introduced a repair flow that can restore missing raw materializations and then reconcile related full-text search data.

* **Bug Fixes**
  * Improved ingest behavior to skip unchanged duplicates more reliably.
  * Raw-state updates now go to the correct database tier, and batch persistence handles skipped/succeeded records more accurately.

* **Documentation**
  * Updated CLI and workflow docs to reflect the new target and coverage status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->