### PR TITLE
perf: skip provider usage rollup on plain appends

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -409,7 +409,7 @@ def write_parsed_session_to_archive(
         _write_session_link(conn, session_id, session)
         add_timing("index.session_link", t0)
         t0 = time.perf_counter()
-        _write_session_events(
+        wrote_provider_usage_events = _write_session_events(
             conn,
             session_id,
             messages,
@@ -428,9 +428,10 @@ def write_parsed_session_to_archive(
         t0 = time.perf_counter()
         _write_reported_costs(conn, session_id, session)
         add_timing("index.reported_costs", t0)
-        t0 = time.perf_counter()
-        _aggregate_provider_usage_into_model_usage(conn, session_id)
-        add_timing("index.provider_usage_rollup", t0)
+        if not merge_append or wrote_provider_usage_events:
+            t0 = time.perf_counter()
+            _aggregate_provider_usage_into_model_usage(conn, session_id)
+            add_timing("index.provider_usage_rollup", t0)
         t0 = time.perf_counter()
         _refresh_session_counts(conn, session_id)
         add_timing("index.session_counts", t0)
@@ -1970,7 +1971,7 @@ def _write_session_events(
     position_offset: int = 0,
     event_position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
-) -> None:
+) -> bool:
     by_native_id = {
         message.provider_message_id: _message_id(
             session_id,
@@ -1982,6 +1983,7 @@ def _write_session_events(
         for fallback_position, message in enumerate(messages)
         if message.provider_message_id and message.provider_message_id not in duplicate_native_ids
     }
+    wrote_provider_usage_events = False
     position = event_position_offset
     for event in events:
         if event.event_type == "compaction":
@@ -2028,7 +2030,9 @@ def _write_session_events(
                 position,
                 event,
             )
+            wrote_provider_usage_events = True
             position += 1
+    return wrote_provider_usage_events
 
 
 def _write_provider_usage_event(

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -4,6 +4,8 @@ import hashlib
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import BlockType, MaterialOrigin, MessageType, Provider, TitleSource, WebConstructType
@@ -16,6 +18,7 @@ from polylogue.sources.parsers.base import (
     ParsedSessionEvent,
     ParsedWebConstruct,
 )
+from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import (
@@ -1270,6 +1273,100 @@ def test_provider_usage_events_append_preserves_prior_history(tmp_path: Path) ->
             "total_output_tokens": 15,
         },
     ]
+
+
+def test_provider_usage_rollup_skips_append_without_usage_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _connect(tmp_path / "index.db")
+    rollup_calls: list[str] = []
+    original_rollup = archive_tier_write._aggregate_provider_usage_into_model_usage
+
+    def _record_rollup(conn_arg: sqlite3.Connection, session_id_arg: str) -> None:
+        rollup_calls.append(session_id_arg)
+        original_rollup(conn_arg, session_id_arg)
+
+    monkeypatch.setattr(archive_tier_write, "_aggregate_provider_usage_into_model_usage", _record_rollup)
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first answer")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m1",
+                payload={
+                    "type": "token_count",
+                    "total_token_usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            )
+        ],
+    )
+    no_usage_append = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="plain append")],
+            )
+        ],
+    )
+    usage_append = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m3",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="usage append")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m3",
+                payload={
+                    "type": "token_count",
+                    "total_token_usage": {"input_tokens": 30, "output_tokens": 15},
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    assert rollup_calls == [session_id]
+
+    write_parsed_session_to_archive(conn, no_usage_append, merge_append=True)
+    assert rollup_calls == [session_id]
+
+    write_parsed_session_to_archive(conn, usage_append, merge_append=True)
+    assert rollup_calls == [session_id, session_id]
+
+    row = conn.execute(
+        """
+        SELECT input_tokens, output_tokens, cost_provenance
+        FROM session_model_usage
+        WHERE session_id = ? AND model_name = 'gpt-5-codex'
+        """,
+        (session_id,),
+    ).fetchone()
+    assert dict(row) == {
+        "input_tokens": 30,
+        "output_tokens": 15,
+        "cost_provenance": "origin_reported",
+    }
 
 
 def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Plain merge-append writes now skip the provider-usage rollup scan when the append batch did not write any provider usage events. Full rewrites and append batches that carry `token_count` or `message_usage` events still recompute the rollup from the complete event stream.

## Problem

Live daemon timings after the watcher and thread-refresh fixes still showed `append.index.provider_usage_rollup` as a recurring convergence leaf. Source inspection showed that `write_parsed_session_to_archive(..., merge_append=True)` always scanned the session's full `session_provider_usage_events` history even when the current append had no provider usage rows and therefore could not change that rollup.

Ref #2391.

## Solution

`_write_session_events` now returns whether it wrote provider usage events. `write_parsed_session_to_archive` uses that signal to run `index.provider_usage_rollup` only for full rewrites or usage-bearing appends. A regression test patches the rollup helper to prove no-usage appends avoid the helper while usage-bearing appends still update final rollup totals.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'provider_usage' -q --tb=short` -> `7 passed, 34 deselected in 9.29s`
- `devtools verify --quick` -> `exit_code=0`
- Pre-push `devtools verify --quick` -> `exit_code=0`

Remaining #2391 scope: continue live daemon observation after deploy; append convergence can still spend time in merge preparation, session counts, graph resolution, and other leaves depending on active session shape.
