### PR TITLE
perf: avoid full-session active-leaf churn

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -306,7 +306,10 @@ def write_parsed_session_to_archive(
                 (session_id,),
             ).fetchone()
             position_offset = int(row[0] or 0) if row is not None else 0
-            conn.execute("UPDATE messages SET is_active_leaf = 0 WHERE session_id = ?", (session_id,))
+            conn.execute(
+                "UPDATE messages SET is_active_leaf = 0 WHERE session_id = ? AND is_active_leaf != 0",
+                (session_id,),
+            )
             active_leaf_message_id = _active_leaf_message_id(
                 session_id,
                 messages,

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1272,6 +1272,54 @@ def test_provider_usage_events_append_preserves_prior_history(tmp_path: Path) ->
     ]
 
 
+def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    message_count = 200
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-large-append",
+        messages=[
+            ParsedMessage(
+                provider_message_id=f"m{i}",
+                role=Role.USER if i % 2 == 0 else Role.ASSISTANT,
+                text=f"large append baseline {i}",
+                is_active_leaf=i == message_count - 1,
+            )
+            for i in range(message_count)
+        ],
+    )
+    second = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-large-append",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m200",
+                role=Role.ASSISTANT,
+                text="large append tail",
+                is_active_leaf=True,
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    before_changes = conn.total_changes
+    write_parsed_session_to_archive(conn, second, merge_append=True)
+    append_changes = conn.total_changes - before_changes
+
+    rows = conn.execute(
+        """
+        SELECT native_id, position, is_active_leaf
+        FROM messages
+        WHERE session_id = ? AND is_active_leaf = 1
+        ORDER BY position
+        """,
+        (session_id,),
+    ).fetchall()
+    assert [dict(row) for row in rows] == [{"native_id": "m200", "position": 200, "is_active_leaf": 1}]
+    assert conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)).fetchone()[0] == 201
+    assert append_changes < 80
+
+
 def test_provider_usage_rollup_clears_stale_message_pricing(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(


### PR DESCRIPTION
## Summary

Tightens the merge-append archive writer so appending to a live session clears only rows that are currently marked as active leaves, then appends the new tail. This keeps the active-leaf invariant while avoiding full-session message rewrites for giant Codex/Claude sessions.

## Problem

Live `polylogued` evidence for a 137 MB active Codex JSONL showed append batches reading only KB-sized tails while still spending about 5.4-5.8 seconds inside the append parse/write window. The append path already avoided full message replacement, but it still ran `UPDATE messages SET is_active_leaf = 0 WHERE session_id = ?`, which dirtied every prior message row. Because message updates fire the FTS update trigger, moving a single active leaf could churn FTS rows for the entire giant session.

## Solution

The append writer now narrows the reset predicate to `session_id = ? AND is_active_leaf != 0`. That preserves cleanup of stale multiple-active-leaf states but keeps normal appends proportional to the number of current active leaves plus the appended messages.

A regression test builds a 200-message Codex session, appends one message through `merge_append=True`, and asserts the active leaf moves, total messages remain present, and SQLite changes stay bounded rather than proportional to the existing session size.

## Verification

Passed:

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'merge_append_clears_only_existing_active_leaf or provider_usage_events_append_preserves_prior_history'` — 2 passed.
- `devtools test tests/unit/sources/test_live_watcher.py -k 'codex_append_uses_existing_session_identity_when_tail_lacks_session_meta or live_append_merges_tail_visible_through_public_archive_read'` — 2 passed.
- `devtools verify --quick` — passed before commit.
- pre-push `devtools verify --quick` — passed for commit `1cda48f18`.

Default `devtools verify` static checks passed, then pytest-testmon selected 2429 tests and failed 26 unrelated contract/snapshot tests. The failures were in origin enum expectations, CLI/query/action snapshots, artifact graph/scenario coverage expectations, raw-materialization/check health contracts, MCP tool classification, and product workflow guard text. None exercised the changed archive append predicate or live append workflow.

Ref #2391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved append behavior for archived sessions so only the currently active message is cleared when adding new content.
  * Prevents unnecessary broad updates during large session appends, helping preserve existing data and improve efficiency.
* **Tests**
  * Added coverage for appending to a large existing session and verifying that only one active message remains after the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->