### PR TITLE
fix(maintenance): classify blob reference debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1563,6 +1563,9 @@ The report has a stable top-level shape carrying its `report_version`,
   `polylogue ops maintenance blob-reference-debt --output-format json`; that
   read-only classifier groups missing blob refs by table, ref type, origin,
   raw-row joinability, validation/parse state, and source-path availability.
+  The paired `polylogue ops maintenance blob-reference-restore-direct`
+  command only restores direct-file source paths after exact SHA-256
+  verification; archive-member paths remain source re-acquisition work.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1559,6 +1559,10 @@ The report has a stable top-level shape carrying its `report_version`,
   `--blob-reference-debt` when diagnosing backup/integrity incidents; the
   section then reports the exact missing referenced-blob count, bounded hash
   sample, reference-source counts, and source/index DB path used.
+  For recovery planning, run
+  `polylogue ops maintenance blob-reference-debt --output-format json`; that
+  read-only classifier groups missing blob refs by table, ref type, origin,
+  raw-row joinability, validation/parse state, and source-path availability.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -414,6 +414,12 @@ For a richer recovery map, run
 not mutate the archive and classifies missing refs by origin, reference table,
 ref type, raw-row joinability, and whether the recorded source path still
 exists.
+For direct source files whose current bytes still hash to the missing blob
+address, `polylogue ops maintenance blob-reference-restore-direct --yes`
+can repopulate the blob store without touching SQLite rows. Container/member
+paths such as `export.zip:conversations.json` are deliberately skipped by that
+command because the referenced blob may be an extracted record inside the
+member, not the member file itself.
 
 ### Vacuum Guidance
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -409,6 +409,11 @@ the backup directory includes `blob-reference-debt.json` with the exact count,
 bounded hash sample, and reference-source counts. Treat that report as
 read-only recovery evidence: restore missing blob files from an older backup or
 re-ingest the affected raw sources before deleting any source/blob/link rows.
+For a richer recovery map, run
+`polylogue ops maintenance blob-reference-debt --output-format json`; it does
+not mutate the archive and classifies missing refs by origin, reference table,
+ref type, raw-row joinability, and whether the recorded source path still
+exists.
 
 ### Vacuum Guidance
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -508,6 +508,9 @@ The report has a stable top-level shape carrying its `report_version`,
   `polylogue ops maintenance blob-reference-debt --output-format json`; that
   read-only classifier groups missing blob refs by table, ref type, origin,
   raw-row joinability, validation/parse state, and source-path availability.
+  The paired `polylogue ops maintenance blob-reference-restore-direct`
+  command only restores direct-file source paths after exact SHA-256
+  verification; archive-member paths remain source re-acquisition work.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -504,6 +504,10 @@ The report has a stable top-level shape carrying its `report_version`,
   `--blob-reference-debt` when diagnosing backup/integrity incidents; the
   section then reports the exact missing referenced-blob count, bounded hash
   sample, reference-source counts, and source/index DB path used.
+  For recovery planning, run
+  `polylogue ops maintenance blob-reference-debt --output-format json`; that
+  read-only classifier groups missing blob refs by table, ref type, origin,
+  raw-row joinability, validation/parse state, and source-path availability.
 - `gc_state` — high-water `gc_generations` row, `last_completed_at`,
   total generation count.
 - `fts_trigger_state` — the three expected FTS sync triggers

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -26,6 +26,10 @@ from polylogue.maintenance.targets import MAINTENANCE_TARGET_NAMES, build_mainte
 from polylogue.operations.archive_debt import _source_path_native_id_candidates
 from polylogue.paths import archive_file_set_root_for_paths, archive_root, blob_store_root, db_path, render_root
 from polylogue.storage.blob_gc import read_gc_history, run_blob_gc_report
+from polylogue.storage.blob_integrity import (
+    BlobReferenceDebtClassificationReport,
+    classify_blob_reference_debt,
+)
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveInitBlockedError,
@@ -1173,6 +1177,96 @@ def blob_gc_command(max_batch: int, yes: bool, output_format: str) -> None:
             click.echo(f"Generation: {result.generation_id}")
 
 
+@maintenance_group.command("blob-reference-debt")
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative missing-blob samples to include.",
+)
+@click.option(
+    "--group-limit",
+    type=int,
+    default=20,
+    show_default=True,
+    help="Maximum number of grouped classifications to include.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_debt_command(sample_limit: int, group_limit: int, output_format: str) -> None:
+    """Classify missing referenced blobs without mutating the archive."""
+    report = classify_blob_reference_debt(
+        archive_root() / "source.db",
+        sample_size=sample_limit,
+        group_limit=group_limit,
+    )
+    payload = {
+        "mode": "blob_reference_debt",
+        "mutates": False,
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_debt_plain(report)
+
+
+def _render_blob_reference_debt_plain(report: BlobReferenceDebtClassificationReport) -> None:
+    click.echo("Blob reference debt")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Blob root:    {report.blob_root}")
+    click.echo(f"References:   {report.reference_rows:,} row(s), {report.distinct_referenced_blobs:,} distinct blob(s)")
+    click.echo(f"Missing:      {report.missing_distinct_blobs:,} distinct blob(s)")
+    click.echo(f"Status:       {'ok' if report.ok else 'debt-present'}")
+
+    def _render_counts(label: str, counts: dict[str, int]) -> None:
+        if not counts:
+            return
+        rendered = ", ".join(f"{key}={value:,}" for key, value in sorted(counts.items()))
+        click.echo(f"{label}: {rendered}")
+
+    _render_counts("By table    ", report.missing_by_table)
+    _render_counts("By ref type ", report.missing_by_ref_type)
+    _render_counts("By origin   ", report.missing_by_origin)
+    _render_counts("Ref-id join ", report.missing_ref_id_join)
+    _render_counts("Source paths", report.missing_source_path_presence)
+    _render_counts("Validation  ", report.missing_validation_status)
+    _render_counts("Parse errors", report.missing_parse_error)
+
+    if report.top_groups:
+        click.echo("Top groups:")
+        for group in report.top_groups:
+            tables_value = group.get("tables", ())
+            ref_types_value = group.get("ref_types", ())
+            origins_value = group.get("origins", ())
+            count_value = group.get("count", 0)
+            tables = ",".join(str(item) for item in tables_value) if isinstance(tables_value, list | tuple) else ""
+            ref_types = (
+                ",".join(str(item) for item in ref_types_value) if isinstance(ref_types_value, list | tuple) else ""
+            )
+            origins = ",".join(str(item) for item in origins_value) if isinstance(origins_value, list | tuple) else ""
+            count = count_value if isinstance(count_value, int) else 0
+            click.echo(f"  {count:>8,}  tables={tables} ref_types={ref_types} origins={origins}")
+
+    if report.samples:
+        click.echo("Samples:")
+        for sample in report.samples[:5]:
+            source = sample.sample_source_path or "(none)"
+            origin = ",".join(sample.origins) if sample.origins else "(none)"
+            click.echo(
+                f"  {sample.blob_hash} origin={origin} source_available={sample.sample_source_available} {source}"
+            )
+
+
 @maintenance_group.command("gc-history")
 @click.option(
     "--limit",
@@ -1381,6 +1475,7 @@ def _render_record_plain(record: OperationRecord) -> None:
 
 __all__ = [
     "assertion_export_command",
+    "blob_reference_debt_command",
     "gc_history_command",
     "maintenance_group",
     "plan_command",

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -28,7 +28,9 @@ from polylogue.paths import archive_file_set_root_for_paths, archive_root, blob_
 from polylogue.storage.blob_gc import read_gc_history, run_blob_gc_report
 from polylogue.storage.blob_integrity import (
     BlobReferenceDebtClassificationReport,
+    BlobReferenceDebtRestoreReport,
     classify_blob_reference_debt,
+    restore_direct_blob_reference_debt,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.archive_init import (
@@ -1267,6 +1269,89 @@ def _render_blob_reference_debt_plain(report: BlobReferenceDebtClassificationRep
             )
 
 
+@maintenance_group.command("blob-reference-restore-direct")
+@click.option(
+    "--max-count",
+    type=int,
+    default=None,
+    help="Maximum number of direct-file candidates to restore or preview.",
+)
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative samples to include.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Write missing blob files. Without this flag the command is a dry-run preview.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_restore_direct_command(
+    max_count: int | None,
+    sample_limit: int,
+    yes: bool,
+    output_format: str,
+) -> None:
+    """Restore direct-file missing blobs after exact hash verification."""
+    report = restore_direct_blob_reference_debt(
+        archive_root() / "source.db",
+        dry_run=not yes,
+        max_count=max_count,
+        sample_size=sample_limit,
+    )
+    payload = {
+        "mode": "blob_reference_restore_direct",
+        "mutates": bool(yes),
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_restore_plain(report)
+
+
+def _render_blob_reference_restore_plain(report: BlobReferenceDebtRestoreReport) -> None:
+    click.echo("Blob reference direct-file restore")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Blob root:    {report.blob_root}")
+    click.echo(f"Mode:         {'dry-run' if report.dry_run else 'apply'}")
+    click.echo(f"Missing:      {report.missing_distinct_blobs:,} distinct blob(s)")
+    click.echo(f"Candidates:   {report.candidate_count:,}")
+    action = "would restore" if report.dry_run else "restored"
+    affected = report.candidate_count if report.dry_run else report.restored_count
+    click.echo(f"Result:       {action} {affected:,} blob(s)")
+    if not report.dry_run:
+        click.echo(f"Bytes:        {report.restored_bytes:,}")
+    click.echo(
+        "Skipped:      "
+        f"existing={report.skipped_existing:,} "
+        f"no_source={report.skipped_no_source_path:,} "
+        f"container_member={report.skipped_container_member:,} "
+        f"source_missing={report.skipped_source_missing:,} "
+        f"size_mismatch={report.skipped_size_mismatch:,} "
+        f"hash_mismatch={report.skipped_hash_mismatch:,} "
+        f"error={report.skipped_error:,}"
+    )
+    if report.samples:
+        click.echo("Samples:")
+        for sample in report.samples[:5]:
+            detail = f" reason={sample.reason}" if sample.reason else ""
+            source = sample.source_path or "(none)"
+            click.echo(f"  {sample.action} {sample.blob_hash}{detail} {source}")
+
+
 @maintenance_group.command("gc-history")
 @click.option(
     "--limit",
@@ -1476,6 +1561,7 @@ def _render_record_plain(record: OperationRecord) -> None:
 __all__ = [
     "assertion_export_command",
     "blob_reference_debt_command",
+    "blob_reference_restore_direct_command",
     "gc_history_command",
     "maintenance_group",
     "plan_command",

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from collections import Counter, defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from polylogue.storage.blob_store import BlobStore, get_blob_store
 from polylogue.storage.sqlite.connection import open_read_connection
@@ -116,6 +118,83 @@ class BlobReferenceDebtReport:
         }
 
 
+@dataclass(frozen=True)
+class BlobReferenceDebtSample:
+    blob_hash: str
+    tables: tuple[str, ...]
+    ref_types: tuple[str, ...]
+    origins: tuple[str, ...]
+    reference_rows: int
+    sample_ref_id: str | None
+    sample_ref_id_has_raw_session: bool
+    sample_source_path: str | None
+    sample_source_outer_path: str | None
+    sample_source_available: bool | None
+    sample_size_bytes: int | None
+    sample_parse_error: str | None
+    sample_validation_status: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blob_hash": self.blob_hash,
+            "tables": list(self.tables),
+            "ref_types": list(self.ref_types),
+            "origins": list(self.origins),
+            "reference_rows": self.reference_rows,
+            "sample_ref_id": self.sample_ref_id,
+            "sample_ref_id_has_raw_session": self.sample_ref_id_has_raw_session,
+            "sample_source_path": self.sample_source_path,
+            "sample_source_outer_path": self.sample_source_outer_path,
+            "sample_source_available": self.sample_source_available,
+            "sample_size_bytes": self.sample_size_bytes,
+            "sample_parse_error": self.sample_parse_error,
+            "sample_validation_status": self.sample_validation_status,
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceDebtClassificationReport:
+    """Grouped, exact read-only classifier for missing referenced blobs."""
+
+    source_db: str
+    blob_root: str
+    distinct_referenced_blobs: int
+    reference_rows: int
+    missing_distinct_blobs: int
+    missing_by_table: dict[str, int]
+    missing_by_ref_type: dict[str, int]
+    missing_by_origin: dict[str, int]
+    missing_ref_id_join: dict[str, int]
+    missing_source_path_presence: dict[str, int]
+    missing_validation_status: dict[str, int]
+    missing_parse_error: dict[str, int]
+    top_groups: tuple[dict[str, object], ...]
+    samples: tuple[BlobReferenceDebtSample, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.missing_distinct_blobs == 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "source_db": self.source_db,
+            "blob_root": self.blob_root,
+            "distinct_referenced_blobs": self.distinct_referenced_blobs,
+            "reference_rows": self.reference_rows,
+            "missing_distinct_blobs": self.missing_distinct_blobs,
+            "missing_by_table": dict(self.missing_by_table),
+            "missing_by_ref_type": dict(self.missing_by_ref_type),
+            "missing_by_origin": dict(self.missing_by_origin),
+            "missing_ref_id_join": dict(self.missing_ref_id_join),
+            "missing_source_path_presence": dict(self.missing_source_path_presence),
+            "missing_validation_status": dict(self.missing_validation_status),
+            "missing_parse_error": dict(self.missing_parse_error),
+            "top_groups": [dict(group) for group in self.top_groups],
+            "samples": [sample.to_dict() for sample in self.samples],
+        }
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
@@ -133,6 +212,12 @@ def _blob_hash_text(value: object) -> str | None:
         return None
     text = str(value)
     return text if text else None
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})").fetchall())
 
 
 def _archive_source_blob_hashes(conn: sqlite3.Connection) -> list[str]:
@@ -217,6 +302,231 @@ def referenced_blob_hashes(db_path: str | Path) -> list[str]:
     resolved_db_path = Path(db_path)
     with sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True) as conn:
         return _referenced_blob_hashes(resolved_db_path, conn)
+
+
+def _source_db_for_blob_reference_report(db_path: str | Path) -> Path:
+    resolved = Path(db_path)
+    sibling_source = resolved.with_name("source.db")
+    if sibling_source.exists():
+        return sibling_source
+    return resolved
+
+
+def _source_path_availability(path: str | None) -> tuple[bool | None, str | None]:
+    if not path:
+        return None, None
+    direct = Path(path)
+    if direct.exists():
+        return True, str(direct)
+    if ":" in path:
+        outer, _inner = path.split(":", 1)
+        outer_path = Path(outer)
+        return outer_path.exists(), str(outer_path)
+    return False, str(direct)
+
+
+def _optional_str(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def _blob_ref_source_path_column(conn: sqlite3.Connection) -> str:
+    return "source_path" if _column_exists(conn, "blob_refs", "source_path") else "NULL"
+
+
+def _blob_ref_size_column(conn: sqlite3.Connection) -> str:
+    return "size_bytes" if _column_exists(conn, "blob_refs", "size_bytes") else "0"
+
+
+def _blob_ref_id_column(conn: sqlite3.Connection) -> str:
+    if _column_exists(conn, "blob_refs", "ref_id"):
+        return "ref_id"
+    if _column_exists(conn, "blob_refs", "raw_id"):
+        return "raw_id"
+    return "NULL"
+
+
+def _raw_session_reference_rows(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "raw_sessions"):
+        return []
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT lower(hex(blob_hash)) AS blob_hash,
+               'raw_sessions' AS table_name,
+               'raw_payload' AS ref_type,
+               raw_id AS ref_id,
+               origin,
+               native_id,
+               source_path,
+               blob_size AS size_bytes,
+               parse_error,
+               validation_status,
+               1 AS ref_id_has_raw_session
+        FROM raw_sessions
+        WHERE blob_hash IS NOT NULL
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _blob_ref_reference_rows(
+    conn: sqlite3.Connection,
+    *,
+    raw_by_id: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "blob_refs"):
+        return []
+    conn.row_factory = sqlite3.Row
+    ref_id_column = _blob_ref_id_column(conn)
+    source_path_column = _blob_ref_source_path_column(conn)
+    size_column = _blob_ref_size_column(conn)
+    rows = conn.execute(
+        f"""
+        SELECT lower(hex(blob_hash)) AS blob_hash,
+               'blob_refs' AS table_name,
+               ref_type,
+               {ref_id_column} AS ref_id,
+               {source_path_column} AS source_path,
+               {size_column} AS size_bytes
+        FROM blob_refs
+        WHERE blob_hash IS NOT NULL
+        """
+    ).fetchall()
+    refs: list[dict[str, Any]] = []
+    for row in rows:
+        ref = dict(row)
+        raw = raw_by_id.get(str(ref.get("ref_id")))
+        ref["origin"] = raw.get("origin") if raw else None
+        ref["native_id"] = raw.get("native_id") if raw else None
+        ref["parse_error"] = raw.get("parse_error") if raw else None
+        ref["validation_status"] = raw.get("validation_status") if raw else None
+        ref["ref_id_has_raw_session"] = raw is not None
+        refs.append(ref)
+    return refs
+
+
+def _group_reference_rows(rows: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    by_hash: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        blob_hash = str(row.get("blob_hash") or "")
+        if blob_hash:
+            by_hash[blob_hash].append(row)
+    return by_hash
+
+
+def classify_blob_reference_debt(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    sample_size: int = 30,
+    group_limit: int = 20,
+) -> BlobReferenceDebtClassificationReport:
+    """Classify missing referenced blobs without mutating archive state."""
+
+    blob_store = store if store is not None else get_blob_store()
+    source_db = _source_db_for_blob_reference_report(db_path)
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        raw_refs = _raw_session_reference_rows(conn)
+        raw_by_id = {str(row["ref_id"]): row for row in raw_refs if row.get("ref_id")}
+        refs = [*raw_refs, *_blob_ref_reference_rows(conn, raw_by_id=raw_by_id)]
+
+    by_hash = _group_reference_rows(refs)
+    missing = [(blob_hash, group) for blob_hash, group in by_hash.items() if not blob_store.exists(blob_hash)]
+
+    by_table: Counter[str] = Counter()
+    by_ref_type: Counter[str] = Counter()
+    by_origin: Counter[str] = Counter()
+    ref_id_join: Counter[str] = Counter()
+    source_path_presence: Counter[str] = Counter()
+    validation_status: Counter[str] = Counter()
+    parse_error: Counter[str] = Counter()
+    grouped: Counter[tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]] = Counter()
+    samples: list[BlobReferenceDebtSample] = []
+
+    for blob_hash, group in missing:
+        tables = tuple(sorted({str(row.get("table_name")) for row in group if row.get("table_name")}))
+        ref_types = tuple(sorted({str(row.get("ref_type")) for row in group if row.get("ref_type")}))
+        origins = tuple(sorted({str(row.get("origin")) for row in group if row.get("origin")}))
+        for table in tables:
+            by_table[table] += 1
+        for ref_type in ref_types:
+            by_ref_type[ref_type] += 1
+        for origin in origins or ("(none)",):
+            by_origin[origin] += 1
+        if any(bool(row.get("ref_id_has_raw_session")) for row in group):
+            ref_id_join["ref_id_has_raw_session"] += 1
+        else:
+            ref_id_join["ref_id_without_raw_session"] += 1
+
+        source_availability = [_source_path_availability(_optional_str(row.get("source_path")))[0] for row in group]
+        known_source_availability = [value for value in source_availability if value is not None]
+        if not known_source_availability:
+            source_path_presence["no_source_path_recorded"] += 1
+        elif any(known_source_availability):
+            source_path_presence["recoverable_source_path_exists"] += 1
+        else:
+            source_path_presence["source_path_missing"] += 1
+
+        statuses = {str(row.get("validation_status")) for row in group if row.get("validation_status")}
+        validation_status[",".join(sorted(statuses)) if statuses else "(none)"] += 1
+        errors = {str(row.get("parse_error")) for row in group if row.get("parse_error")}
+        parse_error["has_parse_error" if errors else "no_parse_error"] += 1
+        grouped[(tables, ref_types, origins or ("(none)",))] += 1
+
+        if len(samples) < max(0, sample_size):
+            sample = group[0]
+            sample_source_path = _optional_str(sample.get("source_path"))
+            available, outer = _source_path_availability(sample_source_path)
+            size = sample.get("size_bytes")
+            samples.append(
+                BlobReferenceDebtSample(
+                    blob_hash=blob_hash,
+                    tables=tables,
+                    ref_types=ref_types,
+                    origins=origins,
+                    reference_rows=len(group),
+                    sample_ref_id=_optional_str(sample.get("ref_id")),
+                    sample_ref_id_has_raw_session=any(bool(row.get("ref_id_has_raw_session")) for row in group),
+                    sample_source_path=sample_source_path,
+                    sample_source_outer_path=outer,
+                    sample_source_available=available,
+                    sample_size_bytes=int(size) if size is not None else None,
+                    sample_parse_error=_optional_str(sample.get("parse_error")),
+                    sample_validation_status=_optional_str(sample.get("validation_status")),
+                )
+            )
+
+    top_groups: list[dict[str, object]] = []
+    for (tables, ref_types, origins), count in grouped.most_common(max(0, group_limit)):
+        top_groups.append(
+            {
+                "tables": list(tables),
+                "ref_types": list(ref_types),
+                "origins": list(origins),
+                "count": count,
+            }
+        )
+
+    return BlobReferenceDebtClassificationReport(
+        source_db=str(source_db),
+        blob_root=str(blob_store.root),
+        distinct_referenced_blobs=len(by_hash),
+        reference_rows=len(refs),
+        missing_distinct_blobs=len(missing),
+        missing_by_table=_counter_dict(by_table),
+        missing_by_ref_type=_counter_dict(by_ref_type),
+        missing_by_origin=_counter_dict(by_origin),
+        missing_ref_id_join=_counter_dict(ref_id_join),
+        missing_source_path_presence=_counter_dict(source_path_presence),
+        missing_validation_status=_counter_dict(validation_status),
+        missing_parse_error=_counter_dict(parse_error),
+        top_groups=tuple(top_groups),
+        samples=tuple(samples),
+    )
 
 
 def _pending_blob_leases(conn: sqlite3.Connection) -> dict[str, int]:
@@ -391,7 +701,10 @@ __all__ = [
     "BlobIntegrityFinding",
     "BlobIntegrityKind",
     "BlobIntegrityReport",
+    "BlobReferenceDebtClassificationReport",
     "BlobReferenceDebtReport",
+    "BlobReferenceDebtSample",
+    "classify_blob_reference_debt",
     "referenced_blob_hashes",
     "scan_blob_reference_debt",
     "scan_blob_integrity",

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -8,7 +8,10 @@ integrity classes with bounded default cost.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import sqlite3
+import tempfile
 import time
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -195,6 +198,69 @@ class BlobReferenceDebtClassificationReport:
         }
 
 
+@dataclass(frozen=True)
+class BlobReferenceDebtRestoreSample:
+    blob_hash: str
+    source_path: str | None
+    action: str
+    reason: str | None = None
+    bytes_restored: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blob_hash": self.blob_hash,
+            "source_path": self.source_path,
+            "action": self.action,
+            "reason": self.reason,
+            "bytes_restored": self.bytes_restored,
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceDebtRestoreReport:
+    """Dry-run/apply report for direct-file blob debt restoration."""
+
+    source_db: str
+    blob_root: str
+    dry_run: bool
+    missing_distinct_blobs: int
+    candidate_count: int
+    restored_count: int
+    restored_bytes: int
+    skipped_existing: int
+    skipped_no_source_path: int
+    skipped_container_member: int
+    skipped_source_missing: int
+    skipped_size_mismatch: int
+    skipped_hash_mismatch: int
+    skipped_error: int
+    samples: tuple[BlobReferenceDebtRestoreSample, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.skipped_hash_mismatch == 0 and self.skipped_error == 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "source_db": self.source_db,
+            "blob_root": self.blob_root,
+            "dry_run": self.dry_run,
+            "missing_distinct_blobs": self.missing_distinct_blobs,
+            "candidate_count": self.candidate_count,
+            "restored_count": self.restored_count,
+            "restored_bytes": self.restored_bytes,
+            "skipped_existing": self.skipped_existing,
+            "skipped_no_source_path": self.skipped_no_source_path,
+            "skipped_container_member": self.skipped_container_member,
+            "skipped_source_missing": self.skipped_source_missing,
+            "skipped_size_mismatch": self.skipped_size_mismatch,
+            "skipped_hash_mismatch": self.skipped_hash_mismatch,
+            "skipped_error": self.skipped_error,
+            "samples": [sample.to_dict() for sample in self.samples],
+        }
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
@@ -353,18 +419,26 @@ def _raw_session_reference_rows(conn: sqlite3.Connection) -> list[dict[str, Any]
     if not _table_exists(conn, "raw_sessions"):
         return []
     conn.row_factory = sqlite3.Row
+    origin_column = "origin" if _column_exists(conn, "raw_sessions", "origin") else "NULL"
+    native_id_column = "native_id" if _column_exists(conn, "raw_sessions", "native_id") else "NULL"
+    source_path_column = "source_path" if _column_exists(conn, "raw_sessions", "source_path") else "NULL"
+    blob_size_column = "blob_size" if _column_exists(conn, "raw_sessions", "blob_size") else "0"
+    parse_error_column = "parse_error" if _column_exists(conn, "raw_sessions", "parse_error") else "NULL"
+    validation_status_column = (
+        "validation_status" if _column_exists(conn, "raw_sessions", "validation_status") else "NULL"
+    )
     rows = conn.execute(
-        """
+        f"""
         SELECT lower(hex(blob_hash)) AS blob_hash,
                'raw_sessions' AS table_name,
                'raw_payload' AS ref_type,
                raw_id AS ref_id,
-               origin,
-               native_id,
-               source_path,
-               blob_size AS size_bytes,
-               parse_error,
-               validation_status,
+               {origin_column} AS origin,
+               {native_id_column} AS native_id,
+               {source_path_column} AS source_path,
+               {blob_size_column} AS size_bytes,
+               {parse_error_column} AS parse_error,
+               {validation_status_column} AS validation_status,
                1 AS ref_id_has_raw_session
         FROM raw_sessions
         WHERE blob_hash IS NOT NULL
@@ -418,6 +492,13 @@ def _group_reference_rows(rows: Iterable[dict[str, Any]]) -> dict[str, list[dict
     return by_hash
 
 
+def _reference_rows_for_blob_debt(source_db: Path) -> list[dict[str, Any]]:
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        raw_refs = _raw_session_reference_rows(conn)
+        raw_by_id = {str(row["ref_id"]): row for row in raw_refs if row.get("ref_id")}
+        return [*raw_refs, *_blob_ref_reference_rows(conn, raw_by_id=raw_by_id)]
+
+
 def classify_blob_reference_debt(
     db_path: str | Path,
     *,
@@ -429,11 +510,7 @@ def classify_blob_reference_debt(
 
     blob_store = store if store is not None else get_blob_store()
     source_db = _source_db_for_blob_reference_report(db_path)
-    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
-        raw_refs = _raw_session_reference_rows(conn)
-        raw_by_id = {str(row["ref_id"]): row for row in raw_refs if row.get("ref_id")}
-        refs = [*raw_refs, *_blob_ref_reference_rows(conn, raw_by_id=raw_by_id)]
-
+    refs = _reference_rows_for_blob_debt(source_db)
     by_hash = _group_reference_rows(refs)
     missing = [(blob_hash, group) for blob_hash, group in by_hash.items() if not blob_store.exists(blob_hash)]
 
@@ -525,6 +602,205 @@ def classify_blob_reference_debt(
         missing_validation_status=_counter_dict(validation_status),
         missing_parse_error=_counter_dict(parse_error),
         top_groups=tuple(top_groups),
+        samples=tuple(samples),
+    )
+
+
+def _path_is_container_member(path: str) -> bool:
+    return ":" in path
+
+
+def _direct_restore_candidate(group: list[dict[str, Any]]) -> tuple[Path | None, str]:
+    saw_source_path = False
+    saw_container_member = False
+    saw_missing = False
+    saw_size_mismatch = False
+    for row in group:
+        source_path = _optional_str(row.get("source_path"))
+        if not source_path:
+            continue
+        saw_source_path = True
+        if _path_is_container_member(source_path):
+            saw_container_member = True
+            continue
+        path = Path(source_path)
+        if not path.exists():
+            saw_missing = True
+            continue
+        size = row.get("size_bytes")
+        if size is not None and path.stat().st_size != int(size):
+            saw_size_mismatch = True
+            continue
+        return path, "candidate"
+    if not saw_source_path:
+        return None, "no_source_path"
+    if saw_container_member:
+        return None, "container_member"
+    if saw_missing:
+        return None, "source_missing"
+    if saw_size_mismatch:
+        return None, "size_mismatch"
+    return None, "no_candidate"
+
+
+def _restore_expected_hash_from_path(blob_store: BlobStore, expected_hash: str, source_path: Path) -> tuple[str, int]:
+    blob_store.root.mkdir(parents=True, exist_ok=True)
+    fd: int | None = None
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=blob_store.root, prefix=".restore.")
+        hasher = hashlib.sha256()
+        size = 0
+        with source_path.open("rb") as source:
+            while True:
+                chunk = source.read(1024 * 1024)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+                os.write(fd, chunk)
+                size += len(chunk)
+        os.close(fd)
+        fd = None
+        actual_hash = hasher.hexdigest()
+        if actual_hash != expected_hash:
+            return actual_hash, size
+        destination = blob_store.blob_path(expected_hash)
+        if destination.exists():
+            return actual_hash, size
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, destination)
+        tmp_path = None
+        return actual_hash, size
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def restore_direct_blob_reference_debt(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    dry_run: bool = True,
+    max_count: int | None = None,
+    sample_size: int = 30,
+) -> BlobReferenceDebtRestoreReport:
+    """Restore direct-file missing blob refs after exact hash verification."""
+
+    blob_store = store if store is not None else get_blob_store()
+    source_db = _source_db_for_blob_reference_report(db_path)
+    refs = _reference_rows_for_blob_debt(source_db)
+    by_hash = _group_reference_rows(refs)
+    missing = {blob_hash: group for blob_hash, group in by_hash.items() if not blob_store.exists(blob_hash)}
+
+    candidate_count = 0
+    restored_count = 0
+    restored_bytes = 0
+    skipped_existing = 0
+    skipped_no_source_path = 0
+    skipped_container_member = 0
+    skipped_source_missing = 0
+    skipped_size_mismatch = 0
+    skipped_hash_mismatch = 0
+    skipped_error = 0
+    samples: list[BlobReferenceDebtRestoreSample] = []
+
+    for blob_hash, group in missing.items():
+        if max_count is not None and candidate_count >= max_count:
+            break
+        if blob_store.exists(blob_hash):
+            skipped_existing += 1
+            continue
+        source_path, reason = _direct_restore_candidate(group)
+        if source_path is None:
+            if reason == "no_source_path":
+                skipped_no_source_path += 1
+            elif reason == "container_member":
+                skipped_container_member += 1
+            elif reason == "source_missing":
+                skipped_source_missing += 1
+            elif reason == "size_mismatch":
+                skipped_size_mismatch += 1
+            else:
+                skipped_no_source_path += 1
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceDebtRestoreSample(
+                        blob_hash=blob_hash,
+                        source_path=None,
+                        action="skipped",
+                        reason=reason,
+                    )
+                )
+            continue
+
+        candidate_count += 1
+        if dry_run:
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceDebtRestoreSample(
+                        blob_hash=blob_hash,
+                        source_path=str(source_path),
+                        action="would_restore",
+                    )
+                )
+            continue
+
+        try:
+            actual_hash, size = _restore_expected_hash_from_path(blob_store, blob_hash, source_path)
+        except OSError as exc:
+            skipped_error += 1
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceDebtRestoreSample(
+                        blob_hash=blob_hash,
+                        source_path=str(source_path),
+                        action="skipped",
+                        reason=f"error:{exc}",
+                    )
+                )
+            continue
+        if actual_hash != blob_hash:
+            skipped_hash_mismatch += 1
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceDebtRestoreSample(
+                        blob_hash=blob_hash,
+                        source_path=str(source_path),
+                        action="skipped",
+                        reason=f"hash_mismatch:{actual_hash}",
+                    )
+                )
+            continue
+        restored_count += 1
+        restored_bytes += size
+        if len(samples) < max(0, sample_size):
+            samples.append(
+                BlobReferenceDebtRestoreSample(
+                    blob_hash=blob_hash,
+                    source_path=str(source_path),
+                    action="restored",
+                    bytes_restored=size,
+                )
+            )
+
+    return BlobReferenceDebtRestoreReport(
+        source_db=str(source_db),
+        blob_root=str(blob_store.root),
+        dry_run=dry_run,
+        missing_distinct_blobs=len(missing),
+        candidate_count=candidate_count,
+        restored_count=restored_count,
+        restored_bytes=restored_bytes,
+        skipped_existing=skipped_existing,
+        skipped_no_source_path=skipped_no_source_path,
+        skipped_container_member=skipped_container_member,
+        skipped_source_missing=skipped_source_missing,
+        skipped_size_mismatch=skipped_size_mismatch,
+        skipped_hash_mismatch=skipped_hash_mismatch,
+        skipped_error=skipped_error,
         samples=tuple(samples),
     )
 
@@ -703,9 +979,12 @@ __all__ = [
     "BlobIntegrityReport",
     "BlobReferenceDebtClassificationReport",
     "BlobReferenceDebtReport",
+    "BlobReferenceDebtRestoreReport",
+    "BlobReferenceDebtRestoreSample",
     "BlobReferenceDebtSample",
     "classify_blob_reference_debt",
     "referenced_blob_hashes",
+    "restore_direct_blob_reference_debt",
     "scan_blob_reference_debt",
     "scan_blob_integrity",
 ]

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -138,6 +139,23 @@ def _seed_blob_reference_debt(archive_root: Path, source: Path) -> None:
             """,
             (missing_ref_hash, "raw-gone", "raw_payload", str(archive_root / "missing-browser-capture.json"), 10, 1),
         )
+
+
+def _seed_direct_restorable_blob_ref(archive_root: Path, source: Path) -> str:
+    source.parent.mkdir(parents=True, exist_ok=True)
+    payload = b"direct restorable payload"
+    source.write_bytes(payload)
+    blob_hash = hashlib.sha256(payload).digest()
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs (
+                blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (blob_hash, "raw-direct-restore", "raw_payload", str(source), source.stat().st_size, 1),
+        )
+    return blob_hash.hex()
 
 
 def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
@@ -465,6 +483,69 @@ def test_blob_reference_debt_cli_plain_output_names_read_only_debt(
     assert "Blob reference debt" in result.output
     assert "Status:       debt-present" in result.output
     assert "Source paths: recoverable_source_path_exists=1, source_path_missing=1" in result.output
+
+
+def test_blob_reference_restore_direct_cli_dry_run_keeps_blob_missing(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "direct.jsonl"
+    blob_hash = _seed_direct_restorable_blob_ref(cli_workspace["archive_root"], source)
+    blob_path = cli_workspace["data_root"] / "polylogue" / "blob" / blob_hash[:2] / blob_hash[2:]
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-restore-direct",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "blob_reference_restore_direct"
+    assert payload["mutates"] is False
+    assert payload["dry_run"] is True
+    assert payload["candidate_count"] == 1
+    assert payload["restored_count"] == 0
+    assert not blob_path.exists()
+
+
+def test_blob_reference_restore_direct_cli_apply_writes_hash_checked_blob(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "direct.jsonl"
+    blob_hash = _seed_direct_restorable_blob_ref(cli_workspace["archive_root"], source)
+    blob_path = cli_workspace["data_root"] / "polylogue" / "blob" / blob_hash[:2] / blob_hash[2:]
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-restore-direct",
+            "--yes",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mutates"] is True
+    assert payload["dry_run"] is False
+    assert payload["candidate_count"] == 1
+    assert payload["restored_count"] == 1
+    assert payload["skipped_hash_mismatch"] == 0
+    assert blob_path.read_bytes() == source.read_bytes()
 
 
 def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -114,6 +114,32 @@ def _seed_missing_blob_cursor(archive_root: Path, source: Path) -> None:
     )
 
 
+def _seed_blob_reference_debt(archive_root: Path, source: Path) -> None:
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text('{"title":"recoverable"}\n', encoding="utf-8")
+    missing_raw_hash = b"b" * 32
+    missing_ref_hash = b"c" * 32
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        write_source_raw_session_blob_ref(
+            conn,
+            origin="chatgpt-export",
+            source_path=str(source),
+            source_index=0,
+            blob_hash=missing_raw_hash,
+            blob_size=source.stat().st_size,
+            acquired_at_ms=1,
+            native_id="recoverable-chat",
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (
+                blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (missing_ref_hash, "raw-gone", "raw_payload", str(archive_root / "missing-browser-capture.json"), 10, 1),
+        )
+
+
 def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
     _stage_uninitialized_archive(cli_workspace)
     result = cli_runner.invoke(
@@ -377,6 +403,68 @@ def test_blob_gc_cli_yes_deletes_and_records_generation(
     assert len(history) == 1
     assert history[0].generation_id == payload["generation_id"]
     assert history[0].reclaimed_count == 1
+
+
+def test_blob_reference_debt_cli_classifies_missing_refs(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-debt",
+            "--sample-limit",
+            "1",
+            "--group-limit",
+            "2",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "blob_reference_debt"
+    assert payload["mutates"] is False
+    assert payload["ok"] is False
+    assert payload["missing_distinct_blobs"] == 2
+    assert payload["missing_by_table"] == {"blob_refs": 2, "raw_sessions": 1}
+    assert payload["missing_by_origin"] == {"(none)": 1, "chatgpt-export": 1}
+    assert payload["missing_ref_id_join"] == {
+        "ref_id_has_raw_session": 1,
+        "ref_id_without_raw_session": 1,
+    }
+    assert payload["missing_source_path_presence"] == {
+        "recoverable_source_path_exists": 1,
+        "source_path_missing": 1,
+    }
+    assert len(payload["samples"]) == 1
+
+
+def test_blob_reference_debt_cli_plain_output_names_read_only_debt(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "blob-reference-debt", "--sample-limit", "1"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Blob reference debt" in result.output
+    assert "Status:       debt-present" in result.output
+    assert "Source paths: recoverable_source_path_exists=1, source_path_missing=1" in result.output
 
 
 def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from polylogue.storage.blob_integrity import referenced_blob_hashes, scan_blob_integrity, scan_blob_reference_debt
+from polylogue.storage.blob_integrity import (
+    classify_blob_reference_debt,
+    referenced_blob_hashes,
+    scan_blob_integrity,
+    scan_blob_reference_debt,
+)
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -219,6 +224,106 @@ def test_scan_blob_reference_debt_reads_initialized_source_tier(tmp_path: Path) 
     assert report.ok is True
     assert report.total_references_seen == 1
     assert report.reference_sources == {"raw_sessions": 1}
+
+
+def test_classify_blob_reference_debt_groups_recovery_evidence(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    source_file = tmp_path / "exports" / "chatgpt.json"
+    source_file.parent.mkdir()
+    source_file.write_text("{}", encoding="utf-8")
+    present_hash, present_size = store.write_from_bytes(b"present")
+    missing_raw_hash = "1" * 64
+    missing_attachment_hash = "2" * 64
+    orphan_ref_hash = "3" * 64
+
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                origin TEXT,
+                native_id TEXT,
+                source_path TEXT,
+                blob_hash BLOB,
+                blob_size INTEGER NOT NULL,
+                parse_error TEXT,
+                validation_status TEXT
+            );
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                raw_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                PRIMARY KEY(blob_hash, raw_id, ref_type)
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, validation_status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "raw-present",
+                "codex-session",
+                "native-present",
+                str(source_file),
+                bytes.fromhex(present_hash),
+                present_size,
+                "passed",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, validation_status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "raw-missing",
+                "chatgpt-export",
+                "native-missing",
+                str(source_file),
+                bytes.fromhex(missing_raw_hash),
+                123,
+                "passed",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, raw_id, ref_type, source_path, size_bytes) VALUES (?, ?, ?, ?, ?)",
+            (bytes.fromhex(missing_attachment_hash), "raw-missing", "attachment", str(source_file), 456),
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, raw_id, ref_type, source_path, size_bytes) VALUES (?, ?, ?, ?, ?)",
+            (bytes.fromhex(orphan_ref_hash), "raw-gone", "raw_payload", str(tmp_path / "missing.json"), 789),
+        )
+
+    report = classify_blob_reference_debt(source_db, store=store, sample_size=2, group_limit=3)
+
+    assert report.ok is False
+    assert report.distinct_referenced_blobs == 4
+    assert report.reference_rows == 4
+    assert report.missing_distinct_blobs == 3
+    assert report.missing_by_table == {"blob_refs": 2, "raw_sessions": 1}
+    assert report.missing_by_ref_type == {"attachment": 1, "raw_payload": 2}
+    assert report.missing_by_origin == {"(none)": 1, "chatgpt-export": 2}
+    assert report.missing_ref_id_join == {"ref_id_has_raw_session": 2, "ref_id_without_raw_session": 1}
+    assert report.missing_source_path_presence == {
+        "recoverable_source_path_exists": 2,
+        "source_path_missing": 1,
+    }
+    assert report.missing_validation_status == {"(none)": 1, "passed": 2}
+    assert report.missing_parse_error == {"no_parse_error": 3}
+    assert len(report.samples) == 2
+    payload = report.to_dict()
+    samples = payload["samples"]
+    assert isinstance(samples, list)
+    first_sample = samples[0]
+    assert isinstance(first_sample, dict)
+    assert first_sample["sample_source_available"] is True
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from polylogue.storage.blob_integrity import (
     classify_blob_reference_debt,
     referenced_blob_hashes,
+    restore_direct_blob_reference_debt,
     scan_blob_integrity,
     scan_blob_reference_debt,
 )
@@ -324,6 +325,94 @@ def test_classify_blob_reference_debt_groups_recovery_evidence(tmp_path: Path) -
     first_sample = samples[0]
     assert isinstance(first_sample, dict)
     assert first_sample["sample_source_available"] is True
+
+
+def test_restore_direct_blob_reference_debt_dry_run_and_apply(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    source = tmp_path / "session.jsonl"
+    source.write_bytes(b"direct raw payload")
+    expected_hash = "e6e9b015177c95ba07d4d2bd2cb423697aa06973606e922da27371e06dc0f457"
+    container_hash = "4" * 64
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                blob_hash BLOB NOT NULL,
+                blob_size INTEGER NOT NULL,
+                source_path TEXT
+            );
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                raw_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                PRIMARY KEY(blob_hash, raw_id, ref_type)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, raw_id, ref_type, source_path, size_bytes) VALUES (?, ?, ?, ?, ?)",
+            (bytes.fromhex(expected_hash), "raw-direct", "raw_payload", str(source), source.stat().st_size),
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, raw_id, ref_type, source_path, size_bytes) VALUES (?, ?, ?, ?, ?)",
+            (bytes.fromhex(container_hash), "raw-container", "raw_payload", f"{source}:inner.json", 10),
+        )
+
+    dry_run = restore_direct_blob_reference_debt(source_db, store=store)
+
+    assert dry_run.dry_run is True
+    assert dry_run.missing_distinct_blobs == 2
+    assert dry_run.candidate_count == 1
+    assert dry_run.restored_count == 0
+    assert dry_run.skipped_container_member == 1
+    assert not store.exists(expected_hash)
+
+    applied = restore_direct_blob_reference_debt(source_db, store=store, dry_run=False)
+
+    assert applied.dry_run is False
+    assert applied.candidate_count == 1
+    assert applied.restored_count == 1
+    assert applied.restored_bytes == source.stat().st_size
+    assert applied.skipped_container_member == 1
+    assert store.exists(expected_hash)
+    assert not store.exists(container_hash)
+
+
+def test_restore_direct_blob_reference_debt_rejects_hash_mismatch(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    source = tmp_path / "session.jsonl"
+    source.write_bytes(b"different bytes")
+    expected_hash = "5" * 64
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                raw_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                PRIMARY KEY(blob_hash, raw_id, ref_type)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, raw_id, ref_type, source_path, size_bytes) VALUES (?, ?, ?, ?, ?)",
+            (bytes.fromhex(expected_hash), "raw-mismatch", "raw_payload", str(source), source.stat().st_size),
+        )
+
+    report = restore_direct_blob_reference_debt(source_db, store=store, dry_run=False)
+
+    assert report.candidate_count == 1
+    assert report.restored_count == 0
+    assert report.skipped_hash_mismatch == 1
+    assert not store.exists(expected_hash)
+    assert [path for path in store.root.rglob("*") if path.is_file()] == []
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds supported read-only blob reference debt classification and a conservative direct-file restore command for backup/integrity incidents. The classifier reports whether missing referenced blobs are raw payload rows or blob-ref rows, whether refs join back to raw acquisition evidence, which origins/ref types are involved, and whether recorded source paths still exist. The restore command only writes missing blob files for direct source paths after exact SHA-256 verification.

## Problem

`polylogue ops backup` now preserves missing referenced-blob debt in backup manifests, but recovery planning still required ad hoc SQLite probes to classify that debt. On the production archive, the important distinction is not just “39,586 blob hashes are missing”; it is whether those refs are raw payloads, attachments, orphan-looking rows, source-recoverable rows, paths that are now missing, or paths that need provider/source re-acquisition because they point inside an export container. Without supported read-only and hash-checked repair surfaces, the next recovery step is too easy to guess and too risky to turn into evidence loss.

## Solution

- Added `classify_blob_reference_debt()` in `polylogue/storage/blob_integrity.py`.
- Added `polylogue ops maintenance blob-reference-debt` with JSON and plain output.
- Grouped missing refs by table, ref type, origin, raw-row joinability, source-path presence, validation status, and parse-error state.
- Added bounded representative samples for operational triage.
- Added `polylogue ops maintenance blob-reference-restore-direct`, dry-run by default.
- The direct restore command writes only blob files, never SQLite rows, and publishes a blob only if the current source bytes hash exactly to the missing blob address.
- Container/member paths such as `export.zip:conversations.json` are intentionally skipped because the missing blob may be an extracted record inside that member, not the member bytes themselves.
- Documented both commands beside backup and diagnostics guidance.

Ref #2421

Remaining #2421 scope: finish the non-direct recovery path. The supported direct restore command has already been run locally against production and restored 211 hash-verified direct-file blobs. Current post-restore live evidence shows 39,375 missing distinct raw-payload refs remain: 389 raw-session-backed export-member refs, 38,986 blob-ref-only refs, 39,354 refs with some recoverable source path evidence, and 21 missing source paths. The remaining large subset should be handled through source re-acquisition or a source-aware reconstruction path rather than raw direct copying because dry-run classified 38,981 refs as recorded-size mismatches and 373 as container/member paths.

## Verification

- `devtools test tests/unit/storage/test_blob_integrity.py tests/unit/cli/test_archive_maintenance_cli.py -q` -> 30 passed.
- `devtools verify --quick` -> passed.
- Push hook reran `devtools verify --quick` -> passed.
- Live read-only classifier before direct restore captured in `.agent/scratch/blob-reference-debt-classifier-live-20260626T0252Z.json`:
  - `missing_distinct_blobs=39586`
  - `missing_by_ref_type={"raw_payload": 39586}`
  - `missing_ref_id_join={"ref_id_has_raw_session": 389, "ref_id_without_raw_session": 39197}`
  - `missing_source_path_presence={"recoverable_source_path_exists": 39565, "source_path_missing": 21}`
- Live direct restore dry-run captured in `.agent/scratch/blob-reference-restore-direct-dryrun-live-20260626T0304Z.json`:
  - `candidate_count=211`
  - `skipped_container_member=373`
  - `skipped_source_missing=21`
  - `skipped_size_mismatch=38981`
  - `skipped_hash_mismatch=0`
  - `skipped_error=0`
- Live direct restore apply captured in `.agent/scratch/blob-reference-restore-direct-apply-live-20260626T0305Z.json`:
  - `restored_count=211`
  - `restored_bytes=1941524505`
  - `skipped_hash_mismatch=0`
  - `skipped_error=0`
- Live read-only classifier after direct restore captured in `.agent/scratch/blob-reference-debt-classifier-live-after-direct-restore-20260626T0306Z.json`:
  - `missing_distinct_blobs=39375`
  - `missing_by_ref_type={"raw_payload": 39375}`
  - `missing_ref_id_join={"ref_id_has_raw_session": 389, "ref_id_without_raw_session": 38986}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maintenance commands to inspect missing blob references and generate a recovery plan.
  * Added an optional direct-restore flow for eligible blobs when the source bytes match the expected hash.

* **Bug Fixes**
  * Improved handling of missing blob records with clearer breakdowns and sample details.
  * Prevents restoring archive-member paths that should be reacquired instead.

* **Tests**
  * Expanded coverage for blob-reference classification, dry-run behavior, successful restoration, and hash-mismatch rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->