### PR TITLE
fix(browser): type temporary capture sessions

### DIFF
--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -67,6 +67,7 @@
     turns,
     model = null,
     providerSessionId = null,
+    sessionKind = null,
     title = null,
     createdAt = null,
     updatedAt = null,
@@ -92,6 +93,12 @@
     if (urlSessionId === "__polylogue_temporary_chat__" || stableProviderSessionId.startsWith("temporary:")) {
       sessionProviderMeta.session_kind = "temporary";
     }
+    const stableSessionKind =
+      sessionKind === "temporary" ||
+      sessionProviderMeta.session_kind === "temporary" ||
+      stableProviderSessionId.startsWith("temporary:")
+        ? "temporary"
+        : "standard";
     const now = new Date().toISOString();
     const envelope = {
       polylogue_capture_kind: CAPTURE_KIND,
@@ -110,6 +117,7 @@
       session: {
         provider,
         provider_session_id: stableProviderSessionId,
+        session_kind: stableSessionKind,
         title: title || document.title || stableProviderSessionId,
         created_at: createdAt,
         updated_at: updatedAt || now,

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -330,6 +330,7 @@
       adapterName: nativeAdapterName,
       turns,
       providerSessionId: String(payload.conversation_id || payload.id || conversationIdFromUrl()),
+      sessionKind: payload.is_temporary === true ? "temporary" : null,
       title: typeof payload.title === "string" && payload.title ? payload.title : null,
       createdAt: timestampFromSeconds(payload.create_time),
       updatedAt: timestampFromSeconds(payload.update_time),
@@ -338,7 +339,8 @@
         capture_source: "chatgpt_backend_api",
         current_node: payload.current_node || null,
         mapping_node_count: payload.mapping ? Object.keys(payload.mapping).length : 0,
-        is_temporary: payload.is_temporary === true
+        is_temporary: payload.is_temporary === true,
+        session_kind: payload.is_temporary === true ? "temporary" : null
       },
       rawProviderPayload: payload
     });

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -196,6 +196,7 @@
       adapterName: nativeAdapterName,
       turns,
       providerSessionId: String(payload.uuid || conversationIdFromUrl()),
+      sessionKind: payload.is_temporary === true ? "temporary" : null,
       title: typeof payload.name === "string" && payload.name ? payload.name : null,
       createdAt: payload.created_at || null,
       updatedAt: payload.updated_at || null,

--- a/browser-extension/tests/common.test.js
+++ b/browser-extension/tests/common.test.js
@@ -63,6 +63,7 @@ function buildEnvelope({
   turns,
   model = null,
   providerSessionId = null,
+  sessionKind = null,
   title = null,
   createdAt = null,
   updatedAt = null,
@@ -90,6 +91,12 @@ function buildEnvelope({
   ) {
     sessionProviderMeta.session_kind = "temporary";
   }
+  const stableSessionKind =
+    sessionKind === "temporary" ||
+    sessionProviderMeta.session_kind === "temporary" ||
+    resolvedProviderSessionId.startsWith("temporary:")
+      ? "temporary"
+      : "standard";
   const now = new Date().toISOString();
   const envelope = {
     polylogue_capture_kind: "browser_llm_session",
@@ -108,6 +115,7 @@ function buildEnvelope({
     session: {
       provider,
       provider_session_id: resolvedProviderSessionId,
+      session_kind: stableSessionKind,
       title: title || "Test Page",
       created_at: createdAt,
       updated_at: updatedAt || now,
@@ -209,6 +217,30 @@ describe("sessionIdFromUrl", () => {
       "https://chatgpt.com/?temporary-chat=true",
     );
     expect(id).toBe("__polylogue_temporary_chat__");
+  });
+
+  it("marks temporary-chat envelopes with typed session_kind", () => {
+    const envelope = buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-dom-v1",
+      sourceUrl: "https://chatgpt.com/?temporary-chat=true",
+      turns: [{ role: "user", text: "Preserve this" }],
+    });
+    expect(envelope.session.provider_session_id).toMatch(/^temporary:/);
+    expect(envelope.session.session_kind).toBe("temporary");
+    expect(envelope.session.provider_meta.session_kind).toBe("temporary");
+  });
+
+  it("honors explicit temporary sessionKind from native adapters", () => {
+    const envelope = buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-native-v1",
+      providerSessionId: "native-temporary",
+      sessionKind: "temporary",
+      turns: [{ role: "user", text: "Native temporary" }],
+    });
+    expect(envelope.session.provider_session_id).toBe("native-temporary");
+    expect(envelope.session.session_kind).toBe("temporary");
   });
 
   it("does not invent Claude ids for non-conversation routes", () => {

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -136,6 +136,14 @@ updates the same archive session instead of creating a second visible session.
 Fallback DOM captures are therefore acceptable as temporary live evidence, but
 not as a reason to prefer DOM over a clean provider payload.
 
+Temporary chats are a typed browser-capture session property, not only a
+provider metadata convention. The extension writes
+`session.session_kind = "temporary"` when the page URL or provider-native
+payload identifies a temporary conversation, and the parser persists the
+existing `capture:temporary-chat` ingest flag from that typed field. Legacy
+captures that only carry `provider_meta.session_kind = "temporary"` remain
+accepted for already-spooled artifacts.
+
 The Claude.ai content script also hooks same-origin conversation fetches and
 uses native payloads when the response is the current
 `/chat_conversations/<id>` JSON shape with `chat_messages`. DOM extraction

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -16,6 +16,7 @@ BROWSER_CAPTURE_TRANSPORT_SOURCE: Literal["browser-extension"] = "browser-extens
 BROWSER_CAPTURE_RECEIVER: Literal["polylogue-browser-capture"] = "polylogue-browser-capture"
 BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD: Literal["chrome-extension://*"] = "chrome-extension://*"
 BrowserCaptureArchiveLifecycle = Literal["missing", "spooled_only", "ingest_pending", "archived", "failed"]
+BrowserCaptureSessionKind = Literal["standard", "temporary"]
 
 
 class BrowserCaptureAttachment(BaseModel):
@@ -90,6 +91,7 @@ class BrowserCaptureSession(BaseModel):
 
     provider: Provider
     provider_session_id: str
+    session_kind: BrowserCaptureSessionKind = "standard"
     title: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
@@ -109,6 +111,13 @@ class BrowserCaptureSession(BaseModel):
         if isinstance(value, Provider):
             return value
         return Provider.from_string(str(value) if value is not None else None)
+
+    @field_validator("session_kind", mode="before")
+    @classmethod
+    def coerce_session_kind(cls, value: object) -> BrowserCaptureSessionKind:
+        if value in ("temporary", True):
+            return "temporary"
+        return "standard"
 
     @model_validator(mode="after")
     def require_turns(self) -> BrowserCaptureSession:
@@ -245,6 +254,7 @@ __all__ = [
     "BrowserCaptureProvenance",
     "BrowserCaptureReceiverStatusPayload",
     "BrowserCaptureSession",
+    "BrowserCaptureSessionKind",
     "BrowserCaptureTurn",
     "looks_like_browser_capture",
 ]

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -31,8 +31,11 @@ def _has_claude_ai_native_payload(payload: object) -> TypeGuard[Mapping[str, obj
 
 
 def _ingest_flags_for_browser_capture(envelope: BrowserCaptureEnvelope, provider_session_id: str) -> list[str]:
-    session_kind = envelope.session.provider_meta.get("session_kind")
+    session_kind = envelope.session.session_kind
+    legacy_session_kind = envelope.session.provider_meta.get("session_kind")
     if session_kind == "temporary" or provider_session_id.startswith("temporary:"):
+        return [TEMPORARY_CHAT_INGEST_FLAG]
+    if legacy_session_kind == "temporary":
         return [TEMPORARY_CHAT_INGEST_FLAG]
     return []
 

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -250,6 +250,26 @@ def test_browser_capture_session_kind_marks_temporary_chat() -> None:
     assert parsed[0].ingest_flags == [TEMPORARY_CHAT_INGEST_FLAG]
 
 
+def test_browser_capture_typed_session_kind_marks_temporary_chat() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    session_payload["session_kind"] = "temporary"
+
+    envelope = BrowserCaptureEnvelope.model_validate(payload)
+    parsed = parse_payload(Provider.CHATGPT, payload, "file-fallback")
+
+    assert envelope.session.session_kind == "temporary"
+    assert parsed[0].provider_session_id == "conv-123"
+    assert parsed[0].ingest_flags == [TEMPORARY_CHAT_INGEST_FLAG]
+
+
+def test_browser_capture_session_kind_defaults_to_standard() -> None:
+    envelope = BrowserCaptureEnvelope.model_validate(_capture_payload())
+
+    assert envelope.session.session_kind == "standard"
+
+
 def test_browser_capture_raw_chatgpt_normalizes_legacy_synthetic_fallback_id() -> None:
     payload = _capture_payload()
     session = payload["session"]


### PR DESCRIPTION
## Summary

Makes temporary-chat status a typed browser-capture session property instead of relying only on provider metadata conventions.

## Problem

Browser-captured temporary chats should be preserved and recognized as temporary in Polylogue. The existing path could infer this from synthetic temporary ids or `provider_meta.session_kind`, but that left degraded DOM captures and source-envelope consumers dependent on an untyped metadata escape hatch.

## Solution

`BrowserCaptureSession` now exposes `session_kind` with `standard`/`temporary` values. The extension writes `session.session_kind` when URL-derived ids or provider-native payloads identify a temporary conversation. The browser-capture parser now prefers the typed field, while keeping `provider_meta.session_kind` as compatibility for already-spooled envelopes. The docs describe the typed contract and legacy fallback.

## Verification

- `devtools test tests/unit/sources/test_browser_capture.py` -> 24 passed.
- `npm --prefix browser-extension test -- --run` -> 79 passed.
- `npm --prefix browser-extension run lint` -> exit 0.
- `npm --prefix browser-extension run build` -> exit 0.
- `devtools verify --quick` -> exit 0, run `20260625T153501Z-quick-4165279-e41416c0`.
- pre-push `devtools verify --quick` -> exit 0, run `20260625T153530Z-quick-4166483-5a37579a`.

Ref #2308