### PR TITLE
feat(cost): price current Opus 4.7/4.8 flagships

### DIFF
--- a/polylogue/archive/semantic/pricing.py
+++ b/polylogue/archive/semantic/pricing.py
@@ -197,6 +197,8 @@ class ModelPricing:
 # 1M tokens. This is intentionally small and provenance-marked; provider-
 # reported exact archive costs still take precedence.
 PRICING: dict[str, ModelPricing] = {
+    "claude-opus-4-8": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
+    "claude-opus-4-7": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
     "claude-opus-4-6": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
     "claude-opus-4-5": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
     "claude-sonnet-4-6": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -163,3 +163,15 @@ def test_model_normalization_accepts_provider_prefixes_and_version_suffixes() ->
     assert _normalize_model("openai/gpt-4o-2024-08-06") == "gpt-4o"
     assert _normalize_model("anthropic/claude-sonnet-4-5-20250929") == "claude-sonnet-4-5"
     assert estimate_cost(1000, 500, "openai/gpt-4o-2024-08-06") == pytest.approx(0.0075)
+
+
+def test_current_opus_flagships_are_priced_not_zero() -> None:
+    """Opus 4.7/4.8 must be priced (regression: they fell through to $0).
+
+    The version-suffix prefix match cannot reach ``claude-opus-4-6`` from a
+    ``claude-opus-4-8`` model, so the current flagship needs its own entry.
+    """
+    for version in ("claude-opus-4-7", "claude-opus-4-8"):
+        assert _normalize_model(f"{version}-20260101") == version
+        # 1M input + 1M output at Opus rates ($15 + $75) = $90.
+        assert estimate_cost(1_000_000, 1_000_000, version) == pytest.approx(90.0)


### PR DESCRIPTION
## Summary

Adds `claude-opus-4-7` and `claude-opus-4-8` to the curated price catalog so the
current flagship model is priced instead of returning \$0. Ref #2316.

## Problem

The catalog stopped at `claude-opus-4-6`/`4-5`. Sessions on `claude-opus-4-8`
(the operator's primary model) priced at \$0: `_normalize_model`'s version-suffix
prefix match cannot reach `claude-opus-4-6` from a `claude-opus-4-8` identifier,
so the lookup misses and `estimate_cost` returns 0.0 — silently understating
real cost on the cost-outlook, postmortem, and cost-rollup surfaces.

## Solution

Add the two flagships at the established Opus rate (\$15/\$75 in/out, \$1.5/\$18.75
cache read/write) — identical to the `4-5`/`4-6` rows the catalog already carries;
Anthropic Opus flagship pricing has been stable across the 4.x line.

## Remaining #2316 pricing scope

These need an authoritative price source (not memory) and stay open: gpt-5 /
gpt-5-codex / o4-mini, fable-5, gemini-2.5-flash.

## Verification

`devtools test tests/unit/core/test_pricing.py tests/unit/storage/test_pricing_chain_roundtrip.py`
— 20 passed (new test asserts 4.7/4.8 normalize and price to \$90 for 1M+1M
tokens; the roundtrip test seeds `len(PRICING)` models dynamically so the catalog
addition is covered). mypy + ruff clean.

Ref #2316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)