### PR TITLE
fix(cost): flag paid models missing a catalog cache rate instead of $0

### DIFF
--- a/polylogue/archive/semantic/pricing.py
+++ b/polylogue/archive/semantic/pricing.py
@@ -539,6 +539,20 @@ def _estimate_from_usage(
         )
     components = _cost_components(usage, pricing)
     total = sum(component.usd for component in components)
+    # Flag a paid model that carries cache tokens but has no catalog cache rate:
+    # _cost_components priced that lane at $0 silently, which understates cost.
+    # The likely cause is a model new enough that the vendored LiteLLM snapshot
+    # lacks its cache pricing. Surface it as a data-quality reason rather than a
+    # hidden understatement. Gated on the model being paid so genuinely-free
+    # models (e.g. local-llama, all lanes $0) are not flagged.
+    missing_reasons: tuple[str, ...] = ()
+    if pricing.input_usd_per_1m > 0 or pricing.output_usd_per_1m > 0:
+        unpriced: list[str] = []
+        if usage.cache_read_tokens > 0 and pricing.cache_read_usd_per_1m == 0.0:
+            unpriced.append("missing_cache_read_price")
+        if usage.cache_write_tokens > 0 and pricing.cache_write_usd_per_1m == 0.0:
+            unpriced.append("missing_cache_write_price")
+        missing_reasons = tuple(unpriced)
     return CostEstimatePayload(
         source_name=source_name,
         session_id=session_id,
@@ -556,6 +570,7 @@ def _estimate_from_usage(
         price=pricing.to_payload(model_name=model_name, normalized_model=normalized_model),
         components=components,
         provenance=(*provenance, CATALOG_PROVENANCE),
+        missing_reasons=missing_reasons,
     )
 
 

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -175,3 +175,74 @@ def test_current_opus_flagships_are_priced_not_zero() -> None:
         assert _normalize_model(f"{version}-20260101") == version
         # 1M input + 1M output at Opus rates ($15 + $75) = $90.
         assert estimate_cost(1_000_000, 1_000_000, version) == pytest.approx(90.0)
+
+
+def test_paid_model_missing_cache_rate_is_flagged_not_silently_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A paid model carrying cache tokens but no catalog cache rate must surface
+    a data-quality reason instead of silently pricing that lane at $0 (e.g. a
+    model newer than the vendored LiteLLM snapshot)."""
+    from polylogue.archive.semantic import pricing as pricing_mod
+    from polylogue.archive.semantic.pricing import CostUsagePayload, ModelPricing, _estimate_from_usage
+
+    paid_no_cache = ModelPricing(
+        source_name="test",
+        input_usd_per_1m=1.0,
+        output_usd_per_1m=2.0,
+        cache_read_usd_per_1m=0.0,
+        cache_write_usd_per_1m=0.0,
+    )
+    monkeypatch.setitem(pricing_mod.PRICING, "test-paid-nocache", paid_no_cache)
+
+    estimate = _estimate_from_usage(
+        source_name="test",
+        model_name="test-paid-nocache",
+        usage=CostUsagePayload(input_tokens=100, output_tokens=10, cache_read_tokens=1000),
+        provenance=("message_token_usage",),
+    )
+    assert estimate.status == "priced"
+    assert "missing_cache_read_price" in estimate.missing_reasons
+    # Priced lanes still cost; the unpriced cache lane is $0 but now flagged.
+    assert estimate.total_usd > 0
+
+
+def test_free_model_with_cache_tokens_is_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A genuinely free model (all lanes $0, e.g. local-llama) must NOT be
+    flagged just because it has cache tokens — the guard is gated on paid."""
+    from polylogue.archive.semantic import pricing as pricing_mod
+    from polylogue.archive.semantic.pricing import CostUsagePayload, ModelPricing, _estimate_from_usage
+
+    free_model = ModelPricing(source_name="test", input_usd_per_1m=0.0, output_usd_per_1m=0.0)
+    monkeypatch.setitem(pricing_mod.PRICING, "test-free-model", free_model)
+
+    estimate = _estimate_from_usage(
+        source_name="test",
+        model_name="test-free-model",
+        usage=CostUsagePayload(input_tokens=100, output_tokens=10, cache_read_tokens=1000),
+        provenance=("message_token_usage",),
+    )
+    assert estimate.status == "priced"
+    assert estimate.missing_reasons == ()
+
+
+def test_paid_model_with_cache_rate_is_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A paid model that has a cache rate is not flagged — control case."""
+    from polylogue.archive.semantic import pricing as pricing_mod
+    from polylogue.archive.semantic.pricing import CostUsagePayload, ModelPricing, _estimate_from_usage
+
+    paid_with_cache = ModelPricing(
+        source_name="test",
+        input_usd_per_1m=1.0,
+        output_usd_per_1m=2.0,
+        cache_read_usd_per_1m=0.1,
+        cache_write_usd_per_1m=1.25,
+    )
+    monkeypatch.setitem(pricing_mod.PRICING, "test-paid-cache", paid_with_cache)
+
+    estimate = _estimate_from_usage(
+        source_name="test",
+        model_name="test-paid-cache",
+        usage=CostUsagePayload(input_tokens=100, output_tokens=10, cache_read_tokens=1000, cache_write_tokens=50),
+        provenance=("message_token_usage",),
+    )
+    assert estimate.status == "priced"
+    assert estimate.missing_reasons == ()


### PR DESCRIPTION
## Summary

When a paid model carries cache tokens but the catalog has no cache rate for it,
the cost was silently $0 for that lane. This adds a data-quality flag
(`missing_cache_read_price` / `missing_cache_write_price`) instead of a hidden
understatement.

## Problem

`_cost_components` prices each lane as `tokens * rate`. If a paid model has
cache-read/cache-write tokens but `cache_read_usd_per_1m == 0.0` (no catalog
cache rate), that lane was priced at $0 silently. The realistic trigger is a
model newer than the vendored LiteLLM snapshot whose cache pricing has not
landed yet. (Legacy models that lack cache rates predate prompt caching and
carry ~no cache tokens, so they are not the hazard — a new paid model with real
cache traffic is. The originally-suggested "fall back to the fresh-input rate"
was rejected: OpenAI cache reads are *discounted*, not full input rate, so that
fallback would overcharge.)

## Solution

`_estimate_from_usage` inspects the priced result and appends the missing-rate
reason(s) to `missing_reasons` when a **paid** model (input or output rate > 0)
has cache tokens on a zero-rate lane. Gated on paid so genuinely-free models
(e.g. `local-llama`, all lanes $0) are not flagged. `missing_reasons` already
propagates to the session-level estimate and surfaces in the daemon `/cost` HTTP
payload and web shell, so the signal reaches operators.

The cost number is unchanged (the lane is still $0 — we do not invent a price);
this only adds the provenance/quality signal.

## Verification

- `devtools test tests/unit/core/test_pricing.py tests/unit/cost/` → 60 passed
  (3 new: paid-missing-cache flagged, free-model not flagged, paid-with-cache control)
- `ruff format` / `ruff check` / `mypy` → clean