### PR TITLE
perf: expose insight profile timing

### DIFF
--- a/polylogue/archive/semantic/cost_compute.py
+++ b/polylogue/archive/semantic/cost_compute.py
@@ -11,23 +11,28 @@ from polylogue.archive.semantic.tokenizer import TOKENIZER_VERSION, estimate_tok
 
 if TYPE_CHECKING:
     from polylogue.archive.models import Session
+    from polylogue.archive.semantic.pricing import CostEstimatePayload
 
 _PRICE_SNAPSHOT_VERSION = "polylogue-curated-litellm-shaped-seed"
 
 
-def compute_session_cost(session: Session) -> SessionCostSummary:
+def compute_session_cost(
+    session: Session,
+    *,
+    session_estimate: CostEstimatePayload | None = None,
+) -> SessionCostSummary:
     """Compute per-model cost breakdown and aggregate cost summary."""
-    session_estimate = estimate_session_cost(session)
-    if session_estimate.status == "exact":
+    estimate = session_estimate or estimate_session_cost(session)
+    if estimate.status == "exact":
         return SessionCostSummary(
-            total_input_tokens=session_estimate.usage.input_tokens,
-            total_output_tokens=session_estimate.usage.output_tokens,
-            total_cache_read_tokens=session_estimate.usage.cache_read_tokens,
-            total_cache_write_tokens=session_estimate.usage.cache_write_tokens,
-            total_api_cost_usd=round(session_estimate.total_usd, 6),
+            total_input_tokens=estimate.usage.input_tokens,
+            total_output_tokens=estimate.usage.output_tokens,
+            total_cache_read_tokens=estimate.usage.cache_read_tokens,
+            total_cache_write_tokens=estimate.usage.cache_write_tokens,
+            total_api_cost_usd=round(estimate.total_usd, 6),
             total_credit_cost=0.0,
             total_subscription_equivalent_usd=round(
-                session_estimate.basis.subscription_equivalent_usd,
+                estimate.basis.subscription_equivalent_usd,
                 6,
             ),
             cost_provenance="provider_reported",
@@ -36,16 +41,16 @@ def compute_session_cost(session: Session) -> SessionCostSummary:
             price_snapshot_version=_PRICE_SNAPSHOT_VERSION,
             per_model=(
                 SessionCostBreakdown(
-                    normalized_model=session_estimate.normalized_model,
-                    provider_model_name=session_estimate.model_name,
-                    input_tokens=session_estimate.usage.input_tokens,
-                    output_tokens=session_estimate.usage.output_tokens,
-                    cache_read_tokens=session_estimate.usage.cache_read_tokens,
-                    cache_write_tokens=session_estimate.usage.cache_write_tokens,
-                    total_tokens=session_estimate.usage.total_tokens,
-                    api_cost_usd=round(session_estimate.total_usd, 6),
+                    normalized_model=estimate.normalized_model,
+                    provider_model_name=estimate.model_name,
+                    input_tokens=estimate.usage.input_tokens,
+                    output_tokens=estimate.usage.output_tokens,
+                    cache_read_tokens=estimate.usage.cache_read_tokens,
+                    cache_write_tokens=estimate.usage.cache_write_tokens,
+                    total_tokens=estimate.usage.total_tokens,
+                    api_cost_usd=round(estimate.total_usd, 6),
                     subscription_equivalent_usd=round(
-                        session_estimate.basis.subscription_equivalent_usd,
+                        estimate.basis.subscription_equivalent_usd,
                         6,
                     ),
                     confidence="reported",

--- a/polylogue/archive/session/runtime.py
+++ b/polylogue/archive/session/runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json as _json
+import time
+from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -231,13 +233,28 @@ def build_session_analysis(
     session: Session,
     *,
     facts: SessionSemanticFacts | None = None,
+    stage_timing_add: Callable[[str, float], None] | None = None,
 ) -> SessionAnalysis:
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timing_add is not None:
+            stage_timing_add(name, started_at)
+
+    t0 = time.perf_counter()
     semantic_facts = facts or build_session_semantic_facts(session)
+    add_timing("analysis.facts", t0)
+    t0 = time.perf_counter()
     phases = tuple(extract_phases(session, facts=semantic_facts))
+    add_timing("analysis.phases", t0)
+    t0 = time.perf_counter()
+    attribution = extract_attribution(session, facts=semantic_facts)
+    add_timing("analysis.attribution", t0)
+    t0 = time.perf_counter()
+    work_events = tuple(extract_work_events(session, facts=semantic_facts, phases=phases))
+    add_timing("analysis.work_events", t0)
     return SessionAnalysis(
         facts=semantic_facts,
-        attribution=extract_attribution(session, facts=semantic_facts),
-        work_events=tuple(extract_work_events(session, facts=semantic_facts, phases=phases)),
+        attribution=attribution,
+        work_events=work_events,
         phases=phases,
     )
 
@@ -262,45 +279,73 @@ def build_session_profile(
     *,
     analysis: SessionAnalysis | None = None,
     compaction_count: int | None = None,
+    stage_timing_add: Callable[[str, float], None] | None = None,
 ) -> SessionProfile:
     from polylogue.archive.semantic.cost_compute import compute_session_cost
-    from polylogue.archive.semantic.pricing import harmonize_session_cost
+    from polylogue.archive.semantic.pricing import estimate_session_cost
 
-    session_analysis = analysis or build_session_analysis(session)
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timing_add is not None:
+            stage_timing_add(name, started_at)
+
+    t0 = time.perf_counter()
+    session_analysis = analysis or build_session_analysis(session, stage_timing_add=stage_timing_add)
+    add_timing("profile.ensure_analysis", t0)
     facts = session_analysis.facts
     attribution = session_analysis.attribution
-    cost_usd, cost_is_estimated = harmonize_session_cost(session)
-    cost_summary = compute_session_cost(session)
+    t0 = time.perf_counter()
+    cost_estimate = estimate_session_cost(session)
+    add_timing("profile.cost_estimate", t0)
+    cost_usd = cost_estimate.total_usd
+    cost_is_estimated = cost_estimate.status != "exact"
+    t0 = time.perf_counter()
+    cost_summary = compute_session_cost(session, session_estimate=cost_estimate)
+    add_timing("profile.cost_summary", t0)
+    t0 = time.perf_counter()
     resolved_compaction_count = (
         compaction_count
         if compaction_count is not None
         else sum(1 for event in session.session_events if event.event_type == "compaction")
     )
+    add_timing("profile.compactions", t0)
+    t0 = time.perf_counter()
     engaged_duration_ms = sum(int(phase.duration_ms or 0) for phase in session_analysis.phases)
     if engaged_duration_ms <= 0:
         engaged_duration_ms = max(int(session.total_duration_ms or 0), 0)
     tool_active_duration_ms = compute_tool_active_duration_ms(session.session_events)
+    add_timing("profile.durations", t0)
+    t0 = time.perf_counter()
     workflow_shape, workflow_shape_confidence, workflow_shape_features = _workflow_shape(
         session_analysis,
         compaction_count=resolved_compaction_count,
         tool_active_duration_ms=tool_active_duration_ms,
     )
+    add_timing("profile.workflow_shape", t0)
+    t0 = time.perf_counter()
     terminal_state, terminal_state_confidence, terminal_state_evidence = _terminal_state(
         session,
         session_analysis,
     )
+    add_timing("profile.terminal_state", t0)
+    t0 = time.perf_counter()
     first_message_at, last_message_at, timestamp_source = _profile_timestamp_bounds(session, facts)
     canonical_session_at = first_message_at or last_message_at
+    add_timing("profile.timestamp_bounds", t0)
+    t0 = time.perf_counter()
     timing = compute_session_timing(
         list(session.messages),
         tool_use_count=facts.tool_messages,
         wall_duration_ms=facts.wall_duration_ms,
     )
+    add_timing("profile.session_timing", t0)
+    t0 = time.perf_counter()
     inferred_topic, inferred_topic_source = _infer_topic(
         session,
         session_analysis,
         repo_names=attribution.repo_names,
     )
+    add_timing("profile.infer_topic", t0)
+    t0 = time.perf_counter()
     partial = SessionProfile(
         session_id=str(session.id),
         origin=str(session.origin),
@@ -364,7 +409,11 @@ def build_session_profile(
         tool_calls_per_minute=timing.tool_calls_per_minute,
         timing_provenance=timing.timing_provenance,
     )
-    return replace(partial, auto_tags=infer_auto_tags(partial))
+    add_timing("profile.construct", t0)
+    t0 = time.perf_counter()
+    result = replace(partial, auto_tags=infer_auto_tags(partial))
+    add_timing("profile.auto_tags", t0)
+    return result
 
 
 __all__ = ["build_session_analysis", "build_session_profile", "infer_auto_tags"]

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 import time
 from collections import defaultdict
-from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 
 import aiosqlite
@@ -525,32 +525,62 @@ def build_session_insight_records(
     *,
     compaction_count: int | None = None,
     logical_session_id: str | None = None,
+    stage_timing_add: Callable[[str, float], None] | None = None,
 ) -> SessionInsightRecordBundle:
     from polylogue.storage.insights.session.repo_observations import attribution_to_observations
 
-    analysis = build_session_analysis(session)
-    profile = build_session_profile(session, analysis=analysis, compaction_count=compaction_count)
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timing_add is not None:
+            stage_timing_add(name, started_at)
+
+    t0 = time.perf_counter()
+    analysis = build_session_analysis(session, stage_timing_add=stage_timing_add)
+    add_timing("build_records.analysis", t0)
+    t0 = time.perf_counter()
+    profile = build_session_profile(
+        session,
+        analysis=analysis,
+        compaction_count=compaction_count,
+        stage_timing_add=stage_timing_add,
+    )
+    add_timing("build_records.profile", t0)
+    t0 = time.perf_counter()
     materialized_at = now_iso()
     repo_observations = attribution_to_observations(
         analysis.attribution,
         git_repository_url=session.git_repository_url,
     )
+    add_timing("build_records.repo_observations", t0)
+    t0 = time.perf_counter()
     latency_facts = build_latency_profile_facts(session, profile)
+    add_timing("build_records.latency_facts", t0)
+    t0 = time.perf_counter()
+    profile_record = build_session_profile_record(
+        profile,
+        analysis=analysis,
+        logical_session_id=logical_session_id,
+        materialized_at=materialized_at,
+    )
+    add_timing("build_records.profile_record", t0)
+    t0 = time.perf_counter()
+    latency_profile_record = build_session_latency_profile_record(
+        session,
+        profile,
+        latency_facts,
+        materialized_at=materialized_at,
+    )
+    add_timing("build_records.latency_profile_record", t0)
+    t0 = time.perf_counter()
+    work_event_records = build_session_work_event_records(profile, materialized_at=materialized_at)
+    add_timing("build_records.work_event_records", t0)
+    t0 = time.perf_counter()
+    phase_records = build_session_phase_records(profile, materialized_at=materialized_at)
+    add_timing("build_records.phase_records", t0)
     return SessionInsightRecordBundle(
-        profile_record=build_session_profile_record(
-            profile,
-            analysis=analysis,
-            logical_session_id=logical_session_id,
-            materialized_at=materialized_at,
-        ),
-        latency_profile_record=build_session_latency_profile_record(
-            session,
-            profile,
-            latency_facts,
-            materialized_at=materialized_at,
-        ),
-        work_event_records=build_session_work_event_records(profile, materialized_at=materialized_at),
-        phase_records=build_session_phase_records(profile, materialized_at=materialized_at),
+        profile_record=profile_record,
+        latency_profile_record=latency_profile_record,
+        work_event_records=work_event_records,
+        phase_records=phase_records,
         repo_observations=repo_observations,
     )
 
@@ -560,6 +590,7 @@ def build_session_insight_record_bundles(
     *,
     compaction_counts_by_session: dict[str, int] | None = None,
     logical_session_ids_by_session: dict[str, str] | None = None,
+    stage_timing_add: Callable[[str, float], None] | None = None,
 ) -> list[SessionInsightRecordBundle]:
     compaction_counts = compaction_counts_by_session or {}
     logical_ids = logical_session_ids_by_session or {}
@@ -568,6 +599,7 @@ def build_session_insight_record_bundles(
             session,
             compaction_count=compaction_counts.get(str(session.id)),
             logical_session_id=logical_ids.get(str(session.id)),
+            stage_timing_add=stage_timing_add,
         )
         for session in sessions
     ]
@@ -857,6 +889,7 @@ def rebuild_session_insights_sync(
             hydrated_sessions,
             compaction_counts_by_session=batch.compaction_counts_by_session,
             logical_session_ids_by_session=root_ids_by_session,
+            stage_timing_add=add_timing,
         )
         add_timing("build_records", t0)
         t0 = time.perf_counter()

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -290,7 +290,10 @@ def test_insights_stage_materializes_archive_profiles_from_archive_tiers(tmp_pat
     assert stage.check_sessions is not None
     assert stage.execute_sessions is not None
     assert stage.check_sessions([session_id]) == {session_id}
-    assert stage.execute_sessions([session_id]) is True
+    result = stage.execute_sessions([session_id])
+    assert result
+    assert isinstance(result, StageExecutionResult)
+    assert "insights.analysis.facts" in result.stage_timings_s
     assert stage.check_sessions([session_id]) == set()
     with sqlite3.connect(archive_db) as conn:
         profile = conn.execute("SELECT session_id, substantive_count FROM session_profiles").fetchone()
@@ -797,6 +800,10 @@ def test_insights_stage_rebuilds_large_session_after_quiet_window(
     assert result
     assert isinstance(result, StageExecutionResult)
     assert "insights.load_batch" in result.stage_timings_s
+    assert "insights.build_records.analysis" in result.stage_timings_s
+    assert "insights.build_records.profile" in result.stage_timings_s
+    assert "insights.analysis.facts" in result.stage_timings_s
+    assert "insights.profile.cost_estimate" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1
@@ -822,6 +829,10 @@ def test_insights_stage_rebuilds_small_active_session(
     assert result
     assert isinstance(result, StageExecutionResult)
     assert "insights.load_batch" in result.stage_timings_s
+    assert "insights.build_records.analysis" in result.stage_timings_s
+    assert "insights.build_records.profile" in result.stage_timings_s
+    assert "insights.analysis.facts" in result.stage_timings_s
+    assert "insights.profile.cost_estimate" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1


### PR DESCRIPTION
## Summary

This reduces duplicate cost-estimation work during session insight profile construction and exposes the remaining insight-analysis/profile sub-stage timings in daemon convergence evidence.

## Problem

Ref #2391. Large full-session replacement had a coarse `insights.build_records` bucket that hid which part of insight materialization dominated giant-session catch-up. The latest isolated 363.8 MB Codex benchmark showed `insights.build_records` around 5.32s, with profile construction around 2.90s after the first inner timing pass. Reading the profile path showed it computed `estimate_session_cost` once for the legacy `(total_cost_usd, cost_is_estimated)` tuple and then again inside `compute_session_cost`.

## Solution

`compute_session_cost` now accepts an optional already-computed session estimate. `build_session_profile` computes that estimate once and passes it into the summary builder, preserving the existing non-exact detailed-summary behavior while removing the duplicate pricing pass.

The insight rebuild path now threads optional timing callbacks through `build_session_insight_records`, `build_session_analysis`, and `build_session_profile`. Daemon stage events can now report `insights.analysis.*`, `insights.profile.*`, and `insights.build_records.*` keys, so the next performance pass can target actual residual work instead of another opaque bucket.

## Verification

- `devtools test tests/unit/storage/test_session_insight_profiles.py tests/unit/insights/test_cost_basis_split.py tests/unit/cost/test_contract_suite.py tests/unit/daemon/test_convergence_stages.py -k 'not browser' -q --tb=short`
  - `64 passed`
- `devtools verify --quick`
  - passed locally before push and again in the pre-push hook
- Isolated temp-archive benchmark against the 363.8 MB Codex session:
  - `/realm/tmp/polylogue-full-ingest-bench-cost-reuse-20260625`
  - `/realm/tmp/polylogue-full-ingest-bench-analysis-timings-20260625`

Benchmark deltas from the latest comparable runs:

```text
before cost reuse:
insights.build_records: 5.320983
insights.build_records.profile: 2.895584

with cost reuse:
insights.build_records: 3.890502
insights.build_records.profile: 1.443323

final inner timing run:
insights.build_records: 3.884990
insights.build_records.analysis: 2.349109
insights.analysis.facts: 1.891339
insights.build_records.profile: 1.444428
insights.profile.cost_estimate: 1.062644
insights.profile.cost_summary: 0.357201
```

Remaining #2391 scope: `insights.analysis.facts`, `insights.profile.cost_estimate`, `full.index.full_replace.fts_insert`, message/block full replacement writes, provider parse, and the unrelated developer-loop startup source catch-up that runs before explicit `--root` watcher benchmarking.
