### PR TITLE
docs: showcase realized lineage, recovery, OTel, and importer breadth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ work.**
 >   vocabulary is translated in the [glossary](docs/glossary.md).
 
 It ingests the session files that ChatGPT, Claude (web and Claude Code),
-Codex, Gemini, Google Drive exports, and Antigravity already leave on disk,
+Codex, Gemini (Gemini CLI and Google Drive exports), Antigravity, and Hermes
+agents already leave on disk,
 normalizes them into a content-addressed SQLite archive, and gives you
 full-text and semantic search, materialized session insights, cost rollups,
 git-correlation, a daemon HTTP reader, and an MCP bridge — all running on your
@@ -90,6 +91,16 @@ Polylogue is that substrate, and a cockpit over it:
   phases, threads, tag rollups, and cost rollups are materialized into the
   archive so the CLI, the HTTP reader, the MCP bridge, and the Python API all
   see the same numbers.
+- **Lineage & topology.** Continuations, forks, sidechains, and subagent runs
+  are linked by typed topology edges and rolled up to one *logical session*, so
+  you can ask which branch burned the time and which session is the real root
+  worth turning into a skill. Exposed through `get_session_topology`,
+  `get_logical_session`, and `get_session_tree`.
+- **Recovery & resume.** Polylogue assembles a recovery work-packet and resume
+  brief from evidence — what an interrupted agent session was doing, what it
+  touched, and what to pick up next — and surfaces abandoned or resumable
+  sessions through `find_resume_candidates`, `find_abandoned_sessions`,
+  `get_resume_brief`, `get_recovery_report`, and `get_recovery_work_packet`.
 - **Built to be inspected.** Schema is fresh-first (no in-place upgrade chain
   to guess at), blob storage is content-addressed, and the daemon exposes
   health checks and Prometheus metrics.
@@ -196,14 +207,22 @@ search plus the verbs and maintenance commands above.
 that serves live archive search, session rendering, and insight views. It
 uses the same query layer as the CLI, plus health checks
 (`polylogued health`) and a Prometheus `/metrics` endpoint. See
-[docs/daemon.md](docs/daemon.md).
+[docs/daemon.md](docs/daemon.md). Agent runs project into
+OpenTelemetry-shaped traces too: terminal query-unit rows map to spans, log
+records, and Polylogue refs via the outbound OTel projection, so an external
+observability tool can read session/cost/tool structure without copying message
+text or local paths.
 
 ### MCP bridge
 
 `polylogue-mcp --role read` exposes the archive as a Model Context Protocol
 server so AI assistants can search, list, and retrieve sessions, insights, and
 context packs from their own sessions. See
-[docs/mcp-integration.md](docs/mcp-integration.md).
+[docs/mcp-integration.md](docs/mcp-integration.md). It also composes a context
+preamble from the archive — recent lineage, project state, and resume guidance
+for a seed session — so a coding agent can inject prior memory at SessionStart
+via `compose_context_preamble` and `compile_context` (the same payload backs
+`read --view context`).
 
 ### Browser capture
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -36,7 +36,9 @@ Read only as deep as you need:
 | **Work packet / recovery digest** | A compact, shareable bundle summarizing what an agent session did — cost, repos touched, tools used, what to resume next — assembled from evidence, not free-typed. |
 | **Topology edge** | A typed cross-session parent link (continuation, fork, sidechain, subagent). Stored durably even when the parent is ingested out of order. |
 | **Logical session** | The resolved root of a session's parent chain. Continuations, forks, and subagent runs all roll up to one logical work session. |
+| **Context preamble** | A typed bundle composed from the archive — seed session, recent lineage, project state, and resume guidance — that a coding agent can inject at SessionStart as prior memory. Backs `read --view context` and the MCP `compose_context_preamble` / `compile_context` tools. |
 | **Daemon (`polylogued`)** | The background process that watches source directories, ingests live, rebuilds insights, and serves a local HTTP reader plus health checks and Prometheus `/metrics`. |
+| **OTel projection** | An outbound, OpenTelemetry-shaped view of evidence rows: terminal query-unit rows mapped to spans, log records, and Polylogue refs for external observability tools. An export format, not a source of truth — message text and local paths are never copied in. |
 | **Convergence** | The daemon's process of bringing the archive up to date with its sources: acquire raw rows, parse, materialize index rows, refresh insights, keep FTS in sync. |
 | **Readiness** | Whether a tier is trustworthy *right now* — e.g. all raw rows materialized, FTS index current. Stale or unverified state makes a surface report not-ready rather than silently wrong. |
 | **Archive debt** | Acquired-but-not-materialized state: a raw row with no matching parsed session, or a referenced blob with no file. Surfaced by `ops diagnostics workload`, not hidden. |


### PR DESCRIPTION
## Summary

Surface five capabilities that are already realized in-tree but were not visible
in the README or glossary: Hermes / Gemini-CLI importers, the outbound OTel
projection, lineage/topology rollups, recovery/resume read surfaces, and the
context preamble. Pure documentation — no code behavior change.

## Problem

A research pass over the open issue set found multiple shipped capabilities with
no entry point in the top-of-funnel docs. A stranger reading the README could
not tell Polylogue ingests Hermes agent logs, projects OTel-shaped traces, links
subagent lineage, or composes a SessionStart context preamble — all of which
exist and are tested.

## Solution

- `README.md`: extend the importer list (Gemini CLI + Google Drive, Hermes
  agents), add a lineage/topology bullet and a recovery/resume bullet, and note
  the OTel projection on the daemon section and the context-preamble composition
  on the MCP section.
- `docs/glossary.md`: add rows for context preamble and OTel projection.

## Verification

`devtools verify doc-commands` — 79 doc files scanned, no stale commands.
`devtools render docs-surface` — sync OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)