### PR TITLE
fix(test): refresh status snapshot for index schema v10

### DIFF
--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -333,8 +333,8 @@
         "path": "<PATH>",
         "exists": true,
         "size_bytes": <SIZE_BYTES>,
-        "expected_user_version": 9,
-        "user_version": 9,
+        "expected_user_version": 10,
+        "user_version": 10,
         "version_status": "ok",
         "table_counts": {
           "sessions": 2,


### PR DESCRIPTION
## Summary

Refresh the one stale `test_json_status_snapshot` baseline so `master` CI goes green again.

## Problem

`test_json_status_snapshot` has been failing on `master` since #2420 bumped the
index tier to schema version 10 (role-leading facet index) without refreshing
this snapshot — it still pinned `user_version` / `expected_user_version` at `9`.
The latest `master` CI run (`62f3e532e`) is red on exactly this assertion. Any
PR that touches `tests/unit/cli/test_plain_cli_snapshots.py` inherits the red.

## Solution

Regenerated the single affected snapshot. The only delta is `9 → 10` on both
`user_version` (what the seeded test archive reports) and `expected_user_version`
(what the deployed package expects). Both agree on `10`, which matches the
`INDEX` version constant in `polylogue/storage/sqlite/archive_tiers/index.py`
(`= 10`) — so this refreshes a stale baseline rather than masking a regression.

## Verification

- `devtools test tests/unit/cli/test_plain_cli_snapshots.py -k test_json_status_snapshot`
  → `1 failed` on clean `master`, `1 passed` after `--snapshot-update`.
- `git diff` is exactly two lines (`9 → 10`).
- `devtools verify --quick` → `exit_code 0`.

Ref #2420.