### PR TITLE
feat(demo): enrich demo cost and fix profile token-lane round-trip

### DIFF
--- a/polylogue/archive/session/models.py
+++ b/polylogue/archive/session/models.py
@@ -309,6 +309,17 @@ class SessionProfile:
             ),
             tool_calls_per_minute=coerce_float(payload.get("tool_calls_per_minute"), 0.0),
             timing_provenance=optional_string(payload.get("timing_provenance")) or "sort_key_estimated",
+            # Cost/token attribution — present in to_dict() and the record
+            # payload but previously dropped here, so a round-tripped or
+            # batch-hydrated profile reported zero tokens (and lost credit/
+            # provenance/per-model cost) even when the columns were populated.
+            total_input_tokens=coerce_int(payload.get("total_input_tokens"), 0),
+            total_output_tokens=coerce_int(payload.get("total_output_tokens"), 0),
+            total_cache_read_tokens=coerce_int(payload.get("total_cache_read_tokens"), 0),
+            total_cache_write_tokens=coerce_int(payload.get("total_cache_write_tokens"), 0),
+            total_credit_cost=coerce_float(payload.get("total_credit_cost"), 0.0),
+            cost_provenance=optional_string(payload.get("cost_provenance")) or "unknown",
+            per_model_cost_json=optional_string(payload.get("per_model_cost_json")) or "{}",
         )
 
 

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from polylogue.config import Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
-from polylogue.scenarios import build_demo_corpus_specs, seed_demo_user_overlays
+from polylogue.scenarios import DEMO_CLAUDE_CODE_SESSION_ID, build_demo_corpus_specs, seed_demo_user_overlays
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
@@ -71,6 +71,50 @@ def _materialize_session_insights(archive_root: Path, session_ids: list[str]) ->
         conn.close()
 
 
+# Deterministic per-assistant-message Opus usage injected into the demo
+# claude-code session so cost surfaces (`analyze --postmortem` top session,
+# cost rollups) render a believable bundle on the demo archive instead of $0.
+# The demo corpus is fully synthetic; the synthetic generator does not emit
+# token usage, and adding it there would ripple every synthetic test snapshot.
+# Scoping the injection to the one demo session keeps it ripple-free.
+_DEMO_USAGE_MODEL = "claude-opus-4-8"
+_DEMO_USAGE = {
+    "input_tokens": 8000,
+    "output_tokens": 1500,
+    "cache_read_tokens": 40000,
+    "cache_write_tokens": 6000,
+}
+
+
+def _inject_demo_session_usage(archive_root: Path) -> None:
+    """Set deterministic Opus token usage on the demo claude-code assistant turns.
+
+    Cost is materialized into ``session_profiles.total_cost_usd`` from the
+    per-message token columns, so this must run *before*
+    ``_materialize_session_insights``. Demo-scoped by session id: no synthetic
+    generator change, no test-snapshot ripple.
+    """
+
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        conn.execute(
+            "UPDATE messages SET model_name = ?, input_tokens = ?, output_tokens = ?, "
+            "cache_read_tokens = ?, cache_write_tokens = ? "
+            "WHERE session_id = ? AND role = 'assistant'",
+            (
+                _DEMO_USAGE_MODEL,
+                _DEMO_USAGE["input_tokens"],
+                _DEMO_USAGE["output_tokens"],
+                _DEMO_USAGE["cache_read_tokens"],
+                _DEMO_USAGE["cache_write_tokens"],
+                DEMO_CLAUDE_CODE_SESSION_ID,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def demo_source_specs(source_root: Path) -> list[Source]:
     """Return relative source specs for the materialized demo world."""
 
@@ -94,6 +138,7 @@ async def seed_demo_archive(
         result = await parse_sources_archive(archive_root, demo_source_specs(source_root))
 
     session_ids = sorted(result.processed_ids)
+    _inject_demo_session_usage(archive_root)
     _materialize_session_insights(archive_root, session_ids)
 
     overlay = seed_demo_user_overlays(archive_root) if with_overlays else None

--- a/tests/unit/archive/test_session_profile_roundtrip.py
+++ b/tests/unit/archive/test_session_profile_roundtrip.py
@@ -1,0 +1,45 @@
+"""SessionProfile cost/token round-trip contract.
+
+Regression: ``SessionProfile.from_dict`` dropped the cost/token-attribution
+fields that ``to_dict`` emits, so a round-tripped or batch-hydrated profile
+reported zero tokens (and lost credit/provenance/per-model cost) even when the
+columns were populated — which zeroed the postmortem token lanes.
+"""
+
+from __future__ import annotations
+
+from polylogue.archive.session.models import SessionProfile
+
+_COST_FIELDS: dict[str, object] = {
+    "total_input_tokens": 40000,
+    "total_output_tokens": 7500,
+    "total_cache_read_tokens": 200000,
+    "total_cache_write_tokens": 30000,
+    "total_credit_cost": 1.5,
+    "cost_provenance": "priced",
+    "per_model_cost_json": '{"claude-opus-4-8": 2.025}',
+}
+
+
+def _payload() -> dict[str, object]:
+    payload: dict[str, object] = {
+        "session_id": "claude-code-session:abc",
+        "origin": "claude-code-session",
+        "total_cost_usd": 2.025,
+    }
+    payload.update(_COST_FIELDS)
+    return payload
+
+
+def test_from_dict_reads_cost_and_token_fields() -> None:
+    profile = SessionProfile.from_dict(_payload())
+    for field, value in _COST_FIELDS.items():
+        assert getattr(profile, field) == value, field
+    assert profile.total_cost_usd == 2.025
+
+
+def test_cost_and_token_fields_survive_roundtrip() -> None:
+    profile = SessionProfile.from_dict(_payload())
+    restored = SessionProfile.from_dict(profile.to_dict())
+    for field, value in _COST_FIELDS.items():
+        assert getattr(restored, field) == value, field

--- a/tests/unit/demo/test_demo_seed_verify.py
+++ b/tests/unit/demo/test_demo_seed_verify.py
@@ -80,3 +80,27 @@ async def test_demo_verify_can_skip_daemon_source_path_leak_posture(tmp_path: Pa
     assert "raw source paths contain absolute paths" in "\n".join(strict.problems)
     assert daemon_wait.ok is True
     assert daemon_wait.absolute_path_leaks == ()
+
+
+@pytest.mark.asyncio
+async def test_seed_injects_demo_cost_for_postmortem(tmp_path: Path) -> None:
+    """The demo claude-code session must carry usage so the postmortem blade
+    renders real cost + token lanes (not $0) on the demo archive. Guards #2196
+    slice 2 and the SessionProfile cost/token round-trip."""
+
+    from polylogue.scenarios import DEMO_CLAUDE_CODE_SESSION_ID
+
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=True)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        row = conn.execute(
+            "SELECT total_cost_usd, total_input_tokens, total_output_tokens FROM session_profiles WHERE session_id = ?",
+            (DEMO_CLAUDE_CODE_SESSION_ID,),
+        ).fetchone()
+
+    assert row is not None
+    total_cost_usd, total_input_tokens, total_output_tokens = row
+    assert total_cost_usd > 0
+    assert total_input_tokens > 0
+    assert total_output_tokens > 0


### PR DESCRIPTION
## Summary

Makes `analyze --postmortem` render a believable distilled bundle on the demo
archive (real top-expensive session ≈\$2.03 + matching token lanes) instead of
\$0 / 0 tokens. Completes the cost leg of #2196 slice 2 and fixes a real,
production-affecting profile round-trip bug found along the way.

## Problem

After #2439 materialized demo session profiles, `analyze --postmortem` rendered
on the demo archive but with \$0 cost — the synthetic demo corpus emits no token
usage. A first pass injecting usage produced \$2.03 cost but **0 token lanes**, an
incoherent blade. Root cause: `SessionProfile.from_dict` dropped the seven
cost/token-attribution fields that `to_dict` emits, so every batch-hydrated or
round-tripped profile reported zero tokens even when the columns were populated
— zeroing the postmortem token lanes for *all* archives, not just the demo.

## Solution

1. **`demo/seed.py`** — inject deterministic Opus 4.8 usage into the demo
   claude-code session's assistant turns before insight materialization. The
   demo corpus is fully synthetic and the generator emits no usage; injecting it
   there would ripple every synthetic snapshot, so the injection is scoped to the
   one demo session (no generator change, no snapshot ripple).
2. **`archive/session/models.py`** — fix `SessionProfile.from_dict` to read the
   seven cost/token fields (`total_{input,output,cache_read,cache_write}_tokens`,
   `total_credit_cost`, `cost_provenance`, `per_model_cost_json`) it previously
   dropped. This is the production fix that makes cost and token lanes agree.

## Verification

Demo seed → `analyze --postmortem`: cost=\$2.025, cost_is_estimated=true,
tokens input=40106/output=7500/cache_read=200000/cache_write=30000, top session =
claude-code. `devtools test` on demo + postmortem + profile + session-summary
slices — 41 passed, including new regressions:
`test_session_profile_roundtrip.py` (the from_dict round-trip) and
`test_seed_injects_demo_cost_for_postmortem`. mypy + ruff clean.

## Remaining #2196 scope

The demo blade still shows generic repo names and no subagent branches; repo-name
and subagent enrichment for the demo corpus remain follow-ups.

Ref #2196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved token usage and cost attribution details when loading and saving session data, including input/output tokens, cache usage, and cost breakdowns.
  * Demo archives now include realistic usage data for a sample assistant session, improving cost and token reporting in demo views.

* **Tests**
  * Added coverage to verify session cost/token fields survive round-trips and that demo data produces non-zero usage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->