### PR TITLE
perf: scope append attachment refcounts

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -377,6 +377,7 @@ def write_parsed_session_to_archive(
             session.attachments,
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
+            refresh_all_ref_counts=not merge_append,
         )
         add_timing("append.index.attachments", t0)
         t0 = time.perf_counter()
@@ -1486,6 +1487,7 @@ def _write_attachments(
     *,
     position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
+    refresh_all_ref_counts: bool = True,
 ) -> None:
     by_native_message_id = {
         message.provider_message_id: _message_id(
@@ -1498,6 +1500,7 @@ def _write_attachments(
         for fallback_position, message in enumerate(messages)
         if message.provider_message_id and message.provider_message_id not in duplicate_native_ids
     }
+    touched_attachment_ids: set[str] = set()
     for attachment in attachments:
         attachment_id = _attachment_id(session_id, attachment)
         message_id = (
@@ -1505,6 +1508,7 @@ def _write_attachments(
         )
         if message_id is None:
             continue
+        touched_attachment_ids.add(attachment_id)
         conn.execute(
             """
             INSERT INTO attachments (
@@ -1543,13 +1547,28 @@ def _write_attachments(
         )
         ref_id = f"{message_id}:attachment:{ref_position}"
         _write_attachment_native_ids(conn, ref_id, attachment)
+    if refresh_all_ref_counts:
+        conn.execute(
+            """
+            UPDATE attachments
+            SET ref_count = (
+                SELECT COUNT(*) FROM attachment_refs WHERE attachment_refs.attachment_id = attachments.attachment_id
+            )
+            """
+        )
+        return
+    if not touched_attachment_ids:
+        return
+    placeholders = ",".join("?" for _ in touched_attachment_ids)
     conn.execute(
-        """
+        f"""
         UPDATE attachments
         SET ref_count = (
             SELECT COUNT(*) FROM attachment_refs WHERE attachment_refs.attachment_id = attachments.attachment_id
         )
-        """
+        WHERE attachment_id IN ({placeholders})
+        """,
+        tuple(sorted(touched_attachment_ids)),
     )
 
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1320,6 +1320,68 @@ def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:
     assert append_changes < 80
 
 
+def test_merge_append_without_attachments_does_not_refresh_all_attachment_counts(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    unrelated_attachment_count = 120
+    for i in range(unrelated_attachment_count):
+        write_parsed_session_to_archive(
+            conn,
+            ParsedSession(
+                source_name=Provider.CHATGPT,
+                provider_session_id=f"attachment-neighbor-{i}",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=f"neighbor attachment {i}")],
+                    )
+                ],
+                attachments=[
+                    ParsedAttachment(
+                        provider_attachment_id=f"att-{i}",
+                        message_provider_id="m1",
+                        name=f"neighbor-{i}.txt",
+                        mime_type="text/plain",
+                        path=f"neighbor-{i}.txt",
+                    )
+                ],
+            ),
+        )
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-append-no-attachments",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                text="append baseline without attachments",
+                is_active_leaf=True,
+            )
+        ],
+    )
+    second = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-append-no-attachments",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                text="append tail without attachments",
+                is_active_leaf=True,
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    before_changes = conn.total_changes
+    write_parsed_session_to_archive(conn, second, merge_append=True)
+    append_changes = conn.total_changes - before_changes
+
+    assert conn.execute("SELECT COUNT(*) FROM attachments").fetchone()[0] == unrelated_attachment_count
+    assert conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)).fetchone()[0] == 2
+    assert append_changes < 80
+
+
 def test_provider_usage_rollup_clears_stale_message_pricing(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(


### PR DESCRIPTION
## Summary

Scopes attachment refcount refreshes on merge-append writes so active Codex appends without attachments no longer update every attachment row in the archive.

## Problem

The deployed deep timing build showed `append.index.attachments` consuming about 5.3s of a 5.45s active Codex append even when the appended tail payload had no attachments. The cause was `_write_attachments` ending every parsed-session write with an archive-wide `UPDATE attachments SET ref_count = (...)`.

## Solution

Full-session replacements keep the existing global refcount refresh, preserving cleanup behavior after old `attachment_refs` are deleted. Merge-append writes now refresh only attachment IDs touched by the appended payload, and append payloads with no attachments skip attachment refcount refresh entirely. A regression seeds 120 unrelated attachments, appends a no-attachment Codex tail, and asserts the write count remains bounded.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'merge_append_clears_only_existing_active_leaf or merge_append_without_attachments_does_not_refresh_all_attachment_counts'`
- `devtools test tests/unit/sources/test_live_watcher.py -k codex_append_uses_existing_session_identity_when_tail_lacks_session_meta`
- `devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #2391
