### PR TITLE
feat(export): redact Windows paths and emails in sanitized export

### DIFF
--- a/polylogue/export/sanitize.py
+++ b/polylogue/export/sanitize.py
@@ -39,6 +39,7 @@ SANITIZED_EXPORT_BUNDLE_VERSION = 1
 
 REDACTED_PATH_PREFIX = "<redacted-path>"
 REDACTED_SECRET = "<redacted-secret>"
+REDACTED_EMAIL = "<redacted-email>"
 
 DATASET_FILENAME = "dataset.jsonl"
 MANIFEST_FILENAME = "redaction-manifest.json"
@@ -64,6 +65,14 @@ _TILDE_PATH_RE = re.compile(r"~/(?:[A-Za-z0-9._\- ]+/)*[A-Za-z0-9._\- ]*[A-Za-z0
 _KNOWN_ROOT_PATH_RE = re.compile(
     r"/(?:home|Users|root|tmp|var|etc|opt|mnt|media|srv|usr|private|data|realm|persist)(?![A-Za-z0-9._\-/])"
 )
+# Windows-style filesystem paths: a drive-letter root (``C:\Users\me\...``) or a
+# UNC share (``\\server\share\...``). Backslash-separated, so there is no overlap
+# with the POSIX ``/``-based path regexes above. Matching runs of non-space,
+# non-quote characters keeps a whole path together; over-matching is the safe
+# direction for a sanitizer.
+_WINDOWS_PATH_RE = re.compile(r"(?:[A-Za-z]:\\|\\\\)[^\s\"'<>|]*")
+# Email addresses (PII). Conservative shape: local@domain.tld.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 # Candidate opaque token for high-entropy detection.
 _HIGH_ENTROPY_CANDIDATE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{9,}")
 
@@ -157,9 +166,17 @@ def _redact_string(value: str) -> tuple[str, list[tuple[str, str]]]:
         reasons.append(("absolute_path", "high"))
         return REDACTED_PATH_PREFIX
 
+    def _winpath_repl(match: re.Match[str]) -> str:
+        reasons.append(("windows_path", "high"))
+        return REDACTED_PATH_PREFIX
+
     def _secret_repl(match: re.Match[str]) -> str:
         reasons.append(("secret_pattern", "high"))
         return REDACTED_SECRET
+
+    def _email_repl(match: re.Match[str]) -> str:
+        reasons.append(("email", "high"))
+        return REDACTED_EMAIL
 
     def _entropy_repl(match: re.Match[str]) -> str:
         token = match.group(0)
@@ -171,6 +188,10 @@ def _redact_string(value: str) -> tuple[str, list[tuple[str, str]]]:
     result = _ABS_PATH_RE.sub(_path_repl, value)
     result = _TILDE_PATH_RE.sub(_home_repl, result)
     result = _KNOWN_ROOT_PATH_RE.sub(_known_root_repl, result)
+    result = _WINDOWS_PATH_RE.sub(_winpath_repl, result)
+    # Emails before secret/entropy passes so the address is replaced as one unit
+    # rather than partly mangled by the opaque-token detector.
+    result = _EMAIL_RE.sub(_email_repl, result)
     for pattern in _SECRET_VALUE_PATTERNS:
         result = pattern.sub(_secret_repl, result)
     result = _HIGH_ENTROPY_CANDIDATE_RE.sub(_entropy_repl, result)
@@ -253,6 +274,7 @@ def _scan_text(text: str, *, home: str) -> tuple[list[str], list[str], list[str]
     abs_leaks = sorted(
         {match.group(0) for match in _ABS_PATH_RE.finditer(text)}
         | {match.group(0) for match in _KNOWN_ROOT_PATH_RE.finditer(text)}
+        | {match.group(0) for match in _WINDOWS_PATH_RE.finditer(text)}
     )
     home_leaks: list[str] = [match.group(0) for match in _TILDE_PATH_RE.finditer(text)]
     normalized_home = home.rstrip("/")
@@ -261,6 +283,7 @@ def _scan_text(text: str, *, home: str) -> tuple[list[str], list[str], list[str]
     secret_leaks: list[str] = []
     for pattern in _SECRET_VALUE_PATTERNS:
         secret_leaks.extend(match.group(0) for match in pattern.finditer(text))
+    secret_leaks.extend(match.group(0) for match in _EMAIL_RE.finditer(text))
     return abs_leaks, sorted(set(home_leaks)), sorted(set(secret_leaks))
 
 

--- a/tests/unit/export/test_sanitize.py
+++ b/tests/unit/export/test_sanitize.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.export.sanitize import (
+    REDACTED_EMAIL,
     REDACTED_PATH_PREFIX,
     REDACTED_SECRET,
     SanitizedExportError,
@@ -200,3 +201,51 @@ def test_gate_independently_catches_raw_root_and_tilde(tmp_path: Path) -> None:
     assert verdict.ok is False
     assert verdict.absolute_path_leaks
     assert verdict.home_path_leaks
+
+
+def test_windows_path_is_redacted_and_gated() -> None:
+    """Windows drive-letter and UNC paths must not survive (#2434)."""
+    rows = [{"title": r"opened C:\Users\me\Secret\plans.md", "unc": r"see \\fileserver\share\creds.txt"}]
+    sanitized, report = sanitize_rows(rows, config=PrivacyConfig(level="standard"))
+    title = sanitized[0]["title"]
+    unc = sanitized[0]["unc"]
+    assert isinstance(title, str) and isinstance(unc, str)
+    assert "C:\\Users" not in title
+    assert "Secret" not in title
+    assert "\\\\fileserver" not in unc
+    assert REDACTED_PATH_PREFIX in title
+    assert report.rejection_reasons.get("windows_path", 0) >= 1
+
+
+def test_gate_independently_catches_raw_windows_path(tmp_path: Path) -> None:
+    """The fail-closed gate must flag a raw Windows path."""
+    (tmp_path / "dataset.jsonl").write_text(
+        json.dumps({"x": r"C:\Users\me\secret\notes.md"}) + "\n",
+        encoding="utf-8",
+    )
+    verdict = verify_sanitized_export(tmp_path, home="/home/me")
+    assert verdict.ok is False
+    assert verdict.absolute_path_leaks
+
+
+def test_email_is_redacted_and_gated() -> None:
+    """Email addresses (PII) must not survive (#2434)."""
+    rows = [{"note": "reach me at Alice.Doe+work@example.co.uk for review"}]
+    sanitized, report = sanitize_rows(rows, config=PrivacyConfig(level="standard"))
+    note = sanitized[0]["note"]
+    assert isinstance(note, str)
+    assert "@example.co.uk" not in note
+    assert "Alice.Doe" not in note
+    assert REDACTED_EMAIL in note
+    assert report.rejection_reasons.get("email", 0) >= 1
+
+
+def test_gate_independently_catches_raw_email(tmp_path: Path) -> None:
+    """The fail-closed gate must flag a raw email address."""
+    (tmp_path / "dataset.jsonl").write_text(
+        json.dumps({"contact": "bob@example.org"}) + "\n",
+        encoding="utf-8",
+    )
+    verdict = verify_sanitized_export(tmp_path, home="/nonexistent-home")
+    assert verdict.ok is False
+    assert verdict.secret_leaks


### PR DESCRIPTION
## Summary

Extends the fail-closed sanitized-export leak gate (#2381) to cover Windows
filesystem paths and email addresses. Closes the Windows/email leg of #2434.

## Problem

The v0 gate redacted POSIX absolute paths, `$HOME` paths, and known-secret value
patterns only. Windows drive-letter / UNC paths and email addresses (PII) passed
through **both** the redactor and the independent gate — a real leak surface,
now more exposed since the sanitized export became reachable via MCP (#2436).

## Solution

- `_WINDOWS_PATH_RE` — drive-letter (`C:\Users\me\...`) and UNC
  (`\\server\share\...`) paths. Backslash-based, so no overlap with the POSIX
  `/` regexes.
- `_EMAIL_RE` — `local@domain.tld`, redacted to a new `<redacted-email>` token.
- Both wired into `_redact_string` (redactor) **and** `_scan_text` (the
  fail-closed gate): Windows paths gate as absolute-path leaks, emails as secret
  leaks. Over-redaction remains the safe direction.

## Remaining #2434 scope

`--format spans-jsonl` (AC1) and opt-in message-text content redaction (AC2,
the riskiest leg) remain as the larger follow-up, per the issue's own sequencing.

## Verification

`devtools test tests/unit/export/` — 18 passed, including 4 new regressions
covering Windows drive/UNC paths and emails on both the redactor and gate sides
(mirroring the existing space-path regression). mypy + ruff clean.

Ref #2434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)