### PR TITLE
perf: expose insight refresh stage timings

### DIFF
--- a/polylogue/daemon/convergence.py
+++ b/polylogue/daemon/convergence.py
@@ -45,6 +45,20 @@ class StageState(Enum):
 
 
 @dataclass(frozen=True, slots=True)
+class StageExecutionResult:
+    """Optional rich result for convergence stages that report sub-timings."""
+
+    success: bool
+    stage_timings_s: dict[str, float] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
+StageExecuteReturn = bool | StageExecutionResult
+
+
+@dataclass(frozen=True, slots=True)
 class ConvergenceStage:
     """A named pipeline stage with a check function and an execute function."""
 
@@ -53,15 +67,15 @@ class ConvergenceStage:
     # Check returns True if this stage needs work for the given file.
     check: Callable[[Path], bool]
     # Execute performs the work. Returns True on success.
-    execute: Callable[[Path], bool]
+    execute: Callable[[Path], StageExecuteReturn]
     # Optional batch check/execute pair for stages that can collapse many
     # changed source paths into one repair transaction.
     check_many: Callable[[Sequence[Path]], set[Path]] | None = None
-    execute_many: Callable[[Sequence[Path]], bool] | None = None
+    execute_many: Callable[[Sequence[Path]], StageExecuteReturn] | None = None
     # Optional session-scoped pair for durable convergence debt retries.
     # These avoid resolving a failed derived subject back to source files.
     check_sessions: Callable[[Sequence[str]], set[str]] | None = None
-    execute_sessions: Callable[[Sequence[str]], bool] | None = None
+    execute_sessions: Callable[[Sequence[str]], StageExecuteReturn] | None = None
     # Can run in a worker process (CPU-bound, no SQLite write).
     cpu_bound: bool = False
     # Some stages intentionally return False after doing bounded successful
@@ -122,6 +136,23 @@ def _record_execute_result(
         return
     state.stages[stage_name] = StageState.FAILED
     state.error_count += 1
+
+
+def _coerce_execute_result(result: StageExecuteReturn) -> tuple[bool, dict[str, float]]:
+    if isinstance(result, StageExecutionResult):
+        return result.success, dict(result.stage_timings_s)
+    return bool(result), {}
+
+
+def _record_stage_times(
+    batch_stage_times: dict[str, float],
+    stage_name: str,
+    elapsed: float,
+    extra_stage_timings_s: dict[str, float],
+) -> None:
+    batch_stage_times[stage_name] = batch_stage_times.get(stage_name, 0.0) + elapsed
+    for name, value in extra_stage_timings_s.items():
+        batch_stage_times[name] = batch_stage_times.get(name, 0.0) + float(value)
 
 
 class DaemonConverger:
@@ -211,9 +242,9 @@ class DaemonConverger:
             try:
                 if stage.cpu_bound and self._executor is not None:
                     future = self._executor.submit(stage.execute, path)
-                    success = future.result()
+                    execute_result = future.result()
                 else:
-                    success = stage.execute(path)
+                    execute_result = stage.execute(path)
             except Exception as exc:
                 logger.warning(
                     "converger: execute failed for %s stage=%s: %s",
@@ -227,8 +258,12 @@ class DaemonConverger:
                 continue
 
             elapsed = time.perf_counter() - t_stage
+            success, extra_stage_timings_s = _coerce_execute_result(execute_result)
             state.stage_times[stage_name] = elapsed
             state.last_stage_times[stage_name] = elapsed
+            for name, value in extra_stage_timings_s.items():
+                state.stage_times[name] = value
+                state.last_stage_times[name] = value
             _record_execute_result(
                 state,
                 stage_name=stage_name,
@@ -297,7 +332,7 @@ class DaemonConverger:
                     state.stages[stage_name] = StageState.IN_PROGRESS
                     t_stage = time.perf_counter()
                     try:
-                        success = stage.execute(path)
+                        execute_result = stage.execute(path)
                     except Exception as exc:
                         logger.warning(
                             "converger: execute failed for %s stage=%s: %s",
@@ -311,9 +346,13 @@ class DaemonConverger:
                         continue
 
                     elapsed = time.perf_counter() - t_stage
-                    batch_stage_times[stage_name] = batch_stage_times.get(stage_name, 0.0) + elapsed
+                    success, extra_stage_timings_s = _coerce_execute_result(execute_result)
+                    _record_stage_times(batch_stage_times, stage_name, elapsed, extra_stage_timings_s)
                     state.stage_times[stage_name] = elapsed
                     state.last_stage_times[stage_name] = elapsed
+                    for name, value in extra_stage_timings_s.items():
+                        state.stage_times[name] = value
+                        state.last_stage_times[name] = value
                     _record_execute_result(
                         state,
                         stage_name=stage_name,
@@ -345,17 +384,21 @@ class DaemonConverger:
 
             t_stage = time.perf_counter()
             try:
-                success = stage.execute_many(tuple(batch_needs_work))
+                execute_result = stage.execute_many(tuple(batch_needs_work))
             except Exception as exc:
                 logger.warning("converger: batch execute failed stage=%s: %s", stage_name, exc)
-                success = False
+                execute_result = False
 
             elapsed = time.perf_counter() - t_stage
-            batch_stage_times[stage_name] = elapsed
+            success, extra_stage_timings_s = _coerce_execute_result(execute_result)
+            _record_stage_times(batch_stage_times, stage_name, elapsed, extra_stage_timings_s)
             for path in batch_needs_work:
                 state = self._file_states[path]
                 state.stage_times[stage_name] = elapsed
                 state.last_stage_times[stage_name] = elapsed
+                for name, value in extra_stage_timings_s.items():
+                    state.stage_times[name] = value
+                    state.last_stage_times[name] = value
                 _record_execute_result(
                     state,
                     stage_name=stage_name,
@@ -414,17 +457,21 @@ class DaemonConverger:
 
             t_stage = time.perf_counter()
             try:
-                success = stage.execute_sessions(tuple(batch_needs_work))
+                execute_result = stage.execute_sessions(tuple(batch_needs_work))
             except Exception as exc:
                 logger.warning("converger: session batch execute failed stage=%s: %s", stage_name, exc)
-                success = False
+                execute_result = False
 
             elapsed = time.perf_counter() - t_stage
-            batch_stage_times[stage_name] = elapsed
+            success, extra_stage_timings_s = _coerce_execute_result(execute_result)
+            _record_stage_times(batch_stage_times, stage_name, elapsed, extra_stage_timings_s)
             for session_id in batch_needs_work:
                 state = self._session_states[session_id]
                 state.stage_times[stage_name] = elapsed
                 state.last_stage_times[stage_name] = elapsed
+                for name, value in extra_stage_timings_s.items():
+                    state.stage_times[name] = value
+                    state.last_stage_times[name] = value
                 _record_execute_result(
                     state,
                     stage_name=stage_name,

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.config import load_polylogue_config
-from polylogue.daemon.convergence import ConvergenceStage
+from polylogue.daemon.convergence import ConvergenceStage, StageExecuteReturn, StageExecutionResult
 from polylogue.logging import get_logger
 from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.source_sessions import (
@@ -104,7 +104,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return False
 
-    def execute(path: Path) -> bool:
+    def execute(path: Path) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
             return _archive_fts_execute(archive_db, path)
@@ -160,7 +160,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return set()
 
-    def execute_many(paths: Sequence[Path]) -> bool:
+    def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         if not paths:
             return False
         archive_db = _active_archive_index_path(db_path)
@@ -210,7 +210,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return set()
 
-    def execute_sessions(session_ids: Sequence[str]) -> bool:
+    def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         if not session_ids:
             return True
         archive_db = _active_archive_index_path(db_path)
@@ -265,7 +265,7 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_check(archive_db, path) if archive_db is not None else False
 
-    def execute(path: Path) -> bool:
+    def execute(path: Path) -> StageExecuteReturn:
         if not _embedding_config_enabled():
             return True
         archive_db = _active_archive_index_path(db_path)
@@ -277,7 +277,7 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_check_many(archive_db, paths) if archive_db is not None else set()
 
-    def execute_many(paths: Sequence[Path]) -> bool:
+    def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         if not paths or not _embedding_config_enabled():
             return True
         archive_db = _active_archive_index_path(db_path)
@@ -289,7 +289,7 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_check_sessions(archive_db, session_ids) if archive_db is not None else set()
 
-    def execute_sessions(session_ids: Sequence[str]) -> bool:
+    def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         if not session_ids or not _embedding_config_enabled():
             return True
         archive_db = _active_archive_index_path(db_path)
@@ -341,7 +341,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return False
 
-    def execute(path: Path) -> bool:
+    def execute(path: Path) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
             return _archive_insights_execute(archive_db, path)
@@ -407,7 +407,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return set()
 
-    def execute_many(paths: Sequence[Path]) -> bool:
+    def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
             return _archive_insights_execute_many(archive_db, paths)
@@ -469,7 +469,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return set()
 
-    def execute_sessions(session_ids: Sequence[str]) -> bool:
+    def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
             return _archive_insights_execute_sessions(archive_db, session_ids)
@@ -1351,7 +1351,7 @@ def _archive_insights_check(db_path: Path, path: Path) -> bool:
         return False
 
 
-def _archive_insights_execute(db_path: Path, path: Path) -> bool:
+def _archive_insights_execute(db_path: Path, path: Path) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
@@ -1390,7 +1390,7 @@ def _archive_insights_check_many(db_path: Path, paths: Sequence[Path]) -> set[Pa
         return set()
 
 
-def _archive_insights_execute_many(db_path: Path, paths: Sequence[Path]) -> bool:
+def _archive_insights_execute_many(db_path: Path, paths: Sequence[Path]) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
@@ -1421,7 +1421,7 @@ def _archive_insights_check_sessions(db_path: Path, session_ids: Sequence[str]) 
         return set()
 
 
-def _archive_insights_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> bool:
+def _archive_insights_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
@@ -1437,7 +1437,7 @@ def _archive_insights_execute_sessions(db_path: Path, session_ids: Sequence[str]
         return False
 
 
-def _archive_insights_execute_ids(conn: sqlite3.Connection, session_ids: Sequence[str]) -> bool:
+def _archive_insights_execute_ids(conn: sqlite3.Connection, session_ids: Sequence[str]) -> StageExecuteReturn:
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
     session_ids = list(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
@@ -1455,10 +1455,13 @@ def _archive_insights_execute_ids(conn: sqlite3.Connection, session_ids: Sequenc
     # connection (name-based column reads throughout). The archive callers
     # use plain sqlite3.connect() without row_factory, so set it here.
     conn.row_factory = sqlite3.Row
+    stage_timings_s: dict[str, float] = {}
     counts = rebuild_session_insights_sync(
         conn,
         session_ids=list(session_ids),
         page_size=_DAEMON_INSIGHT_REBUILD_PAGE_SIZE,
+        stage_timings_s=stage_timings_s,
+        stage_timing_prefix="insights",
     )
     # rebuild_session_insights_sync commits internally when session_ids is
     # not None; no explicit conn.commit() needed here.
@@ -1472,7 +1475,7 @@ def _archive_insights_execute_ids(conn: sqlite3.Connection, session_ids: Sequenc
         counts.threads,
         len(remaining),
     )
-    return not remaining
+    return StageExecutionResult(success=not remaining, stage_timings_s=stage_timings_s)
 
 
 __all__ = [

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from collections import defaultdict
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -767,7 +768,15 @@ def rebuild_session_insights_sync(
     page_size: int = _SESSION_INSIGHT_REBUILD_PAGE_SIZE,
     progress_callback: ProgressCallback | None = None,
     progress_total: int | None = None,
+    stage_timings_s: dict[str, float] | None = None,
+    stage_timing_prefix: str = "insights",
 ) -> SessionInsightCounts:
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timings_s is None:
+            return
+        key = f"{stage_timing_prefix}.{name}"
+        stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
+
     session_chunks: Iterable[Sequence[str]]
     previous_profile_groups: set[tuple[str, str]] = set()
     thread_materialized_at_ms = _epoch_ms_or_none(now_iso()) or 0
@@ -802,12 +811,17 @@ def rebuild_session_insights_sync(
         session_chunks = iter_session_id_pages_sync(conn, page_size=page_size)
     else:
         session_ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids))
+        t0 = time.perf_counter()
         previous_profile_groups = {
             group
             for record in _session_profile_records_for_session_ids_sync(conn, session_ids)
             if (group := profile_provider_day(record)) is not None
         }
+        add_timing("existing_profile_groups", t0)
+        t0 = time.perf_counter()
         message_counts = _load_message_counts_sync(conn, session_ids)
+        add_timing("message_counts", t0)
+        t0 = time.perf_counter()
         session_chunks = (
             chunk.session_ids
             for chunk in _chunk_session_ids_by_message_budget_sync(
@@ -817,6 +831,7 @@ def rebuild_session_insights_sync(
                 message_budget=_SESSION_INSIGHT_REBUILD_MESSAGE_BUDGET,
             )
         )
+        add_timing("chunk_plan", t0)
     if session_ids is not None and not session_ids:
         conn.commit()
         return _empty_rebuild_counts()
@@ -828,32 +843,53 @@ def rebuild_session_insights_sync(
     saw_session_ids = False
     for chunk in session_chunks:
         saw_session_ids = True
+        t0 = time.perf_counter()
         batch = load_sync_batch(conn, chunk)
+        add_timing("load_batch", t0)
+        t0 = time.perf_counter()
         root_ids_by_session = thread_root_ids_sync(conn, chunk)
+        add_timing("thread_root_lookup", t0)
+        t0 = time.perf_counter()
+        hydrated_sessions = hydrate_sessions(batch)
+        add_timing("hydrate", t0)
+        t0 = time.perf_counter()
         record_bundles = build_session_insight_record_bundles(
-            hydrate_sessions(batch),
+            hydrated_sessions,
             compaction_counts_by_session=batch.compaction_counts_by_session,
             logical_session_ids_by_session=root_ids_by_session,
         )
+        add_timing("build_records", t0)
+        t0 = time.perf_counter()
         chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
+        add_timing("count_records", t0)
+        t0 = time.perf_counter()
         replace_session_profiles_bulk_sync(conn, [bundle.profile_record for bundle in record_bundles])
+        add_timing("write_profiles", t0)
+        t0 = time.perf_counter()
         replace_session_latency_profiles_bulk_sync(
             conn,
             [bundle.latency_profile_record for bundle in record_bundles],
         )
+        add_timing("write_latency_profiles", t0)
+        t0 = time.perf_counter()
         replace_session_work_events_bulk_sync(
             conn,
             {bundle.session_id: bundle.work_event_records for bundle in record_bundles},
         )
+        add_timing("write_work_events", t0)
+        t0 = time.perf_counter()
         replace_session_phases_bulk_sync(
             conn,
             {bundle.session_id: bundle.phase_records for bundle in record_bundles},
         )
+        add_timing("write_phases", t0)
+        t0 = time.perf_counter()
         for bundle in record_bundles:
             _stamp_bundle_materialization(conn, bundle)
             group = profile_provider_day(bundle.profile_record)
             if group is not None:
                 refreshed_profile_groups.add(group)
+        add_timing("stamp_materialization", t0)
         profile_count += chunk_profiles
         work_event_count += chunk_work_events
         phase_count += chunk_phases
@@ -879,18 +915,28 @@ def rebuild_session_insights_sync(
         return _empty_rebuild_counts()
 
     if session_ids is not None:
+        t0 = time.perf_counter()
         affected_roots = tuple(thread_root_ids_sync(conn, session_ids).values())
+        add_timing("affected_thread_roots", t0)
+        t0 = time.perf_counter()
         thread_count = _refresh_thread_roots_sync(
             conn,
             affected_roots,
             materialized_at_ms=thread_materialized_at_ms,
         )
+        add_timing("refresh_threads", t0)
+        t0 = time.perf_counter()
         refresh_sync_provider_day_aggregates(
             conn,
             previous_profile_groups | refreshed_profile_groups,
         )
+        add_timing("provider_day_aggregates", t0)
+        t0 = time.perf_counter()
         tag_rollup_count = conn.execute("SELECT COUNT(*) FROM session_tag_rollups").fetchone()[0]
+        add_timing("tag_rollup_count", t0)
+        t0 = time.perf_counter()
         conn.commit()
+        add_timing("commit", t0)
         return _finalize_rebuild_counts(
             profiles=profile_count,
             work_events=work_event_count,

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -15,6 +15,7 @@ import pytest
 import polylogue.daemon.convergence_stages as stages
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
+from polylogue.daemon.convergence import StageExecutionResult
 from polylogue.daemon.convergence_stages import (
     make_default_convergence_stages,
     make_embed_stage,
@@ -347,12 +348,16 @@ def test_insights_stage_rebuilds_sync_against_configured_db(
         *,
         session_ids: list[str],
         page_size: int,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "insights",
     ) -> SessionInsightCounts:
         nonlocal rebuilt
-        del conn
+        del conn, stage_timing_prefix
         rebuilt = True
         assert session_ids == ["conv-1"]
         assert page_size == 10
+        if stage_timings_s is not None:
+            stage_timings_s["insights.fake"] = 0.125
         return SessionInsightCounts(
             profiles=1,
             work_events=2,
@@ -595,8 +600,10 @@ def test_insights_stage_batches_sync_rebuild_chunks(
         *,
         session_ids: list[str],
         page_size: int,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "insights",
     ) -> SessionInsightCounts:
-        del conn
+        del conn, stage_timings_s, stage_timing_prefix
         rebuild_calls.append((session_ids, page_size))
         return SessionInsightCounts(profiles=2, work_events=0, phases=0, threads=0, tag_rollups=0)
 
@@ -755,8 +762,10 @@ def test_insights_session_rebuild_returns_false_when_still_stale(
         *,
         session_ids: list[str],
         page_size: int,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "insights",
     ) -> SessionInsightCounts:
-        del conn, session_ids, page_size
+        del conn, session_ids, page_size, stage_timings_s, stage_timing_prefix
         return SessionInsightCounts(profiles=0, work_events=0, phases=0, threads=0, tag_rollups=0)
 
     monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", no_op_rebuild)
@@ -784,7 +793,10 @@ def test_insights_stage_rebuilds_large_session_after_quiet_window(
 
     stage = make_insights_stage(db_path)
     assert stage.execute_sessions is not None
-    assert stage.execute_sessions([session_id]) is True
+    result = stage.execute_sessions([session_id])
+    assert result
+    assert isinstance(result, StageExecutionResult)
+    assert "insights.load_batch" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1
@@ -806,7 +818,10 @@ def test_insights_stage_rebuilds_small_active_session(
 
     stage = make_insights_stage(db_path)
     assert stage.execute_sessions is not None
-    assert stage.execute_sessions([session_id]) is True
+    result = stage.execute_sessions([session_id])
+    assert result
+    assert isinstance(result, StageExecutionResult)
+    assert "insights.load_batch" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1
@@ -889,9 +904,18 @@ def test_archive_insights_execute_ids_deduplicates_session_ids(tmp_path: Path, m
 
     seen_session_ids: list[list[str]] = []
 
-    def fake_rebuild(conn: sqlite3.Connection, *, session_ids: list[str], page_size: int) -> SimpleNamespace:
-        del conn, page_size
+    def fake_rebuild(
+        conn: sqlite3.Connection,
+        *,
+        session_ids: list[str],
+        page_size: int,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "insights",
+    ) -> SimpleNamespace:
+        del conn, page_size, stage_timing_prefix
         seen_session_ids.append(session_ids)
+        if stage_timings_s is not None:
+            stage_timings_s["insights.fake"] = 0.25
         return SimpleNamespace(profiles=1, work_events=0, phases=0, threads=0)
 
     monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fake_rebuild)
@@ -899,7 +923,7 @@ def test_archive_insights_execute_ids_deduplicates_session_ids(tmp_path: Path, m
     monkeypatch.setattr(stages, "_archive_stale_session_profile_ids", lambda _conn, _ids: [])
 
     with sqlite3.connect(db_path) as conn:
-        assert stages._archive_insights_execute_ids(
+        result = stages._archive_insights_execute_ids(
             conn,
             [
                 "codex-session:conv-dupe",
@@ -907,6 +931,9 @@ def test_archive_insights_execute_ids_deduplicates_session_ids(tmp_path: Path, m
                 "codex-session:conv-dupe",
             ],
         )
+        assert result
+        assert isinstance(result, StageExecutionResult)
+        assert result.stage_timings_s == {"insights.fake": 0.25}
 
     assert seen_session_ids == [["codex-session:conv-dupe"]]
 

--- a/tests/unit/daemon/test_daemon_convergence.py
+++ b/tests/unit/daemon/test_daemon_convergence.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from polylogue.daemon.convergence import ConvergenceStage, DaemonConverger, StageState
+from polylogue.daemon.convergence import ConvergenceStage, DaemonConverger, StageExecutionResult, StageState
 
 
 def test_converger_reports_only_current_run_stage_timings(tmp_path: Path) -> None:
@@ -161,6 +161,40 @@ def test_converger_batches_session_execution() -> None:
     assert set(stage_times) == {"insights"}
     assert all(state.converged for state in states.values())
     assert converger._session_states == {}
+
+
+def test_converger_propagates_nested_session_stage_timings() -> None:
+    def check_sessions(session_ids: Sequence[str]) -> set[str]:
+        return set(session_ids)
+
+    def execute_sessions(_session_ids: Sequence[str]) -> StageExecutionResult:
+        return StageExecutionResult(
+            success=True,
+            stage_timings_s={
+                "insights.load_batch": 0.25,
+                "insights.build_records": 0.5,
+            },
+        )
+
+    converger = DaemonConverger(
+        [
+            ConvergenceStage(
+                name="insights",
+                description="test session stage",
+                check=lambda _candidate: False,
+                execute=lambda _candidate: False,
+                check_sessions=check_sessions,
+                execute_sessions=execute_sessions,
+            )
+        ]
+    )
+
+    states, stage_times = converger.converge_sessions(["conv-a", "conv-b"])
+
+    assert set(stage_times) == {"insights", "insights.build_records", "insights.load_batch"}
+    assert stage_times["insights.build_records"] == 0.5
+    assert all(state.converged for state in states.values())
+    assert all(state.last_stage_times["insights.load_batch"] == 0.25 for state in states.values())
 
 
 def test_converger_keeps_bounded_session_false_as_pending_debt() -> None:


### PR DESCRIPTION
Summary

Expose nested daemon insight-refresh timings so full-ingest diagnostics can show where the large insights bucket is spent.

Problem

The Ref #2391 full-ingest benchmark showed a roughly ten-second insights convergence bucket for a single giant Codex session. The existing live metrics could not distinguish row loading, hydration, record derivation, timeline writes, thread refresh, provider-day rollups, or commit time.

Solution

Convergence stages may now return a StageExecutionResult that carries nested timing keys while existing boolean stages remain valid. The archive insight session executor records sync rebuild sub-stages under insights.* and returns those timings to the daemon converger, which folds them into the existing stage_timings_s map. Tests cover rich timing propagation and archive insight execution timing output.

Verification

- devtools test tests/unit/daemon/test_daemon_convergence.py -k 'stage_timings or batches_session_execution' tests/unit/daemon/test_convergence_stages.py -k 'archive_insights_execute_ids_deduplicates_session_ids or insights_stage_rebuilds_sync_against_configured_db or insights_stage_batches_sync_rebuild_chunks or insights_stage_rebuilds_large_session_after_quiet_window or insights_stage_rebuilds_small_active_session or insights_stage_scopes_session_debt_to_stale_profiles or archive_insights_execute_sessions_uses_write_connection_profile or archive_insights_execute_sessions_defers_transient_sqlite_lock' -q --tb=short: 8 passed, 29 deselected.
- devtools verify --quick: passed.

Ref #2391
