### PR TITLE
perf: use indexed thread refresh predicate

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1904,10 +1904,10 @@ def _refresh_thread(conn: sqlite3.Connection, root_session_id: str) -> None:
         """
         SELECT session_id
         FROM sessions
-        WHERE COALESCE(root_session_id, session_id) = ?
+        WHERE root_session_id = ? OR session_id = ?
         ORDER BY sort_key_ms IS NULL, sort_key_ms, session_id
         """,
-        (root_session_id,),
+        (root_session_id, root_session_id),
     ).fetchall()
     for position, row in enumerate(session_rows):
         conn.execute(

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1534,6 +1534,19 @@ def test_archive_tiers_writer_resolves_parent_link_when_parent_already_exists(tm
         {"thread_id": parent_id, "session_id": child_id, "position": 1},
     ]
     assert conn.execute("SELECT session_count FROM threads WHERE thread_id = ?", (parent_id,)).fetchone()[0] == 2
+    plan_rows = conn.execute(
+        """
+        EXPLAIN QUERY PLAN
+        SELECT session_id
+        FROM sessions
+        WHERE root_session_id = ? OR session_id = ?
+        ORDER BY sort_key_ms IS NULL, sort_key_ms, session_id
+        """,
+        (parent_id, parent_id),
+    ).fetchall()
+    plan = "\n".join(str(row[3]) for row in plan_rows)
+    assert "idx_sessions_root" in plan
+    assert "SCAN sessions" not in plan
 
 
 def test_archive_tiers_writer_resolves_existing_child_link_when_parent_arrives_later(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Thread refresh now finds sessions for a root with `root_session_id = ? OR session_id = ?` instead of `COALESCE(root_session_id, session_id) = ?`, allowing SQLite to use the existing root/session indexes during append graph convergence.

## Problem

Ref #2391 append evidence still shows time in `append.index.graph_resolve` after read amplification was reduced. Direct query-plan evidence against the deployed archive showed `_refresh_thread`'s membership query scanning the full `sessions` table:

```text
EXPLAIN QUERY PLAN ... WHERE COALESCE(root_session_id, session_id) = ?
SCAN sessions
USE TEMP B-TREE FOR ORDER BY
```

The archive already has `idx_sessions_root` and the session primary-key index, but the `COALESCE` expression prevents the planner from using them.

## Solution

Rewrite the predicate to the equivalent indexed form:

```sql
WHERE root_session_id = ? OR session_id = ?
```

The existing behavior test for parent/thread materialization now also asserts the query plan uses `idx_sessions_root` and does not regress to `SCAN sessions`.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'resolves_parent_link_when_parent_already_exists or resolves_existing_child_link_when_parent_arrives_later' -q --tb=short` -> `2 passed, 38 deselected`.
- `devtools verify --quick` -> passed, run id `20260625T213208Z-quick-546186-5fa8aadf`.
- Push hook reran `devtools verify --quick` on the pushed commit -> passed, run id `20260625T213259Z-quick-546937-98b80baa`.

Ref #2391.

Remaining #2391 scope: this removes one full-session scan from thread refresh. It does not claim to finish all append convergence or full-replace write cost; usage rollup, merge preparation, and FTS/message/block writes still need separate evidence-backed work.
