### PR TITLE
fix(cost): count Codex cumulative tokens per session, not per model

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -2323,11 +2323,19 @@ def _provider_usage_disjoint_lanes(
 def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session_id: str) -> None:
     """Fold provider-reported token-count totals into model usage rows.
 
-    Codex ``token_count`` rows may carry cumulative ``total_token_usage``. For
-    those rows we take the latest total per model instead of summing the whole
-    event stream. Older/simple token-count rows only expose request-scoped
-    ``last_token_usage``; those are summed per model. Unknown-model events only
-    fall back to a session model when exactly one model row exists, keeping
+    Codex ``token_count`` rows carry a *session-global* cumulative running total
+    in their ``total_*`` columns — the counter spans the whole session, not a
+    single model. So the cumulative is taken as one session-wide latest value
+    (the highest-position ``token_count`` row that carries any ``total_*``),
+    attributed to the model named on that row, and written as a single rollup.
+    Partitioning the cumulative by model and summing would double-count, because
+    each model's "latest cumulative" already includes every prior model's
+    tokens (#2472).
+
+    Older/simple token-count rows only expose request-scoped ``last_token_usage``
+    (Claude-style per-message per-model deltas); when no cumulative ``total_*``
+    appears at all, those are summed per model. Unknown-model events only fall
+    back to a session model when exactly one model row exists, keeping
     multi-model sessions auditable rather than guessed.
     """
 
@@ -2357,7 +2365,13 @@ def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session
         if row[0] and str(row[0]).strip()
     ]
 
-    latest_total_by_model: dict[str, tuple[int, int, int, int, int, int]] = {}
+    # The cumulative is session-global, so we keep a single latest cumulative
+    # for the whole session (rows are ordered by position, so the last row that
+    # carries any total_* wins = highest position) attributed to the model named
+    # on that row. summed_last_* stays per-model for Claude-style per-message
+    # reporting, and is only used when no cumulative total appears at all.
+    latest_total: tuple[int, int, int, int, int, int] | None = None
+    latest_total_model = ""
     summed_last_by_model: dict[str, list[int]] = {}
 
     for row in rows:
@@ -2381,7 +2395,7 @@ def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session
         total_tokens = int(row[14] or 0)
 
         if total_input or total_output or total_cache_read or total_cache_write or total_reasoning or total_tokens:
-            latest_total_by_model[model_name] = (
+            latest_total = (
                 total_input,
                 total_output,
                 total_cache_read,
@@ -2389,6 +2403,7 @@ def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session
                 total_reasoning,
                 total_tokens,
             )
+            latest_total_model = model_name
             continue
 
         if last_input or last_output or last_cache_read or last_cache_write or last_reasoning or last_total:
@@ -2399,23 +2414,25 @@ def _aggregate_provider_usage_into_model_usage(conn: sqlite3.Connection, session
             bucket[3] += last_cache_write
             bucket[4] += last_reasoning
 
-    for model_name, totals in latest_total_by_model.items():
+    if latest_total is not None:
+        # Session-global cumulative: one rollup for the latest model. The
+        # cumulative already subsumes every per-request last_*, so summed_last
+        # rows are intentionally not written (writing them too double-counts).
         lane_input, lane_output, lane_cache_read, lane_cache_write = _provider_usage_disjoint_lanes(
-            totals[0], totals[1], totals[2], totals[3]
+            latest_total[0], latest_total[1], latest_total[2], latest_total[3]
         )
         _upsert_provider_usage_model_rollup(
             conn,
             session_id,
-            model_name,
+            latest_total_model,
             input_tokens=lane_input,
             output_tokens=lane_output,
             cache_read_tokens=lane_cache_read,
             cache_write_tokens=lane_cache_write,
         )
+        return
 
     for model_name, summed_totals in summed_last_by_model.items():
-        if model_name in latest_total_by_model:
-            continue
         lane_input, lane_output, lane_cache_read, lane_cache_write = _provider_usage_disjoint_lanes(
             summed_totals[0], summed_totals[1], summed_totals[2], summed_totals[3]
         )
@@ -2457,7 +2474,13 @@ def _aggregate_appended_provider_usage_into_model_usage(
         return
 
     existing_models = _provider_usage_existing_models(conn, session_id)
-    latest_total_by_model: dict[str, tuple[int, int, int, int, int, int]] = {}
+    # The cumulative total_* is session-global (see the full-write aggregator).
+    # The highest-position appended row that carries any total_* therefore holds
+    # the authoritative running total for the *whole* session, including rows
+    # before start_position, so we keep one session-wide latest cumulative
+    # rather than partitioning it per model (#2472).
+    latest_total: tuple[int, int, int, int, int, int] | None = None
+    latest_total_model = ""
     summed_last_by_model: dict[str, list[int]] = {}
 
     for row in rows:
@@ -2479,7 +2502,7 @@ def _aggregate_appended_provider_usage_into_model_usage(
         total_tokens = int(row[13] or 0)
 
         if total_input or total_output or total_cache_read or total_cache_write or total_reasoning or total_tokens:
-            latest_total_by_model[model_name] = (
+            latest_total = (
                 total_input,
                 total_output,
                 total_cache_read,
@@ -2487,6 +2510,7 @@ def _aggregate_appended_provider_usage_into_model_usage(
                 total_reasoning,
                 total_tokens,
             )
+            latest_total_model = model_name
             continue
 
         if last_input or last_output or last_cache_read or last_cache_write or last_reasoning or last_total:
@@ -2497,22 +2521,29 @@ def _aggregate_appended_provider_usage_into_model_usage(
             bucket[3] += last_cache_write
             bucket[4] += last_reasoning
 
-    for model_name, totals in latest_total_by_model.items():
+    if latest_total is not None:
+        # Overwrite the single session-global cumulative rollup. If the model
+        # switched since a prior append window, the earlier model's cumulative
+        # rollup is now stale (the new cumulative already subsumes it); clear
+        # those stale origin_reported cumulative rows so they are not summed
+        # back in alongside the new latest.
         lane_input, lane_output, lane_cache_read, lane_cache_write = _provider_usage_disjoint_lanes(
-            totals[0], totals[1], totals[2], totals[3]
+            latest_total[0], latest_total[1], latest_total[2], latest_total[3]
         )
         _upsert_provider_usage_model_rollup(
             conn,
             session_id,
-            model_name,
+            latest_total_model,
             input_tokens=lane_input,
             output_tokens=lane_output,
             cache_read_tokens=lane_cache_read,
             cache_write_tokens=lane_cache_write,
         )
+        _clear_stale_cumulative_rollups(conn, session_id, keep_model=latest_total_model)
+        return
 
     for model_name, summed_totals in summed_last_by_model.items():
-        if model_name in latest_total_by_model or _provider_usage_has_cumulative_total(conn, session_id, model_name):
+        if _provider_usage_has_cumulative_total(conn, session_id, model_name):
             continue
         lane_input, lane_output, lane_cache_read, lane_cache_write = _provider_usage_disjoint_lanes(
             summed_totals[0], summed_totals[1], summed_totals[2], summed_totals[3]
@@ -2567,6 +2598,34 @@ def _provider_usage_has_cumulative_total(conn: sqlite3.Connection, session_id: s
         (session_id, model_name),
     ).fetchone()
     return row is not None
+
+
+def _clear_stale_cumulative_rollups(conn: sqlite3.Connection, session_id: str, *, keep_model: str) -> None:
+    """Zero origin-reported token rollups for all models except ``keep_model``.
+
+    The Codex cumulative total is session-global, so exactly one rollup row
+    should carry it. When an append window's latest cumulative is attributed to
+    a different model than a previous window, the earlier model's rollup still
+    holds a (now-subsumed) cumulative; left in place it would be summed back in
+    on read. This resets those stale token counts to zero while keeping the
+    model row itself (#2472).
+    """
+    conn.execute(
+        """
+        UPDATE session_model_usage
+        SET input_tokens = 0,
+            output_tokens = 0,
+            cache_read_tokens = 0,
+            cache_write_tokens = 0,
+            cost_usd = NULL,
+            priced_with = NULL,
+            priced_at_ms = NULL
+        WHERE session_id = ?
+          AND model_name != ?
+          AND cost_provenance = 'origin_reported'
+        """,
+        (session_id, keep_model),
+    )
 
 
 def _upsert_provider_usage_model_rollup(

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -979,13 +979,18 @@ def _provider_cumulative_usage(conn: sqlite3.Connection, origin: str | None) -> 
         JOIN sessions s ON s.session_id = e.session_id
         {_where_origin(origin, table_alias="s")}
           {"AND" if origin is not None else "WHERE"} ({total_predicate})
-        ORDER BY s.origin, e.session_id, model_key, e.position
+        ORDER BY s.origin, e.session_id, e.position
         """,
         _origin_args(origin),
     ).fetchall()
-    latest: dict[tuple[str, str, str], UsageCounters] = {}
+    # The cumulative total_* is session-global, so dedupe to one latest
+    # cumulative per (origin, session) — the highest-position event — rather
+    # than per model. Partitioning by model and summing double-counts because
+    # each model's latest cumulative already includes prior models' tokens
+    # (#2472). ORDER BY ... e.position makes the last write per session win.
+    latest: dict[tuple[str, str], UsageCounters] = {}
     for row in rows:
-        latest[(str(row["origin"]), str(row["session_id"]), str(row["model_key"]))] = UsageCounters.from_row(
+        latest[(str(row["origin"]), str(row["session_id"]))] = UsageCounters.from_row(
             row,
             input_key="input_tokens",
             output_key="output_tokens",
@@ -995,7 +1000,7 @@ def _provider_cumulative_usage(conn: sqlite3.Connection, origin: str | None) -> 
             total_key="total_tokens",
         )
     by_origin: dict[str, UsageCounters] = defaultdict(UsageCounters)
-    for (origin_name, _session_id, _model_key), counters in latest.items():
+    for (origin_name, _session_id), counters in latest.items():
         by_origin[origin_name] = by_origin[origin_name].plus(counters)
     return dict(by_origin)
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1108,7 +1108,7 @@ def test_provider_usage_events_roll_up_simple_last_usage_when_no_cumulative_tota
     }
 
 
-def test_provider_usage_events_roll_up_multiple_named_models_without_guessing(tmp_path: Path) -> None:
+def test_provider_usage_events_roll_up_session_global_cumulative_to_latest_model(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(
         source_name=Provider.CODEX,
@@ -1153,9 +1153,120 @@ def test_provider_usage_events_roll_up_multiple_named_models_without_guessing(tm
         """,
         (session_id,),
     ).fetchall()
+    # The Codex cumulative total_* is session-global, not per-model. The highest
+    # position token_count row with a resolved model is the o4-mini event (the
+    # final 999/999 row has no model and 2 models exist, so it is not guessed).
+    # Its cumulative already subsumes the earlier gpt-5-codex total, so the
+    # rollup attributes the whole session to o4-mini and leaves gpt-5-codex's
+    # skeleton row at zero rather than summing 100+50 across models (#2472).
     assert [dict(row) for row in rows] == [
-        {"model_name": "gpt-5-codex", "input_tokens": 100, "output_tokens": 20},
+        {"model_name": "gpt-5-codex", "input_tokens": 0, "output_tokens": 0},
         {"model_name": "o4-mini", "input_tokens": 50, "output_tokens": 10},
+    ]
+
+
+def test_provider_usage_cumulative_model_switch_uses_highest_position_not_per_model_sum(
+    tmp_path: Path,
+) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-model-switch",
+        models_used=["gpt-5.3-codex", "gpt-5.4"],
+        messages=[],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-5.3-codex",
+                    "total_token_usage": {"input_tokens": 100, "total_tokens": 100},
+                },
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-5.3-codex",
+                    "total_token_usage": {"input_tokens": 300, "total_tokens": 300},
+                },
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-5.4",
+                    "total_token_usage": {"input_tokens": 500, "total_tokens": 500},
+                },
+            ),
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    rows = conn.execute(
+        """
+        SELECT model_name, input_tokens
+        FROM session_model_usage
+        WHERE session_id = ?
+        ORDER BY model_name
+        """,
+        (session_id,),
+    ).fetchall()
+    # The cumulative is session-global. The highest-position event (gpt-5.4,
+    # total 500) holds the running total for the WHOLE session, so the rollup is
+    # exactly 500 attributed to gpt-5.4 — NOT 300 (gpt-5.3 latest) + 500 = 800
+    # split across the two models (#2472).
+    assert [dict(row) for row in rows] == [
+        {"model_name": "gpt-5.3-codex", "input_tokens": 0},
+        {"model_name": "gpt-5.4", "input_tokens": 500},
+    ]
+
+
+def test_provider_usage_per_message_last_usage_still_rolls_up_per_model(tmp_path: Path) -> None:
+    # No cumulative total_* anywhere — the Claude-style per-message per-model
+    # delta path. These legitimately sum per model and must not regress to a
+    # single session-global rollup (#2472).
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-per-message",
+        models_used=["model-a", "model-b"],
+        messages=[],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "model-a",
+                    "last_token_usage": {"input_tokens": 10, "output_tokens": 4},
+                },
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "model-b",
+                    "last_token_usage": {"input_tokens": 7, "output_tokens": 2},
+                },
+            ),
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, session)
+
+    rows = conn.execute(
+        """
+        SELECT model_name, input_tokens, output_tokens
+        FROM session_model_usage
+        WHERE session_id = ?
+        ORDER BY model_name
+        """,
+        (session_id,),
+    ).fetchall()
+    assert [dict(row) for row in rows] == [
+        {"model_name": "model-a", "input_tokens": 10, "output_tokens": 4},
+        {"model_name": "model-b", "input_tokens": 7, "output_tokens": 2},
     ]
 
 
@@ -1558,6 +1669,78 @@ def test_provider_usage_append_last_usage_does_not_override_cumulative(tmp_path:
         "output_tokens": 40,
         "cost_provenance": "origin_reported",
     }
+
+
+def test_provider_usage_append_model_switch_clears_stale_cumulative(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    first = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append-switch",
+        models_used=["gpt-5.3-codex", "gpt-5.4"],
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                model_name="gpt-5.3-codex",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m1",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-5.3-codex",
+                    "total_token_usage": {"input_tokens": 300, "total_tokens": 300},
+                },
+            )
+        ],
+    )
+    second = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-usage-append-switch",
+        models_used=["gpt-5.3-codex", "gpt-5.4"],
+        messages=[
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                model_name="gpt-5.4",
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="second")],
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                source_message_provider_id="m2",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-5.4",
+                    "total_token_usage": {"input_tokens": 500, "total_tokens": 500},
+                },
+            )
+        ],
+    )
+
+    session_id = write_parsed_session_to_archive(conn, first)
+    write_parsed_session_to_archive(conn, second, merge_append=True)
+
+    rows = conn.execute(
+        """
+        SELECT model_name, input_tokens
+        FROM session_model_usage
+        WHERE session_id = ?
+        ORDER BY model_name
+        """,
+        (session_id,),
+    ).fetchall()
+    # The appended window's latest cumulative (gpt-5.4, 500) is the session-
+    # global running total. The earlier gpt-5.3-codex cumulative rollup (300) is
+    # now subsumed and must be cleared, not left to be summed back to 800 (#2472).
+    assert [dict(row) for row in rows] == [
+        {"model_name": "gpt-5.3-codex", "input_tokens": 0},
+        {"model_name": "gpt-5.4", "input_tokens": 500},
+    ]
 
 
 def test_reported_costs_skip_message_token_aggregate_on_plain_append(


### PR DESCRIPTION
## Summary

Fixes a double-count in Codex token accounting: the session-global cumulative
counter was partitioned by model and summed across models. Corrects the
materializers so a session's "tokens used" equals the highest-position cumulative
event, matching the authoritative source.

## Problem

Codex `token_count` events carry a **session-global** cumulative counter in their
`total_*` columns — the running total for the whole session at that point, not
per-model. Three materializers keyed the "latest cumulative" by `model_name`, so
a session that switches model mid-run (e.g. `gpt-5.3-codex` → `gpt-5.4`) stored
each model's latest cumulative separately and then **summed them** — double/triple
counting, because each cumulative already includes all prior tokens.

Cross-verification (research wave, `.agent/scratch/research/02-codex-token-overcount.md`):
the live `session_model_usage` Codex total is 199.6B (current algorithm) vs the
authoritative `~/.codex/state_5.sqlite` `threads.tokens_used` ≈ 139.3B; the
per-model partition is the 199.6B→177.1B portion of that gap (the rest is lineage
duplication, #2467). The 376.6B figure some reports show is separately stale rows
predating `3938bc6c2`, cleared by re-ingest.

## Correctness invariant

For a Codex session, "tokens used" = the `total_*` of the **highest-position**
`token_count` event — not a per-model sum of `total_*`, not a SUM of `last_*`.
On the corpus this reproduces `state_5.sqlite.tokens_used` to median ratio 1.000.

## Solution

Three sites, all changed from per-(session, model) to per-session-latest cumulative:

- **`write.py` `_aggregate_provider_usage_into_model_usage`** (full path): replace
  the per-model `latest_total_by_model` dict with a single session-wide
  `latest_total` / `latest_total_model` (the last row by position carrying any
  `total_*`). When a cumulative exists, write ONE rollup and drop the
  `summed_last_*` rows (the session-global cumulative already subsumes every
  per-request `last_*`). When NO cumulative exists (older rows / Claude-style
  per-message `last_*` usage), the per-model `summed_last` behavior is unchanged.
- **`write.py` `_aggregate_appended_provider_usage_into_model_usage`** (append
  path): same single-latest-cumulative fix, plus `_clear_stale_cumulative_rollups`
  which zeroes the prior model's rollup (scoped to `cost_provenance =
  'origin_reported'`, so priced/message-derived rollups are untouched) when the
  cumulative's model switches across append windows.
- **`usage.py` `_provider_cumulative_usage`** (read/stats): drop `model_key` from
  the dedupe key — `(origin, session_id, model_key)` → `(origin, session_id)` —
  and order by position so the highest-position cumulative wins per session.

## Re-ingest note

This corrects materialization logic, not the stored schema. The live
`session_model_usage` rows are recomputed on the next re-ingest
(`polylogue ops reset --database && polylogued run`); no schema version change.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_provider_usage_report.py` → 54 passed, incl. 3 new:
  - cumulative model-switch (A:100,300 then B:500) rolls up to 500 on B, not 800 split
  - Claude-style per-message `last_*` (two models) still rolls up per-model (no regression)
  - append-path cross-window model switch clears the stale prior-model rollup
- `devtools test tests/unit/cost/ tests/unit/insights/test_cost_basis_split.py tests/unit/insights/test_cost_rollup_summary_path.py` → 62 passed
- One existing test (`..._roll_up_multiple_named_models_without_guessing`) asserted the OLD per-model-summed cumulative (the bug); renamed and updated to the session-global-latest invariant.
- `ruff` + `mypy` clean

Ref #2472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider token usage rollups so cumulative totals are counted once at the session level, preventing double counting across models.
  * Ensured the latest cumulative usage entry is attributed to the correct model, even when model context changes during appends.
  * Preserved per-model rollups for non-cumulative message-level usage data when cumulative totals are not present.

* **Tests**
  * Added and updated coverage for session-global cumulative totals, model switches, and append/merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->