### PR TITLE
feat(mcp): expose postmortem bundle and sanitized export as agent tools

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,10 @@ These expose the archive and its insights:
 
 - CLI: `polylogue/cli/`
 - Python API: `polylogue/api/__init__.py`
-- MCP server: `polylogue/mcp/`
+- MCP server: `polylogue/mcp/` — exposes the distilled, agent-preferred
+  surfaces (`get_postmortem_bundle`, fail-closed `export_sanitized`) alongside
+  search/list/insight tools; the raw unredacted `export_session` /
+  `export_query_results` exporters stay behind the admin role (#2436).
 - daemon web reader: `polylogue/daemon/web_shell.py`
 - dashboard and TUI: `polylogue/ui/`
 - renderers: `polylogue/rendering/`

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -53,6 +53,14 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 | `list_sessions` | List recent sessions, optionally filtered |
 | `get_session` | Get a single session by ID (supports prefix matching) |
 | `stats` | Archive statistics: totals, provider breakdown, database size |
+| `get_postmortem_bundle` | Distilled postmortem bundle over a matched scope (#2380): top sessions by cost, repos touched, tool/work-kind rollups, failure signals. Read-only. |
+| `export_sanitized` | Write a fail-closed **redacted** shareable bundle (#2381) to a path; refuses (typed error, nothing published) if any private path or secret survives the leak gate. Write role. |
+
+> **Redacted vs. raw.** `get_postmortem_bundle` and `export_sanitized` are the
+> agent-preferred distilled/redacted surfaces. The raw, unredacted
+> `export_session` / `export_query_results` exporters render full message
+> content and are gated behind the **admin** role; `export_sanitized` has no
+> redaction-disable affordance by construction.
 
 ## Available Resources
 

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -8,6 +8,7 @@ derived distributions are registered directly.
 from __future__ import annotations
 
 import inspect
+from dataclasses import replace
 from datetime import date
 from math import ceil
 from typing import TYPE_CHECKING, Any, cast
@@ -1096,6 +1097,12 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 tag=tag,
                 repo=repo,
             ).build_spec(hooks.clamp_limit)
+            # build_spec writes the MCP default page limit (10) into spec.limit,
+            # which `_archive_query_kwargs` prefers over the candidate-scope
+            # default — that would cap the postmortem at 10 sessions and defeat
+            # its own analysis cap. Drop the page limit so the full matched scope
+            # is considered; `postmortem_bundle`'s `limit` is the analysis cap.
+            spec = replace(spec, limit=None)
             bundle = await poly.postmortem_bundle(spec, limit=limit)
             return hooks.json_payload(bundle, exclude_none=True)
 

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -28,6 +28,7 @@ from polylogue.insights.registry import (
 )
 from polylogue.mcp.insight_tool_contracts import InsightListToolSpec
 from polylogue.mcp.payloads import MCPRootPayload
+from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -1059,6 +1060,46 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
 
         return await hooks.async_safe_call("session_tool_timing", run)
+
+    @mcp.tool()
+    async def get_postmortem_bundle(
+        query: str | None = None,
+        origin: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        tag: str | None = None,
+        repo: str | None = None,
+        limit: int | None = None,
+    ) -> str:
+        """Distilled postmortem bundle over a matched session scope (#2380).
+
+        Read-shaped delegate to :meth:`Polylogue.postmortem_bundle`: resolves
+        the matched session set from the filter scope, aggregates per-session
+        recovery digests, and returns the typed
+        :class:`polylogue.insights.postmortem.PostmortemBundle` (top sessions
+        by cost, repos touched, tool/work-kind rollups, failure-mode signals).
+        The analysis cap defaults to 200 sessions; a larger match marks the
+        bundle ``truncated`` rather than silently capping.
+
+        This is the agent-preferred distilled read — for a shareable file
+        bundle use ``export_sanitized`` (fail-closed redacted), not the
+        unredacted ``export_*`` tools.
+        """
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            spec = MCPSessionQueryRequest(
+                query=query,
+                origin=origin,
+                since=since,
+                until=until,
+                tag=tag,
+                repo=repo,
+            ).build_spec(hooks.clamp_limit)
+            bundle = await poly.postmortem_bundle(spec, limit=limit)
+            return hooks.json_payload(bundle, exclude_none=True)
+
+        return await hooks.async_safe_call("get_postmortem_bundle", run)
 
 
 __all__ = ["register_insight_tools"]

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from contextlib import suppress
 from hashlib import sha256
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from polylogue.core.user_state_targets import MARK_TYPE_NAMES, TARGET_SESSION, is_mark_type_supported
 from polylogue.mcp.archive_support import blackboard_note_payload
@@ -24,6 +24,7 @@ from polylogue.mcp.payloads import (
     MCPUserMarkPayload,
     MutationResultPayload,
 )
+from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -867,6 +868,69 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
 
         return await hooks.async_safe_call("clear_corrections", run)
+
+    @mcp.tool()
+    async def export_sanitized(
+        output_path: str,
+        query: str | None = None,
+        origin: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        tag: str | None = None,
+        repo: str | None = None,
+        privacy_level: str = "standard",
+        with_postmortem: bool = False,
+        overwrite: bool = False,
+        limit: int | None = None,
+    ) -> str:
+        """Write a fail-closed sanitized shareable export bundle (#2381).
+
+        Write-shaped delegate to :meth:`Polylogue.sanitized_export`: resolves
+        the matched scope, redacts session-level metadata rows, writes the
+        bundle (``dataset.jsonl`` + ``redaction-manifest.json`` + ``README.md``,
+        plus a sanitized ``postmortem.json`` when requested) to *output_path*,
+        and runs an independent leak-check gate over the written files. If any
+        private absolute path or known secret survives, the publish is **refused**
+        and a typed error envelope is returned — nothing is written that leaks.
+
+        Redaction is mandatory on this surface by construction: there is no
+        disable affordance. The unredacted ``export_session`` /
+        ``export_query_results`` tools remain admin-gated for raw content.
+        """
+        from polylogue.export.sanitize import SanitizedExportError, SanitizedExportRequest
+
+        async def run() -> str:
+            from pathlib import Path
+
+            poly = hooks.get_polylogue()
+            spec = MCPSessionQueryRequest(
+                query=query,
+                origin=origin,
+                since=since,
+                until=until,
+                tag=tag,
+                repo=repo,
+            ).build_spec(hooks.clamp_limit)
+            try:
+                request = SanitizedExportRequest(
+                    output_path=Path(output_path),
+                    privacy_level=cast(Any, privacy_level),
+                    with_postmortem=with_postmortem,
+                    overwrite=overwrite,
+                    # Redacted-only by construction — no MCP redaction-disable path.
+                    redact=True,
+                    acknowledge_unredacted=False,
+                )
+                result = await poly.sanitized_export(spec, request, limit=limit)
+            except SanitizedExportError as exc:
+                return hooks.error_json(
+                    str(exc),
+                    code="sanitized_export_refused",
+                    tool="export_sanitized",
+                )
+            return hooks.json_payload(result, exclude_none=True)
+
+        return await hooks.async_safe_call("export_sanitized", run)
 
 
 __all__ = ["register_mutation_tools"]

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import suppress
+from dataclasses import replace
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any, cast
 
@@ -911,6 +912,9 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 tag=tag,
                 repo=repo,
             ).build_spec(hooks.clamp_limit)
+            # Drop the MCP default page limit (10) so the full matched scope is
+            # exported; the per-call cap is `limit` (default 1000 in the API).
+            spec = replace(spec, limit=None)
             try:
                 request = SanitizedExportRequest(
                     output_path=Path(output_path),

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -61,6 +61,8 @@ EXPECTED_TOOL_NAMES = {
     "update_index",
     "export_session",
     "export_query_results",
+    "export_sanitized",
+    "get_postmortem_bundle",
     "rebuild_session_insights",
     "maintenance_preview",
     "maintenance_execute",

--- a/tests/unit/mcp/test_distilled_bundle_tools.py
+++ b/tests/unit/mcp/test_distilled_bundle_tools.py
@@ -37,6 +37,10 @@ async def test_get_postmortem_bundle_delegates_and_serializes(mcp_server: MCPSer
     assert "scope" in payload
     assert "schema_version" in payload
     assert mock_poly.postmortem_bundle.await_count == 1
+    # The candidate scope must not inherit the MCP default page limit (10),
+    # which would silently cap the postmortem below its own analysis cap.
+    resolved_spec = mock_poly.postmortem_bundle.await_args.args[0]
+    assert resolved_spec.limit is None
 
 
 @pytest.mark.asyncio
@@ -107,6 +111,8 @@ async def test_export_sanitized_forces_redaction(mcp_server: MCPServerUnderTest,
     request = mock_poly.sanitized_export.await_args.args[1]
     assert request.redact is True
     assert request.acknowledge_unredacted is False
+    # The candidate scope must not inherit the MCP default page limit (10).
+    assert mock_poly.sanitized_export.await_args.args[0].limit is None
 
 
 def test_export_sanitized_has_no_redaction_disable_param(mcp_server: MCPServerUnderTest) -> None:

--- a/tests/unit/mcp/test_distilled_bundle_tools.py
+++ b/tests/unit/mcp/test_distilled_bundle_tools.py
@@ -1,0 +1,117 @@
+"""Tests for the distilled-bundle MCP tools (#2436).
+
+`get_postmortem_bundle` (read) and `export_sanitized` (write) delegate to the
+#2380/#2381 substrate. The sanitized surface is redacted-only by construction:
+it has no redaction-disable affordance and returns a typed refusal — never a
+partial bundle — when the fail-closed gate trips.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polylogue.export.sanitize import SanitizedExportError, SanitizedExportResult
+from polylogue.insights.postmortem import PostmortemScope, compile_postmortem_bundle
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface_async, make_polylogue_mock
+
+
+@pytest.mark.asyncio
+async def test_get_postmortem_bundle_delegates_and_serializes(mcp_server: MCPServerUnderTest) -> None:
+    bundle = compile_postmortem_bundle([], {}, scope=PostmortemScope(matched_session_count=0))
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.postmortem_bundle = AsyncMock(return_value=bundle)
+        mock_get_polylogue.return_value = mock_poly
+
+        raw = await invoke_surface_async(
+            mcp_server._tool_manager._tools["get_postmortem_bundle"].fn,
+            since="2026-01-01",
+        )
+
+    payload = json.loads(raw)
+    assert "scope" in payload
+    assert "schema_version" in payload
+    assert mock_poly.postmortem_bundle.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_export_sanitized_refuses_on_gate_failure(mcp_server: MCPServerUnderTest, tmp_path: Path) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.sanitized_export = AsyncMock(side_effect=SanitizedExportError("absolute path survived the gate"))
+        mock_get_polylogue.return_value = mock_poly
+
+        raw = await invoke_surface_async(
+            mcp_server._tool_manager._tools["export_sanitized"].fn,
+            output_path=str(tmp_path / "bundle"),
+        )
+
+    payload = json.loads(raw)
+    # Typed refusal — nothing published, no raised exception.
+    assert payload.get("code") == "sanitized_export_refused"
+    assert "message" in payload
+
+
+@pytest.mark.asyncio
+async def test_export_sanitized_returns_result_on_success(mcp_server: MCPServerUnderTest, tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    result = SanitizedExportResult(
+        output_path=out,
+        dataset_path=out / "dataset.jsonl",
+        manifest_path=out / "redaction-manifest.json",
+        readme_path=out / "README.md",
+        row_count=2,
+        total_included=2,
+        verify_ok=True,
+    )
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.sanitized_export = AsyncMock(return_value=result)
+        mock_get_polylogue.return_value = mock_poly
+
+        raw = await invoke_surface_async(
+            mcp_server._tool_manager._tools["export_sanitized"].fn,
+            output_path=str(out),
+        )
+
+    payload = json.loads(raw)
+    assert payload["row_count"] == 2
+    assert payload["verify_ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_export_sanitized_forces_redaction(mcp_server: MCPServerUnderTest, tmp_path: Path) -> None:
+    out = tmp_path / "bundle"
+    result = SanitizedExportResult(
+        output_path=out,
+        dataset_path=out / "dataset.jsonl",
+        manifest_path=out / "redaction-manifest.json",
+        readme_path=out / "README.md",
+    )
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.sanitized_export = AsyncMock(return_value=result)
+        mock_get_polylogue.return_value = mock_poly
+
+        await invoke_surface_async(
+            mcp_server._tool_manager._tools["export_sanitized"].fn,
+            output_path=str(out),
+        )
+
+    # The request handed to the substrate must be redacted-only.
+    request = mock_poly.sanitized_export.await_args.args[1]
+    assert request.redact is True
+    assert request.acknowledge_unredacted is False
+
+
+def test_export_sanitized_has_no_redaction_disable_param(mcp_server: MCPServerUnderTest) -> None:
+    """AC3: the MCP sanitized path exposes no redaction-disable affordance."""
+    params = set(inspect.signature(mcp_server._tool_manager._tools["export_sanitized"].fn).parameters)
+    assert "redact" not in params
+    assert "acknowledge_unredacted" not in params
+    assert "no_redact" not in params

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -142,6 +142,8 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "update_index": "operation_result",
     "export_session": "operation_result",
     "export_query_results": "operation_result",
+    "export_sanitized": "operation_result",
+    "get_postmortem_bundle": "single_object",
     "maintenance_preview": "operation_result",
     "maintenance_execute": "operation_result",
     "maintenance_status": "operation_result",


### PR DESCRIPTION
## Summary

Adds two MCP tools so agents reach the distilled postmortem bundle (#2380) and
the fail-closed sanitized export (#2381), instead of those products being
CLI+API-only. Ref #2436.

## Problem

Two recently-landed distillation products were unreachable from MCP, while the
only MCP exporters (`export_session` / `export_query_results`) render
**unredacted** content with no privacy gate — a footgun on the agent-facing
surface. Train-2 wants agent-consumable *distilled* bundles; MCP was the surface
left behind.

## Solution

Leaf-adapter tools delegating to the existing substrate (no new distillation
logic in MCP):

- **`get_postmortem_bundle`** (read role) — wraps `Polylogue.postmortem_bundle`,
  returns the typed `PostmortemBundle` over a matched filter scope.
- **`export_sanitized`** (write role) — wraps `Polylogue.sanitized_export`, runs
  the fail-closed leak gate; on gate failure returns a typed
  `sanitized_export_refused` envelope and publishes nothing. Redaction is
  mandatory — the MCP surface exposes **no** `redact`/`acknowledge_unredacted`
  affordance.

The raw unredacted exporters stay `admin`-gated, giving a clean privilege
ladder: read = postmortem < write = sanitized < admin = raw.

Both tools are registered in the enumeration gates (`EXPECTED_TOOL_NAMES`,
`TOOL_CONTRACT`). Docs: `mcp-integration.md` catalog + `architecture.md` MCP
note with the redacted-vs-raw distinction.

## Acceptance criteria (#2436)

- [x] `get_postmortem_bundle` and `export_sanitized` registered, delegating to
  the #2380/#2381 substrate (no reimplementation)
- [x] `export_sanitized` runs the fail-closed gate; a leak returns a typed
  refusal and publishes nothing
- [x] The MCP sanitized path has no redaction-disable affordance (signature test)
- [x] Edge-case tests under `tests/unit/mcp/`; enumeration/contract gates updated
- [x] `architecture.md` + MCP tool catalog reflect the new tools and the
  unredacted-vs-sanitized distinction
- [x] `devtools verify` green on the MCP slice

## Verification

`devtools test tests/unit/mcp/test_distilled_bundle_tools.py` — 5 passed.
`devtools test tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_server_surfaces.py`
— 109 passed (enumeration gate accepts both tools). mypy + ruff clean;
`devtools render all --check` sync OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only postmortem bundle tool for scoped, distilled session insights.
  * Added a sanitized export option that produces a shareable redacted bundle and safely refuses unsafe requests.

* **Documentation**
  * Updated architecture and integration docs to describe the new tools and clarify which export options are redacted versus raw.

* **Bug Fixes**
  * Improved tool coverage and response handling for the new MCP surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->