### PR TITLE
fix(backup): report missing referenced blob debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1554,6 +1554,11 @@ The report has a stable top-level shape carrying its `report_version`,
   FTS/source-row drift and the archive can afford the scan.
 - `blob_lease_state` — pending lease count, distinct lease operations,
   oldest `acquired_at`. See the lease/GC concurrency model above.
+- `blob_reference_debt` — skipped by default so routine workload snapshots do
+  not stat every referenced blob path on large archives. Pass
+  `--blob-reference-debt` when diagnosing backup/integrity incidents; the
+  section then reports the exact missing referenced-blob count, bounded hash
+  sample, reference-source counts, and source/index DB path used.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -22,13 +22,14 @@ from pathlib import Path
 from typing import Any
 
 from polylogue.paths import active_index_db_path
+from polylogue.storage.blob_integrity import scan_blob_reference_debt
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
 # The compare path uses this to refuse incompatible inputs loudly.
-REPORT_VERSION = 12  # v12 exposes physical DB/table locations for logical observability surfaces.
+REPORT_VERSION = 13  # v13 adds exact missing referenced-blob debt.
 UNKNOWN_TABLE_COUNT = -2
 
 _EXPECTED_FTS_TRIGGERS: tuple[str, ...] = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
@@ -1642,6 +1643,37 @@ def _blob_lease_state(conn: sqlite3.Connection) -> dict[str, Any]:
     }
 
 
+def _blob_reference_debt_state(db: Path, *, enabled: bool) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "checked": False,
+            "ok": True,
+            "reason": "skipped; pass --blob-reference-debt to scan referenced blob files",
+        }
+    source_db = db.with_name("source.db")
+    target = source_db if source_db.exists() else db
+    if not target.exists():
+        return {
+            "checked": False,
+            "ok": False,
+            "db_path": str(target),
+            "error": "source/index database does not exist",
+        }
+    try:
+        report = scan_blob_reference_debt(target)
+    except (OSError, sqlite3.Error) as exc:
+        return {
+            "checked": False,
+            "ok": False,
+            "db_path": str(target),
+            "error": str(exc),
+        }
+    payload = report.to_dict()
+    payload["checked"] = True
+    payload["db_path"] = str(target)
+    return payload
+
+
 def _gc_state(conn: sqlite3.Connection) -> dict[str, Any]:
     if not _table_exists(conn, "gc_generations"):
         return {
@@ -2022,6 +2054,7 @@ def probe(
     integrity_check: bool = False,
     exact_derived_counts: bool = False,
     exact_table_counts: bool = False,
+    blob_reference_debt: bool = False,
 ) -> dict[str, Any]:
     ops_db = db.with_name("ops.db")
     index_db = db.with_name("index.db")
@@ -2071,6 +2104,7 @@ def probe(
             ),
             "topology_quarantine_state": _topology_quarantine_state(conn),
             "blob_lease_state": _tier_state_or_current(conn, db.with_name("source.db"), _blob_lease_state),
+            "blob_reference_debt": _blob_reference_debt_state(db, enabled=blob_reference_debt),
             "gc_state": _tier_state_or_current(conn, db.with_name("source.db"), _gc_state),
             "fts_trigger_state": _fts_trigger_state(conn),
             "daemon_resource_signal": _daemon_resource_signal(recent_attempts, conn, ops_db=ops_db),
@@ -2610,6 +2644,11 @@ def _parser() -> argparse.ArgumentParser:
         help="Run exact boundary/archive table counts instead of cheap planner estimates",
     )
     parser.add_argument(
+        "--blob-reference-debt",
+        action="store_true",
+        help="Count missing referenced blob files exactly (can stat many blob paths on large archives)",
+    )
+    parser.add_argument(
         "--compare",
         nargs=2,
         metavar=("BEFORE", "AFTER"),
@@ -2643,6 +2682,7 @@ def main(argv: list[str] | None = None) -> int:
         integrity_check=args.integrity_check,
         exact_derived_counts=args.exact_derived_counts,
         exact_table_counts=args.exact_table_counts,
+        blob_reference_debt=args.blob_reference_debt,
     )
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -402,6 +402,14 @@ identical content is automatically deduplicated. For backup:
 - For large archives, use restic or rsync targeting the `blob/` directory
 - Blobs are write-once, read-many — incremental backup tools work well
 
+When a backup sees source rows or attachment references whose content-addressed
+blob file is absent, it keeps the backup usable but records the debt instead of
+silently hiding it. The warning names the total missing referenced blobs and
+the backup directory includes `blob-reference-debt.json` with the exact count,
+bounded hash sample, and reference-source counts. Treat that report as
+read-only recovery evidence: restore missing blob files from an older backup or
+re-ingest the affected raw sources before deleting any source/blob/link rows.
+
 ### Vacuum Guidance
 
 SQLite `VACUUM` rebuilds the database file, reclaiming free pages. It

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -499,6 +499,11 @@ The report has a stable top-level shape carrying its `report_version`,
   FTS/source-row drift and the archive can afford the scan.
 - `blob_lease_state` — pending lease count, distinct lease operations,
   oldest `acquired_at`. See the lease/GC concurrency model above.
+- `blob_reference_debt` — skipped by default so routine workload snapshots do
+  not stat every referenced blob path on large archives. Pass
+  `--blob-reference-debt` when diagnosing backup/integrity incidents; the
+  section then reports the exact missing referenced-blob count, bounded hash
+  sample, reference-source counts, and source/index DB path used.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -33,6 +33,11 @@ def diagnostics_group() -> None:
     help="Run exact derived-readiness reconciliation counts. This can scan large archive tables.",
 )
 @click.option(
+    "--blob-reference-debt",
+    is_flag=True,
+    help="Count missing referenced blob files exactly. This can stat many blob paths on large archives.",
+)
+@click.option(
     "--compare",
     nargs=2,
     type=click.Path(path_type=Path),
@@ -46,6 +51,7 @@ def workload_command(
     limit: int,
     integrity_check: bool,
     exact_derived_counts: bool,
+    blob_reference_debt: bool,
     compare: tuple[Path, Path] | None,
 ) -> None:
     """Inspect daemon ingest workload, convergence debt, and hot query plans."""
@@ -61,6 +67,8 @@ def workload_command(
         argv.append("--integrity-check")
     if exact_derived_counts:
         argv.append("--exact-derived-counts")
+    if blob_reference_debt:
+        argv.append("--blob-reference-debt")
     if compare is not None:
         before, after = compare
         argv.extend(("--compare", str(before), str(after)))

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root, blob_store_root
+from polylogue.storage.blob_integrity import BlobReferenceDebtReport, referenced_blob_hashes, scan_blob_reference_debt
 from polylogue.storage.blob_store import BlobStore
 
 logger = get_logger(__name__)
@@ -209,43 +210,53 @@ def _backup_sqlite(src: Path, dst: Path) -> int:
 
 
 def _source_blob_hashes(source_db: Path) -> set[str]:
-    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
-    try:
-        rows = conn.execute("SELECT DISTINCT hex(blob_hash) FROM blob_refs").fetchall()
-    finally:
-        conn.close()
-    return {str(row[0]).lower() for row in rows if row and row[0]}
+    return set(referenced_blob_hashes(source_db))
 
 
-def _copy_referenced_blobs(*, source_db: Path, backup_root: Path, warnings: list[str]) -> tuple[int, int]:
+def _write_blob_reference_debt_report(backup_root: Path, report: BlobReferenceDebtReport) -> Path:
+    path = backup_root / "blob-reference-debt.json"
+    path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _copy_referenced_blobs(
+    *,
+    source_db: Path,
+    backup_root: Path,
+    warnings: list[str],
+) -> tuple[int, int, BlobReferenceDebtReport]:
     hashes = _source_blob_hashes(source_db)
-    if not hashes:
-        return 0, 0
-
     store = BlobStore(blob_store_root())
+    debt_report = scan_blob_reference_debt(
+        source_db,
+        store=store,
+        sample_size=_MISSING_BLOB_WARNING_SAMPLE_LIMIT,
+    )
+    if not hashes:
+        return 0, 0, debt_report
+
     blob_dst_root = backup_root / "blob"
     count = 0
     size = 0
-    missing_count = 0
-    missing_samples: list[str] = []
     for hash_hex in sorted(hashes):
         src = store.blob_path(hash_hex)
         if not src.exists():
-            missing_count += 1
-            if len(missing_samples) < _MISSING_BLOB_WARNING_SAMPLE_LIMIT:
-                missing_samples.append(hash_hex)
             continue
         dst = blob_dst_root / hash_hex[:2] / hash_hex[2:]
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         count += 1
         size += dst.stat().st_size
-    if missing_count:
+    if debt_report.missing_referenced_blobs:
+        _write_blob_reference_debt_report(backup_root, debt_report)
+        sample = ", ".join(debt_report.sample)
         warnings.append(
             "referenced blobs missing: "
-            f"{missing_count} total" + (f" (sample: {', '.join(missing_samples)})" if missing_samples else "")
+            f"{debt_report.missing_referenced_blobs} total"
+            + (f" (sample: {sample})" if sample else "")
+            + "; details: blob-reference-debt.json"
         )
-    return count, size
+    return count, size, debt_report
 
 
 def _write_manifest(
@@ -259,6 +270,7 @@ def _write_manifest(
     blob_count: int,
     blob_size: int,
     warnings: list[str],
+    blob_reference_debt: BlobReferenceDebtReport | None = None,
 ) -> None:
     manifest = {
         "format": "polylogue-backup-v1",
@@ -272,6 +284,8 @@ def _write_manifest(
         "blob_size_bytes": blob_size,
         "warnings": warnings,
     }
+    if blob_reference_debt is not None:
+        manifest["blob_reference_debt"] = blob_reference_debt.to_dict()
     (backup_root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
 
 
@@ -351,8 +365,9 @@ def _backup_archive(*, output_dir: Path, started: float, profile: BackupProfile)
         db_size += _backup_sqlite(src, dst)
         backed_up_files.append(str(dst))
 
+    blob_reference_debt: BlobReferenceDebtReport | None = None
     if "source" in included_tiers:
-        blob_count, blob_size = _copy_referenced_blobs(
+        blob_count, blob_size, blob_reference_debt = _copy_referenced_blobs(
             source_db=included_tiers["source"],
             backup_root=backup_root,
             warnings=warnings,
@@ -374,8 +389,11 @@ def _backup_archive(*, output_dir: Path, started: float, profile: BackupProfile)
         blob_count=blob_count,
         blob_size=blob_size,
         warnings=warnings,
+        blob_reference_debt=blob_reference_debt,
     )
     backed_up_files.append(str(backup_root / "manifest.json"))
+    if blob_reference_debt is not None and blob_reference_debt.missing_referenced_blobs:
+        backed_up_files.append(str(backup_root / "blob-reference-debt.json"))
 
     return BackupResult(
         ok=True,

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -87,6 +87,35 @@ class BlobIntegrityReport:
         }
 
 
+@dataclass(frozen=True)
+class BlobReferenceDebtReport:
+    """Exact, read-only debt report for DB references with no blob file.
+
+    Unlike :func:`scan_blob_integrity`, this path does not walk every blob file
+    and does not re-hash blob contents. It checks every referenced blob hash
+    from source evidence, counts the missing files exactly, and keeps only a
+    bounded sample for operator output.
+    """
+
+    total_references_seen: int
+    missing_referenced_blobs: int
+    sample: tuple[str, ...]
+    reference_sources: dict[str, int]
+
+    @property
+    def ok(self) -> bool:
+        return self.missing_referenced_blobs == 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "total_references_seen": self.total_references_seen,
+            "missing_referenced_blobs": self.missing_referenced_blobs,
+            "sample": list(self.sample),
+            "reference_sources": dict(self.reference_sources),
+        }
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
@@ -107,14 +136,26 @@ def _blob_hash_text(value: object) -> str | None:
 
 
 def _archive_source_blob_hashes(conn: sqlite3.Connection) -> list[str]:
+    hashes_by_table = _archive_source_blob_hashes_by_table(conn)
     hashes: set[str] = set()
+    for table_hashes in hashes_by_table.values():
+        hashes.update(table_hashes)
+    return sorted(hashes)
+
+
+def _archive_source_blob_hashes_by_table(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    hashes_by_table: dict[str, list[str]] = {}
     if _table_exists(conn, "raw_sessions"):
         rows = conn.execute("SELECT blob_hash FROM raw_sessions").fetchall()
-        hashes.update(hash_text for row in rows if (hash_text := _blob_hash_text(row[0])) is not None)
+        raw_hashes = {hash_text for row in rows if (hash_text := _blob_hash_text(row[0])) is not None}
+        if raw_hashes:
+            hashes_by_table["raw_sessions"] = sorted(raw_hashes)
     if _table_exists(conn, "blob_refs"):
         rows = conn.execute("SELECT blob_hash FROM blob_refs").fetchall()
-        hashes.update(hash_text for row in rows if (hash_text := _blob_hash_text(row[0])) is not None)
-    return sorted(hashes)
+        ref_hashes = {hash_text for row in rows if (hash_text := _blob_hash_text(row[0])) is not None}
+        if ref_hashes:
+            hashes_by_table["blob_refs"] = sorted(ref_hashes)
+    return hashes_by_table
 
 
 def _raw_session_hashes(conn: sqlite3.Connection) -> list[str]:
@@ -146,6 +187,36 @@ def _referenced_blob_hashes(db_path: Path, conn: sqlite3.Connection) -> list[str
             pass
 
     return _raw_session_hashes(conn)
+
+
+def _reference_source_counts(db_path: Path, conn: sqlite3.Connection) -> dict[str, int]:
+    direct = _archive_source_blob_hashes_by_table(conn)
+    if direct:
+        return {table: len(hashes) for table, hashes in direct.items()}
+
+    source_db = db_path.with_name("source.db")
+    if source_db != db_path and source_db.exists():
+        try:
+            source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+            try:
+                source = _archive_source_blob_hashes_by_table(source_conn)
+                if source:
+                    return {f"source.db:{table}": len(hashes) for table, hashes in source.items()}
+            finally:
+                source_conn.close()
+        except sqlite3.Error:
+            pass
+
+    fallback_count = len(_raw_session_hashes(conn))
+    return {"raw_sessions.raw_id": fallback_count} if fallback_count else {}
+
+
+def referenced_blob_hashes(db_path: str | Path) -> list[str]:
+    """Return distinct blob hashes referenced by archive source evidence."""
+
+    resolved_db_path = Path(db_path)
+    with sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True) as conn:
+        return _referenced_blob_hashes(resolved_db_path, conn)
 
 
 def _pending_blob_leases(conn: sqlite3.Connection) -> dict[str, int]:
@@ -181,6 +252,37 @@ def _blob_size(store: BlobStore, blob_hash: str) -> int:
         return int(store.blob_path(blob_hash).stat().st_size)
     except (OSError, ValueError):
         return 0
+
+
+def scan_blob_reference_debt(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    sample_size: int = _MAX_FINDING_SAMPLE,
+) -> BlobReferenceDebtReport:
+    """Count missing referenced blob files exactly without mutating state."""
+
+    blob_store = store if store is not None else get_blob_store()
+    resolved_db_path = Path(db_path)
+    with sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True) as conn:
+        referenced = _referenced_blob_hashes(resolved_db_path, conn)
+        reference_sources = _reference_source_counts(resolved_db_path, conn)
+
+    missing_count = 0
+    sample: list[str] = []
+    sample_limit = max(0, sample_size)
+    for blob_hash in referenced:
+        if blob_store.exists(blob_hash):
+            continue
+        missing_count += 1
+        if len(sample) < sample_limit:
+            sample.append(blob_hash)
+    return BlobReferenceDebtReport(
+        total_references_seen=len(referenced),
+        missing_referenced_blobs=missing_count,
+        sample=tuple(sample),
+        reference_sources=reference_sources,
+    )
 
 
 def scan_blob_integrity(
@@ -289,5 +391,8 @@ __all__ = [
     "BlobIntegrityFinding",
     "BlobIntegrityKind",
     "BlobIntegrityReport",
+    "BlobReferenceDebtReport",
+    "referenced_blob_hashes",
+    "scan_blob_reference_debt",
     "scan_blob_integrity",
 ]

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -332,23 +332,46 @@ def test_backup_missing_blob_warnings_are_bounded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     hashes = tuple(f"{idx:064x}" for idx in range(25))
-    monkeypatch.setattr(backup_mod, "_source_blob_hashes", lambda _source_db: hashes)
+    source_db = tmp_path / "source.db"
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                raw_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                PRIMARY KEY(blob_hash, raw_id, ref_type)
+            );
+            """
+        )
+        for idx, blob_hash in enumerate(hashes):
+            conn.execute(
+                "INSERT INTO blob_refs (blob_hash, raw_id, ref_type) VALUES (?, ?, ?)",
+                (bytes.fromhex(blob_hash), f"raw-{idx}", "attachment"),
+            )
     monkeypatch.setattr(backup_mod, "blob_store_root", lambda: tmp_path / "blob-store")
 
     warnings: list[str] = []
-    count, size = backup_mod._copy_referenced_blobs(
-        source_db=tmp_path / "source.db",
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+    count, size, debt = backup_mod._copy_referenced_blobs(
+        source_db=source_db,
         backup_root=tmp_path / "backup",
         warnings=warnings,
     )
 
     assert count == 0
     assert size == 0
+    assert debt.missing_referenced_blobs == 25
     assert len(warnings) == 1
     assert "25 total" in warnings[0]
+    assert "blob-reference-debt.json" in warnings[0]
     assert hashes[0] in warnings[0]
     assert hashes[9] in warnings[0]
     assert hashes[10] not in warnings[0]
+    debt_payload = json.loads((backup_root / "blob-reference-debt.json").read_text())
+    assert debt_payload["missing_referenced_blobs"] == 25
+    assert debt_payload["sample"] == list(hashes[:10])
 
 
 def test_backup_archive_requires_precious_tiers(workspace_env: dict[str, Path], tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import devtools.daemon_workload_probe as workload_probe
 from devtools.daemon_workload_probe import (
     REPORT_VERSION,
     UNKNOWN_TABLE_COUNT,
@@ -16,6 +17,7 @@ from devtools.daemon_workload_probe import (
     probe,
 )
 from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.blob_integrity import BlobReferenceDebtReport
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     add_convergence_debt,
@@ -129,6 +131,45 @@ def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -
     assert fts_plan["hazards"] == []
     assert not any(item.startswith("unavailable:") for item in fts_plan["plan"])
     assert any("blocks" in item for item in fts_plan["plan"])
+
+
+def test_daemon_workload_probe_reports_blob_reference_debt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "archive.sqlite"
+    source = tmp_path / "session.jsonl"
+    _seed_minimal_archive(db, source)
+
+    def fake_scan(path: Path) -> BlobReferenceDebtReport:
+        assert path == tmp_path / "source.db"
+        return BlobReferenceDebtReport(
+            total_references_seen=3,
+            missing_referenced_blobs=2,
+            sample=("a" * 64, "b" * 64),
+            reference_sources={"raw_sessions": 1, "blob_refs": 2},
+        )
+
+    monkeypatch.setattr(workload_probe, "scan_blob_reference_debt", fake_scan)
+
+    default_payload = probe(db)
+    assert default_payload["blob_reference_debt"] == {
+        "checked": False,
+        "ok": True,
+        "reason": "skipped; pass --blob-reference-debt to scan referenced blob files",
+    }
+
+    payload = probe(db, blob_reference_debt=True)
+
+    assert payload["blob_reference_debt"] == {
+        "checked": True,
+        "db_path": str(tmp_path / "source.db"),
+        "ok": False,
+        "total_references_seen": 3,
+        "missing_referenced_blobs": 2,
+        "sample": ["a" * 64, "b" * 64],
+        "reference_sources": {"raw_sessions": 1, "blob_refs": 2},
+    }
 
 
 def test_daemon_workload_probe_defaults_to_estimated_table_counts(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from polylogue.storage.blob_integrity import scan_blob_integrity
+from polylogue.storage.blob_integrity import referenced_blob_hashes, scan_blob_integrity, scan_blob_reference_debt
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 
 def _make_db(path: Path) -> sqlite3.Connection:
@@ -146,6 +148,77 @@ def test_scan_blob_integrity_reads_source_tier_blob_refs(tmp_path: Path) -> None
     assert by_kind["orphan_blobs"].sample == (orphan_hash,)
     assert raw_hash not in by_kind["orphan_blobs"].sample
     assert attachment_hash not in by_kind["orphan_blobs"].sample
+
+
+def test_scan_blob_reference_debt_counts_all_missing_refs_with_bounded_sample(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    present_hash, present_size = store.write_from_bytes(b"present")
+    missing_hashes = [f"{idx:064x}" for idx in range(5)]
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                blob_hash BLOB NOT NULL,
+                blob_size INTEGER NOT NULL
+            );
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                raw_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                PRIMARY KEY(blob_hash, raw_id, ref_type)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO raw_sessions (raw_id, blob_hash, blob_size) VALUES (?, ?, ?)",
+            ("raw-present", bytes.fromhex(present_hash), present_size),
+        )
+        for idx, blob_hash in enumerate(missing_hashes):
+            conn.execute(
+                "INSERT INTO blob_refs (blob_hash, raw_id, ref_type) VALUES (?, ?, ?)",
+                (bytes.fromhex(blob_hash), f"raw-{idx}", "attachment"),
+            )
+
+    report = scan_blob_reference_debt(source_db, store=store, sample_size=2)
+
+    assert report.ok is False
+    assert report.total_references_seen == 6
+    assert report.missing_referenced_blobs == 5
+    assert report.sample == tuple(missing_hashes[:2])
+    assert report.reference_sources == {"raw_sessions": 1, "blob_refs": 5}
+    assert referenced_blob_hashes(source_db) == sorted([present_hash, *missing_hashes])
+
+
+def test_scan_blob_reference_debt_reads_initialized_source_tier(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    present_hash, present_size = store.write_from_bytes(b"present")
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    with sqlite3.connect(source_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "raw-present",
+                "codex-session",
+                "native-1",
+                "/tmp/session.jsonl",
+                bytes.fromhex(present_hash),
+                present_size,
+                1,
+            ),
+        )
+
+    report = scan_blob_reference_debt(source_db, store=store)
+
+    assert report.ok is True
+    assert report.total_references_seen == 1
+    assert report.reference_sources == {"raw_sessions": 1}
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a source-backed, read-only missing-blob reference debt report for backups and diagnostics. Backups now write `blob-reference-debt.json` when referenced blob files are absent, and workload diagnostics can run an explicit exact scan with `--blob-reference-debt` without slowing the default probe path.

## Problem

A verified production backup reported `referenced blobs missing: 39586 total`, but the durable output was only a bounded warning string. That is not enough to audit recoverability, distinguish source tables involved, or preserve the evidence needed for a careful repair plan. Ref #2421.

## Solution

`polylogue.storage.blob_integrity` now exposes an exact reference-only debt scanner that reads source-tier blob references without going through index-schema guards and without walking or hashing the whole blob store. `polylogue ops backup` uses the shared reference source, emits the existing warning plus a `blob-reference-debt.json` sidecar, and includes the same report in `manifest.json`. `polylogue ops diagnostics workload --blob-reference-debt --json` exposes the exact count, bounded sample, source table counts, and DB path; routine workload diagnostics keep a cheap skipped marker by default.

Docs were updated to make the recovery posture explicit: preserve source/blob/link evidence first, then restore blobs from backup or re-ingest affected raw sources.

## Verification

- `devtools test tests/unit/storage/test_blob_integrity.py tests/unit/daemon/test_backup.py::test_backup_missing_blob_warnings_are_bounded tests/unit/devtools/test_daemon_workload_probe.py::test_daemon_workload_probe_reports_blob_reference_debt -q` → 8 passed
- `devtools verify --quick` → passed
- pre-push `devtools verify --quick` → passed
- `uv run polylogue ops diagnostics workload --json` → `blob_reference_debt.checked=false`, default path stays cheap
- `uv run polylogue ops diagnostics workload --json --blob-reference-debt` against the live archive → `missing_referenced_blobs=39586`, `total_references_seen=68151`, `reference_sources={'blob_refs': 66355, 'raw_sessions': 19900}`

## Residuals

This PR makes the debt auditable and reproducible. It does not mutate production archive state or attempt repair; the next #2421 step is to classify the missing references by recoverability and draft a data-preserving recovery plan.
