### PR TITLE
feat(demo): materialize session insights in no-daemon seed

### DIFF
--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -12,6 +13,7 @@ from polylogue.config import Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import build_demo_corpus_specs, seed_demo_user_overlays
 from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
 from .models import DemoSeedResult
 
@@ -46,6 +48,29 @@ def materialize_demo_source(root: Path, *, force: bool = False) -> Path:
     return source_root
 
 
+def _materialize_session_insights(archive_root: Path, session_ids: list[str]) -> None:
+    """Build the session-profile insight read models for *session_ids*.
+
+    ``parse_sources_archive`` writes the ``sessions``/``messages`` tree but does
+    not materialize the derived insight tables (``session_profiles`` and
+    siblings); the daemon convergence path normally does that in a separate
+    stage. The no-daemon demo seed must run the same rebuild so that the
+    postmortem / recovery-digest read surfaces resolve against a populated demo
+    archive instead of an empty one. Passing ``session_ids`` makes
+    ``rebuild_session_insights_sync`` commit internally and skip the full-table
+    delete/rebuild path.
+    """
+
+    if not session_ids:
+        return
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        conn.row_factory = sqlite3.Row
+        rebuild_session_insights_sync(conn, session_ids=session_ids)
+    finally:
+        conn.close()
+
+
 def demo_source_specs(source_root: Path) -> list[Source]:
     """Return relative source specs for the materialized demo world."""
 
@@ -67,6 +92,9 @@ async def seed_demo_archive(
     source_root = materialize_demo_source(archive_root, force=force)
     with _pushd(source_root):
         result = await parse_sources_archive(archive_root, demo_source_specs(source_root))
+
+    session_ids = sorted(result.processed_ids)
+    _materialize_session_insights(archive_root, session_ids)
 
     overlay = seed_demo_user_overlays(archive_root) if with_overlays else None
     return DemoSeedResult(

--- a/tests/unit/demo/test_demo_seed_verify.py
+++ b/tests/unit/demo/test_demo_seed_verify.py
@@ -33,6 +33,24 @@ async def test_seed_demo_archive_creates_ready_queryable_archive(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_seed_materializes_session_profiles_for_postmortem(tmp_path: Path) -> None:
+    """The no-daemon seed must materialize the session-profile insight read model.
+
+    Without it ``analyze --postmortem`` (and the recovery-digest surfaces) render
+    an empty bundle on the demo archive because the postmortem aggregator fetches
+    profiles that ``parse_sources_archive`` never wrote. Guards the #2196 fix.
+    """
+
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=True)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        profile_count = conn.execute("SELECT count(*) FROM session_profiles").fetchone()[0]
+
+    assert profile_count == 3
+
+
+@pytest.mark.asyncio
 async def test_demo_verify_reports_missing_overlays(tmp_path: Path) -> None:
     archive_root = tmp_path / "archive"
 


### PR DESCRIPTION
## Summary

The no-daemon demo seed now materializes the `session_profiles` insight read
model so `analyze --postmortem` (and the recovery-digest read surfaces) render a
populated bundle on the demo archive instead of an empty one. Slice 1 of #2196.

## Problem

`parse_sources_archive` writes the `sessions`/`messages` tree but does not
materialize the derived insight tables — the daemon convergence path normally
does that in a separate stage. The no-daemon `polylogue demo seed` therefore
left `session_profiles` empty (sessions=3, profiles=0), so the one-command
"wow" surface (`analyze --postmortem`) rendered analyzed=0 on a freshly seeded
demo archive.

## Solution

- `polylogue/demo/seed.py`: after `parse_sources_archive`, run
  `rebuild_session_insights_sync(conn, session_ids=...)` against `index.db`.
  Passing explicit `session_ids` makes the rebuild commit internally and skip
  the full-table delete/rebuild path.
- Regression test in `tests/unit/demo/test_demo_seed_verify.py` asserts
  `session_profiles` count == 3 after a seed.

## Verification

`devtools test tests/unit/demo/test_demo_seed_verify.py tests/unit/cli/test_demo_command.py`
— 7 passed; mypy clean. End-to-end: seeded a demo archive and confirmed
`analyze --postmortem` analyzed count went 0 → 3 with a real wallclock span.

Ref #2196

Remaining #2196 scope: the synthetic demo corpus still emits zero
token/cost/usage data, so the blade renders \$0 cost / no top session / synthetic
repo names. Demo-corpus enrichment is tracked as slice 2 on #2196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo seeding now also prepares session-level insight data, so postmortem analysis works immediately after creating a demo archive.
  * Only the sessions touched during seeding are updated, keeping the process efficient.

* **Tests**
  * Added coverage to confirm the demo seeding flow populates the expected session-profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->