### PR TITLE
perf(storage): memoize lineage composition + expression sortkey index

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,6 +106,17 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 15 makes `idx_messages_session_sortkey` an expression
+  index — `(session_id, (occurred_at_ms IS NULL), occurred_at_ms, message_id)`
+  (#2475 perf audit). The keyset/paginated message reads order by
+  `(occurred_at_ms IS NULL), occurred_at_ms, message_id` so NULL-timestamp rows
+  sort last; the v14 plain `(session_id, occurred_at_ms, message_id)` index could
+  not satisfy that leading `IS NULL` expression, so the planner fell back to
+  `USE TEMP B-TREE FOR ORDER BY` and sorted the whole session per chunk
+  (expensive on multi-thousand-message sessions). The expression index matches
+  the ORDER BY exactly and plans as a covering-index scan with no temp sort
+  (verified via EXPLAIN QUERY PLAN). Rebuild from source evidence
+  (`polylogue ops reset --database && polylogued run`).
 - Index schema version 14 hardens lineage normalization (#2467 audit).
   `session_links.branch_point_message_id` is no longer a FK with `ON DELETE SET
   NULL`: a parent's full-replace re-ingest (`DELETE FROM messages` then re-INSERT)

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -214,7 +214,11 @@ def _append_delta_payload(
 
 
 def _write_session(
-    conn: sqlite3.Connection, payload: SessionWritePayload, *, force_write: bool = False
+    conn: sqlite3.Connection,
+    payload: SessionWritePayload,
+    *,
+    force_write: bool = False,
+    signature_cache: dict[str, list[tuple[str, str]]] | None = None,
 ) -> tuple[bool, dict[str, int]]:
     """Write one parsed session payload into the current archive index.
 
@@ -290,6 +294,7 @@ def _write_session(
         content_hash=payload.content_hash,
         raw_id=payload.raw_id,
         merge_append=merge_append,
+        signature_cache=signature_cache,
     )
     counts["sessions"] = 1
     counts["messages"] = len(session_to_write.messages)
@@ -362,10 +367,11 @@ def _write_session_entry(
     *,
     summary: _IngestBatchSummary,
     force_write: bool = False,
+    signature_cache: dict[str, list[tuple[str, str]]] | None = None,
 ) -> bool:
     try:
         t_write = time.perf_counter()
-        content_changed, counts = _write_session(conn, cdata, force_write=force_write)
+        content_changed, counts = _write_session(conn, cdata, force_write=force_write, signature_cache=signature_cache)
         write_elapsed = time.perf_counter() - t_write
         summary.write_elapsed_s += write_elapsed
         if write_elapsed > summary.max_write_elapsed_s:
@@ -465,8 +471,15 @@ def _drain_ready_session_entries(
 ) -> int:
     _delete_stale_sessions_for_raw_entries(conn, ready_entries)
     written_count = 0
+    # One signature cache per drained batch memoizes each session's own composed
+    # signatures so a parent with K fork-children is computed once, not K times
+    # (#2475, hotspot 1). Entries are invalidated when their own rows are
+    # rewritten or re-extracted in this same batch.
+    signature_cache: dict[str, list[tuple[str, str]]] = {}
     for raw_id, cdata in _topo_sort_session_entries(ready_entries):
-        wrote = _write_session_entry(conn, raw_id, cdata, summary=summary, force_write=force_write)
+        wrote = _write_session_entry(
+            conn, raw_id, cdata, summary=summary, force_write=force_write, signature_cache=signature_cache
+        )
         discard_session_data_payload(cdata)
         if not wrote:
             continue

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -33,7 +33,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
     nullable_check,
 )
 
-INDEX_SCHEMA_VERSION = 14
+INDEX_SCHEMA_VERSION = 15
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -128,11 +128,16 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_position
 ON messages(session_id, position, variant_index);
 
 -- Serves the sort-key ordering used by iter_messages keyset pagination,
--- get_messages_batch, and get_messages_paginated. Without it those reads filter
--- by session_id (via the position index) then sort the whole session in a temp
--- B-tree on every chunk (#2467 perf audit).
+-- get_messages_batch, and get_messages_paginated. Those reads order by
+-- `(occurred_at_ms IS NULL), occurred_at_ms, message_id` (NULL-timestamp rows
+-- sort last). The leading IS NULL expression must itself be an indexed column or
+-- the planner ignores the index and sorts the whole session in a temp B-tree on
+-- every chunk — verified via EXPLAIN QUERY PLAN: a plain
+-- (session_id, occurred_at_ms, message_id) index still triggers
+-- `USE TEMP B-TREE FOR ORDER BY`, while the expression index below plans as a
+-- covering-index scan with no sort (#2467 / #2475 perf audit).
 CREATE INDEX IF NOT EXISTS idx_messages_session_sortkey
-ON messages(session_id, occurred_at_ms, message_id);
+ON messages(session_id, (occurred_at_ms IS NULL), occurred_at_ms, message_id);
 
 CREATE INDEX IF NOT EXISTS idx_messages_parent
 ON messages(parent_message_id)

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -227,6 +227,7 @@ def write_parsed_session_to_archive(
     merge_append: bool = False,
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
+    signature_cache: dict[str, list[tuple[str, str]]] | None = None,
 ) -> str:
     """Write one parsed session into an initialized archive index DB."""
     t0 = time.perf_counter()
@@ -243,6 +244,10 @@ def write_parsed_session_to_archive(
     origin = origin_from_provider(session.source_name)
     native_id = session.provider_session_id
     session_id = archive_session_id(origin.value, native_id)
+    # This session's own rows are about to be rewritten; drop any stale memoized
+    # own-signatures so the batch cache never serves pre-write rows for it.
+    if signature_cache is not None:
+        signature_cache.pop(session_id, None)
     messages = _normalized_messages(session.messages)
     # Lineage normalization (#2467): when this is a prefix-sharing child whose
     # parent is already in the archive, drop the inherited prefix and keep only
@@ -256,7 +261,7 @@ def write_parsed_session_to_archive(
         parent_session_id = _existing_parent_session_id(conn, session, origin.value)
         if parent_session_id is not None and messages:
             branch_point_message_id, lineage_inheritance, messages = _extract_prefix_tail(
-                conn, parent_session_id, messages
+                conn, parent_session_id, messages, cache=signature_cache
             )
     duplicate_message_native_ids = _duplicate_message_native_ids(messages)
     active_leaf_message_id = _active_leaf_message_id(
@@ -487,7 +492,7 @@ def write_parsed_session_to_archive(
             _refresh_session_counts(conn, session_id)
         add_timing("index.session_counts", t0)
         t0 = time.perf_counter()
-        _resolve_session_graph(conn, session_id, native_id, origin.value)
+        _resolve_session_graph(conn, session_id, native_id, origin.value, cache=signature_cache)
         add_timing("index.graph_resolve", t0)
         if session.ingest_flags:
             t0 = time.perf_counter()
@@ -1932,7 +1937,14 @@ def _write_session_link(
     )
 
 
-def _resolve_session_graph(conn: sqlite3.Connection, session_id: str, native_id: str, origin: str) -> None:
+def _resolve_session_graph(
+    conn: sqlite3.Connection,
+    session_id: str,
+    native_id: str,
+    origin: str,
+    *,
+    cache: dict[str, list[tuple[str, str]]] | None = None,
+) -> None:
     conn.execute(
         """
         UPDATE sessions
@@ -1968,7 +1980,7 @@ def _resolve_session_graph(conn: sqlite3.Connection, session_id: str, native_id:
         # stored whole (the inherited prefix could not be aligned yet). Now that
         # the parent exists, normalize the child the same way the parent-known
         # write path does — drop the inherited prefix rows and record the edge.
-        _reextract_prefix_tail_db(conn, str(row[0]), session_id)
+        _reextract_prefix_tail_db(conn, str(row[0]), session_id, cache=cache)
 
     impacted_session_ids = {session_id, *(str(row[0]) for row in inbound_rows)}
     old_root_ids = _root_ids(conn, impacted_session_ids)
@@ -2946,10 +2958,11 @@ def _parsed_message_signature(message: ParsedMessage) -> str:
     return _message_signature_from_blocks(role, fields)
 
 
-def _composed_db_signatures(conn: sqlite3.Connection, session_id: str, *, _depth: int = 0) -> list[tuple[str, str]]:
-    """Return ``[(message_id, signature), ...]`` for ``session_id``'s composed
-    transcript (its inherited prefix + own tail), recursively resolving any
-    prefix-sharing lineage edge. Mirrors the read-side composition."""
+def _own_db_signatures(conn: sqlite3.Connection, session_id: str) -> list[tuple[str, str]]:
+    """Return ``[(message_id, signature), ...]`` for ``session_id``'s OWN stored
+    message rows (no inherited prefix). This is the expensive SQL+SHA-256 leg of
+    composition; it depends only on the session's own rows, so it can be memoized
+    per ingest batch and invalidated whenever those rows change."""
     own_rows = conn.execute(
         """
         SELECT m.message_id, m.position, m.role,
@@ -2986,6 +2999,30 @@ def _composed_db_signatures(conn: sqlite3.Connection, session_id: str, *, _depth
                 )
             )
     flush()
+    return own
+
+
+def _composed_db_signatures(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    cache: dict[str, list[tuple[str, str]]] | None = None,
+    _depth: int = 0,
+) -> list[tuple[str, str]]:
+    """Return ``[(message_id, signature), ...]`` for ``session_id``'s composed
+    transcript (its inherited prefix + own tail), recursively resolving any
+    prefix-sharing lineage edge. Mirrors the read-side composition.
+
+    When ``cache`` is supplied, each session's OWN signatures are memoized by
+    ``session_id`` for the life of one ingest batch. The composed (prefix+own)
+    result is never cached because it embeds ancestor signatures that could be
+    rewritten in the same batch; only the own-row leg is stable per session.
+    """
+    own = cache.get(session_id) if cache is not None else None
+    if own is None:
+        own = _own_db_signatures(conn, session_id)
+        if cache is not None:
+            cache[session_id] = own
 
     if _depth >= _MAX_LINEAGE_DEPTH:
         return own
@@ -3004,7 +3041,7 @@ def _composed_db_signatures(conn: sqlite3.Connection, session_id: str, *, _depth
     if edge is None:
         return own
     parent_id, branch_point_message_id = edge
-    parent_composed = _composed_db_signatures(conn, str(parent_id), _depth=_depth + 1)
+    parent_composed = _composed_db_signatures(conn, str(parent_id), cache=cache, _depth=_depth + 1)
     prefix: list[tuple[str, str]] = []
     for entry in parent_composed:
         prefix.append(entry)
@@ -3013,7 +3050,13 @@ def _composed_db_signatures(conn: sqlite3.Connection, session_id: str, *, _depth
     return prefix + own
 
 
-def _reextract_prefix_tail_db(conn: sqlite3.Connection, child_session_id: str, parent_session_id: str) -> None:
+def _reextract_prefix_tail_db(
+    conn: sqlite3.Connection,
+    child_session_id: str,
+    parent_session_id: str,
+    *,
+    cache: dict[str, list[tuple[str, str]]] | None = None,
+) -> None:
     """Normalize a child that was stored whole because its parent was ingested
     later (#2467). Aligns the child's already-stored messages against the parent's
     composed transcript, deletes the inherited-prefix rows, and records the edge.
@@ -3033,8 +3076,8 @@ def _reextract_prefix_tail_db(conn: sqlite3.Connection, child_session_id: str, p
     if edge is None:
         return
     dst_origin, dst_native_id, link_type = edge
-    parent_composed = _composed_db_signatures(conn, parent_session_id)
-    child_composed = _composed_db_signatures(conn, child_session_id)
+    parent_composed = _composed_db_signatures(conn, parent_session_id, cache=cache)
+    child_composed = _composed_db_signatures(conn, child_session_id, cache=cache)
     k = 0
     limit = min(len(parent_composed), len(child_composed))
     while k < limit and parent_composed[k][1] == child_composed[k][1]:
@@ -3059,6 +3102,10 @@ def _reextract_prefix_tail_db(conn: sqlite3.Connection, child_session_id: str, p
         f"DELETE FROM messages WHERE message_id IN ({placeholders})",
         tuple(prefix_message_ids),
     )
+    # The child's own rows just changed (inherited prefix deleted); drop its
+    # memoized own-signatures so any later compose in this batch recomputes them.
+    if cache is not None:
+        cache.pop(child_session_id, None)
     _set_edge(parent_composed[k - 1][0], "prefix-sharing")
     _refresh_session_counts(conn, child_session_id)
 
@@ -3067,11 +3114,13 @@ def _extract_prefix_tail(
     conn: sqlite3.Connection,
     parent_session_id: str,
     messages: list[ParsedMessage],
+    *,
+    cache: dict[str, list[tuple[str, str]]] | None = None,
 ) -> tuple[str | None, str | None, list[ParsedMessage]]:
     """Align ``messages`` (the child's full parsed messages, which replay the
     parent's prefix) against the parent's composed transcript. Returns
     ``(branch_point_message_id, inheritance, tail_messages)``."""
-    parent_composed = _composed_db_signatures(conn, parent_session_id)
+    parent_composed = _composed_db_signatures(conn, parent_session_id, cache=cache)
     if not parent_composed:
         return (None, "spawned-fresh", messages)
     child_sigs = [_parsed_message_signature(m) for m in messages]

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -381,3 +381,76 @@ def test_fork_composes_on_paginated_batch_and_iter(tmp_path: Path) -> None:
             await conn.close()
 
     asyncio.run(_exercise())
+
+
+def test_shared_signature_cache_composes_correctly(tmp_path: Path) -> None:
+    """A batch-scoped signature cache shared across writes must not corrupt
+    lineage composition (#2475). Two forks of one parent and a parent re-ingest
+    all share a single cache dict; every child must still compose its full
+    logical transcript and the parent re-ingest invalidation must hold.
+    """
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    cache: dict[str, list[tuple[str, str]]] = {}
+
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        title="parent",
+        messages=[
+            _msg("p0", Role.USER, "hello", 0),
+            _msg("p1", Role.ASSISTANT, "hi there", 1),
+            _msg("p2", Role.USER, "parent continues alone", 2),
+        ],
+    )
+    write_parsed_session_to_archive(conn, parent, signature_cache=cache)
+
+    def _fork(name: str, tail_user: str, tail_assistant: str) -> str:
+        child = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=name,
+            title=name,
+            parent_session_provider_id="parent",
+            branch_type=BranchType.FORK,
+            messages=[
+                _msg(f"{name}0", Role.USER, "hello", 0),
+                _msg(f"{name}1", Role.ASSISTANT, "hi there", 1),
+                _msg(f"{name}x", Role.USER, tail_user, 2),
+                _msg(f"{name}y", Role.ASSISTANT, tail_assistant, 3),
+            ],
+        )
+        # Two SEPARATE write calls that SHARE one signature_cache dict.
+        return write_parsed_session_to_archive(conn, child, signature_cache=cache)
+
+    fork_a_id = _fork("forka", "fork A diverges", "fork A reply")
+    fork_b_id = _fork("forkb", "fork B diverges", "fork B reply")
+
+    def _composed(session_id: str) -> list[str]:
+        return [
+            "".join(block.text or "" for block in message.blocks)
+            for message in read_archive_session_envelope(conn, session_id).messages
+        ]
+
+    assert _composed(fork_a_id) == ["hello", "hi there", "fork A diverges", "fork A reply"]
+    assert _composed(fork_b_id) == ["hello", "hi there", "fork B diverges", "fork B reply"]
+
+    # Re-ingest the parent with a grown tail through the SAME shared cache. The
+    # per-write invalidation must drop the parent's stale own-signatures so both
+    # forks still compose the (unchanged) shared prefix + their own tails.
+    parent_grown = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        title="parent",
+        messages=[
+            _msg("p0", Role.USER, "hello", 0),
+            _msg("p1", Role.ASSISTANT, "hi there", 1),
+            _msg("p2", Role.USER, "parent continues alone", 2),
+            _msg("p3", Role.ASSISTANT, "parent grows more", 3),
+        ],
+    )
+    write_parsed_session_to_archive(conn, parent_grown, signature_cache=cache)
+
+    assert _composed(fork_a_id) == ["hello", "hi there", "fork A diverges", "fork A reply"]
+    assert _composed(fork_b_id) == ["hello", "hi there", "fork B diverges", "fork B reply"]
+
+    conn.close()

--- a/tests/unit/storage/test_message_query_reads.py
+++ b/tests/unit/storage/test_message_query_reads.py
@@ -161,3 +161,36 @@ async def test_message_query_reads_cover_type_filters_batches_and_stream_limits(
         ] == [f"{current_session_id}:msg-user"]
 
     await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_paginated_read_uses_sortkey_index_without_temp_btree(tmp_path: Path) -> None:
+    """idx_messages_session_sortkey (expression index, v15) must satisfy the
+    `(occurred_at_ms IS NULL), occurred_at_ms, message_id` ordering so paginated/
+    keyset reads do not fall back to a per-session temp B-tree sort (#2475)."""
+    import sqlite3
+
+    initialize_active_archive_root(tmp_path)
+    backend = SQLiteBackend(db_path=tmp_path / "index.db")
+    conv = make_session("conv-eqp", title="EQP")
+    messages = [
+        make_message(f"msg-{i}", "conv-eqp", role="user", text=f"t{i}", timestamp=f"2026-01-01T00:00:{i:02d}Z")
+        for i in range(20)
+    ]
+    await save_session_to_archive(backend, session=conv, messages=messages)
+
+    conn = sqlite3.connect(tmp_path / "index.db")
+    try:
+        sid = conn.execute("SELECT session_id FROM sessions LIMIT 1").fetchone()[0]
+        query = (
+            "SELECT m.message_id FROM messages m JOIN sessions s ON s.session_id = m.session_id "
+            "WHERE m.session_id = ? "
+            "ORDER BY (m.occurred_at_ms IS NULL), m.occurred_at_ms, m.message_id LIMIT 50"
+        )
+        plan_rows = conn.execute(f"EXPLAIN QUERY PLAN {query}", (sid,)).fetchall()
+        plan = " | ".join(str(r[3]) for r in plan_rows)
+    finally:
+        conn.close()
+
+    assert "TEMP B-TREE" not in plan.upper(), f"unexpected temp sort in plan: {plan}"
+    assert "idx_messages_session_sortkey" in plan, f"sortkey index not used: {plan}"


### PR DESCRIPTION
## Summary

Two verified ingest/read performance fixes from the #2475 audit, plus an
evidence-based decision to leave the third audit item unchanged. Schema-touching
(`INDEX_SCHEMA_VERSION` 14 → 15), so a re-ingest is required (plan below).

## Problem

The #2475 perf audit flagged three hot paths that a full re-ingest hits 16K×:

1. **Composition signature recompute** — `_composed_db_signatures` recomputed a
   parent's full composed transcript (SQL over all parent blocks + SHA-256 per
   message) once per fork-child. A parent with K forks recomputed its signatures
   K times; deep lineages compounded it.
2. **FTS docsize filter** — claimed to scan the whole global
   `messages_fts_docsize` table per session write.
3. **Sortkey index / temp B-tree** — the v14 `idx_messages_session_sortkey`
   was claimed to remove the per-chunk temp sort on paginated/keyset reads.

## Solution

**Hotspot 1 — memoize (commit 1).** Split each session's own-signature
computation into `_own_db_signatures` and memoize it in a batch-scoped cache
(keyed by session_id), threaded from the batch driver
(`_drain_ready_session_entries`) through `write_parsed_session_to_archive`.
Caching *own* signatures (not the composed prefix+own) keeps it correct under
ancestor rewrites; the cache entry for a session is invalidated when that session
is (re)written or re-extracted. Benchmark
(`.agent/scratch/bench_lineage_ingest.py`, 30 forks of a 1500-msg parent): fork
phase **1050ms → 598ms**; cProfile confirms the redundant parent DB recompute is
eliminated (the residual per-fork cost is inherent child-side parsed-signature
alignment, which is not memoizable).

**Hotspot 3 — expression index (commit 2).** The reads order by
`(occurred_at_ms IS NULL), occurred_at_ms, message_id`. EXPLAIN QUERY PLAN showed
the v14 plain index could not satisfy the leading `IS NULL` expression, so the
planner used `USE TEMP B-TREE FOR ORDER BY` and sorted the whole session per
chunk. The index is now an expression index
`(session_id, (occurred_at_ms IS NULL), occurred_at_ms, message_id)` matching the
ORDER BY exactly → covering-index scan, **no temp sort** (verified with and
without the sessions JOIN, and on small data with no ANALYZE).

**Hotspot 2 — left unchanged (evidence-based).** EXPLAIN QUERY PLAN **refutes**
the audit: `rowid IN (SELECT id FROM messages_fts_docsize)` already plans as
`USING ROWID SEARCH ... FOR IN-OPERATOR` (an indexed rowid probe, not a scan)
because `id` is the docsize rowid. A correlated-EXISTS rewrite measured identical
(0.007ms at 120K docsize rows). No change made; documented in the commit so the
misdiagnosis is on record.

## Re-ingest plan (required — schema bump 14 → 15)

`idx_messages_session_sortkey`'s DDL changed, so v14 archives are rejected at
open. This is a deletes-then-defines index change, not an in-place upgrade:

- Trigger: `polylogue ops reset --database && polylogued run` re-acquires from
  source and rebuilds the canonical `index.db` at v15.
- Rebuilt automatically: FTS, search indexes, derived insight read models — all
  of `index.db`. `source.db` and `user.db` are untouched (no user-data impact).
- End-user impact: a full re-ingest (hours on the 38 GB archive; the FTS
  `full_replace` path is the dominant cost — tracked under #2391). The
  memoization in commit 1 reduces lineage-family ingest cost during that rebuild.

## Verification

- `devtools test tests/unit/storage/test_message_query_reads.py` → 2 passed
  (incl. EQP guard asserting no temp B-tree + sortkey index used)
- `devtools test tests/unit/storage/test_lineage_normalization.py tests/unit/storage/test_archive_tiers_write.py` → 53 passed (incl. new shared-cache composition test)
- `devtools test tests/unit/cli/test_status_diagnostics.py tests/unit/daemon/test_daemon_cli.py` → 62 passed (version constant followed)
- Benchmarks: `.agent/scratch/bench_lineage_ingest.py` (memoization), `bench_fts_delete.py` (hotspot-2 refutation), `bench_idx_fix*.py` (index EQP)
- `ruff` + `mypy` clean

Ref #2475