### PR TITLE
test(release): probe installed runtime dependency closure via --diagnose find (#2307)

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -45,6 +45,12 @@ anything different; release-please consumes the existing history.
       runtime dependencies changed.
 - [ ] `devtools release build-package` passes when Nix packaging or dependency
       closure changed.
+- [ ] `pytest tests/integration/test_installed_package_smoke.py` passes — it
+      builds + installs the wheel into a fresh venv and runs
+      `polylogue --diagnose find ...` against an empty archive root, proving the
+      installed artifact's runtime dependency closure reaches archive handling
+      (the query-first path that a previously-missed `lark` dependency broke)
+      rather than dying on a missing import.
 - [ ] `devtools workspace deployment-smoke --json` captures installed command
       versions, daemon URL, browser-capture receiver URL, archive root, and
       resource signals on the deployment host when this release claims deployed

--- a/tests/integration/test_installed_package_smoke.py
+++ b/tests/integration/test_installed_package_smoke.py
@@ -207,6 +207,35 @@ def test_installed_polylogue_entrypoints_under_fresh_xdg(
     daemon_status = _run((str(bin_dir / "polylogued"), "status"), env=env, timeout=60)
     assert "Traceback" not in daemon_status.stdout + daemon_status.stderr
 
+    # Runtime dependency-closure probe (#2307): the query-first `find` path pulls
+    # in the Lark grammar, FTS/search providers, and archive storage — a strictly
+    # broader import closure than --version/status/analyze. A previously-missed
+    # package dependency (`lark`) only surfaced on this path, so the installed
+    # artifact must reach archive handling here rather than ModuleNotFoundError.
+    # --diagnose makes the dispatch decision observable; check=False because a
+    # zero-result query against a fresh archive may exit non-zero, which is fine —
+    # the contract is that imports resolve and dispatch reaches the archive.
+    diagnose = _run(
+        (str(bin_dir / "polylogue"), "--diagnose", "find", "polylogue"),
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    combined = diagnose.stdout + diagnose.stderr
+    assert "Traceback" not in combined
+    assert "ModuleNotFoundError" not in combined
+    assert "ImportError" not in combined
+    assert "[diagnose]" in diagnose.stderr, (
+        "expected --diagnose dispatch trace; query-first import closure did not "
+        f"reach archive handling. stderr=\n{diagnose.stderr}"
+    )
+    # Reaching archive handling (here: the missing index.db report on a fresh
+    # root) is the closure proof — dispatch ran the query path through to
+    # storage instead of dying on a missing import.
+    assert "archive" in combined.lower(), (
+        f"query-first dispatch did not reach archive handling on a fresh root; stdout+stderr=\n{combined}"
+    )
+
     after = _snapshot(home)
     _assert_no_home_leak(home, before, after)
 


### PR DESCRIPTION
## Summary

Adds the runtime dependency-closure probe #2307 AC7 calls for: the installed-wheel smoke test now exercises the query-first `find` path, whose import closure is strictly broader than the surfaces it covered before — and is exactly where a missing package dependency surfaces.

## Problem

#2307: "Release/package checks must prove runtime dependency closure of the installed artifact, not just the source tree. Deployed package closure previously missed `lark`, proving release/package verification needs a runtime dependency probe." The installed-wheel smoke test (`test_installed_polylogue_entrypoints_under_fresh_xdg`) exercised `--version`/`--help`/`status`/`analyze --count`, but never the query-first `find` path that pulls in the Lark grammar, FTS/search providers, and archive storage — the closure a missing `lark` broke.

## Solution

- `tests/integration/test_installed_package_smoke.py`: add a `polylogue --diagnose find polylogue` probe against a fresh XDG archive root. Asserts no `ModuleNotFoundError`/`ImportError`/`Traceback`, that the `--diagnose` dispatch trace is emitted, and that dispatch **reaches archive handling** (the missing-`index.db` report on a fresh root). `check=False` because a zero-result query on a fresh archive exits non-zero — the contract is import resolution + archive reach, not exit code.
- `docs/release.md`: document the installed-package smoke (with the `--diagnose find` closure probe) as a pre-flight gate.

Verified the probe's behavior locally against an empty archive root: 5 `[diagnose]` lines on stderr, `Error: archive index database not found at .../index.db`, no import error, exit 1.

## Verification

- Local source run of `polylogue --diagnose find polylogue` against an empty `POLYLOGUE_ARCHIVE_ROOT` reproduces the asserted output (dispatch trace + archive-reach + no import error).
- `mypy` clean on the changed test file. (The test itself is `@pytest.mark.slow`/`integration` — it builds+installs a wheel; it runs in the release/integration lane.)

Ref #2307

🤖 Generated with [Claude Code](https://claude.com/claude-code)