### PR TITLE
feat(insights): emit pathology findings as candidate assertions (#2383)

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1371,6 +1371,7 @@ components:
       - run_state
       - prompt_eval
       - transform_candidate
+      - pathology
       title: AssertionKind
       type: string
     AssertionQueryRowPayload:

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -142,7 +142,8 @@
         "judgment",
         "run_state",
         "prompt_eval",
-        "transform_candidate"
+        "transform_candidate",
+        "pathology"
       ],
       "title": "AssertionKind",
       "type": "string"

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -7,7 +7,7 @@ import json
 import logging
 import sqlite3
 import uuid
-from collections.abc import AsyncIterator, Iterable, Sequence
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -851,6 +851,44 @@ def _archive_judge_assertion_candidate(
         raise RuntimeError(f"failed to judge assertion candidate: {exc}") from exc
 
 
+def _archive_emit_pathology_assertions(
+    config: Config,
+    findings_by_session: Mapping[str, Sequence[Any]],
+) -> int:
+    """Upsert pathology findings as candidate assertions in ``user.db`` (#2383).
+
+    Returns the number of candidate assertion rows written. Idempotent: the
+    deterministic assertion id means re-emitting identical findings updates the
+    same candidate rows rather than duplicating them.
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.user_write import (
+        upsert_pathology_findings_as_assertions,
+    )
+
+    if not findings_by_session:
+        return 0
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        raise ValueError("assertion user tier is not initialized")
+    emitted = 0
+    try:
+        conn = sqlite3.connect(user_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            for session_id, findings in findings_by_session.items():
+                if not findings:
+                    continue
+                envelopes = upsert_pathology_findings_as_assertions(conn, session_id, list(findings))
+                emitted += len(envelopes)
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"failed to emit pathology assertions: {exc}") from exc
+    return emitted
+
+
 def _archive_assertion_work_packet_entries(claims: Sequence[Any], session_id: str) -> tuple[Any, ...]:
     """Return assertion-backed work-packet rows for one target session."""
 
@@ -884,7 +922,7 @@ def _archive_assertion_work_packet_entries(claims: Sequence[Any], session_id: st
 def _archive_assertion_support(kind: str) -> WorkPacketSupport:
     if kind in {"blocker", "caveat"}:
         return "caveat"
-    if kind == "transform_candidate":
+    if kind in {"transform_candidate", "pathology"}:
         return "inference"
     return "assertion"
 
@@ -1785,6 +1823,63 @@ class PolylogueArchiveMixin:
             if digest is not None:
                 projections.append(digest.run_projection)
         return compile_pathology_report(projections)
+
+    async def materialize_pathology_assertions(
+        self,
+        spec: SessionQuerySpec | None = None,
+        *,
+        limit: int | None = None,
+    ) -> int:
+        """Emit pathology findings as candidate assertions queryable via #2006 (#2383).
+
+        Runs the deterministic detectors over a matched session scope (the same
+        path :meth:`pathology_report` uses) and upserts each finding as a private,
+        non-injected ``AssertionKind.PATHOLOGY`` candidate in ``user.db``. The
+        candidates are then queryable through the standard assertion-claims surface
+        (``list_assertion_claims(kinds="pathology")``) and promotable through the
+        existing accept/reject/defer lifecycle (Ref #2182) — nothing is
+        auto-injected into agent context. Returns the number of candidate rows
+        written. Idempotent by deterministic assertion id. The analysis cap
+        defaults to 200 sessions.
+        """
+        from polylogue.insights.pathology import detect_session_pathologies
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        cap = limit if limit is not None and limit > 0 else 200
+
+        with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
+            if spec is not None and spec.has_filters():
+                summaries = _archive_list_summaries_for_spec(archive, spec, default_limit=1_000_000)
+            else:
+                summaries = archive.list_summaries(limit=1_000_000)
+
+        session_ids: list[str] = []
+        seen: set[str] = set()
+        for summary in summaries:
+            if summary.session_id in seen:
+                continue
+            seen.add(summary.session_id)
+            session_ids.append(summary.session_id)
+
+        matched = len(session_ids)
+        analyzed_ids = session_ids[:cap]
+        if matched > cap:
+            logger.warning(
+                "materialize_pathology_assertions truncated: matched=%d cap=%d dropped=%d dropped_preview=%s",
+                matched,
+                cap,
+                matched - cap,
+                session_ids[cap : cap + 5],
+            )
+        findings_by_session: dict[str, list[Any]] = {}
+        for sid in analyzed_ids:
+            digest = await self.recovery_digest(sid)
+            if digest is None:
+                continue
+            findings = detect_session_pathologies(digest.run_projection)
+            if findings:
+                findings_by_session[sid] = findings
+        return _archive_emit_pathology_assertions(self.config, findings_by_session)
 
     async def sanitized_export(
         self,

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -425,6 +425,7 @@ class AssertionKind(PolylogueStrEnum):
     RUN_STATE = "run_state"
     PROMPT_EVAL = "prompt_eval"
     TRANSFORM_CANDIDATE = "transform_candidate"
+    PATHOLOGY = "pathology"
 
     @classmethod
     def from_string(cls, value: str | AssertionKind) -> AssertionKind:

--- a/polylogue/storage/sqlite/archive_tiers/user_audit.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_audit.py
@@ -29,6 +29,7 @@ _ASSERTION_BACKED_SURFACES: dict[str, AssertionKind] = {
     "run_state": AssertionKind.RUN_STATE,
     "prompt_evals": AssertionKind.PROMPT_EVAL,
     "transform_candidates": AssertionKind.TRANSFORM_CANDIDATE,
+    "pathologies": AssertionKind.PATHOLOGY,
 }
 
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -24,6 +24,7 @@ from polylogue.core.json import JSONValue
 from polylogue.core.refs import ObjectRef, normalize_object_ref_text, normalize_public_ref_text
 
 if TYPE_CHECKING:
+    from polylogue.insights.pathology import PathologyFinding
     from polylogue.insights.transforms import DecisionCandidate, RecoveryDigest, TransformRawRef
 
 
@@ -231,6 +232,26 @@ def assertion_id_for_transform_candidate(
         str(candidate_index),
         candidate_kind,
         candidate_text,
+        *evidence_refs,
+    )
+
+
+def assertion_id_for_pathology_finding(
+    *,
+    session_id: str,
+    finding_kind: str,
+    detector_version: int,
+    finding_detail: str,
+    evidence_refs: Sequence[str],
+) -> str:
+    """Return the assertion id for one deterministic pathology finding."""
+
+    return _deterministic_id(
+        f"assertion-{AssertionKind.PATHOLOGY}",
+        session_id,
+        finding_kind,
+        str(detector_version),
+        finding_detail,
         *evidence_refs,
     )
 
@@ -1030,6 +1051,68 @@ def upsert_transform_candidate_assertions(
     return envelopes
 
 
+def upsert_pathology_findings_as_assertions(
+    conn: sqlite3.Connection,
+    session_id: str,
+    findings: Sequence[PathologyFinding],
+    *,
+    now_ms: int | None = None,
+) -> list[ArchiveAssertionEnvelope]:
+    """Mirror deterministic pathology detector findings as candidate assertions (#2383).
+
+    Each finding becomes a private, non-injected ``AssertionKind.PATHOLOGY``
+    candidate awaiting explicit promotion (Ref #2182), keyed by a deterministic
+    id so a rebuild over identical evidence is idempotent. An operator-promoted
+    finding (status != CANDIDATE) is never silently downgraded back to candidate.
+    """
+
+    timestamp = now_ms if now_ms is not None else _now_ms()
+    target_ref = f"session:{session_id}"
+    envelopes: list[ArchiveAssertionEnvelope] = []
+
+    for finding in findings:
+        evidence_refs = [ref.format() for ref in finding.evidence_refs]
+        scope_ref = f"insight:pathology-detector@v{finding.detector_version}"
+        assertion_id = assertion_id_for_pathology_finding(
+            session_id=session_id,
+            finding_kind=finding.kind,
+            detector_version=finding.detector_version,
+            finding_detail=finding.detail,
+            evidence_refs=evidence_refs,
+        )
+        existing = read_assertion_envelope(conn, assertion_id)
+        if existing is not None and existing.status != AssertionStatus.CANDIDATE:
+            envelopes.append(existing)
+            continue
+        envelopes.append(
+            upsert_assertion(
+                conn,
+                assertion_id=assertion_id,
+                scope_ref=scope_ref,
+                target_ref=target_ref,
+                key=finding.kind,
+                kind=AssertionKind.PATHOLOGY,
+                value={
+                    "pathology_kind": finding.kind,
+                    "severity": finding.severity,
+                    "occurrence_count": finding.occurrence_count,
+                    "detector_version": finding.detector_version,
+                    "session_id": session_id,
+                },
+                body_text=finding.detail,
+                author_ref=scope_ref,
+                author_kind="detector",
+                evidence_refs=evidence_refs,
+                status=AssertionStatus.CANDIDATE,
+                visibility=AssertionVisibility.PRIVATE,
+                context_policy={"inject": False, "promotion_required": True},
+                now_ms=timestamp,
+            )
+        )
+
+    return envelopes
+
+
 def _transform_candidate_evidence_refs(candidate: DecisionCandidate) -> list[str]:
     return [_format_transform_raw_ref(ref) for ref in candidate.raw_refs]
 
@@ -1435,6 +1518,7 @@ ASSERTION_CLAIM_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.LESSON,
     AssertionKind.RUN_STATE,
     AssertionKind.TRANSFORM_CANDIDATE,
+    AssertionKind.PATHOLOGY,
 )
 
 
@@ -1532,6 +1616,7 @@ __all__ = [
     "assertion_id_for_saved_view",
     "assertion_id_for_session_tag",
     "assertion_id_for_suppression",
+    "assertion_id_for_pathology_finding",
     "assertion_id_for_transform_candidate",
     "assertion_id_for_workspace",
     "correction_id_for",
@@ -1563,6 +1648,7 @@ __all__ = [
     "upsert_session_metadata_assertion",
     "upsert_session_tag_assertion",
     "upsert_suppression",
+    "upsert_pathology_findings_as_assertions",
     "upsert_transform_candidate_assertions",
     "upsert_workspace",
 ]

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -28,6 +28,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     AssertionVisibility,
     assertion_envelope_to_payload,
     assertion_id_for_candidate_judgment,
+    assertion_id_for_pathology_finding,
     assertion_id_for_promoted_candidate,
     assertion_id_for_transform_candidate,
     judge_assertion_candidate,
@@ -39,6 +40,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     mark_assertion_status,
     read_assertion_envelope,
     upsert_assertion,
+    upsert_pathology_findings_as_assertions,
     upsert_transform_candidate_assertions,
 )
 from polylogue.types import SessionId
@@ -673,6 +675,7 @@ def test_list_assertion_claims_filters_lifecycle_assertions(tmp_path: Path) -> N
             AssertionKind.LESSON,
             AssertionKind.RUN_STATE,
             AssertionKind.TRANSFORM_CANDIDATE,
+            AssertionKind.PATHOLOGY,
         }
 
         rows: list[tuple[str, str, AssertionKind, str, str, dict[str, object] | None, int]] = [
@@ -1175,3 +1178,85 @@ def test_candidate_reviews_survive_remirror_without_becoming_authoritative(tmp_p
         assert all(row.latest_judgment is not None for row in reviews)
     finally:
         conn.close()
+
+
+def test_upsert_pathology_findings_emits_queryable_candidates(tmp_path: Path) -> None:
+    """Pathology findings become PATHOLOGY candidate claims with evidence (#2383)."""
+    from polylogue.core.refs import EvidenceRef
+    from polylogue.insights.pathology import PathologyFinding
+
+    conn = _connect(tmp_path / "user.db")
+    try:
+        session_id = "codex-session:pathology-demo"
+        findings = [
+            PathologyFinding(
+                kind="wasted_loop",
+                session_id=session_id,
+                severity="medium",
+                detail="5 failed test/check turns without a clean pass between them",
+                occurrence_count=5,
+                evidence_refs=(EvidenceRef(session_id=session_id, message_id="m7"),),
+            ),
+            PathologyFinding(
+                kind="stale_context",
+                session_id=session_id,
+                severity="medium",
+                detail="1 resume boundary(ies) re-inherited context in lossy mode(s): summary",
+                occurrence_count=1,
+                evidence_refs=(EvidenceRef(session_id=session_id, message_id="m1"),),
+            ),
+        ]
+
+        envelopes = upsert_pathology_findings_as_assertions(conn, session_id, findings)
+        conn.commit()
+        assert len(envelopes) == 2
+        for envelope in envelopes:
+            assert envelope.kind == AssertionKind.PATHOLOGY
+            assert envelope.status == AssertionStatus.CANDIDATE
+            assert envelope.visibility == AssertionVisibility.PRIVATE
+            assert envelope.context_policy.get("inject") is False
+            assert envelope.evidence_refs  # drillable
+
+        # Queryable via the standard assertion-claims surface (#2006).
+        claims = list_assertion_claims(
+            conn,
+            kinds=(AssertionKind.PATHOLOGY,),
+            statuses=(AssertionStatus.CANDIDATE,),
+        )
+        claim_kinds = {claim.value["pathology_kind"] for claim in claims if isinstance(claim.value, dict)}
+        assert claim_kinds == {"wasted_loop", "stale_context"}
+
+        # Deterministic id: re-emitting identical findings is idempotent.
+        again = upsert_pathology_findings_as_assertions(conn, session_id, findings)
+        conn.commit()
+        assert {e.assertion_id for e in again} == {e.assertion_id for e in envelopes}
+        recount = list_assertion_claims(conn, kinds=(AssertionKind.PATHOLOGY,))
+        assert len(recount) == 2
+
+        # An operator-promoted candidate is never downgraded back to candidate.
+        promoted_id = envelopes[0].assertion_id
+        mark_assertion_status(conn, promoted_id, AssertionStatus.ACCEPTED)
+        conn.commit()
+        preserved = upsert_pathology_findings_as_assertions(conn, session_id, findings)
+        conn.commit()
+        promoted = read_assertion_envelope(conn, promoted_id)
+        assert promoted is not None
+        assert promoted.status == AssertionStatus.ACCEPTED
+        assert any(e.assertion_id == promoted_id for e in preserved)
+    finally:
+        conn.close()
+
+
+def test_assertion_id_for_pathology_finding_is_stable() -> None:
+    """The deterministic id changes only when finding identity changes (#2383)."""
+    base = {
+        "session_id": "codex-session:x",
+        "finding_kind": "wasted_loop",
+        "detector_version": 1,
+        "finding_detail": "3 failed test/check turns",
+        "evidence_refs": ["codex-session:x::m1"],
+    }
+    first = assertion_id_for_pathology_finding(**base)  # type: ignore[arg-type]
+    assert first == assertion_id_for_pathology_finding(**base)  # type: ignore[arg-type]
+    changed = assertion_id_for_pathology_finding(**{**base, "finding_kind": "stale_context"})  # type: ignore[arg-type]
+    assert changed != first


### PR DESCRIPTION
## Summary

Closes the final acceptance criterion of #2383: the deterministic pathology
detectors now emit their findings as `Assertion(kind=pathology)` candidate rows
that are queryable through the existing #2006 assertion-claims surface and
promotable through the standard accept/reject/defer lifecycle — with no
auto-injection into agent context.

## Problem

#2448 shipped the detectors and #2449 shipped the distribution view, but both
surfaced findings only as a computed report. #2383's last AC requires detector
output to be *queryable via #2006* (`assertions where kind:pathology`) and to
require *explicit promotion* (Ref #2182). Until now there was no persisted,
promotable representation of a pathology finding.

## Solution

- **`core/enums.py`**: add `AssertionKind.PATHOLOGY`. The `assertions.kind`
  column is plain `TEXT` with no DB `CHECK`, so this is schema-free — no
  user-tier `SCHEMA_VERSION` bump.
- **`storage/.../user_write.py`**:
  - `assertion_id_for_pathology_finding(...)` — a deterministic id over
    `(session, kind, detector_version, detail, evidence)` so rebuilds are
    idempotent.
  - `upsert_pathology_findings_as_assertions(...)` — mirrors each
    `PathologyFinding` as a **PRIVATE**, non-injected
    (`context_policy={"inject": False, "promotion_required": True}`)
    **CANDIDATE** assertion. An operator-promoted candidate
    (`status != CANDIDATE`) is never silently downgraded.
  - Register `PATHOLOGY` in `ASSERTION_CLAIM_KINDS` so it appears in the
    default claims query.
- **`storage/.../user_audit.py`**: register the `pathologies` overlay surface
  so the "every AssertionKind has a surface" audit invariant holds.
- **`api/archive.py`**: `Polylogue.materialize_pathology_assertions(spec, *,
  limit)` — runs the detectors over a matched scope (mirroring
  `pathology_report`, including the truncation warning) and upserts the
  candidates in one `user.db` transaction, returning the count written. Maps
  `pathology` work-packet support to `inference`.
- Regenerated `docs/openapi/search.yaml` and
  `docs/schemas/cli-output/query-unit-envelope.schema.json` (the AssertionKind
  enum is embedded in both).

The loop is complete and consumed: `materialize_pathology_assertions` →
`list_assertion_claims(kinds="pathology")` (existing MCP/CLI/API query) →
`mark candidates accept/reject` (existing promotion lifecycle).

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_assertions.py` → 25 passed
  (new round-trip: emit → query candidates → idempotent re-emit →
  promoted-candidate-not-downgraded; plus deterministic-id stability)
- `devtools test tests/unit/storage/test_archive_tiers_user_audit.py` → 2 passed
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py` → 26 passed
- `devtools test tests/unit/cli/test_assertion_candidates.py` → 3 passed
- `devtools test tests/unit/insights/test_postmortem.py` → 27 passed
- `devtools render all --check` → exit 0
- `mypy` clean on all changed files

## #2383 status

All acceptance criteria now satisfied:
- ✅ ≥3 detectors emit candidate assertions with `EvidenceRef`s (#2448 + this PR)
- ✅ Deterministic and versioned; rebuild → identical output (#2448)
- ✅ Queryable via #2006; distribution/summary view renders (#2449 + this PR)
- ✅ No auto-injection; candidates require explicit promotion (this PR)

Ref #2383

🤖 Generated with [Claude Code](https://claude.com/claude-code)