### PR TITLE
fix(test): refresh terminal snapshots for raw_materialization + facets

### DIFF
--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -10,15 +10,16 @@
                                     maintenance repairs
     --cleanup                       Run destructive archive cleanup for orphaned
                                     or empty persisted data
-    --target [session_insights|dangling_fts|message_type_backfill|message_embeddin
-  gs|wal_checkpoint|orphaned_messages|empty_sessions|orphaned_attachments|orphaned
-  _blobs|superseded_raw_snapshots]
+    --target [session_insights|dangling_fts|message_type_backfill|raw_materializat
+  ion|message_embeddings|wal_checkpoint|orphaned_messages|empty_sessions|orphaned_
+  attachments|orphaned_blobs|superseded_raw_snapshots]
                                     Limit maintenance to named targets such as
                                     session_insights, dangling_fts,
-                                    message_type_backfill, message_embeddings,
-                                    wal_checkpoint, orphaned_messages,
-                                    empty_sessions, orphaned_attachments,
-                                    orphaned_blobs, or superseded_raw_snapshots
+                                    message_type_backfill, raw_materialization,
+                                    message_embeddings, wal_checkpoint,
+                                    orphaned_messages, empty_sessions,
+                                    orphaned_attachments, orphaned_blobs, or
+                                    superseded_raw_snapshots
     --preview                       Preview maintenance without executing
                                     (requires --repair or --cleanup)
     --vacuum                        Reclaim unused space after maintenance
@@ -282,7 +283,7 @@
         routed your invocation.
     Product roles:
         Search<PATH>:   find QUERY then read|select|mark
-  |analyze|delete|continue
+  |analyze|delete|continue; facets
         Setup<PATH>:  config, init, import, demo, tuto
   rial
         Reader<PATH>:           dashboard --status, dashboard
@@ -302,6 +303,7 @@
         polylogue find id:abc then read --view messages
         polylogue find id:abc then read --to browser
         polylogue find id:abc then analyze --facets
+        polylogue facets --query "vector store" --format json
         polylogue find "urgent" then delete --dry-run
         polylogue find 'repo:polylogue' then read --all --form
   at ndjson
@@ -525,11 +527,12 @@
   r mark candidates.
       analyze   Analyze matched sessions and named facet famil
   ies.
+      facets    Show global or scoped archive facet families.
       delete    Delete matched sessions.
       continue  Compile a successor-agent continuation report.
-      Use `find QUERY then ACTION`; root action words act on t
-  he query result
-      set.
+      Use `find QUERY then ACTION`; `facets` is the direct arc
+  hive aggregate
+      command.
     Setup, import, and evidence:
       config    Show resolved Polylogue configuration with...
       init      Detect chat sources and write a starter polylo
@@ -566,7 +569,7 @@
         `polylogue --diagnose <args>` to have the parser explain how it
         routed your invocation.
     Product roles:
-        Search<PATH>:   find QUERY then read|select|mark|analyze|delete|continue
+        Search<PATH>:   find QUERY then read|select|mark|analyze|delete|continue; facets
         Setup<PATH>:  config, init, import, demo, tutorial
         Reader<PATH>:           dashboard --status, dashboard
         Operations:           status (same as polylogue ops status), ops diagnostics, ops maintenance, ops backup
@@ -580,6 +583,7 @@
         polylogue find id:abc then read --view messages
         polylogue find id:abc then read --to browser
         polylogue find id:abc then analyze --facets
+        polylogue facets --query "vector store" --format json
         polylogue find "urgent" then delete --dry-run
         polylogue find 'repo:polylogue' then read --all --format ndjson
     Combined filters:
@@ -716,10 +720,11 @@
       select    Select one matched session or print candidate identities.
       mark      Mark selected sessions; review candidates under mark candidates.
       analyze   Analyze matched sessions and named facet families.
+      facets    Show global or scoped archive facet families.
       delete    Delete matched sessions.
       continue  Compile a successor-agent continuation report.
-      Use `find QUERY then ACTION`; root action words act on the query result
-      set.
+      Use `find QUERY then ACTION`; `facets` is the direct archive aggregate
+      command.
     Setup, import, and evidence:
       config    Show resolved Polylogue configuration with...
       init      Detect chat sources and write a starter polylogue.toml.


### PR DESCRIPTION
## Summary

Refresh three stale `test_terminal_snapshots` baselines so the master regression net goes green.

## Problem

`test_terminal_snapshots::{test_check_output_snapshot, test_help_at_wide_width,
test_help_at_narrow_width}` fail on clean `master`, independent of any current
PR. Two prior surface changes were never reflected in the terminal snapshots:

- `check --target` gained the `raw_materialization` maintenance target (the
  raw-backed blob recovery work, #2424–#2427).
- The root help "Search:" line gained the `facets` direct arc plus a `facets`
  command entry and example.

Because the heavy `test` job is intentionally off the per-PR path (it runs
post-merge on master), these stale snapshots surfaced only after merge and were
never refreshed.

## Solution

Regenerated the three affected terminal snapshots. The diff is confined to the
`raw_materialization` `--target` choice and the `facets` help/command lines —
both current real CLI surface — so this refreshes stale baselines rather than
masking a regression.

## Verification

- `devtools test tests/unit/cli/test_terminal_snapshots.py` → `3 failed` on
  clean master; `--snapshot-update` → `3 updated`, then `9 passed`.
- `git diff` is one file, confined to the two known surface additions.

Ref #2426.