### PR TITLE
feat(export): add sanitized spans-jsonl bundle leg (#2434)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2032,8 +2032,9 @@ class PolylogueArchiveMixin:
 
         spans: list[dict[str, object]] | None = None
         if request.with_spans:
+            exported_session_ids = {sid for sid in analyzed_ids if sid in profiles_map}
             scope_origins = tuple(dict.fromkeys(profile.origin for profile in profiles if profile.origin))
-            spans = await self._sanitized_export_spans(spec, scope_origins, cap)
+            spans = await self._sanitized_export_spans(spec, scope_origins, cap, session_ids=exported_session_ids)
 
         return produce_sanitized_export(rows=rows, scope=scope, request=request, postmortem=postmortem, spans=spans)
 
@@ -2042,6 +2043,8 @@ class PolylogueArchiveMixin:
         spec: SessionQuerySpec | None,
         origins: Sequence[str],
         cap: int,
+        *,
+        session_ids: set[str],
     ) -> list[dict[str, object]]:
         """Project scope-bounded run/action evidence into OTel-style span dicts.
 
@@ -2049,11 +2052,14 @@ class PolylogueArchiveMixin:
         are sanitized + leak-gated by the same fail-closed contract as the rest
         of the bundle; this method only fetches and shapes them.
 
-        Query-unit expressions require an explicit predicate, so spans are scoped
-        by the origins present in the exported session set (one
-        ``<unit> where session.origin:<origin>`` query per origin), additionally
-        bounded by the export's ``since``/``until`` window. This covers the same
-        sessions the dataset rows describe without a query-unit "select all" form.
+        Query-unit expressions require an explicit predicate, so spans are
+        fetched per origin present in the exported session set (one
+        ``<unit> where session.origin:<origin>`` query per origin), bounded by the
+        export's ``since``/``until`` window, and then **filtered to the exact
+        exported session ids**. Origin/time scoping alone would pull runs/actions
+        for unrelated sessions of the same origin when the export was narrowed by
+        a repo/tag/text/limit filter; the ``session_ids`` filter keeps
+        ``spans.jsonl`` aligned with the dataset rows.
         """
         from polylogue.surfaces.payloads import model_json_document
         from polylogue.telemetry.otel_projection import project_query_unit_rows_to_otel
@@ -2070,7 +2076,7 @@ class PolylogueArchiveMixin:
                     since=since,
                     until=until,
                 )
-                rows.extend(envelope.items)
+                rows.extend(row for row in envelope.items if str(getattr(row, "session_id", "")) in session_ids)
 
         projection = project_query_unit_rows_to_otel("export:sanitized-spans", rows)
         return [cast("dict[str, object]", model_json_document(span)) for span in projection.spans]

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2030,7 +2030,50 @@ class PolylogueArchiveMixin:
             bundle = await self.postmortem_bundle(spec, limit=limit)
             postmortem = model_json_document(bundle, exclude_none=True)
 
-        return produce_sanitized_export(rows=rows, scope=scope, request=request, postmortem=postmortem)
+        spans: list[dict[str, object]] | None = None
+        if request.with_spans:
+            scope_origins = tuple(dict.fromkeys(profile.origin for profile in profiles if profile.origin))
+            spans = await self._sanitized_export_spans(spec, scope_origins, cap)
+
+        return produce_sanitized_export(rows=rows, scope=scope, request=request, postmortem=postmortem, spans=spans)
+
+    async def _sanitized_export_spans(
+        self,
+        spec: SessionQuerySpec | None,
+        origins: Sequence[str],
+        cap: int,
+    ) -> list[dict[str, object]]:
+        """Project scope-bounded run/action evidence into OTel-style span dicts.
+
+        Used only by the opt-in ``--with-spans`` export leg (#2434). The spans
+        are sanitized + leak-gated by the same fail-closed contract as the rest
+        of the bundle; this method only fetches and shapes them.
+
+        Query-unit expressions require an explicit predicate, so spans are scoped
+        by the origins present in the exported session set (one
+        ``<unit> where session.origin:<origin>`` query per origin), additionally
+        bounded by the export's ``since``/``until`` window. This covers the same
+        sessions the dataset rows describe without a query-unit "select all" form.
+        """
+        from polylogue.surfaces.payloads import model_json_document
+        from polylogue.telemetry.otel_projection import project_query_unit_rows_to_otel
+
+        since = spec.since if spec is not None else None
+        until = spec.until if spec is not None else None
+
+        rows: list[Any] = []
+        for origin in origins:
+            for unit in ("runs", "actions"):
+                envelope = await self.query_units(
+                    f"{unit} where session.origin:{origin}",
+                    limit=cap,
+                    since=since,
+                    until=until,
+                )
+                rows.extend(envelope.items)
+
+        projection = project_query_unit_rows_to_otel("export:sanitized-spans", rows)
+        return [cast("dict[str, object]", model_json_document(span)) for span in projection.spans]
 
     async def recovery_report(self, session_id: str, preset: RecoveryReportPreset) -> str | None:
         """Render one deterministic recovery report preset for a session."""

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -1627,6 +1627,13 @@ def analyze_verb(
     default=False,
     help="Embed a sanitized postmortem report alongside the dataset.",
 )
+@click.option(
+    "--with-spans",
+    "with_spans",
+    is_flag=True,
+    default=False,
+    help="Embed sanitized OTel-style run/action spans (spans.jsonl) in the bundle.",
+)
 @click.option("--overwrite", is_flag=True, default=False, help="Replace an existing bundle directory.")
 @click.option(
     "--no-redact",
@@ -1670,6 +1677,7 @@ def export_verb(
     accept_unredacted: bool = False,
     output_format: str | None = None,
     limit: int | None = None,
+    with_spans: bool = False,
 ) -> None:
     """Export the matched session scope as a fail-closed sanitized bundle (#2381).
 
@@ -1708,6 +1716,7 @@ def export_verb(
         output_path=_Path(out_path),
         privacy_level=level,
         with_postmortem=with_postmortem,
+        with_spans=with_spans,
         overwrite=overwrite,
         redact=not no_redact,
         acknowledge_unredacted=accept_unredacted,

--- a/polylogue/export/sanitize.py
+++ b/polylogue/export/sanitize.py
@@ -45,6 +45,7 @@ DATASET_FILENAME = "dataset.jsonl"
 MANIFEST_FILENAME = "redaction-manifest.json"
 README_FILENAME = "README.md"
 POSTMORTEM_FILENAME = "postmortem.json"
+SPANS_FILENAME = "spans.jsonl"
 
 # Absolute filesystem path: a leading slash followed by at least two path
 # segments. The two-segment minimum avoids flagging a lone ``/word`` token in
@@ -103,6 +104,7 @@ class SanitizedExportRequest(ArchiveInsightModel):
     output_path: Path
     privacy_level: PrivacyLevel = "standard"
     with_postmortem: bool = False
+    with_spans: bool = False
     overwrite: bool = False
     redact: bool = True
     acknowledge_unredacted: bool = False
@@ -116,7 +118,9 @@ class SanitizedExportResult(ArchiveInsightModel):
     manifest_path: Path
     readme_path: Path
     postmortem_path: Path | None = None
+    spans_path: Path | None = None
     row_count: int = 0
+    span_count: int = 0
     redacted: bool = True
     total_included: int = 0
     total_rejected: int = 0
@@ -301,7 +305,7 @@ def verify_sanitized_export(
     """
 
     resolved_home = _home_dir(home)
-    files = (DATASET_FILENAME, MANIFEST_FILENAME, README_FILENAME, POSTMORTEM_FILENAME)
+    files = (DATASET_FILENAME, MANIFEST_FILENAME, README_FILENAME, POSTMORTEM_FILENAME, SPANS_FILENAME)
     scanned: list[str] = []
     abs_leaks: list[str] = []
     home_leaks: list[str] = []
@@ -354,6 +358,7 @@ def _readme_text(*, redacted: bool, row_count: int) -> str:
         f"- `{DATASET_FILENAME}` — one session-level metadata row per line.",
         f"- `{MANIFEST_FILENAME}` — every redaction decision (what was removed, by which rule).",
         f"- `{POSTMORTEM_FILENAME}` — sanitized postmortem report (only when requested).",
+        f"- `{SPANS_FILENAME}` — sanitized OTel-style run/action spans (only when requested).",
         "",
         "## What is included",
         "",
@@ -412,6 +417,7 @@ def write_sanitized_bundle(
     scope: Mapping[str, object],
     request: SanitizedExportRequest,
     postmortem: Mapping[str, object] | None = None,
+    spans: Sequence[Mapping[str, object]] | None = None,
     home: str | None = None,
     run_gate: bool = True,
 ) -> SanitizedExportResult:
@@ -430,6 +436,7 @@ def write_sanitized_bundle(
     tmp_target.mkdir(parents=False)
 
     postmortem_path: Path | None = None
+    spans_path: Path | None = None
     try:
         _write_text(tmp_target / DATASET_FILENAME, _dataset_text(rows))
         manifest = _manifest_document(report=report, scope=scope, request=request, row_count=len(rows))
@@ -438,6 +445,9 @@ def write_sanitized_bundle(
         if postmortem is not None:
             postmortem_path = target / POSTMORTEM_FILENAME
             _write_text(tmp_target / POSTMORTEM_FILENAME, dumps(dict(postmortem)))
+        if spans is not None:
+            spans_path = target / SPANS_FILENAME
+            _write_text(tmp_target / SPANS_FILENAME, _dataset_text(spans))
 
         verify_ok = True
         if run_gate:
@@ -479,7 +489,9 @@ def write_sanitized_bundle(
         manifest_path=target / MANIFEST_FILENAME,
         readme_path=target / README_FILENAME,
         postmortem_path=postmortem_path,
+        spans_path=spans_path,
         row_count=len(rows),
+        span_count=len(spans) if spans is not None else 0,
         redacted=request.redact,
         total_included=report.total_included,
         total_rejected=report.total_rejected,
@@ -493,6 +505,7 @@ def produce_sanitized_export(
     scope: Mapping[str, object],
     request: SanitizedExportRequest,
     postmortem: Mapping[str, object] | None = None,
+    spans: Sequence[Mapping[str, object]] | None = None,
     home: str | None = None,
 ) -> SanitizedExportResult:
     """Sanitize ``rows`` (+ scope/postmortem) and write the gated bundle.
@@ -516,6 +529,7 @@ def produce_sanitized_export(
             scope=dict(scope),
             request=request,
             postmortem=None if postmortem is None else dict(postmortem),
+            spans=None if spans is None else [dict(span) for span in spans],
             home=home,
             run_gate=False,
         )
@@ -530,6 +544,13 @@ def produce_sanitized_export(
         sanitized_pm_value = sanitizer.value(dict(postmortem), "postmortem")
         if isinstance(sanitized_pm_value, dict):
             sanitized_postmortem = sanitized_pm_value
+    sanitized_spans: list[dict[str, object]] | None = None
+    if spans is not None:
+        sanitized_spans = []
+        for index, span in enumerate(spans):
+            sanitized_span_value = sanitizer.value(dict(span), f"spans[{index}]")
+            if isinstance(sanitized_span_value, dict):
+                sanitized_spans.append(sanitized_span_value)
     report = sanitizer.finalize()
     return write_sanitized_bundle(
         rows=sanitized_rows,
@@ -537,6 +558,7 @@ def produce_sanitized_export(
         scope=sanitized_scope,
         request=request,
         postmortem=sanitized_postmortem,
+        spans=sanitized_spans,
         home=home,
         run_gate=True,
     )
@@ -569,6 +591,7 @@ __all__ = [
     "MANIFEST_FILENAME",
     "POSTMORTEM_FILENAME",
     "README_FILENAME",
+    "SPANS_FILENAME",
     "REDACTED_PATH_PREFIX",
     "REDACTED_SECRET",
     "SANITIZED_EXPORT_BUNDLE_VERSION",

--- a/tests/unit/export/test_sanitize.py
+++ b/tests/unit/export/test_sanitize.py
@@ -249,3 +249,16 @@ def test_gate_independently_catches_raw_email(tmp_path: Path) -> None:
     verdict = verify_sanitized_export(tmp_path, home="/nonexistent-home")
     assert verdict.ok is False
     assert verdict.secret_leaks
+
+
+def test_gate_scans_spans_file_for_raw_leak(tmp_path: Path) -> None:
+    """The fail-closed gate must also scan spans.jsonl, not just dataset.jsonl (#2434)."""
+    (tmp_path / "spans.jsonl").write_text(
+        json.dumps({"name": "run", "attributes": {"cwd": "/home/me/secret/private-repo"}}) + "\n",
+        encoding="utf-8",
+    )
+    verdict = verify_sanitized_export(tmp_path, home="/home/me")
+    assert verdict.ok is False
+    assert verdict.absolute_path_leaks
+    assert any("spans.jsonl" in leak for leak in verdict.absolute_path_leaks)
+    assert "spans.jsonl" in verdict.files_scanned

--- a/tests/unit/export/test_sanitized_export_e2e.py
+++ b/tests/unit/export/test_sanitized_export_e2e.py
@@ -122,3 +122,37 @@ def test_full_export_with_postmortem_payload_is_gated(tmp_path: Path) -> None:
     pm_text = result.postmortem_path.read_text(encoding="utf-8")
     assert PLANTED_REPO_PATH not in pm_text
     assert PLANTED_SECRET not in pm_text
+
+
+def test_full_export_with_spans_payload_is_redacted_and_gated(tmp_path: Path) -> None:
+    out_dir = tmp_path / "shareable-spans"
+    request = SanitizedExportRequest(output_path=out_dir, with_spans=True)
+    # OTel-style spans whose attributes carry a leaked absolute path + secret.
+    spans: list[dict[str, object]] = [
+        {
+            "name": "run",
+            "span_id": "abc123",
+            "attributes": {
+                "polylogue.cwd": PLANTED_REPO_PATH,
+                "note": f"token {PLANTED_SECRET}",
+            },
+        },
+        {
+            "name": "action",
+            "span_id": "def456",
+            "attributes": {"detail": f"opened {PLANTED_ABS_PATH}"},
+        },
+    ]
+    result = produce_sanitized_export(
+        rows=_rows(),
+        scope={},
+        request=request,
+        spans=spans,
+        home=PLANTED_HOME,
+    )
+    assert result.verify_ok is True
+    assert result.spans_path is not None
+    assert result.span_count == 2
+    spans_text = result.spans_path.read_text(encoding="utf-8")
+    for planted in (PLANTED_ABS_PATH, PLANTED_REPO_PATH, PLANTED_HOME, PLANTED_SECRET):
+        assert planted not in spans_text, f"{planted!r} leaked into spans.jsonl"


### PR DESCRIPTION
## Summary

First leg of #2434: an opt-in `export --sanitized --with-spans` that embeds an OTel-style run/action span file (`spans.jsonl`) in the shareable bundle, covered by the **same fail-closed redaction + leak-gate contract** as the rest of the bundle — zero new bypass.

## Problem

The v0 sanitized export (#2381, shipped in #2433) intentionally bounded its leak surface to session metadata; spans (the OTel projection from #2183) were a named deferral. A shareable evidence bundle that carries run/action spans must inherit the redaction + independent gate rather than leaking raw telemetry.

## Solution

- `polylogue/export/sanitize.py`: add `SPANS_FILENAME = "spans.jsonl"`, `SanitizedExportRequest.with_spans`, and `SanitizedExportResult.spans_path`/`span_count`. `write_sanitized_bundle` / `produce_sanitized_export` accept an optional `spans` sequence, redact it through the **same `_Sanitizer`** used for rows/postmortem, and write `spans.jsonl`. `verify_sanitized_export` now scans `spans.jsonl`, so a surviving path/secret in a span attribute **refuses the publish**.
- `polylogue/api/archive.py`: `sanitized_export` projects scope-bounded spans when `with_spans` is set. Query-unit expressions require an explicit predicate (there is no "select all" form), so `_sanitized_export_spans` issues `runs/actions where session.origin:<o>` per origin present in the exported session set, bounded by the export's `since`/`until`, and lowers the rows through `project_query_unit_rows_to_otel`.
- `polylogue/cli/query_verbs.py`: `--with-spans` flag, mirroring `--with-postmortem`.

**Flag-name note:** the AC wrote `--format spans-jsonl`; this ships spans as an additive `spans.jsonl` file behind `--with-spans`, consistent with the existing `--with-postmortem` additive-bundle pattern, keeping `--format` as the result-summary selector. The deliverable (redaction-gated spans in the bundle) matches the AC intent. **Leg 2** (opt-in message-text redaction) is a follow-up PR under the same issue.

## Verification

- `devtools test tests/unit/export/test_sanitize.py tests/unit/export/test_sanitized_export_e2e.py` → 20 passed, including:
  - `test_full_export_with_spans_payload_is_redacted_and_gated` — planted abs-path/repo-path/secret in span attributes do not survive `spans.jsonl`.
  - `test_gate_scans_spans_file_for_raw_leak` — the independent gate flags a raw path in `spans.jsonl` and lists it in `files_scanned`.
- CLI smoke over the demo archive: `find ... then export --sanitized -o <dir> --with-spans` wrote `spans.jsonl` (21 spans), `verify_ok=True`, projection ids redacted.
- `mypy` clean; `ruff` clean; `render all --check` clean.

Ref #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional export of sanitized span data alongside existing export files.
  * Export bundles can now include a `spans.jsonl` file when enabled.

* **Bug Fixes**
  * Expanded leak checks to scan span exports for paths and secret-like values.
  * Ensured span content is redacted before being written out.

* **Tests**
  * Added coverage for span-file leak detection.
  * Added an end-to-end test for exporting, redacting, and validating span payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->