### PR TITLE
fix: ensure runtime indexes in batch ingest

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -52,6 +52,7 @@ from polylogue.storage.sqlite.connection_profile import (
     DB_TIMEOUT,
     WRITE_CONNECTION_PRAGMA_STATEMENTS,
 )
+from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 
 if TYPE_CHECKING:
     from polylogue.pipeline.services.parsing import ParsingService
@@ -117,6 +118,8 @@ def _open_sync_connection(db_path: Path) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     for statement in WRITE_CONNECTION_PRAGMA_STATEMENTS:
         conn.execute(statement)
+    if db_path.name == "index.db":
+        ensure_runtime_indexes_sync(conn)
     _load_sqlite_vec(conn)
     return conn
 

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -86,6 +86,18 @@ def test_parse_batch_observation_reports_unsupported_write_mode() -> None:
     assert "archive_sync_elapsed_ms" not in observation
 
 
+def test_sync_index_connection_ensures_runtime_indexes(tmp_path: Path) -> None:
+    conn = ingest_batch_core._open_sync_connection(tmp_path / "archive" / "index.db")
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_messages_active_leaf'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+
+
 class _FakeConnectionBackend:
     def __init__(self, connection: Callable[[], AbstractAsyncContextManager[aiosqlite.Connection]]) -> None:
         self._connection = connection


### PR DESCRIPTION
## Summary

Ensure runtime SQLite indexes are created on the sync batch-ingest writer path, not only on general schema/read-open paths.

## Problem

After deploying PR #2417, installed binaries were correct and `polylogued.service` restarted, but the production archive still lacked `idx_messages_active_leaf`; the active-leaf clear still planned through `idx_messages_active_path`. The daemon append writer opens `index.db` through `pipeline/services/ingest_batch/_core.py:_open_sync_connection`, bypassing the `ArchiveStore` read-open runtime-index ensure path.

Ref #2308. Ref #2391.

## Solution

`_open_sync_connection()` now runs `ensure_runtime_indexes_sync(conn)` for `index.db` connections after write PRAGMAs and before batch writes begin. A pipeline regression test asserts that a fresh sync index connection materializes `idx_messages_active_leaf`.

This is a wiring fix for the runtime-index mechanism introduced by PR #2417; it does not change ingest semantics.

## Verification

- `devtools test tests/unit/pipeline/test_ingest_batch.py::test_sync_index_connection_ensures_runtime_indexes tests/unit/storage/test_archive_tiers_write.py::test_merge_append_clears_only_existing_active_leaf -q --tb=short` -> `2 passed in 4.07s`
- `devtools verify --quick` -> exit 0 (`20260625T232517Z-quick-817326-d71d56cb`)
- pre-push `devtools verify --quick` -> exit 0 (`20260625T232611Z-quick-817986-2ca516df`)