### PR TITLE
fix: bound daemon archive read contention

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -79,6 +79,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_ARCHIVE_READER_BUSY_TIMEOUT_S = 0.25
+
 RouteMethod = Literal["GET", "POST", "DELETE"]
 _FacetQueryResult = TypeVar("_FacetQueryResult")
 
@@ -931,6 +933,22 @@ def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
                     field=field,
                 ).model_dump(mode="json"),
             )
+        except sqlite3.OperationalError as exc:
+            if _is_sqlite_busy_error(exc):
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    QueryErrorPayload(
+                        error="archive_busy",
+                        detail="Archive read route is temporarily unavailable while the daemon is writing catch-up data.",
+                    ).model_dump(mode="json"),
+                    extra_headers={"Retry-After": "1"},
+                )
+                return
+            logger.exception("sqlite error in %s", fn.__name__)
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                QueryErrorPayload(error="sqlite_error").model_dump(mode="json"),
+            )
         except _CLIENT_DISCONNECT_ERRORS:
             logger.debug("daemon http client disconnected in %s", fn.__name__)
         except Exception:
@@ -941,6 +959,11 @@ def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
             )
 
     return wrapper
+
+
+def _is_sqlite_busy_error(exc: sqlite3.OperationalError) -> bool:
+    detail = str(exc).lower()
+    return "database is locked" in detail or "database is busy" in detail or "database table is locked" in detail
 
 
 def _build_query_spec_params(
@@ -2010,7 +2033,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             or has_thinking
         )
 
-        with ArchiveStore.open_existing(archive_root) as archive:
+        with ArchiveStore.open_existing(archive_root, read_timeout=_ARCHIVE_READER_BUSY_TIMEOUT_S) as archive:
             # Resolve an ``id:`` clause once, up front, so both branches share one
             # miss/ambiguous policy. list_summaries/search_summaries resolve the
             # token internally and raise KeyError (miss) / ValueError (ambiguous);
@@ -2318,7 +2341,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _do_archive_get_session(self, archive_root: Path, conv_id: str) -> object | None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
-        with ArchiveStore.open_existing(archive_root) as archive:
+        with ArchiveStore.open_existing(archive_root, read_timeout=_ARCHIVE_READER_BUSY_TIMEOUT_S) as archive:
             try:
                 session_id = archive.resolve_session_id(conv_id)
                 envelope = archive.read_session(session_id)
@@ -2842,7 +2865,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.SERVICE_UNAVAILABLE, "archive_unavailable")
             return
 
-        with ArchiveStore.open_existing(archive_root) as archive:
+        with ArchiveStore.open_existing(archive_root, read_timeout=_ARCHIVE_READER_BUSY_TIMEOUT_S) as archive:
             payload = query_unit_envelope(archive, request)
 
         self._send_json(HTTPStatus.OK, payload.model_dump(mode="json"))
@@ -3334,7 +3357,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     ) -> object:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
-        with ArchiveStore.open_existing(archive_root) as archive:
+        with ArchiveStore.open_existing(archive_root, read_timeout=_ARCHIVE_READER_BUSY_TIMEOUT_S) as archive:
             try:
                 session_id = archive.resolve_session_id(conv_id)
                 envelope = archive.read_session(session_id)
@@ -3484,7 +3507,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         default_deferred = {
             family: _FACET_DEFERRED_REASON for family in _FACET_EXPENSIVE_FAMILIES if family not in requested_optional
         }
-        with ArchiveStore.open_existing(archive_root) as archive:
+        with ArchiveStore.open_existing(archive_root, read_timeout=_ARCHIVE_READER_BUSY_TIMEOUT_S) as archive:
             global_result = self._archive_facet_bucket(
                 archive,
                 optional_families=requested_optional,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -368,7 +368,14 @@ def _query_unit_group_expression(unit: str, row_alias: str, group_by: str | None
 class ArchiveStore:
     """Minimal archive-root façade for archive source/index/user tiers."""
 
-    def __init__(self, archive_root: Path, *, initialize: bool = True, read_only: bool = False) -> None:
+    def __init__(
+        self,
+        archive_root: Path,
+        *,
+        initialize: bool = True,
+        read_only: bool = False,
+        read_timeout: float = 5.0,
+    ) -> None:
         self.archive_root = archive_root
         self.source_db_path = archive_root / "source.db"
         self.index_db_path = archive_root / "index.db"
@@ -381,31 +388,29 @@ class ArchiveStore:
         if read_only:
             self._ensure_read_runtime_indexes()
         if read_only:
-            self._conn = sqlite3.connect(f"file:{self.index_db_path}?mode=ro", uri=True)
+            self._conn = sqlite3.connect(f"file:{self.index_db_path}?mode=ro", uri=True, timeout=read_timeout)
             pragma_statements = READ_CONNECTION_PRAGMA_STATEMENTS
         else:
             self._conn = sqlite3.connect(self.index_db_path)
             pragma_statements = WRITE_CONNECTION_PRAGMA_STATEMENTS
         self._conn.row_factory = sqlite3.Row
-        # Apply the canonical connection profile rather than a bare connection.
-        # A bare sqlite3.connect defaults to a 5s busy_timeout with no WAL
-        # tuning; under daemon write contention (live ingest and convergence
-        # stages both writing index.db) that window is exceeded and ingest
-        # writes fail with "database is locked", marking files failed and
-        # collapsing throughput. The write profile raises busy_timeout to 30s so
-        # writers queue instead of failing (docs/internals.md: SQLite tuning is
-        # profile-driven, not backend-local).
+        # Apply the canonical connection profile rather than relying on sqlite3
+        # defaults. Daemon read routes may opt into a shorter busy timeout so
+        # write-heavy catch-up surfaces as a typed degraded response instead of
+        # a client-side route timeout.
         for statement in pragma_statements:
             self._conn.execute(statement)
+        if read_only:
+            self._conn.execute(f"PRAGMA busy_timeout = {max(0, int(read_timeout * 1000))}")
         self._user_tier_attached = False
         self._tags_relation = "session_tags"
         self._attach_user_tier_if_present()
 
     @classmethod
-    def open_existing(cls, archive_root: Path, *, read_only: bool = True) -> ArchiveStore:
+    def open_existing(cls, archive_root: Path, *, read_only: bool = True, read_timeout: float = 5.0) -> ArchiveStore:
         """Open archive tier files, bootstrapping the five-tier root for writes."""
         initialize = not read_only or cls._needs_tier_bootstrap(archive_root)
-        return cls(archive_root, initialize=initialize, read_only=read_only)
+        return cls(archive_root, initialize=initialize, read_only=read_only, read_timeout=read_timeout)
 
     @staticmethod
     def _needs_tier_bootstrap(archive_root: Path) -> bool:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -715,6 +715,27 @@ class TestReaderSearchState:
         assert repo_status["expensive"] is True
         assert "repos" not in payload["complete_families"]
 
+    @pytest.mark.parametrize("path", ["/api/sessions", "/api/facets"])
+    def test_archive_busy_routes_return_typed_503(
+        self,
+        workspace_env: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        path: str,
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        def _raise_locked(*args: object, **kwargs: object) -> ArchiveStore:
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(ArchiveStore, "open_existing", _raise_locked)
+
+        with _running_server(workspace_env) as (_, base_url):
+            status, payload = _get_json_ex(base_url, path)
+
+        assert status == 503
+        assert payload["error"] == "archive_busy"
+        assert "temporarily unavailable" in cast(str, payload["detail"])
+
     def test_facets_can_materialize_deferred_families_when_requested(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
             payload = _get_json(base_url, "/api/facets?families=repos,action_types&budget_ms=5000")

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -40,6 +40,17 @@ def test_active_archive_root_facade_writes_reads_and_searches_archive_db(tmp_pat
     assert matching_blocks == ["codex-session:codex-archive-1:m1:0"]
 
 
+def test_open_existing_read_timeout_updates_busy_timeout(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as facade:
+        assert facade.index_db_path.exists()
+
+    with ArchiveStore.open_existing(root, read_timeout=0.25) as facade:
+        busy_timeout_ms = facade._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert busy_timeout_ms == 250
+
+
 def test_archive_tiers_archive_facade_sorts_search_matches(tmp_path: Path) -> None:
     short = ParsedSession(
         source_name=Provider.CODEX,


### PR DESCRIPTION
## Summary

Bound daemon archive reader routes so SQLite write contention during catch-up becomes a fast typed degraded response instead of an opaque client-side timeout.

## Problem

Live deployment smoke after the append-cost work observed `/api/sessions?limit=1&offset=0` and `/api/facets` timing out during daemon restart catch-up while lightweight routes such as `/api/status`, `/api/read-view-profiles`, `/`, and receiver status stayed responsive. That made archive read contention look like a broken API process and left smoke output without a useful route-level reason.

Ref #2308. Ref #2304. Ref #2391.

## Solution

`ArchiveStore.open_existing` now accepts an explicit `read_timeout` and applies the matching `PRAGMA busy_timeout` after the canonical read profile, so route-specific timeouts are not overwritten by the shared profile. The daemon's direct archive reader routes use a 250 ms read timeout. SQLite busy/locked errors are converted by `daemon_safe_handler` into HTTP 503 `archive_busy` payloads with `Retry-After: 1`; other SQLite operational errors still log and return `sqlite_error`.

This does not make busy read routes successful during catch-up. It makes the degraded state explicit and fast, which is the behavior the smoke and UI can reason about.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_archive.py::test_open_existing_read_timeout_updates_busy_timeout tests/unit/daemon/test_web_reader.py -k 'archive_busy_routes or facets_budget_exceeded or each_reader_route_responds' -q --tb=short` -> `9 passed, 139 deselected in 22.41s`
- `devtools verify --quick` -> exit 0 (`20260625T225912Z-quick-752101-24512118`)
- pre-push `devtools verify --quick` -> exit 0 (`20260625T230017Z-quick-753613-65275f3d`)