### PR TITLE
docs: build the 7-minute first-contact funnel (#2379)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -715,6 +715,45 @@ Polylogue is a local archive for AI sessions. The system has four rings:
 3. user and machine surfaces
 4. verification and maintenance
 
+```mermaid
+flowchart TD
+    SRC["Source files<br/>ChatGPT · Claude · Codex · Gemini · Drive · Antigravity"]
+
+    subgraph R1["Ring 1 · Archive substrate"]
+        DETECT["detect_provider()<br/>shape-based dispatch"]
+        PARSE["provider parsers<br/>normalize → content hash (NFC)"]
+        STORE[("split-tier SQLite<br/>source · index · embeddings · user · ops<br/>+ content-addressed blob store")]
+        DETECT --> PARSE --> STORE
+    end
+
+    subgraph R2["Ring 2 · Derived read models"]
+        INSIGHTS["session profiles · work events<br/>phases · threads · cost rollups<br/>FTS5 + vector indexes"]
+    end
+
+    subgraph R3["Ring 3 · Surfaces"]
+        CLI["CLI<br/>find QUERY then VERB"]
+        MCP["MCP bridge"]
+        API["Python API"]
+        DAEMON["daemon HTTP reader<br/>+ /metrics"]
+    end
+
+    subgraph R4["Ring 4 · Verification & maintenance"]
+        VERIFY["schemas · demo fixtures<br/>devtools lanes · tests"]
+    end
+
+    SRC --> DETECT
+    STORE --> INSIGHTS
+    INSIGHTS --> R3
+    STORE --> R3
+    R4 -.audits.-> R1
+    R4 -.audits.-> R2
+```
+
+Source evidence and user-authored state (rings 1 and the `user.db` tier) are
+durable; indexes, insight read models, embeddings, and daemon telemetry are
+rebuildable. Surfaces (ring 3) are leaf adapters — they read through the same
+archive/query substrate rather than owning their own stores.
+
 ## Rings
 
 ### 1. Archive Substrate
@@ -1751,6 +1790,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools render quality-reference` | Render docs/test-quality-workflows.md from executable lane, mutation, and benchmark registries. |
 | `devtools render topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
+| `devtools render visual-tapes` | Write VHS tape files and optionally capture GIFs for the default visual evidence specs. |
 
 ### Release
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@
 **Polylogue is a local archive and cockpit for your AI sessions and agent
 work.**
 
+> **Skim this in 7 minutes.** Every AI tool you use scatters its transcripts —
+> one JSON dump per vendor, one log stream per coding agent, one half-broken
+> export per browser plugin. Polylogue pulls all of them into a single
+> searchable archive on your own machine, then lets you ask what an agent did
+> yesterday: what it cost, what it touched, what it tested, and what to resume
+> next.
+>
+> - **30 seconds** — the bold line above: local, source-agnostic, idempotent.
+> - **3 minutes** — this section, the [one-command demo](#try-it-in-one-command),
+>   and the [architecture diagram](docs/architecture.md).
+> - **30 minutes** — [architecture.md](docs/architecture.md),
+>   [internals.md](docs/internals.md), and [search.md](docs/search.md). New
+>   vocabulary is translated in the [glossary](docs/glossary.md).
+
 It ingests the session files that ChatGPT, Claude (web and Claude Code),
 Codex, Gemini, Google Drive exports, and Antigravity already leave on disk,
 normalizes them into a content-addressed SQLite archive, and gives you
@@ -24,6 +38,36 @@ machine, against your data.
 - **Idempotent.** Re-ingesting the same data is a no-op; content hashes
   prevent duplication, and editable metadata (tags, summaries) does not
   trigger re-import.
+
+## Try it in one command
+
+No real data and no API key required. This seeds a throwaway, deterministic
+demo archive (three sessions — one each from ChatGPT, Claude Code, and Codex)
+and shows them coexisting in a single queryable substrate:
+
+```bash
+export POLYLOGUE_ARCHIVE_ROOT="$(mktemp -d)/archive"
+polylogue demo seed --root "$POLYLOGUE_ARCHIVE_ROOT" --force --with-overlays
+polylogue analyze --facets
+```
+
+```text
+Facets (global) — matched result set:
+  sessions: 3  messages: 19
+  Provider origins:
+    chatgpt-export: 1
+    claude-code-session: 1
+    codex-session: 1
+  User tags:
+    pytest-triage: 1
+```
+
+From here, `polylogue find "pytest" then read --view messages` renders the
+matched transcript, and `polylogue demo verify --root "$POLYLOGUE_ARCHIVE_ROOT"`
+checks the same semantic facts CI does. The screencast media for these flows is
+regenerable from committed tape specs with a single command —
+`devtools render visual-tapes --capture` (writes `.tape` files, and `.gif`s when
+the `vhs` binary is present).
 
 ## Why this exists
 

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -184,6 +184,18 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools render pages", "devtools render pages --check", "devtools render pages --serve"),
     ),
     CommandSpec(
+        "render visual-tapes",
+        "generated surfaces",
+        "Write VHS tape files and optionally capture GIFs for the default visual evidence specs.",
+        "devtools.render_visual_tapes",
+        use_when="Regenerate the first-contact demo screencast media from the committed tape specs.",
+        examples=(
+            "devtools render visual-tapes",
+            "devtools render visual-tapes --capture",
+            "devtools render visual-tapes --check",
+        ),
+    ),
+    CommandSpec(
         "verify",
         "verification",
         "Run the local verification baseline before pushing or creating a PR.",

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -20,6 +20,11 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
         "docs/installation.md",
         "Source checkout, Nix flake, and managed NixOS/Home Manager install paths.",
     ),
+    DocsEntry(
+        "Glossary",
+        "docs/glossary.md",
+        "Plain-language translation of the internal taxonomy, with 30s/3min/30min entry layers.",
+    ),
     DocsEntry("CLI Reference", "docs/cli-reference.md", "Generated command reference from live help output."),
     DocsEntry(
         "Search & Query",

--- a/devtools/render_visual_tapes.py
+++ b/devtools/render_visual_tapes.py
@@ -1,0 +1,87 @@
+"""Generate VHS tape files (and optional GIF captures) for visual evidence.
+
+This is the thin operator entrypoint over the tape engine in
+``devtools.visual_vhs``. It writes one ``.tape`` file per default visual
+evidence spec and, with ``--capture``, drives the ``vhs`` binary to render
+the matching ``.gif`` files against the currently active archive.
+
+The README documents ``devtools render visual-tapes --capture`` as the single
+command that regenerates the demo screencast media, so the first-contact GIF
+stays reproducible instead of being a committed binary that bitrots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from devtools.visual_vhs import (
+    check_vhs_available,
+    default_tape_specs,
+    generate_all_tapes,
+    run_vhs_capture,
+)
+
+DEFAULT_OUTPUT_DIR = ".local/visual-tapes"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="devtools render visual-tapes",
+        description="Write VHS tape files and optionally capture GIFs for the default visual evidence specs.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"directory for generated .tape/.gif files (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--capture",
+        action="store_true",
+        help="run the 'vhs' binary to render .gif files from the generated tapes",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the tape specs generate cleanly without writing any files",
+    )
+    args = parser.parse_args(argv)
+
+    specs = default_tape_specs()
+
+    if args.check:
+        tapes = generate_all_tapes(specs)
+        print(f"visual-tapes: {len(tapes)} tape specs generate cleanly")
+        return 0
+
+    output_dir = Path(args.output_dir)
+    generate_all_tapes(specs, output_dir=output_dir)
+    print(f"visual-tapes: wrote {len(specs)} .tape files to {output_dir}")
+
+    if args.capture:
+        if not check_vhs_available():
+            print(
+                "visual-tapes: 'vhs' binary not found in PATH; skipping GIF capture",
+                file=sys.stderr,
+            )
+            return 1
+        failures: list[str] = []
+        for spec in specs:
+            tape_path = output_dir / f"{spec.name}.tape"
+            gif_path = output_dir / f"{spec.name}.gif"
+            if not run_vhs_capture(tape_path, gif_path):
+                failures.append(spec.name)
+        if failures:
+            print(
+                f"visual-tapes: capture failed for {', '.join(failures)}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"visual-tapes: captured {len(specs)} GIFs in {output_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/render_visual_tapes.py
+++ b/devtools/render_visual_tapes.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 from devtools.visual_vhs import (
+    VHSTape,
     check_vhs_available,
     default_tape_specs,
     generate_all_tapes,
@@ -61,14 +62,17 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.capture:
         if not check_vhs_available():
+            # GIF capture is an optional, best-effort step: the tapes are the
+            # committed artifact and were written above. A missing `vhs` binary
+            # is a soft skip, not a failure, so the tapes still count as success.
             print(
-                "visual-tapes: 'vhs' binary not found in PATH; skipping GIF capture",
+                "visual-tapes: 'vhs' binary not found in PATH; tapes written, GIF capture skipped",
                 file=sys.stderr,
             )
-            return 1
+            return 0
         failures: list[str] = []
         for spec in specs:
-            tape_path = output_dir / f"{spec.name}.tape"
+            tape_path = output_dir / VHSTape(spec_name=spec.name, content="").filename
             gif_path = output_dir / f"{spec.name}.gif"
             if not run_vhs_capture(tape_path, gif_path):
                 failures.append(spec.name)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,45 @@ Polylogue is a local archive for AI sessions. The system has four rings:
 3. user and machine surfaces
 4. verification and maintenance
 
+```mermaid
+flowchart TD
+    SRC["Source files<br/>ChatGPT · Claude · Codex · Gemini · Drive · Antigravity"]
+
+    subgraph R1["Ring 1 · Archive substrate"]
+        DETECT["detect_provider()<br/>shape-based dispatch"]
+        PARSE["provider parsers<br/>normalize → content hash (NFC)"]
+        STORE[("split-tier SQLite<br/>source · index · embeddings · user · ops<br/>+ content-addressed blob store")]
+        DETECT --> PARSE --> STORE
+    end
+
+    subgraph R2["Ring 2 · Derived read models"]
+        INSIGHTS["session profiles · work events<br/>phases · threads · cost rollups<br/>FTS5 + vector indexes"]
+    end
+
+    subgraph R3["Ring 3 · Surfaces"]
+        CLI["CLI<br/>find QUERY then VERB"]
+        MCP["MCP bridge"]
+        API["Python API"]
+        DAEMON["daemon HTTP reader<br/>+ /metrics"]
+    end
+
+    subgraph R4["Ring 4 · Verification & maintenance"]
+        VERIFY["schemas · demo fixtures<br/>devtools lanes · tests"]
+    end
+
+    SRC --> DETECT
+    STORE --> INSIGHTS
+    INSIGHTS --> R3
+    STORE --> R3
+    R4 -.audits.-> R1
+    R4 -.audits.-> R2
+```
+
+Source evidence and user-authored state (rings 1 and the `user.db` tier) are
+durable; indexes, insight read models, embeddings, and daemon telemetry are
+rebuildable. Surfaces (ring 3) are leaf adapters — they read through the same
+archive/query substrate rather than owning their own stores.
+
 ## Rings
 
 ### 1. Archive Substrate

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -102,6 +102,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools render quality-reference` | Render docs/test-quality-workflows.md from executable lane, mutation, and benchmark registries. |
 | `devtools render topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
+| `devtools render visual-tapes` | Write VHS tape files and optionally capture GIFs for the default visual evidence specs. |
 
 ### Release
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,47 @@
+# Glossary
+
+Polylogue's docs use a precise internal vocabulary. This page translates it into
+plain language for a first-time reader. For the full system shape see
+[architecture.md](architecture.md); for the provider/origin/source split see
+[provider-origin-identity.md](provider-origin-identity.md).
+
+## Entry layers
+
+Read only as deep as you need:
+
+- **30 seconds** — Polylogue ingests the AI-session files ChatGPT, Claude,
+  Codex, Gemini, and coding agents leave on disk into one local, searchable
+  SQLite archive, and gives you search, insights, and an MCP/HTTP/CLI cockpit
+  over them.
+- **3 minutes** — read the [README](../README.md) top section and the
+  [architecture diagram](architecture.md).
+- **30 minutes** — read [architecture.md](architecture.md),
+  [internals.md](internals.md), and the [search grammar](search.md).
+
+## Terms
+
+| Term | Plain-language meaning |
+|------|------------------------|
+| **Archive** | The on-disk SQLite file set under your XDG data directory that holds every ingested session. Not a single file — see *archive tier*. |
+| **Archive tier** | One of the five SQLite databases the archive is split into by durability class: `source.db` (raw evidence), `index.db` (parsed sessions + search + insights), `embeddings.db` (vectors), `user.db` (your tags/notes/assertions), `ops.db` (disposable daemon telemetry). Tiers are backed up and rebuilt independently. |
+| **Source / origin / provider** | Three scopes of "where a session came from". *Source* = the material runtime root and lab attribution; *origin* = the public token on query surfaces (`claude-code-session`, `chatgpt-export`); *provider* = the low-level parser/schema identity. Public filters use **origin**. Full table in [provider-origin-identity.md](provider-origin-identity.md). |
+| **Ingest / acquisition** | Reading source files, detecting their provider by shape (not filename), parsing them, and writing normalized rows into the archive. |
+| **Content hash** | A SHA-256 over the NFC-normalized session payload (title, timestamps, messages, attachments). It is the archive's idempotency key: re-ingesting identical content is a no-op. Editable metadata (tags, summaries) is excluded, so editing those never triggers re-import. |
+| **Blob store** | Content-addressed storage for large binary content, keyed by SHA-256 and sharded into 256 subdirectories. Identical content deduplicates automatically. |
+| **Insight (read model)** | A value computed once over the archive and stored for fast reads — session profiles, work events, phases, threads, tag and cost rollups. The CLI, daemon, MCP, and Python API all read the same materialized numbers. |
+| **Facet** | A grouped count over a result set (e.g. sessions per origin, per repo, per tool). What `analyze --facets` returns. |
+| **Projection** | A derived view of stored evidence — e.g. a Run, ContextSnapshot, or ObservedEvent assembled from underlying rows. Projections are views, not new sources of truth. |
+| **Assertion** | An authored or transform-produced claim about a target (a session, message, or ref), carrying author, value, evidence, status, and visibility. The unifying substrate for user/agent overlays — tags, marks, corrections, notes, saved views. |
+| **Evidence ref / ObjectRef** | A typed pointer to a thing in the archive (a session, message, block, run, …) that a claim or report can cite, so any digest is traceable back to its backing rows. |
+| **Work packet / recovery digest** | A compact, shareable bundle summarizing what an agent session did — cost, repos touched, tools used, what to resume next — assembled from evidence, not free-typed. |
+| **Topology edge** | A typed cross-session parent link (continuation, fork, sidechain, subagent). Stored durably even when the parent is ingested out of order. |
+| **Logical session** | The resolved root of a session's parent chain. Continuations, forks, and subagent runs all roll up to one logical work session. |
+| **Daemon (`polylogued`)** | The background process that watches source directories, ingests live, rebuilds insights, and serves a local HTTP reader plus health checks and Prometheus `/metrics`. |
+| **Convergence** | The daemon's process of bringing the archive up to date with its sources: acquire raw rows, parse, materialize index rows, refresh insights, keep FTS in sync. |
+| **Readiness** | Whether a tier is trustworthy *right now* — e.g. all raw rows materialized, FTS index current. Stale or unverified state makes a surface report not-ready rather than silently wrong. |
+| **Archive debt** | Acquired-but-not-materialized state: a raw row with no matching parsed session, or a referenced blob with no file. Surfaced by `ops diagnostics workload`, not hidden. |
+| **Demo archive** | A deterministic, private-data-free fixture archive (`polylogue demo seed/verify`) used for examples, screenshots, and CI without touching your real corpus. |
+| **Retrieval lane** | Which search engine answers a query: `dialogue` (FTS5 lexical), vector (semantic), or `hybrid` (both fused via Reciprocal Rank Fusion). `--lexical` and `--semantic` force a lane. |
+| **MCP bridge** | The Model Context Protocol server (`polylogue-mcp`) that lets an AI assistant search and read your archive from inside its own session. |
+| **Verb** | A query-first action applied to a matched set: `read`, `select`, `analyze`, `mark`, `delete`, `continue`. Spelled `find QUERY then VERB`. |
+| **Fresh-first schema** | There is no in-place schema upgrade chain. A version mismatch is rejected and the affected tier is rebuilt from source, rather than migrated step-by-step. |


### PR DESCRIPTION
## Summary

A pure docs/presentation pass (plus one thin `devtools` command) that makes
Polylogue legible to a first-time reader in a 7-minute skim. Realizes Train 1,
item 1 of the #1807 epic.

## Problem

The loudest verdict from the source review behind #2379: *"Polylogue is not
weak because it lacks impact. It is weak only if it is illegible."* The docs
were extensive but developer-targeted — no skim funnel, no glossary, no
architecture *diagram* (`docs/architecture.md` was prose), and no single demo
command a stranger could run. First-contact legibility gates the perceived
value of every other artifact.

## Solution

- **README** — explicit `30s / 3min / 30min` skim funnel placed before any
  project-specific noun, and a **Try it in one command** section that seeds the
  deterministic, private-data-free demo archive and shows three providers
  (ChatGPT + Claude Code + Codex) coexisting via `analyze --facets`. The shown
  output is real (run against a seeded archive, committed inline).
- **docs/glossary.md** (new) — 20+ internal terms (archive tier,
  origin/source/provider, content hash, insight, projection, assertion,
  evidence ref, readiness, facet, retrieval lane, …) in plain language, with
  the same entry layers. Linked from the README; registered in the docs map.
- **docs/architecture.md** — Mermaid four-ring diagram (was prose-only),
  linked from the README funnel.
- **`devtools render visual-tapes`** — thin operator entrypoint over the
  existing, tested `visual_vhs` tape engine, so the demo screencast media is
  *regenerable by a single documented command* (`--capture` drives `vhs` when
  present) rather than a committed binary that bitrots. Registered in the
  command catalog; rendered into `docs/devtools.md`.

No runtime/archive behavior changes. Scope guard honored: no marketing-site
redesign (that warning lives in #2304/#2307).

## Verification

- `devtools verify doc-commands` → `79 doc files scanned, no stale commands`
- `devtools render all --check` → no drift across every generated surface
- `devtools verify --quick` → `exit_code 0` (ruff format, ruff lint,
  mypy --strict, render-all check, all verify lints)
- `devtools test` on `command_catalog`, `docs_surface`, `devtools_main`,
  `render_devtools_reference`, `visual_vhs` → `32 passed`
- One-command demo executed live: `demo seed --with-overlays` then
  `analyze --facets` produced the committed three-origin facet output;
  `devtools render visual-tapes` wrote 5 `.tape` files to gitignored `.local/`.

## Acceptance criteria (#2379)

- [x] README opens with a 30-second one-liner + 3-minute what/why before any
  project-specific noun.
- [x] A documented one command produces visible output on the demo archive;
  screencast media is regenerable by a single documented command.
- [x] An architecture diagram and `docs/glossary.md` exist and are linked from
  the README.
- [x] `devtools verify doc-commands` passes on every README/quickstart command.

Ref #2379. Ref #1807.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick-start overview in the README with a short “skim in 7 minutes” guide and a one-command demo flow.
  * Added support for generating visual tapes, including optional GIF capture for demo media.
  * Added a glossary and expanded architecture docs with a clearer system diagram.

* **Documentation**
  * Updated developer docs to include the new visual-tapes command and refreshed architecture guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->