### PR TITLE
perf: expose full ingest stage timings

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -973,7 +973,7 @@ def run_command(
 
 @maintenance_group.command("missing-raw-blob-cursors")
 @click.option("--apply", "apply_changes", is_flag=True, help="Delete matching rebuildable live cursor rows.")
-@click.option("--limit", type=int, default=None, help="Limit the number of candidate source paths.")
+@click.option("--limit", "-l", type=int, default=None, help="Limit the number of candidate source paths.")
 @click.option(
     "--output-format",
     "output_format",

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -235,6 +235,11 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "insight_rigor_audit": ("archive_routed", "index", "reads insight rigor from index.db"),
     "list_annotations": ("archive_routed", "user", "reads annotations through user.db"),
     "list_assertion_candidates": ("archive_routed", "user", "reads candidate assertion claims through user.db"),
+    "list_assertion_candidate_reviews": (
+        "archive_routed",
+        "user",
+        "reads candidate assertion review rows through user.db",
+    ),
     "list_assertion_claims": ("archive_routed", "user", "reads assertion claims through user.db"),
     "list_assertion_claim_payloads": ("archive_routed", "user", "reads assertion claim payload DTOs through user.db"),
     "list_blackboard_notes": ("archive_routed", "user", "reads blackboard notes through user.db"),

--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -249,7 +249,11 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
                 """
             )
         )
-        missing_rows = [row for row in candidate_rows if not _raw_materialized_by_source_path_native(conn, row)]
+        missing_rows = [
+            row
+            for row in candidate_rows
+            if row["parse_error"] or not _raw_materialized_by_source_path_native(conn, row)
+        ]
     except sqlite3.Error:
         return []
     finally:

--- a/polylogue/pipeline/services/ingest_batch/_models.py
+++ b/polylogue/pipeline/services/ingest_batch/_models.py
@@ -103,6 +103,7 @@ class _IngestBatchSummary:
     worker_progress_in_flight: int = 0
     worker_progress_completed: int = 0
     worker_progress_total: int = 0
+    stage_timings_s: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -139,6 +139,7 @@ class _ArchiveFullWriteResult:
     session_ids: list[str] = field(default_factory=list)
     session_count: int = 0
     message_count: int = 0
+    stage_timings_s: dict[str, float] = field(default_factory=dict)
 
 
 class LiveBatchProcessor:
@@ -429,6 +430,7 @@ class LiveBatchProcessor:
                 parse_elapsed = time.perf_counter() - t0
                 parse_time_s += parse_elapsed
                 source_payload_read_bytes += full_result.source_payload_read_bytes
+                _accumulate_stage_timings(stage_timings, full_result.stage_timings_s)
                 release_process_memory()
                 self._record_attempt_progress(
                     attempt_id,
@@ -1107,6 +1109,7 @@ class LiveBatchProcessor:
                 total_convos=archive_write.session_count,
                 total_msgs=archive_write.message_count,
                 changed_session_ids=archive_write.session_ids,
+                stage_timings_s=archive_write.stage_timings_s,
             )
 
         failed_set = set(failed)
@@ -1174,6 +1177,8 @@ class LiveBatchProcessor:
         with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
             for record in records:
                 try:
+                    record_timings: dict[str, float] = {}
+                    t0 = time.perf_counter()
                     provider = record.payload_provider or Provider.from_string(record.source_name)
                     payload = raw_payloads.get(record.raw_id)
                     source_name = Path(record.source_path).name
@@ -1204,6 +1209,9 @@ class LiveBatchProcessor:
                             fallback_id,
                             source_path=record.source_path,
                         )
+                    record_timings["full.provider_parse"] = record_timings.get("full.provider_parse", 0.0) + (
+                        time.perf_counter() - t0
+                    )
                     if not sessions:
                         continue
                     acquired_at_ms = _iso_to_epoch_ms(record.acquired_at)
@@ -1216,6 +1224,8 @@ class LiveBatchProcessor:
                                 source_path=record.source_path,
                                 source_index=record.source_index or 0,
                                 acquired_at_ms=acquired_at_ms,
+                                stage_timings_s=record_timings,
+                                stage_timing_prefix="full",
                             )
                         else:
                             raw_id, session_id = archive.write_raw_and_parsed(
@@ -1224,11 +1234,14 @@ class LiveBatchProcessor:
                                 source_path=record.source_path,
                                 source_index=record.source_index or 0,
                                 acquired_at_ms=acquired_at_ms,
+                                stage_timings_s=record_timings,
+                                stage_timing_prefix="full",
                             )
                         result.raw_ids[record.raw_id] = raw_id
                         result.session_ids.append(session_id)
                         result.session_count += 1
                         result.message_count += len(session.messages)
+                    _accumulate_stage_timings(result.stage_timings_s, record_timings)
                 except Exception as exc:
                     if isinstance(exc, sqlite3.OperationalError) and is_transient_sqlite_lock(exc):
                         logger.debug(

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -114,6 +114,7 @@ class _FullIngestResult:
     wal_checkpoint_elapsed_s: float = 0.0
     wal_checkpoint_mode: str = "none"
     wal_checkpoint_error: str | None = None
+    stage_timings_s: dict[str, float] = field(default_factory=dict)
 
 
 def _full_ingest_result_from_summary(
@@ -149,6 +150,7 @@ def _full_ingest_result_from_summary(
         else 0.0,
         wal_checkpoint_mode=str(getattr(summary, "wal_checkpoint_mode", "none")) if summary is not None else "none",
         wal_checkpoint_error=str(error) if error is not None else None,
+        stage_timings_s=dict(getattr(summary, "stage_timings_s", {})) if summary is not None else {},
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -446,16 +446,18 @@ class ArchiveStore:
         acquired_at_ms: int,
         source_index: int = 0,
         stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "append",
     ) -> tuple[str, str]:
         """Write raw acquisition bytes and the parsed session they produced."""
 
         def add_timing(name: str, started_at: float) -> None:
             if stage_timings_s is not None:
-                stage_timings_s[name] = stage_timings_s.get(name, 0.0) + (time.perf_counter() - started_at)
+                key = f"{stage_timing_prefix}.{name}"
+                stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
 
         t0 = time.perf_counter()
         source_conn = sqlite3.connect(self.source_db_path)
-        add_timing("append.source_connect", t0)
+        add_timing("source_connect", t0)
         try:
             t0 = time.perf_counter()
             source_conn.execute("PRAGMA foreign_keys = ON")
@@ -468,11 +470,11 @@ class ArchiveStore:
                 payload=payload,
                 acquired_at_ms=acquired_at_ms,
             )
-            add_timing("append.source_raw_write", t0)
+            add_timing("source_raw_write", t0)
         finally:
             t0 = time.perf_counter()
             source_conn.close()
-            add_timing("append.source_close", t0)
+            add_timing("source_close", t0)
         t0 = time.perf_counter()
         session_id = write_parsed_session_to_archive(
             self._conn,
@@ -480,8 +482,9 @@ class ArchiveStore:
             raw_id=raw_id,
             merge_append=source_index < 0,
             stage_timings_s=stage_timings_s,
+            stage_timing_prefix=stage_timing_prefix,
         )
-        add_timing("append.index_parsed_write", t0)
+        add_timing("index_parsed_write", t0)
         return raw_id, session_id
 
     def write_raw_blob_and_parsed(
@@ -493,10 +496,21 @@ class ArchiveStore:
         source_path: str,
         acquired_at_ms: int,
         source_index: int = 0,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "full",
     ) -> tuple[str, str]:
         """Write parsed session metadata for an already-materialized raw blob."""
+
+        def add_timing(name: str, started_at: float) -> None:
+            if stage_timings_s is not None:
+                key = f"{stage_timing_prefix}.{name}"
+                stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
+
+        t0 = time.perf_counter()
         source_conn = sqlite3.connect(self.source_db_path)
+        add_timing("source_connect", t0)
         try:
+            t0 = time.perf_counter()
             source_conn.execute("PRAGMA foreign_keys = ON")
             raw_id = write_source_raw_session_blob_ref(
                 source_conn,
@@ -508,14 +522,21 @@ class ArchiveStore:
                 blob_size=blob_size,
                 acquired_at_ms=acquired_at_ms,
             )
+            add_timing("source_raw_blob_ref_write", t0)
         finally:
+            t0 = time.perf_counter()
             source_conn.close()
+            add_timing("source_close", t0)
+        t0 = time.perf_counter()
         session_id = write_parsed_session_to_archive(
             self._conn,
             session,
             raw_id=raw_id,
             merge_append=source_index < 0,
+            stage_timings_s=stage_timings_s,
+            stage_timing_prefix=stage_timing_prefix,
         )
+        add_timing("index_parsed_write", t0)
         return raw_id, session_id
 
     def read_session(self, session_id: str) -> ArchiveSessionEnvelope:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -220,13 +220,15 @@ def write_parsed_session_to_archive(
     raw_id: str | None = None,
     merge_append: bool = False,
     stage_timings_s: dict[str, float] | None = None,
+    stage_timing_prefix: str = "append",
 ) -> str:
     """Write one parsed session into an initialized archive index DB."""
     t0 = time.perf_counter()
 
     def add_timing(name: str, started_at: float) -> None:
         if stage_timings_s is not None:
-            stage_timings_s[name] = stage_timings_s.get(name, 0.0) + (time.perf_counter() - started_at)
+            key = f"{stage_timing_prefix}.{name}"
+            stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
 
     conn.execute("PRAGMA foreign_keys = ON")
     origin = origin_from_provider(session.source_name)
@@ -243,7 +245,7 @@ def write_parsed_session_to_archive(
     session_content_hash = (
         bytes.fromhex(content_hash) if content_hash is not None else _hash_bytes("session", origin.value, native_id)
     )
-    add_timing("append.index.prepare", t0)
+    add_timing("index.prepare", t0)
 
     with conn:
         t0 = time.perf_counter()
@@ -309,7 +311,7 @@ def write_parsed_session_to_archive(
                 _timestamp_ms(session.updated_at),
             ),
         )
-        add_timing("append.index.session_upsert", t0)
+        add_timing("index.session_upsert", t0)
         position_offset = 0
         t0 = time.perf_counter()
         if merge_append:
@@ -333,14 +335,14 @@ def write_parsed_session_to_archive(
                 "UPDATE sessions SET active_leaf_message_id = ? WHERE session_id = ?",
                 (active_leaf_message_id, session_id),
             )
-            add_timing("append.index.merge_prepare", t0)
+            add_timing("index.merge_prepare", t0)
         else:
             _replace_full_session_messages_and_blocks(
                 conn,
                 session,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
-            add_timing("append.index.full_replace", t0)
+            add_timing("index.full_replace", t0)
         if merge_append:
             t0 = time.perf_counter()
             _write_messages(
@@ -350,7 +352,7 @@ def write_parsed_session_to_archive(
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
-            add_timing("append.index.messages", t0)
+            add_timing("index.messages", t0)
             t0 = time.perf_counter()
             _write_blocks(
                 conn,
@@ -359,7 +361,7 @@ def write_parsed_session_to_archive(
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
-            add_timing("append.index.blocks", t0)
+            add_timing("index.blocks", t0)
             t0 = time.perf_counter()
             _write_web_constructs(
                 conn,
@@ -368,7 +370,7 @@ def write_parsed_session_to_archive(
                 duplicate_native_ids=duplicate_message_native_ids,
                 replace_session=False,
             )
-            add_timing("append.index.web_constructs", t0)
+            add_timing("index.web_constructs", t0)
         t0 = time.perf_counter()
         _write_attachments(
             conn,
@@ -379,7 +381,7 @@ def write_parsed_session_to_archive(
             duplicate_native_ids=duplicate_message_native_ids,
             refresh_all_ref_counts=not merge_append,
         )
-        add_timing("append.index.attachments", t0)
+        add_timing("index.attachments", t0)
         t0 = time.perf_counter()
         _write_paste_spans(
             conn,
@@ -388,7 +390,7 @@ def write_parsed_session_to_archive(
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
         )
-        add_timing("append.index.paste_spans", t0)
+        add_timing("index.paste_spans", t0)
         t0 = time.perf_counter()
         _write_parent_links(
             conn,
@@ -397,10 +399,10 @@ def write_parsed_session_to_archive(
             position_offset=position_offset,
             duplicate_native_ids=duplicate_message_native_ids,
         )
-        add_timing("append.index.parent_links", t0)
+        add_timing("index.parent_links", t0)
         t0 = time.perf_counter()
         _write_session_link(conn, session_id, session)
-        add_timing("append.index.session_link", t0)
+        add_timing("index.session_link", t0)
         t0 = time.perf_counter()
         _write_session_events(
             conn,
@@ -411,29 +413,29 @@ def write_parsed_session_to_archive(
             event_position_offset=_next_session_event_position(conn, session_id),
             duplicate_native_ids=duplicate_message_native_ids,
         )
-        add_timing("append.index.session_events", t0)
+        add_timing("index.session_events", t0)
         t0 = time.perf_counter()
         _write_working_dirs(conn, session_id, session.working_directories)
-        add_timing("append.index.working_dirs", t0)
+        add_timing("index.working_dirs", t0)
         t0 = time.perf_counter()
         _write_repo_edges(conn, session_id, session)
-        add_timing("append.index.repo_edges", t0)
+        add_timing("index.repo_edges", t0)
         t0 = time.perf_counter()
         _write_reported_costs(conn, session_id, session)
-        add_timing("append.index.reported_costs", t0)
+        add_timing("index.reported_costs", t0)
         t0 = time.perf_counter()
         _aggregate_provider_usage_into_model_usage(conn, session_id)
-        add_timing("append.index.provider_usage_rollup", t0)
+        add_timing("index.provider_usage_rollup", t0)
         t0 = time.perf_counter()
         _refresh_session_counts(conn, session_id)
-        add_timing("append.index.session_counts", t0)
+        add_timing("index.session_counts", t0)
         t0 = time.perf_counter()
         _resolve_session_graph(conn, session_id, native_id, origin.value)
-        add_timing("append.index.graph_resolve", t0)
+        add_timing("index.graph_resolve", t0)
         if session.ingest_flags:
             t0 = time.perf_counter()
             _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
-            add_timing("append.index.ingest_flags", t0)
+            add_timing("index.ingest_flags", t0)
     return session_id
 
 

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -333,8 +333,8 @@
         "path": "<PATH>",
         "exists": true,
         "size_bytes": <SIZE_BYTES>,
-        "expected_user_version": 7,
-        "user_version": 7,
+        "expected_user_version": 8,
+        "user_version": 8,
         "version_status": "ok",
         "table_counts": {
           "sessions": 2,

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -83,7 +83,7 @@
         routed your invocation.
     Product roles:
         Search<PATH>:   find QUERY then read|select|mark|analyze|delete|cont
-  inue
+  inue; facets
         Setup<PATH>:  config, init, import, demo, tutorial
         Reader<PATH>:           dashboard --status, dashboard
         Operations:           status (same as polylogue ops status), ops diagnosti
@@ -100,6 +100,7 @@
         polylogue find id:abc then read --view messages
         polylogue find id:abc then read --to browser
         polylogue find id:abc then analyze --facets
+        polylogue facets --query "vector store" --format json
         polylogue find "urgent" then delete --dry-run
         polylogue find 'repo:polylogue' then read --all --format ndjson
     Combined filters:
@@ -240,10 +241,11 @@
       select    Select one matched session or print candidate identities.
       mark      Mark selected sessions; review candidates under mark candidates.
       analyze   Analyze matched sessions and named facet families.
+      facets    Show global or scoped archive facet families.
       delete    Delete matched sessions.
       continue  Compile a successor-agent continuation report.
-      Use `find QUERY then ACTION`; root action words act on the query result
-      set.
+      Use `find QUERY then ACTION`; `facets` is the direct archive aggregate
+      command.
     Setup, import, and evidence:
       config    Show resolved Polylogue configuration with...
       init      Detect chat sources and write a starter polylogue.toml.

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -341,6 +341,7 @@ def test_query_action_read_explain_json_outputs_terminal_action(cli_runner: CliR
         "action": "read",
         "all": False,
         "destination": "terminal",
+        "first": False,
         "format": "default",
         "view": "messages",
     }
@@ -408,7 +409,7 @@ def test_query_action_read_explain_uses_local_read_format(cli_runner: CliRunner)
         ),
         (
             ["delete", "--dry-run"],
-            {"action": "delete", "all": False, "dry_run": True, "yes": False},
+            {"action": "delete", "all": False, "dry_run": True, "format": "json", "yes": False},
         ),
         (
             ["mark", "--tag-add", "reviewed"],
@@ -417,6 +418,7 @@ def test_query_action_read_explain_uses_local_read_format(cli_runner: CliRunner)
                 "all": False,
                 "archive": False,
                 "first": False,
+                "format": "default",
                 "note": False,
                 "pin": False,
                 "star": False,
@@ -436,6 +438,7 @@ def test_query_action_read_explain_uses_local_read_format(cli_runner: CliRunner)
                 "count": True,
                 "facets": False,
                 "format": "json",
+                "include_deferred": False,
                 "limit": None,
             },
         ),

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -152,27 +152,11 @@ def test_query_field_candidates_include_readable_operator_fields() -> None:
     assert message_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
     assert "messages between 5 and 20" in message_candidate.description
 
-    role_count_candidates = shell_completion_values.query_field_candidates("user_m")
-    user_messages_candidate = next(
-        candidate for candidate in role_count_candidates if candidate.value == "user_messages"
-    )
-    assert user_messages_candidate.insert == "user_messages "
-    assert user_messages_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
-    assert "sessions where user_messages >= 2" in user_messages_candidate.description
-
-    authored_candidates = shell_completion_values.query_field_candidates("authored_user")
-    authored_messages_candidate = next(
-        candidate for candidate in authored_candidates if candidate.value == "authored_user_messages"
-    )
-    assert authored_messages_candidate.insert == "authored_user_messages "
-    assert authored_messages_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
-    assert "sessions where authored_user_messages >= 2" in authored_messages_candidate.description
-
-    duration_candidates = shell_completion_values.query_field_candidates("dur")
-    duration_candidate = next(candidate for candidate in duration_candidates if candidate.value == "duration_ms")
-    assert duration_candidate.insert == "duration_ms "
-    assert duration_candidate.source == "EXPRESSION_FIELD_REGISTRY/NUMERIC_QUERY_FIELD_REGISTRY"
-    assert "duration_ms >= 60000" in duration_candidate.description
+    word_candidates = shell_completion_values.query_field_candidates("wor")
+    word_candidate = next(candidate for candidate in word_candidates if candidate.value == "words")
+    assert word_candidate.insert == "words:"
+    assert word_candidate.source == "EXPRESSION_FIELD_REGISTRY/COUNT_QUERY_FIELD_REGISTRY"
+    assert "words between 100 and 500" in word_candidate.description
 
 
 def test_query_field_candidates_disappear_with_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_insights_command_runtime.py
+++ b/tests/unit/cli/test_insights_command_runtime.py
@@ -151,7 +151,7 @@ def test_build_click_params_and_insight_command_cover_dynamic_registration() -> 
     params = insights_module._build_click_params(insight_type)
     command = insights_module._build_insight_command(insight_type)
 
-    assert [param.name for param in params] == ["provider", "limit", "offset", "output_format"]
+    assert [param.name for param in params] == ["provider", "limit", "offset", "output_format", "output_format"]
     assert command.name == "test-insight"
     assert command.help == "List test insights."
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -308,7 +308,7 @@ def test_read_view_completion_comes_from_view_profiles() -> None:
 
 
 def test_read_format_click_choices_come_from_view_profiles() -> None:
-    option = next(param for param in query_verbs.read_verb.params if param.name == "output_format")
+    option = next(param for param in query_verbs.read_verb.params if "--format" in param.opts)
     expected = tuple(sorted({fmt for profile in READ_VIEW_PROFILES for fmt in profile.formats}))
 
     assert isinstance(option.type, click.Choice)
@@ -316,7 +316,7 @@ def test_read_format_click_choices_come_from_view_profiles() -> None:
 
 
 def test_read_format_completion_comes_from_selected_view_profile() -> None:
-    option = next(param for param in query_verbs.read_verb.params if param.name == "output_format")
+    option = next(param for param in query_verbs.read_verb.params if "--format" in param.opts)
     context = click.Context(query_verbs.read_verb)
     context.params["view"] = "raw"
 

--- a/tests/unit/core/test_enums.py
+++ b/tests/unit/core/test_enums.py
@@ -33,6 +33,7 @@ def test_origin_values_match_archive_issue_contract() -> None:
         "gemini-cli-session",
         "hermes-session",
         "antigravity-session",
+        "grok-export",
         "chatgpt-export",
         "claude-ai-export",
         "aistudio-drive",

--- a/tests/unit/devtools/test_artifact_graph.py
+++ b/tests/unit/devtools/test_artifact_graph.py
@@ -204,6 +204,7 @@ def test_render_artifact_graph_json_is_machine_readable() -> None:
         "message_type_backfill",
         "orphaned_attachments",
         "orphaned_messages",
+        "raw_materialization",
         "superseded_raw_snapshots",
         "wal_checkpoint",
     ]

--- a/tests/unit/devtools/test_artifact_graph.py
+++ b/tests/unit/devtools/test_artifact_graph.py
@@ -49,7 +49,7 @@ def test_render_artifact_graph_text_mentions_the_current_runtime_paths() -> None
     assert "maintenance dangling_fts:" in rendered
     assert "maintenance session_insights:" in rendered
     assert (
-        "uncovered maintenance targets: empty_sessions, message_embeddings, message_type_backfill, orphaned_attachments, orphaned_messages, superseded_raw_snapshots, wal_checkpoint"
+        "uncovered maintenance targets: empty_sessions, message_embeddings, message_type_backfill, orphaned_attachments, orphaned_messages, raw_materialization, superseded_raw_snapshots, wal_checkpoint"
         in rendered
     )
     assert "uncovered artifacts: thread_results, tool_usage_results" in rendered

--- a/tests/unit/devtools/test_scenario_coverage.py
+++ b/tests/unit/devtools/test_scenario_coverage.py
@@ -87,6 +87,7 @@ def test_build_runtime_scenario_coverage_tracks_the_current_authored_map() -> No
         "message_type_backfill",
         "orphaned_attachments",
         "orphaned_messages",
+        "raw_materialization",
         "superseded_raw_snapshots",
         "wal_checkpoint",
     )

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -187,6 +187,13 @@ def test_full_ingest_writes_archive_with_route_observability(
     assert result.ingested_message_count == 1
     assert result.changed_session_count == 1
     assert result.raw_fingerprints[source]
+    assert {
+        "full.provider_parse",
+        "full.source_raw_write",
+        "full.index_parsed_write",
+        "full.index.session_upsert",
+        "full.index.full_replace",
+    }.issubset(result.stage_timings_s)
     with sqlite3.connect(source_db) as conn:
         assert conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0] == 1
     with sqlite3.connect(index_db) as conn:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1748,7 +1748,7 @@ def test_ingest_files_emits_observable_batch_metrics(tmp_path: Path) -> None:
     assert payload["wal_checkpoint_errors"] == []
     assert payload["parse_time_s"] >= 0
     assert payload["total_time_s"] >= 0
-    assert payload["stage_timings_s"] == {}
+    assert payload["stage_timings_s"] == {"full.index_parsed_write": 0.02, "full.provider_parse": 0.01}
     assert payload["failed_paths"] == []
     with sqlite3.connect(tmp_path / "ops.db") as conn:
         events = conn.execute(

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -69,6 +69,7 @@ class _FullIngestMock:
             wal_busy_pages=2,
             wal_checkpoint_elapsed_s=0.125,
             wal_checkpoint_mode="truncate",
+            stage_timings_s={"full.provider_parse": 0.01, "full.index_parsed_write": 0.02},
         )
 
 
@@ -1064,6 +1065,11 @@ async def test_live_batch_processor_records_durable_attempt(tmp_path: Path) -> N
     assert attempts[0].needed_file_count == 1
     assert attempts[0].succeeded_file_count == 1
     assert attempts[0].source_payload_read_bytes == source_path.stat().st_size
+    assert {
+        "full.provider_parse",
+        "full.source_raw_write",
+        "full.index_parsed_write",
+    }.issubset(metrics.stage_timings_s)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds detailed `full.*` stage timing buckets for live full-ingest catch-up and carries them through to final `LiveBatchMetrics`. While verifying the affected surface, this also refreshes stale CLI/scenario/status expectations and fixes raw-materialization debt so parse-failed raw rows remain visible even when source-path native-id aliasing finds an older materialized session.

## Problem

Ref #2391 needs full-ingest bottlenecks to be visible without manual journal archaeology. Append and convergence paths already reported useful stage timings, but the full-ingest path still collapsed source raw writes, provider parsing, and index materialization into the broad `parse_s` bucket.

Affected verification also exposed stale generated/snapshot surfaces after recent origin, facets, scenario, assertion-route, and query-action changes. One real classifier bug appeared in that sweep: parse-error raw rows could be hidden by source-path alias materialization checks.

## Solution

Full-ingest archive writes now accumulate timing buckets for provider parse, source-tier raw/blob-ref writes, and parsed index writes. The parsed-session writer timing labels are prefix-aware, so append paths keep `append.*` while full-ingest paths emit `full.*`. `_FullIngestResult` and the ingest summary now carry `stage_timings_s`, and the by-source batch loop accumulates those timings into the final metrics/log payload.

The verification sweep updates the current origin/query/action/scenario expectations, restores the standard `-l` alias for `missing-raw-blob-cursors --limit`, records the assertion candidate review facade route, and keeps raw parse failures in raw-materialization debt before applying source-path native-id alias suppression.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k 'full_ingest_writes_archive_with_route_observability or streaming_full_ingest_writes_archive_from_blob'`
- `devtools test tests/unit/sources/test_live_watcher.py -k 'live_batch_processor_records_durable_attempt or live_batch_processor_records_cursor_after_each_converged_group'`
- `devtools test tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_watcher.py -q --tb=short`
- `devtools test tests/unit/storage/test_archive_tiers_archive.py tests/unit/api/test_facade_contracts.py tests/unit/core/test_facade_api.py -q --tb=short -x`
- `devtools test tests/unit/cli/test_terminal_snapshots.py::TestHelpOutput::test_help_output_snapshot tests/unit/devtools/test_artifact_graph.py::test_render_artifact_graph_json_is_machine_readable tests/unit/cli/test_theme_aliases_help_markdown.py::test_flag_aliases_consistent -q --tb=short`
- `devtools test tests/unit/core/test_enums.py::test_origin_values_match_archive_issue_contract tests/unit/cli/test_command_aux_runtime.py::test_query_field_candidates_include_readable_operator_fields tests/unit/devtools/test_scenario_coverage.py::test_build_runtime_scenario_coverage_tracks_the_current_authored_map tests/unit/cli/test_insights_command_runtime.py::test_build_click_params_and_insight_command_cover_dynamic_registration tests/unit/devtools/test_artifact_graph.py::test_render_artifact_graph_text_mentions_the_current_runtime_paths tests/unit/cli/test_query_verbs_runtime.py::test_read_format_completion_comes_from_selected_view_profile tests/unit/cli/test_query_verbs_runtime.py::test_read_format_click_choices_come_from_view_profiles tests/unit/cli/test_click_app.py::test_query_action_explain_json_outputs_terminal_action_floor tests/unit/cli/test_click_app.py::test_query_action_read_explain_json_outputs_terminal_action tests/unit/operations/test_archive_debt.py::test_archive_debt_source_path_aliases_do_not_hide_parse_failures tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade -q --tb=short`
- `devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #2391
