### PR TITLE
fix(devtools): trust indexed browser captures in smoke

### DIFF
--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -507,14 +507,6 @@ def _probe_browser_capture_archive(*, archive_root: Path) -> BrowserCaptureArchi
         error = "spooled_without_raw_rows"
     if error is None and files and raw_rows is not None and raw_rows > 0 and latest_raw_id is None:
         error = "latest_spooled_without_raw_row"
-    if (
-        error is None
-        and files
-        and latest_mtime_ms is not None
-        and latest_raw_file_mtime_ms is not None
-        and latest_mtime_ms > latest_raw_file_mtime_ms
-    ):
-        error = "spooled_newer_than_raw_rows"
     if error is None and files and not index_db_path.exists():
         error = "index_db_missing"
     if error is None and latest_raw_id is not None and index_db_path.exists():
@@ -547,6 +539,15 @@ def _probe_browser_capture_archive(*, archive_root: Path) -> BrowserCaptureArchi
                     error = "latest_spooled_indexed_native_id_mismatch"
         except sqlite3.Error as exc:
             error = f"index:{type(exc).__name__}: {exc}"
+    if (
+        error is None
+        and files
+        and latest_indexed_session_id is None
+        and latest_mtime_ms is not None
+        and latest_raw_file_mtime_ms is not None
+        and latest_mtime_ms > latest_raw_file_mtime_ms
+    ):
+        error = "spooled_newer_than_raw_rows"
     ok = error is None
     return BrowserCaptureArchiveProbe(
         spool_path=str(spool_path),

--- a/tests/unit/devtools/test_deployment_smoke.py
+++ b/tests/unit/devtools/test_deployment_smoke.py
@@ -707,7 +707,7 @@ def test_deployment_smoke_reports_spooled_browser_capture_without_raw_rows(tmp_p
     assert probe.error == "spooled_without_raw_rows"
 
 
-def test_deployment_smoke_reports_spooled_browser_capture_newer_than_raw_row(tmp_path: Path) -> None:
+def test_deployment_smoke_prioritizes_missing_index_over_stale_raw_mtime(tmp_path: Path) -> None:
     capture = _write_spooled_capture(tmp_path)
     _create_browser_source_db(
         tmp_path,
@@ -723,7 +723,27 @@ def test_deployment_smoke_reports_spooled_browser_capture_newer_than_raw_row(tmp
     assert probe.latest_spooled_mtime_ms is not None
     assert probe.latest_raw_file_mtime_ms is not None
     assert probe.latest_spooled_mtime_ms > probe.latest_raw_file_mtime_ms
-    assert probe.error == "spooled_newer_than_raw_rows"
+    assert probe.error == "index_db_missing"
+
+
+def test_deployment_smoke_accepts_indexed_capture_with_stale_raw_mtime(tmp_path: Path) -> None:
+    capture = _write_spooled_capture(tmp_path)
+    _create_browser_source_db(
+        tmp_path,
+        file_mtime_ms=int(capture.stat().st_mtime * 1000) - 1000,
+        capture_path=capture,
+    )
+    _create_browser_index_db(tmp_path)
+
+    probe = deployment_smoke._probe_browser_capture_archive(archive_root=tmp_path)
+
+    assert probe.ok is True
+    assert probe.error is None
+    assert probe.latest_spooled_mtime_ms is not None
+    assert probe.latest_raw_file_mtime_ms is not None
+    assert probe.latest_spooled_mtime_ms > probe.latest_raw_file_mtime_ms
+    assert probe.latest_indexed_session_id == "chatgpt-export:capture"
+    assert probe.latest_indexed_message_count == 1
 
 
 def test_deployment_smoke_reports_latest_browser_capture_missing_index_row(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes deployment smoke so an indexed browser-capture session is not failed solely because the spool file mtime is newer than the raw row mtime.

## Problem

After the source repair deployment, `devtools workspace deployment-smoke --json` failed with `browser-capture-archive:spooled_newer_than_raw_rows`. The same smoke artifact also showed the receiver archive-state endpoint proving the latest capture was archived, raw-backed, indexed, and had 86 indexed messages. The generic archive probe was raising the stale-mtime error before checking index evidence.

Ref #2421.

## Solution

The browser-capture archive probe now performs the index lookup before emitting the stale-spool mtime error, and only reports `spooled_newer_than_raw_rows` when the latest capture is not otherwise indexed. Regression coverage accepts an indexed capture with stale raw mtime while preserving missing-index failures.

## Verification

- `devtools test tests/unit/devtools/test_deployment_smoke.py -q` -> `31 passed`
- `devtools verify --quick` -> `exit_code 0`
- pre-push `devtools verify --quick` at `641a794d29e1c684952c8acd4ac345adbb1b89be` -> `exit_code 0`

## Residual

After merge/deploy, rerun deployment smoke against the live daemon. The current production data already has zero blob-reference debt; this PR only fixes the smoke classifier for archived browser captures with stale raw mtime metadata.
