### PR TITLE
docs: fix dead list/show/-p surfaces in getting-started funnel

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,14 +39,14 @@ rendered in your pager.
 List recent sessions with natural-language time filters:
 
 ```bash
-polylogue --since yesterday list
-polylogue --since "last week" -p claude-code list
+polylogue --since yesterday read --all
+polylogue --since "last week" --origin claude-code-session read --all
 ```
 
 Limit and format:
 
 ```bash
-polylogue --since 2026-01 --limit 5 list --format json
+polylogue --since 2026-01 --limit 5 read --all --format json
 ```
 
 ## First cost check
@@ -91,7 +91,7 @@ polylogued status
 | `polylogue --since yesterday read --all` | Batch export |
 | `polylogued run` | Start the daemon |
 | `polylogued status` | Daemon health check |
-| `polylogue <id> show` | Display full session |
+| `polylogue --id <id> read --view transcript` | Display full session |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The getting-started quickstart taught three CLI surfaces that no longer exist.
A stranger following the funnel hit "no such command" on the first list/show
step. This corrects them to the live verbs.

## Problem

`docs/getting-started.md` used `-p <provider>` (now `--origin`), the `list`
verb (removed — the reader verb is `read`), and `polylogue <id> show` (removed).
`verify doc-commands` passed because it validates command *names* but not
subcommand/flag drift inside fenced examples (hardening tracked in #2438).

## Solution

- `-p claude-code` → `--origin claude-code-session`
- `polylogue ... list` → `polylogue ... read --all`
- `polylogue <id> show` → `polylogue --id <id> read --view transcript`

Each replacement verified against live `polylogue run read --help` / `read --views`.

## Verification

`devtools verify doc-commands` — 79 doc files scanned, no stale commands.
`devtools render all --check` — all surfaces sync OK.
`polylogue run read --views` confirms `transcript` is a real view.

Ref #2317

🤖 Generated with [Claude Code](https://claude.com/claude-code)