### PR TITLE
perf: split append storage timing

### DIFF
--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -94,6 +94,7 @@ def _ingest_append_plans_archive(
                             source_path=str(plan.path),
                             source_index=-1,
                             acquired_at_ms=acquired_at_ms,
+                            stage_timings_s=timings,
                         )
                         _add_timing(timings, "append.raw_and_index_write", t0)
                     succeeded.append(plan)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -444,10 +445,19 @@ class ArchiveStore:
         source_path: str,
         acquired_at_ms: int,
         source_index: int = 0,
+        stage_timings_s: dict[str, float] | None = None,
     ) -> tuple[str, str]:
         """Write raw acquisition bytes and the parsed session they produced."""
+
+        def add_timing(name: str, started_at: float) -> None:
+            if stage_timings_s is not None:
+                stage_timings_s[name] = stage_timings_s.get(name, 0.0) + (time.perf_counter() - started_at)
+
+        t0 = time.perf_counter()
         source_conn = sqlite3.connect(self.source_db_path)
+        add_timing("append.source_connect", t0)
         try:
+            t0 = time.perf_counter()
             source_conn.execute("PRAGMA foreign_keys = ON")
             raw_id = write_source_raw_session(
                 source_conn,
@@ -458,14 +468,19 @@ class ArchiveStore:
                 payload=payload,
                 acquired_at_ms=acquired_at_ms,
             )
+            add_timing("append.source_raw_write", t0)
         finally:
+            t0 = time.perf_counter()
             source_conn.close()
+            add_timing("append.source_close", t0)
+        t0 = time.perf_counter()
         session_id = write_parsed_session_to_archive(
             self._conn,
             session,
             raw_id=raw_id,
             merge_append=source_index < 0,
         )
+        add_timing("append.index_parsed_write", t0)
         return raw_id, session_id
 
     def write_raw_blob_and_parsed(

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1531,9 +1531,11 @@ async def test_codex_append_uses_existing_session_identity_when_tail_lacks_sessi
         assert {
             "append.archive_open",
             "append.blob_write",
+            "append.index_parsed_write",
             "append.json_stream",
             "append.provider_parse",
             "append.raw_and_index_write",
+            "append.source_raw_write",
         }.issubset(append_metrics.stage_timings_s)
         assert existing is not None
         assert [message.text for message in existing.messages] == ["codex first", "codex appended"]


### PR DESCRIPTION
## Summary

Splits the deployed append storage timing bucket into source raw-evidence write and index parsed-session write timings.

## Problem

PR #2395 showed that `append.raw_and_index_write` accounts for nearly all remaining live Codex append latency, but that bucket still combines two different persistence surfaces: `source.db` raw evidence insertion and `index.db` session append/materialization. We need that split before the next source-level optimization.

## Solution

`ArchiveStore.write_raw_and_parsed` now accepts an optional timing dictionary. Existing callers keep the same behavior. Live append calls pass their timing sink through, producing `append.source_connect`, `append.source_raw_write`, `append.source_close`, and `append.index_parsed_write` timings in addition to the existing aggregate bucket.

The Codex append regression asserts the new split keys appear in live append metrics.

## Verification

Passed:

- `devtools test tests/unit/sources/test_live_watcher.py -k codex_append_uses_existing_session_identity_when_tail_lacks_session_meta` — 1 passed.
- `devtools verify --quick` — passed.
- pre-push `devtools verify --quick` — passed for commit `1d1da7bce`.

Ref #2391
