### PR TITLE
fix: align raw materialization with v8 schema

### DIFF
--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -238,8 +238,8 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
                   ON r.native_id IS NOT NULL
                  AND s_by_native.origin = r.origin
                  AND s_by_native.native_id = r.native_id
-                WHERE s_by_raw.session_id IS NULL
-                  AND s_by_native.session_id IS NULL
+                WHERE s_by_raw.raw_id IS NULL
+                  AND s_by_native.native_id IS NULL
                   AND NOT (
                     r.validation_status = 'skipped'
                     AND r.parsed_at_ms IS NOT NULL
@@ -249,12 +249,7 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
                 """
             )
         )
-        missing_rows = [
-            row
-            for row in candidate_rows
-            if _raw_materialization_category(row, archive_root) != "parsed-without-session"
-            or not _raw_materialized_by_source_path_native(conn, row)
-        ]
+        missing_rows = [row for row in candidate_rows if not _raw_materialized_by_source_path_native(conn, row)]
     except sqlite3.Error:
         return []
     finally:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -70,8 +70,8 @@ def _raw_materialization_candidate_ids(config: Config) -> tuple[list[str], int]:
               ON r.native_id IS NOT NULL
              AND s_by_native.origin = r.origin
              AND s_by_native.native_id = r.native_id
-            WHERE s_by_raw.session_id IS NULL
-              AND s_by_native.session_id IS NULL
+            WHERE s_by_raw.raw_id IS NULL
+              AND s_by_native.native_id IS NULL
               AND r.parse_error IS NULL
               AND NOT (
                 r.validation_status = 'skipped'


### PR DESCRIPTION
## Summary

Align raw-materialization repair and archive-debt reporting with the v8 index schema. The selectors now test the joined `(raw_id)` and `(origin, native_id)` keys that actually exist, and archive-debt reporting applies the same source-path/native alias exclusion used by repair.

## Problem

Live archive evidence after the v8 replay showed `polylogue ops debt list --kind raw-materialization --kind fts --exact-fts` reporting six `parse-pending` Claude Code rows even though `raw_materialization` repair reported zero replayable rows. Inspection showed the debt/repair selectors still referenced the removed `sessions.session_id` column and the debt view classified source-path/native aliases as actionable parse debt.

## Solution

- Replace legacy joined `session_id` null checks with v8-safe joined-key null checks.
- Use the same source-path/native alias exclusion in archive-debt reporting that repair already uses.
- Keep missing-blob rows visible as actionable debt; no raw rows, blobs, or sessions are deleted.

Ref #2308

## Verification

- `devtools test tests/unit/operations/test_archive_debt.py -k raw_materialization tests/unit/storage/test_repair.py::test_raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs`
- `devtools verify --quick`
- Pre-push hook: `devtools verify --quick`
- Live source-branch probe against `/home/sinity/.local/share/polylogue`: raw-materialization dry-run reported `affected_rows=0`; exact raw/FTS debt reported only the four missing-blob groups totaling 315 raw rows.