### PR TITLE
perf: skip append cost aggregate without tokens

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -440,6 +440,7 @@ def write_parsed_session_to_archive(
             session_id,
             session,
             replace_existing_model_rows=not merge_append,
+            aggregate_message_tokens=not merge_append or _messages_have_token_counts(messages),
         )
         add_timing("index.reported_costs", t0)
         if merge_append and session_event_result.wrote_provider_usage_events:
@@ -1597,6 +1598,13 @@ def _session_count_values(messages: list[ParsedMessage]) -> dict[str, int]:
     return counts
 
 
+def _messages_have_token_counts(messages: Sequence[ParsedMessage]) -> bool:
+    return any(
+        message.input_tokens or message.output_tokens or message.cache_read_tokens or message.cache_write_tokens
+        for message in messages
+    )
+
+
 def _increment_session_counts_for_append(
     conn: sqlite3.Connection,
     session_id: str,
@@ -2518,6 +2526,7 @@ def _write_reported_costs(
     session: ParsedSession,
     *,
     replace_existing_model_rows: bool = True,
+    aggregate_message_tokens: bool = True,
 ) -> None:
     observed_at_ms = _timestamp_ms(session.updated_at) or _timestamp_ms(session.created_at)
     if session.reported_cost_usd is not None:
@@ -2547,7 +2556,8 @@ def _write_reported_costs(
     )
     for model_name in sorted(model_names):
         conn.execute(model_usage_sql, (session_id, _sqlite_text(model_name)))
-    _aggregate_message_tokens_into_model_usage(conn, session_id)
+    if aggregate_message_tokens:
+        _aggregate_message_tokens_into_model_usage(conn, session_id)
 
 
 def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session_id: str) -> None:

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1525,6 +1525,68 @@ def test_provider_usage_append_last_usage_does_not_override_cumulative(tmp_path:
     }
 
 
+def test_reported_costs_skip_message_token_aggregate_on_plain_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _connect(tmp_path / "index.db")
+    aggregate_calls: list[str] = []
+    original_aggregate = archive_tier_write._aggregate_message_tokens_into_model_usage
+
+    def _record_aggregate(conn_arg: sqlite3.Connection, session_id_arg: str) -> None:
+        aggregate_calls.append(session_id_arg)
+        original_aggregate(conn_arg, session_id_arg)
+
+    monkeypatch.setattr(archive_tier_write, "_aggregate_message_tokens_into_model_usage", _record_aggregate)
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-cost-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first")],
+            )
+        ],
+    )
+    plain_append = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-cost-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="plain append")],
+            )
+        ],
+    )
+    token_append = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-cost-append-skip",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m3",
+                role=Role.ASSISTANT,
+                model_name="gpt-5-codex",
+                input_tokens=2,
+                output_tokens=3,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="token append")],
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    assert aggregate_calls == [session_id]
+
+    write_parsed_session_to_archive(conn, plain_append, merge_append=True)
+    assert aggregate_calls == [session_id]
+
+    write_parsed_session_to_archive(conn, token_append, merge_append=True)
+    assert aggregate_calls == [session_id, session_id]
+
+
 def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     clear_plan = conn.execute(


### PR DESCRIPTION
## Summary

Plain merge-appends now skip the all-message token-cost aggregate when the appended batch carries no per-message token counters. Full writes and token-bearing appends keep the existing aggregate path.

## Problem

After PR #2414 removed the provider-usage rollup scan from usage-bearing appends, live append evidence showed `append.index.reported_costs` as a remaining visible leaf. Source inspection showed `_write_reported_costs` always called `_aggregate_message_tokens_into_model_usage`, which groups all messages for the session. For append batches whose messages have no token counters, that scan cannot change the aggregate.

## Solution

Add `_messages_have_token_counts` and pass an explicit `aggregate_message_tokens` flag into `_write_reported_costs`. Merge-appends aggregate message-token costs only when the appended messages carry token counters; full writes still aggregate unconditionally. The regression test verifies that a plain append skips the aggregate while a later token-bearing append runs it.

Ref #2391

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'reported_costs_skip or provider_usage or merge_append' -q --tb=short` -> `13 passed, 32 deselected in 56.65s`
- `devtools verify --quick` -> `exit_code=0`, run id `20260625T224040Z-quick-718139-1a217559`
- pre-push `devtools verify --quick` -> `exit_code=0`, run id `20260625T224119Z-quick-719187-1272e24f`
