### PR TITLE
perf: expose live ingest stage timings

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -46,14 +46,24 @@ _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
 INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson")
 
 
+def _stage_timing_summary(stage_timings_s: dict[str, float], *, limit: int = 4) -> str:
+    if not stage_timings_s:
+        return "none"
+    ordered = sorted(stage_timings_s.items(), key=lambda item: item[1], reverse=True)
+    return ",".join(f"{name}:{elapsed:.3f}" for name, elapsed in ordered[:limit])
+
+
 def _log_ingest_metrics(prefix: str, metrics: LiveBatchMetrics) -> None:
     """Log actual live-ingest read work separately from candidate file size."""
     input_bytes = getattr(metrics, "input_bytes", 0)
     source_payload_read_bytes = getattr(metrics, "source_payload_read_bytes", 0)
     read_amp = source_payload_read_bytes / input_bytes if input_bytes > 0 else 0.0
+    stage_timings_s = getattr(metrics, "stage_timings_s", {})
+    stage_summary = _stage_timing_summary(stage_timings_s if isinstance(stage_timings_s, dict) else {})
     logger.info(
         "%s complete: read=%.1f MB input=%.1f MB read_amp=%.6fx append_files=%d full_files=%d "
-        "succeeded=%d failed=%d parse_s=%.3f convergence_s=%.3f",
+        "succeeded=%d failed=%d parse_s=%.3f convergence_s=%.3f stages=%s "
+        "wal_before_checkpoint=%.1f MB wal_after_checkpoint=%.1f MB wal_busy_pages=%d",
         prefix,
         source_payload_read_bytes / 1e6,
         input_bytes / 1e6,
@@ -64,6 +74,10 @@ def _log_ingest_metrics(prefix: str, metrics: LiveBatchMetrics) -> None:
         getattr(metrics, "failed_file_count", 0),
         getattr(metrics, "parse_time_s", 0.0),
         getattr(metrics, "convergence_time_s", 0.0),
+        stage_summary,
+        getattr(metrics, "wal_bytes_before_checkpoint_max", 0) / 1e6,
+        getattr(metrics, "wal_bytes_after_checkpoint_max", 0) / 1e6,
+        getattr(metrics, "wal_busy_pages_total", 0),
     )
 
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -109,12 +109,18 @@ def test_live_ingest_metrics_log_separates_read_bytes_from_candidate_size(
         parse_time_s=0.5,
         convergence_time_s=0.25,
         total_time_s=1.0,
+        wal_bytes_before_checkpoint_max=8_000_000,
+        wal_bytes_after_checkpoint_max=1_000_000,
+        wal_busy_pages_total=3,
+        stage_timings_s={"full_parse": 0.45, "fts": 0.05, "insights": 0.2},
     )
 
     live_watcher._log_ingest_metrics("live.watcher: changed-file batch", metrics)
 
     message, *args = logger.info.call_args.args
     assert "read=%.1f MB input=%.1f MB read_amp=%.6fx" in message
+    assert "stages=%s" in message
+    assert "wal_before_checkpoint=%.1f MB" in message
     assert args[:6] == [
         "live.watcher: changed-file batch",
         0.04,
@@ -123,6 +129,24 @@ def test_live_ingest_metrics_log_separates_read_bytes_from_candidate_size(
         2,
         0,
     ]
+    assert args[10:] == ["full_parse:0.450,insights:0.200,fts:0.050", 8.0, 1.0, 3]
+
+
+def test_live_ingest_stage_timing_summary_is_bounded_and_sorted() -> None:
+    assert live_watcher._stage_timing_summary({}) == "none"
+    assert (
+        live_watcher._stage_timing_summary(
+            {
+                "parse": 1.25,
+                "fts": 0.01,
+                "insights": 0.4,
+                "usage": 0.2,
+                "checkpoint": 0.8,
+            },
+            limit=3,
+        )
+        == "parse:1.250,checkpoint:0.800,insights:0.400"
+    )
 
 
 # --- CursorStore ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds actionable live-ingest observability to the watcher log line: the largest stage timings plus WAL before/after checkpoint shape are now emitted alongside read/input amplification.

## Problem

Live catch-up evidence for Ref #2391 showed batches where parse time dominated and WAL briefly grew very large, but the normal watcher log only exposed aggregate parse/convergence time. That made it harder to tell whether a slow batch was file-read amplification, parser work, FTS/insight work, or checkpoint contention.

## Solution

`polylogue.sources.live.watcher` now formats the top stage timings from `LiveBatchMetrics.stage_timings_s` and includes WAL checkpoint maxima and busy-page totals in the existing ingest-complete log line. The watcher tests cover the new log arguments and the bounded stage-summary ordering.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py` -> 72 passed in 172.84s.
- `devtools verify --quick` -> exit 0, run `20260625T152757Z-quick-4157191-9052a9b6`.
- pre-push `devtools verify --quick` -> exit 0, run `20260625T152842Z-quick-4157972-83d9a4c6`.

Ref #2391