### PR TITLE
perf: classify agent control actions

### DIFF
--- a/polylogue/archive/actions/actions.py
+++ b/polylogue/archive/actions/actions.py
@@ -40,6 +40,24 @@ _CANONICAL_TOOL_NAMES = {
     "update_plan": "todo",
 }
 
+_PATH_EXTRACTING_CATEGORIES = frozenset(
+    {
+        ToolCategory.FILE_READ,
+        ToolCategory.FILE_WRITE,
+        ToolCategory.FILE_EDIT,
+        ToolCategory.SHELL,
+        ToolCategory.GIT,
+        ToolCategory.SEARCH,
+        ToolCategory.WEB,
+        ToolCategory.OTHER,
+    }
+)
+_COMMAND_EXTRACTING_CATEGORIES = frozenset({ToolCategory.SHELL, ToolCategory.GIT, ToolCategory.OTHER})
+_CWD_EXTRACTING_CATEGORIES = frozenset({ToolCategory.SHELL, ToolCategory.GIT, ToolCategory.OTHER})
+_BRANCH_EXTRACTING_CATEGORIES = frozenset({ToolCategory.SHELL, ToolCategory.GIT, ToolCategory.OTHER})
+_QUERY_EXTRACTING_CATEGORIES = frozenset({ToolCategory.SEARCH, ToolCategory.OTHER})
+_URL_EXTRACTING_CATEGORIES = frozenset({ToolCategory.WEB, ToolCategory.OTHER})
+
 
 def canonical_tool_name(name: str) -> str:
     """Return the cross-provider canonical tool name used for statistics."""
@@ -103,19 +121,20 @@ def _build_action_from_message_fields(
     call: ToolCall,
     sequence_index: int,
 ) -> Action:
-    command = extract_command(call)
-    affected_paths = tuple(call.affected_paths)
-    cwd_path = extract_cwd_path(call)
-    branch_names = extract_branch_names(call, command)
-    query = extract_search_query(call)
-    url = extract_url(call)
+    category = call.category
+    command = extract_command(call) if category in _COMMAND_EXTRACTING_CATEGORIES else None
+    affected_paths = tuple(call.affected_paths) if category in _PATH_EXTRACTING_CATEGORIES else ()
+    cwd_path = extract_cwd_path(call) if category in _CWD_EXTRACTING_CATEGORIES else None
+    branch_names = extract_branch_names(call, command) if category in _BRANCH_EXTRACTING_CATEGORIES else ()
+    query = extract_search_query(call) if category in _QUERY_EXTRACTING_CATEGORIES else None
+    url = extract_url(call) if category in _URL_EXTRACTING_CATEGORIES else None
     output_text = normalize_output_text(call)
     return Action(
         action_id=make_action_id(message_id, sequence_index, call.id, call.name),
         message_id=message_id,
         timestamp=timestamp,
         sequence_index=sequence_index,
-        kind=call.category,
+        kind=category,
         tool_name=call.name,
         tool_id=call.id,
         provider=call.provider,
@@ -127,7 +146,7 @@ def _build_action_from_message_fields(
         url=url,
         output_text=output_text,
         search_text=build_search_text(
-            kind=call.category,
+            kind=category,
             tool_name=call.name,
             affected_paths=affected_paths,
             cwd_path=cwd_path,

--- a/polylogue/archive/viewport/tools.py
+++ b/polylogue/archive/viewport/tools.py
@@ -45,7 +45,21 @@ def classify_tool(name: str, input_data: Mapping[str, JSONValue]) -> ToolCategor
         or "__create_or_update_file" in name_lower
     ):
         return ToolCategory.FILE_EDIT
-    if name_lower in ("glob", "grep", "search", "find", "file_search", "ls", "toolsearch") or any(
+    if name_lower in (
+        "glob",
+        "grep",
+        "search",
+        "find",
+        "file_search",
+        "ls",
+        "toolsearch",
+        "find_symbol",
+        "find_referencing_symbols",
+        "search_for_pattern",
+        "get_symbols_overview",
+        "query_docs",
+        "resolve_library_id",
+    ) or any(
         marker in name_lower
         for marker in (
             "__query-docs",
@@ -85,6 +99,15 @@ def classify_tool(name: str, input_data: Mapping[str, JSONValue]) -> ToolCategor
             "skill",
             "batch",
             "update_plan",
+            "write_stdin",
+            "send_input",
+            "wait_agent",
+            "close_agent",
+            "initial_instructions",
+            "activate_project",
+            "get_current_config",
+            "get_goal",
+            "update_goal",
             "mcp__sequential-thinking__sequentialthinking",
             "mcp__cclsp__restart_server",
         )

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 import time
 from collections import Counter
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -1370,7 +1370,8 @@ def _write_web_constructs(
         blocks = _message_blocks(message)
         for block_position, block in enumerate(blocks):
             block_id = f"{message_id}:{block_position}"
-            block_ids.append(block_id)
+            if not replace_session:
+                block_ids.append(block_id)
             for construct_position, construct in enumerate(block.web_constructs):
                 rows.append(
                     (
@@ -2438,12 +2439,12 @@ def _normalized_messages(messages: list[ParsedMessage]) -> list[ParsedMessage]:
     ]
 
 
-def _message_blocks(message: ParsedMessage) -> list[ParsedContentBlock]:
+def _message_blocks(message: ParsedMessage) -> Sequence[ParsedContentBlock]:
     if message.blocks:
-        return list(message.blocks)
+        return message.blocks
     if message.text:
-        return [ParsedContentBlock(type=BlockType.TEXT, text=message.text)]
-    return []
+        return (ParsedContentBlock(type=BlockType.TEXT, text=message.text),)
+    return ()
 
 
 def _active_leaf_message_id(

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -16,7 +16,7 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.models import Message
 from polylogue.archive.raw_payload import build_raw_payload_envelope
-from polylogue.archive.viewport.viewports import ToolCall, classify_tool
+from polylogue.archive.viewport.viewports import ToolCall, ToolCategory, classify_tool
 from polylogue.core.enums import Origin, Provider, SemanticBlockType
 from polylogue.core.json import JSONDocument, JSONValue, json_document
 from polylogue.core.provider_identity import (
@@ -88,6 +88,20 @@ def _json_input(payload: dict[str, JSONValue]) -> JSONDocument:
 
 
 class TestToolCallProperties:
+    @pytest.mark.parametrize(
+        ("tool_name", "expected"),
+        [
+            ("write_stdin", ToolCategory.AGENT),
+            ("initial_instructions", ToolCategory.AGENT),
+            ("activate_project", ToolCategory.AGENT),
+            ("find_symbol", ToolCategory.SEARCH),
+            ("find_referencing_symbols", ToolCategory.SEARCH),
+            ("search_for_pattern", ToolCategory.SEARCH),
+        ],
+    )
+    def test_classifies_agent_control_and_symbol_tools(self, tool_name: str, expected: ToolCategory) -> None:
+        assert classify_tool(tool_name, {}) is expected
+
     @pytest.mark.parametrize(("tool_name", "expected"), TOOL_FILE_OPS)
     def test_is_file_operation(self, tool_name: str, expected: bool) -> None:
         assert _make_tool(tool_name).is_file_operation is expected

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -26,6 +26,7 @@ from polylogue.archive.session import runtime as session_profile_runtime
 from polylogue.archive.session.attribution import extract_attribution
 from polylogue.archive.session.events import SessionEvent
 from polylogue.archive.session.session_profile import build_session_profile
+from polylogue.archive.viewport.viewports import ToolCategory
 from polylogue.core.enums import MaterialOrigin, Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.archive_views import SessionRenderProjection
@@ -1068,6 +1069,55 @@ def test_actions_capture_normalized_command_query_branch_and_cwd() -> None:
 
     profile = build_session_profile(session)
     assert profile.repo_names == (EXPECTED_REPO_NAME,)
+
+
+def test_agent_control_actions_skip_path_and_query_extractors() -> None:
+    session = make_conv(
+        id="conv-agent-control-action",
+        origin="codex",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="a1",
+                    role="assistant",
+                    origin="codex",
+                    text="Polling the running command.",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "write_stdin",
+                            "tool_id": "tool-1",
+                            "tool_input": {
+                                "session_id": 123,
+                                "chars": "",
+                                "cwd": str(REPO_ROOT),
+                                "query": "not a search query",
+                                "url": "https://example.invalid/not-web-navigation",
+                            },
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-1",
+                            "text": "still running",
+                        },
+                    ],
+                ),
+            ]
+        ),
+    )
+
+    facts = build_session_semantic_facts(session)
+
+    action = facts.actions[0]
+    assert action.kind is ToolCategory.AGENT
+    assert action.command is None
+    assert action.affected_paths == ()
+    assert action.cwd_path is None
+    assert action.branch_names == ()
+    assert action.query is None
+    assert action.url is None
+    assert action.output_text == "still running"
+    assert "still running" in action.search_text
 
 
 def test_actions_do_not_treat_checkout_pathspec_as_branch_or_commit_message_words_as_paths() -> None:


### PR DESCRIPTION
## Summary

Classify common agent/control and symbol-search tool calls explicitly, and make semantic action field extraction category-aware so large sessions spend less time deriving irrelevant action fields.

## Problem

The large-session timing work under Ref #2391 showed that after profile-cost cleanup, semantic fact projection was still one of the main insight-side residuals. The benchmark session contains tens of thousands of tool calls. Many control-plane calls such as `write_stdin`, Serena setup calls, and symbol lookup tools were falling into the generic `other` bucket, so `build_action` ran every extractor over every call: command, affected paths, cwd, branch, query, URL, and output.

That produced avoidable work and muddier tool-category counts for agent/control activity.

## Solution

- Classify common agent/control tools (`write_stdin`, `send_input`, `initial_instructions`, `activate_project`, goal helpers, etc.) as `agent`.
- Classify symbol/docs lookup tools (`find_symbol`, `find_referencing_symbols`, `search_for_pattern`, `query_docs`, `resolve_library_id`, etc.) as `search`.
- Make `build_action` category-aware: agent/subagent calls keep output summaries but skip irrelevant path/cwd/branch/query/url extraction. File, shell, git, search, web, and compatibility `other` calls keep the meaningful extractors.
- Remove two small full-replace row-generation costs found during the same investigation: avoid copying `message.blocks` in `_message_blocks`, and do not accumulate every block id in full-session web-construct replacement where the delete is session-scoped.

## Verification

- `devtools test tests/unit/core/test_models.py tests/unit/core/test_semantic_facts.py tests/unit/storage/test_archive_tiers_write.py -k 'classifies_agent_control or agent_control_actions or actions_capture or checkout_pathspec or action_output_text or blocks or web_construct' -q --tb=short`  
  Result: `19 passed, 156 deselected`.
- `devtools verify --quick`  
  Result: `exit_code: 0`, latest run `20260625T205247Z-quick-479100-a88b42b7`.

Temp-archive benchmark, no production DB mutation:

- Archive: `/realm/tmp/polylogue-full-ingest-bench-action-category-aware-20260625/archive`.
- Source: symlink to `/home/sinity/.codex/sessions/2026/06/18/rollout-2026-06-18T02-59-46-019ed83d-c034-7070-84de-2b87c55affa1.jsonl`.
- Input: 363.8 MB.
- Result: `parse_s=17.969`, `convergence_s=7.304`, `rss_peak_self_mb=1249.1`.
- Relevant timing movement versus the post-#2406 baseline:
  - `insights.build_records`: about `2.943s` -> `2.840s`.
  - `insights.build_records.analysis`: about `2.460s` -> `2.364s`.
  - `insights.analysis.facts`: about `2.004s` -> `1.909s`.
  - `insights.facts.message_facts`: about `1.978s` -> `1.884s`.

Remaining #2391 scope: full ingest is still dominated by full index replacement, especially `fts_insert`, `messages`, and `blocks`. Two schema/index prototypes were tested and recorded as dead ends in `.agent/scratch/live-append-active-leaf-churn-2026-06-25.md`.
