### PR TITLE
fix(insights): upsert run-projection rows on cross-session ref collisions

### DIFF
--- a/polylogue/storage/insights/session/storage.py
+++ b/polylogue/storage/insights/session/storage.py
@@ -189,9 +189,10 @@ def _placeholders(columns: Sequence[str]) -> str:
     return ", ".join("?" for _ in columns)
 
 
-def build_insert_sql(table: str, columns: Sequence[str]) -> str:
+def build_insert_sql(table: str, columns: Sequence[str], *, or_replace: bool = False) -> str:
+    verb = "INSERT OR REPLACE" if or_replace else "INSERT"
     return f"""
-        INSERT INTO {table} (
+        {verb} INTO {table} (
             {", ".join(columns)}
         ) VALUES ({_placeholders(columns)})
         """
@@ -956,7 +957,7 @@ def replace_session_runs_sync(
     conn.execute("DELETE FROM session_runs WHERE session_id = ?", (session_id,))
     if records:
         conn.executemany(
-            build_insert_sql("session_runs", _SESSION_RUN_COLUMNS),
+            build_insert_sql("session_runs", _SESSION_RUN_COLUMNS, or_replace=True),
             [session_run_insert_values(record) for record in records],
         )
 
@@ -971,7 +972,7 @@ def replace_session_runs_bulk_sync(
     records = [record for session_records in records_by_session.values() for record in session_records]
     if records:
         conn.executemany(
-            build_insert_sql("session_runs", _SESSION_RUN_COLUMNS),
+            build_insert_sql("session_runs", _SESSION_RUN_COLUMNS, or_replace=True),
             [session_run_insert_values(record) for record in records],
         )
 
@@ -984,7 +985,7 @@ def replace_session_observed_events_sync(
     conn.execute("DELETE FROM session_observed_events WHERE session_id = ?", (session_id,))
     if records:
         conn.executemany(
-            build_insert_sql("session_observed_events", _SESSION_OBSERVED_EVENT_COLUMNS),
+            build_insert_sql("session_observed_events", _SESSION_OBSERVED_EVENT_COLUMNS, or_replace=True),
             [session_observed_event_insert_values(record) for record in records],
         )
 
@@ -999,7 +1000,7 @@ def replace_session_observed_events_bulk_sync(
     records = [record for session_records in records_by_session.values() for record in session_records]
     if records:
         conn.executemany(
-            build_insert_sql("session_observed_events", _SESSION_OBSERVED_EVENT_COLUMNS),
+            build_insert_sql("session_observed_events", _SESSION_OBSERVED_EVENT_COLUMNS, or_replace=True),
             [session_observed_event_insert_values(record) for record in records],
         )
 
@@ -1012,7 +1013,7 @@ def replace_session_context_snapshots_sync(
     conn.execute("DELETE FROM session_context_snapshots WHERE session_id = ?", (session_id,))
     if records:
         conn.executemany(
-            build_insert_sql("session_context_snapshots", _SESSION_CONTEXT_SNAPSHOT_COLUMNS),
+            build_insert_sql("session_context_snapshots", _SESSION_CONTEXT_SNAPSHOT_COLUMNS, or_replace=True),
             [session_context_snapshot_insert_values(record) for record in records],
         )
 
@@ -1027,7 +1028,7 @@ def replace_session_context_snapshots_bulk_sync(
     records = [record for session_records in records_by_session.values() for record in session_records]
     if records:
         conn.executemany(
-            build_insert_sql("session_context_snapshots", _SESSION_CONTEXT_SNAPSHOT_COLUMNS),
+            build_insert_sql("session_context_snapshots", _SESSION_CONTEXT_SNAPSHOT_COLUMNS, or_replace=True),
             [session_context_snapshot_insert_values(record) for record in records],
         )
 

--- a/polylogue/storage/sqlite/queries/_bulk_replace.py
+++ b/polylogue/storage/sqlite/queries/_bulk_replace.py
@@ -39,6 +39,7 @@ async def replace_insight_rows(
     records: Sequence[T],
     extractor: Callable[[T], tuple[Any, ...]],
     transaction_depth: int,
+    or_replace: bool = False,
 ) -> None:
     """DELETE rows matching ``id_values`` then INSERT ``records``.
 
@@ -59,7 +60,7 @@ async def replace_insight_rows(
         )
     if records:
         await conn.executemany(
-            build_insert_sql(table, columns),
+            build_insert_sql(table, columns, or_replace=or_replace),
             [extractor(record) for record in records],
         )
     if transaction_depth == 0:

--- a/polylogue/storage/sqlite/queries/session_insight_run_projection_writes.py
+++ b/polylogue/storage/sqlite/queries/session_insight_run_projection_writes.py
@@ -55,6 +55,7 @@ async def replace_session_runs_bulk(
         records=records,
         extractor=session_run_insert_values,
         transaction_depth=transaction_depth,
+        or_replace=True,
     )
 
 
@@ -82,6 +83,7 @@ async def replace_session_observed_events_bulk(
         records=records,
         extractor=session_observed_event_insert_values,
         transaction_depth=transaction_depth,
+        or_replace=True,
     )
 
 
@@ -109,4 +111,5 @@ async def replace_session_context_snapshots_bulk(
         records=records,
         extractor=session_context_snapshot_insert_values,
         transaction_depth=transaction_depth,
+        or_replace=True,
     )

--- a/tests/unit/insights/test_run_projection_materialization.py
+++ b/tests/unit/insights/test_run_projection_materialization.py
@@ -136,3 +136,60 @@ async def test_run_projection_materialization_parity(tmp_path: Path) -> None:
         await replace_session_runs(conn, session_id, run_records, 0)
         rerun = await list_runs(conn, RunProjectionListQuery(session_id=session_id, limit=None))
         assert [record.run for record in rerun] == list(projection.runs)
+
+
+def test_run_ref_collision_across_sessions_upserts(tmp_path: Path) -> None:
+    """A subagent run (parent's projection) shares its run_ref with the child
+    session's own main run — both are ``run:<child_session_id>``. Materializing
+    both in one bulk pass must not violate the ``run_ref`` PRIMARY KEY; the
+    run-projection writers upsert (INSERT OR REPLACE) so the shared run collapses
+    to one row. Reproduces the real-archive failure that synthetic distinct-id
+    fixtures never triggered.
+    """
+    from polylogue.core.refs import EvidenceRef, ObjectRef
+    from polylogue.insights.run_projection import ProjectedRun, RunProjection
+    from polylogue.storage.insights.session.storage import replace_session_runs_bulk_sync
+
+    ev = (EvidenceRef.parse("codex-session:child::m1"),)
+    shared = ObjectRef.parse("run:codex-session:child")
+    parent = RunProjection(
+        session_id="codex-session:parent",
+        runs=(
+            ProjectedRun(run_ref=ObjectRef.parse("run:codex-session:parent"), role="main", evidence_refs=ev),
+            ProjectedRun(
+                run_ref=shared,
+                role="subagent",
+                parent_run_ref=ObjectRef.parse("run:codex-session:parent"),
+                evidence_refs=ev,
+            ),
+        ),
+    )
+    child = RunProjection(
+        session_id="codex-session:child",
+        runs=(ProjectedRun(run_ref=shared, role="main", evidence_refs=ev),),
+    )
+
+    conn = sqlite3.connect(tmp_path / "index.db")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(INDEX_DDL)
+    for native in ("parent", "child"):
+        conn.execute(
+            "INSERT INTO sessions(native_id, origin, content_hash) VALUES(?, ?, ?)",
+            (native, "codex-session", b"\x00" * 32),
+        )
+    conn.commit()
+
+    # Previously raised: sqlite3.IntegrityError: UNIQUE constraint failed: session_runs.run_ref
+    replace_session_runs_bulk_sync(
+        conn,
+        {
+            "codex-session:parent": build_session_run_records(parent, materialized_at=_MATERIALIZED_AT),
+            "codex-session:child": build_session_run_records(child, materialized_at=_MATERIALIZED_AT),
+        },
+    )
+
+    shared_rows = conn.execute("SELECT run_ref FROM session_runs WHERE run_ref = ?", (shared.format(),)).fetchall()
+    assert len(shared_rows) == 1  # the shared run collapsed to one row, no crash
+    total = conn.execute("SELECT count(*) FROM session_runs").fetchone()[0]
+    assert total == 2  # run:...:parent (main) + the single shared run:...:child
+    conn.close()


### PR DESCRIPTION
## Summary

The run-projection materializer (#2458) crashes on any real archive that contains subagent lineages: `UNIQUE constraint failed: session_runs.run_ref`, aborting the entire insight rebuild. This makes the run-projection writers `INSERT OR REPLACE` so a `run_ref`/`event_ref`/`snapshot_ref` shared across sessions collapses to a single row.

## Problem

`session_runs.run_ref` (and the `event_ref`/`snapshot_ref` PKs) are **global** primary keys, but run refs are **not** globally unique: a subagent's run is emitted twice —

- as the **child session's own main run** (`run:<child_session_id>`), and
- as the **parent session's subagent run** (also `run:<child_session_id>`).

In a full insight rebuild both land in one `executemany`, violating the PK. Synthetic fixtures (distinct ids per session) never hit this; it fires immediately on a real archive. Discovered live while migrating the production 16,398-session archive to index v11 — the very first full materialization aborted on it.

## Solution

`build_insert_sql(..., or_replace=True)` and a matching `or_replace` flag on the async `replace_insight_rows` helper; the three run-projection writers (sync single + bulk, async) opt in. The shared run collapses to one row, last write wins. This is deterministic: the bulk rebuild flattens records in stable session-page order (`iter_session_id_pages_sync`, ordered by `session_id`), so the same archive always yields the same winner.

Follow-up (not blocking): make the canonical winner *semantically* preferred (the child's `main` run over the parent's `subagent` view) rather than order-determined.

## Verification

- New regression test `test_run_ref_collision_across_sessions_upserts` reproduces the parent+child shared-`run_ref` collision through `replace_session_runs_bulk_sync`; asserts no crash and one row for the shared run. Fails (IntegrityError) without the fix.
- `pytest tests/unit/insights/test_run_projection_materialization.py` → 2 passed.
- `mypy --strict` clean on the changed files.
- Confirmed against the real production archive: the full 16,398-session materialization that aborted now completes.

Ref #2458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session data saving so repeated writes update existing records instead of failing or creating duplicates.
  * Fixed an edge case where shared run references across sessions are now handled safely during bulk updates.
  * Session run, observed event, and context snapshot syncing now uses replace-on-conflict behavior for more reliable persistence.

* **Tests**
  * Added coverage for cross-session run reference collisions to verify the new update behavior works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->