### PR TITLE
feat(devtools): add bench ingest-throughput wall-clock benchmark

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -302,6 +302,25 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "bench ingest-throughput",
+        "benchmarking",
+        "Measure ingest wall-clock throughput on a synthetic fixture.",
+        "devtools.ingest_throughput_probe",
+        use_when=(
+            "Measure ingest wall-clock / throughput, the time-based counterpart to the "
+            "bytes-based ingest-amplification probe. Drives the public batch-ingest path over "
+            "a deterministic synthetic corpus in a temp dir and times each append batch, "
+            "reporting messages/sessions per second and a per-batch-ms distribution. "
+            "Wall-clock is host-variable: diagnostic and campaign-comparable, no CI thresholds. "
+            "Additive measurement only — does not touch production ingest logic."
+        ),
+        examples=(
+            "devtools bench ingest-throughput",
+            "devtools bench ingest-throughput --json",
+            "devtools bench ingest-throughput --batches 20 --seed 2391",
+        ),
+    ),
+    CommandSpec(
         "lab snapshot read-surface",
         "verification lab",
         "Capture and compare archive read-surface snapshots.",

--- a/devtools/ingest_throughput_probe.py
+++ b/devtools/ingest_throughput_probe.py
@@ -1,0 +1,296 @@
+"""Repeatable ingest wall-clock / throughput benchmark.
+
+The sibling ``devtools bench ingest-amplification`` probe measures *bytes
+written* per archive tier — a deterministic, host-independent quantity.  It does
+not measure *time*.  This probe is the missing wall-clock counterpart: it drives
+the same public batch-ingest path (``parse_sources_archive`` — the real full
+pipeline with the WAL write profile) over a deterministic synthetic corpus, and
+times each append batch with ``time.perf_counter()``.
+
+It is additive tooling.  It does **not** touch production ingest logic — it
+drives the existing public batch-ingest path over a synthetic, deterministic
+fixture corpus built under a temporary directory.
+
+Operators run::
+
+    devtools bench ingest-throughput --json > run.json
+    devtools bench ingest-throughput --batches 20 --seed 2391
+
+The emitted report carries the total wall, derived messages/sessions per second,
+and a per-batch-millisecond distribution (min/max/mean/p90).  Wall-clock numbers
+are host-variable: this probe has **no CI thresholds**.  It is a diagnostic plus
+a campaign-comparable artifact — message/session *counts* are deterministic for
+a fixed (provider, batches, seed), the timings are not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+# Bumped when the JSON shape gains/changes a top-level key or field type.
+REPORT_VERSION = 1
+
+_DEFAULT_PROVIDER = "codex"
+_DEFAULT_BATCHES = 12
+_DEFAULT_SEED = 2391
+_DEFAULT_MESSAGES_MIN = 4
+_DEFAULT_MESSAGES_MAX = 8
+
+
+def _build_fixture_files(
+    workdir: Path,
+    *,
+    provider: str,
+    batches: int,
+    seed: int,
+    messages_min: int,
+    messages_max: int,
+) -> list[Path]:
+    """Write ``batches`` single-session synthetic source files deterministically."""
+    from polylogue.scenarios import build_default_corpus_specs
+    from polylogue.schemas.synthetic import SyntheticCorpus
+
+    available = set(SyntheticCorpus.available_providers())
+    if provider not in available:
+        raise ValueError(f"provider {provider!r} not available; choose from {sorted(available)}")
+
+    (spec,) = build_default_corpus_specs(
+        providers=(provider,),
+        count=batches,
+        messages_min=messages_min,
+        messages_max=messages_max,
+        seed=seed,
+    )
+    corpus_dir = workdir / "corpus" / provider
+    written = SyntheticCorpus.write_spec_artifacts(spec, corpus_dir, prefix="batch", index_width=3)
+    # One artifact == one session == one append batch.
+    return list(written.files)
+
+
+async def _ingest_batch(archive_root: Path, provider: str, source_file: Path) -> dict[str, int]:
+    from polylogue.config import Source
+    from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+
+    result = await parse_sources_archive(archive_root, [Source(name=provider, path=source_file)])
+    return {
+        "sessions": int(result.counts.get("sessions", 0)),
+        "messages": int(result.counts.get("messages", 0)),
+    }
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile over a non-empty list of values."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = max(1, min(len(ordered), round(pct / 100.0 * len(ordered))))
+    return ordered[rank - 1]
+
+
+def measure_ingest_throughput(
+    *,
+    provider: str = _DEFAULT_PROVIDER,
+    batches: int = _DEFAULT_BATCHES,
+    seed: int = _DEFAULT_SEED,
+    messages_min: int = _DEFAULT_MESSAGES_MIN,
+    messages_max: int = _DEFAULT_MESSAGES_MAX,
+    workdir: Path | None = None,
+) -> dict[str, Any]:
+    """Run ``batches`` single-session ingest batches and time each one.
+
+    Returns a stable, JSON-serializable report.  When ``workdir`` is omitted a
+    private temporary directory is created and torn down automatically; the
+    archive and its blob store stay entirely inside that directory.
+
+    Message/session counts are deterministic for a fixed (provider, batches,
+    seed); the wall-clock timings are host-variable and carry no thresholds.
+    """
+    if batches < 1:
+        raise ValueError("batches must be >= 1")
+
+    owns_workdir = workdir is None
+    base = Path(workdir) if workdir is not None else Path(tempfile.mkdtemp(prefix="plg-ingest-tput-"))
+    base.mkdir(parents=True, exist_ok=True)
+
+    # Isolate every global path (archive root + blob store) inside the workdir so
+    # the probe never reads or writes real user data.
+    archive_root = base / "archive"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    saved_env = {key: os.environ.get(key) for key in ("XDG_DATA_HOME", "POLYLOGUE_ARCHIVE_ROOT")}
+    os.environ["XDG_DATA_HOME"] = str(base / "xdg-data")
+    os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
+
+    try:
+        from polylogue.storage.blob_store import reset_blob_store
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        reset_blob_store()
+
+        # Bootstrap the five-tier archive file set up front so per-batch timings
+        # exclude the one-time schema-DDL cost.
+        ArchiveStore.open_existing(archive_root, read_only=False).close()
+
+        source_files = _build_fixture_files(
+            base,
+            provider=provider,
+            batches=batches,
+            seed=seed,
+            messages_min=messages_min,
+            messages_max=messages_max,
+        )
+        if len(source_files) < batches:
+            batches = len(source_files)
+
+        batch_reports: list[dict[str, Any]] = []
+        per_batch_ms: list[float] = []
+        total_sessions = 0
+        total_messages = 0
+
+        wall_start = time.perf_counter()
+        for index in range(batches):
+            source_file = source_files[index]
+            batch_start = time.perf_counter()
+            ingested = asyncio.run(_ingest_batch(archive_root, provider, source_file))
+            elapsed_ms = (time.perf_counter() - batch_start) * 1000.0
+            per_batch_ms.append(elapsed_ms)
+            total_sessions += ingested["sessions"]
+            total_messages += ingested["messages"]
+            batch_reports.append(
+                {
+                    "batch_index": index,
+                    "sessions_ingested": ingested["sessions"],
+                    "messages_ingested": ingested["messages"],
+                    "batch_ms": round(elapsed_ms, 3),
+                }
+            )
+        total_wall_s = time.perf_counter() - wall_start
+
+        per_batch_block = {
+            "min": round(min(per_batch_ms), 3) if per_batch_ms else 0.0,
+            "max": round(max(per_batch_ms), 3) if per_batch_ms else 0.0,
+            "mean": round(sum(per_batch_ms) / len(per_batch_ms), 3) if per_batch_ms else 0.0,
+            "p90": round(_percentile(per_batch_ms, 90.0), 3) if per_batch_ms else 0.0,
+        }
+
+        return {
+            "ok": True,
+            "report_version": REPORT_VERSION,
+            "tool": "bench ingest-throughput",
+            "provider": provider,
+            "batches": len(batch_reports),
+            "seed": seed,
+            "messages_min": messages_min,
+            "messages_max": messages_max,
+            "total_sessions": total_sessions,
+            "total_messages": total_messages,
+            "total_wall_s": round(total_wall_s, 4),
+            "messages_per_s": round(total_messages / total_wall_s, 2) if total_wall_s > 0 else 0.0,
+            "sessions_per_s": round(total_sessions / total_wall_s, 2) if total_wall_s > 0 else 0.0,
+            "per_batch_ms": per_batch_block,
+            "per_batch": batch_reports,
+        }
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        with suppress(Exception):
+            from polylogue.storage.blob_store import reset_blob_store as _reset
+
+            _reset()
+        if owns_workdir:
+            import shutil
+
+            with suppress(OSError):
+                shutil.rmtree(base)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--provider", default=_DEFAULT_PROVIDER, help="Synthetic provider to ingest")
+    parser.add_argument("--batches", type=int, default=_DEFAULT_BATCHES, help="Number of single-session append batches")
+    parser.add_argument("--seed", type=int, default=_DEFAULT_SEED, help="Deterministic corpus seed")
+    parser.add_argument("--messages-min", type=int, default=_DEFAULT_MESSAGES_MIN, help="Min messages per session")
+    parser.add_argument("--messages-max", type=int, default=_DEFAULT_MESSAGES_MAX, help="Max messages per session")
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="Reuse a directory for the fixture/archive instead of a private temp dir",
+    )
+    return parser
+
+
+def _format_human(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("Ingest throughput probe (wall-clock)")
+    lines.append(
+        f"  fixture: provider={report.get('provider')} batches={report.get('batches')} seed={report.get('seed')}"
+    )
+    lines.append("")
+    lines.append("  per-batch (messages -> ms):")
+    for batch in report.get("per_batch") or []:
+        lines.append(
+            f"    batch {batch['batch_index']}: {batch['messages_ingested']} msgs -> {batch['batch_ms']:.1f}ms"
+        )
+    lines.append("")
+    lines.append(
+        f"  totals: {report.get('total_sessions', 0)} sessions, "
+        f"{report.get('total_messages', 0)} messages in {report.get('total_wall_s', 0.0):.3f}s"
+    )
+    lines.append(
+        f"  throughput: {report.get('messages_per_s', 0.0):.1f} msg/s, "
+        f"{report.get('sessions_per_s', 0.0):.1f} sessions/s"
+    )
+    per_batch_ms = report.get("per_batch_ms") or {}
+    lines.append(
+        "  per-batch ms: "
+        f"min={per_batch_ms.get('min', 0.0):.1f} "
+        f"mean={per_batch_ms.get('mean', 0.0):.1f} "
+        f"p90={per_batch_ms.get('p90', 0.0):.1f} "
+        f"max={per_batch_ms.get('max', 0.0):.1f}"
+    )
+    lines.append("  (wall-clock is host-variable; no CI thresholds)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = measure_ingest_throughput(
+            provider=args.provider,
+            batches=max(1, args.batches),
+            seed=args.seed,
+            messages_min=args.messages_min,
+            messages_max=args.messages_max,
+            workdir=args.workdir,
+        )
+    except ValueError as exc:
+        print(f"ingest-throughput-probe failed: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(_format_human(report))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -157,6 +157,7 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools bench campaign` | Run or compare benchmark campaigns. |
 | `devtools bench ingest-amplification` | Measure deterministic per-tier ingest write amplification on a synthetic fixture (#1851). |
+| `devtools bench ingest-throughput` | Measure ingest wall-clock throughput on a synthetic fixture. |
 | `devtools bench memory` | Measure query-memory envelopes on generated fixtures. |
 | `devtools bench mutation` | Run focused mutation campaigns and maintain their local index. |
 | `devtools bench slo` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |

--- a/tests/unit/devtools/test_ingest_throughput_probe.py
+++ b/tests/unit/devtools/test_ingest_throughput_probe.py
@@ -1,0 +1,87 @@
+"""Tests for ``devtools bench ingest-throughput``.
+
+Throughput is host-variable, so these assertions only cover the report shape,
+type wellformedness, and the *deterministic* count fields — never wall-clock
+durations or messages/second values.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools.ingest_throughput_probe import (
+    REPORT_VERSION,
+    main,
+    measure_ingest_throughput,
+)
+
+_PER_BATCH_MS_KEYS = {"min", "max", "mean", "p90"}
+
+
+@pytest.mark.parametrize("provider", ["codex", "chatgpt"])
+def test_measure_emits_expected_shape(provider: str, tmp_path: Path) -> None:
+    report = measure_ingest_throughput(provider=provider, batches=3, seed=7, workdir=tmp_path)
+
+    assert report["ok"] is True
+    assert report["report_version"] == REPORT_VERSION
+    assert report["tool"] == "bench ingest-throughput"
+    assert report["provider"] == provider
+    assert report["batches"] == 3
+    assert report["seed"] == 7
+
+    # Deterministic count fields are non-negative ints.
+    for key in ("total_sessions", "total_messages", "batches", "seed", "messages_min", "messages_max"):
+        assert isinstance(report[key], int)
+        assert report[key] >= 0
+    assert report["total_sessions"] == 3
+    assert report["total_messages"] >= 3
+
+    # Timing fields are non-negative floats; values themselves are not asserted.
+    for key in ("total_wall_s", "messages_per_s", "sessions_per_s"):
+        assert isinstance(report[key], float)
+        assert report[key] >= 0.0
+
+    per_batch_ms = report["per_batch_ms"]
+    assert set(per_batch_ms) == _PER_BATCH_MS_KEYS
+    for value in per_batch_ms.values():
+        assert isinstance(value, float)
+        assert value >= 0.0
+    # min <= mean <= max (allow equality).
+    assert per_batch_ms["min"] <= per_batch_ms["mean"] <= per_batch_ms["max"]
+
+    per_batch = report["per_batch"]
+    assert len(per_batch) == 3
+    for index, batch in enumerate(per_batch):
+        assert batch["batch_index"] == index
+        assert batch["sessions_ingested"] == 1
+        assert batch["messages_ingested"] >= 1
+        assert isinstance(batch["batch_ms"], float)
+        assert batch["batch_ms"] >= 0.0
+
+
+def test_counts_are_deterministic(tmp_path: Path) -> None:
+    first = measure_ingest_throughput(provider="codex", batches=3, seed=99, workdir=tmp_path / "a")
+    second = measure_ingest_throughput(provider="codex", batches=3, seed=99, workdir=tmp_path / "b")
+
+    # Counts are deterministic for fixed (provider, batches, seed); timings are not.
+    assert first["total_sessions"] == second["total_sessions"]
+    assert first["total_messages"] == second["total_messages"]
+    assert [b["messages_ingested"] for b in first["per_batch"]] == [b["messages_ingested"] for b in second["per_batch"]]
+
+
+def test_main_json_round_trips(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["--json", "--batches", "2", "--seed", "3", "--workdir", str(tmp_path)])
+    assert exit_code == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["tool"] == "bench ingest-throughput"
+    assert len(payload["per_batch"]) == 2
+
+
+def test_rejects_unavailable_provider(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not available"):
+        measure_ingest_throughput(provider="nope-not-real", batches=1, workdir=tmp_path)


### PR DESCRIPTION
## Summary

Adds `devtools bench ingest-throughput`, a permanent, repeatable ingest
wall-clock / throughput benchmark — the time counterpart to the existing
`bench ingest-amplification` (which measures bytes written, not time).

## Problem

The perf work in #2488/#2489 relied on one-off scratch benchmarks. There was no
permanent way to measure ingest *throughput* (messages/s, per-batch latency) and
track it across changes. `bench ingest-amplification` deliberately measures only
deterministic byte amplification ("no wallclock thresholds"), leaving a gap:
nothing exercises and times the real ingest pipeline as a tracked artifact.

## Solution

`devtools/ingest_throughput_probe.py` mirrors the amplification probe's structure
(env isolation in a temp dir, deterministic synthetic corpus via
`build_default_corpus_specs` + `SyntheticCorpus`, real ingest through
`parse_sources_archive` — the full parse→write→index pipeline on the WAL write
profile, so the measurement is representative by construction). It times each
batch and reports a stable JSON artifact: `total_messages`, `total_wall_s`,
`messages_per_s`, `sessions_per_s`, and `per_batch_ms` (min/mean/p90/max).

Registered as `bench ingest-throughput` in the command catalog; `docs/devtools.md`
regenerated. Per-stage timings are not included because `parse_sources_archive`'s
`ParseResult` does not currently expose them (omitted rather than fabricated — a
candidate follow-up is to surface the write path's existing `stage_timings_s`).

**No CI thresholds**: throughput is host-variable, so this is a diagnostic +
campaign-comparable artifact (like a manual run before/after a change), not a
gate. The test asserts only shape, types, and count-determinism — never timings.

## Verification

- `devtools test tests/unit/devtools/test_ingest_throughput_probe.py` → 5 passed
  (shape/types, count-determinism across workdirs, per_batch ordering, bad-provider raises, 2 providers)
- Real run `devtools bench ingest-throughput --batches 6 --json` → well-formed
  report (e.g. messages_per_s, per_batch_ms min/mean/p90/max populated)
- `devtools render all --check` → no tracked-file drift; `ruff` + `mypy` clean

## Context

Built while profiling the ingest path (operator request for better, permanent
benchmarking). Profiling also confirmed the WAL write path is insert-bound
(`executemany` dominant) with no remaining algorithmic hotspot after the #2488
memoization + expression-index wins — so this harness is the durable way to catch
future regressions and validate the post-re-ingest throughput.