### PR TITLE
fix(cost): bill subscription output credits at 5x input rate

### DIFF
--- a/polylogue/archive/semantic/subscription_pricing.py
+++ b/polylogue/archive/semantic/subscription_pricing.py
@@ -82,20 +82,25 @@ class ModelCreditRate:
 
 
 MODEL_CREDIT_RATES: dict[str, ModelCreditRate] = {
+    # Subscription credits are "billed at API rates"
+    # (https://docs.anthropic.com/en/docs/claude-code/pricing), and every Claude
+    # model prices output at 5x input ($15/$75 Opus, $3/$15 Sonnet, $0.80/$4
+    # Haiku). So output_credits must be 5x input_credits; cache writes (5-min)
+    # bill at the input rate, cache reads are free on subscription plans.
     "claude-opus-4-6": ModelCreditRate(
-        "anthropic", "claude-opus-4-6", 10, 10, cache_read_credits=0, cache_write_credits=10
+        "anthropic", "claude-opus-4-6", 10, 50, cache_read_credits=0, cache_write_credits=10
     ),
     "claude-opus-4-5": ModelCreditRate(
-        "anthropic", "claude-opus-4-5", 10, 10, cache_read_credits=0, cache_write_credits=10
+        "anthropic", "claude-opus-4-5", 10, 50, cache_read_credits=0, cache_write_credits=10
     ),
     "claude-sonnet-4-6": ModelCreditRate(
-        "anthropic", "claude-sonnet-4-6", 6, 6, cache_read_credits=0, cache_write_credits=6
+        "anthropic", "claude-sonnet-4-6", 6, 30, cache_read_credits=0, cache_write_credits=6
     ),
     "claude-sonnet-4-5": ModelCreditRate(
-        "anthropic", "claude-sonnet-4-5", 6, 6, cache_read_credits=0, cache_write_credits=6
+        "anthropic", "claude-sonnet-4-5", 6, 30, cache_read_credits=0, cache_write_credits=6
     ),
     "claude-haiku-4-5": ModelCreditRate(
-        "anthropic", "claude-haiku-4-5", 2, 2, cache_read_credits=0, cache_write_credits=2
+        "anthropic", "claude-haiku-4-5", 2, 10, cache_read_credits=0, cache_write_credits=2
     ),
 }
 

--- a/tests/unit/storage/test_cost_queries.py
+++ b/tests/unit/storage/test_cost_queries.py
@@ -52,3 +52,38 @@ def test_subscription_credit_cost() -> None:
     # Verify the model-specific rate is non-trivial
     rate = get_credit_rate("claude-sonnet-4-6")
     assert rate is not None, "expected a credit rate for claude-sonnet-4-6"
+
+
+def test_subscription_output_credits_are_5x_input() -> None:
+    """Claude bills output at 5x input at API rates; credits must mirror that.
+
+    Regression guard: every entry previously set output_credits == input_credits,
+    understating output (and therefore total subscription) cost by 5x.
+    """
+    from polylogue.archive.semantic.subscription_pricing import MODEL_CREDIT_RATES
+
+    assert MODEL_CREDIT_RATES, "expected at least one Claude credit rate"
+    for name, rate in MODEL_CREDIT_RATES.items():
+        # rates share one divisor, so the 5x ratio holds on the credit ints.
+        assert rate.input_divisor == rate.output_divisor, name
+        assert rate.output_credits == 5 * rate.input_credits, (
+            f"{name}: output_credits {rate.output_credits} must be 5x input "
+            f"{rate.input_credits} (API output:input ratio)"
+        )
+        # cache reads are free on subscription plans; cache writes bill at input rate.
+        assert rate.cache_read_credits == 0, name
+        assert rate.cache_write_credits == rate.input_credits, name
+
+
+def test_subscription_credit_cost_output_weight() -> None:
+    """Output tokens must cost 5x input tokens for the same count.
+
+    Uses a divisor-aligned token count (15) so math.ceil rounding does not mask
+    the exact 5x ratio.
+    """
+    from polylogue.archive.semantic.subscription_pricing import compute_credit_cost
+
+    input_only = compute_credit_cost("claude-opus-4-6", input_tokens=1500, output_tokens=0)
+    output_only = compute_credit_cost("claude-opus-4-6", input_tokens=0, output_tokens=1500)
+    assert input_only > 0 and output_only > 0
+    assert output_only == 5 * input_only


### PR DESCRIPTION
## Summary

Corrects a 5x understatement in the Claude subscription credit-cost view. Every
`MODEL_CREDIT_RATES` entry set `output_credits` equal to `input_credits`, so the
credit-cost and subscription-equivalent USD figures undercounted output (and
therefore total subscription cost) by 5x.

## Problem

Claude Code subscription credits are "billed at API rates"
(https://docs.anthropic.com/en/docs/claude-code/pricing), and every Claude model
prices output at 5x input: Opus $15/$75, Sonnet $3/$15, Haiku $0.80/$4. The
credit table did not reflect that ratio — `output_credits == input_credits` for
all five entries — so any surface deriving subscription credits or
subscription-equivalent dollars (cost rollups `sub_usd`, cost outlook, cost
panel) understated the dominant output lane fivefold. Surfaced during the
cost/usage analytics research wave (`.agent/scratch/research/10-subscription-credit-model.md`).

## Solution

`polylogue/archive/semantic/subscription_pricing.py`: set `output_credits` to
5x `input_credits` for all Claude entries (Opus 10/50, Sonnet 6/30, Haiku 2/10),
with an inline comment tying the ratio to API rates. `cache_read_credits` stays
0 (free on subscription plans); `cache_write_credits` stays at the input rate.
No other entry shape changed; `credits_for` math is untouched.

Added two regression tests in `tests/unit/storage/test_cost_queries.py`:
- structural: `output_credits == 5 * input_credits` (and shared divisor,
  free cache reads, input-rate cache writes) for every entry;
- behavioral: 1500 output tokens cost exactly 5x 1500 input tokens
  (divisor-aligned count to avoid `math.ceil` boundary noise).

## Verification

- `devtools test tests/unit/storage/test_cost_queries.py` → 6 passed
- `devtools test tests/unit/cost/ tests/unit/insights/test_cost_basis_split.py tests/unit/daemon/test_cost_panel_endpoint.py tests/unit/mcp/test_cost_outlook_tool.py tests/unit/cli/test_cost_outlook_cli.py tests/unit/archive/test_session_profile_roundtrip.py` → 88 passed (no test hardcoded the old values; all compute dynamically)
- `ruff format` / `ruff check` / `mypy` on changed files → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription credit calculations to better match API-equivalent billing across supported models.
  * Output usage now costs 5× input usage, while cache reads remain free and cache write pricing stays unchanged.
  * Added regression coverage to help keep future pricing calculations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->