### PR TITLE
feat(query): add Terminal pipeline stage; route verbs through one executor (#2006)

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -266,7 +266,17 @@ class QueryUnitSort:
     direction: Literal["asc", "desc"] = "asc"
 
 
-QueryUnitPipelineStageKind = Literal["session_scope", "sort", "limit", "offset", "group", "count"]
+QueryUnitPipelineStageKind = Literal[
+    "session_scope", "sort", "limit", "offset", "group", "count", "transform", "terminal"
+]
+
+#: Closed vocabulary of terminal actions that a query-unit pipeline can end in.
+#: Each action name must have a registered executor in
+#: :data:`polylogue.archive.query.unit_results.TERMINAL_ACTION_EXECUTORS`.
+#: ``rows`` returns the resolved unit rows; ``count`` returns the aggregate
+#: ``group by ... | count`` rollup. Future actions (read/analyze/bundle/
+#: postmortem) register their unit-level executors here as they land (#2006).
+QueryUnitTerminalAction = Literal["rows", "count"]
 
 
 @dataclass(frozen=True)
@@ -333,6 +343,48 @@ class QueryUnitCountStage:
         return {"kind": "count", "metric": "count"}
 
 
+@dataclass(frozen=True)
+class QueryUnitTransformStage:
+    """Named row-shaping transform stage in a terminal query-unit pipeline.
+
+    Reserved vocabulary member for #2006's ``Transform(name, args)`` pipeline
+    node. No row-level transform is wired today, so this stage is part of the
+    closed AST/payload vocabulary but is never produced by the current parser;
+    it exists so surfaces and the executor registry share one source of truth
+    for the pipeline-stage taxonomy rather than re-deriving it.
+    """
+
+    name: str
+    args: tuple[tuple[str, str], ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": "transform", "name": self.name}
+        if self.args:
+            payload["args"] = dict(self.args)
+        return payload
+
+
+@dataclass(frozen=True)
+class QueryUnitTerminalStage:
+    """Terminal action that emits the resolved query-unit set (#2006).
+
+    Every terminal query-unit pipeline ends in exactly one terminal node. The
+    ``action`` names the executor that runs the final ``select -> shape ->
+    terminal`` step (``rows`` for unit rows, ``count`` for the aggregate
+    rollup). ``args`` carries typed terminal parameters for future actions
+    (read view, analyze mode, bundle kind) without widening the node shape.
+    """
+
+    action: QueryUnitTerminalAction
+    args: tuple[tuple[str, str], ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": "terminal", "action": self.action}
+        if self.args:
+            payload["args"] = dict(self.args)
+        return payload
+
+
 QueryUnitPipelineStage = (
     QueryUnitSessionScopeStage
     | QueryUnitSortStage
@@ -340,6 +392,8 @@ QueryUnitPipelineStage = (
     | QueryUnitOffsetStage
     | QueryUnitGroupStage
     | QueryUnitCountStage
+    | QueryUnitTransformStage
+    | QueryUnitTerminalStage
 )
 
 
@@ -356,14 +410,19 @@ class QueryUnitPipeline:
     sort: QueryUnitSort | None = None
     group_by: str | None = None
     aggregate: Literal["count"] | None = None
+    terminal: QueryUnitTerminalStage = QueryUnitTerminalStage(action="rows")
 
     def to_payload(self) -> dict[str, object]:
+        # The terminal node is the final element of the ordered stage sequence
+        # (#2006 Pipeline AST: ``... Sort, Limit, Terminal(action)``), so
+        # ``stages`` and the executed ``pipeline_stages`` page metadata stay
+        # identical and always culminate in the terminal action.
         payload: dict[str, object] = {
             "source": {
                 "unit": self.source_unit,
                 "predicate": self.predicate.to_payload(),
             },
-            "stages": [stage.to_payload() for stage in self.stages],
+            "stages": [stage.to_payload() for stage in self.stages] + [self.terminal.to_payload()],
         }
         if self.session_predicate is not None:
             payload["session_scope"] = self.session_predicate.to_payload()
@@ -404,6 +463,7 @@ class QueryUnitSource:
     def pipeline(self) -> QueryUnitPipeline:
         """Return the typed executable pipeline for this terminal source."""
 
+        terminal_action: QueryUnitTerminalAction = "count" if self.aggregate == "count" else "rows"
         return QueryUnitPipeline(
             source_unit=self.unit,
             predicate=self.predicate,
@@ -414,6 +474,7 @@ class QueryUnitSource:
             sort=self.sort,
             group_by=self.group_by,
             aggregate=self.aggregate,
+            terminal=QueryUnitTerminalStage(action=terminal_action),
         )
 
 
@@ -2642,6 +2703,9 @@ __all__ = [
     "QueryUnitSortStage",
     "QueryUnitSort",
     "QueryUnitSource",
+    "QueryUnitTerminalAction",
+    "QueryUnitTerminalStage",
+    "QueryUnitTransformStage",
     "_HAS_BOOL_MAP",
     "parse_unit_source_expression",
     "parse_expression_ast",

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, cast
 
-from polylogue.archive.query.expression import QueryUnitPipeline, QueryUnitSource
+from polylogue.archive.query.expression import (
+    ExpressionCompileError,
+    QueryUnitPipeline,
+    QueryUnitSource,
+)
 from polylogue.archive.query.metadata import (
     QueryUnitDescriptor,
     query_unit_descriptor,
@@ -32,7 +36,22 @@ from polylogue.surfaces.payloads import (
 
 
 def _pipeline_stage_payloads(pipeline: QueryUnitPipeline) -> tuple[dict[str, object], ...]:
-    return tuple(stage.to_payload() for stage in pipeline.stages)
+    """Return the executed pipeline stages, ending in the terminal-action node.
+
+    The terminal node is always appended so every executed page carries the
+    full ``select -> shape -> terminal`` chain in its ``pipeline_stages``,
+    mirroring the typed AST (#2006).
+    """
+
+    return tuple(stage.to_payload() for stage in pipeline.stages) + (pipeline.terminal.to_payload(),)
+
+
+class UnsupportedTerminalActionError(ExpressionCompileError):
+    """Raised when a query-unit terminal action has no registered executor.
+
+    Typed and narrow by construction: an unknown or unwired terminal action
+    fails loudly rather than silently broadening to a different terminal (#2006).
+    """
 
 
 @dataclass(frozen=True)
@@ -163,6 +182,107 @@ def query_unit_request(
     )
 
 
+@dataclass(frozen=True)
+class TerminalExecutionContext:
+    """Resolved inputs for a single terminal-action executor invocation.
+
+    Shared shape across every registered terminal so the dispatcher in
+    :func:`_build_sql_envelope` stays a thin registry lookup and each executor
+    runs the same ``select -> shape -> terminal`` chain (#2006).
+    """
+
+    archive: ArchiveStore
+    source: QueryUnitSource
+    descriptor: QueryUnitDescriptor
+    query: str
+    limit: int
+    offset: int
+    caller_offset: int
+    fetch_limit: int
+    session_filters: Mapping[str, object] | None
+
+
+TerminalExecutor = Callable[[TerminalExecutionContext], QueryUnitResultEnvelope]
+
+
+def _execute_count_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnvelope:
+    """Terminal ``count`` action: emit the aggregate group rollup page."""
+
+    pipeline = ctx.source.pipeline
+    aggregate_sort = (
+        cast(Literal["count", "key"], pipeline.sort.field)
+        if pipeline.sort is not None and pipeline.sort.field in {"count", "key"}
+        else None
+    )
+    aggregate_sort_direction: Literal["asc", "desc"] = (
+        pipeline.sort.direction if aggregate_sort is not None and pipeline.sort is not None else "desc"
+    )
+    aggregate_rows = ctx.archive.query_unit_counts(
+        pipeline.source_unit,
+        pipeline.predicate,
+        group_by=pipeline.group_by,
+        sort=aggregate_sort,
+        sort_direction=aggregate_sort_direction,
+        limit=ctx.fetch_limit,
+        offset=ctx.offset,
+        session_filters=ctx.session_filters,
+    )
+    return build_query_unit_aggregate_envelope(
+        tuple(QueryUnitAggregateRowPayload.from_row(row) for row in aggregate_rows[: ctx.limit]),
+        unit=ctx.source.unit,
+        query=ctx.query,
+        limit=ctx.limit,
+        offset=ctx.caller_offset,
+        has_next=len(aggregate_rows) > ctx.limit,
+        pipeline=pipeline.to_payload(),
+        pipeline_stages=_pipeline_stage_payloads(pipeline),
+    )
+
+
+def _execute_rows_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnvelope:
+    """Terminal ``rows`` action: emit the resolved unit-row page."""
+
+    pipeline = ctx.source.pipeline
+    sort = pipeline.sort.field if pipeline.sort is not None else None
+    sort_direction = pipeline.sort.direction if pipeline.sort is not None else "asc"
+    method_name = ctx.descriptor.sql_query_method
+    payload_model = _row_payload_model(ctx.descriptor)
+    if method_name is None or payload_model is None:
+        raise ValueError(f"Query unit {ctx.source.unit!r} is not wired to a SQL executor")
+    query_method = cast(Any, getattr(ctx.archive, method_name))
+    rows = cast(
+        Sequence[Any],
+        query_method(
+            pipeline.predicate,
+            limit=ctx.fetch_limit,
+            offset=ctx.offset,
+            session_filters=ctx.session_filters,
+            sort=sort,
+            sort_direction=sort_direction,
+        ),
+    )
+    return build_query_unit_envelope(
+        tuple(payload_model.from_row(row) for row in rows[: ctx.limit]),
+        unit=ctx.source.unit,
+        query=ctx.query,
+        limit=ctx.limit,
+        offset=ctx.caller_offset,
+        has_next=len(rows) > ctx.limit,
+        pipeline=pipeline.to_payload(),
+        pipeline_stages=_pipeline_stage_payloads(pipeline),
+    )
+
+
+#: Single source of truth mapping a terminal-action name to its executor.
+#: The pipeline's ``terminal.action`` selects the executor; one executor runs
+#: the full ``select -> shape -> terminal`` chain for every read surface
+#: (CLI find, MCP query_units, daemon /api/query-units, Python API) (#2006).
+TERMINAL_ACTION_EXECUTORS: dict[str, TerminalExecutor] = {
+    "rows": _execute_rows_terminal,
+    "count": _execute_count_terminal,
+}
+
+
 def _build_sql_envelope(
     archive: ArchiveStore,
     source: QueryUnitSource,
@@ -176,62 +296,26 @@ def _build_sql_envelope(
     session_filters: Mapping[str, object] | None,
 ) -> QueryUnitResultEnvelope:
     pipeline = source.pipeline
-    if pipeline.aggregate == "count":
-        aggregate_sort = (
-            cast(Literal["count", "key"], pipeline.sort.field)
-            if pipeline.sort is not None and pipeline.sort.field in {"count", "key"}
-            else None
+    action = pipeline.terminal.action
+    executor = TERMINAL_ACTION_EXECUTORS.get(action)
+    if executor is None:
+        registered = ", ".join(sorted(TERMINAL_ACTION_EXECUTORS))
+        raise UnsupportedTerminalActionError(
+            f"unsupported terminal action {action!r} for {source.unit} rows; registered actions: {registered}",
+            field=None,
         )
-        aggregate_sort_direction: Literal["asc", "desc"] = (
-            pipeline.sort.direction if aggregate_sort is not None and pipeline.sort is not None else "desc"
-        )
-        aggregate_rows = archive.query_unit_counts(
-            pipeline.source_unit,
-            pipeline.predicate,
-            group_by=pipeline.group_by,
-            sort=aggregate_sort,
-            sort_direction=aggregate_sort_direction,
-            limit=fetch_limit,
-            offset=offset,
-            session_filters=session_filters,
-        )
-        return build_query_unit_aggregate_envelope(
-            tuple(QueryUnitAggregateRowPayload.from_row(row) for row in aggregate_rows[:limit]),
-            unit=source.unit,
+    return executor(
+        TerminalExecutionContext(
+            archive=archive,
+            source=source,
+            descriptor=descriptor,
             query=query,
             limit=limit,
-            offset=caller_offset,
-            has_next=len(aggregate_rows) > limit,
-            pipeline=pipeline.to_payload(),
-            pipeline_stages=_pipeline_stage_payloads(pipeline),
-        )
-    sort = pipeline.sort.field if pipeline.sort is not None else None
-    sort_direction = pipeline.sort.direction if pipeline.sort is not None else "asc"
-    method_name = descriptor.sql_query_method
-    payload_model = _row_payload_model(descriptor)
-    if method_name is None or payload_model is None:
-        raise ValueError(f"Query unit {source.unit!r} is not wired to a SQL executor")
-    query_method = cast(Any, getattr(archive, method_name))
-    rows = cast(
-        Sequence[Any],
-        query_method(
-            pipeline.predicate,
-            limit=fetch_limit,
             offset=offset,
+            caller_offset=caller_offset,
+            fetch_limit=fetch_limit,
             session_filters=session_filters,
-            sort=sort,
-            sort_direction=sort_direction,
-        ),
-    )
-    return build_query_unit_envelope(
-        tuple(payload_model.from_row(row) for row in rows[:limit]),
-        unit=source.unit,
-        query=query,
-        limit=limit,
-        offset=caller_offset,
-        has_next=len(rows) > limit,
-        pipeline=pipeline.to_payload(),
-        pipeline_stages=_pipeline_stage_payloads(pipeline),
+        )
     )
 
 
@@ -284,6 +368,10 @@ def query_unit_envelope(archive: ArchiveStore, request: QueryUnitRequest) -> Que
 
 __all__ = [
     "QueryUnitRequest",
+    "TERMINAL_ACTION_EXECUTORS",
+    "TerminalExecutionContext",
+    "TerminalExecutor",
+    "UnsupportedTerminalActionError",
     "query_unit_envelope",
     "query_unit_request",
     "query_unit_rows",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1921,6 +1921,7 @@ async def test_query_units_reports_pipeline_stages(tmp_path: Path) -> None:
             },
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},
+            {"kind": "terminal", "action": "rows"},
         )
         assert envelope.pipeline is not None
         assert envelope.pipeline["stages"] == list(envelope.pipeline_stages)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -360,7 +360,7 @@ class TestExplainExpression:
                             "kind": "and",
                         },
                     },
-                    "stages": [],
+                    "stages": [{"kind": "terminal", "action": "rows"}],
                 },
             },
         }
@@ -411,6 +411,7 @@ class TestExplainExpression:
                         {"kind": "sort", "sort": {"field": "time", "direction": "desc"}},
                         {"kind": "limit", "value": 2},
                         {"kind": "offset", "value": 3},
+                        {"kind": "terminal", "action": "rows"},
                     ],
                     "result": {
                         "sort": {"field": "time", "direction": "desc"},
@@ -460,6 +461,7 @@ class TestExplainExpression:
             "stages": [
                 _session_scope_stage("repo", "polylogue"),
                 {"kind": "limit", "value": 5},
+                {"kind": "terminal", "action": "rows"},
             ],
             "result": {"limit": 5},
         }
@@ -2063,6 +2065,7 @@ class TestBooleanQueryExpression:
             _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},
+            {"kind": "terminal", "action": "rows"},
         )
         assert envelope.pipeline is not None
         assert envelope.pipeline["stages"] == list(envelope.pipeline_stages)
@@ -2136,6 +2139,7 @@ class TestBooleanQueryExpression:
                 },
             },
             {"kind": "sort", "sort": {"field": "time", "direction": "asc"}},
+            {"kind": "terminal", "action": "rows"},
         )
         rows = [row for row in envelope.items if isinstance(row, MessageQueryRowPayload)]
         assert [row.session_id for row in rows] == [
@@ -2179,6 +2183,7 @@ class TestBooleanQueryExpression:
             _session_scope_stage("repo", "polylogue"),
             {"kind": "limit", "value": 1},
             {"kind": "offset", "value": 1},
+            {"kind": "terminal", "action": "rows"},
         ]
         assert [item["text"] for item in payload["items"]] == ["second"]
 
@@ -2224,6 +2229,7 @@ class TestBooleanQueryExpression:
             _session_scope_stage("repo", "polylogue"),
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
+            {"kind": "terminal", "action": "count"},
         )
         assert envelope.pipeline is not None
         assert envelope.pipeline["stages"] == list(envelope.pipeline_stages)
@@ -2268,6 +2274,7 @@ class TestBooleanQueryExpression:
             {"kind": "count", "metric": "count"},
             {"kind": "sort", "sort": {"field": "count", "direction": "asc"}},
             {"kind": "limit", "value": 2},
+            {"kind": "terminal", "action": "count"},
         )
         assert [(row.group_key, row.count) for row in envelope.items] == [
             ("system", 1),
@@ -2311,6 +2318,7 @@ class TestBooleanQueryExpression:
             _session_scope_stage("repo", "polylogue"),
             {"kind": "group", "field": "role"},
             {"kind": "count", "metric": "count"},
+            {"kind": "terminal", "action": "count"},
         ]
         assert sorted((item["group_key"], item["count"]) for item in payload["items"]) == [
             ("assistant", 1),
@@ -2328,6 +2336,93 @@ class TestBooleanQueryExpression:
 
         with pytest.raises(ValueError, match="Unsupported terminal query unit: bundle"):
             query_unit_rows(cast(ArchiveStore, object()), source, query="bundles where text:needle", limit=10)
+
+    def test_pipeline_carries_typed_rows_terminal_node(self) -> None:
+        from polylogue.archive.query.expression import QueryUnitTerminalStage
+
+        source = parse_unit_source_expression("messages where role:assistant | limit 2")
+        assert source is not None
+        pipeline = source.pipeline
+        assert pipeline.terminal == QueryUnitTerminalStage(action="rows")
+        stages = cast(list[dict[str, object]], pipeline.to_payload()["stages"])
+        assert stages[-1] == {"kind": "terminal", "action": "rows"}
+
+    def test_pipeline_carries_typed_count_terminal_node(self) -> None:
+        from polylogue.archive.query.expression import QueryUnitTerminalStage
+
+        source = parse_unit_source_expression("messages where role:assistant | group by role | count")
+        assert source is not None
+        pipeline = source.pipeline
+        assert pipeline.terminal == QueryUnitTerminalStage(action="count")
+        stages = cast(list[dict[str, object]], pipeline.to_payload()["stages"])
+        assert stages[-1] == {"kind": "terminal", "action": "count"}
+
+    def test_single_executor_runs_select_shape_terminal_chain(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.archive.query.unit_results import query_unit_rows
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.surfaces.payloads import MessageQueryRowPayload
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        (
+            SessionBuilder(index_db, "hit")
+            .provider("claude-code")
+            .git_repository_url("polylogue")
+            .title("terminal chain")
+            .add_message("m-old", role="assistant", text="old", timestamp="2026-01-01T00:00:00+00:00")
+            .add_message("m-new", role="assistant", text="new", timestamp="2026-01-02T00:00:00+00:00")
+            .save()
+        )
+
+        # Full pipeline: session scope -> unit filter -> shape (sort) -> terminal rows.
+        source = parse_unit_source_expression(
+            "sessions where repo:polylogue | messages where role:assistant | sort by time desc | limit 1"
+        )
+        assert source is not None
+        assert source.pipeline.terminal.action == "rows"
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            envelope = query_unit_rows(archive, source, query="terminal-chain", limit=20)
+
+        # One executor ran the whole select -> shape -> terminal chain: the page
+        # carries the terminal node as the final pipeline stage and the rows are
+        # shaped/sorted by it.
+        assert envelope.pipeline_stages[-1] == {"kind": "terminal", "action": "rows"}
+        assert envelope.limit == 1
+        rows = [row for row in envelope.items if isinstance(row, MessageQueryRowPayload)]
+        assert [row.text for row in rows] == ["new"]
+
+    def test_unsupported_terminal_action_raises_typed_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from polylogue.archive.query import unit_results
+        from polylogue.archive.query.metadata import query_unit_descriptor
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        source = parse_unit_source_expression("messages where role:assistant")
+        assert source is not None
+        descriptor = query_unit_descriptor("message")
+        assert descriptor is not None
+
+        # Simulate a terminal action with no registered executor (e.g. a future
+        # `read`/`analyze` action not yet wired). The dispatcher must fail typed
+        # and narrow, never silently broaden to a different terminal.
+        monkeypatch.delitem(unit_results.TERMINAL_ACTION_EXECUTORS, "rows")
+        with pytest.raises(unit_results.UnsupportedTerminalActionError, match="unsupported terminal action 'rows'"):
+            unit_results._build_sql_envelope(
+                cast(ArchiveStore, object()),
+                source,
+                descriptor,
+                query="messages where role:assistant",
+                limit=10,
+                offset=0,
+                caller_offset=0,
+                fetch_limit=11,
+                session_filters=None,
+            )
 
     def test_terminal_source_pipeline_sort_desc_executes_before_limit(
         self,


### PR DESCRIPTION
## Summary

Adds the `Terminal` (and reserved `Transform`) member to the query-unit
pipeline AST and routes terminal-unit dispatch (`rows` / aggregate `count`)
through a single executor registry instead of an inline `if aggregate ==
"count"` branch. This is the foundation slice of #2006's Pipeline AST
(`Source -> Filter -> ... -> Sort -> Limit -> Terminal(action)`): every
query-unit pipeline now ends in an explicit, typed terminal node, and one
executor runs the full `select -> shape -> terminal` chain for every read
surface (CLI `find`, MCP `query_units`, daemon `/api/query-units`, Python API).

## Problem

`QueryUnitPipelineStageKind` in `polylogue/archive/query/expression.py` was
`Literal["session_scope","sort","limit","offset","group","count"]` — it had no
member representing "run a terminal action over the resolved unit set." The
terminal step (return unit rows vs. return the aggregate rollup) was
special-cased inside `unit_results.py:_build_sql_envelope` with a hardcoded
`if pipeline.aggregate == "count"` branch rather than the single-source-of-truth
pipeline node + executor registry that #2006 calls for. Adding future terminal
actions meant extending that out-of-band branch.

## Solution

- `polylogue/archive/query/expression.py`
  - Extend the closed `QueryUnitPipelineStageKind` vocabulary with `transform`
    and `terminal`; add the `QueryUnitTerminalAction = Literal["rows","count"]`
    closed vocabulary.
  - Add typed AST nodes `QueryUnitTransformStage` (reserved #2006
    `Transform(name, args)` member; no row-level transform is wired today) and
    `QueryUnitTerminalStage(action, args)`.
  - `QueryUnitPipeline` carries an explicit `terminal` node, derived `rows` /
    `count` from the aggregate. The terminal is the final element of the ordered
    stage sequence, so `pipeline.to_payload()["stages"]` and the executed
    `pipeline_stages` page metadata both culminate in the terminal action and
    stay identical (the existing `pipeline["stages"] == pipeline_stages`
    invariant holds).
- `polylogue/archive/query/unit_results.py`
  - Add `TERMINAL_ACTION_EXECUTORS` mapping terminal-action name -> executor
    (`rows` -> `_execute_rows_terminal`, `count` -> `_execute_count_terminal`),
    a shared `TerminalExecutionContext`, and route `_build_sql_envelope` through
    one registry lookup. The old `if aggregate == "count"` special-case is gone
    (grep-confirmed: no second terminal dispatch remains).
  - Unknown/unwired terminal actions raise the typed
    `UnsupportedTerminalActionError` (subclass of `ExpressionCompileError`)
    instead of broadening to a different terminal.

Scope note: this slice lands the Terminal node and registry inside the
executable query-unit pipeline that `QueryUnitPipelineStageKind` governs, and
routes that subsystem's two terminals (`rows`, `count`) through it. Rerouting
the session-level CLI verbs (`read` / `analyze` / postmortem) onto this registry
is the larger #2006 ceiling that first requires `sessions` to be a pipeline
`Source` unit; the `args` field on `QueryUnitTerminalStage` and the open
`QueryUnitTerminalAction` vocabulary are the seams those actions register
against next. The session-verb dispatch (`cli/query_contracts.py` `QueryAction`
algebra) is intentionally untouched here.

## Verification

- `nix develop -c devtools verify --quick` -> `exit_code 0` (ruff format/lint,
  mypy --strict over 1675 files, `render all --check`, manifests, doc-commands).
- `nix develop -c mypy polylogue/archive/query/{expression,unit_results}.py` ->
  `Success: no issues found in 2 source files`.
- `nix develop -c python -m pytest tests/unit/cli/test_query_exec_laws.py
  tests/unit/cli/test_query_expression.py
  tests/unit/archive/test_query_metadata.py` -> `446 passed, 1 skipped`.
- Added `tests/unit/cli/test_query_expression.py` cases: typed rows/count
  terminal nodes, a full `sessions where ... | messages where ... | sort | limit`
  pipeline asserting one executor runs select->shape->terminal, and
  `test_unsupported_terminal_action_raises_typed_error` (registry miss raises
  `UnsupportedTerminalActionError`, never broadens).
- Updated envelope/explain snapshots that assert the pipeline AST shape
  (`test_query_expression`, `test_facade_contracts`) to include the terminal
  node; behavioral `read`/`analyze`/search CLI outputs are unchanged.

Ref #2006 Ref #2380