### PR TITLE
fix: fail deployment smoke on route errors

### DIFF
--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -40,9 +40,12 @@ REQUIRED_DAEMON_ROUTES = (
 REQUIRED_WEB_ROUTES = (
     "/",
     "/api/sessions?limit=1&offset=0",
+    "/api/facets",
 )
-OPTIONAL_WEB_ROUTES = ("/api/facets",)
 REQUIRED_RECEIVER_ROUTES = ("/v1/status",)
+ROUTE_MIN_TIMEOUT_S = {
+    "/api/facets": 15.0,
+}
 COMPLETION_PROBES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("query-then-connector", "polylogue find id:abc t", ("then",)),
     ("query-action", "polylogue find id:abc then s", ("select",)),
@@ -744,6 +747,10 @@ def _probe_route(url: str, *, timeout_s: float) -> RouteProbe:
         return RouteProbe(url=url, status=None, ok=False, error=f"{type(exc).__name__}: {exc}")
 
 
+def _route_timeout(route: str, default_timeout_s: float) -> float:
+    return max(default_timeout_s, ROUTE_MIN_TIMEOUT_S.get(route, default_timeout_s))
+
+
 def _resolve_browser_executable(path: str, executable: str | None) -> str | None:
     if executable:
         if os.path.isabs(executable) or os.sep in executable or (os.altsep is not None and os.altsep in executable):
@@ -911,9 +918,9 @@ def _diagnose(
         likely_causes.append("deployed daemon API predates /api/read-view-profiles or is not restarted")
         next_actions.append("restart polylogued after deploying a build that contains the read-view profiles route")
     if facets_route is not None and not facets_route.ok:
-        likely_causes.append("optional web-shell facets route exceeds the deployed smoke timeout")
+        likely_causes.append("web-shell facets route exceeds the deployed smoke timeout")
         next_actions.append(
-            "verify first paint still succeeds from / and /api/sessions, then profile deferred /api/facets families"
+            "verify first paint still succeeds from / and /api/sessions, then profile /api/facets route families"
         )
     if root_route is not None and not root_route.ok:
         likely_causes.append("web-shell root document is unavailable or exceeds the deployed smoke timeout")
@@ -1067,24 +1074,17 @@ def build_report(
     ]
     routes = [
         *(
-            _probe_route(f"{daemon_base_url.rstrip('/')}{route}", timeout_s=timeout_s)
-            for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES, *OPTIONAL_WEB_ROUTES)
+            _probe_route(f"{daemon_base_url.rstrip('/')}{route}", timeout_s=_route_timeout(route, timeout_s))
+            for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES)
         ),
         *(
             _probe_route(f"{receiver_base_url.rstrip('/')}{route}", timeout_s=timeout_s)
             for route in REQUIRED_RECEIVER_ROUTES
         ),
     ]
-    required_route_urls = {
-        f"{daemon_base_url.rstrip('/')}{route}" for route in (*REQUIRED_DAEMON_ROUTES, *REQUIRED_WEB_ROUTES)
-    } | {f"{receiver_base_url.rstrip('/')}{route}" for route in REQUIRED_RECEIVER_ROUTES}
     failures: list[str] = []
     failures.extend(f"command:{probe.name}:{probe.error or probe.exit_code}" for probe in commands if not probe.ok)
-    failures.extend(
-        f"route:{probe.url}:{probe.error or probe.status}"
-        for probe in routes
-        if not probe.ok and probe.url in required_route_urls
-    )
+    failures.extend(f"route:{probe.url}:{probe.error or probe.status}" for probe in routes if not probe.ok)
     failures.extend(
         f"completion:{probe.name}:{probe.error or 'missing=' + ','.join(probe.missing)}"
         for probe in completions

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -413,7 +413,7 @@ def test_deployment_smoke_reports_missing_completion_candidate(
     assert report.completions[0].missing == ["then"]
 
 
-def test_deployment_smoke_keeps_facets_timeout_optional(
+def test_deployment_smoke_reports_facets_timeout_as_route_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -442,8 +442,10 @@ def test_deployment_smoke_keeps_facets_timeout_optional(
         ),
     )
 
+    observed_timeouts: dict[str, float] = {}
+
     def fake_open_url(url: str, *, timeout_s: float) -> _FakeResponse:
-        del timeout_s
+        observed_timeouts[url] = timeout_s
         if url.endswith("/api/facets"):
             raise TimeoutError("facets exceeded budget")
         return _FakeResponse(200, {"ok": True, "url": url})
@@ -458,10 +460,11 @@ def test_deployment_smoke_keeps_facets_timeout_optional(
         timeout_s=1,
     )
 
-    assert report.ok is True
-    assert not any(failure.startswith("route:http://daemon/api/facets:") for failure in report.failures)
-    assert "optional web-shell facets route exceeds the deployed smoke timeout" in report.diagnostics["likely_causes"]
-    assert any("deferred /api/facets" in action for action in report.diagnostics["next_actions"])
+    assert report.ok is False
+    assert "route:http://daemon/api/facets:TimeoutError: facets exceeded budget" in report.failures
+    assert observed_timeouts["http://daemon/api/facets"] == 15.0
+    assert "web-shell facets route exceeds the deployed smoke timeout" in report.diagnostics["likely_causes"]
+    assert any("profile /api/facets" in action for action in report.diagnostics["next_actions"])
 
 
 def test_deployment_smoke_accepts_html_root_document(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Deployment smoke now treats every route it probes as part of the smoke contract. `/api/facets` remains allowed a larger cold-route timeout, but a timeout or other route error now makes the top-level report fail instead of producing `ok=True` with an embedded failed route record.

## Problem

The live #2410 deployment smoke produced top-level `ok=True` and `failures=[]` while the `/api/facets` route entry contained `ok=False` and `TimeoutError: timed out`. That makes the smoke report untrustworthy as deployment evidence.

Ref #2391.

## Solution

Move `/api/facets` into the required web route set, add a route-specific minimum timeout of 15 seconds for that cold path, and aggregate failures from all probed routes. The existing facets diagnostic remains, but it is now explanatory rather than a pass condition.

## Verification

- `devtools test tests/unit/devtools/test_deployment_smoke.py -q --tb=short` -> `30 passed in 1.43s`
- `devtools verify --quick` -> `exit_code=0`
- Pre-push `devtools verify --quick` -> `exit_code=0`

Remaining #2391 scope: rerun deployment smoke after this lands to prove the live report no longer hides route failures.
