### PR TITLE
perf(insights): bound insight-rebuild WAL via per-chunk commits (Ref #2458)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1201,6 +1201,16 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 11 materializes the run projection into three derived
+  read-model tables — `session_runs`, `session_observed_events`, and
+  `session_context_snapshots` — recomputed by the session-insight materializer
+  (`compile_recovery_digest(...).run_projection`) exactly like `session_profiles`.
+  They give the `run` / `observed-event` / `context-snapshot` query units a
+  durable SQL-backed lowerer (terminal rows, `exists`, and sort) instead of the
+  per-query recovery-transform scan. They are derived/rebuildable, not a new
+  source of truth; the durable evidence stays `session_events` + `messages` +
+  `topology_edges`. Existing index tiers must be rebuilt from source evidence
+  (`polylogue ops reset --database && polylogued run`).
 - Index schema version 10 adds a role-leading `idx_messages_role` index so
   daemon `/api/facets` can compute global role counts without scanning the
   session-role compound index and spilling to a temp B-tree. Existing index

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -855,6 +855,77 @@ def _delete_tables_with_progress_sync(
             )
 
 
+# Per-session insight tables keyed by session_id with ON DELETE CASCADE to
+# sessions(session_id). The full rebuild upserts these per chunk and commits
+# per chunk (bounded WAL), so it no longer clears them upfront — old rows for
+# not-yet-processed sessions stay visible until their chunk runs (no empty
+# window). Rows whose session was deleted since the last rebuild are pruned
+# after the chunk loop instead (see _delete_orphan_session_insights_*).
+_PER_SESSION_INSIGHT_TABLES: tuple[str, ...] = (
+    "session_work_events",
+    "session_phases",
+    "session_runs",
+    "session_observed_events",
+    "session_context_snapshots",
+    "session_latency_profiles",
+    "session_profiles",
+)
+
+
+def _delete_orphan_session_insights_sync(
+    conn: sqlite3.Connection,
+    *,
+    progress_callback: ProgressCallback | None,
+) -> None:
+    """Delete per-session insight rows whose session no longer exists.
+
+    Because the full rebuild upserts per-session insight rows chunk-by-chunk
+    instead of clearing them upfront, sessions deleted since the last rebuild
+    leave orphan insight rows behind. The write profile enforces
+    ``foreign_keys=ON`` so a session DELETE normally cascades to these tables,
+    but ingest/maintenance paths that mutate ``sessions`` with FK enforcement
+    disabled can leave orphans; prune them explicitly for safety.
+    """
+    for table in _PER_SESSION_INSIGHT_TABLES:
+        deleted = conn.execute(
+            f"DELETE FROM {table} WHERE session_id NOT IN (SELECT session_id FROM sessions)"
+        ).rowcount
+        if progress_callback is not None:
+            progress_callback(int(max(deleted, 0)), desc=f"rebuild: pruned orphans from {table}")
+
+
+async def _delete_orphan_session_insights_async(
+    conn: aiosqlite.Connection,
+    *,
+    progress_callback: ProgressCallback | None,
+) -> None:
+    """Async sibling of ``_delete_orphan_session_insights_sync``."""
+    for table in _PER_SESSION_INSIGHT_TABLES:
+        cursor = await conn.execute(f"DELETE FROM {table} WHERE session_id NOT IN (SELECT session_id FROM sessions)")
+        if progress_callback is not None:
+            rowcount = getattr(cursor, "rowcount", 0) or 0
+            progress_callback(int(rowcount if rowcount > 0 else 0), desc=f"rebuild: pruned orphans from {table}")
+
+
+async def _load_message_counts_async(
+    conn: aiosqlite.Connection,
+    session_ids: Sequence[str],
+) -> dict[str, int]:
+    if not session_ids:
+        return {}
+    placeholders = ", ".join("?" for _ in session_ids)
+    cursor = await conn.execute(
+        f"""
+        SELECT session_id, message_count
+        FROM sessions
+        WHERE session_id IN ({placeholders})
+        """,
+        tuple(session_ids),
+    )
+    rows = await cursor.fetchall()
+    return {str(row["session_id"]): int(row["message_count"] or 0) for row in rows}
+
+
 def rebuild_session_insights_sync(
     conn: sqlite3.Connection,
     *,
@@ -875,37 +946,47 @@ def rebuild_session_insights_sync(
     previous_profile_groups: set[tuple[str, str]] = set()
     thread_materialized_at_ms = _epoch_ms_or_none(now_iso()) or 0
     if session_ids is None:
-        # #1607: the seven DELETEs hold the write lock for seconds-to-minutes
-        # at archive scale and were previously silent. Emit a progress
-        # heartbeat per table so the operator sees forward motion instead
-        # of full insight rebuilds appearing to hang with no output.
-        # The full rebuild stays inside one transaction (the implicit tx
-        # started by the first DELETE spans every subsequent DML through
-        # the final ``conn.commit()`` at the bottom of this function), so
-        # a SIGKILL mid-rebuild rolls the WAL back to the prior state on
-        # the next open — the prior insights are intact, not emptied.
-        # thread_sessions before threads keeps the FK cascade ordering explicit
-        # even if foreign_keys are off; both are repopulated per root in the
-        # thread-refresh phase below. The 'thread' materialization markers are
-        # cleared then re-stamped there so readiness stale_thread_count reflects
-        # exactly the rebuilt membership.
-        _delete_tables_with_progress_sync(
-            conn,
-            tables=(
-                "session_work_events",
-                "session_phases",
-                "session_runs",
-                "session_observed_events",
-                "session_context_snapshots",
-                "session_latency_profiles",
-                "session_profiles",
-                "session_tag_rollups",
-                "thread_sessions",
-                "threads",
-            ),
-            progress_callback=progress_callback,
+        # #1607 / bounded-WAL rebuild model:
+        #
+        # The previous design cleared every per-session insight table upfront
+        # and rebuilt the whole archive inside ONE transaction, committing
+        # once at the end. At production scale (16K+ sessions) that held the
+        # write lock for minutes and grew the WAL into multi-GB territory
+        # (~6 GB observed), and it blocked readers for the entire window.
+        #
+        # The new model commits per chunk so the WAL is bounded to roughly one
+        # message-budget chunk:
+        #   * Per-session insight rows are NOT cleared upfront. Each chunk
+        #     upserts (DELETE-by-session + INSERT) via the bulk writers, so a
+        #     not-yet-processed session keeps its OLD insight rows visible until
+        #     its chunk runs — there is no window where the archive shows empty
+        #     per-session insights.
+        #   * Sessions deleted since the last rebuild leave orphan insight rows
+        #     (the rebuild no longer wipes the tables); they are pruned by
+        #     _delete_orphan_session_insights_sync after the chunk loop.
+        #   * Aggregate tables (thread_sessions, threads, session_tag_rollups)
+        #     and the 'thread' materialization markers are still cleared and
+        #     rebuilt in the aggregate phase below; that phase is comparatively
+        #     small and stays in its own final transaction.
+        #
+        # Resumability: a crash mid-rebuild leaves a mix of freshly-upserted and
+        # stale per-session insight rows (never an emptied archive). The next
+        # full rebuild or incremental convergence simply re-upserts and finishes
+        # the orphan/aggregate phases.
+        #
+        # The full path message-budget chunks like the incremental path so a
+        # page of a few giant sessions cannot blow up RSS or the per-chunk WAL.
+        all_session_ids = tuple(str(row["session_id"]) for row in conn.execute(_ALL_SESSION_IDS_SQL).fetchall())
+        message_counts = _load_message_counts_sync(conn, all_session_ids)
+        session_chunks = (
+            chunk.session_ids
+            for chunk in _chunk_session_ids_by_message_budget_sync(
+                all_session_ids,
+                message_counts=message_counts,
+                page_size=page_size,
+                message_budget=_SESSION_INSIGHT_REBUILD_MESSAGE_BUDGET,
+            )
         )
-        session_chunks = iter_session_id_pages_sync(conn, page_size=page_size)
     else:
         session_ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids))
         t0 = time.perf_counter()
@@ -1016,11 +1097,18 @@ def rebuild_session_insights_sync(
         if len(batch.messages) >= _SESSION_INSIGHT_RELEASE_MESSAGE_THRESHOLD:
             del batch, record_bundles
             release_process_memory()
+        # Commit each chunk so the WAL is bounded to one message-budget chunk
+        # instead of the whole archive. The bulk writers upsert per session, so
+        # committing mid-rebuild leaves processed sessions fresh and
+        # not-yet-processed sessions on their prior rows (no empty window).
+        conn.commit()
     if not saw_session_ids:
         if session_ids is None:
+            # Empty-archive full rebuild: every per-session insight row is now an
+            # orphan (its session is gone). Prune them plus the aggregate tables.
+            _delete_orphan_session_insights_sync(conn, progress_callback=progress_callback)
             conn.execute("DELETE FROM thread_sessions")
             conn.execute("DELETE FROM threads")
-            conn.execute("DELETE FROM session_phases")
             conn.execute("DELETE FROM session_tag_rollups")
             conn.execute("DELETE FROM insight_materialization WHERE insight_type = 'thread'")
         conn.commit()
@@ -1057,8 +1145,19 @@ def rebuild_session_insights_sync(
             tag_rollups=int(tag_rollup_count),
         )
 
-    # threads / thread_sessions were cleared in the DELETE phase above; re-stamp
-    # the 'thread' markers so readiness reflects only the rebuilt membership.
+    # Per-session insight rows were upserted (not cleared upfront), so prune any
+    # whose session no longer exists before the aggregate phase. foreign_keys=ON
+    # on the write profile normally cascades session deletes here, but prune
+    # explicitly so an FK-disabled mutation path cannot leave stale insights.
+    _delete_orphan_session_insights_sync(conn, progress_callback=progress_callback)
+
+    # threads / thread_sessions are rebuilt by upsert per surviving root; clear
+    # them (and the 'thread' markers) first so roots that disappeared do not
+    # leave stale aggregate rows. This aggregate phase is comparatively small
+    # and commits once at the end. thread_sessions before threads keeps the FK
+    # cascade ordering explicit even if foreign_keys are off.
+    conn.execute("DELETE FROM thread_sessions")
+    conn.execute("DELETE FROM threads")
     conn.execute("DELETE FROM insight_materialization WHERE insight_type = 'thread'")
     thread_count = 0
     for root_chunk in iter_root_id_pages_sync(conn):
@@ -1105,37 +1204,40 @@ async def rebuild_session_insights_async(
         replace_session_work_events,
     )
 
-    if session_ids is None:
-        # See _delete_tables_with_progress_sync for the sync analogue and
-        # the #1607 context. The implicit transaction spans every DML
-        # through the eventual COMMIT, so SIGKILL mid-rebuild rolls back
-        # to prior state on next open.
-        for table in (
-            "session_work_events",
-            "session_phases",
-            "session_runs",
-            "session_observed_events",
-            "session_context_snapshots",
-            "session_latency_profiles",
-            "session_profiles",
-            "session_tag_rollups",
-        ):
-            cursor = await conn.execute(f"DELETE FROM {table}")
-            if progress_callback is not None:
-                rowcount = getattr(cursor, "rowcount", 0) or 0
-                progress_callback(int(rowcount if rowcount > 0 else 0), desc=f"rebuild: cleared {table}")
-    elif not session_ids:
+    # Bounded-WAL parity with rebuild_session_insights_sync (#1607): the full
+    # rebuild no longer clears the per-session insight tables upfront. Each
+    # chunk upserts (DELETE-by-session + INSERT) and commits, so the WAL is
+    # bounded to one chunk and not-yet-processed sessions keep their prior
+    # insight rows visible (no empty window). Orphan rows for deleted sessions
+    # are pruned after the loop; aggregate tables are cleared in the aggregate
+    # phase below. Per-chunk commits are gated on transaction_depth == 0 so a
+    # nested-savepoint caller is never committed out from under.
+    if session_ids is not None and not session_ids:
         # An empty target list means "rebuild these zero sessions" — a no-op,
         # NOT a global wipe. Mirror rebuild_session_insights_sync, which returns
         # early for an empty (non-None) session_ids without deleting anything.
-        # Only session_ids is None (full rebuild) clears the derived tables above.
         return _empty_rebuild_counts()
+
+    commit_per_chunk = transaction_depth == 0
 
     profile_count = 0
     work_event_count = 0
     phase_count = 0
     if session_ids is None:
-        async for chunk in iter_session_id_pages_async(conn, page_size=page_size):
+        all_session_ids = [
+            str(row["session_id"]) for row in await (await conn.execute(_ALL_SESSION_IDS_SQL)).fetchall()
+        ]
+        message_counts = await _load_message_counts_async(conn, all_session_ids)
+        full_chunks = [
+            full_chunk.session_ids
+            for full_chunk in _chunk_session_ids_by_message_budget_sync(
+                all_session_ids,
+                message_counts=message_counts,
+                page_size=page_size,
+                message_budget=_SESSION_INSIGHT_REBUILD_MESSAGE_BUDGET,
+            )
+        ]
+        for chunk in full_chunks:
             batch = await load_async_batch(conn, chunk)
             root_ids_by_session = await thread_root_ids_async(conn, chunk)
             record_bundles = build_session_insight_record_bundles(
@@ -1191,6 +1293,8 @@ async def rebuild_session_insights_async(
             if len(batch.messages) >= _SESSION_INSIGHT_RELEASE_MESSAGE_THRESHOLD:
                 del batch, record_bundles
                 release_process_memory()
+            if commit_per_chunk:
+                await conn.commit()
     else:
         for chunk_ids in chunked(list(session_ids), size=page_size):
             batch = await load_async_batch(conn, chunk_ids)
@@ -1248,6 +1352,15 @@ async def rebuild_session_insights_async(
             if len(batch.messages) >= _SESSION_INSIGHT_RELEASE_MESSAGE_THRESHOLD:
                 del batch, record_bundles
                 release_process_memory()
+            if commit_per_chunk:
+                await conn.commit()
+
+    if session_ids is None:
+        # Full rebuild upserted per-session insight rows without an upfront
+        # clear; prune rows for sessions deleted since the last rebuild before
+        # the aggregate phase (foreign_keys=ON normally cascades, but prune
+        # explicitly for safety — parity with the sync path).
+        await _delete_orphan_session_insights_async(conn, progress_callback=progress_callback)
 
     await conn.execute("DELETE FROM threads")
     thread_count = 0

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -712,19 +712,21 @@ def test_session_insight_rebuild_sync_reports_progress(cli_workspace: CliWorkspa
         progress_callback=lambda amount, desc=None: observed.append((json_int(amount), desc)),
     )
 
-    # The canonical full-rebuild path emits a "rebuild: cleared <table>" event
-    # per DELETE before materializing the session-insight tables (#1743 P13:
-    # the archive rebuild now delegates to rebuild_session_insights_sync).
-    cleared_events = [event for event in observed if event[1] and event[1].startswith("rebuild: cleared ")]
-    assert [desc for _, desc in cleared_events] == [
-        "rebuild: cleared session_work_events",
-        "rebuild: cleared session_phases",
-        "rebuild: cleared session_latency_profiles",
-        "rebuild: cleared session_profiles",
-        "rebuild: cleared session_tag_rollups",
-        "rebuild: cleared thread_sessions",
-        "rebuild: cleared threads",
+    # Bounded-WAL model (#2458): the full rebuild no longer clears per-session
+    # insight tables upfront. It upserts/commits per chunk and prunes orphan
+    # rows after the loop, emitting a per-table "pruned orphans" heartbeat. The
+    # old upfront "cleared session_*" heartbeats must be gone.
+    prune_events = [event for event in observed if event[1] and event[1].startswith("rebuild: pruned orphans from ")]
+    assert [desc for _, desc in prune_events] == [
+        "rebuild: pruned orphans from session_work_events",
+        "rebuild: pruned orphans from session_phases",
+        "rebuild: pruned orphans from session_runs",
+        "rebuild: pruned orphans from session_observed_events",
+        "rebuild: pruned orphans from session_context_snapshots",
+        "rebuild: pruned orphans from session_latency_profiles",
+        "rebuild: pruned orphans from session_profiles",
     ]
+    assert not [event for event in observed if event[1] and event[1].startswith("rebuild: cleared session_")]
 
 
 def test_session_insight_rebuild_materializes_profile_and_repo_for_git_session(

--- a/tests/unit/storage/test_session_insight_rebuild_progress.py
+++ b/tests/unit/storage/test_session_insight_rebuild_progress.py
@@ -1,17 +1,20 @@
-"""Progress reporting + atomicity invariants for ``rebuild_session_insights_sync`` (#1607).
+"""Progress reporting + bounded-WAL invariants for ``rebuild_session_insights_sync``.
 
-Pins two contracts:
+Pins the contracts of the bounded-WAL rebuild model (#1607 heartbeats, #2458
+per-chunk commit):
 
-1. The seven DELETEs that open a full rebuild emit a progress event per
-   table (instead of running silently for seconds-to-minutes against
-   the production-scale insight tables). Operators tailing the log see
-   forward motion at table granularity, not "stuck at start".
+1. ``_delete_tables_with_progress_sync`` still emits one progress event per
+   table it clears (the aggregate-table helper, exercised directly below).
 
-2. The full rebuild runs as a single transaction — the implicit
-   transaction started by the first DELETE spans every subsequent DML
-   through the eventual ``conn.commit()``. A SIGKILL or unraised
-   exception before COMMIT must leave the prior insights intact rather
-   than emptying the archive.
+2. The full rebuild no longer clears per-session insight tables upfront. It
+   upserts per chunk, commits per chunk (bounded WAL), and prunes orphan rows
+   after the chunk loop — emitting a per-table "pruned orphans" heartbeat so
+   operators still see forward motion.
+
+3. Because per-session insight rows are upserted (not wiped) and the failing
+   chunk never commits, an exception mid-rebuild leaves the prior insights
+   intact rather than emptying the archive — now achieved by upsert + no
+   upfront delete instead of one giant transaction.
 """
 
 from __future__ import annotations
@@ -102,12 +105,13 @@ def test_delete_tables_progress_callback_is_optional(tmp_path: Path) -> None:
         conn.close()
 
 
-def test_full_rebuild_emits_progress_for_each_deleted_table(
+def test_full_rebuild_emits_orphan_prune_progress_per_table(
     cli_workspace: dict[str, Path],
 ) -> None:
-    """The full native ``rebuild_insights`` path must surface DELETE progress
-    through the user-supplied callback so "polylogue ... --rebuild-insights"
-    stops hanging silently (#1607 parity over archive)."""
+    """The bounded-WAL full rebuild (#2458) does not clear per-session insight
+    tables upfront; it prunes orphan rows after the chunk loop and emits a
+    per-table heartbeat so the operator still sees forward motion. The old
+    upfront "cleared session_*" heartbeats must be gone."""
     db_path = cli_workspace["db_path"]
     (
         SessionBuilder(db_path, "conv-1")
@@ -125,31 +129,34 @@ def test_full_rebuild_emits_progress_for_each_deleted_table(
 
     _rebuild(db_path, progress_callback=progress)
 
-    delete_events = [desc for desc in events if desc and desc.startswith("rebuild: cleared ")]
-    assert delete_events == [
-        "rebuild: cleared session_work_events",
-        "rebuild: cleared session_phases",
-        "rebuild: cleared session_latency_profiles",
-        "rebuild: cleared session_profiles",
-        "rebuild: cleared session_tag_rollups",
-        "rebuild: cleared thread_sessions",
-        "rebuild: cleared threads",
+    prune_events = [desc for desc in events if desc and desc.startswith("rebuild: pruned orphans from ")]
+    assert prune_events == [
+        "rebuild: pruned orphans from session_work_events",
+        "rebuild: pruned orphans from session_phases",
+        "rebuild: pruned orphans from session_runs",
+        "rebuild: pruned orphans from session_observed_events",
+        "rebuild: pruned orphans from session_context_snapshots",
+        "rebuild: pruned orphans from session_latency_profiles",
+        "rebuild: pruned orphans from session_profiles",
     ]
+    # The bounded-WAL model removed the upfront per-session table wipe.
+    assert not [desc for desc in events if desc and desc.startswith("rebuild: cleared session_")]
 
 
 # ---------------------------------------------------------------------------
-# Atomicity — SIGKILL/exception mid-rebuild leaves prior insights intact
+# No-empty-window — exception mid-rebuild leaves prior insights intact
 # ---------------------------------------------------------------------------
 
 
-def test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles(
+def test_full_rebuild_failure_preserves_prior_profiles(
     cli_workspace: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If the rebuild loop raises between the DELETE phase and ``conn.commit()``,
-    the implicit transaction must roll back so prior session_profiles
-    survive — not the "seconds-to-minutes of empty archive" the #1607
-    report worried about.
+    """In the bounded-WAL model (#2458) there is no upfront wipe of per-session
+    insight tables: each chunk upserts and commits independently. If the loop
+    raises while building the first chunk's records, that chunk never commits
+    and no other session's rows were touched, so the prior session_profiles
+    survive — not the "seconds-to-minutes of empty archive" #1607 worried about.
     """
     db_path = cli_workspace["db_path"]
     (
@@ -166,9 +173,10 @@ def test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles(
     baseline = _count_profiles(db_path)
     assert baseline >= 1, "baseline rebuild produced no profiles"
 
-    # Now arrange for the next rebuild's per-session loop to fail after the
-    # DELETE phase. The archive rebuild imports build_session_insight_records
-    # at call time from the rebuild module, so patching it there is observed.
+    # Now arrange for the next rebuild's per-session loop to fail while building
+    # the first chunk's records (before any chunk commit). The archive rebuild
+    # imports build_session_insight_records at call time from the rebuild
+    # module, so patching it there is observed.
     from polylogue.storage.insights.session import rebuild as rebuild_module
 
     def _explode(*args: object, **kwargs: object) -> None:
@@ -179,7 +187,7 @@ def test_full_rebuild_rolls_back_on_exception_keeping_prior_profiles(
     with pytest.raises(RuntimeError, match="simulated mid-rebuild failure"):
         _rebuild(db_path)
 
-    # The post-failure count must equal the baseline. If the DELETEs had
-    # leaked past their implicit transaction, this would be 0.
+    # The post-failure count must equal the baseline. If the rebuild had wiped
+    # the per-session tables upfront, this would be 0.
     surviving = _count_profiles(db_path)
     assert surviving == baseline, f"rebuild failure emptied prior insights: baseline={baseline}, surviving={surviving}"

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -688,6 +689,107 @@ def test_targeted_session_insight_rebuild_splits_large_message_batches(
 
     assert counts.profiles == 3
     assert chunk_profile_counts == [1, 2]
+
+
+def test_full_rebuild_commits_incrementally_and_prunes_orphans(tmp_path: Path) -> None:
+    """Bounded-WAL full rebuild (#2458) must:
+
+    1. commit each chunk so intermediate committed state is visible from a
+       second connection;
+    2. keep prior per-session insights visible for not-yet-processed sessions
+       during the rebuild (no empty window);
+    3. prune per-session insight rows whose session was deleted since the last
+       rebuild (orphan cleanup).
+    """
+    db_path = _current_index_db(tmp_path, "bounded-wal-rebuild")
+    live_natives = ["conv-live-0", "conv-live-1", "conv-live-2"]
+    orphan_native = "conv-orphan"
+
+    with open_connection(db_path) as conn:
+        for native in [*live_natives, orphan_native]:
+            store_records(
+                session=make_session(native, title=f"v1-{native}"),
+                messages=[make_message(f"{native}:msg-1", native, text=f"work {native}")],
+                attachments=[],
+                conn=conn,
+            )
+        conn.commit()
+        # Baseline rebuild: every session gets a profile row.
+        rebuild_session_insights_sync(conn)
+        conn.commit()
+
+    live_ids = [_sid(native) for native in live_natives]
+    orphan_id = _sid(orphan_native)
+
+    with open_connection(db_path) as conn:
+        baseline = {
+            str(row["session_id"]) for row in conn.execute("SELECT session_id FROM session_profiles").fetchall()
+        }
+    assert baseline == {*live_ids, orphan_id}
+
+    # Flip live session titles v1 -> v2 (so the rebuilt profile.title changes).
+    with open_connection(db_path) as conn:
+        for native in live_natives:
+            conn.execute("UPDATE sessions SET title = ? WHERE session_id = ?", (f"v2-{native}", _sid(native)))
+        conn.commit()
+
+    # Delete the orphan's session row WITHOUT FK cascade (a plain sqlite3
+    # connection has foreign_keys OFF by default) so its session_profiles row
+    # survives as an orphan the rebuild must prune.
+    with sqlite3.connect(str(db_path)) as raw:
+        raw.execute("DELETE FROM sessions WHERE session_id = ?", (orphan_id,))
+        raw.commit()
+
+    with open_connection(db_path) as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM session_profiles WHERE session_id = ?",
+                (orphan_id,),
+            ).fetchone()[0]
+            == 1
+        ), "orphan profile should still be present going into the rebuild"
+
+    committed_v2_counts: list[int] = []
+    live_profile_counts: list[int] = []
+
+    def observe(amount: int, desc: str | None = None) -> None:
+        del amount
+        # Sample only on per-chunk materialize heartbeats, not the orphan-prune
+        # or aggregate-clear heartbeats (those descs start with "rebuild:").
+        if desc is not None and desc.startswith("rebuild:"):
+            return
+        with sqlite3.connect(str(db_path)) as probe:
+            probe.row_factory = sqlite3.Row
+            rows = probe.execute(
+                "SELECT session_id, title FROM session_profiles WHERE session_id IN (?, ?, ?)",
+                tuple(live_ids),
+            ).fetchall()
+        # Every live session always has a profile row at every callback (no empty window).
+        live_profile_counts.append(len({str(row["session_id"]) for row in rows}))
+        # Live profiles whose committed title already flipped to v2.
+        committed_v2_counts.append(sum(1 for row in rows if str(row["title"]).startswith("v2-")))
+
+    with open_connection(db_path) as conn:
+        counts = rebuild_session_insights_sync(conn, page_size=1, progress_callback=observe)
+
+    # 3 live sessions, page_size=1 -> 3 single-session chunks -> 3 materialize callbacks.
+    assert len(committed_v2_counts) == 3
+    # No empty window: every live session is present at every callback.
+    assert live_profile_counts == [3, 3, 3]
+    # Incremental commit: the callback fires before its own chunk commits, so the
+    # count of already-committed v2 profiles grows 0 -> 1 -> 2 across chunks. A
+    # single end-of-rebuild commit would instead leave this [0, 0, 0].
+    assert committed_v2_counts == [0, 1, 2]
+
+    with open_connection(db_path) as conn:
+        final = {
+            str(row["session_id"]): str(row["title"])
+            for row in conn.execute("SELECT session_id, title FROM session_profiles").fetchall()
+        }
+    # Orphan pruned; all live profiles rebuilt to v2.
+    assert set(final) == set(live_ids)
+    assert all(title.startswith("v2-") for title in final.values())
+    assert counts.profiles == 3
 
 
 def test_full_rebuild_restores_thread_spine_membership_and_markers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`rebuild_session_insights_sync`/`_async` now commit per chunk instead of once
per call, and the full-rebuild path message-budget chunks like the incremental
path. This bounds the rebuild WAL to roughly one message-budget chunk and
removes the empty-insight window, without regressing correctness.

## Problem

The full-rebuild path (`session_ids is None`) cleared every per-session insight
table upfront and rebuilt the entire archive inside ONE transaction, committing
once at the end. On the production archive (16,398 sessions / 28.8 GB) this held
the write lock for many minutes and grew a **~6 GB WAL**, blocking readers for
the whole window. The full path also paginated by a fixed `page_size` (50)
rather than by message budget, so a page of a few giant sessions was unbounded
in RSS and per-chunk WAL. (The incremental `session_ids` path already
message-budget-chunked but still committed once per call.)

## Solution

`polylogue/storage/insights/session/rebuild.py`:

- **Commit per chunk** in the shared rebuild loop (sync) — bounds the WAL to one
  message-budget chunk. The async sibling mirrors this, gated on
  `transaction_depth == 0` so a nested-savepoint caller is never committed out
  from under (its `replace_*` helpers already commit at depth 0).
- **Full path message-budget chunks**: gather all `session_ids`,
  `_load_message_counts_*`, then `_chunk_session_ids_by_message_budget_sync`
  instead of fixed `iter_session_id_pages_sync(page_size)`. Added
  `_load_message_counts_async` for parity.
- **No empty-window regression**: dropped the upfront global DELETE of the
  per-session insight tables (`session_profiles`, `session_latency_profiles`,
  `session_work_events`, `session_phases`, `session_runs`,
  `session_observed_events`, `session_context_snapshots`). The per-session bulk
  writers already DELETE-by-session + INSERT (upsert), so processed sessions get
  fresh rows while not-yet-processed sessions keep their OLD rows visible until
  their chunk runs.
- **Orphan cleanup**: new `_delete_orphan_session_insights_sync/_async` delete
  per-session insight rows whose `session_id` is no longer in `sessions`, run
  after the chunk loop. The write profile sets `foreign_keys=ON` (so a session
  DELETE normally cascades — every per-session insight table is
  `REFERENCES sessions(session_id) ON DELETE CASCADE`), but an FK-disabled
  mutation path could leave orphans, so the prune is explicit for safety.
- Aggregate tables (`thread_sessions`, `threads`, `session_tag_rollups`) and the
  `'thread'` markers are still cleared+rebuilt in the comparatively small
  aggregate phase, which keeps its own final transaction (clear-all-then-upsert
  there inherently can't commit per-chunk without a thread-level empty window;
  its WAL footprint is aggregate-sized, not per-session).
- Updated the #1607 comment block to the new model (per-chunk commit, upsert
  keeps old insights visible, orphan cleanup, resumability).

Resumability: a crash mid-rebuild leaves a mix of fresh and stale per-session
insights (never an emptied archive); the next rebuild/incremental convergence
completes it.

Tests: the prior progress/atomicity tests encoded the old single-transaction
"cleared `<table>`" guarantee and were already failing against the schema-v11
run-projection tables. Updated `test_session_insight_rebuild_progress.py` and
`tests/unit/cli/test_insights.py` to assert the new model (per-table
orphan-prune heartbeats, no upfront wipe, failure preserves prior profiles via
upsert). Added
`test_full_rebuild_commits_incrementally_and_prunes_orphans` proving:
intermediate committed state is visible from a second connection (incremental
commit), every still-existing session keeps a visible profile at every chunk
boundary (no empty window), and a deleted session's orphan profile is pruned.

## Verification

- `nix develop -c devtools verify --quick` → `exit_code: 0` (ruff format/check,
  mypy --strict, render all --check, topology/layering/manifests/etc).
- `nix develop -c devtools test tests/unit/storage/test_session_insight_refresh.py tests/unit/storage/test_session_insight_rebuild_progress.py`
  → `24 passed`.
- `nix develop -c devtools test tests/unit/pipeline/test_run_stages_runtime.py tests/unit/demo/test_demo_seed_verify.py tests/unit/pipeline/test_resilience.py`
  → `34 passed` (async materialize + demo seed paths).
- `nix develop -c devtools test tests/unit/cli/test_insights.py tests/unit/core/test_insight_readiness.py tests/unit/core/test_facade_api.py tests/unit/core/test_sync_surface_runtime.py`
  → `79 passed` after updating the stale progress assertion.
- `nix develop -c devtools test tests/unit/maintenance/test_registry.py` → `14
  passed` (empty-archive full-rebuild branch).

Ref #2458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pcNXbmmzXHFrpARz48gN6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Full session insight rebuilds now run in smaller chunks, improving progress visibility and reducing the chance of large, disruptive rebuilds.
  * Rebuilds now preserve existing insight data until replacement data is ready, so interrupted runs are less likely to leave results empty.
  * Orphaned insight rows are cleaned up after rebuilds, helping keep insight counts and listings accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->