### PR TITLE
fix(storage): compose forks on paginated, batch, and streaming reads

### DIFF
--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -139,6 +139,41 @@ async def get_messages(
     return prefix + own
 
 
+def _filter_composed(
+    records: list[MessageRecord],
+    *,
+    message_role: MessageRoleFilter = (),
+    message_type: MessageTypeName | None = None,
+    sort_key_since: float | None = None,
+    sort_key_until: float | None = None,
+) -> list[MessageRecord]:
+    """Apply the SQL-level read filters in Python over an already-composed
+    lineage transcript.
+
+    Composition (#2467) spans two sessions, so these filters cannot be pushed
+    into the per-session SQL. Forks are a minority of sessions, so filtering the
+    composed list in memory keeps the common (non-fork) read paths on their fast
+    SQL/keyset queries while making fork reads return the full logical transcript
+    instead of a tail-only truncation (#2470). The predicates mirror the SQL:
+    a NULL ``sort_key`` is excluded whenever a ``since``/``until`` bound is set,
+    exactly as ``m.occurred_at_ms >= ?`` drops NULL rows.
+    """
+    role_set = set(message_role) if message_role else None
+    type_match = validate_message_type_filter(message_type) if message_type else None
+    out: list[MessageRecord] = []
+    for record in records:
+        if role_set is not None and record.role not in role_set:
+            continue
+        if type_match is not None and record.message_type != type_match:
+            continue
+        if sort_key_since is not None and (record.sort_key is None or record.sort_key < sort_key_since):
+            continue
+        if sort_key_until is not None and (record.sort_key is None or record.sort_key > sort_key_until):
+            continue
+        out.append(record)
+    return out
+
+
 async def get_messages_batch(
     conn: aiosqlite.Connection,
     session_ids: list[str],
@@ -155,45 +190,67 @@ async def get_messages_batch(
     result: dict[str, list[MessageRecord]] = {cid: [] for cid in session_ids}
     result.update({cid: [] for cid in resolved_ids})
     all_messages: list[MessageRecord] = []
-    placeholders = ",".join("?" for _ in resolved_ids)
-    query = f"""
-        SELECT {_MESSAGE_RECORD_SELECT}
-        FROM messages m
-        JOIN sessions s ON s.session_id = m.session_id
-        WHERE m.session_id IN ({placeholders})
-    """
-    params: list[str | float] = list(resolved_ids)
 
-    role_values = message_role_sql_values(message_role)
-    if role_values:
-        role_placeholders = ",".join("?" for _ in role_values)
-        query += f" AND m.role IN ({role_placeholders})"
-        params.extend(role_values)
+    # Prefix-sharing children store only their divergent tail; the plain SQL
+    # IN-query below would return that truncated tail. Compose them per-session
+    # instead so a batched fork read carries its full logical transcript (#2470).
+    fork_ids = {rid for rid in dict.fromkeys(resolved_ids) if await _prefix_sharing_edge(conn, rid) is not None}
+    sql_ids = [rid for rid in resolved_ids if rid not in fork_ids]
 
-    if sort_key_since is not None:
-        query += " AND m.occurred_at_ms >= ?"
-        params.append(sort_key_since * 1000.0)
+    if sql_ids:
+        placeholders = ",".join("?" for _ in sql_ids)
+        query = f"""
+            SELECT {_MESSAGE_RECORD_SELECT}
+            FROM messages m
+            JOIN sessions s ON s.session_id = m.session_id
+            WHERE m.session_id IN ({placeholders})
+        """
+        params: list[str | float] = list(sql_ids)
 
-    if sort_key_until is not None:
-        query += " AND m.occurred_at_ms <= ?"
-        params.append(sort_key_until * 1000.0)
+        role_values = message_role_sql_values(message_role)
+        if role_values:
+            role_placeholders = ",".join("?" for _ in role_values)
+            query += f" AND m.role IN ({role_placeholders})"
+            params.extend(role_values)
 
-    query += " ORDER BY (m.occurred_at_ms IS NULL), m.occurred_at_ms, m.message_id"
-    cursor = await conn.execute(
-        query,
-        tuple(params),
-    )
-    rows = await cursor.fetchall()
+        if sort_key_since is not None:
+            query += " AND m.occurred_at_ms >= ?"
+            params.append(sort_key_since * 1000.0)
 
-    for row in rows:
-        cid = row["session_id"]
-        msg = _row_to_message(row)
-        if cid in result:
-            result[cid].append(msg)
+        if sort_key_until is not None:
+            query += " AND m.occurred_at_ms <= ?"
+            params.append(sort_key_until * 1000.0)
+
+        query += " ORDER BY (m.occurred_at_ms IS NULL), m.occurred_at_ms, m.message_id"
+        cursor = await conn.execute(
+            query,
+            tuple(params),
+        )
+        rows = await cursor.fetchall()
+
+        for row in rows:
+            cid = row["session_id"]
+            msg = _row_to_message(row)
+            if cid in result:
+                result[cid].append(msg)
+            for requested, resolved in resolved_pairs:
+                if requested != cid and resolved == cid and requested in result:
+                    result[requested].append(msg)
+            all_messages.append(msg)
+
+    for fork_id in fork_ids:
+        composed = _filter_composed(
+            await get_messages(conn, fork_id),
+            message_role=message_role,
+            sort_key_since=sort_key_since,
+            sort_key_until=sort_key_until,
+        )
         for requested, resolved in resolved_pairs:
-            if requested != cid and resolved == cid and requested in result:
-                result[requested].append(msg)
-        all_messages.append(msg)
+            if resolved == fork_id and requested in result:
+                result[requested] = list(composed)
+        if fork_id in result:
+            result[fork_id] = list(composed)
+        all_messages.extend(composed)
 
     return result, all_messages
 
@@ -213,6 +270,19 @@ async def get_messages_paginated(
     count of messages matching the SQL-level filters (before limit/offset).
     """
     session_id = await _resolve_session_id(conn, session_id)
+
+    # A prefix-sharing child stores only its divergent tail, so paginating its
+    # own ``messages`` rows returns a truncated transcript. Compose the full
+    # lineage view, filter in Python, and slice it for offset/limit (#2470).
+    # ``total`` is the filtered composed length so page math stays consistent.
+    if await _prefix_sharing_edge(conn, session_id) is not None:
+        composed = _filter_composed(
+            await get_messages(conn, session_id),
+            message_role=message_role,
+            message_type=message_type,
+        )
+        return composed[offset : offset + limit], len(composed)
+
     query = f"""
         SELECT {_MESSAGE_RECORD_SELECT}
         FROM messages m
@@ -275,6 +345,21 @@ async def iter_messages(
     session_id = await _resolve_session_id(conn, session_id)
     yielded = 0
     effective_roles = message_roles or ((Role.USER, Role.ASSISTANT) if dialogue_only else ())
+
+    # Keyset streaming is per-session, but a prefix-sharing child's logical
+    # transcript spans its parent, so the cursor cannot stream across the
+    # lineage boundary. Compose the full transcript and yield from it for forks
+    # (a minority of sessions); plain sessions keep the linear keyset stream
+    # below (#2470).
+    if await _prefix_sharing_edge(conn, session_id) is not None:
+        composed = _filter_composed(await get_messages(conn, session_id), message_role=effective_roles)
+        for record in composed:
+            if limit is not None and yielded >= limit:
+                return
+            yield record
+            yielded += 1
+        return
+
     role_values = message_role_sql_values(effective_roles)
 
     # Keyset cursor of the previous chunk's final row. ``have_cursor``

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -26,7 +26,12 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     read_archive_session_envelope,
     write_parsed_session_to_archive,
 )
-from polylogue.storage.sqlite.queries.message_query_reads import get_messages
+from polylogue.storage.sqlite.queries.message_query_reads import (
+    get_messages,
+    get_messages_batch,
+    get_messages_paginated,
+    iter_messages,
+)
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -300,3 +305,79 @@ def test_spawned_fresh_child_keeps_all_messages(tmp_path: Path) -> None:
     conn.close()
     composed = asyncio.run(_read_texts(db, child_id))
     assert composed == ["fresh subagent prompt", "fresh subagent answer"]
+
+
+def _build_parent_and_fork(db: Path) -> tuple[str, str]:
+    """Persist a parent and a prefix-sharing fork; return (parent_id, child_id).
+
+    The fork replays the parent's first two messages then diverges, so its full
+    logical transcript is 4 messages while only 2 (its tail) are physically
+    stored under the child.
+    """
+    conn = _connect(db)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        title="parent",
+        messages=[
+            _msg("p0", Role.USER, "hello", 0),
+            _msg("p1", Role.ASSISTANT, "hi there", 1),
+            _msg("p2", Role.USER, "parent continues alone", 2),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent)
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        title="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "hello", 0),
+            _msg("c1", Role.ASSISTANT, "hi there", 1),
+            _msg("cx", Role.USER, "child diverges here", 2),
+            _msg("cy", Role.ASSISTANT, "child reply", 3),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+    conn.close()
+    return parent_id, child_id
+
+
+def test_fork_composes_on_paginated_batch_and_iter(tmp_path: Path) -> None:
+    """All read surfaces compose a fork's full logical transcript, not the
+    tail-only physical rows (#2470)."""
+    db = tmp_path / "index.db"
+    _parent_id, child_id = _build_parent_and_fork(db)
+    full = ["hello", "hi there", "child diverges here", "child reply"]
+
+    async def _exercise() -> None:
+        conn = await aiosqlite.connect(db)
+        try:
+            conn.row_factory = aiosqlite.Row
+
+            # Paginated: total is the composed length; pages slice the composed list.
+            page1, total = await get_messages_paginated(conn, child_id, limit=2, offset=0)
+            assert total == 4
+            assert [r.text for r in page1] == full[:2]
+            page2, total2 = await get_messages_paginated(conn, child_id, limit=2, offset=2)
+            assert total2 == 4
+            assert [r.text for r in page2] == full[2:]
+
+            # Batch: the child's entry carries the composed transcript.
+            result, all_messages = await get_messages_batch(conn, [child_id])
+            assert [r.text for r in result[child_id]] == full
+            # all_messages must include every composed record for block hydration.
+            assert {r.message_id for r in result[child_id]} <= {r.message_id for r in all_messages}
+
+            # Streaming: iter_messages yields the composed transcript in order.
+            streamed = [r.text async for r in iter_messages(conn, child_id)]
+            assert streamed == full
+
+            # limit is honored over the composed stream.
+            limited = [r.text async for r in iter_messages(conn, child_id, limit=3)]
+            assert limited == full[:3]
+        finally:
+            await conn.close()
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary

Routes the three remaining message read paths — `get_messages_paginated`,
`get_messages_batch`, and `iter_messages` — through lineage composition, so a
prefix-sharing fork's full logical transcript is returned everywhere instead of
just in `get_messages` / `read_archive_session_envelope`.

## Problem

Lineage normalization (#2467) stores a prefix-sharing child (fork / resume /
spawned subagent / auto-compaction copy) as only its divergent tail and composes
the parent prefix back in on read. Composition was wired into `get_messages` and
`read_archive_session_envelope` only. The other three read paths read the
child's own `messages` rows directly, so **CLI pagination, batched reads, and
streaming/export of a fork returned a truncated tail-only transcript** (e.g. a
4-message fork showing only its 2 divergent messages). Surfaced by the lineage
research wave (`.agent/scratch/research/00-INDEX.md`, agent #11).

## Solution

`polylogue/storage/sqlite/queries/message_query_reads.py`:
- **`_filter_composed()`** — applies the SQL-level role / message-type /
  sort-key-range filters in Python over an already-composed transcript.
  Composition spans two sessions, so those filters cannot be pushed into the
  per-session SQL. Mirrors SQL semantics (NULL `sort_key` excluded when a
  `since`/`until` bound is set).
- **`get_messages_paginated`** — for a prefix-sharing session, compose then slice
  `offset`/`limit`; `total` becomes the filtered composed length so page math
  stays consistent.
- **`get_messages_batch`** — fork sessions are excluded from the SQL `IN` query
  and composed per-id; composed records are appended to `all_messages` so block
  hydration still covers the inherited prefix.
- **`iter_messages`** — keyset streaming is per-session and cannot cross the
  lineage boundary, so forks compose-and-yield (honoring the role filter and
  `limit`); plain sessions keep the linear keyset stream.

All branches are gated on `_prefix_sharing_edge`, so **non-fork sessions (the
vast majority) keep their existing SQL/keyset paths unchanged**.

## Verification

- `devtools test tests/unit/storage/test_lineage_normalization.py` → 5 passed,
  including new `test_fork_composes_on_paginated_batch_and_iter` (asserts all
  three paths return the full 4-message transcript, correct pagination `total`,
  `offset`/`limit` slicing, and `iter_messages` limit, for a 2-message-tail fork)
- `devtools test tests/unit/storage/test_message_query_reads.py tests/unit/storage/test_iter_messages_keyset.py tests/unit/api/test_facade_contracts.py` → exit 0 (non-fork paths unaffected)
- `ruff format` / `ruff check` / `mypy` on changed files → clean

Ref #2470