### PR TITLE
fix(maintenance): plan raw-backed blob recovery

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -30,7 +30,9 @@ from polylogue.storage.blob_integrity import (
     BlobReferenceDebtClassificationReport,
     BlobReferenceDebtRestoreReport,
     BlobReferenceOrphanPruneReport,
+    BlobReferenceRecoveryPlanReport,
     classify_blob_reference_debt,
+    plan_raw_backed_blob_reference_recovery,
     prune_orphan_blob_reference_debt,
     restore_direct_blob_reference_debt,
 )
@@ -1354,6 +1356,84 @@ def _render_blob_reference_restore_plain(report: BlobReferenceDebtRestoreReport)
             click.echo(f"  {sample.action} {sample.blob_hash}{detail} {source}")
 
 
+@maintenance_group.command("blob-reference-recovery-plan")
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative raw-backed missing blob rows to include.",
+)
+@click.option(
+    "--manifest-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional JSONL destination for the complete raw-backed missing blob recovery manifest.",
+)
+@click.option(
+    "--include-rows",
+    is_flag=True,
+    help="Include every plan row in JSON output. By default JSON output includes samples plus aggregate counts.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_recovery_plan_command(
+    sample_limit: int,
+    manifest_file: Path | None,
+    include_rows: bool,
+    output_format: str,
+) -> None:
+    """Plan recovery for raw-backed missing blobs without mutating archive state."""
+    report = plan_raw_backed_blob_reference_recovery(
+        archive_root() / "source.db",
+        manifest_path=manifest_file,
+        sample_size=sample_limit,
+        include_rows=include_rows,
+    )
+    payload = {
+        "mode": "blob_reference_recovery_plan",
+        "mutates": False,
+        "writes_manifest": manifest_file is not None,
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_recovery_plan_plain(report)
+
+
+def _render_blob_reference_recovery_plan_plain(report: BlobReferenceRecoveryPlanReport) -> None:
+    click.echo("Blob reference raw-backed recovery plan")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Blob root:    {report.blob_root}")
+    click.echo(f"Missing:      {report.missing_raw_backed_blobs:,} raw-backed blob(s)")
+
+    def _render_counts(label: str, counts: dict[str, int]) -> None:
+        if not counts:
+            return
+        rendered = ", ".join(f"{key}={value:,}" for key, value in sorted(counts.items()))
+        click.echo(f"{label}: {rendered}")
+
+    _render_counts("By action   ", report.by_action)
+    _render_counts("By origin   ", report.by_origin)
+    _render_counts("By shape    ", report.by_source_shape)
+    if report.manifest_path:
+        click.echo(f"Manifest:    {report.manifest_path}")
+    if report.samples:
+        click.echo("Samples:")
+        for sample in report.samples[:5]:
+            source = sample.source_path or "(none)"
+            click.echo(f"  {sample.action} {sample.blob_hash} origin={sample.origin} {source}")
+
+
 @maintenance_group.command("blob-reference-prune-orphans")
 @click.option(
     "--max-count",
@@ -1656,6 +1736,7 @@ __all__ = [
     "assertion_export_command",
     "blob_reference_debt_command",
     "blob_reference_prune_orphans_command",
+    "blob_reference_recovery_plan_command",
     "blob_reference_restore_direct_command",
     "gc_history_command",
     "maintenance_group",

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -319,6 +319,65 @@ class BlobReferenceOrphanPruneReport:
         }
 
 
+@dataclass(frozen=True)
+class BlobReferenceRecoveryPlanRow:
+    blob_hash: str
+    raw_id: str
+    origin: str | None
+    native_id: str | None
+    source_path: str | None
+    source_index: int | None
+    expected_size_bytes: int | None
+    action: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blob_hash": self.blob_hash,
+            "raw_id": self.raw_id,
+            "origin": self.origin,
+            "native_id": self.native_id,
+            "source_path": self.source_path,
+            "source_index": self.source_index,
+            "expected_size_bytes": self.expected_size_bytes,
+            "action": self.action,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceRecoveryPlanReport:
+    """Read-only plan for raw-session-backed missing referenced blobs."""
+
+    source_db: str
+    blob_root: str
+    missing_raw_backed_blobs: int
+    manifest_path: str | None
+    by_action: dict[str, int]
+    by_origin: dict[str, int]
+    by_source_shape: dict[str, int]
+    rows: tuple[BlobReferenceRecoveryPlanRow, ...]
+    samples: tuple[BlobReferenceRecoveryPlanRow, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.missing_raw_backed_blobs == 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "source_db": self.source_db,
+            "blob_root": self.blob_root,
+            "missing_raw_backed_blobs": self.missing_raw_backed_blobs,
+            "manifest_path": self.manifest_path,
+            "by_action": dict(self.by_action),
+            "by_origin": dict(self.by_origin),
+            "by_source_shape": dict(self.by_source_shape),
+            "rows": [row.to_dict() for row in self.rows],
+            "samples": [sample.to_dict() for sample in self.samples],
+        }
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_schema WHERE type='table' AND name = ? LIMIT 1",
@@ -775,12 +834,87 @@ def _blob_ref_rows_for_orphan_prune(conn: sqlite3.Connection) -> list[dict[str, 
     return [dict(row) for row in rows]
 
 
+def _missing_raw_backed_blob_rows(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "raw_sessions"):
+        return []
+    conn.row_factory = sqlite3.Row
+    origin_column = "origin" if _column_exists(conn, "raw_sessions", "origin") else "NULL"
+    native_id_column = "native_id" if _column_exists(conn, "raw_sessions", "native_id") else "NULL"
+    source_path_column = "source_path" if _column_exists(conn, "raw_sessions", "source_path") else "NULL"
+    source_index_column = "source_index" if _column_exists(conn, "raw_sessions", "source_index") else "NULL"
+    blob_size_column = "blob_size" if _column_exists(conn, "raw_sessions", "blob_size") else "NULL"
+    rows = conn.execute(
+        f"""
+        SELECT lower(hex(blob_hash)) AS blob_hash,
+               raw_id,
+               {origin_column} AS origin,
+               {native_id_column} AS native_id,
+               {source_path_column} AS source_path,
+               {source_index_column} AS source_index,
+               {blob_size_column} AS expected_size_bytes
+        FROM raw_sessions
+        WHERE blob_hash IS NOT NULL
+        ORDER BY origin, source_path, source_index, raw_id
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _raw_backed_recovery_action(blob_hash: str, source_path: str | None, expected_size: int | None) -> tuple[str, str]:
+    if not source_path:
+        return "no_source_path", "raw row does not record a source path"
+    if _path_is_container_member(source_path):
+        outer_path, _inner = source_path.split(":", 1)
+        if not Path(outer_path).exists():
+            return "source_missing", "container source path is missing"
+        return "container_member_reacquire_required", "container member requires exact source-aware re-acquisition"
+    path = Path(source_path)
+    if not path.exists():
+        return "source_missing", "source file is missing"
+    actual_size = path.stat().st_size
+    if expected_size is not None and actual_size != expected_size:
+        return "direct_source_size_mismatch", f"source size is {actual_size}, expected {expected_size}"
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    actual_hash = hasher.hexdigest()
+    if actual_hash == blob_hash:
+        return "direct_exact_restore_candidate", "source bytes match the expected blob hash"
+    return "direct_source_hash_mismatch", f"source hash is {actual_hash}"
+
+
 def _default_blob_ref_quarantine_path(source_db: Path) -> Path:
     stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     return source_db.parent / ".maintenance-state" / "blob-ref-quarantine" / f"orphan-blob-refs-{stamp}.jsonl"
 
 
 def _write_blob_ref_quarantine(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd: int | None = None
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", text=True)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            for row in rows:
+                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")))
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, object]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd: int | None = None
     tmp_path: str | None = None
@@ -899,6 +1033,68 @@ def prune_orphan_blob_reference_debt(
         skipped_existing_blob=skipped_existing_blob,
         skipped_raw_session_present=skipped_raw_session_present,
         samples=samples,
+    )
+
+
+def plan_raw_backed_blob_reference_recovery(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    manifest_path: str | Path | None = None,
+    sample_size: int = 30,
+    include_rows: bool = False,
+) -> BlobReferenceRecoveryPlanReport:
+    """Classify raw-backed missing blob refs without mutating archive state."""
+
+    blob_store = store if store is not None else get_blob_store()
+    source_db = _source_db_for_blob_reference_report(db_path)
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        rows = _missing_raw_backed_blob_rows(conn)
+
+    plan_rows: list[BlobReferenceRecoveryPlanRow] = []
+    by_action: Counter[str] = Counter()
+    by_origin: Counter[str] = Counter()
+    by_source_shape: Counter[str] = Counter()
+    for row in rows:
+        blob_hash = str(row.get("blob_hash") or "")
+        if not blob_hash or blob_store.exists(blob_hash):
+            continue
+        source_path = _optional_str(row.get("source_path"))
+        source_shape = "container_member" if source_path and _path_is_container_member(source_path) else "direct_file"
+        expected_size_value = row.get("expected_size_bytes")
+        expected_size = int(expected_size_value) if expected_size_value is not None else None
+        action, reason = _raw_backed_recovery_action(blob_hash, source_path, expected_size)
+        origin = _optional_str(row.get("origin"))
+        plan_row = BlobReferenceRecoveryPlanRow(
+            blob_hash=blob_hash,
+            raw_id=str(row.get("raw_id") or ""),
+            origin=origin,
+            native_id=_optional_str(row.get("native_id")),
+            source_path=source_path,
+            source_index=int(row["source_index"]) if row.get("source_index") is not None else None,
+            expected_size_bytes=expected_size,
+            action=action,
+            reason=reason,
+        )
+        plan_rows.append(plan_row)
+        by_action[action] += 1
+        by_origin[origin or "(none)"] += 1
+        by_source_shape[source_shape] += 1
+
+    resolved_manifest_path: Path | None = Path(manifest_path) if manifest_path is not None else None
+    if resolved_manifest_path is not None:
+        _write_jsonl_rows(resolved_manifest_path, (row.to_dict() for row in plan_rows))
+
+    return BlobReferenceRecoveryPlanReport(
+        source_db=str(source_db),
+        blob_root=str(blob_store.root),
+        missing_raw_backed_blobs=len(plan_rows),
+        manifest_path=str(resolved_manifest_path) if resolved_manifest_path is not None else None,
+        by_action=_counter_dict(by_action),
+        by_origin=_counter_dict(by_origin),
+        by_source_shape=_counter_dict(by_source_shape),
+        rows=tuple(plan_rows) if include_rows else (),
+        samples=tuple(plan_rows[: max(0, sample_size)]),
     )
 
 
@@ -1203,11 +1399,14 @@ __all__ = [
     "BlobReferenceDebtClassificationReport",
     "BlobReferenceOrphanPruneSample",
     "BlobReferenceOrphanPruneReport",
+    "BlobReferenceRecoveryPlanReport",
+    "BlobReferenceRecoveryPlanRow",
     "BlobReferenceDebtReport",
     "BlobReferenceDebtRestoreReport",
     "BlobReferenceDebtRestoreSample",
     "BlobReferenceDebtSample",
     "classify_blob_reference_debt",
+    "plan_raw_backed_blob_reference_recovery",
     "prune_orphan_blob_reference_debt",
     "referenced_blob_hashes",
     "restore_direct_blob_reference_debt",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -548,6 +548,42 @@ def test_blob_reference_restore_direct_cli_apply_writes_hash_checked_blob(
     assert blob_path.read_bytes() == source.read_bytes()
 
 
+def test_blob_reference_recovery_plan_cli_writes_raw_backed_manifest(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+    manifest = cli_workspace["archive_root"] / "plans" / "raw-backed.jsonl"
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-recovery-plan",
+            "--manifest-file",
+            str(manifest),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "blob_reference_recovery_plan"
+    assert payload["mutates"] is False
+    assert payload["writes_manifest"] is True
+    assert payload["missing_raw_backed_blobs"] == 1
+    assert payload["by_origin"] == {"chatgpt-export": 1}
+    assert payload["by_action"] == {"direct_source_hash_mismatch": 1}
+    manifest_rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
+    assert len(manifest_rows) == 1
+    assert manifest_rows[0]["source_path"] == str(source)
+
+
 def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from polylogue.storage.blob_integrity import (
     classify_blob_reference_debt,
+    plan_raw_backed_blob_reference_recovery,
     prune_orphan_blob_reference_debt,
     referenced_blob_hashes,
     restore_direct_blob_reference_debt,
@@ -502,6 +503,118 @@ def test_prune_orphan_blob_reference_debt_quarantines_before_delete(tmp_path: Pa
     with sqlite3.connect(source_db) as conn:
         remaining_refs = conn.execute("SELECT ref_id FROM blob_refs ORDER BY ref_id").fetchall()
     assert remaining_refs == [("raw-gone-present",), ("raw-present",)]
+
+
+def test_plan_raw_backed_blob_reference_recovery_writes_manifest(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    exact_source = tmp_path / "exact.json"
+    exact_source.write_bytes(b"exact payload")
+    exact_hash = "0cfefcacfe03534dd908444efd6e4d0d1075fd8cf59ac79bf956312385679cfe"
+    changed_source = tmp_path / "changed.json"
+    changed_source.write_bytes(b"changed payload")
+    container_outer = tmp_path / "export.zip"
+    container_outer.write_bytes(b"zip bytes are not inspected by the planner")
+    manifest_path = tmp_path / "manifest" / "raw-backed.jsonl"
+    present_hash, present_size = store.write_from_bytes(b"present raw")
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                origin TEXT,
+                native_id TEXT,
+                source_path TEXT,
+                source_index INTEGER,
+                blob_hash BLOB,
+                blob_size INTEGER NOT NULL
+            );
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "raw-present",
+                    "chatgpt-export",
+                    "native-present",
+                    str(tmp_path / "present.json"),
+                    0,
+                    bytes.fromhex(present_hash),
+                    present_size,
+                ),
+                (
+                    "raw-exact",
+                    "chatgpt-export",
+                    "native-exact",
+                    str(exact_source),
+                    0,
+                    bytes.fromhex(exact_hash),
+                    exact_source.stat().st_size,
+                ),
+                (
+                    "raw-container",
+                    "chatgpt-export",
+                    "native-container",
+                    f"{container_outer}:conversations.json",
+                    2,
+                    bytes.fromhex("8" * 64),
+                    123,
+                ),
+                (
+                    "raw-size-mismatch",
+                    "claude-ai-export",
+                    "native-size",
+                    str(changed_source),
+                    0,
+                    bytes.fromhex("9" * 64),
+                    changed_source.stat().st_size + 10,
+                ),
+                (
+                    "raw-missing",
+                    "claude-ai-export",
+                    "native-missing",
+                    str(tmp_path / "missing.json"),
+                    0,
+                    bytes.fromhex("a" * 64),
+                    456,
+                ),
+            ],
+        )
+
+    report = plan_raw_backed_blob_reference_recovery(
+        source_db,
+        store=store,
+        manifest_path=manifest_path,
+        include_rows=True,
+    )
+
+    assert report.missing_raw_backed_blobs == 4
+    assert report.by_action == {
+        "container_member_reacquire_required": 1,
+        "direct_exact_restore_candidate": 1,
+        "direct_source_size_mismatch": 1,
+        "source_missing": 1,
+    }
+    assert report.by_origin == {"chatgpt-export": 2, "claude-ai-export": 2}
+    assert report.by_source_shape == {"container_member": 1, "direct_file": 3}
+    assert {row.raw_id for row in report.rows} == {
+        "raw-exact",
+        "raw-container",
+        "raw-size-mismatch",
+        "raw-missing",
+    }
+    manifest_rows = [json.loads(line) for line in manifest_path.read_text(encoding="utf-8").splitlines()]
+    assert {row["raw_id"] for row in manifest_rows} == {
+        "raw-exact",
+        "raw-container",
+        "raw-size-mismatch",
+        "raw-missing",
+    }
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a read-only maintenance command for the remaining raw-session-backed missing blob debt. `blob-reference-recovery-plan` classifies every missing raw-backed blob by recommended action and can write a complete JSONL recovery manifest without mutating archive state.

## Problem

After orphan `blob_refs` were quarantined, the remaining live missing blob debt was all raw-session-backed. Existing commands could show the debt and direct restore could reject unsupported cases, but there was no durable row-level plan distinguishing exact direct restore candidates from container-member re-acquisition and changed direct-source files.

Ref #2421.

## Solution

Added `polylogue ops maintenance blob-reference-recovery-plan`:

- reads `raw_sessions` and filters to blob hashes missing from the blob store;
- classifies each row by action, origin, and source shape;
- supports `--manifest-file` for a complete JSONL manifest;
- supports `--include-rows` for full JSON output when desired;
- never mutates archive DB rows or blob files.

The action vocabulary is intentionally conservative:

- `direct_exact_restore_candidate`
- `direct_source_size_mismatch`
- `direct_source_hash_mismatch`
- `container_member_reacquire_required`
- `source_missing`
- `no_source_path`

## Verification

- `devtools test tests/unit/storage/test_blob_integrity.py tests/unit/cli/test_archive_maintenance_cli.py -q` -> `35 passed`
- `devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` at `a51f97c91de52e1154975722e5bdfa9218665aad` -> `exit_code 0`
- live command against production archive wrote `.agent/scratch/blob-reference-recovery-plan-live-20260626T0354Z.jsonl` with `389` rows and reported:
  - `missing_raw_backed_blobs=389`
  - `container_member_reacquire_required=371`
  - `direct_source_size_mismatch=18`
  - `chatgpt-export=377`
  - `claude-ai-export=12`
  - `mutates=false`

## Residual

This makes the remaining debt explicit and exportable. It does not invent a restore path for historical blob bytes. The next implementation step should either reproduce the historical serialization exactly for the container-member rows or model a deliberate re-acquisition/update operation for those raw rows.
