### PR TITLE
feat(parsers): capture Claude server_tool_use web request counts

### DIFF
--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -133,6 +133,22 @@ def _message_usage_event_payload(
         "semantics": "per_message",
         "last_token_usage": last_usage,
     }
+    # Anthropic bills web_search / web_fetch separately from token usage and
+    # reports the request counts under usage.server_tool_use. The token lanes
+    # above never carry them, so they would otherwise be lost. Record only when a
+    # count is positive: most CLI sessions never call web tools, and an all-zero
+    # sub-dict on every message would bloat the persisted payload_json for no
+    # signal. The bytes ride into payload_json via the existing writer, so this
+    # needs no schema change. (server_tool_use research, agent #03.)
+    server_tool_use = usage.get("server_tool_use")
+    if isinstance(server_tool_use, dict):
+        web_search_requests = _safe_int(server_tool_use.get("web_search_requests"))
+        web_fetch_requests = _safe_int(server_tool_use.get("web_fetch_requests"))
+        if web_search_requests or web_fetch_requests:
+            payload["server_tool_use"] = {
+                "web_search_requests": web_search_requests,
+                "web_fetch_requests": web_fetch_requests,
+            }
     if model_name:
         payload["model"] = model_name
     if model_effort:

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -206,3 +206,48 @@ def test_parse_code_drops_progress_hook_records() -> None:
     provider_ids = {m.provider_message_id for m in result.messages}
     assert provider_ids == {"u-1", "a-1"}
     assert all("prog" not in pid for pid in provider_ids)
+
+
+def test_message_usage_payload_captures_server_tool_use() -> None:
+    """web_search/web_fetch request counts are billed separately and must be
+    preserved in the usage event payload (they ride into payload_json)."""
+    from polylogue.sources.parsers.claude.code_parser import _message_usage_event_payload
+
+    payload = _message_usage_event_payload(
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "server_tool_use": {"web_search_requests": 3, "web_fetch_requests": 1},
+        },
+        model_name="claude-opus-4-8",
+        model_effort=None,
+    )
+    assert payload["server_tool_use"] == {"web_search_requests": 3, "web_fetch_requests": 1}
+
+
+def test_message_usage_payload_omits_all_zero_server_tool_use() -> None:
+    """Most CLI sessions never call web tools; an all-zero sub-dict is dropped so
+    payload_json is not bloated on every message."""
+    from polylogue.sources.parsers.claude.code_parser import _message_usage_event_payload
+
+    payload = _message_usage_event_payload(
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "server_tool_use": {"web_search_requests": 0, "web_fetch_requests": 0},
+        },
+        model_name=None,
+        model_effort=None,
+    )
+    assert "server_tool_use" not in payload
+
+
+def test_message_usage_payload_without_server_tool_use_key() -> None:
+    from polylogue.sources.parsers.claude.code_parser import _message_usage_event_payload
+
+    payload = _message_usage_event_payload(
+        {"input_tokens": 10, "output_tokens": 5},
+        model_name=None,
+        model_effort=None,
+    )
+    assert "server_tool_use" not in payload


### PR DESCRIPTION
## Summary

Captures the `web_search_requests` / `web_fetch_requests` counts that Anthropic
reports under `message.usage.server_tool_use` into the Claude Code message-usage
event payload, closing a small data-loss gap. No schema change.

## Problem

Anthropic bills web_search and web_fetch separately from token usage and reports
the request counts under `message.usage.server_tool_use`. The Claude Code parser
(`_message_usage_event_payload`) read only the four token lanes, so these
billable counts were dropped at ingest with no post-hoc recovery path. Surfaced
by the cost/usage research wave (`.agent/scratch/research/03-server-tool-use-capture.md`).

## Solution

`polylogue/sources/parsers/claude/code_parser.py`: `_message_usage_event_payload`
now reads `usage.server_tool_use` and adds a `server_tool_use` sub-dict to the
`message_usage` event payload when at least one count is positive. The existing
writer dumps the event payload verbatim into
`session_provider_usage_events.payload_json`, so the counts become durable with
**no schema change** (Tier A). An all-zero sub-dict is omitted so the common
no-web-tools CLI case does not bloat `payload_json` on every message.

A typed-column promotion (Tier B: typed `last_web_search_requests` /
`last_web_fetch_requests` columns + `INDEX_SCHEMA_VERSION` bump + re-ingest
plan) is deferred until a concrete cost/analytics consumer needs SQL-level
access to the counts.

## Verification

- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py` → 7 passed (3 new: positive capture, all-zero omission, key-absent)
- `devtools test tests/unit/storage/test_provider_usage_report.py tests/unit/storage/test_archive_tiers_write.py` → 51 passed (usage event materialization unaffected)
- `ruff format` / `ruff check` / `mypy` on changed files → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved web search and web fetch request counts in Claude Code session usage details.
  * Ensured usage records only include web tool data when those counts are present, avoiding empty entries.

* **Tests**
  * Added coverage for usage payload handling with non-zero, zero, and missing web tool request counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->