### PR TITLE
feat(demo): give demo session a canonical repo for repos_touched

### DIFF
--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -115,6 +115,29 @@ def _inject_demo_session_usage(archive_root: Path) -> None:
         conn.close()
 
 
+# Canonical repo identity for the demo claude-code session so the postmortem
+# `repos_touched` metric renders a believable project instead of an empty list.
+# The synthetic demo corpus emits no cwd/repo attribution, so profile
+# materialization derives no repo names; this is set *after* materialization
+# (which would otherwise overwrite it with the empty attribution result) and is
+# scoped to the one demo session.
+_DEMO_REPO_NAMES = '["polylogue"]'
+
+
+def _inject_demo_session_repos(archive_root: Path) -> None:
+    """Set a canonical repo name on the demo claude-code session profile."""
+
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        conn.execute(
+            "UPDATE session_profiles SET repo_names_json = ? WHERE session_id = ?",
+            (_DEMO_REPO_NAMES, DEMO_CLAUDE_CODE_SESSION_ID),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def demo_source_specs(source_root: Path) -> list[Source]:
     """Return relative source specs for the materialized demo world."""
 
@@ -140,6 +163,7 @@ async def seed_demo_archive(
     session_ids = sorted(result.processed_ids)
     _inject_demo_session_usage(archive_root)
     _materialize_session_insights(archive_root, session_ids)
+    _inject_demo_session_repos(archive_root)
 
     overlay = seed_demo_user_overlays(archive_root) if with_overlays else None
     return DemoSeedResult(

--- a/tests/unit/demo/test_demo_seed_verify.py
+++ b/tests/unit/demo/test_demo_seed_verify.py
@@ -104,3 +104,25 @@ async def test_seed_injects_demo_cost_for_postmortem(tmp_path: Path) -> None:
     assert total_cost_usd > 0
     assert total_input_tokens > 0
     assert total_output_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_seed_gives_demo_session_canonical_repo(tmp_path: Path) -> None:
+    """The demo claude-code session must carry a canonical repo so the
+    postmortem `repos_touched` metric renders a project, not an empty list."""
+
+    import json as _json
+
+    from polylogue.scenarios import DEMO_CLAUDE_CODE_SESSION_ID
+
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=True)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        row = conn.execute(
+            "SELECT repo_names_json FROM session_profiles WHERE session_id = ?",
+            (DEMO_CLAUDE_CODE_SESSION_ID,),
+        ).fetchone()
+
+    assert row is not None
+    assert "polylogue" in _json.loads(row[0])


### PR DESCRIPTION
## Summary

Makes the demo postmortem's `repos_touched` metric render a project
(`polylogue`) instead of an empty list. Ref #2196 (slice-2 polish).

## Problem

The synthetic demo corpus emits no cwd/repo attribution, so profile
materialization derives no repo names and the postmortem `repos_touched` was
`[]` — a blank field in the otherwise-populated demo blade.

## Solution

`demo/seed.py`: set a canonical repo name on the demo claude-code session
profile after materialization (materialization would otherwise overwrite it with
the empty attribution result). Scoped to the one demo session — no synthetic
generator change, no snapshot ripple.

## Verification

Demo seed → `analyze --postmortem` shows
`repos_touched=[{repo: polylogue, session_count: 1, ...}]`.
`devtools test tests/unit/demo/test_demo_seed_verify.py` — 6 passed (new repo
regression). mypy + ruff clean.

## Remaining #2196 scope

`subagent_branch_count` (needs a demo subagent topology edge) and the
`failure_mode`/`wasted_loop` signals (need the pathology detector, #2383) remain.

Ref #2196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)