### PR TITLE
perf(daemon): allow skipping configured source catch-up

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -686,6 +686,7 @@ async def run_daemon_services(
     sources: tuple[WatchSource, ...],
     debounce_s: float,
     enable_watch: bool,
+    enable_source_catchup: bool = True,
     enable_browser_capture: bool,
     browser_capture_host: str,
     browser_capture_port: int,
@@ -797,6 +798,7 @@ async def run_daemon_services(
                 "browser_capture_host": browser_capture_host,
                 "browser_capture_port": browser_capture_port,
                 "watch_enabled": enable_watch,
+                "source_catchup_enabled": enable_source_catchup,
                 "source_roots": [str(src.root) for src in sources],
             },
         )
@@ -891,22 +893,24 @@ async def run_daemon_services(
             # not trigger a merge of the full (hundreds-of-MB) existing
             # segments (#1851).  A periodic merge pass amortises the cost.
             await _configure_fts_automerge()
-            changed_drive_sessions = await _run_drive_source_catchup_safely()
-            if changed_drive_sessions:
-                logger.info("daemon: startup Drive catch-up refreshed %d session(s)", changed_drive_sessions)
-            maintenance_tasks.extend(
-                asyncio.create_task(loop)
-                for loop in (
-                    _periodic_wal_checkpoint(),
-                    _periodic_fts_merge(),
-                    _periodic_heartbeat(),
-                    periodic_embedding_backlog_check(),
-                    _periodic_drive_source_catchup(),
-                    _periodic_health_check(),
-                    _periodic_db_optimize(),
-                    _periodic_status_snapshot_refresh(),
-                )
-            )
+            if enable_source_catchup:
+                changed_drive_sessions = await _run_drive_source_catchup_safely()
+                if changed_drive_sessions:
+                    logger.info("daemon: startup Drive catch-up refreshed %d session(s)", changed_drive_sessions)
+            else:
+                logger.info("daemon: configured source catch-up disabled for this run")
+            periodic_loops = [
+                _periodic_wal_checkpoint(),
+                _periodic_fts_merge(),
+                _periodic_heartbeat(),
+                periodic_embedding_backlog_check(),
+                _periodic_health_check(),
+                _periodic_db_optimize(),
+                _periodic_status_snapshot_refresh(),
+            ]
+            if enable_source_catchup:
+                periodic_loops.append(_periodic_drive_source_catchup())
+            maintenance_tasks.extend(asyncio.create_task(loop) for loop in periodic_loops)
             if not enable_watch:
                 maintenance_tasks.append(asyncio.create_task(_periodic_convergence_check(sources)))
             # Reclaim blob leases leaked by a previously SIGKILLed writer so a
@@ -1296,6 +1300,11 @@ def health_command(
     help="Do not run the live source watcher.",
 )
 @click.option(
+    "--no-source-catchup",
+    is_flag=True,
+    help="Do not run configured non-watch source catch-up during this daemon run.",
+)
+@click.option(
     "--no-browser-capture",
     is_flag=True,
     help="Do not run the browser-capture receiver.",
@@ -1351,6 +1360,7 @@ def run_command(
     port: int,
     spool_path: Path | None,
     no_watch: bool,
+    no_source_catchup: bool,
     no_browser_capture: bool,
     insecure_allow_remote: bool,
     browser_capture_auth_token: str | None,
@@ -1410,6 +1420,7 @@ def run_command(
         api_auth_token = cfg.api_auth_token
 
     enable_watch = not no_watch
+    enable_source_catchup = not no_source_catchup
     enable_browser_capture = not no_browser_capture
     enable_api = not no_api
     if not enable_watch and not enable_browser_capture and not enable_api:
@@ -1436,6 +1447,7 @@ def run_command(
                 sources=sources,
                 debounce_s=debounce_s,
                 enable_watch=enable_watch,
+                enable_source_catchup=enable_source_catchup,
                 enable_browser_capture=enable_browser_capture,
                 browser_capture_host=host,
                 browser_capture_port=port,

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -385,6 +385,33 @@ def test_polylogued_run_uses_default_sources() -> None:
     assert "Starting polylogued (watch=1 source(s)). Ctrl-C to stop." in result.stderr
 
 
+def test_polylogued_run_can_skip_configured_source_catchup() -> None:
+    recorded: dict[str, object] = {}
+
+    async def fake_run_daemon_services(**kwargs: object) -> None:
+        recorded.update(kwargs)
+
+    with patch("polylogue.daemon.cli.run_daemon_services", side_effect=fake_run_daemon_services):
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--root",
+                "/tmp/codex",
+                "--no-source-catchup",
+                "--no-browser-capture",
+                "--no-api",
+            ],
+        )
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert recorded["enable_watch"] is True
+    assert recorded["enable_source_catchup"] is False
+    recorded_sources = recorded["sources"]
+    assert isinstance(recorded_sources, tuple)
+    assert tuple(source.root for source in recorded_sources) == (Path("/tmp/codex"),)
+
+
 def test_polylogued_run_rejects_empty_component_set() -> None:
     # All three components default to ON; only when every one is explicitly
     # disabled should `run` refuse to start.


### PR DESCRIPTION
## Summary

Adds an explicit `polylogued run --no-source-catchup` runtime mode so dev-loop and benchmark runs over explicit `--root` paths can start the watcher without first running configured Drive/non-watch source catch-up.

## Problem

Ref #2391. The large-session benchmark loop uses isolated temp archives and explicit watch roots, but `polylogued run --root <temp>` still performed configured startup Drive/source catch-up before the watcher began. Across repeated isolated benchmarks this added about 49-51s of unrelated latency before touching the requested root.

That behavior is correct for the normal deployed daemon, but bad for fast local dogfooding and bounded temp-archive probes where the operator has explicitly selected a root and does not want configured non-watch sources involved.

## Solution

`run_daemon_services` now has an `enable_source_catchup` gate. The CLI exposes it as `--no-source-catchup` and threads it through to the service layer.

Default behavior is unchanged: startup and periodic configured-source catch-up still run unless the operator explicitly passes the new flag. The new mode skips startup plus periodic configured-source catch-up, but keeps explicit watch roots, FTS readiness, convergence, API, browser capture, and normal maintenance loops intact.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_daemon_cli_remote_bind.py -q --tb=short`
  - `60 passed`
- `devtools verify --quick`
  - passed locally and in the pre-push hook
- Runtime smoke against a temp archive/root:

```text
POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/polylogue-no-source-catchup-smoke-20260625/archive \
  polylogued run --root /realm/tmp/polylogue-no-source-catchup-smoke-20260625/root \
  --no-source-catchup --debounce-s 0.2 --no-api --no-browser-capture

Starting polylogued (watch=1 source(s)). Ctrl-C to stop.
daemon started
daemon: configured source catch-up disabled for this run
converger: started without worker pool, stages=['fts', 'embed', 'insights']
live.watcher: watching /realm/tmp/polylogue-no-source-catchup-smoke-20260625/root
```

Remaining #2391 scope: insight semantic facts/cost residuals, full-replace FTS/message/block writes, provider parse, and deeper large-session read/write optimization remain separate from this dev-loop startup gate.
