### PR TITLE
perf(ingest): batch commits by accumulated message count

### DIFF
--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,26 @@ from polylogue.pipeline.services.parsing_models import ParseResult
 from polylogue.sources.source_parsing import iter_source_sessions_with_raw
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
+# Work-based commit batching (#dogfood ingest-commit-batching). Re-ingest is
+# I/O-wait-bound: source.db and index.db each fsync per session under
+# per-session commit. Committing once ~8000 accumulated messages have been
+# written amortizes the fsync/WAL churn (validated ~1.37x throughput, ~4x fewer
+# bytes, peak WAL ~14 MB << 40 MB autocheckpoint). Session-count batching was
+# rejected (uneven transaction size -> larger WAL); one-shot was rejected
+# (slower + large WAL). Override with POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES;
+# a value <= 0 restores per-session commit (escape hatch).
+COMMIT_BATCH_MESSAGE_THRESHOLD = 8000
+
+
+def _commit_batch_message_threshold() -> int:
+    raw = os.environ.get("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES")
+    if raw is None:
+        return COMMIT_BATCH_MESSAGE_THRESHOLD
+    try:
+        return int(raw)
+    except ValueError:
+        return COMMIT_BATCH_MESSAGE_THRESHOLD
+
 
 async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> ParseResult:
     """Parse configured sources directly into archive source/index tiers."""
@@ -19,20 +40,32 @@ async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> Pa
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     raw_rows_written = 0
     index_rows_written = 0
+    threshold = _commit_batch_message_threshold()
+    batched = threshold > 0
+    pending_messages = 0
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
         for source in sources:
             for raw_data, session in iter_source_sessions_with_raw(source, capture_raw=True):
                 payload = _archive_raw_payload(raw_data, session)
                 source_path = _archive_raw_source_path(raw_data, source)
                 source_index = _archive_raw_source_index(raw_data)
-                _raw_id, session_id = archive.write_raw_and_parsed(
-                    session,
-                    payload=payload,
-                    source_path=source_path,
-                    acquired_at_ms=acquired_at_ms,
-                    source_index=source_index,
-                    stage_timings_s=result.stage_timings_s,
-                )
+                try:
+                    _raw_id, session_id = archive.write_raw_and_parsed(
+                        session,
+                        payload=payload,
+                        source_path=source_path,
+                        acquired_at_ms=acquired_at_ms,
+                        source_index=source_index,
+                        stage_timings_s=result.stage_timings_s,
+                        manage_transaction=not batched,
+                    )
+                except Exception:
+                    # Discard the in-flight uncommitted batch so a failed write
+                    # never leaves prior sessions in this batch half-applied.
+                    # Re-ingest is restartable from durable source evidence.
+                    if batched:
+                        archive.rollback()
+                    raise
                 raw_rows_written += 1
                 index_rows_written += 1
                 await result.merge_result(
@@ -47,6 +80,13 @@ async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> Pa
                     },
                     content_changed=True,
                 )
+                if batched:
+                    pending_messages += len(session.messages)
+                    if pending_messages >= threshold:
+                        archive.commit()
+                        pending_messages = 0
+        if batched and pending_messages > 0:
+            archive.commit()
     result.batch_observations.append(
         {
             "primary_ingest_store": "archive_file_set",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -436,6 +436,11 @@ class ArchiveStore:
             self._conn.execute(f"PRAGMA busy_timeout = {max(0, int(read_timeout * 1000))}")
         self._user_tier_attached = False
         self._tags_relation = "session_tags"
+        # Lazily opened persistent write connection to source.db. Keeping it open
+        # across writes lets a bulk caller batch raw-session commits (it is the
+        # twin of the index.db commit batched on self._conn) instead of paying a
+        # source-tier fsync per session. Opened on first raw write only.
+        self._source_conn: sqlite3.Connection | None = None
         self._attach_user_tier_if_present()
 
     @classmethod
@@ -467,7 +472,38 @@ class ArchiveStore:
         except sqlite3.Error:
             return
 
+    def _ensure_source_conn(self) -> sqlite3.Connection:
+        """Return the persistent source.db write connection, opening it lazily."""
+        if self._source_conn is None:
+            conn = sqlite3.connect(self.source_db_path)
+            conn.execute("PRAGMA foreign_keys = ON")
+            self._source_conn = conn
+        return self._source_conn
+
+    def commit(self) -> None:
+        """Commit the index.db and (if open) source.db write connections.
+
+        Bulk callers that pass ``manage_transaction=False`` to the write methods
+        own commit cadence; this flushes both tiers' in-flight batch.
+        """
+        self._conn.commit()
+        if self._source_conn is not None:
+            self._source_conn.commit()
+
+    def rollback(self) -> None:
+        """Roll back the index.db and (if open) source.db write connections.
+
+        Used by a bulk caller to discard an uncommitted, half-applied batch when
+        a write raises, before propagating the error.
+        """
+        self._conn.rollback()
+        if self._source_conn is not None:
+            self._source_conn.rollback()
+
     def close(self) -> None:
+        if self._source_conn is not None:
+            self._source_conn.close()
+            self._source_conn = None
         self._conn.close()
 
     def write_parsed(self, session: ParsedSession, *, content_hash: str | None = None) -> str:
@@ -484,8 +520,15 @@ class ArchiveStore:
         source_index: int = 0,
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "append",
+        manage_transaction: bool = True,
     ) -> tuple[str, str]:
-        """Write raw acquisition bytes and the parsed session they produced."""
+        """Write raw acquisition bytes and the parsed session they produced.
+
+        With the default ``manage_transaction=True`` each tier write commits on
+        its own. A bulk caller passes ``manage_transaction=False`` and owns
+        commit cadence via :meth:`commit` / :meth:`rollback` so the source.db and
+        index.db writes are batched into shared transactions.
+        """
 
         def add_timing(name: str, started_at: float) -> None:
             if stage_timings_s is not None:
@@ -493,25 +536,20 @@ class ArchiveStore:
                 stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
 
         t0 = time.perf_counter()
-        source_conn = sqlite3.connect(self.source_db_path)
+        source_conn = self._ensure_source_conn()
         add_timing("source_connect", t0)
-        try:
-            t0 = time.perf_counter()
-            source_conn.execute("PRAGMA foreign_keys = ON")
-            raw_id = write_source_raw_session(
-                source_conn,
-                origin=origin_from_provider(session.source_name),
-                source_path=source_path,
-                source_index=source_index,
-                native_id=session.provider_session_id,
-                payload=payload,
-                acquired_at_ms=acquired_at_ms,
-            )
-            add_timing("source_raw_write", t0)
-        finally:
-            t0 = time.perf_counter()
-            source_conn.close()
-            add_timing("source_close", t0)
+        t0 = time.perf_counter()
+        raw_id = write_source_raw_session(
+            source_conn,
+            origin=origin_from_provider(session.source_name),
+            source_path=source_path,
+            source_index=source_index,
+            native_id=session.provider_session_id,
+            payload=payload,
+            acquired_at_ms=acquired_at_ms,
+            manage_transaction=manage_transaction,
+        )
+        add_timing("source_raw_write", t0)
         t0 = time.perf_counter()
         session_id = write_parsed_session_to_archive(
             self._conn,
@@ -520,6 +558,7 @@ class ArchiveStore:
             merge_append=source_index < 0,
             stage_timings_s=stage_timings_s,
             stage_timing_prefix=stage_timing_prefix,
+            manage_transaction=manage_transaction,
         )
         add_timing("index_parsed_write", t0)
         return raw_id, session_id
@@ -535,8 +574,12 @@ class ArchiveStore:
         source_index: int = 0,
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "full",
+        manage_transaction: bool = True,
     ) -> tuple[str, str]:
-        """Write parsed session metadata for an already-materialized raw blob."""
+        """Write parsed session metadata for an already-materialized raw blob.
+
+        See :meth:`write_raw_and_parsed` for the ``manage_transaction`` contract.
+        """
 
         def add_timing(name: str, started_at: float) -> None:
             if stage_timings_s is not None:
@@ -544,26 +587,21 @@ class ArchiveStore:
                 stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
 
         t0 = time.perf_counter()
-        source_conn = sqlite3.connect(self.source_db_path)
+        source_conn = self._ensure_source_conn()
         add_timing("source_connect", t0)
-        try:
-            t0 = time.perf_counter()
-            source_conn.execute("PRAGMA foreign_keys = ON")
-            raw_id = write_source_raw_session_blob_ref(
-                source_conn,
-                origin=origin_from_provider(session.source_name),
-                source_path=source_path,
-                source_index=source_index,
-                native_id=session.provider_session_id,
-                blob_hash=bytes.fromhex(blob_hash_hex),
-                blob_size=blob_size,
-                acquired_at_ms=acquired_at_ms,
-            )
-            add_timing("source_raw_blob_ref_write", t0)
-        finally:
-            t0 = time.perf_counter()
-            source_conn.close()
-            add_timing("source_close", t0)
+        t0 = time.perf_counter()
+        raw_id = write_source_raw_session_blob_ref(
+            source_conn,
+            origin=origin_from_provider(session.source_name),
+            source_path=source_path,
+            source_index=source_index,
+            native_id=session.provider_session_id,
+            blob_hash=bytes.fromhex(blob_hash_hex),
+            blob_size=blob_size,
+            acquired_at_ms=acquired_at_ms,
+            manage_transaction=manage_transaction,
+        )
+        add_timing("source_raw_blob_ref_write", t0)
         t0 = time.perf_counter()
         session_id = write_parsed_session_to_archive(
             self._conn,
@@ -572,6 +610,7 @@ class ArchiveStore:
             merge_append=source_index < 0,
             stage_timings_s=stage_timings_s,
             stage_timing_prefix=stage_timing_prefix,
+            manage_transaction=manage_transaction,
         )
         add_timing("index_parsed_write", t0)
         return raw_id, session_id

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+from contextlib import nullcontext
 from dataclasses import dataclass
 
 from polylogue.core.enums import ArtifactSupportStatus, Origin, ValidationMode, ValidationStatus
@@ -212,8 +213,16 @@ def write_source_raw_session(
     additional_blob_refs: tuple[ArchiveSourceBlobRef, ...] = (),
     artifact: ArchiveSourceArtifact | None = None,
     hook_event: ArchiveHookEvent | None = None,
+    manage_transaction: bool = True,
 ) -> str:
-    """Insert one raw session and its required raw-payload blob reference."""
+    """Insert one raw session and its required raw-payload blob reference.
+
+    By default the write runs in its own transaction (``with conn:``) committed
+    on success. A bulk caller that batches many sessions into one transaction —
+    to amortize the per-commit fsync and WAL churn that dominate re-ingest I/O —
+    passes ``manage_transaction=False`` and owns the surrounding commit and any
+    rollback-on-error itself.
+    """
     conn.execute("PRAGMA foreign_keys = ON")
     origin_value = _enum_value(origin)
     blob_hash = deterministic_blob_hash(payload)
@@ -226,7 +235,7 @@ def write_source_raw_session(
         native_id,
     )
 
-    with conn:
+    with conn if manage_transaction else nullcontext():
         conn.execute(
             """
             INSERT OR REPLACE INTO raw_sessions (
@@ -298,8 +307,12 @@ def write_source_raw_session_blob_ref(
     acquired_at_ms: int,
     native_id: str | None = None,
     raw_id: str | None = None,
+    manage_transaction: bool = True,
 ) -> str:
-    """Insert one raw session that already has a materialized raw-payload blob."""
+    """Insert one raw session that already has a materialized raw-payload blob.
+
+    See :func:`write_source_raw_session` for the ``manage_transaction`` contract.
+    """
     if len(blob_hash) != 32:
         raise ValueError("blob_hash must be a 32-byte SHA-256 digest")
     conn.execute("PRAGMA foreign_keys = ON")
@@ -311,7 +324,7 @@ def write_source_raw_session_blob_ref(
         blob_hash,
         native_id,
     )
-    with conn:
+    with conn if manage_transaction else nullcontext():
         conn.execute(
             """
             INSERT OR REPLACE INTO raw_sessions (

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -9,6 +9,7 @@ import sqlite3
 import time
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -228,8 +229,16 @@ def write_parsed_session_to_archive(
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
     signature_cache: dict[str, list[tuple[str, str]]] | None = None,
+    manage_transaction: bool = True,
 ) -> str:
-    """Write one parsed session into an initialized archive index DB."""
+    """Write one parsed session into an initialized archive index DB.
+
+    By default the whole write runs in its own transaction (``with conn:``)
+    committed on success. A bulk caller that wants many sessions in one
+    transaction — to amortize the per-commit fsync and WAL page churn that
+    dominate re-ingest I/O — passes ``manage_transaction=False`` and owns the
+    surrounding commit and any rollback-on-error itself.
+    """
     t0 = time.perf_counter()
 
     def add_timing(name: str, started_at: float) -> None:
@@ -276,7 +285,10 @@ def write_parsed_session_to_archive(
     add_timing("index.prepare", t0)
     session_counts = _session_count_values(messages)
 
-    with conn:
+    # When the caller owns the transaction (bulk batching) we must not commit
+    # per session; nullcontext leaves BEGIN/COMMIT to the caller.
+    transaction = conn if manage_transaction else nullcontext()
+    with transaction:
         t0 = time.perf_counter()
         conn.execute(
             """

--- a/tests/unit/pipeline/test_archive_ingest_commit_batching.py
+++ b/tests/unit/pipeline/test_archive_ingest_commit_batching.py
@@ -1,0 +1,150 @@
+"""Work-based commit batching for the re-ingest path (parse_sources_archive).
+
+Covers:
+- (a) batched mode: a tiny message threshold commits in several batches yet the
+  final archive contains every session and message.
+- (b) per-session escape hatch (threshold <= 0) still ingests everything.
+- (c) atomicity: a write that raises mid-batch rolls back the uncommitted batch
+  so no partial rows from that batch survive, and rollback() is invoked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.pipeline.services import archive_ingest
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import build_default_corpus_specs
+from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+
+def _build_sources(tmp_path: Path, *, count: int, seed: int = 7) -> list[Source]:
+    available = set(SyntheticCorpus.available_providers())
+    providers = [p for p in ("chatgpt", "claude-ai") if p in available]
+    specs = build_default_corpus_specs(
+        providers=providers,
+        count=count,
+        messages_min=4,
+        messages_max=11,
+        seed=seed,
+    )
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir(exist_ok=True)
+    sources: list[Source] = []
+    for spec in specs:
+        provider_dir = corpus_dir / spec.provider
+        written = SyntheticCorpus.write_spec_artifacts(spec, provider_dir, prefix="corpus")
+        sources.extend(Source(name=spec.provider, path=file_path) for file_path in written.files)
+    return sources
+
+
+def _counts(index_db: Path) -> tuple[int, int]:
+    conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    try:
+        sessions = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+        messages = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+    finally:
+        conn.close()
+    return sessions, messages
+
+
+def _expected_session_count(sources: Sequence[Source]) -> int:
+    # Each synthetic artifact in this corpus produces exactly one session.
+    return len(sources)
+
+
+def test_batched_commit_persists_all_sessions(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tiny threshold forces multiple batch commits; all data still lands."""
+    monkeypatch.setenv("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES", "5")
+    archive_root = workspace_env["archive_root"]
+    sources = _build_sources(tmp_path, count=4)
+    assert len(sources) >= 4  # multiple batches given >=4 msgs/session and threshold 5
+
+    result = asyncio.run(parse_sources_archive(archive_root, sources))
+
+    index_db = archive_root / "index.db"
+    sessions, messages = _counts(index_db)
+    assert sessions == _expected_session_count(sources)
+    assert sessions == result.counts["sessions"]
+    assert messages == result.counts["messages"]
+    assert messages > 0
+
+
+def test_per_session_escape_hatch(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """threshold <= 0 preserves per-session commit behavior and ingests all."""
+    monkeypatch.setenv("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES", "0")
+    archive_root = workspace_env["archive_root"]
+    sources = _build_sources(tmp_path, count=3, seed=11)
+
+    result = asyncio.run(parse_sources_archive(archive_root, sources))
+
+    sessions, messages = _counts(archive_root / "index.db")
+    assert sessions == _expected_session_count(sources)
+    assert sessions == result.counts["sessions"]
+    assert messages == result.counts["messages"]
+
+
+def test_failed_write_rolls_back_uncommitted_batch(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-batch failure rolls back so no prior session in the batch survives."""
+    # Large threshold so nothing commits until the (never reached) tail flush:
+    # the whole run is one uncommitted batch.
+    monkeypatch.setenv("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES", "1000000")
+    archive_root = workspace_env["archive_root"]
+    sources = _build_sources(tmp_path, count=4, seed=23)
+    assert len(sources) >= 2
+
+    original_write = ArchiveStore.write_raw_and_parsed
+    calls = {"n": 0}
+
+    def failing_write(self: ArchiveStore, *args: object, **kwargs: object) -> tuple[str, str]:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated mid-batch write failure")
+        return original_write(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    rollbacks = {"n": 0}
+    original_rollback = ArchiveStore.rollback
+
+    def spy_rollback(self: ArchiveStore) -> None:
+        rollbacks["n"] += 1
+        original_rollback(self)
+
+    monkeypatch.setattr(ArchiveStore, "write_raw_and_parsed", failing_write)
+    monkeypatch.setattr(ArchiveStore, "rollback", spy_rollback)
+
+    with pytest.raises(RuntimeError, match="simulated mid-batch write failure"):
+        asyncio.run(parse_sources_archive(archive_root, sources))
+
+    assert calls["n"] == 2
+    assert rollbacks["n"] == 1
+    # The first session's index rows were written but never committed; rollback
+    # must have discarded them so the archive carries no partial batch rows.
+    sessions, messages = _counts(archive_root / "index.db")
+    assert sessions == 0
+    assert messages == 0
+
+
+def test_invalid_env_falls_back_to_default_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES", "not-an-int")
+    assert archive_ingest._commit_batch_message_threshold() == archive_ingest.COMMIT_BATCH_MESSAGE_THRESHOLD
+    monkeypatch.delenv("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES", raising=False)
+    assert archive_ingest._commit_batch_message_threshold() == archive_ingest.COMMIT_BATCH_MESSAGE_THRESHOLD


### PR DESCRIPTION
## Summary

Re-ingest commits per session today (each session = 2 fsyncs: one for the
source.db raw row, one for the index.db parsed tree). This batches commits by
**accumulated message count** so many sessions land in one transaction,
amortizing fsync and WAL page-churn. On the real re-ingest path this measured
**~4.8× throughput and ~16.8× fewer bytes written**.

## Problem (measured, not assumed)

A new comprehensive instrument (`devtools bench ingest-throughput`, #2491) showed
ingest is **I/O-wait-bound** (cpu_utilization ≈ 0.60), not CPU- or parallel-bound.
The cost is per-session commits: `write_parsed_session_to_archive` and
`write_source_raw_session` each ran their own `with conn:` transaction. A policy
sweep over a mixed workload (200 small + 6×2000-msg sessions) compared per-session
vs session-count vs message-count vs one-shot commit cadences.

## Solution

- `manage_transaction: bool = True` on `write_parsed_session_to_archive`,
  `write_source_raw_session`, and `write_source_raw_session_blob_ref`
  (`nullcontext` when False — caller owns the transaction).
- `ArchiveStore` gains a persistent (lazily-opened) source.db write connection
  plus `commit()`/`rollback()` covering both tiers; `write_raw_and_parsed` /
  `write_raw_blob_and_parsed` thread `manage_transaction` to both writes.
  (The source.db connection had to become persistent so a deferred batch isn't
  lost on a per-call close; `close()`/`__exit__` close it — no leak.)
- `parse_sources_archive` is now a work-based batch driver:
  `COMMIT_BATCH_MESSAGE_THRESHOLD = 8000` (env override
  `POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES`; `<= 0` = per-session escape hatch),
  commits once ~8000 messages have accumulated, flushes the tail, and
  `rollback()`s a half-applied batch before propagating any write error.

### Why message-count (not session-count or one-shot)

Sessions vary from a handful to tens of thousands of messages, so "every N
sessions" gives wildly uneven transaction work. The sweep (msg/s · bytes · peak WAL):

| policy | msg/s | written | peak WAL |
|---|---|---|---|
| per-session | 9,622 | 119.9 MB | — |
| session-count N=20 | 13,195 | 30.0 MB | 27.9 MB |
| **message-count M=8000** | 12,745 | 25.1 MB | **13.9 MB** |
| one-shot | 11,335 (slower) | 22.7 MB | grows |

Work-based M=8000 matches the best throughput, writes near the one-shot floor,
and keeps **peak WAL ~14 MB** — ~half of session-count (a batch catching several
large sessions stays bounded) and well under the 40 MB autocheckpoint / 160 MB
`journal_size_limit`. One-shot is slower (giant single commit) and grows WAL.
`synchronous=OFF` (1.45×) was rejected: batching is faster *and* crash-safe at
`synchronous=NORMAL` (a crash rolls back the in-flight batch; re-ingest redoes it).

Page size and autocheckpoint were also swept and left unchanged (default 4096 is
optimal; autocheckpoint is irrelevant once WAL peaks ~14 MB).

## Verification

- Real re-ingest path (one `parse_sources_archive` call, 500 sessions / 3749 msgs):
  per-session **354.8 msg/s, 374.8 MB** → batched **1711.6 msg/s, 22.3 MB**
  (~4.8× throughput, ~16.8× fewer bytes). Host-variable; the conservative sweep
  figure is ~1.37×/~4×.
- `devtools test tests/unit/storage tests/unit/pipeline` → 74 passed (incl. new
  `test_archive_ingest_commit_batching.py`: batched-persists-all, escape-hatch,
  mid-batch-rollback atomicity, invalid-env fallback)
- `devtools test tests/integration` → 31 passed (ingest, idempotency,
  write-amplification, facade — cross-tier correctness under batching)
- `ruff` + `mypy` clean

Ref #2391