### PR TITLE
perf(storage): index message role facets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1161,6 +1161,12 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 10 adds a role-leading `idx_messages_role` index so
+  daemon `/api/facets` can compute global role counts without scanning the
+  session-role compound index and spilling to a temp B-tree. Existing index
+  tiers must be rebuilt from source evidence or explicitly operator-patched by
+  adding the index to a backed-up archive before moving that archive to version
+  10 with the matching deployed package.
 - Index schema version 9 adds typed `sessions.session_kind` for standard vs
   temporary sessions. Existing index tiers must be rebuilt from source evidence
   or explicitly operator-patched so temporary ChatGPT/Claude/browser-capture

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,6 +106,12 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 10 adds a role-leading `idx_messages_role` index so
+  daemon `/api/facets` can compute global role counts without scanning the
+  session-role compound index and spilling to a temp B-tree. Existing index
+  tiers must be rebuilt from source evidence or explicitly operator-patched by
+  adding the index to a backed-up archive before moving that archive to version
+  10 with the matching deployed package.
 - Index schema version 9 adds typed `sessions.session_kind` for standard vs
   temporary sessions. Existing index tiers must be rebuilt from source evidence
   or explicitly operator-patched so temporary ChatGPT/Claude/browser-capture

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ over the `CREATE TABLE` statement.
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 1` |
-| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 9` |
+| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 10` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 1` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 3` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -133,8 +133,10 @@ _FACET_COMPLETE_ARCHIVE_FAMILIES = (
     "total_counts",
     "origins",
     "tags",
+    "role_counts",
     "repos",
     "message_types",
+    "material_origins",
     "action_types",
     "has_flags",
 )

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -21,7 +21,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
     nullable_check,
 )
 
-INDEX_SCHEMA_VERSION = 9
+INDEX_SCHEMA_VERSION = 10
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -121,6 +121,9 @@ WHERE parent_message_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_messages_session_role
 ON messages(session_id, role);
+
+CREATE INDEX IF NOT EXISTS idx_messages_role
+ON messages(role);
 
 CREATE INDEX IF NOT EXISTS idx_messages_session_material_origin
 ON messages(session_id, material_origin);

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -313,6 +313,17 @@ def test_archive_tiers_cost_price_basis_has_typed_tables(tmp_path: Path) -> None
     } <= tables
 
 
+def test_archive_tiers_messages_have_role_leading_facet_index(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    _apply_tier(conn, ArchiveTier.INDEX)
+
+    indexes = {row["name"] for row in conn.execute("PRAGMA index_list('messages')").fetchall()}
+    assert "idx_messages_role" in indexes
+
+    columns = [row["name"] for row in conn.execute("PRAGMA index_info('idx_messages_role')").fetchall()]
+    assert columns == ["role"]
+
+
 def test_archive_tier_specs_capture_file_and_backup_policy() -> None:
     assert {tier: spec.filename for tier, spec in ARCHIVE_TIER_SPECS.items()} == {
         ArchiveTier.SOURCE: "source.db",


### PR DESCRIPTION
## Summary

Adds a role-leading `messages(role)` index and bumps the index tier schema to v10 so deployed `/api/facets` can compute role-count facets without timing out on the production archive.

Ref #2304

## Problem

After deploying typed `session_kind`, the deployment smoke still failed because `/api/facets` exceeded the smoke timeout. Live SQL timing showed `SELECT role, COUNT(*) FROM messages GROUP BY role` took roughly 24 seconds on the production archive: SQLite scanned `idx_messages_session_role` and spilled to a temp B-tree because the existing compound index is session-leading.

## Solution

Add `idx_messages_role ON messages(role)` to the canonical index schema, document index schema v10, refresh generated agent docs, and add a focused DDL regression test that asserts the role-leading index exists with the expected column order.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_ddl.py::test_archive_tiers_messages_have_role_leading_facet_index -q` -> 1 passed.
- `devtools verify --quick` -> success locally.
- Pre-push `devtools verify --quick` -> success on pushed HEAD `72bb6dff`.

## Deployment notes

Existing production `index.db` can be patched additively after a verified backup by running `CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role)` and setting `PRAGMA user_version = 10`. No row data is rewritten beyond the new index build. The live archive already has a verified full-evidence backup at `/home/sinity/.local/share/polylogue/archive-db-backups/polylogue-archive-20260626T004605Z`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message facet performance by adding a role-based index for faster global role counts.

* **Bug Fixes**
  * Reduced the chance of slower facet queries that could previously require extra temporary work on larger datasets.

* **Documentation**
  * Updated schema and internal documentation to reflect the new schema version and indexing change.

* **Tests**
  * Added coverage to verify the new role-leading index is present and correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->