### PR TITLE
perf: expose append ingest stage timings

### DIFF
--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
@@ -16,6 +17,10 @@ from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
 logger = get_logger(__name__)
+
+
+def _add_timing(timings: dict[str, float], name: str, started_at: float) -> None:
+    timings[name] = timings.get(name, 0.0) + (time.perf_counter() - started_at)
 
 
 class _AppendIngestOwner(Protocol):
@@ -36,36 +41,53 @@ def _ingest_append_plans_archive(
     plans: list[_AppendPlan],
     archive_root: Path,
 ) -> _AppendResult:
+    timings: dict[str, float] = {}
     index_db = archive_root / "index.db"
     source_db = archive_root / "source.db"
     if not index_db.exists() or not source_db.exists():
+        t0 = time.perf_counter()
         initialize_active_archive_root(archive_root)
+        _add_timing(timings, "append.archive_init", t0)
 
+    t0 = time.perf_counter()
     from polylogue.sources.decoders import _iter_json_stream
     from polylogue.sources.dispatch import parse_payload
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
+    _add_timing(timings, "append.imports", t0)
+
+    t0 = time.perf_counter()
     blob_store = BlobStore(blob_store_root())
+    _add_timing(timings, "append.blob_store_open", t0)
     succeeded: list[_AppendPlan] = []
     failed: list[_AppendPlan] = []
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     try:
+        t0 = time.perf_counter()
         with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            _add_timing(timings, "append.archive_open", t0)
             for plan in plans:
                 try:
+                    t0 = time.perf_counter()
                     blob_store.write_from_bytes(plan.payload)
+                    _add_timing(timings, "append.blob_write", t0)
                     provider = Provider.from_string(plan.source_name)
+                    t0 = time.perf_counter()
                     payloads = list(_iter_json_stream(BytesIO(plan.payload), plan.path.name))
+                    _add_timing(timings, "append.json_stream", t0)
+                    t0 = time.perf_counter()
                     sessions = parse_payload(
                         provider,
                         payloads,
                         plan.path.stem,
                         source_path=str(plan.path),
                     )
+                    _add_timing(timings, "append.provider_parse", t0)
                     if not sessions:
                         failed.append(plan)
                         continue
                     for session in sessions:
+                        t0 = time.perf_counter()
                         archive.write_raw_and_parsed(
                             session,
                             payload=plan.payload,
@@ -73,14 +95,15 @@ def _ingest_append_plans_archive(
                             source_index=-1,
                             acquired_at_ms=acquired_at_ms,
                         )
+                        _add_timing(timings, "append.raw_and_index_write", t0)
                     succeeded.append(plan)
                 except Exception:
                     logger.warning("live.watcher: archive append ingest failed for %s", plan.path, exc_info=True)
                     failed.append(plan)
     except Exception as exc:
         logger.warning("live.watcher: archive append ingest failed: %s", exc)
-        return _AppendResult(succeeded=[], failed=plans, worker_count=0)
-    return _AppendResult(succeeded=succeeded, failed=failed, worker_count=1)
+        return _AppendResult(succeeded=[], failed=plans, worker_count=0, stage_timings_s=timings)
+    return _AppendResult(succeeded=succeeded, failed=failed, worker_count=1, stage_timings_s=timings)
 
 
 __all__ = ["ingest_append_plans"]

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -258,6 +258,13 @@ class LiveBatchProcessor:
                 append_result = _AppendResult(succeeded=[], failed=[], worker_count=0)
             ingest_worker_count_max = max(ingest_worker_count_max, append_result.worker_count)
             parse_time_s += time.perf_counter() - t0
+            _accumulate_stage_timings(stage_timings, append_result.stage_timings_s)
+            append_stage_payload: dict[str, object] = {
+                "storage_route": "archive_append",
+                "append_stage_timings_s": {
+                    name: round(elapsed, 6) for name, elapsed in append_result.stage_timings_s.items()
+                },
+            }
             release_process_memory()
             self._record_attempt_progress(
                 attempt_id,
@@ -270,7 +277,7 @@ class LiveBatchProcessor:
                 convergence_time_s=convergence_time_s,
                 current_source=plans[0].source_name,
                 current_path=plans[0].path,
-                stage_payload={"storage_route": "archive_append"},
+                stage_payload=append_stage_payload,
             )
             _converged_paths, elapsed, timings, convergence_debt = await asyncio.to_thread(
                 self._converge_paths,

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -85,6 +85,7 @@ class _AppendResult:
     succeeded: list[_AppendPlan]
     failed: list[_AppendPlan]
     worker_count: int = 0
+    stage_timings_s: dict[str, float] = field(default_factory=dict)
 
 
 class _DeferredAppend:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1528,6 +1528,13 @@ async def test_codex_append_uses_existing_session_identity_when_tail_lacks_sessi
         fallback = await archive.get_session("codex:codex-session")
         assert append_metrics.append_file_count == 1
         assert append_metrics.full_file_count == 0
+        assert {
+            "append.archive_open",
+            "append.blob_write",
+            "append.json_stream",
+            "append.provider_parse",
+            "append.raw_and_index_write",
+        }.issubset(append_metrics.stage_timings_s)
         assert existing is not None
         assert [message.text for message in existing.messages] == ["codex first", "codex appended"]
         assert fallback is None


### PR DESCRIPTION
## Summary

Adds append-specific live ingest stage timings so the remaining Codex append latency can be diagnosed from deployed logs and diagnostics instead of being collapsed under `parse_s`.

## Problem

After PR #2394, live append batches still show about 5.4 seconds in the append parse/write window despite only reading small tail payloads. Local replay shows the parser and append writer are fast on synthetic archives, so the deployed path needs finer-grained evidence before the next optimization. The existing batch metric only reports aggregate `parse_s`, which cannot distinguish archive open/setup, blob write, JSON stream decode, provider parse, or raw/index writes.

## Solution

`_AppendResult` now carries append stage timings. The archive append helper records timing for archive initialization, imports, blob-store setup, archive open, blob write, JSON stream decode, provider parse, and raw/index write. The live batch processor merges those timings into `stage_timings_s` and includes rounded append timings in the progress payload.

The Codex append live-watcher regression now asserts the key append timing fields are present.

## Verification

Passed:

- `devtools test tests/unit/sources/test_live_watcher.py -k codex_append_uses_existing_session_identity_when_tail_lacks_session_meta` — 1 passed.
- `devtools verify --quick` — passed.
- pre-push `devtools verify --quick` — passed for commit `c1a52f6ba`.

Known baseline caveat from the immediately preceding branch: default `devtools verify` static checks passed, but pytest-testmon failed 26 unrelated contract/snapshot tests. This PR only changes append observability and uses focused plus quick verification.

Ref #2391
