### PR TITLE
fix: reacquire missing raw blob evidence

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -23,6 +23,7 @@ from polylogue.maintenance.registry import MaintenanceOperationRegistry, Operati
 from polylogue.maintenance.replay import ReplayProgress, execute_replay
 from polylogue.maintenance.scope import MaintenanceScopeFilter
 from polylogue.maintenance.targets import MAINTENANCE_TARGET_NAMES, build_maintenance_target_catalog
+from polylogue.operations.archive_debt import _source_path_native_id_candidates
 from polylogue.paths import archive_file_set_root_for_paths, archive_root, blob_store_root, db_path, render_root
 from polylogue.storage.blob_gc import read_gc_history, run_blob_gc_report
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -192,6 +193,113 @@ def _apply_scope_filter_options(fn: Callable[..., Any]) -> Callable[..., Any]:
 
 
 _MAINTENANCE_TARGET_HELP = build_maintenance_target_catalog().help_text()
+
+
+def _raw_blob_path_for_hash(root: Path, blob_hash: bytes | str) -> Path | None:
+    hex_hash = blob_hash.hex() if isinstance(blob_hash, bytes) else str(blob_hash).lower()
+    if len(hex_hash) != 64 or any(char not in "0123456789abcdef" for char in hex_hash):
+        return None
+    return root / "blob" / hex_hash[:2] / hex_hash[2:]
+
+
+def _missing_raw_blob_cursor_candidates(root: Path, *, limit: int | None = None) -> list[dict[str, object]]:
+    source_db = root / "source.db"
+    index_db = root / "index.db"
+    ops_db = root / "ops.db"
+    if not source_db.exists() or not index_db.exists() or not ops_db.exists():
+        return []
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    ops_conn = sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)
+    ops_conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
+        rows = conn.execute(
+            """
+            SELECT
+                r.raw_id,
+                r.origin,
+                r.native_id,
+                r.source_path,
+                r.blob_hash,
+                r.blob_size,
+                r.validation_status,
+                r.parse_error
+            FROM raw_sessions AS r
+            LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
+            LEFT JOIN index_tier.sessions AS s_by_native
+              ON r.native_id IS NOT NULL
+             AND s_by_native.origin = r.origin
+             AND s_by_native.native_id = r.native_id
+            WHERE r.blob_hash IS NOT NULL
+              AND r.source_path IS NOT NULL
+              AND s_by_raw.raw_id IS NULL
+              AND s_by_native.native_id IS NULL
+              AND NOT (
+                r.validation_status = 'skipped'
+                AND r.parsed_at_ms IS NOT NULL
+                AND r.parse_error IS NULL
+              )
+            ORDER BY r.origin, r.blob_size DESC, r.raw_id
+            """
+        ).fetchall()
+        candidates: list[dict[str, object]] = []
+        seen_paths: set[str] = set()
+        for row in rows:
+            source_path = str(row["source_path"] or "")
+            if not source_path or source_path in seen_paths:
+                continue
+            blob_path = _raw_blob_path_for_hash(root, row["blob_hash"])
+            if blob_path is None or blob_path.exists() or not Path(source_path).exists():
+                continue
+            if _raw_materialized_by_source_path_candidate(conn, row):
+                continue
+            cursor = ops_conn.execute(
+                "SELECT stat_size, byte_offset, updated_at_ms FROM ingest_cursor WHERE source_path = ?",
+                (source_path,),
+            ).fetchone()
+            if cursor is None:
+                continue
+            candidates.append(
+                {
+                    "source_path": source_path,
+                    "raw_id": str(row["raw_id"]),
+                    "origin": str(row["origin"] or ""),
+                    "native_id": str(row["native_id"] or ""),
+                    "blob_path": str(blob_path),
+                    "blob_size": int(row["blob_size"] or 0),
+                    "cursor_stat_size": int(cursor["stat_size"] or 0),
+                    "cursor_byte_offset": int(cursor["byte_offset"] or 0),
+                    "cursor_updated_at_ms": int(cursor["updated_at_ms"] or 0),
+                }
+            )
+            seen_paths.add(source_path)
+            if limit is not None and len(candidates) >= limit:
+                break
+        return candidates
+    finally:
+        ops_conn.close()
+        conn.close()
+
+
+def _raw_materialized_by_source_path_candidate(conn: sqlite3.Connection, row: sqlite3.Row) -> bool:
+    origin = str(row["origin"] or "")
+    if not origin:
+        return False
+    for native_id in _source_path_native_id_candidates(str(row["source_path"] or "")):
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM index_tier.sessions
+            WHERE origin = ?
+              AND native_id = ?
+            LIMIT 1
+            """,
+            (origin, native_id),
+        ).fetchone()
+        if existing is not None:
+            return True
+    return False
 
 
 @click.group("maintenance")
@@ -861,6 +969,70 @@ def run_command(
             completed = datetime.fromisoformat(result.completed_at)
             elapsed = (completed - started).total_seconds()
             click.echo(f"\nElapsed: {elapsed:.1f}s")
+
+
+@maintenance_group.command("missing-raw-blob-cursors")
+@click.option("--apply", "apply_changes", is_flag=True, help="Delete matching rebuildable live cursor rows.")
+@click.option("--limit", type=int, default=None, help="Limit the number of candidate source paths.")
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+@click.pass_obj
+def missing_raw_blob_cursors_command(
+    env: AppEnv,
+    apply_changes: bool,
+    limit: int | None,
+    output_format: str,
+) -> None:
+    """Invalidate cursors hiding missing raw-blob re-acquisition debt.
+
+    This command only touches ``ops.db.ingest_cursor`` rows. It leaves
+    source-tier raw rows, source files, blobs, index rows, and user state
+    intact so the next daemon catch-up can re-acquire through the normal
+    ingestion path.
+    """
+    del env
+    root = archive_root()
+    candidates = _missing_raw_blob_cursor_candidates(root, limit=limit)
+    deleted = 0
+    if apply_changes and candidates:
+        ops_db = root / "ops.db"
+        with sqlite3.connect(ops_db) as conn:
+            for candidate in candidates:
+                deleted += conn.execute(
+                    "DELETE FROM ingest_cursor WHERE source_path = ?",
+                    (str(candidate["source_path"]),),
+                ).rowcount
+            conn.commit()
+
+    payload = {
+        "archive_root": str(root),
+        "mode": "apply" if apply_changes else "dry-run",
+        "candidate_count": len(candidates),
+        "deleted_cursor_count": deleted,
+        "candidates": candidates,
+        "next_action": "restart or run polylogued catch-up" if apply_changes and deleted else None,
+    }
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    action = "Deleted" if apply_changes else "Would delete"
+    click.echo(f"{action} {deleted if apply_changes else len(candidates)} live cursor row(s)")
+    for candidate in candidates[:10]:
+        click.echo(
+            f"  {candidate['origin']} {candidate['source_path']} "
+            f"raw={candidate['raw_id']} blob_size={candidate['blob_size']}"
+        )
+    if len(candidates) > 10:
+        click.echo(f"  ... {len(candidates) - 10} more")
+    if apply_changes and deleted:
+        click.echo("Next: restart or run polylogued catch-up.")
 
 
 @maintenance_group.command("preview")

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -53,6 +53,7 @@ from polylogue.sources.live.batch_support import (
     _append_plan_group_ready,
     _AppendPlan,
     _AppendResult,
+    _archive_blob_exists,
     _blob_copy_heartbeat,
     _DeferredAppend,
     _detect_provider_from_path_sample,
@@ -785,7 +786,7 @@ class LiveBatchProcessor:
             try:
                 row = conn.execute(
                     """
-                    SELECT raw_id
+                    SELECT raw_id, blob_hash
                     FROM raw_sessions
                     WHERE source_path = ?
                       AND COALESCE(source_index, 0) >= 0
@@ -800,7 +801,15 @@ class LiveBatchProcessor:
             return None
         if row is None:
             return None
-        raw_id = row[0]
+        raw_id, blob_hash = row
+        if isinstance(blob_hash, bytes):
+            blob_hash_hex = blob_hash.hex()
+        elif isinstance(blob_hash, str):
+            blob_hash_hex = blob_hash.lower()
+        else:
+            return None
+        if not _archive_blob_exists(source_db.parent, blob_hash_hex):
+            return None
         return raw_id if isinstance(raw_id, str) and raw_id else None
 
     def _current_parser_fingerprint(self) -> str:

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -33,6 +33,14 @@ _BROWSER_CAPTURE_PREFIX_PROBE_BYTES = 1 * 1024 * 1024
 _BROWSER_CAPTURE_PROVIDER_RE = re.compile(rb'"provider"\s*:\s*"([^"\\]{1,80})"')
 
 
+def _archive_blob_exists(archive_root: Path, blob_hash_hex: str) -> bool:
+    """Return whether a content-addressed archive blob is present on disk."""
+    normalized = blob_hash_hex.lower()
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        return False
+    return (archive_root / "blob" / normalized[:2] / normalized[2:]).is_file()
+
+
 class _FullIngestHeartbeat(Protocol):
     def __call__(
         self,

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -26,7 +26,11 @@ from polylogue.core.enums import Origin
 from polylogue.core.sources import provider_from_origin
 from polylogue.logging import get_logger
 from polylogue.sources.live.batch import LiveBatchEventEmitter, LiveBatchProcessor, fingerprint_file
-from polylogue.sources.live.batch_support import tail_hash_and_last_complete_newline_from_path, tail_hash_from_path
+from polylogue.sources.live.batch_support import (
+    _archive_blob_exists,
+    tail_hash_and_last_complete_newline_from_path,
+    tail_hash_from_path,
+)
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
 from polylogue.sources.live.deferred_cursor import record_deferred_append_cursor
 from polylogue.sources.live.metrics import LiveBatchMetrics
@@ -572,6 +576,8 @@ class LiveWatcher:
         elif isinstance(blob_hash, str):
             content_fingerprint = blob_hash.lower()
         else:
+            return False
+        if not _archive_blob_exists(archive_root, content_fingerprint):
             return False
         try:
             if archived_size == current_size:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands import maintenance
 from polylogue.core.enums import Provider
+from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.blob_gc import read_gc_history
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
@@ -19,6 +20,7 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
 )
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitAction, ArchiveInitPlan
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session_blob_ref
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
 
@@ -80,6 +82,36 @@ def _seed_assertion_export_rows(archive_root: Path) -> None:
             visibility="private",
             now_ms=1_700_000_002_000,
         )
+
+
+def _seed_missing_blob_cursor(archive_root: Path, source: Path) -> None:
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text('{"type":"session_meta","payload":{"id":"missing-blob"}}\n', encoding="utf-8")
+    blob_hash = b"a" * 32
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        write_source_raw_session_blob_ref(
+            conn,
+            origin="codex-session",
+            source_path=str(source),
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=source.stat().st_size,
+            acquired_at_ms=1,
+            native_id="missing-blob",
+        )
+    stat = source.stat()
+    CursorStore(archive_root / "ops.db").set(
+        source,
+        stat.st_size,
+        byte_offset=stat.st_size,
+        last_complete_newline=stat.st_size,
+        parser_fingerprint="live-batched-v2",
+        content_fingerprint=blob_hash.hex(),
+        source_name="codex",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
 
 
 def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
@@ -419,6 +451,68 @@ def test_archive_maintenance_help_omits_copy_activation_surface(cli_runner: CliR
         "archive-activate",
     ):
         assert removed not in result.output
+
+
+def test_missing_raw_blob_cursor_repair_dry_run_keeps_cursor(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "watch" / "missing-blob.jsonl"
+    _seed_missing_blob_cursor(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "missing-raw-blob-cursors",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "dry-run"
+    assert payload["candidate_count"] == 1
+    assert payload["deleted_cursor_count"] == 0
+    assert payload["candidates"][0]["source_path"] == str(source)
+    with sqlite3.connect(cli_workspace["archive_root"] / "ops.db") as conn:
+        assert conn.execute("SELECT 1 FROM ingest_cursor WHERE source_path = ?", (str(source),)).fetchone() == (1,)
+
+
+def test_missing_raw_blob_cursor_repair_apply_deletes_only_cursor(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "watch" / "missing-blob.jsonl"
+    _seed_missing_blob_cursor(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "missing-raw-blob-cursors",
+            "--apply",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "apply"
+    assert payload["candidate_count"] == 1
+    assert payload["deleted_cursor_count"] == 1
+    with sqlite3.connect(cli_workspace["archive_root"] / "ops.db") as conn:
+        assert conn.execute("SELECT 1 FROM ingest_cursor WHERE source_path = ?", (str(source),)).fetchone() is None
+    with sqlite3.connect(cli_workspace["archive_root"] / "source.db") as conn:
+        assert conn.execute("SELECT 1 FROM raw_sessions WHERE source_path = ?", (str(source),)).fetchone() == (1,)
 
 
 def test_archive_read_cli_lists_archive_sessions(

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -25,6 +25,13 @@ from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 
 
+def _write_archive_blob(archive_root: Path, blob_hash: bytes | str, payload: bytes) -> None:
+    blob_hash_hex = blob_hash.hex() if isinstance(blob_hash, bytes) else blob_hash.lower()
+    blob_path = archive_root / "blob" / blob_hash_hex[:2] / blob_hash_hex[2:]
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(payload)
+
+
 def test_full_ingest_heartbeats_small_file_groups_with_current_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -845,6 +852,8 @@ def test_codex_append_plan_uses_append_only_session_identity(tmp_path: Path) -> 
             payload=original,
             acquired_at_ms=1_770_000_000_000,
         )
+        blob_hash = conn.execute("SELECT blob_hash FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
+    _write_archive_blob(tmp_path, cast(bytes, blob_hash), original)
     with sqlite3.connect(index_db) as conn:
         conn.execute(
             """
@@ -916,6 +925,8 @@ def test_codex_append_plan_reads_archive_file_set_session_identity(tmp_path: Pat
             payload=original,
             acquired_at_ms=1_770_000_000_000,
         )
+        blob_hash = conn.execute("SELECT blob_hash FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
+    _write_archive_blob(tmp_path, cast(bytes, blob_hash), original)
     with sqlite3.connect(index_db) as conn:
         conn.execute(
             """
@@ -963,6 +974,46 @@ def test_codex_append_plan_reads_archive_file_set_session_identity(tmp_path: Pat
     assert processor._latest_raw_fingerprint(path) == raw_id
     with cursor._connect() as conn:
         assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_sessions'").fetchone() is None
+
+
+def test_latest_raw_fingerprint_ignores_archive_source_row_with_missing_blob(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "missing-blob.jsonl"
+    payload = b'{"type":"session_meta","payload":{"id":"missing-blob"}}\n'
+    path.write_bytes(payload)
+    index_db = tmp_path / "index.db"
+    source_db = tmp_path / "source.db"
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    blob_hash = b"a" * 32
+    with sqlite3.connect(source_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index,
+                blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("raw-missing-blob", "codex-session", "missing-blob", str(path), 0, blob_hash, len(payload), 1),
+        )
+        conn.commit()
+    cursor = CursorStore(index_db)
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+        parser_fingerprint="test-parser",
+    )
+
+    assert processor._latest_raw_fingerprint(path) is None
+
+    _write_archive_blob(tmp_path, blob_hash, payload)
+
+    assert processor._latest_raw_fingerprint(path) == "raw-missing-blob"
 
 
 def test_append_ingest_preserves_successes_when_other_plan_fails(

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -18,6 +18,13 @@ from polylogue.sources.live.cursor import CursorStore
 from tests.infra.frozen_clock import FrozenClock
 
 
+def _write_archive_blob(archive_root: Path, blob_hash: bytes | str, payload: bytes) -> None:
+    blob_hash_hex = blob_hash.hex() if isinstance(blob_hash, bytes) else blob_hash.lower()
+    blob_path = archive_root / "blob" / blob_hash_hex[:2] / blob_hash_hex[2:]
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(payload)
+
+
 def test_catch_up_plan_carries_statted_candidates_without_payload_reads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -72,6 +79,45 @@ def test_catch_up_repairs_missing_cursor_from_archive_source_row(tmp_path: Path)
     source_db = tmp_path / "source.db"
     initialize_archive_database(source_db, ArchiveTier.SOURCE)
     with sqlite3.connect(source_db) as conn:
+        blob_hash = b"a" * 32
+        write_source_raw_session_blob_ref(
+            conn,
+            origin="codex-session",
+            source_path=str(archived),
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=archived.stat().st_size,
+            acquired_at_ms=1,
+            native_id="archived",
+        )
+    _write_archive_blob(tmp_path, blob_hash, archived.read_bytes())
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="codex", root=root),), cursor=cursor)
+
+    plan = watcher._plan_catch_up(watcher._scan_catch_up_candidates([root]))
+    record = cursor.get_record(archived)
+
+    assert plan.needed == ()
+    assert plan.skipped_file_count == 1
+    assert record is not None
+    assert record.byte_size == archived.stat().st_size
+    assert record.content_fingerprint == ("61" * 32)
+    assert record.parser_fingerprint == live_watcher._PARSER_FINGERPRINT
+
+
+def test_catch_up_does_not_repair_cursor_from_archive_row_with_missing_blob(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session_blob_ref
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    root = tmp_path / "src"
+    root.mkdir()
+    archived = root / "archived.jsonl"
+    archived.write_text('{"type":"session_meta","payload":{"id":"archived"}}\n', encoding="utf-8")
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    cursor = CursorStore(tmp_path / "ops.db")
+    source_db = tmp_path / "source.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    with sqlite3.connect(source_db) as conn:
         write_source_raw_session_blob_ref(
             conn,
             origin="codex-session",
@@ -85,14 +131,10 @@ def test_catch_up_repairs_missing_cursor_from_archive_source_row(tmp_path: Path)
     watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="codex", root=root),), cursor=cursor)
 
     plan = watcher._plan_catch_up(watcher._scan_catch_up_candidates([root]))
-    record = cursor.get_record(archived)
 
-    assert plan.needed == ()
-    assert plan.skipped_file_count == 1
-    assert record is not None
-    assert record.byte_size == archived.stat().st_size
-    assert record.content_fingerprint == ("61" * 32)
-    assert record.parser_fingerprint == live_watcher._PARSER_FINGERPRINT
+    assert plan.needed == (archived,)
+    assert plan.skipped_file_count == 0
+    assert cursor.get_record(archived) is None
 
 
 def test_catch_up_reconciles_browser_capture_cursor_from_archive_origin(tmp_path: Path) -> None:
@@ -109,16 +151,18 @@ def test_catch_up_reconciles_browser_capture_cursor_from_archive_origin(tmp_path
     source_db = tmp_path / "source.db"
     initialize_archive_database(source_db, ArchiveTier.SOURCE)
     with sqlite3.connect(source_db) as conn:
+        blob_hash = b"b" * 32
         write_source_raw_session_blob_ref(
             conn,
             origin="chatgpt-export",
             source_path=str(archived),
             source_index=0,
-            blob_hash=b"b" * 32,
+            blob_hash=blob_hash,
             blob_size=archived.stat().st_size,
             acquired_at_ms=1,
             native_id="capture",
         )
+    _write_archive_blob(tmp_path, blob_hash, archived.read_bytes())
     watcher = LiveWatcher(
         cast(Any, polylogue),
         (WatchSource(name="browser-capture", root=root, suffixes=(".json",)),),


### PR DESCRIPTION
Summary

This PR makes missing raw blob rows stop acting as valid live-cursor proof, adds a dry-run-by-default cursor invalidation maintenance command, and uses that path to repair the live archive without deleting raw rows, source files, index rows, blobs, or user state.

Problem

The live archive had `source.db.raw_sessions` rows whose `blob_hash` pointed at absent blob files. Some of those rows were not materialized in `index.db.sessions`, but the live watcher and batch helper could still treat the source-tier row as acquisition evidence. Existing `ops.db.ingest_cursor` rows then kept those source files settled, so normal startup catch-up did not re-acquire the missing raw payloads.

Solution

- Require the named content-addressed blob to exist before watcher cursor reconciliation accepts a source-tier raw row.
- Require the named blob to exist before archive-tier raw fingerprints are returned to append/full-ingest planning.
- Add `polylogue ops maintenance missing-raw-blob-cursors`, dry-run by default, which finds unmaterialized missing-blob raw rows whose source files still exist and optionally deletes only the matching rebuildable `ops.db.ingest_cursor` rows.
- Add focused tests for the positive and negative cursor/fingerprint cases and for dry-run/apply CLI behavior.

Live repair evidence

Ref #2308.

Before repair, the live archive had 315 unmaterialized missing-blob raw rows: 96 ChatGPT browser-capture, 5 Claude.ai browser-capture, 55 Codex, and 159 Claude Code. A current durable-tier backup was written at `/home/sinity/.local/share/polylogue/archive-db-backups/manual-durable-pre-reacquire-20260625T133437Z` before mutation.

The new maintenance command dry-run reported 315 cursor candidates, then `--apply` deleted exactly 315 rebuildable cursor rows. Branch-local `polylogued run --no-api --no-browser-capture` catch-up then re-acquired those source files through the normal ingest path. After repair, a direct source/index/blob reconciliation reported `missing_unmaterialized: 0`; 389 remaining missing blob rows are already materialized by current source/native evidence and are not user-visible materialization debt.

Operational caveat

Full re-acquisition is currently slow: browser-capture and Claude Code full-ingest chunks processed around 0.2 files/s, and one 50-file chunk briefly grew `index.db-wal` to about 5.9 GiB before checkpointing back down. That is not fixed here; it is runtime performance evidence for a follow-up optimization of full-ingest batching/transaction shape.

Verification

- `devtools test tests/unit/sources/test_live_catchup_planning.py::test_catch_up_repairs_missing_cursor_from_archive_source_row tests/unit/sources/test_live_catchup_planning.py::test_catch_up_does_not_repair_cursor_from_archive_row_with_missing_blob tests/unit/sources/test_live_catchup_planning.py::test_catch_up_reconciles_browser_capture_cursor_from_archive_origin tests/unit/sources/test_live_batch_support.py::test_codex_append_plan_reads_archive_file_set_session_identity tests/unit/sources/test_live_batch_support.py::test_latest_raw_fingerprint_ignores_archive_source_row_with_missing_blob`
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py::test_missing_raw_blob_cursor_repair_dry_run_keeps_cursor tests/unit/cli/test_archive_maintenance_cli.py::test_missing_raw_blob_cursor_repair_apply_deletes_only_cursor tests/unit/sources/test_live_catchup_planning.py::test_catch_up_does_not_repair_cursor_from_archive_row_with_missing_blob tests/unit/sources/test_live_batch_support.py::test_latest_raw_fingerprint_ignores_archive_source_row_with_missing_blob`
- `devtools verify --quick`
- push hook: `devtools verify --quick`
- `devtools verify` static steps passed, but pytest-testmon selected 9,964 tests because the local seed was stale for this head and timed out at 2700s before producing a JSON report. This is recorded as run `20260625T142529Z-testmon-4089363-7abcaa74`; it is not treated as a focused failure of this patch.
- Live branch catch-up against `/home/sinity/.local/share/polylogue`: zero remaining unmaterialized missing-blob rows by direct source/index/blob reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintenance command to find and optionally remove stale ingestion cursors related to missing archived content.
  * Supports dry-run, apply mode, limits, and plain or JSON output with a summary of affected items.

* **Bug Fixes**
  * Improved archive recovery so missing content is detected before restoring cursor state.
  * Prevents cursor repair when the referenced archive file is unavailable, reducing inconsistent recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->