### PR TITLE
feat(insights): expose pathology distribution via API + MCP tool (#2383)

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -54,6 +54,7 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 | `get_session` | Get a single session by ID (supports prefix matching) |
 | `stats` | Archive statistics: totals, provider breakdown, database size |
 | `get_postmortem_bundle` | Distilled postmortem bundle over a matched scope (#2380): top sessions by cost, repos touched, tool/work-kind rollups, failure signals. Read-only. |
+| `get_pathologies` | Deterministic agent-workflow pathology distribution over a matched scope (#2383): wasted-loop, missed-review, and stale-context findings with drillable evidence. Read-only. |
 | `export_sanitized` | Write a fail-closed **redacted** shareable bundle (#2381) to a path; refuses (typed error, nothing published) if any private path or secret survives the leak gate. Write role. |
 
 > **Redacted vs. raw.** `get_postmortem_bundle` and `export_sanitized` are the

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from polylogue.export.sanitize import SanitizedExportRequest, SanitizedExportResult
     from polylogue.insights.audit import InsightRigorAuditQuery, InsightRigorAuditReport
     from polylogue.insights.export_bundles import InsightExportBundleRequest, InsightExportBundleResult
+    from polylogue.insights.pathology import PathologyReport
     from polylogue.insights.postmortem import PostmortemBundle
     from polylogue.insights.readiness import InsightReadinessQuery, InsightReadinessReport
     from polylogue.insights.resume import ResumeBrief, ResumeCandidate
@@ -1732,6 +1733,49 @@ class PolylogueArchiveMixin:
         bundle = compile_postmortem_bundle(profiles, digests, scope=scope)
         assert isinstance(bundle, _PostmortemBundle)
         return bundle
+
+    async def pathology_report(
+        self,
+        spec: SessionQuerySpec | None = None,
+        *,
+        limit: int | None = None,
+    ) -> PathologyReport:
+        """Mine agent-workflow pathologies across a matched session scope (#2383).
+
+        Resolves the matched session set (the same summary path
+        ``postmortem_bundle`` uses), fetches each session's recovery digest, and
+        runs the deterministic detectors in :mod:`polylogue.insights.pathology`
+        over the typed run projections. Returns the aggregate
+        :class:`PathologyReport` (findings + per-kind distribution), the
+        queryable distribution/summary view for #2383. The analysis cap defaults
+        to 200 sessions.
+        """
+        from polylogue.insights.pathology import compile_pathology_report
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        cap = limit if limit is not None and limit > 0 else 200
+
+        with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
+            if spec is not None and spec.has_filters():
+                summaries = _archive_list_summaries_for_spec(archive, spec, default_limit=1_000_000)
+            else:
+                summaries = archive.list_summaries(limit=1_000_000)
+
+        session_ids: list[str] = []
+        seen: set[str] = set()
+        for summary in summaries:
+            if summary.session_id in seen:
+                continue
+            seen.add(summary.session_id)
+            session_ids.append(summary.session_id)
+
+        analyzed_ids = session_ids[:cap]
+        projections = []
+        for sid in analyzed_ids:
+            digest = await self.recovery_digest(sid)
+            if digest is not None:
+                projections.append(digest.run_projection)
+        return compile_pathology_report(projections)
 
     async def sanitized_export(
         self,

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1769,7 +1769,16 @@ class PolylogueArchiveMixin:
             seen.add(summary.session_id)
             session_ids.append(summary.session_id)
 
+        matched = len(session_ids)
         analyzed_ids = session_ids[:cap]
+        if matched > cap:
+            logger.warning(
+                "pathology_report truncated: matched=%d cap=%d dropped=%d dropped_preview=%s",
+                matched,
+                cap,
+                matched - cap,
+                session_ids[cap : cap + 5],
+            )
         projections = []
         for sid in analyzed_ids:
             digest = await self.recovery_digest(sid)

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -1108,5 +1108,42 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
         return await hooks.async_safe_call("get_postmortem_bundle", run)
 
+    @mcp.tool()
+    async def get_pathologies(
+        query: str | None = None,
+        origin: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        tag: str | None = None,
+        repo: str | None = None,
+        limit: int | None = None,
+    ) -> str:
+        """Agent-workflow pathology distribution over a matched scope (#2383).
+
+        Read-shaped delegate to :meth:`Polylogue.pathology_report`: runs the
+        deterministic detectors (wasted-loop, missed-review, stale-context) over
+        the matched sessions' run projections and returns the typed
+        :class:`polylogue.insights.pathology.PathologyReport` — findings with
+        evidence refs plus the per-kind distribution. Deterministic and
+        rule-based (no LLM-as-judge); a rebuild over identical evidence is
+        identical.
+        """
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            spec = MCPSessionQueryRequest(
+                query=query,
+                origin=origin,
+                since=since,
+                until=until,
+                tag=tag,
+                repo=repo,
+            ).build_spec(hooks.clamp_limit)
+            spec = replace(spec, limit=None)
+            report = await poly.pathology_report(spec, limit=limit)
+            return hooks.json_payload(report, exclude_none=True)
+
+        return await hooks.async_safe_call("get_pathologies", run)
+
 
 __all__ = ["register_insight_tools"]

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -63,6 +63,7 @@ EXPECTED_TOOL_NAMES = {
     "export_query_results",
     "export_sanitized",
     "get_postmortem_bundle",
+    "get_pathologies",
     "rebuild_session_insights",
     "maintenance_preview",
     "maintenance_execute",

--- a/tests/unit/mcp/test_distilled_bundle_tools.py
+++ b/tests/unit/mcp/test_distilled_bundle_tools.py
@@ -121,3 +121,29 @@ def test_export_sanitized_has_no_redaction_disable_param(mcp_server: MCPServerUn
     assert "redact" not in params
     assert "acknowledge_unredacted" not in params
     assert "no_redact" not in params
+
+
+@pytest.mark.asyncio
+async def test_get_pathologies_delegates_and_serializes(mcp_server: MCPServerUnderTest) -> None:
+    from polylogue.insights.pathology import PathologyFinding, PathologyReport
+
+    report = PathologyReport(
+        findings=(PathologyFinding(kind="wasted_loop", session_id="s1", severity="medium", detail="3 failed turns"),),
+        counts_by_kind={"wasted_loop": 1},
+        session_count=1,
+    )
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.pathology_report = AsyncMock(return_value=report)
+        mock_get_polylogue.return_value = mock_poly
+
+        raw = await invoke_surface_async(
+            mcp_server._tool_manager._tools["get_pathologies"].fn,
+            since="2026-01-01",
+        )
+
+    payload = json.loads(raw)
+    assert payload["counts_by_kind"] == {"wasted_loop": 1}
+    assert payload["findings"][0]["kind"] == "wasted_loop"
+    # candidate scope must not inherit the MCP default page limit
+    assert mock_poly.pathology_report.await_args.args[0].limit is None

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -144,6 +144,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "export_query_results": "operation_result",
     "export_sanitized": "operation_result",
     "get_postmortem_bundle": "single_object",
+    "get_pathologies": "single_object",
     "maintenance_preview": "operation_result",
     "maintenance_execute": "operation_result",
     "maintenance_status": "operation_result",


### PR DESCRIPTION
## Summary

Surfaces the deterministic agent-workflow pathology detectors (#2448) as a
first-class queryable distribution: a new `Polylogue.pathology_report()` API
method and a `get_pathologies` MCP read tool that return every finding from all
three v1 detectors over a matched scope, with counts by kind and drillable
evidence refs.

## Problem

The v1 pathology detectors landed in #2448 but were only reachable through the
postmortem bundle's `wasted_loop` / `failure_mode` summary fields. There was no
way to pull the full pathology distribution — all three detectors
(wasted_loop / missed_review / stale_context), every finding, and the
per-kind counts — across a matched scope from the API or an agent surface.

## Solution

- `polylogue/api/archive.py`: add `Polylogue.pathology_report(spec, *, limit)`.
  It mirrors `postmortem_bundle`'s scope resolution but fetches only the
  recovery-digest run projections the detectors consume, then runs
  `compile_pathology_report` over them.
- `polylogue/mcp/server_insight_tools.py`: add the `get_pathologies` read tool.
  It forces `limit=None` on the resolved spec via `dataclasses.replace` so the
  matched scope is not silently capped at the `MCPSessionQueryRequest` default
  of 10 (the same footgun CodeRabbit caught in #2443).
- Register `get_pathologies` in `EXPECTED_TOOL_NAMES` (tests/infra/mcp.py) and
  `TOOL_CONTRACT` as `single_object` (tests/unit/mcp/test_envelope_contracts.py).
- Add a delegation/serialization test asserting counts_by_kind, findings, and
  that the delegated spec carries `limit is None`.
- Document the tool in `docs/mcp-integration.md`.

## Verification

- `devtools test tests/unit/mcp/test_server_surfaces.py` → 75 passed
- `devtools test tests/unit/mcp/test_distilled_bundle_tools.py tests/unit/mcp/test_envelope_contracts.py` → 40 passed
- `mypy` clean on all changed files
- `ruff format` / `ruff check` clean

## Follow-up

Remaining #2383 scope: emit `Assertion(kind=pathology)` candidate rows
queryable via the #2006 assertion lifecycle. `assertions.kind` is plain TEXT
(no DB CHECK), so the `AssertionKind` addition is schema-free — this is the
final slice.

Ref #2383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new read-only tool to surface pathology insights for a session scope.
  * Results are returned as a single structured object and can be limited for larger scopes.

* **Documentation**
  * Updated the tool reference to include the new pathology insights command.

* **Tests**
  * Expanded coverage for tool registration, response formatting, and scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->