### PR TITLE
feat(devtools): catch subcommand/flag drift in verify doc-commands

### DIFF
--- a/devtools/verify_doc_commands.py
+++ b/devtools/verify_doc_commands.py
@@ -1,27 +1,33 @@
 """Verify that doc-file command examples resolve to real commands.
 
 Scans ``README.md`` and every committed ``docs/**/*.md`` file for
-inline references to two strict-subcommand surfaces:
+inline references to three command surfaces:
 
-- ``polylogued`` -> ``polylogue.daemon.cli:main``
-- ``devtools``   -> ``devtools.command_catalog.COMMANDS``
+- ``polylogued`` -> ``polylogue.daemon.cli:main`` (strict subcommands)
+- ``devtools``   -> ``devtools.command_catalog.COMMANDS`` (strict subcommands)
+- ``polylogue``  -> the query-first CLI (recognized commands + flags)
 
-For each occurrence the lint extracts the first non-flag token after
-the surface name and verifies it is a real subcommand for that
-surface. The ``polylogue`` CLI is intentionally *not* checked as a
-strict surface, because the root command is query-first: any bare
-token after ``polylogue`` is a valid FTS query, not a typo. Stale
-``polylogue ...`` invocations are caught instead by the explicit
-denylist below.
+For ``polylogued`` and ``devtools`` the lint extracts the first non-flag
+token after the surface name and verifies it is a real subcommand.
+
+The ``polylogue`` CLI is query-first — any bare token after ``polylogue``
+is normally a valid FTS query, not a typo — so it is validated *by command
+recognition* (#2438): a documented invocation is only checked when its
+leading token resolves to a known command path or a removed command name.
+A recognized command path then has its long-flags validated against the
+union of root and full-path options (lazy subcommands are materialized via
+``get_params`` so ``analyze insights profiles --tier`` resolves correctly),
+while a leading token that resolves to neither a known nor a removed command
+is left alone so ``polylogue rate limiting retries`` stays legal.
 
 The lint only reads tokens that appear inside Markdown code surfaces
 (inline ``` `code` ``` spans and fenced ``` ```bash/sh/shell/console``` `` blocks);
 plain prose is ignored to avoid false positives from sentences such as
 "polylogue and devtools share a workflow".
 
-It exists to keep #1262 / #869 closed: doc drift away from the
-daemon-first command surface should fail a CI gate, not survive in
-master until a user files a bug.
+It exists to keep #1262 / #869 / #2438 closed: doc drift away from the
+live command surface should fail a CI gate, not survive in master until a
+user files a bug.
 """
 
 from __future__ import annotations
@@ -44,12 +50,88 @@ from polylogue.daemon.cli import main as polylogued_root
 ROOT = _get_root()
 
 
+def _materialized_params(cmd: click.Command) -> list[click.Parameter]:
+    """Real parameters of a command, resolving lazy-loaded proxies.
+
+    The root CLI registers many subcommands as lazy proxies whose ``.params``
+    attribute is empty until the underlying module is imported. ``get_params``
+    triggers that resolution (and includes Click's auto-added ``--help``), so it
+    is the only reliable source of a lazy command's true option set.
+    """
+    try:
+        return list(cmd.get_params(click.Context(cmd)))
+    except Exception:
+        return list(cmd.params)
+
+
+def _long_opts(cmd: click.Command) -> frozenset[str]:
+    """All ``--long`` option strings declared on a Click command."""
+    out: set[str] = set()
+    for param in _materialized_params(cmd):
+        for opt in (*getattr(param, "opts", ()), *getattr(param, "secondary_opts", ())):
+            if opt.startswith("--"):
+                out.add(opt)
+    return frozenset(out)
+
+
+def _polylogue_cli() -> click.Command:
+    from polylogue.cli.click_app import cli
+
+    return cli
+
+
+def _polylogue_root_value_flags(root: click.Command) -> frozenset[str]:
+    """Root long-flags that consume the following token as their value.
+
+    Used so a flag *value* (``--since yesterday``, ``--add-tag export``) is not
+    mistaken for a subcommand during command detection.
+    """
+    out: set[str] = set()
+    for param in _materialized_params(root):
+        if getattr(param, "is_flag", False) or getattr(param, "count", False):
+            continue
+        for opt in getattr(param, "opts", ()):
+            if opt.startswith("--"):
+                out.add(opt)
+    return frozenset(out)
+
+
+def _polylogue_path_flags(root: click.Command) -> dict[tuple[str, ...], frozenset[str]]:
+    """Long-flags declared on every command path in the ``polylogue`` tree.
+
+    ``iter_command_paths`` descends the full tree, so leaf subcommands such as
+    ``analyze insights profiles`` expose their real options here even though the
+    top ``analyze`` group does not.
+    """
+    return {cp.path: _long_opts(cp.command) for cp in iter_command_paths(root, include_root=False) if cp.path}
+
+
+# ``polylogue`` subcommands that were removed/renamed. The root command is
+# query-first — any bare token after ``polylogue`` is normally a valid FTS
+# query, not a typo — so a removed command name (``polylogue list``) is
+# indistinguishable from a search ("find sessions matching 'list'") without
+# remembering it once *was* a command. This intentionally small, documented set
+# replaces the previous hand-maintained per-flag denylist for the cases where
+# command recognition alone cannot fire.
+REMOVED_POLYLOGUE_COMMANDS: dict[str, str] = {
+    "list": "polylogue: the 'list' verb was removed; use 'read --all' (optionally with --format).",
+    "show": "polylogue: the 'show' verb was removed; use 'read --view transcript' for one session.",
+}
+
+
+# Dated point-in-time records under these trees assert the command surface *as
+# of their date*, not the current one. Holding them to live-command accuracy
+# would force rewriting history, so they are excluded from the drift lint.
+_EXCLUDED_DOC_DIRS: tuple[str, ...] = ("docs/audits",)
+
+
 def _doc_files(root: Path) -> list[Path]:
     paths = [root / "README.md"]
     docs_dir = root / "docs"
     if docs_dir.exists():
         paths.extend(sorted(docs_dir.rglob("*.md")))
-    return [p for p in paths if p.exists()]
+    excluded = tuple(root / Path(d) for d in _EXCLUDED_DOC_DIRS)
+    return [p for p in paths if p.exists() and not any(p.is_relative_to(d) for d in excluded)]
 
 
 # Match ``surface rest_of_line`` where surface is a strict-subcommand
@@ -59,7 +141,7 @@ def _doc_files(root: Path) -> list[Path]:
 # neighbours such as ``polylogued.service`` (systemd unit) or
 # ``polylogue-mcp`` (sibling executable). The preceding ``(?<![\w-])``
 # rejects mid-word matches so ``run-polylogued-helper`` doesn't trip.
-_SURFACE_RE = re.compile(r"(?<![\w-])(polylogued|devtools)(?![.\w-])([^\n`]*)")
+_SURFACE_RE = re.compile(r"(?<![\w-])(polylogued|polylogue|devtools)(?![.\w-])([^\n`]*)")
 _TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
 
 # Stale invocation patterns flagged across all three surfaces, including
@@ -150,6 +232,97 @@ def _real_tokens(rest: str) -> tuple[str, ...]:
     return tuple(tokens)
 
 
+def _invocation_tokens(rest: str) -> list[str]:
+    """Ordered raw tokens (flags kept) up to a shell/pipeline boundary."""
+    stripped = rest.lstrip()
+    for stop in ("&&", "||", "|", ";", "#", "$(", "`"):
+        idx = stripped.find(stop)
+        if idx >= 0:
+            stripped = stripped[:idx]
+    tokens: list[str] = []
+    for part in stripped.split():
+        cleaned = part.strip(".,:;\"'`()[]<>")
+        if cleaned:
+            tokens.append(cleaned)
+    return tokens
+
+
+def _polylogue_invocation_errors(
+    rel: str,
+    line: int,
+    rest: str,
+    *,
+    ctx: _PolylogueContext,
+) -> list[str]:
+    """Validate a single ``polylogue ...`` invocation.
+
+    Opt-in by command recognition: a removed command name fails; a recognized
+    command path has its long-flags validated against ``root ∪ path ∪ direct``
+    options; a leading token that resolves to neither is left alone so
+    query-first FTS examples (``polylogue rate limiting retries``) stay legal.
+    """
+    tokens = _invocation_tokens(rest)
+    if not tokens:
+        return []
+
+    # 1. Command detection: the first bare token that is a known/removed command.
+    #    A token consumed as the value of a root value-flag (``--add-tag export``)
+    #    is skipped so a flag value is never read as a subcommand.
+    start: int | None = None
+    verb: str | None = None
+    skip_next = False
+    for idx, tok in enumerate(tokens):
+        if skip_next:
+            skip_next = False
+            continue
+        if tok.startswith("-"):
+            if "=" not in tok and tok in ctx.value_flags:
+                skip_next = True
+            continue
+        if tok in REMOVED_POLYLOGUE_COMMANDS:
+            return [f"{rel}:{line}: '{tok}' — {REMOVED_POLYLOGUE_COMMANDS[tok]}"]
+        if (tok,) in ctx.path_flags:
+            start, verb = idx, tok
+            break
+        # Unknown bare token: a flag value or a free-text query word — keep going.
+
+    if verb is None or start is None or "then" in tokens:
+        # Unrecognized leading token (query-first) or a ``then`` chain whose
+        # flags attribute to different verbs — leave it alone.
+        return []
+
+    # 2. Resolve the full command path by descending on consecutive bare tokens
+    #    that are children of the current path. Flags are skipped; the first bare
+    #    token that is not a child terminates the path (it is a positional arg).
+    path: tuple[str, ...] = (verb,)
+    for tok in tokens[start + 1 :]:
+        if tok.startswith("-"):
+            continue
+        if path + (tok,) in ctx.path_flags:
+            path = path + (tok,)
+            continue
+        break
+
+    # 3. Valid flags = root ∪ every command on the resolved path. Lazy commands
+    #    are materialized in ``_long_opts`` so ``analyze --count`` and leaf
+    #    subcommand flags (``analyze insights profiles --tier``) both resolve.
+    valid: set[str] = set(ctx.root_flags)
+    for depth in range(1, len(path) + 1):
+        valid |= ctx.path_flags.get(path[:depth], frozenset())
+
+    errors: list[str] = []
+    label = "polylogue " + " ".join(path)
+    for tok in tokens:
+        if tok == "--":  # end-of-options; remainder is positional
+            break
+        if not tok.startswith("--"):
+            continue
+        flag = tok.split("=", 1)[0]
+        if flag not in valid:
+            errors.append(f"{rel}:{line}: '{flag}' is not a known flag for '{label}'")
+    return errors
+
+
 def _surface_subcommand(surface: str, rest: str) -> str | None:
     tokens = _real_tokens(rest)
     if not tokens:
@@ -205,7 +378,25 @@ def _code_segments(text: str) -> list[tuple[int, str]]:
     return segments
 
 
-def _scan_file(path: Path, root: Path) -> tuple[list[DocCommandRef], list[str]]:
+@dataclass(frozen=True)
+class _PolylogueContext:
+    root_flags: frozenset[str]
+    value_flags: frozenset[str]
+    path_flags: dict[tuple[str, ...], frozenset[str]]
+
+
+def _build_polylogue_context() -> _PolylogueContext:
+    cli = _polylogue_cli()
+    return _PolylogueContext(
+        root_flags=_long_opts(cli),
+        value_flags=_polylogue_root_value_flags(cli),
+        path_flags=_polylogue_path_flags(cli),
+    )
+
+
+def _scan_file(
+    path: Path, root: Path, polylogue_ctx: _PolylogueContext | None = None
+) -> tuple[list[DocCommandRef], list[str]]:
     rel = path.relative_to(root).as_posix()
     refs: list[DocCommandRef] = []
     stale_hits: list[str] = []
@@ -247,6 +438,10 @@ def _scan_file(path: Path, root: Path) -> tuple[list[DocCommandRef], list[str]]:
                 continue
             surface = match.group(1)
             rest = match.group(2)
+            if surface == "polylogue":
+                if polylogue_ctx is not None:
+                    stale_hits.extend(_polylogue_invocation_errors(rel, line_no, rest, ctx=polylogue_ctx))
+                continue
             token = _surface_subcommand(surface, rest)
             if token is None:
                 continue
@@ -262,10 +457,11 @@ def check_docs(root: Path | None = None) -> tuple[list[str], int]:
         "polylogued": _polylogued_subcommands(),
         "devtools": _devtools_subcommands(),
     }
+    polylogue_ctx = _build_polylogue_context()
 
     errors: list[str] = []
     for path in files:
-        refs, stale = _scan_file(path, target_root)
+        refs, stale = _scan_file(path, target_root, polylogue_ctx)
         errors.extend(stale)
         rel = path.relative_to(target_root).as_posix()
         for ref in refs:

--- a/docs/design/whole-product.md
+++ b/docs/design/whole-product.md
@@ -55,8 +55,8 @@ $ polylogue "schema rebuild"
 ```
 
 The user searches for a concept they remember discussing. Results appear
-instantly. Clicking any result (in the web UI) or running `polylogue show`
-(in the CLI) opens the full session.
+instantly. Clicking any result (in the web UI) or running
+`polylogue --id <id> read --view transcript` (in the CLI) opens the full session.
 
 ### 15 minutes: first insight
 
@@ -264,9 +264,9 @@ presentation, not capability.
 | Feature | CLI | MCP | Web |
 |---------|-----|-----|-----|
 | Search | `polylogue "query"` | `polylogue_search` | Search bar |
-| List sessions | `polylogue list --since ...` | `polylogue_list_sessions` | Session list |
-| Show session | `polylogue show <id>` | `polylogue_get_session` | Session detail page |
-| Stats | `polylogue stats` | `polylogue_get_stats` | Dashboard stats panel |
+| List sessions | `polylogue --since ... read --all` | `polylogue_list_sessions` | Session list |
+| Show session | `polylogue --id <id> read --view transcript` | `polylogue_get_session` | Session detail page |
+| Stats | `polylogue analyze` | `polylogue_get_stats` | Dashboard stats panel |
 | Cost | `polylogue analyze --cost-outlook` | `polylogue_get_cost` | Dashboard cost panel |
 | Calendar heatmap | `polylogue calendar` | `polylogue_calendar` | Calendar page |
 | Timeline | `polylogue timeline` | `polylogue_timeline` | Timeline page |

--- a/docs/export.md
+++ b/docs/export.md
@@ -27,7 +27,7 @@ polylogue --id claude-ai:abc123 read --format obsidian
 Export every session matching a filter chain with `read --all`:
 
 ```bash
-polylogue --provider claude-code --since 2026-01 read --all
+polylogue --origin claude-code-session --since 2026-01 read --all
 polylogue --tag important read --all --format markdown
 polylogue "refactor" --has-tool-use read --all --format ndjson
 ```

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -60,7 +60,7 @@ unknown target is rejected at the CLI boundary.
 
 ## When to use which surface
 
-```
+```text
                           something looks off
                                  |
             +--------------------+--------------------+
@@ -213,7 +213,7 @@ this section will gain one worked example per flag:
 ```bash
 # Planned (#1196):
 polylogue ops maintenance run --session-id abc123 --target session_insights
-polylogue ops maintenance run --provider claude        --target session_insights
+polylogue ops maintenance run --origin claude          --target session_insights
 polylogue ops maintenance run --source-root ~/.claude/projects --target dangling_fts
 polylogue ops maintenance run --since 2026-04-01 --until 2026-05-01 \
                           --target action_read_model
@@ -487,7 +487,7 @@ systemctl --user stop polylogued.service
 polylogue ops diagnostics workload --json | jq '{lease: .blob_lease_state, gc: .gc_state}'
 
 # 3. Identify the affected sessions.
-polylogue ops doctor --schemas --blob-integrity --output-format json \
+polylogue ops doctor --schemas --blob-integrity --format json \
   | jq '.unreadable_blobs[]'
 
 # 4. If you have a recent backup, restore just the blob store.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -77,7 +77,7 @@ polylogued status
 
 ```bash
 polylogue "css refactor"
-polylogue --since yesterday list
+polylogue --since yesterday read --all
 polylogue --latest open
 ```
 

--- a/tests/unit/devtools/test_verify_doc_commands.py
+++ b/tests/unit/devtools/test_verify_doc_commands.py
@@ -180,3 +180,74 @@ class TestMainEntrypoint:
         captured = capsys.readouterr()
         assert rc == 0
         assert "blocking" in captured.out
+
+
+class TestPolylogueCommandRecognition:
+    """#2438: query-first ``polylogue`` invocations are validated by command
+    recognition — removed commands and bad flags on recognized commands fail,
+    while free-text FTS queries stay legal."""
+
+    def test_removed_list_verb_fails(self, tmp_path: Path) -> None:
+        _write_docs(
+            tmp_path,
+            {"README.md": "```bash\npolylogue --since yesterday list\n```\n"},
+        )
+        errors, _ = check_docs(root=tmp_path)
+        assert any("'list'" in e for e in errors), errors
+
+    def test_removed_show_verb_fails(self, tmp_path: Path) -> None:
+        _write_docs(tmp_path, {"README.md": "```bash\npolylogue show abc123\n```\n"})
+        errors, _ = check_docs(root=tmp_path)
+        assert any("'show'" in e for e in errors), errors
+
+    def test_recognized_verb_with_valid_flag_passes(self, tmp_path: Path) -> None:
+        _write_docs(
+            tmp_path,
+            {"README.md": "```bash\npolylogue --origin claude-code-session analyze --count\n```\n"},
+        )
+        errors, _ = check_docs(root=tmp_path)
+        assert errors == [], errors
+
+    def test_unknown_flag_on_recognized_verb_fails(self, tmp_path: Path) -> None:
+        _write_docs(tmp_path, {"README.md": "```bash\npolylogue analyze --bogus-flag\n```\n"})
+        errors, _ = check_docs(root=tmp_path)
+        assert any("--bogus-flag" in e for e in errors), errors
+
+    def test_free_text_query_passes(self, tmp_path: Path) -> None:
+        _write_docs(tmp_path, {"README.md": "```bash\npolylogue rate limiting retries\n```\n"})
+        errors, _ = check_docs(root=tmp_path)
+        assert errors == [], errors
+
+    def test_leaf_subcommand_flag_resolves(self, tmp_path: Path) -> None:
+        # The flag lives on the ``analyze insights profiles`` leaf, not the
+        # ``analyze`` group — full-path resolution must accept it.
+        _write_docs(
+            tmp_path,
+            {"README.md": "```bash\npolylogue analyze insights profiles --tier merged\n```\n"},
+        )
+        errors, _ = check_docs(root=tmp_path)
+        assert errors == [], errors
+
+    def test_renamed_flag_fails(self, tmp_path: Path) -> None:
+        # ``--provider`` was renamed to ``--origin``.
+        _write_docs(tmp_path, {"README.md": "```bash\npolylogue read --provider claude-code\n```\n"})
+        errors, _ = check_docs(root=tmp_path)
+        assert any("--provider" in e for e in errors), errors
+
+    def test_then_chain_is_left_alone(self, tmp_path: Path) -> None:
+        # ``then`` chains attribute flags to different verbs; skip flag checks.
+        _write_docs(
+            tmp_path,
+            {"README.md": "```bash\npolylogue find id:abc then read --view messages\n```\n"},
+        )
+        errors, _ = check_docs(root=tmp_path)
+        assert errors == [], errors
+
+    def test_dated_audit_docs_are_excluded(self, tmp_path: Path) -> None:
+        # Point-in-time audits assert past command state; not held to current.
+        _write_docs(
+            tmp_path,
+            {"docs/audits/2020-01-01-x.md": "```bash\npolylogue list\n```\n"},
+        )
+        errors, _ = check_docs(root=tmp_path)
+        assert errors == [], errors


### PR DESCRIPTION
## Summary

Extends `devtools verify doc-commands` to validate the query-first `polylogue`
surface, not just `polylogued`/`devtools`. Removed commands and bad flags on
recognized commands now fail the gate, while free-text FTS examples stay legal.
Ref #2438 (Ref #2307).

## Problem

The lint exempted the entire `polylogue` surface because the root is
query-first (any bare token is a valid FTS query), catching drift only via a
hand-maintained `polylogued` flag denylist. The cost was concrete:
`docs/getting-started.md` shipped three removed surfaces — `list`, `show`,
`-p` — green (fixed in #2441, but the gate never caught them).

## Solution

Validate documented `polylogue` invocations **by command recognition**:

1. A removed command name (`list`, `show`) fails with a migration hint —
   the minimal, documented denylist needed because query-first makes
   `polylogue list` ambiguous with a search.
2. A leading token resolving to a known command path has its long-flags
   validated against `root ∪ full-path` options. Lazy-loaded subcommands are
   materialized via `get_params` (the proxy's `.params` is empty until
   resolved), so `analyze insights profiles --tier` resolves correctly while
   `analyze --bogus-flag` and `read --provider` fail.
3. A leading token resolving to neither is left alone (`polylogue rate
   limiting retries` stays legal).
4. `then` chains skip flag validation (flags attribute to different verbs).

Dated `docs/audits/` records are excluded — they assert the command surface as
of their date, not the current one.

**Real drift surfaced and fixed by the new gate:**
- `export.md`: `--provider` → `--origin`
- `onboarding.md`: `list` → `read --all`
- `maintenance.md`: `ops maintenance run --provider` → `--origin`;
  `ops doctor --output-format` → `--format`; flowchart fence retyped `text`
- `design/whole-product.md`: `list`/`show`/`stats` → current verbs

## Acceptance criteria (#2438)

- [x] `polylogue --since yesterday list` fails (removed command)
- [x] `polylogue --origin claude-code-session analyze --count` passes
- [x] `polylogue ... analyze --bogus-flag` fails
- [x] `polylogue rate limiting retries` passes (no false positive)
- [x] Runs in `devtools verify`, surfaces file:line + offending token
- [x] `docs/getting-started.md` corrected (#2441) and the suite is green

## Verification

`python -m devtools.verify_doc_commands` — 76 files scanned, clean.
`devtools test tests/unit/devtools/test_verify_doc_commands.py` — 30 passed
(9 new AC tests). mypy + ruff clean. `devtools render all --check` — sync OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)