### PR TITLE
fix(storage): remove blob refs with retained raw snapshots

### DIFF
--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -70,6 +70,12 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     return row is not None
 
 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})").fetchall())
+
+
 def _blob_hash_text(value: object) -> str | None:
     if value is None:
         return None
@@ -210,6 +216,10 @@ def cleanup_superseded_raw_snapshots(
         )
 
     placeholders = ", ".join("?" for _ in raw_ids)
+    if _column_exists(conn, "blob_refs", "ref_id"):
+        conn.execute(f"DELETE FROM blob_refs WHERE ref_id IN ({placeholders})", raw_ids)
+    elif _column_exists(conn, "blob_refs", "raw_id"):
+        conn.execute(f"DELETE FROM blob_refs WHERE raw_id IN ({placeholders})", raw_ids)
     conn.execute(f"DELETE FROM raw_sessions WHERE raw_id IN ({placeholders})", raw_ids)
     conn.commit()
 

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -32,12 +32,12 @@ def _ensure_archive_source_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         """CREATE TABLE blob_refs (
             blob_hash BLOB NOT NULL CHECK(length(blob_hash) = 32),
-            raw_id TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+            ref_id TEXT NOT NULL,
             ref_type TEXT NOT NULL CHECK(ref_type IN ('raw_payload', 'attachment', 'sidecar')),
             source_path TEXT,
             size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0),
             acquired_at_ms INTEGER NOT NULL,
-            PRIMARY KEY(blob_hash, raw_id, ref_type)
+            PRIMARY KEY(blob_hash, ref_type, ref_id)
         ) STRICT"""
     )
 
@@ -64,7 +64,7 @@ def _insert_archive_raw_session(
     conn.execute(
         """
         INSERT INTO blob_refs (
-            blob_hash, raw_id, ref_type, source_path, size_bytes, acquired_at_ms
+            blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms
         ) VALUES (?, ?, 'raw_payload', ?, ?, ?)
         """,
         (bytes.fromhex(blob_hash), raw_id, str(source_path), blob_size, acquired_at_ms),
@@ -140,6 +140,8 @@ def test_superseded_raw_snapshot_cleanup_keeps_newest_per_source(tmp_path: Path)
         str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id").fetchall()
     }
     assert remaining_raw_ids == {full_new, append_current, missing_old, missing_new}
+    remaining_ref_ids = {str(row[0]) for row in conn.execute("SELECT ref_id FROM blob_refs ORDER BY ref_id").fetchall()}
+    assert remaining_ref_ids == {full_new, append_current, missing_old, missing_new}
 
 
 def test_superseded_raw_snapshot_cleanup_preserves_index_referenced_raws(tmp_path: Path) -> None:
@@ -240,7 +242,9 @@ def test_archive_cleanup_compacts_append_snapshot_without_session_events(tmp_pat
     assert not blob_store.exists(old_raw)
     assert blob_store.exists(current_raw)
     assert conn.execute("SELECT 1 FROM raw_sessions WHERE raw_id = ?", (old_raw,)).fetchone() is None
+    assert conn.execute("SELECT 1 FROM blob_refs WHERE ref_id = ?", (old_raw,)).fetchone() is None
     assert conn.execute("SELECT 1 FROM raw_sessions WHERE raw_id = ?", (current_raw,)).fetchone() is not None
+    assert conn.execute("SELECT 1 FROM blob_refs WHERE ref_id = ?", (current_raw,)).fetchone() is not None
 
 
 def test_superseded_raw_snapshot_cleanup_uses_archive_blob_hashes(tmp_path: Path) -> None:
@@ -288,4 +292,4 @@ def test_superseded_raw_snapshot_cleanup_uses_archive_blob_hashes(tmp_path: Path
     assert not blob_store.exists(old_blob)
     assert blob_store.exists(current_blob)
     assert conn.execute("SELECT 1 FROM raw_sessions WHERE raw_id = 'raw-old-not-a-blob-hash'").fetchone() is None
-    assert conn.execute("SELECT 1 FROM blob_refs WHERE raw_id = 'raw-old-not-a-blob-hash'").fetchone() is None
+    assert conn.execute("SELECT 1 FROM blob_refs WHERE ref_id = 'raw-old-not-a-blob-hash'").fetchone() is None


### PR DESCRIPTION
## Summary

Raw retention cleanup now removes `blob_refs` rows for raw snapshots it deletes, using production's `ref_id` key shape. The regression test schema no longer hides the issue behind a test-only `raw_id` foreign-key cascade.

## Problem

Live blob-reference debt showed many orphaned `blob_refs` rows after raw retention had compacted superseded raw snapshots. Production `source.db.blob_refs` has no foreign key to `raw_sessions`; it records `ref_id`, not `raw_id`, so deleting a raw row did not delete its blob-reference evidence. That made later integrity diagnostics report stale references as missing recoverable blobs.

Ref #2421.

## Solution

`cleanup_superseded_raw_snapshots` now deletes matching `blob_refs` before deleting the raw rows. The implementation handles the current `ref_id` schema and preserves compatibility with older/test schemas that still expose `raw_id`.

The raw retention tests now use the production-like `ref_id` schema and assert that both ordinary superseded snapshots and append-compaction snapshots remove their blob references together with the raw row.

## Verification

- `devtools test tests/unit/storage/test_raw_retention.py -q` → `4 passed`
- `devtools render all --check` → `sync OK` / site matches sources
- `devtools verify --quick` → `exit_code 0`
- pre-push `devtools verify --quick` at `d744a09a5550afa2af9225abda1921e59590754c` → `exit_code 0`

## Residual

This prevents new stale references from being created by retention cleanup. Existing live archive debt still needs source-aware reconstruction or explicit quarantine/export; it must not be bulk-deleted without preserving evidence because some rows still point at recoverable source paths.
