### PR TITLE
perf: use active-path index for append leaf clear

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -321,7 +321,13 @@ def write_parsed_session_to_archive(
             ).fetchone()
             position_offset = int(row[0] or 0) if row is not None else 0
             conn.execute(
-                "UPDATE messages SET is_active_leaf = 0 WHERE session_id = ? AND is_active_leaf != 0",
+                """
+                UPDATE messages
+                SET is_active_leaf = 0
+                WHERE session_id = ?
+                  AND is_active_path = 1
+                  AND is_active_leaf != 0
+                """,
                 (session_id,),
             )
             active_leaf_message_id = _active_leaf_message_id(

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1371,6 +1371,18 @@ def test_provider_usage_rollup_skips_append_without_usage_events(
 
 def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
+    clear_plan = conn.execute(
+        """
+        EXPLAIN QUERY PLAN
+        UPDATE messages
+        SET is_active_leaf = 0
+        WHERE session_id = ?
+          AND is_active_path = 1
+          AND is_active_leaf != 0
+        """,
+        ("plan-check",),
+    ).fetchall()
+    assert any("idx_messages_active_path" in row["detail"] for row in clear_plan)
     message_count = 200
     first = ParsedSession(
         source_name=Provider.CODEX,


### PR DESCRIPTION
## Summary

Merge-append active-leaf clearing now uses the existing `idx_messages_active_path` partial index instead of scanning the whole session message set through a broad session index.

## Problem

Live append timings still showed `append.index.merge_prepare` as a visible leaf. Query-plan inspection against the live archive showed the active-leaf clear step using a broad session lookup, while adding the existing active-path predicate lets SQLite use `idx_messages_active_path`.

Ref #2391.

## Solution

Add `is_active_path = 1` to the merge-append active-leaf clear predicate. Production evidence before the change showed zero `is_active_leaf != 0` rows outside the active path, so this preserves observed active-leaf semantics without a schema change. The existing merge-append active-leaf test now asserts the clear query uses `idx_messages_active_path`.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'merge_append' -q --tb=short` -> `3 passed, 39 deselected in 7.08s`
- `devtools verify --quick` -> `exit_code=0`
- Pre-push `devtools verify --quick` -> `exit_code=0`

Remaining #2391 scope: deploy and observe whether `merge_prepare` drops out of the named top append stages; provider-usage-bearing rollups and larger block/session-event deltas remain separate leaves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session append behavior so only messages on the active path are deactivated, avoiding unintended changes to other messages in the same session.
* **Tests**
  * Added coverage to verify the update uses the expected active-path index and follows the corrected update scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->