### PR TITLE
fix: snapshot exact FTS readiness checks

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -398,6 +398,8 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
     try:
         conn = open_readonly_connection(dbf)
         try:
+            if exact:
+                conn.execute("BEGIN")
             archive_info = _archive_readiness_payload(conn, exact=exact)
             if archive_info is not None:
                 return archive_info
@@ -458,6 +460,8 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
                     "freshness_detail": None if freshness is None else freshness.get("detail"),
                 }
         finally:
+            if exact:
+                conn.rollback()
             conn.close()
     except sqlite3.Error:
         return {

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1086,6 +1086,27 @@ def test_fts_readiness_exact_detects_missing_docsize_row(tmp_path: Path) -> None
     assert messages["ready"] is False
 
 
+def test_fts_readiness_exact_uses_snapshot_transaction(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from polylogue.daemon import fts_status
+
+    db_path = tmp_path / "index.db"
+    initialize_archive_database(db_path, ArchiveTier.INDEX)
+    traced: list[str] = []
+
+    def _open_traced_connection(path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.set_trace_callback(traced.append)
+        return conn
+
+    monkeypatch.setattr(fts_status, "open_readonly_connection", _open_traced_connection)
+
+    readiness = fts_status.fts_readiness_info(db_path, exact=True)
+
+    assert readiness["coverage_exact"] is True
+    assert any(statement == "BEGIN" for statement in traced)
+    assert any(statement == "ROLLBACK" for statement in traced)
+
+
 def test_fts_readiness_exact_detects_archive_missing_messages_fts_row(tmp_path: Path) -> None:
     from polylogue.daemon.fts_status import fts_readiness_info
 


### PR DESCRIPTION
## Summary

Run exact FTS readiness reconciliation inside a single SQLite read transaction so source counts, docsize counts, and row-level missing/excess checks are read from one stable snapshot.

## Problem

While `polylogued` was appending live data, `polylogue ops debt list --kind fts --exact-fts` could report `messages_fts is not query-ready` even though triggers were present and row-level reconciliation was clean. The exact readiness pass issued multiple statements without `BEGIN`, so SQLite could serve source and docsize counts from different moments.

## Solution

- Wrap exact `fts_readiness_info(..., exact=True)` work in `BEGIN` / `ROLLBACK` on the read-only connection.
- Add a regression test that traces the exact readiness connection and asserts the snapshot transaction is used.
- Keep the existing strict readiness predicate; this fixes the observation boundary rather than weakening FTS trust.

Ref #2308

## Verification

- `devtools test tests/unit/daemon/test_daemon_status.py -k 'fts_readiness_exact or fts_readiness_requires_recorded_freshness or fts_readiness_reports_recorded'`
- `devtools verify --quick`
- Pre-push hook: `devtools verify --quick`
- Live source-branch exact readiness against `/home/sinity/.local/share/polylogue/index.db`: `messages_ready=True`, `source_rows=5204644`, `indexed_rows=5204644`, missing/excess/duplicate all zero.
- Live source-branch exact raw/FTS debt scan reports only the four missing-blob raw-materialization groups.