### PR TITLE
perf: index append active-leaf clearing

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -133,6 +133,10 @@ CREATE INDEX IF NOT EXISTS idx_messages_active_path
 ON messages(session_id, is_active_path, position)
 WHERE is_active_path = 1;
 
+CREATE INDEX IF NOT EXISTS idx_messages_active_leaf
+ON messages(session_id, is_active_leaf)
+WHERE is_active_leaf = 1;
+
 CREATE TABLE IF NOT EXISTS blocks (
     block_id        TEXT GENERATED ALWAYS AS (message_id || ':' || position) STORED UNIQUE,
     message_id      TEXT NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -331,7 +331,7 @@ def write_parsed_session_to_archive(
                 SET is_active_leaf = 0
                 WHERE session_id = ?
                   AND is_active_path = 1
-                  AND is_active_leaf != 0
+                  AND is_active_leaf = 1
                 """,
                 (session_id,),
             )

--- a/polylogue/storage/sqlite/runtime_indexes.py
+++ b/polylogue/storage/sqlite/runtime_indexes.py
@@ -30,6 +30,11 @@ _RUNTIME_INDEX_SQL: tuple[str, ...] = (
     CREATE INDEX IF NOT EXISTS idx_messages_material_origin
     ON messages(material_origin)
     """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_messages_active_leaf
+    ON messages(session_id, is_active_leaf)
+    WHERE is_active_leaf = 1
+    """,
 )
 
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1596,11 +1596,11 @@ def test_merge_append_clears_only_existing_active_leaf(tmp_path: Path) -> None:
         SET is_active_leaf = 0
         WHERE session_id = ?
           AND is_active_path = 1
-          AND is_active_leaf != 0
+          AND is_active_leaf = 1
         """,
         ("plan-check",),
     ).fetchall()
-    assert any("idx_messages_active_path" in row["detail"] for row in clear_plan)
+    assert any("idx_messages_active_leaf" in row["detail"] for row in clear_plan)
     message_count = 200
     first = ParsedSession(
         source_name=Provider.CODEX,


### PR DESCRIPTION
## Summary

Add a partial active-leaf index and make merge-appends clear the previous active leaf through a predicate SQLite can satisfy from that index.

## Problem

Live daemon evidence after the route-contention deployment showed the current Codex session file still had occasional multi-second append spikes. The worst recent attempt on `/home/sinity/.codex/sessions/2026/06/21/rollout-2026-06-21T19-54-51-019eeb52-2a15-7140-8811-143101d0a0dc.jsonl` had `append.index_parsed_write=4.778s`, with `append.index.merge_prepare=3.042s`, `graph_resolve=0.957s`, and `session_events=0.475s`.

That session currently has 45,440 messages. The merge-append active-leaf clear was using `is_active_leaf != 0`, and query-plan evidence showed SQLite selected `idx_messages_active_path`, which can still walk the giant active path instead of the single active leaf row.

Ref #2308. Ref #2391.

## Solution

- Add `idx_messages_active_leaf` to the canonical index tier DDL.
- Add the same index to runtime index ensure so existing archives pick it up without a reingest.
- Change the active-leaf clear predicate from `is_active_leaf != 0` to `is_active_leaf = 1`, matching the column's 0/1 CHECK constraint and allowing SQLite to prove the partial-index predicate.
- Tighten the existing merge-append query-plan test to assert the clear uses `idx_messages_active_leaf`.

This is intentionally narrow: it does not change graph/thread semantics or session-event writes.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py::test_merge_append_clears_only_existing_active_leaf -q --tb=short` -> `1 passed in 2.12s`
- `devtools verify --quick` -> exit 0 (`20260625T231653Z-quick-792132-abf7361c`)
- pre-push `devtools verify --quick` -> exit 0 (`20260625T231747Z-quick-792803-99be5f09`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how active-leaf message rows are cleared during session updates, narrowing the update to only truly active leaf entries.
  * Added support for a new index that speeds up lookups on active leaf messages, including runtime creation when needed.

* **Tests**
  * Updated query-plan coverage to reflect the new index and the tightened active-leaf condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->