### PR TITLE
perf: expose semantic fact stage timings

### DIFF
--- a/polylogue/archive/semantic/facts.py
+++ b/polylogue/archive/semantic/facts.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import time
 from collections import Counter
-from collections.abc import Collection, Iterator, Sequence
+from collections.abc import Callable, Collection, Iterator, Sequence
 from datetime import datetime
 from typing import Protocol
 
@@ -208,11 +209,33 @@ def build_projection_semantic_facts(projection: ProjectionLike) -> ProjectionSem
     )
 
 
-def build_message_semantic_facts(message: SemanticSessionMessageLike) -> MessageSemanticFacts:
-    tool_calls = message_tool_calls(message)
+def build_message_semantic_facts(
+    message: SemanticSessionMessageLike,
+    *,
+    stage_timing_add: Callable[[str, float], None] | None = None,
+) -> MessageSemanticFacts:
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timing_add is not None:
+            stage_timing_add(name, started_at)
+
+    t0 = time.perf_counter()
+    is_tool_use = message.is_tool_use
+    is_thinking = message.is_thinking
+    add_timing("facts.message_flags", t0)
+    t0 = time.perf_counter()
+    tool_calls = message_tool_calls(message) if is_tool_use else ()
+    add_timing("facts.message_tool_calls", t0)
+    t0 = time.perf_counter()
     actions = build_actions(message, tool_calls)
+    add_timing("facts.message_actions", t0)
+    t0 = time.perf_counter()
     tool_category_counts = Counter(action.kind.value for action in actions)
-    return MessageSemanticFacts(
+    add_timing("facts.message_tool_category_counts", t0)
+    t0 = time.perf_counter()
+    reasoning_traces = message_reasoning_traces(message) if is_thinking else ()
+    add_timing("facts.message_reasoning_traces", t0)
+    t0 = time.perf_counter()
+    facts = MessageSemanticFacts(
         message_id=str(message.id),
         role=normalized_role_label(message.role),
         text=message.text or "",
@@ -227,33 +250,35 @@ def build_message_semantic_facts(message: SemanticSessionMessageLike) -> Message
         is_context_dump=message.is_context_dump,
         is_protocol_artifact=message.is_protocol_artifact,
         is_noise=message.is_noise,
-        is_thinking=message.is_thinking,
-        is_tool_use=message.is_tool_use,
+        is_thinking=is_thinking,
+        is_tool_use=is_tool_use,
         is_substantive=message.is_substantive,
         tool_calls=tool_calls,
         actions=actions,
         tool_category_counts=sorted_counts(dict(tool_category_counts)),
-        reasoning_traces=message_reasoning_traces(message),
+        reasoning_traces=reasoning_traces,
     )
+    add_timing("facts.message_construct", t0)
+    return facts
 
 
-# ---------------------------------------------------------------------------
-# Session / detail builders
-# ---------------------------------------------------------------------------
+def build_session_semantic_facts(
+    session: SemanticSessionLike,
+    *,
+    stage_timing_add: Callable[[str, float], None] | None = None,
+) -> SessionSemanticFacts:
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timing_add is not None:
+            stage_timing_add(name, started_at)
 
-
-def _timestamp_coverage(*, total_messages: int, timestamped_messages: int) -> str:
-    if total_messages <= 0 or timestamped_messages <= 0:
-        return "none"
-    if timestamped_messages >= total_messages:
-        return "complete"
-    return "partial"
-
-
-def build_session_semantic_facts(session: SemanticSessionLike) -> SessionSemanticFacts:
     role_counts: Counter[str] = Counter()
     tool_categories: Counter[str] = Counter()
-    message_facts = tuple(build_message_semantic_facts(message) for message in session.messages)
+    t0 = time.perf_counter()
+    message_facts = tuple(
+        build_message_semantic_facts(message, stage_timing_add=stage_timing_add) for message in session.messages
+    )
+    add_timing("facts.message_facts", t0)
+    t0 = time.perf_counter()
     message_ids: list[str] = []
     text_message_ids: list[str] = []
     timestamped_text_messages = 0
@@ -290,15 +315,19 @@ def build_session_semantic_facts(session: SemanticSessionLike) -> SessionSemanti
                 timestamped_text_messages += 1
         for category, count in message_fact.tool_category_counts.items():
             tool_categories[category] += count
+    add_timing("facts.aggregate_messages", t0)
 
+    t0 = time.perf_counter()
     first_message_at = min(timestamps) if timestamps else None
     last_message_at = max(timestamps) if timestamps else None
     wall_duration_ms = 0
     if first_message_at and last_message_at:
         wall_duration_ms = max(int((last_message_at - first_message_at).total_seconds() * 1000), 0)
     untimestamped_messages = max(len(message_facts) - timestamped_messages, 0)
+    add_timing("facts.timestamp_bounds", t0)
 
-    return SessionSemanticFacts(
+    t0 = time.perf_counter()
+    facts = SessionSemanticFacts(
         session_id=str(session.id),
         origin=str(session.origin),
         title=session.display_title,
@@ -328,6 +357,21 @@ def build_session_semantic_facts(session: SemanticSessionLike) -> SessionSemanti
         wall_duration_ms=wall_duration_ms,
         message_facts=message_facts,
     )
+    add_timing("facts.construct", t0)
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Session / detail builders
+# ---------------------------------------------------------------------------
+
+
+def _timestamp_coverage(*, total_messages: int, timestamped_messages: int) -> str:
+    if total_messages <= 0 or timestamped_messages <= 0:
+        return "none"
+    if timestamped_messages >= total_messages:
+        return "complete"
+    return "partial"
 
 
 def build_mcp_detail_semantic_facts(session: SemanticSessionLike) -> MCPDetailSemanticFacts:

--- a/polylogue/archive/session/runtime.py
+++ b/polylogue/archive/session/runtime.py
@@ -240,7 +240,7 @@ def build_session_analysis(
             stage_timing_add(name, started_at)
 
     t0 = time.perf_counter()
-    semantic_facts = facts or build_session_semantic_facts(session)
+    semantic_facts = facts or build_session_semantic_facts(session, stage_timing_add=stage_timing_add)
     add_timing("analysis.facts", t0)
     t0 = time.perf_counter()
     phases = tuple(extract_phases(session, facts=semantic_facts))

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -294,6 +294,9 @@ def test_insights_stage_materializes_archive_profiles_from_archive_tiers(tmp_pat
     assert result
     assert isinstance(result, StageExecutionResult)
     assert "insights.analysis.facts" in result.stage_timings_s
+    assert "insights.facts.message_flags" in result.stage_timings_s
+    assert "insights.facts.message_facts" in result.stage_timings_s
+    assert "insights.facts.aggregate_messages" in result.stage_timings_s
     assert stage.check_sessions([session_id]) == set()
     with sqlite3.connect(archive_db) as conn:
         profile = conn.execute("SELECT session_id, substantive_count FROM session_profiles").fetchone()
@@ -803,6 +806,9 @@ def test_insights_stage_rebuilds_large_session_after_quiet_window(
     assert "insights.build_records.analysis" in result.stage_timings_s
     assert "insights.build_records.profile" in result.stage_timings_s
     assert "insights.analysis.facts" in result.stage_timings_s
+    assert "insights.facts.message_flags" in result.stage_timings_s
+    assert "insights.facts.message_facts" in result.stage_timings_s
+    assert "insights.facts.aggregate_messages" in result.stage_timings_s
     assert "insights.profile.cost_estimate" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
@@ -832,6 +838,9 @@ def test_insights_stage_rebuilds_small_active_session(
     assert "insights.build_records.analysis" in result.stage_timings_s
     assert "insights.build_records.profile" in result.stage_timings_s
     assert "insights.analysis.facts" in result.stage_timings_s
+    assert "insights.facts.message_flags" in result.stage_timings_s
+    assert "insights.facts.message_facts" in result.stage_timings_s
+    assert "insights.facts.aggregate_messages" in result.stage_timings_s
     assert "insights.profile.cost_estimate" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (


### PR DESCRIPTION
## Summary

Adds nested semantic-fact timings to the daemon insight stage and trims a small amount of unnecessary per-message projection work.

## Problem

Ref #2391. After the prior profile-cost work, the largest insight-side residual on the 363.8 MB Codex benchmark is `insights.analysis.facts` at about 2.0s. That bucket was still too coarse: it did not separate message fact construction, typed tool-call projection, action construction, reasoning trace extraction, or session-level aggregation.

## Solution

`build_session_semantic_facts` and `build_message_semantic_facts` now accept the same optional timing callback used by insight analysis/profile construction. The daemon insight path records keys such as:

```text
insights.facts.message_facts
insights.facts.message_flags
insights.facts.message_tool_calls
insights.facts.message_actions
insights.facts.message_construct
insights.facts.aggregate_messages
```

The message fact builder also computes tool/thinking flags once and skips tool-call projection for messages classified as non-tool-use and reasoning trace projection for messages classified as non-thinking. Default public behavior remains unchanged for callers that do not pass a timing callback.

## Verification

- `devtools test tests/unit/storage/test_session_insight_profiles.py tests/unit/core/test_semantic_facts.py tests/unit/daemon/test_convergence_stages.py -k 'semantic or insights_stage_rebuilds_large_session_after_quiet_window or insights_stage_rebuilds_small_active_session or materializes_archive_profiles' -q --tb=short`
  - `33 passed, 36 deselected`
- `devtools verify --quick`
  - passed locally and in the pre-push hook
- Isolated large-session benchmarks with `--no-source-catchup`:
  - `/realm/tmp/polylogue-full-ingest-bench-semantic-facts-timing-20260625`
  - `/realm/tmp/polylogue-full-ingest-bench-semantic-facts-skip-20260625`

Benchmark evidence:

```text
before conditional projection:
parse_s=18.424 convergence_s=8.441 read_amp=1.000000x
insights.analysis.facts: 2.008252
insights.facts.message_facts: 1.982757
insights.facts.message_construct: 0.690486
insights.facts.message_tool_calls: 0.640340
insights.facts.message_actions: 0.430495
insights.facts.message_tool_category_counts: 0.119205
insights.facts.message_reasoning_traces: 0.034267
insights.facts.aggregate_messages: 0.024045

after conditional projection:
parse_s=16.337 convergence_s=8.465 read_amp=1.000000x
insights.analysis.facts: 2.008368
insights.facts.message_facts: 1.982765
insights.facts.message_tool_calls: 0.630437
insights.facts.message_construct: 0.572661
insights.facts.message_actions: 0.430810
insights.facts.message_flags: 0.142643
insights.facts.message_tool_category_counts: 0.117193
insights.facts.message_reasoning_traces: 0.013997
insights.facts.aggregate_messages: 0.024109
```

Remaining #2391 scope: the next useful insight-side optimization should target typed tool-call projection/action construction or a narrower persisted action/fact read model. Session-level semantic aggregation is not the bottleneck. Storage-side full replacement and provider parse remain separate residuals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed timing breakdowns during session and message fact generation.
  * Session analysis now carries timing information through the full facts-building flow.

* **Bug Fixes**
  * Improved timing coverage for insights rebuilds so stage timings now include additional fact-aggregation steps.
  * Session fact creation now more accurately records message timestamps and duration-related details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->