### PR TITLE
perf: expose deep append index timings

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -479,6 +479,7 @@ class ArchiveStore:
             session,
             raw_id=raw_id,
             merge_append=source_index < 0,
+            stage_timings_s=stage_timings_s,
         )
         add_timing("append.index_parsed_write", t0)
         return raw_id, session_id

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import sqlite3
+import time
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -218,8 +219,15 @@ def write_parsed_session_to_archive(
     content_hash: str | None = None,
     raw_id: str | None = None,
     merge_append: bool = False,
+    stage_timings_s: dict[str, float] | None = None,
 ) -> str:
     """Write one parsed session into an initialized archive index DB."""
+    t0 = time.perf_counter()
+
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timings_s is not None:
+            stage_timings_s[name] = stage_timings_s.get(name, 0.0) + (time.perf_counter() - started_at)
+
     conn.execute("PRAGMA foreign_keys = ON")
     origin = origin_from_provider(session.source_name)
     native_id = session.provider_session_id
@@ -235,8 +243,10 @@ def write_parsed_session_to_archive(
     session_content_hash = (
         bytes.fromhex(content_hash) if content_hash is not None else _hash_bytes("session", origin.value, native_id)
     )
+    add_timing("append.index.prepare", t0)
 
     with conn:
+        t0 = time.perf_counter()
         conn.execute(
             """
             INSERT INTO sessions (
@@ -299,7 +309,9 @@ def write_parsed_session_to_archive(
                 _timestamp_ms(session.updated_at),
             ),
         )
+        add_timing("append.index.session_upsert", t0)
         position_offset = 0
+        t0 = time.perf_counter()
         if merge_append:
             row = conn.execute(
                 "SELECT COALESCE(MAX(position) + 1, 0) FROM messages WHERE session_id = ?",
@@ -321,13 +333,16 @@ def write_parsed_session_to_archive(
                 "UPDATE sessions SET active_leaf_message_id = ? WHERE session_id = ?",
                 (active_leaf_message_id, session_id),
             )
+            add_timing("append.index.merge_prepare", t0)
         else:
             _replace_full_session_messages_and_blocks(
                 conn,
                 session,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
+            add_timing("append.index.full_replace", t0)
         if merge_append:
+            t0 = time.perf_counter()
             _write_messages(
                 conn,
                 session_id,
@@ -335,6 +350,8 @@ def write_parsed_session_to_archive(
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
+            add_timing("append.index.messages", t0)
+            t0 = time.perf_counter()
             _write_blocks(
                 conn,
                 session_id,
@@ -342,6 +359,8 @@ def write_parsed_session_to_archive(
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
+            add_timing("append.index.blocks", t0)
+            t0 = time.perf_counter()
             _write_web_constructs(
                 conn,
                 session,
@@ -349,6 +368,8 @@ def write_parsed_session_to_archive(
                 duplicate_native_ids=duplicate_message_native_ids,
                 replace_session=False,
             )
+            add_timing("append.index.web_constructs", t0)
+        t0 = time.perf_counter()
         _write_attachments(
             conn,
             session_id,
@@ -357,6 +378,8 @@ def write_parsed_session_to_archive(
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
         )
+        add_timing("append.index.attachments", t0)
+        t0 = time.perf_counter()
         _write_paste_spans(
             conn,
             session_id,
@@ -364,6 +387,8 @@ def write_parsed_session_to_archive(
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
         )
+        add_timing("append.index.paste_spans", t0)
+        t0 = time.perf_counter()
         _write_parent_links(
             conn,
             session_id,
@@ -371,7 +396,11 @@ def write_parsed_session_to_archive(
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
         )
+        add_timing("append.index.parent_links", t0)
+        t0 = time.perf_counter()
         _write_session_link(conn, session_id, session)
+        add_timing("append.index.session_link", t0)
+        t0 = time.perf_counter()
         _write_session_events(
             conn,
             session_id,
@@ -381,14 +410,29 @@ def write_parsed_session_to_archive(
             event_position_offset=_next_session_event_position(conn, session_id),
             duplicate_native_ids=duplicate_message_native_ids,
         )
+        add_timing("append.index.session_events", t0)
+        t0 = time.perf_counter()
         _write_working_dirs(conn, session_id, session.working_directories)
+        add_timing("append.index.working_dirs", t0)
+        t0 = time.perf_counter()
         _write_repo_edges(conn, session_id, session)
+        add_timing("append.index.repo_edges", t0)
+        t0 = time.perf_counter()
         _write_reported_costs(conn, session_id, session)
+        add_timing("append.index.reported_costs", t0)
+        t0 = time.perf_counter()
         _aggregate_provider_usage_into_model_usage(conn, session_id)
+        add_timing("append.index.provider_usage_rollup", t0)
+        t0 = time.perf_counter()
         _refresh_session_counts(conn, session_id)
+        add_timing("append.index.session_counts", t0)
+        t0 = time.perf_counter()
         _resolve_session_graph(conn, session_id, native_id, origin.value)
+        add_timing("append.index.graph_resolve", t0)
         if session.ingest_flags:
+            t0 = time.perf_counter()
             _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
+            add_timing("append.index.ingest_flags", t0)
     return session_id
 
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1531,7 +1531,12 @@ async def test_codex_append_uses_existing_session_identity_when_tail_lacks_sessi
         assert {
             "append.archive_open",
             "append.blob_write",
+            "append.index.blocks",
             "append.index_parsed_write",
+            "append.index.messages",
+            "append.index.provider_usage_rollup",
+            "append.index.session_events",
+            "append.index.session_upsert",
             "append.json_stream",
             "append.provider_parse",
             "append.raw_and_index_write",


### PR DESCRIPTION
## Summary

Adds deep append index timing buckets inside `write_parsed_session_to_archive` and threads the existing live append timing sink into that writer.

## Problem

The deployed #2396 build split live append latency into source raw evidence writes versus parsed index writes. Live logs show source writes are about 15-17 ms while `append.index_parsed_write` is about 5.45-5.50 s, so the remaining opaque latency is inside the index writer.

## Solution

`write_parsed_session_to_archive` now accepts an optional `stage_timings_s` sink and records major phases inside the transaction: session upsert, append merge preparation, message/block writes, session events, provider usage rollup, session count refresh, graph resolution, and related projection writes. The normal storage API remains backward-compatible because callers only opt in by passing the sink. The live append path passes its existing timing dict through, and the Codex append regression asserts representative deep buckets are present.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k codex_append_uses_existing_session_identity_when_tail_lacks_session_meta`
- `devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #2391
