### PR TITLE
perf: reduce profile cost projection work

### DIFF
--- a/polylogue/archive/actions/actions.py
+++ b/polylogue/archive/actions/actions.py
@@ -88,6 +88,21 @@ def build_action(
     *,
     sequence_index: int,
 ) -> Action:
+    return _build_action_from_message_fields(
+        message_id=str(message.id),
+        timestamp=message.timestamp,
+        call=call,
+        sequence_index=sequence_index,
+    )
+
+
+def _build_action_from_message_fields(
+    *,
+    message_id: str,
+    timestamp: datetime | None,
+    call: ToolCall,
+    sequence_index: int,
+) -> Action:
     command = extract_command(call)
     affected_paths = tuple(call.affected_paths)
     cwd_path = extract_cwd_path(call)
@@ -96,9 +111,9 @@ def build_action(
     url = extract_url(call)
     output_text = normalize_output_text(call)
     return Action(
-        action_id=make_action_id(str(message.id), sequence_index, call.id, call.name),
-        message_id=str(message.id),
-        timestamp=message.timestamp,
+        action_id=make_action_id(message_id, sequence_index, call.id, call.name),
+        message_id=message_id,
+        timestamp=timestamp,
         sequence_index=sequence_index,
         kind=call.category,
         tool_name=call.name,
@@ -130,7 +145,19 @@ def build_actions(
     message: ActionMessageLike,
     calls: tuple[ToolCall, ...],
 ) -> tuple[Action, ...]:
-    return tuple(build_action(message, call, sequence_index=index) for index, call in enumerate(calls))
+    if not calls:
+        return ()
+    message_id = str(message.id)
+    timestamp = message.timestamp
+    return tuple(
+        _build_action_from_message_fields(
+            message_id=message_id,
+            timestamp=timestamp,
+            call=call,
+            sequence_index=index,
+        )
+        for index, call in enumerate(calls)
+    )
 
 
 __all__ = [

--- a/polylogue/archive/actions/fields.py
+++ b/polylogue/archive/actions/fields.py
@@ -71,11 +71,29 @@ def extract_branch_names(call: ToolCall, command: str | None) -> tuple[str, ...]
     return tuple(dict.fromkeys(branches))
 
 
+def _collapsed_text_prefix(value: str, *, limit: int) -> str | None:
+    parts: list[str] = []
+    pending_space = False
+    for char in value:
+        if char.isspace():
+            pending_space = bool(parts)
+            continue
+        if pending_space:
+            parts.append(" ")
+            if len(parts) == limit:
+                break
+            pending_space = False
+        parts.append(char)
+        if len(parts) == limit:
+            break
+    return "".join(parts) if parts else None
+
+
 def normalize_output_text(call: ToolCall) -> str | None:
-    output = _clean_str(call.output)
-    if output is None:
+    output = call.output
+    if not isinstance(output, str):
         return None
-    return " ".join(output.split())[:240]
+    return _collapsed_text_prefix(output, limit=240)
 
 
 def build_search_text(

--- a/polylogue/archive/semantic/cost_compute.py
+++ b/polylogue/archive/semantic/cost_compute.py
@@ -20,10 +20,11 @@ def compute_session_cost(
     session: Session,
     *,
     session_estimate: CostEstimatePayload | None = None,
+    estimate_if_missing: bool = True,
 ) -> SessionCostSummary:
     """Compute per-model cost breakdown and aggregate cost summary."""
-    estimate = session_estimate or estimate_session_cost(session)
-    if estimate.status == "exact":
+    estimate = session_estimate or (estimate_session_cost(session) if estimate_if_missing else None)
+    if estimate is not None and estimate.status == "exact":
         return SessionCostSummary(
             total_input_tokens=estimate.usage.input_tokens,
             total_output_tokens=estimate.usage.output_tokens,

--- a/polylogue/archive/session/runtime.py
+++ b/polylogue/archive/session/runtime.py
@@ -282,7 +282,6 @@ def build_session_profile(
     stage_timing_add: Callable[[str, float], None] | None = None,
 ) -> SessionProfile:
     from polylogue.archive.semantic.cost_compute import compute_session_cost
-    from polylogue.archive.semantic.pricing import estimate_session_cost
 
     def add_timing(name: str, started_at: float) -> None:
         if stage_timing_add is not None:
@@ -294,13 +293,10 @@ def build_session_profile(
     facts = session_analysis.facts
     attribution = session_analysis.attribution
     t0 = time.perf_counter()
-    cost_estimate = estimate_session_cost(session)
-    add_timing("profile.cost_estimate", t0)
-    cost_usd = cost_estimate.total_usd
-    cost_is_estimated = cost_estimate.status != "exact"
-    t0 = time.perf_counter()
-    cost_summary = compute_session_cost(session, session_estimate=cost_estimate)
+    cost_summary = compute_session_cost(session, estimate_if_missing=False)
     add_timing("profile.cost_summary", t0)
+    cost_usd = cost_summary.total_api_cost_usd
+    cost_is_estimated = cost_summary.cost_confidence != "reported"
     t0 = time.perf_counter()
     resolved_compaction_count = (
         compaction_count

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -893,6 +893,82 @@ def test_build_session_semantic_facts_preserves_tool_results_before_tool_use() -
     assert facts.message_facts[0].tool_calls[0].output == "README contents"
 
 
+def test_action_output_text_uses_bounded_normalized_prefix() -> None:
+    raw_output = " \n\t" + ("alpha\t beta\n" * 5000) + "tail"
+    expected_output = " ".join(raw_output.split())[:240]
+    session = make_conv(
+        id="conv-large-tool-result-prefix",
+        origin="claude-code",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="a1",
+                    role="assistant",
+                    origin="claude-code",
+                    text="I ran the command.",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Bash",
+                            "tool_id": "tool-1",
+                            "tool_input": {"command": "pytest -q"},
+                            "semantic_type": "shell",
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-1",
+                            "text": raw_output,
+                        },
+                    ],
+                ),
+            ]
+        ),
+    )
+
+    facts = build_session_semantic_facts(session)
+
+    action = facts.actions[0]
+    assert facts.message_facts[0].tool_calls[0].output == raw_output
+    assert action.output_text == expected_output
+    assert len(action.output_text or "") == 240
+    assert expected_output in action.search_text
+
+
+def test_action_output_text_drops_trailing_whitespace_only_suffix() -> None:
+    session = make_conv(
+        id="conv-tool-result-trailing-space",
+        origin="claude-code",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="a1",
+                    role="assistant",
+                    origin="claude-code",
+                    text="I ran the command.",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Bash",
+                            "tool_id": "tool-1",
+                            "tool_input": {"command": "pytest -q"},
+                            "semantic_type": "shell",
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-1",
+                            "text": "passed   \n\t  ",
+                        },
+                    ],
+                ),
+            ]
+        ),
+    )
+
+    facts = build_session_semantic_facts(session)
+
+    assert facts.actions[0].output_text == "passed"
+
+
 def test_build_session_semantic_facts_upgrades_stale_other_semantic_type() -> None:
     session = make_conv(
         id="conv-db-upgrade-other",

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -809,7 +809,7 @@ def test_insights_stage_rebuilds_large_session_after_quiet_window(
     assert "insights.facts.message_flags" in result.stage_timings_s
     assert "insights.facts.message_facts" in result.stage_timings_s
     assert "insights.facts.aggregate_messages" in result.stage_timings_s
-    assert "insights.profile.cost_estimate" in result.stage_timings_s
+    assert "insights.profile.cost_summary" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1
@@ -841,7 +841,7 @@ def test_insights_stage_rebuilds_small_active_session(
     assert "insights.facts.message_flags" in result.stage_timings_s
     assert "insights.facts.message_facts" in result.stage_timings_s
     assert "insights.facts.aggregate_messages" in result.stage_timings_s
-    assert "insights.profile.cost_estimate" in result.stage_timings_s
+    assert "insights.profile.cost_summary" in result.stage_timings_s
     with sqlite3.connect(db_path) as conn:
         assert (
             conn.execute("SELECT COUNT(*) FROM session_profiles WHERE session_id = ?", (session_id,)).fetchone()[0] == 1


### PR DESCRIPTION
## Summary

Reduce large-session insight refresh work by removing the duplicate pricing-estimate pass from profile construction and by bounding action output summary normalization for large tool results.

## Problem

The large Codex full-ingest benchmark after PR #2405 showed `insights.build_records.profile` still spending about 1.42s, dominated by `insights.profile.cost_estimate` at about 1.04s. That profile path built the heavy `estimate_session_cost` payload and then immediately built the profile cost summary over the same message stream. The same benchmark also kept showing non-trivial per-action construction work, where action output summaries only need a 240-character normalized prefix but the code split the full tool result first.

Ref #2391.

## Solution

`build_session_profile` now derives profile cost fields from `compute_session_cost(..., estimate_if_missing=False)`, keeping `compute_session_cost`'s previous default estimate behavior for other callers. The convergence timing key is now `insights.profile.cost_summary`, matching the single pass used by profile construction.

`normalize_output_text` now streams the collapsed whitespace prefix instead of calling `strip().split()` over the whole tool output. Full raw `ToolCall.output` is preserved; only the existing bounded action summary avoids full-output normalization. `build_actions` also reuses the message id and timestamp across calls while preserving the public `build_action` API.

## Verification

- `devtools test tests/unit/core/test_semantic_facts.py -k 'action_output_text or actions_capture or checkout_pathspec or semantic_facts_uses_canonical_db_content_blocks or preserves_tool_results' -q --tb=short`  
  Result: `6 passed, 26 deselected`.
- `devtools test tests/unit/core/test_semantic_facts.py tests/unit/storage/test_session_insight_profiles.py tests/unit/storage/test_session_insight_refresh.py tests/unit/daemon/test_convergence_stages.py -k 'cost or profile or insights_stage_rebuilds_large_session_after_quiet_window or insights_stage_rebuilds_small_active_session or action_output_text' -q --tb=short`  
  Result: `39 passed, 51 deselected`.
- `devtools verify --quick`  
  Result: `exit_code: 0`, latest run `20260625T202615Z-quick-441946-d29eb610`.

Temp-archive benchmark, no production DB mutation:

- Archive: `/realm/tmp/polylogue-full-ingest-bench-cost-summary-single-pass-20260625/archive`.
- Source: symlink to `/home/sinity/.codex/sessions/2026/06/18/rollout-2026-06-18T02-59-46-019ed83d-c034-7070-84de-2b87c55affa1.jsonl`.
- Input: 363.8 MB.
- Result: `parse_s=17.786`, `convergence_s=7.488`, `rss_peak_self_mb=1245.7`.
- Key comparison: `insights.build_records.profile` improved from about `1.42s` to `0.39s`; `insights.profile.cost_estimate` is gone from the profile path and `insights.profile.cost_summary` is about `0.36s`.

Remaining #2391 scope: full-ingest time is now dominated by index full-replace writes (`messages`, `blocks`, `fts_insert`) and semantic fact/tool-call projection, not profile cost assembly.
