### PR TITLE
fix: debounce same-path watcher events

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 import sqlite3
 import stat as stat_module
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -152,6 +153,7 @@ class LiveWatcher:
         self._drain_task: asyncio.Task[None] | None = None
         self._failed_retry_task: asyncio.Task[None] | None = None
         self._failed_retry_deadline: float | None = None
+        self._last_enqueue_at = 0.0
         self._last_batch_at: float = 0.0
         self._batch_lock = asyncio.Lock()
         self._ingest_lock = asyncio.Lock()
@@ -329,6 +331,7 @@ class LiveWatcher:
     def _enqueue(self, path: Path) -> None:
         """Enqueue a path for batched ingestion after debounce."""
         self._pending_paths.add(path)
+        self._last_enqueue_at = time.monotonic()
         self._ensure_pending_scheduled()
 
     def _ensure_pending_scheduled(self) -> None:
@@ -400,13 +403,7 @@ class LiveWatcher:
             await asyncio.sleep(self._debounce_s)
 
             while not self._stop.is_set():
-                # Re-check: collect any new arrivals during the quiet window.
-                while True:
-                    before = len(self._pending_paths)
-                    await asyncio.sleep(0.5)
-                    after = len(self._pending_paths)
-                    if after == before:
-                        break
+                await self._wait_for_pending_quiet()
 
                 flushed = await self._flush_pending()
                 if not flushed:
@@ -417,6 +414,18 @@ class LiveWatcher:
             else:
                 self._pending_scheduled = False
                 self._drain_task = None
+
+    async def _wait_for_pending_quiet(self) -> None:
+        """Wait until no enqueue event lands during the quiet window."""
+        quiet_s = self._debounce_s
+        while self._pending_paths and not self._stop.is_set():
+            last_enqueue_at = self._last_enqueue_at
+            elapsed_s = time.monotonic() - last_enqueue_at
+            if elapsed_s >= quiet_s:
+                return
+            await asyncio.sleep(max(quiet_s - elapsed_s, 0.01))
+            if self._last_enqueue_at == last_enqueue_at:
+                return
 
     async def _flush_pending(self) -> bool:
         """Flush one pending path snapshot and report whether work ran."""

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1907,6 +1907,38 @@ def test_debounce_coalesces_rapid_changes(tmp_path: Path) -> None:
     assert parse_sources.await_count == 1
 
 
+def test_debounce_waits_for_same_path_quiet_window(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, _parse_sources = _make_watcher(tmp_path, root, debounce_s=0.05)
+    producer_done = asyncio.Event()
+    batches: list[bool] = []
+
+    async def fake_ingest(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        del paths, queued_file_count, skipped_file_count
+        batches.append(producer_done.is_set())
+
+    async def _drive() -> None:
+        watcher._ingest_files = fake_ingest  # type: ignore[assignment,method-assign]
+        for _ in range(4):
+            watcher._enqueue(f)
+            await asyncio.sleep(0.03)
+        producer_done.set()
+        while watcher._pending_scheduled or watcher._pending_paths:
+            await asyncio.sleep(0.01)
+
+    asyncio.run(_drive())
+
+    assert batches == [True]
+
+
 # --- WatchSource ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

The live watcher now treats the debounce quiet window as “no enqueue events occurred,” not “the pending path set size stayed the same.” This keeps a single hot session file from flushing while fresh events for that same file are still arriving.

## Problem

Live deployment logs after Ref #2391 work showed the same large Codex session repeatedly waking the watcher. The append path is now cheap in read amplification, but the debounce layer still had a single-path blind spot: repeated events for an already-pending path do not change `len(_pending_paths)`, so the quiet-window check could decide the batch was stable even though same-path writes continued.

## Solution

`LiveWatcher._enqueue` records a monotonic last-enqueue timestamp, and `_debounced_batch` now waits through `_wait_for_pending_quiet()` before flushing. The pending set still coalesces paths, but the quiet decision is driven by event freshness. A regression test continuously enqueues the same file and asserts ingest happens only after the producer has gone quiet.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k 'debounce or same_path_quiet' -q --tb=short` -> `2 passed, 71 deselected`.
- `devtools verify --quick` -> passed, run id `20260625T210501Z-quick-506820-d452bb9e`.
- Push hook reran `devtools verify --quick` on the pushed commit -> passed, run id `20260625T210543Z-quick-507394-e8ef24a9`.

Ref #2391.

Remaining #2391 scope: this removes one debounce blind spot. It does not claim to finish full-replace ingest optimization or all live watcher wakeup analysis; those still need separate benchmarked patches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-change handling so debounced updates wait for a true quiet period before processing.
  - Reduced the chance of premature batch ingestion when the same path is updated repeatedly.
- **Tests**
  - Added coverage for the debounce behavior to verify processing starts only after incoming changes stop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->