### PR TITLE
fix(maintenance): replace stale raw blobs from source

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -31,9 +31,11 @@ from polylogue.storage.blob_integrity import (
     BlobReferenceDebtRestoreReport,
     BlobReferenceOrphanPruneReport,
     BlobReferenceRecoveryPlanReport,
+    BlobReferenceSourceReplaceReport,
     classify_blob_reference_debt,
     plan_raw_backed_blob_reference_recovery,
     prune_orphan_blob_reference_debt,
+    replace_raw_backed_blob_reference_debt_from_source,
     restore_direct_blob_reference_debt,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -1434,6 +1436,96 @@ def _render_blob_reference_recovery_plan_plain(report: BlobReferenceRecoveryPlan
             click.echo(f"  {sample.action} {sample.blob_hash} origin={sample.origin} {source}")
 
 
+@maintenance_group.command("blob-reference-replace-from-source")
+@click.option(
+    "--yes",
+    "apply",
+    is_flag=True,
+    help="Apply the replacement. Without this flag the command is a dry run.",
+)
+@click.option(
+    "--manifest-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="JSONL destination for before/after replacement rows. Required with --yes.",
+)
+@click.option("--max-count", type=int, default=None, help="Maximum number of candidate rows to process.")
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative replacement rows to include.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_replace_from_source_command(
+    apply: bool,
+    manifest_file: Path | None,
+    max_count: int | None,
+    sample_limit: int,
+    output_format: str,
+) -> None:
+    """Replace raw-backed missing blob refs with current source-derived bytes."""
+    if apply and manifest_file is None:
+        raise click.UsageError("--manifest-file is required with --yes")
+    report = replace_raw_backed_blob_reference_debt_from_source(
+        archive_root() / "source.db",
+        dry_run=not apply,
+        manifest_path=manifest_file,
+        max_count=max_count,
+        sample_size=sample_limit,
+    )
+    payload = {
+        "mode": "blob_reference_replace_from_source",
+        "mutates": apply,
+        "writes_manifest": manifest_file is not None,
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_replace_from_source_plain(report)
+
+
+def _render_blob_reference_replace_from_source_plain(report: BlobReferenceSourceReplaceReport) -> None:
+    click.echo("Blob reference current-source replacement")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Blob root:    {report.blob_root}")
+    click.echo(f"Mode:         {'dry-run' if report.dry_run else 'apply'}")
+    click.echo(f"Scanned:      {report.scanned_rows:,} raw-backed row(s)")
+    click.echo(f"Candidates:   {report.candidate_rows:,}")
+    click.echo(f"Replaced:     {report.replaced_rows:,}")
+    click.echo(f"Written:      {report.written_blobs:,} blob(s), {report.written_bytes:,} byte(s)")
+    click.echo(
+        "Skipped:      "
+        f"existing={report.skipped_existing_blob:,} "
+        f"no_source={report.skipped_no_source_path:,} "
+        f"source_missing={report.skipped_source_missing:,} "
+        f"source_index={report.skipped_source_index:,} "
+        f"unsupported={report.skipped_unsupported_source:,} "
+        f"error={report.skipped_error:,}"
+    )
+    if report.manifest_path:
+        click.echo(f"Manifest:    {report.manifest_path}")
+    if report.samples:
+        click.echo("Samples:")
+        for sample in report.samples[:5]:
+            detail = f" reason={sample.reason}" if sample.reason else ""
+            click.echo(
+                f"  {sample.action} raw_id={sample.raw_id} old={sample.old_blob_hash} "
+                f"new={sample.new_blob_hash}{detail}"
+            )
+
+
 @maintenance_group.command("blob-reference-prune-orphans")
 @click.option(
     "--max-count",
@@ -1737,6 +1829,7 @@ __all__ = [
     "blob_reference_debt_command",
     "blob_reference_prune_orphans_command",
     "blob_reference_recovery_plan_command",
+    "blob_reference_replace_from_source_command",
     "blob_reference_restore_direct_command",
     "gc_history_command",
     "maintenance_group",

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -14,6 +14,7 @@ import os
 import sqlite3
 import tempfile
 import time
+import zipfile
 from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -21,6 +22,8 @@ from itertools import islice
 from pathlib import Path
 from typing import Any, Literal
 
+from polylogue.core.json import dumps_bytes as json_dumps_bytes
+from polylogue.core.json import loads as json_loads
 from polylogue.storage.blob_store import BlobStore, get_blob_store
 from polylogue.storage.sqlite.connection import open_read_connection
 
@@ -374,6 +377,79 @@ class BlobReferenceRecoveryPlanReport:
             "by_origin": dict(self.by_origin),
             "by_source_shape": dict(self.by_source_shape),
             "rows": [row.to_dict() for row in self.rows],
+            "samples": [sample.to_dict() for sample in self.samples],
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceSourceReplaceSample:
+    raw_id: str
+    old_blob_hash: str
+    new_blob_hash: str | None
+    source_path: str | None
+    action: str
+    reason: str | None = None
+    bytes_written: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "raw_id": self.raw_id,
+            "old_blob_hash": self.old_blob_hash,
+            "new_blob_hash": self.new_blob_hash,
+            "source_path": self.source_path,
+            "action": self.action,
+            "reason": self.reason,
+            "bytes_written": self.bytes_written,
+        }
+
+
+@dataclass(frozen=True)
+class BlobReferenceSourceReplaceReport:
+    """Current-source replacement report for raw-session-backed blob debt."""
+
+    source_db: str
+    blob_root: str
+    dry_run: bool
+    manifest_path: str | None
+    scanned_rows: int
+    candidate_rows: int
+    replaced_rows: int
+    written_blobs: int
+    written_bytes: int
+    skipped_existing_blob: int
+    skipped_no_source_path: int
+    skipped_source_missing: int
+    skipped_source_index: int
+    skipped_unsupported_source: int
+    skipped_error: int
+    by_origin: dict[str, int]
+    by_source_shape: dict[str, int]
+    samples: tuple[BlobReferenceSourceReplaceSample, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.replaced_rows > 0 if not self.dry_run else self.candidate_rows > 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "source_db": self.source_db,
+            "blob_root": self.blob_root,
+            "dry_run": self.dry_run,
+            "manifest_path": self.manifest_path,
+            "scanned_rows": self.scanned_rows,
+            "candidate_rows": self.candidate_rows,
+            "replaced_rows": self.replaced_rows,
+            "written_blobs": self.written_blobs,
+            "written_bytes": self.written_bytes,
+            "skipped_existing_blob": self.skipped_existing_blob,
+            "skipped_no_source_path": self.skipped_no_source_path,
+            "skipped_source_missing": self.skipped_source_missing,
+            "skipped_source_index": self.skipped_source_index,
+            "skipped_unsupported_source": self.skipped_unsupported_source,
+            "skipped_error": self.skipped_error,
+            "by_origin": dict(self.by_origin),
+            "by_source_shape": dict(self.by_source_shape),
             "samples": [sample.to_dict() for sample in self.samples],
         }
 
@@ -843,6 +919,8 @@ def _missing_raw_backed_blob_rows(conn: sqlite3.Connection) -> list[dict[str, An
     source_path_column = "source_path" if _column_exists(conn, "raw_sessions", "source_path") else "NULL"
     source_index_column = "source_index" if _column_exists(conn, "raw_sessions", "source_index") else "NULL"
     blob_size_column = "blob_size" if _column_exists(conn, "raw_sessions", "blob_size") else "NULL"
+    acquired_at_ms_column = "acquired_at_ms" if _column_exists(conn, "raw_sessions", "acquired_at_ms") else "NULL"
+    file_mtime_ms_column = "file_mtime_ms" if _column_exists(conn, "raw_sessions", "file_mtime_ms") else "NULL"
     rows = conn.execute(
         f"""
         SELECT lower(hex(blob_hash)) AS blob_hash,
@@ -851,7 +929,9 @@ def _missing_raw_backed_blob_rows(conn: sqlite3.Connection) -> list[dict[str, An
                {native_id_column} AS native_id,
                {source_path_column} AS source_path,
                {source_index_column} AS source_index,
-               {blob_size_column} AS expected_size_bytes
+               {blob_size_column} AS expected_size_bytes,
+               {acquired_at_ms_column} AS acquired_at_ms,
+               {file_mtime_ms_column} AS file_mtime_ms
         FROM raw_sessions
         WHERE blob_hash IS NOT NULL
         ORDER BY origin, source_path, source_index, raw_id
@@ -885,6 +965,147 @@ def _raw_backed_recovery_action(blob_hash: str, source_path: str | None, expecte
     if actual_hash == blob_hash:
         return "direct_exact_restore_candidate", "source bytes match the expected blob hash"
     return "direct_source_hash_mismatch", f"source hash is {actual_hash}"
+
+
+def _split_container_source_path(source_path: str) -> tuple[Path, str] | None:
+    outer, sep, member = source_path.partition(":")
+    if not sep or not outer or not member:
+        return None
+    return Path(outer), member
+
+
+def _json_payload_at_index(raw_bytes: bytes, source_index: int) -> object:
+    loaded = json_loads(raw_bytes)
+    if isinstance(loaded, list):
+        try:
+            return loaded[source_index]
+        except IndexError as exc:
+            raise IndexError(f"source_index {source_index} outside JSON array of {len(loaded)} payloads") from exc
+    if source_index == 0:
+        return loaded
+    raise IndexError("non-array JSON payload only supports source_index 0")
+
+
+def _jsonl_payload_at_index(raw_bytes: bytes, source_index: int) -> object:
+    for idx, line in enumerate(raw_bytes.splitlines()):
+        if idx == source_index:
+            return json_loads(line)
+    raise IndexError(f"source_index {source_index} outside JSONL stream")
+
+
+def _current_raw_payload_bytes(
+    source_path: str,
+    source_index: int | None,
+    *,
+    source_bytes_cache: dict[str, bytes] | None = None,
+    decoded_payload_cache: dict[str, object] | None = None,
+) -> tuple[bytes | None, str | None]:
+    if _path_is_container_member(source_path):
+        split = _split_container_source_path(source_path)
+        if split is None:
+            return None, "unsupported_container_path"
+        zip_path, member = split
+        if not zip_path.exists():
+            return None, "source_missing"
+        try:
+            if source_bytes_cache is not None and source_path in source_bytes_cache:
+                member_bytes = source_bytes_cache[source_path]
+            else:
+                with zipfile.ZipFile(zip_path) as archive, archive.open(member) as handle:
+                    member_bytes = handle.read()
+                if source_bytes_cache is not None:
+                    source_bytes_cache[source_path] = member_bytes
+        except KeyError:
+            return None, "source_missing"
+        if source_index is None:
+            return None, "source_index_missing"
+        try:
+            if decoded_payload_cache is not None and source_path in decoded_payload_cache:
+                decoded_payload = decoded_payload_cache[source_path]
+                if isinstance(decoded_payload, list):
+                    payload = decoded_payload[int(source_index)]
+                elif int(source_index) == 0:
+                    payload = decoded_payload
+                else:
+                    raise IndexError("non-array JSON payload only supports source_index 0")
+            else:
+                if member.endswith(".jsonl"):
+                    payload = _jsonl_payload_at_index(member_bytes, int(source_index))
+                else:
+                    decoded_payload = json_loads(member_bytes)
+                    if decoded_payload_cache is not None:
+                        decoded_payload_cache[source_path] = decoded_payload
+                    if isinstance(decoded_payload, list):
+                        payload = decoded_payload[int(source_index)]
+                    elif int(source_index) == 0:
+                        payload = decoded_payload
+                    else:
+                        raise IndexError("non-array JSON payload only supports source_index 0")
+        except (IndexError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            return None, f"source_index:{exc}"
+        return json_dumps_bytes(payload), None
+
+    path = Path(source_path)
+    if not path.exists():
+        return None, "source_missing"
+    try:
+        return path.read_bytes(), None
+    except OSError as exc:
+        return None, f"error:{exc}"
+
+
+def _delete_blob_refs_for_raw_id(conn: sqlite3.Connection, raw_id: str) -> None:
+    ref_id_column = "ref_id" if _column_exists(conn, "blob_refs", "ref_id") else "raw_id"
+    conn.execute(f"DELETE FROM blob_refs WHERE {ref_id_column} = ?", (raw_id,))
+
+
+def _insert_raw_payload_blob_ref(
+    conn: sqlite3.Connection,
+    *,
+    blob_hash: str,
+    raw_id: str,
+    source_path: str,
+    size_bytes: int,
+    acquired_at_ms: int,
+) -> None:
+    ref_id_column = "ref_id" if _column_exists(conn, "blob_refs", "ref_id") else "raw_id"
+    columns = ["blob_hash", ref_id_column, "ref_type"]
+    values: list[object] = [bytes.fromhex(blob_hash), raw_id, "raw_payload"]
+    if _column_exists(conn, "blob_refs", "source_path"):
+        columns.append("source_path")
+        values.append(source_path)
+    if _column_exists(conn, "blob_refs", "size_bytes"):
+        columns.append("size_bytes")
+        values.append(size_bytes)
+    if _column_exists(conn, "blob_refs", "acquired_at_ms"):
+        columns.append("acquired_at_ms")
+        values.append(acquired_at_ms)
+    placeholders = ", ".join("?" for _ in columns)
+    conn.execute(
+        f"INSERT OR REPLACE INTO blob_refs ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(values),
+    )
+
+
+def _update_raw_session_blob_ref(
+    conn: sqlite3.Connection,
+    *,
+    raw_id: str,
+    new_blob_hash: str,
+    new_blob_size: int,
+    acquired_at_ms: int,
+    file_mtime_ms: int | None,
+) -> None:
+    assignments = ["blob_hash = ?", "blob_size = ?"]
+    values: list[object] = [bytes.fromhex(new_blob_hash), new_blob_size]
+    if _column_exists(conn, "raw_sessions", "acquired_at_ms"):
+        assignments.append("acquired_at_ms = ?")
+        values.append(acquired_at_ms)
+    if file_mtime_ms is not None and _column_exists(conn, "raw_sessions", "file_mtime_ms"):
+        assignments.append("file_mtime_ms = ?")
+        values.append(file_mtime_ms)
+    values.append(raw_id)
+    conn.execute(f"UPDATE raw_sessions SET {', '.join(assignments)} WHERE raw_id = ?", tuple(values))
 
 
 def _default_blob_ref_quarantine_path(source_db: Path) -> Path:
@@ -1095,6 +1316,211 @@ def plan_raw_backed_blob_reference_recovery(
         by_source_shape=_counter_dict(by_source_shape),
         rows=tuple(plan_rows) if include_rows else (),
         samples=tuple(plan_rows[: max(0, sample_size)]),
+    )
+
+
+def replace_raw_backed_blob_reference_debt_from_source(
+    db_path: str | Path,
+    *,
+    store: BlobStore | None = None,
+    dry_run: bool = True,
+    manifest_path: str | Path | None = None,
+    max_count: int | None = None,
+    sample_size: int = 30,
+) -> BlobReferenceSourceReplaceReport:
+    """Replace missing raw-payload blob refs with current source-derived bytes.
+
+    This does not restore the historical missing blob. It records the old hash
+    in the manifest, writes the current source payload to the blob store, and
+    updates the existing raw_id to point at that current evidence.
+    """
+
+    if not dry_run and manifest_path is None:
+        raise ValueError("manifest_path is required when applying source replacement")
+
+    blob_store = store if store is not None else get_blob_store()
+    source_db = _source_db_for_blob_reference_report(db_path)
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        rows = _missing_raw_backed_blob_rows(conn)
+
+    samples: list[BlobReferenceSourceReplaceSample] = []
+    manifest_rows: list[dict[str, object]] = []
+    by_origin: Counter[str] = Counter()
+    by_source_shape: Counter[str] = Counter()
+    candidate_updates: list[tuple[dict[str, Any], str, int, int | None, int]] = []
+    skipped_existing_blob = 0
+    skipped_no_source_path = 0
+    skipped_source_missing = 0
+    skipped_source_index = 0
+    skipped_unsupported_source = 0
+    skipped_error = 0
+    source_bytes_cache: dict[str, bytes] = {}
+    decoded_payload_cache: dict[str, object] = {}
+
+    for row in rows:
+        old_blob_hash = str(row.get("blob_hash") or "")
+        raw_id = str(row.get("raw_id") or "")
+        if not old_blob_hash or not raw_id:
+            continue
+        if blob_store.exists(old_blob_hash):
+            skipped_existing_blob += 1
+            continue
+        if max_count is not None and len(candidate_updates) >= max_count:
+            break
+
+        source_path = _optional_str(row.get("source_path"))
+        origin = _optional_str(row.get("origin")) or "(none)"
+        by_origin[origin] += 1
+        source_shape = "container_member" if source_path and _path_is_container_member(source_path) else "direct_file"
+        by_source_shape[source_shape] += 1
+        if not source_path:
+            skipped_no_source_path += 1
+            reason: str | None = "no_source_path"
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceSourceReplaceSample(raw_id, old_blob_hash, None, source_path, "skipped", reason)
+                )
+            continue
+
+        try:
+            payload_bytes, reason = _current_raw_payload_bytes(
+                source_path,
+                int(row["source_index"]) if row.get("source_index") is not None else None,
+                source_bytes_cache=source_bytes_cache,
+                decoded_payload_cache=decoded_payload_cache,
+            )
+        except OSError as exc:
+            payload_bytes, reason = None, f"error:{exc}"
+        if payload_bytes is None:
+            if reason == "source_missing":
+                skipped_source_missing += 1
+            elif reason and reason.startswith("source_index"):
+                skipped_source_index += 1
+            elif reason and reason.startswith("error:"):
+                skipped_error += 1
+            else:
+                skipped_unsupported_source += 1
+            if len(samples) < max(0, sample_size):
+                samples.append(
+                    BlobReferenceSourceReplaceSample(raw_id, old_blob_hash, None, source_path, "skipped", reason)
+                )
+            manifest_rows.append(
+                {
+                    "action": "skipped",
+                    "reason": reason,
+                    "raw_id": raw_id,
+                    "old_blob_hash": old_blob_hash,
+                    "origin": row.get("origin"),
+                    "native_id": row.get("native_id"),
+                    "source_path": source_path,
+                    "source_index": row.get("source_index"),
+                    "old_blob_size": row.get("expected_size_bytes"),
+                }
+            )
+            continue
+
+        new_blob_hash = hashlib.sha256(payload_bytes).hexdigest()
+        new_blob_size = len(payload_bytes)
+        acquired_at_ms = int(time.time() * 1000)
+        base_path = source_path.partition(":")[0] if _path_is_container_member(source_path) else source_path
+        try:
+            file_mtime_ms: int | None = int(Path(base_path).stat().st_mtime * 1000)
+        except OSError:
+            file_mtime_ms = None
+        manifest_row = {
+            "action": "would_replace" if dry_run else "replaced",
+            "raw_id": raw_id,
+            "origin": row.get("origin"),
+            "native_id": row.get("native_id"),
+            "source_path": source_path,
+            "source_index": row.get("source_index"),
+            "old_blob_hash": old_blob_hash,
+            "old_blob_size": row.get("expected_size_bytes"),
+            "new_blob_hash": new_blob_hash,
+            "new_blob_size": new_blob_size,
+            "new_equals_old": new_blob_hash == old_blob_hash,
+        }
+        manifest_rows.append(manifest_row)
+        candidate_updates.append((row, new_blob_hash, new_blob_size, file_mtime_ms, acquired_at_ms))
+        if len(samples) < max(0, sample_size):
+            samples.append(
+                BlobReferenceSourceReplaceSample(
+                    raw_id=raw_id,
+                    old_blob_hash=old_blob_hash,
+                    new_blob_hash=new_blob_hash,
+                    source_path=source_path,
+                    action="would_replace" if dry_run else "replaced",
+                    bytes_written=new_blob_size,
+                )
+            )
+
+    resolved_manifest_path: Path | None = Path(manifest_path) if manifest_path is not None else None
+    if resolved_manifest_path is not None:
+        _write_jsonl_rows(resolved_manifest_path, manifest_rows)
+
+    replaced_rows = 0
+    written_blobs = 0
+    written_bytes = 0
+    if not dry_run and candidate_updates:
+        apply_source_bytes_cache: dict[str, bytes] = {}
+        apply_decoded_payload_cache: dict[str, object] = {}
+        with sqlite3.connect(source_db) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            with conn:
+                for row, new_blob_hash, new_blob_size, file_mtime_ms, acquired_at_ms in candidate_updates:
+                    raw_id = str(row["raw_id"])
+                    source_path = str(row["source_path"])
+                    if not blob_store.exists(new_blob_hash):
+                        payload_bytes, _reason = _current_raw_payload_bytes(
+                            source_path,
+                            int(row["source_index"]) if row.get("source_index") is not None else None,
+                            source_bytes_cache=apply_source_bytes_cache,
+                            decoded_payload_cache=apply_decoded_payload_cache,
+                        )
+                        if payload_bytes is None:
+                            skipped_error += 1
+                            continue
+                        blob_store.write_from_bytes(payload_bytes)
+                        written_blobs += 1
+                        written_bytes += len(payload_bytes)
+                    _delete_blob_refs_for_raw_id(conn, raw_id)
+                    _update_raw_session_blob_ref(
+                        conn,
+                        raw_id=raw_id,
+                        new_blob_hash=new_blob_hash,
+                        new_blob_size=new_blob_size,
+                        acquired_at_ms=acquired_at_ms,
+                        file_mtime_ms=file_mtime_ms,
+                    )
+                    _insert_raw_payload_blob_ref(
+                        conn,
+                        blob_hash=new_blob_hash,
+                        raw_id=raw_id,
+                        source_path=source_path,
+                        size_bytes=new_blob_size,
+                        acquired_at_ms=acquired_at_ms,
+                    )
+                    replaced_rows += 1
+
+    return BlobReferenceSourceReplaceReport(
+        source_db=str(source_db),
+        blob_root=str(blob_store.root),
+        dry_run=dry_run,
+        manifest_path=str(resolved_manifest_path) if resolved_manifest_path is not None else None,
+        scanned_rows=len(rows),
+        candidate_rows=len(candidate_updates),
+        replaced_rows=replaced_rows,
+        written_blobs=written_blobs,
+        written_bytes=written_bytes,
+        skipped_existing_blob=skipped_existing_blob,
+        skipped_no_source_path=skipped_no_source_path,
+        skipped_source_missing=skipped_source_missing,
+        skipped_source_index=skipped_source_index,
+        skipped_unsupported_source=skipped_unsupported_source,
+        skipped_error=skipped_error,
+        by_origin=_counter_dict(by_origin),
+        by_source_shape=_counter_dict(by_source_shape),
+        samples=tuple(samples),
     )
 
 
@@ -1401,6 +1827,8 @@ __all__ = [
     "BlobReferenceOrphanPruneReport",
     "BlobReferenceRecoveryPlanReport",
     "BlobReferenceRecoveryPlanRow",
+    "BlobReferenceSourceReplaceReport",
+    "BlobReferenceSourceReplaceSample",
     "BlobReferenceDebtReport",
     "BlobReferenceDebtRestoreReport",
     "BlobReferenceDebtRestoreSample",
@@ -1409,6 +1837,7 @@ __all__ = [
     "plan_raw_backed_blob_reference_recovery",
     "prune_orphan_blob_reference_debt",
     "referenced_blob_hashes",
+    "replace_raw_backed_blob_reference_debt_from_source",
     "restore_direct_blob_reference_debt",
     "scan_blob_reference_debt",
     "scan_blob_integrity",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -584,6 +584,55 @@ def test_blob_reference_recovery_plan_cli_writes_raw_backed_manifest(
     assert manifest_rows[0]["source_path"] == str(source)
 
 
+def test_blob_reference_replace_from_source_cli_requires_manifest_for_apply(
+    cli_runner: CliRunner,
+) -> None:
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "blob-reference-replace-from-source", "--yes"],
+    )
+
+    assert result.exit_code != 0
+    assert "--manifest-file is required with --yes" in result.output
+
+
+def test_blob_reference_replace_from_source_cli_applies_with_manifest(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+    manifest = cli_workspace["archive_root"] / "plans" / "replace.jsonl"
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-replace-from-source",
+            "--yes",
+            "--manifest-file",
+            str(manifest),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "blob_reference_replace_from_source"
+    assert payload["mutates"] is True
+    assert payload["writes_manifest"] is True
+    assert payload["candidate_rows"] == 1
+    assert payload["replaced_rows"] == 1
+    assert payload["skipped_error"] == 0
+    manifest_rows = [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()]
+    assert len(manifest_rows) == 1
+    assert manifest_rows[0]["old_blob_hash"] != manifest_rows[0]["new_blob_hash"]
+
+
 def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import zipfile
 from pathlib import Path
 
 from polylogue.storage.blob_integrity import (
@@ -11,6 +12,7 @@ from polylogue.storage.blob_integrity import (
     plan_raw_backed_blob_reference_recovery,
     prune_orphan_blob_reference_debt,
     referenced_blob_hashes,
+    replace_raw_backed_blob_reference_debt_from_source,
     restore_direct_blob_reference_debt,
     scan_blob_integrity,
     scan_blob_reference_debt,
@@ -615,6 +617,117 @@ def test_plan_raw_backed_blob_reference_recovery_writes_manifest(tmp_path: Path)
         "raw-size-mismatch",
         "raw-missing",
     }
+
+
+def test_replace_raw_backed_blob_reference_debt_from_source_updates_raw_refs(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    store = BlobStore(tmp_path / "blob")
+    direct_source = tmp_path / "direct.json"
+    direct_source.write_bytes(b'{"id":"direct","value":2}')
+    zip_source = tmp_path / "export.zip"
+    with zipfile.ZipFile(zip_source, "w") as archive:
+        archive.writestr("conversations.json", json.dumps([{"id": "first"}, {"id": "second", "value": 2}]))
+    stale_direct_hash = "1" * 64
+    stale_zip_hash = "2" * 64
+    manifest_path = tmp_path / "replacement.jsonl"
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY,
+                origin TEXT,
+                native_id TEXT,
+                source_path TEXT,
+                source_index INTEGER,
+                blob_hash BLOB,
+                blob_size INTEGER NOT NULL,
+                acquired_at_ms INTEGER,
+                file_mtime_ms INTEGER
+            );
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                ref_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                acquired_at_ms INTEGER NOT NULL,
+                PRIMARY KEY(blob_hash, ref_type, ref_id)
+            );
+            """
+        )
+        rows = [
+            (
+                "raw-direct",
+                "chatgpt-export",
+                "native-direct",
+                str(direct_source),
+                0,
+                bytes.fromhex(stale_direct_hash),
+                1,
+                10,
+                20,
+            ),
+            (
+                "raw-zip",
+                "chatgpt-export",
+                "native-zip",
+                f"{zip_source}:conversations.json",
+                1,
+                bytes.fromhex(stale_zip_hash),
+                2,
+                11,
+                21,
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, file_mtime_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, ?)
+            """,
+            [
+                (bytes.fromhex(stale_direct_hash), "raw-direct", str(direct_source), 1, 10),
+                (bytes.fromhex(stale_zip_hash), "raw-zip", f"{zip_source}:conversations.json", 2, 11),
+            ],
+        )
+
+    dry = replace_raw_backed_blob_reference_debt_from_source(
+        source_db,
+        store=store,
+        manifest_path=tmp_path / "dry-run.jsonl",
+    )
+    assert dry.dry_run is True
+    assert dry.candidate_rows == 2
+    assert dry.replaced_rows == 0
+
+    report = replace_raw_backed_blob_reference_debt_from_source(
+        source_db,
+        store=store,
+        dry_run=False,
+        manifest_path=manifest_path,
+    )
+
+    assert report.replaced_rows == 2
+    assert report.written_blobs == 2
+    manifest_rows = [json.loads(line) for line in manifest_path.read_text(encoding="utf-8").splitlines()]
+    assert {row["old_blob_hash"] for row in manifest_rows} == {stale_direct_hash, stale_zip_hash}
+    with sqlite3.connect(source_db) as conn:
+        stored = conn.execute(
+            "SELECT raw_id, lower(hex(blob_hash)), blob_size FROM raw_sessions ORDER BY raw_id"
+        ).fetchall()
+        refs = conn.execute("SELECT ref_id, lower(hex(blob_hash)) FROM blob_refs ORDER BY ref_id").fetchall()
+    assert [row[0] for row in stored] == ["raw-direct", "raw-zip"]
+    assert all(blob_hash not in {stale_direct_hash, stale_zip_hash} for _raw_id, blob_hash, _size in stored)
+    assert refs == [(raw_id, blob_hash) for raw_id, blob_hash, _size in stored]
+    assert all(store.exists(blob_hash) for _raw_id, blob_hash, _size in stored)
 
 
 def test_scan_blob_integrity_uses_sibling_archive_source_from_index_db(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a dry-run-by-default maintenance command that replaces raw-session-backed missing blob references with current source-derived raw payload bytes while preserving a complete before/after manifest.

## Problem

After orphan blob references were quarantined and exact direct restore was exhausted, production still had 389 raw-session-backed missing blobs. Those rows are recoverable from current source files, but repairing them must not pretend the old historical blob bytes were restored, and it must not mutate source evidence without an external manifest of the old hash and new hash for every row.

Ref #2421.

## Solution

Added `polylogue ops maintenance blob-reference-replace-from-source`:

- dry-run by default;
- requires `--yes` plus `--manifest-file` to mutate;
- derives current raw payload bytes from direct source files;
- derives source-indexed payload bytes from ZIP member JSON/JSONL using the same canonical JSON byte dumper used by acquisition;
- caches ZIP member bytes and decoded JSON per command run to avoid I/O amplification;
- writes a JSONL before/after manifest containing raw id, source identity, old blob hash/size, and new blob hash/size;
- applies by deleting stale raw-payload blob refs for the raw id, writing the current blob, updating `raw_sessions`, and inserting the new `blob_refs` row.

This is current-source replacement, not historical byte restoration.

## Verification

- `devtools test tests/unit/storage/test_blob_integrity.py tests/unit/cli/test_archive_maintenance_cli.py -q` -> `38 passed`
- `devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` at `df73e793125846f11ea9a7030936c9af64fdccaf` -> `exit_code 0`
- live dry-run against production archive -> `candidate_rows=389`, `skipped_source_missing=0`, `skipped_source_index=0`, `skipped_unsupported_source=0`, `skipped_error=0`, `mutates=false`

## Residual

Remaining #2421 scope after this lands/deploys is the production apply itself: stop/settle the daemon if needed, create a fresh source DB backup, run the command with `--yes --manifest-file`, then verify blob-reference debt reaches zero or record any residual rows with exact reasons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintenance command to refresh missing blob references from current source data.
  * Supports dry-run mode, JSON or plain output, manifest generation, and processing limits.

* **Bug Fixes**
  * Replaces stale blob references with updated hashes and sizes from the latest available source content.
  * Handles both direct files and archived members, including indexed JSON/JSONL content.

* **Tests**
  * Added coverage for required manifest validation and successful replacement output.
  * Added storage-level tests for dry-run and apply behavior, including manifest and database updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->