### PR TITLE
fix(maintenance): quarantine stale orphan blob refs

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -29,7 +29,9 @@ from polylogue.storage.blob_gc import read_gc_history, run_blob_gc_report
 from polylogue.storage.blob_integrity import (
     BlobReferenceDebtClassificationReport,
     BlobReferenceDebtRestoreReport,
+    BlobReferenceOrphanPruneReport,
     classify_blob_reference_debt,
+    prune_orphan_blob_reference_debt,
     restore_direct_blob_reference_debt,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1352,6 +1354,98 @@ def _render_blob_reference_restore_plain(report: BlobReferenceDebtRestoreReport)
             click.echo(f"  {sample.action} {sample.blob_hash}{detail} {source}")
 
 
+@maintenance_group.command("blob-reference-prune-orphans")
+@click.option(
+    "--max-count",
+    type=int,
+    default=None,
+    help="Maximum number of orphan blob-reference rows to prune or preview.",
+)
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative samples to include.",
+)
+@click.option(
+    "--quarantine-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "JSONL destination for rows removed by --yes. Defaults to "
+        "<archive-root>/.maintenance-state/blob-ref-quarantine/<timestamp>.jsonl."
+    ),
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Delete orphan blob_refs after writing them to the quarantine JSONL.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_prune_orphans_command(
+    max_count: int | None,
+    sample_limit: int,
+    quarantine_file: Path | None,
+    yes: bool,
+    output_format: str,
+) -> None:
+    """Quarantine and prune missing blob_refs that no longer have raw rows."""
+    report = prune_orphan_blob_reference_debt(
+        archive_root() / "source.db",
+        dry_run=not yes,
+        quarantine_path=quarantine_file,
+        max_count=max_count,
+        sample_size=sample_limit,
+    )
+    payload = {
+        "mode": "blob_reference_prune_orphans",
+        "mutates": bool(yes),
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_prune_orphans_plain(report)
+
+
+def _render_blob_reference_prune_orphans_plain(report: BlobReferenceOrphanPruneReport) -> None:
+    click.echo("Blob reference orphan prune")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Blob root:    {report.blob_root}")
+    click.echo(f"Mode:         {'dry-run' if report.dry_run else 'apply'}")
+    click.echo(f"Blob refs:    {report.scanned_blob_refs:,} scanned")
+    click.echo(
+        f"Orphans:      {report.missing_orphan_refs:,} row(s), "
+        f"{report.missing_orphan_distinct_blobs:,} distinct blob(s)"
+    )
+    action = "would prune" if report.dry_run else "pruned"
+    click.echo(
+        f"Result:       {action} {report.missing_orphan_refs if report.dry_run else report.pruned_refs:,} row(s)"
+    )
+    click.echo(
+        "Skipped:      "
+        f"existing_blob={report.skipped_existing_blob:,} "
+        f"raw_session_present={report.skipped_raw_session_present:,}"
+    )
+    if report.quarantine_path:
+        click.echo(f"Quarantine:   {report.quarantine_path}")
+    if report.samples:
+        click.echo("Samples:")
+        for sample in report.samples[:5]:
+            source = sample.source_path or "(none)"
+            click.echo(f"  {sample.action} {sample.blob_hash} ref_id={sample.ref_id} {source}")
+
+
 @maintenance_group.command("gc-history")
 @click.option(
     "--limit",
@@ -1561,6 +1655,7 @@ def _render_record_plain(record: OperationRecord) -> None:
 __all__ = [
     "assertion_export_command",
     "blob_reference_debt_command",
+    "blob_reference_prune_orphans_command",
     "blob_reference_restore_direct_command",
     "gc_history_command",
     "maintenance_group",

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -9,6 +9,7 @@ integrity classes with bounded default cost.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import sqlite3
 import tempfile
@@ -261,6 +262,63 @@ class BlobReferenceDebtRestoreReport:
         }
 
 
+@dataclass(frozen=True)
+class BlobReferenceOrphanPruneSample:
+    blob_hash: str
+    ref_id: str | None
+    ref_type: str | None
+    source_path: str | None
+    action: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blob_hash": self.blob_hash,
+            "ref_id": self.ref_id,
+            "ref_type": self.ref_type,
+            "source_path": self.source_path,
+            "action": self.action,
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceOrphanPruneReport:
+    """Dry-run/apply report for quarantine-backed orphan blob-ref pruning."""
+
+    source_db: str
+    blob_root: str
+    dry_run: bool
+    quarantine_path: str | None
+    scanned_blob_refs: int
+    missing_orphan_refs: int
+    missing_orphan_distinct_blobs: int
+    pruned_refs: int
+    pruned_distinct_blobs: int
+    skipped_existing_blob: int
+    skipped_raw_session_present: int
+    samples: tuple[BlobReferenceOrphanPruneSample, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.missing_orphan_refs == 0 or (not self.dry_run and self.pruned_refs == self.missing_orphan_refs)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "source_db": self.source_db,
+            "blob_root": self.blob_root,
+            "dry_run": self.dry_run,
+            "quarantine_path": self.quarantine_path,
+            "scanned_blob_refs": self.scanned_blob_refs,
+            "missing_orphan_refs": self.missing_orphan_refs,
+            "missing_orphan_distinct_blobs": self.missing_orphan_distinct_blobs,
+            "pruned_refs": self.pruned_refs,
+            "pruned_distinct_blobs": self.pruned_distinct_blobs,
+            "skipped_existing_blob": self.skipped_existing_blob,
+            "skipped_raw_session_present": self.skipped_raw_session_present,
+            "samples": [sample.to_dict() for sample in self.samples],
+        }
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
@@ -412,6 +470,14 @@ def _blob_ref_id_column(conn: sqlite3.Connection) -> str:
         return "ref_id"
     if _column_exists(conn, "blob_refs", "raw_id"):
         return "raw_id"
+    return "NULL"
+
+
+def _blob_ref_acquired_at_column(conn: sqlite3.Connection) -> str:
+    if _column_exists(conn, "blob_refs", "acquired_at_ms"):
+        return "acquired_at_ms"
+    if _column_exists(conn, "blob_refs", "acquired_at"):
+        return "acquired_at"
     return "NULL"
 
 
@@ -677,6 +743,163 @@ def _restore_expected_hash_from_path(blob_store: BlobStore, expected_hash: str, 
             os.close(fd)
         if tmp_path is not None and os.path.exists(tmp_path):
             os.unlink(tmp_path)
+
+
+def _blob_ref_rows_for_orphan_prune(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "blob_refs"):
+        return []
+    conn.row_factory = sqlite3.Row
+    ref_id_column = _blob_ref_id_column(conn)
+    source_path_column = _blob_ref_source_path_column(conn)
+    size_column = _blob_ref_size_column(conn)
+    acquired_at_column = _blob_ref_acquired_at_column(conn)
+    raw_join = (
+        f"EXISTS (SELECT 1 FROM raw_sessions r WHERE r.raw_id = {ref_id_column})"
+        if _table_exists(conn, "raw_sessions") and ref_id_column != "NULL"
+        else "0"
+    )
+    rows = conn.execute(
+        f"""
+        SELECT lower(hex(blob_hash)) AS blob_hash,
+               ref_type,
+               {ref_id_column} AS ref_id,
+               {source_path_column} AS source_path,
+               {size_column} AS size_bytes,
+               {acquired_at_column} AS acquired_at,
+               {raw_join} AS raw_session_present
+        FROM blob_refs
+        WHERE blob_hash IS NOT NULL
+        ORDER BY source_path, ref_id, ref_type, blob_hash
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _default_blob_ref_quarantine_path(source_db: Path) -> Path:
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return source_db.parent / ".maintenance-state" / "blob-ref-quarantine" / f"orphan-blob-refs-{stamp}.jsonl"
+
+
+def _write_blob_ref_quarantine(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd: int | None = None
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", text=True)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            for row in rows:
+                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")))
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _delete_blob_ref_rows(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> int:
+    ref_id_column = _blob_ref_id_column(conn)
+    if ref_id_column == "NULL":
+        return 0
+    deleted = 0
+    for row in rows:
+        blob_hash = str(row["blob_hash"])
+        ref_id = row.get("ref_id")
+        ref_type = row.get("ref_type")
+        before = conn.total_changes
+        conn.execute(
+            f"""
+            DELETE FROM blob_refs
+            WHERE blob_hash = ?
+              AND {ref_id_column} IS ?
+              AND ref_type IS ?
+            """,
+            (bytes.fromhex(blob_hash), ref_id, ref_type),
+        )
+        deleted += conn.total_changes - before
+    return deleted
+
+
+def prune_orphan_blob_reference_debt(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    dry_run: bool = True,
+    quarantine_path: str | Path | None = None,
+    max_count: int | None = None,
+    sample_size: int = 30,
+) -> BlobReferenceOrphanPruneReport:
+    """Prune stale missing ``blob_refs`` only after writing quarantine JSONL.
+
+    This intentionally does not touch refs whose ``ref_id`` still has a
+    ``raw_sessions`` row, because those rows may still be reconstructable from
+    source exports or browser-capture files.
+    """
+
+    blob_store = store if store is not None else get_blob_store()
+    source_db = _source_db_for_blob_reference_report(db_path)
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as read_conn:
+        rows = _blob_ref_rows_for_orphan_prune(read_conn)
+
+    skipped_existing_blob = 0
+    skipped_raw_session_present = 0
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        blob_hash = str(row.get("blob_hash") or "")
+        if not blob_hash or blob_store.exists(blob_hash):
+            skipped_existing_blob += 1
+            continue
+        if bool(row.get("raw_session_present")):
+            skipped_raw_session_present += 1
+            continue
+        candidates.append(row)
+
+    limited_candidates = candidates if max_count is None else candidates[: max(0, max_count)]
+    samples = tuple(
+        BlobReferenceOrphanPruneSample(
+            blob_hash=str(row.get("blob_hash") or ""),
+            ref_id=_optional_str(row.get("ref_id")),
+            ref_type=_optional_str(row.get("ref_type")),
+            source_path=_optional_str(row.get("source_path")),
+            action="would_prune" if dry_run else "pruned",
+        )
+        for row in limited_candidates[: max(0, sample_size)]
+    )
+
+    resolved_quarantine_path: Path | None = None
+    pruned_refs = 0
+    pruned_distinct_blobs = 0
+    if not dry_run and limited_candidates:
+        resolved_quarantine_path = (
+            Path(quarantine_path) if quarantine_path is not None else _default_blob_ref_quarantine_path(source_db)
+        )
+        _write_blob_ref_quarantine(resolved_quarantine_path, limited_candidates)
+        with sqlite3.connect(source_db) as write_conn:
+            pruned_refs = _delete_blob_ref_rows(write_conn, limited_candidates)
+            write_conn.commit()
+        pruned_distinct_blobs = len({str(row["blob_hash"]) for row in limited_candidates})
+    elif quarantine_path is not None:
+        resolved_quarantine_path = Path(quarantine_path)
+
+    return BlobReferenceOrphanPruneReport(
+        source_db=str(source_db),
+        blob_root=str(blob_store.root),
+        dry_run=dry_run,
+        quarantine_path=str(resolved_quarantine_path) if resolved_quarantine_path is not None else None,
+        scanned_blob_refs=len(rows),
+        missing_orphan_refs=len(candidates),
+        missing_orphan_distinct_blobs=len({str(row["blob_hash"]) for row in candidates}),
+        pruned_refs=pruned_refs,
+        pruned_distinct_blobs=pruned_distinct_blobs,
+        skipped_existing_blob=skipped_existing_blob,
+        skipped_raw_session_present=skipped_raw_session_present,
+        samples=samples,
+    )
 
 
 def restore_direct_blob_reference_debt(
@@ -978,11 +1201,14 @@ __all__ = [
     "BlobIntegrityKind",
     "BlobIntegrityReport",
     "BlobReferenceDebtClassificationReport",
+    "BlobReferenceOrphanPruneSample",
+    "BlobReferenceOrphanPruneReport",
     "BlobReferenceDebtReport",
     "BlobReferenceDebtRestoreReport",
     "BlobReferenceDebtRestoreSample",
     "BlobReferenceDebtSample",
     "classify_blob_reference_debt",
+    "prune_orphan_blob_reference_debt",
     "referenced_blob_hashes",
     "restore_direct_blob_reference_debt",
     "scan_blob_reference_debt",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -548,6 +548,77 @@ def test_blob_reference_restore_direct_cli_apply_writes_hash_checked_blob(
     assert blob_path.read_bytes() == source.read_bytes()
 
 
+def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-prune-orphans",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "blob_reference_prune_orphans"
+    assert payload["mutates"] is False
+    assert payload["dry_run"] is True
+    assert payload["missing_orphan_refs"] == 1
+    assert payload["pruned_refs"] == 0
+    with sqlite3.connect(cli_workspace["archive_root"] / "source.db") as conn:
+        refs = conn.execute("SELECT source_path FROM blob_refs ORDER BY source_path").fetchall()
+    assert refs == [(str(source),), (str(cli_workspace["archive_root"] / "missing-browser-capture.json"),)]
+
+
+def test_blob_reference_prune_orphans_cli_apply_quarantines_deleted_refs(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+    quarantine_file = cli_workspace["archive_root"] / "quarantine" / "blob-refs.jsonl"
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-prune-orphans",
+            "--yes",
+            "--quarantine-file",
+            str(quarantine_file),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mutates"] is True
+    assert payload["dry_run"] is False
+    assert payload["missing_orphan_refs"] == 1
+    assert payload["pruned_refs"] == 1
+    assert payload["quarantine_path"] == str(quarantine_file)
+    exported = [json.loads(line) for line in quarantine_file.read_text(encoding="utf-8").splitlines()]
+    assert exported[0]["ref_id"] == "raw-gone"
+    assert exported[0]["source_path"].endswith("missing-browser-capture.json")
+    with sqlite3.connect(cli_workspace["archive_root"] / "source.db") as conn:
+        refs = conn.execute("SELECT source_path FROM blob_refs ORDER BY source_path").fetchall()
+    assert refs == [(str(source),)]
+
+
 def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
     _stage_uninitialized_archive(cli_workspace)
     result = cli_runner.invoke(

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
 from polylogue.storage.blob_integrity import (
     classify_blob_reference_debt,
+    prune_orphan_blob_reference_debt,
     referenced_blob_hashes,
     restore_direct_blob_reference_debt,
     scan_blob_integrity,
@@ -413,6 +415,93 @@ def test_restore_direct_blob_reference_debt_rejects_hash_mismatch(tmp_path: Path
     assert report.skipped_hash_mismatch == 1
     assert not store.exists(expected_hash)
     assert [path for path in store.root.rglob("*") if path.is_file()] == []
+
+
+def test_prune_orphan_blob_reference_debt_quarantines_before_delete(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    present_hash, _present_size = store.write_from_bytes(b"present blob")
+    orphan_hash = "6" * 64
+    raw_backed_hash = "7" * 64
+    quarantine_path = tmp_path / "quarantine" / "orphan-refs.jsonl"
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                blob_hash BLOB,
+                blob_size INTEGER NOT NULL,
+                source_path TEXT
+            );
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                ref_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                acquired_at_ms INTEGER NOT NULL,
+                PRIMARY KEY(blob_hash, ref_type, ref_id)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO raw_sessions (raw_id, blob_hash, blob_size, source_path) VALUES (?, ?, ?, ?)",
+            ("raw-present", bytes.fromhex(raw_backed_hash), 10, "recoverable.json"),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (bytes.fromhex(orphan_hash), "raw-gone", "raw_payload", "old.json", 12, 1),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (bytes.fromhex(raw_backed_hash), "raw-present", "raw_payload", "recoverable.json", 10, 1),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (bytes.fromhex(present_hash), "raw-gone-present", "raw_payload", "present.json", 12, 1),
+        )
+
+    dry_run = prune_orphan_blob_reference_debt(source_db, store=store, quarantine_path=quarantine_path)
+
+    assert dry_run.dry_run is True
+    assert dry_run.missing_orphan_refs == 1
+    assert dry_run.pruned_refs == 0
+    assert not quarantine_path.exists()
+
+    applied = prune_orphan_blob_reference_debt(
+        source_db,
+        store=store,
+        dry_run=False,
+        quarantine_path=quarantine_path,
+    )
+
+    assert applied.dry_run is False
+    assert applied.pruned_refs == 1
+    assert applied.pruned_distinct_blobs == 1
+    exported = [json.loads(line) for line in quarantine_path.read_text(encoding="utf-8").splitlines()]
+    assert exported == [
+        {
+            "acquired_at": 1,
+            "blob_hash": orphan_hash,
+            "raw_session_present": 0,
+            "ref_id": "raw-gone",
+            "ref_type": "raw_payload",
+            "size_bytes": 12,
+            "source_path": "old.json",
+        }
+    ]
+    with sqlite3.connect(source_db) as conn:
+        remaining_refs = conn.execute("SELECT ref_id FROM blob_refs ORDER BY ref_id").fetchall()
+    assert remaining_refs == [("raw-gone-present",), ("raw-present",)]
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a preservation-first maintenance command for the largest live blob-reference residual: missing `blob_refs` rows whose `ref_id` no longer has a `raw_sessions` row. The command is dry-run by default and, when applied, writes every deleted row to quarantine JSONL before deleting anything.

## Problem

After direct blob restoration, the live archive still has a large class of missing `blob_refs` with no raw-session join. Those rows inflate missing-blob debt, but deleting them silently would discard source-path and ref evidence that may still be useful for audit or later reconstruction.

Ref #2421.

## Solution

Added `polylogue ops maintenance blob-reference-prune-orphans`:

- dry-run by default;
- only targets missing `blob_refs` whose `ref_id` does not join to `raw_sessions`;
- leaves raw-backed missing refs untouched for source-aware reconstruction;
- supports `--max-count`, `--sample-limit`, `--quarantine-file`, `--yes`, and JSON/plain output;
- writes all applied deletions to JSONL before deleting database rows;
- handles current `ref_id` and older `raw_id` blob-ref table shapes.

## Verification

- `devtools test tests/unit/storage/test_blob_integrity.py tests/unit/cli/test_archive_maintenance_cli.py -q` -> `33 passed`
- `devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` at `4c7f3887b4dcd357f3e97097be986e6c67d730c0` -> `exit_code 0`
- live source-worktree dry-run against production archive -> `mutates=false`, `missing_orphan_refs=38998`, `missing_orphan_distinct_blobs=38986`, `skipped_raw_session_present=389`

## Residual

This adds the safe quarantine/delete path for stale orphan refs. It intentionally does not restore or prune the remaining raw-session-backed missing refs; those need exact source-aware reconstruction from exports/browser-capture files or an explicit archived quarantine decision.
