### PR TITLE
feat(browser-capture): add gated post commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1201,6 +1201,48 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 15 makes `idx_messages_session_sortkey` an expression
+  index — `(session_id, (occurred_at_ms IS NULL), occurred_at_ms, message_id)`
+  (#2475 perf audit). The keyset/paginated message reads order by
+  `(occurred_at_ms IS NULL), occurred_at_ms, message_id` so NULL-timestamp rows
+  sort last; the v14 plain `(session_id, occurred_at_ms, message_id)` index could
+  not satisfy that leading `IS NULL` expression, so the planner fell back to
+  `USE TEMP B-TREE FOR ORDER BY` and sorted the whole session per chunk
+  (expensive on multi-thousand-message sessions). The expression index matches
+  the ORDER BY exactly and plans as a covering-index scan with no temp sort
+  (verified via EXPLAIN QUERY PLAN). Rebuild from source evidence
+  (`polylogue ops reset --database && polylogued run`).
+- Index schema version 14 hardens lineage normalization (#2467 audit).
+  `session_links.branch_point_message_id` is no longer a FK with `ON DELETE SET
+  NULL`: a parent's full-replace re-ingest (`DELETE FROM messages` then re-INSERT)
+  would otherwise null the child's branch point during the DELETE step and
+  permanently break the child's composition. `message_id` is deterministic, so the
+  plain-TEXT reference survives the re-create; reads bail to the child's own tail
+  if a branch point ever dangles. Also adds `idx_messages_session_sortkey` so the
+  keyset/paginated message reads stop doing a temp B-tree sort per chunk. Rebuild
+  from source evidence.
+- Index schema version 13 makes attachment bytes honest (#2468). `attachments.blob_hash`
+  is now nullable and holds the **true SHA-256 of the stored bytes** when acquired
+  (previously a synthetic hash of the attachment id was written with no blob ever
+  stored — 0 blobs for 8,425 rows). A new `acquisition_status`
+  (`acquired` / `unavailable` / `unfetched`) records whether the bytes were
+  fetched. Inline export bytes (e.g. Gemini base64) are written to the
+  content-addressed blob store at ingest; other sources stay `unfetched` with the
+  source ref preserved for later re-acquisition. Rebuild from source evidence.
+- Index schema version 12 normalizes prefix-sharing lineage (#2467). A fork,
+  resume, spawned subagent, or auto-compaction copy physically replays the
+  parent's leading context; the writer now drops that inherited prefix and keeps
+  only the child's divergent tail, recording the relationship on `session_links`
+  via two new columns: `branch_point_message_id` (the last inherited parent
+  message) and `inheritance` (`prefix-sharing` vs `spawned-fresh`). Reads
+  (`get_messages`, `read_archive_session_envelope`) compose the parent transcript
+  up to the branch point + the child's own tail, so each real message is stored
+  once while the full logical transcript is still served. Existing index tiers
+  must be rebuilt from source evidence (`polylogue ops reset --database &&
+  polylogued run`); `source.db` is untouched, so this is a derived-index rebuild
+  with no user-data impact. (The matching parser detection of Codex
+  `forked_from_id`/`thread_spawn` and Claude `agent-acompact-*` shipped
+  alongside.)
 - Index schema version 11 materializes the run projection into three derived
   read-model tables — `session_runs`, `session_observed_events`, and
   `session_context_snapshots` — recomputed by the session-insight materializer
@@ -1856,6 +1898,7 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools bench campaign` | Run or compare benchmark campaigns. |
 | `devtools bench ingest-amplification` | Measure deterministic per-tier ingest write amplification on a synthetic fixture (#1851). |
+| `devtools bench ingest-throughput` | Measure ingest wall-clock throughput on a synthetic fixture. |
 | `devtools bench memory` | Measure query-memory envelopes on generated fixtures. |
 | `devtools bench mutation` | Run focused mutation campaigns and maintain their local index. |
 | `devtools bench slo` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,7 +1,12 @@
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const BACKGROUND_CAPTURE_MIN_INTERVAL_MS = 30000;
 const CAPTURE_LOG_LIMIT = 80;
+const POST_POLL_INTERVAL_MS = 5000;
 const recentBackgroundCaptures = new Map();
+// command_id -> true once dispatched to a content script this SW lifetime, so a
+// fast poll cannot deliver the same command twice before its ack lands.
+const inFlightPostCommands = new Set();
+let postPollTimer = 0;
 
 function injectionPlanForUrl(url) {
   try {
@@ -242,6 +247,150 @@ async function captureSupportedTabs(reason) {
   await Promise.allSettled(tabs.map((tab) => captureTab(tab, reason)));
 }
 
+// ---- Outbound posting (reverse channel) ---------------------------------
+//
+// Disabled by default. The local receiver only serves post commands when its
+// own POLYLOGUE_BROWSER_POST_ENABLED=1 guard is set; the extension adds a second
+// independent guard (`postingEnabled`, default false) so a misconfigured
+// receiver still cannot drive the page without an explicit opt-in here.
+
+async function postingSettings() {
+  const stored = await chrome.storage.local.get({ postingEnabled: false });
+  return { postingEnabled: Boolean(stored.postingEnabled) };
+}
+
+async function savePostingSettings(postingEnabled) {
+  await chrome.storage.local.set({ postingEnabled: Boolean(postingEnabled) });
+  return postingSettings();
+}
+
+function providerTokenForUrl(url) {
+  try {
+    const parsed = new URL(url || "");
+    if (parsed.hostname === "chatgpt.com" || parsed.hostname.endsWith(".chatgpt.com")) return "chatgpt";
+    if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) return "claude";
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function conversationIdForUrl(url) {
+  try {
+    const parsed = new URL(url || "");
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    const provider = providerTokenForUrl(url);
+    if (provider === "chatgpt") {
+      const marker = parts.indexOf("c");
+      return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
+    }
+    if (provider === "claude") {
+      return parts[0] === "chat" && parts[1] ? parts[1] : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function ackPostCommand(commandId, result) {
+  try {
+    await postJson(`/v1/post-commands/${encodeURIComponent(commandId)}/ack`, result);
+  } catch (error) {
+    await appendCaptureLog({ ok: false, reason: "post_ack", command_id: commandId, error: String(error.message || error) });
+  }
+}
+
+async function findTabForCommand(command) {
+  if (!chrome.tabs?.query) return null;
+  const tabs = await chrome.tabs.query({});
+  const provider = command.provider;
+  const target = command.target || {};
+  const wantNew = !target.conversation_id || target.conversation_id === "new";
+  let fallback = null;
+  for (const tab of tabs) {
+    const url = tab.url || tab.pendingUrl || "";
+    if (providerTokenForUrl(url) !== provider) continue;
+    if (wantNew) {
+      if (tab.active) return tab;
+      fallback = fallback || tab;
+      continue;
+    }
+    if (conversationIdForUrl(url) === target.conversation_id) return tab;
+  }
+  return wantNew ? fallback : null;
+}
+
+async function dispatchPostCommand(command) {
+  if (!command || !command.command_id || inFlightPostCommands.has(command.command_id)) return;
+  inFlightPostCommands.add(command.command_id);
+  try {
+    const tab = await findTabForCommand(command);
+    if (!tab?.id) {
+      await ackPostCommand(command.command_id, { status: "failed", detail: "no_matching_tab" });
+      return;
+    }
+    await ensureCaptureScripts(tab);
+    let result;
+    try {
+      result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.postReply", command });
+    } catch (error) {
+      await ackPostCommand(command.command_id, {
+        status: "failed",
+        detail: String(error.message || error),
+        observed_url: tab.url || null,
+      });
+      return;
+    }
+    await ackPostCommand(command.command_id, {
+      status: result?.status === "submitted" ? "submitted" : "failed",
+      detail: result?.detail || null,
+      observed_url: result?.observed_url || tab.url || null,
+    });
+  } finally {
+    inFlightPostCommands.delete(command.command_id);
+  }
+}
+
+async function pollPostCommands() {
+  const { postingEnabled } = await postingSettings();
+  if (!postingEnabled) return;
+  for (const provider of ["chatgpt", "claude"]) {
+    let body;
+    try {
+      body = await getJson(`/v1/post-commands?provider=${provider}`);
+    } catch {
+      continue;
+    }
+    if (!body?.post_enabled || !Array.isArray(body.commands)) continue;
+    for (const command of body.commands) {
+      await dispatchPostCommand(command);
+    }
+  }
+}
+
+async function startPostPolling() {
+  const { postingEnabled } = await postingSettings();
+  if (!postingEnabled) {
+    stopPostPolling();
+    return;
+  }
+  if (postPollTimer) return;
+  postPollTimer = setInterval(() => {
+    void pollPostCommands();
+  }, POST_POLL_INTERVAL_MS);
+  void pollPostCommands();
+}
+
+function stopPostPolling() {
+  if (postPollTimer) {
+    clearInterval(postPollTimer);
+    postPollTimer = 0;
+  }
+}
+
+void startPostPolling();
+
 chrome.runtime.onInstalled?.addListener(() => {
   void captureSupportedTabs("extension_installed_or_updated");
 });
@@ -336,6 +485,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
     if (message.type === "polylogue.captureSupportedTabs") {
       await captureSupportedTabs(message.reason || "popup_sync_open_tabs");
+      sendResponse({ ok: true });
+      return;
+    }
+    if (message.type === "polylogue.configurePosting") {
+      const settings = await savePostingSettings(message.postingEnabled);
+      await startPostPolling();
+      sendResponse({ ok: true, postingEnabled: settings.postingEnabled });
+      return;
+    }
+    if (message.type === "polylogue.pollPostCommands") {
+      await pollPostCommands();
       sendResponse({ ok: true });
       return;
     }

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -6,6 +6,7 @@ const recentBackgroundCaptures = new Map();
 // command_id -> true once dispatched to a content script this SW lifetime, so a
 // fast poll cannot deliver the same command twice before its ack lands.
 const inFlightPostCommands = new Set();
+const pendingPostCommandAcks = new Map();
 let postPollTimer = 0;
 
 function injectionPlanForUrl(url) {
@@ -296,8 +297,19 @@ function conversationIdForUrl(url) {
 async function ackPostCommand(commandId, result) {
   try {
     await postJson(`/v1/post-commands/${encodeURIComponent(commandId)}/ack`, result);
+    pendingPostCommandAcks.delete(commandId);
+    inFlightPostCommands.delete(commandId);
+    return true;
   } catch (error) {
     await appendCaptureLog({ ok: false, reason: "post_ack", command_id: commandId, error: String(error.message || error) });
+    pendingPostCommandAcks.set(commandId, result);
+    return false;
+  }
+}
+
+async function retryPendingPostCommandAcks() {
+  for (const [commandId, result] of [...pendingPostCommandAcks.entries()]) {
+    await ackPostCommand(commandId, result);
   }
 }
 
@@ -312,6 +324,7 @@ async function findTabForCommand(command) {
     const url = tab.url || tab.pendingUrl || "";
     if (providerTokenForUrl(url) !== provider) continue;
     if (wantNew) {
+      if (conversationIdForUrl(url)) continue;
       if (tab.active) return tab;
       fallback = fallback || tab;
       continue;
@@ -324,10 +337,11 @@ async function findTabForCommand(command) {
 async function dispatchPostCommand(command) {
   if (!command || !command.command_id || inFlightPostCommands.has(command.command_id)) return;
   inFlightPostCommands.add(command.command_id);
+  let terminalAckRecorded = false;
   try {
     const tab = await findTabForCommand(command);
     if (!tab?.id) {
-      await ackPostCommand(command.command_id, { status: "failed", detail: "no_matching_tab" });
+      terminalAckRecorded = await ackPostCommand(command.command_id, { status: "failed", detail: "no_matching_tab" });
       return;
     }
     await ensureCaptureScripts(tab);
@@ -335,26 +349,27 @@ async function dispatchPostCommand(command) {
     try {
       result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.postReply", command });
     } catch (error) {
-      await ackPostCommand(command.command_id, {
+      terminalAckRecorded = await ackPostCommand(command.command_id, {
         status: "failed",
         detail: String(error.message || error),
         observed_url: tab.url || null,
       });
       return;
     }
-    await ackPostCommand(command.command_id, {
+    terminalAckRecorded = await ackPostCommand(command.command_id, {
       status: result?.status === "submitted" ? "submitted" : "failed",
       detail: result?.detail || null,
       observed_url: result?.observed_url || tab.url || null,
     });
   } finally {
-    inFlightPostCommands.delete(command.command_id);
+    if (terminalAckRecorded) inFlightPostCommands.delete(command.command_id);
   }
 }
 
 async function pollPostCommands() {
   const { postingEnabled } = await postingSettings();
   if (!postingEnabled) return;
+  await retryPendingPostCommandAcks();
   for (const provider of ["chatgpt", "claude"]) {
     let body;
     try {
@@ -376,7 +391,7 @@ async function startPostPolling() {
     return;
   }
   if (postPollTimer) return;
-  postPollTimer = setInterval(() => {
+  postPollTimer = globalThis.setInterval(() => {
     void pollPostCommands();
   }, POST_POLL_INTERVAL_MS);
   void pollPostCommands();
@@ -384,7 +399,7 @@ async function startPostPolling() {
 
 function stopPostPolling() {
   if (postPollTimer) {
-    clearInterval(postPollTimer);
+    globalThis.clearInterval(postPollTimer);
     postPollTimer = 0;
   }
 }

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -186,7 +186,8 @@
     } else {
       node.textContent = text;
     }
-    node.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, data: text, inputType: "insertText" }));
+    const InputEventCtor = typeof window.InputEvent === "function" ? window.InputEvent : window.Event;
+    node.dispatchEvent(new InputEventCtor("input", { bubbles: true, cancelable: true, data: text, inputType: "insertText" }));
     return true;
   }
 

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -154,6 +154,63 @@
     });
   }
 
+  function firstMatch(selectors) {
+    for (const selector of selectors) {
+      const node = document.querySelector(selector);
+      if (node) return node;
+    }
+    return null;
+  }
+
+  function setComposerText(node, text) {
+    node.focus();
+    // ProseMirror / Lexical / contenteditable composers register input through
+    // beforeinput+input. execCommand("insertText") drives that path most
+    // reliably; selecting all first replaces any existing draft.
+    try {
+      const selection = window.getSelection();
+      if (selection) {
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      const inserted = document.execCommand && document.execCommand("insertText", false, text);
+      if (inserted) return true;
+    } catch {
+      /* fall through to manual path */
+    }
+    // Fallback: set content directly and dispatch an input event.
+    if (typeof node.value === "string") {
+      node.value = text;
+    } else {
+      node.textContent = text;
+    }
+    node.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, data: text, inputType: "insertText" }));
+    return true;
+  }
+
+  // Deliver a post command into a provider composer. SAFETY: this fills the
+  // composer and only clicks send when command.submit === true. The default is a
+  // dry-run that leaves the drafted text in place without submitting, so an
+  // accidental dispatch never posts to a live thread.
+  async function postReplyToComposer({ command, composerSelectors, sendSelectors }) {
+    const observed_url = window.location.href;
+    const text = command && typeof command.text === "string" ? command.text : "";
+    if (!text) return { status: "failed", detail: "empty_text", observed_url };
+    const composer = firstMatch(composerSelectors);
+    if (!composer) return { status: "failed", detail: "composer_not_found", observed_url };
+    setComposerText(composer, text);
+    if (command.submit !== true) {
+      return { status: "submitted", detail: "dry_run_filled_not_sent", observed_url };
+    }
+    const sendButton = firstMatch(sendSelectors);
+    if (!sendButton) return { status: "failed", detail: "send_button_not_found", observed_url };
+    if (sendButton.disabled) return { status: "failed", detail: "send_button_disabled", observed_url };
+    sendButton.click();
+    return { status: "submitted", detail: "sent", observed_url };
+  }
+
   const existingCapture = window.polylogueCapture || {};
   window.polylogueCapture = {
     ...existingCapture,
@@ -161,6 +218,7 @@
     sessionIdFromUrl,
     capturePage: existingCapture.capturePage || null,
     fnv1a,
+    postReplyToComposer,
     refreshArchiveState,
     sendCapture,
     temporarySessionId,

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -385,6 +385,36 @@
     capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
+  // Outbound posting (reverse channel). Selectors target the ChatGPT composer
+  // as of 2026-06 and need live re-verification when the UI changes: composer is
+  // the ProseMirror contenteditable #prompt-textarea (verified live). The submit
+  // button has NO data-testid="send-button" in the current UI — it is the
+  // composer-submit slot (class composer-submit-button-color); its aria-label is
+  // "Start Voice"/dictation when empty and becomes a send label only with text,
+  // so match by the submit-slot class first, aria-label last.
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== "polylogue.postReply") return false;
+    window.polylogueCapture
+      .postReplyToComposer({
+        command: message.command,
+        composerSelectors: [
+          "#prompt-textarea",
+          'div[contenteditable="true"]#prompt-textarea',
+          'form div[contenteditable="true"]'
+        ],
+        sendSelectors: [
+          "button.composer-submit-button-color",
+          'button[data-testid="composer-send-button"]',
+          'button[data-testid="send-button"]',
+          'button[aria-label*="Send" i]'
+        ]
+      })
+      .then(sendResponse)
+      .catch((error) =>
+        sendResponse({ status: "failed", detail: String(error.message || error), observed_url: window.location.href })
+      );
+    return true;
+  });
   new MutationObserver(scheduleCapture).observe(document.documentElement, {
     childList: true,
     subtree: true,

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -250,6 +250,30 @@
     capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
+  // Outbound posting (reverse channel). Selectors target the Claude.ai composer
+  // as of 2026-06 and need live re-verification when the UI changes: composer is
+  // the ProseMirror contenteditable div, send is the aria-labelled send button.
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== "polylogue.postReply") return false;
+    window.polylogueCapture
+      .postReplyToComposer({
+        command: message.command,
+        composerSelectors: [
+          'div.ProseMirror[contenteditable="true"]',
+          'div[contenteditable="true"].ProseMirror',
+          'fieldset div[contenteditable="true"]'
+        ],
+        sendSelectors: [
+          'button[aria-label="Send message"]',
+          'button[aria-label*="Send" i]'
+        ]
+      })
+      .then(sendResponse)
+      .catch((error) =>
+        sendResponse({ status: "failed", detail: String(error.message || error), observed_url: window.location.href })
+      );
+    return true;
+  });
   new MutationObserver(scheduleCapture).observe(document.documentElement, {
     childList: true,
     subtree: true,

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -227,6 +227,108 @@ class BrowserCaptureErrorPayload(BaseModel):
     error: str
 
 
+BrowserPostProvider = Literal["chatgpt", "claude"]
+BrowserPostCommandStatus = Literal["pending", "dispatched", "submitted", "failed"]
+BrowserPostAckStatus = Literal["submitted", "failed"]
+
+
+class BrowserPostTarget(BaseModel):
+    """Where a post command should land.
+
+    ``conversation_id`` is the provider-native conversation id of an existing
+    thread, or the literal ``"new"`` to request a fresh thread. ``project_ref``
+    optionally pins the post to a provider project/workspace (e.g. a ChatGPT
+    ``g-p-<project>`` segment).
+    """
+
+    conversation_id: str = "new"
+    project_ref: str | None = None
+
+    @field_validator("conversation_id", mode="before")
+    @classmethod
+    def coerce_conversation_id(cls, value: object) -> str:
+        if value is None:
+            return "new"
+        text = str(value).strip()
+        return text or "new"
+
+
+class BrowserPostCommandRequest(BaseModel):
+    """Operator/agent request to enqueue an outbound post command."""
+
+    provider: BrowserPostProvider
+    target: BrowserPostTarget = Field(default_factory=BrowserPostTarget)
+    text: str
+    command_id: str | None = None
+    submit: bool = False
+
+    @field_validator("text")
+    @classmethod
+    def require_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("post command text must not be empty")
+        return value
+
+
+class BrowserPostCommand(BaseModel):
+    """A persisted outbound post command and its lifecycle state."""
+
+    polylogue_post_command_kind: Literal["browser_post_command"] = "browser_post_command"
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    command_id: str
+    provider: BrowserPostProvider
+    target: BrowserPostTarget
+    text: str
+    submit: bool = False
+    status: BrowserPostCommandStatus = "pending"
+    created_at: str
+    updated_at: str
+    dispatched_at: str | None = None
+    acked_at: str | None = None
+    detail: str | None = None
+    observed_url: str | None = None
+
+
+class BrowserPostCommandAckRequest(BaseModel):
+    """Extension-reported result for a dispatched post command."""
+
+    status: BrowserPostAckStatus
+    detail: str | None = None
+    observed_url: str | None = None
+
+
+class BrowserPostEnqueuedPayload(BaseModel):
+    """Response to ``POST /v1/post-commands``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    command_id: str
+    provider: BrowserPostProvider
+    status: BrowserPostCommandStatus
+    submit: bool
+
+
+class BrowserPostCommandListPayload(BaseModel):
+    """Response to ``GET /v1/post-commands``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    post_enabled: bool
+    commands: list[BrowserPostCommand] = Field(default_factory=list)
+
+
+class BrowserPostAckPayload(BaseModel):
+    """Response to ``POST /v1/post-commands/<command_id>/ack``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    command_id: str
+    status: BrowserPostCommandStatus
+
+
 def looks_like_browser_capture(payload: object) -> bool:
     """Return whether a payload is a browser-capture envelope."""
     if not isinstance(payload, dict):
@@ -256,5 +358,15 @@ __all__ = [
     "BrowserCaptureSession",
     "BrowserCaptureSessionKind",
     "BrowserCaptureTurn",
+    "BrowserPostAckPayload",
+    "BrowserPostAckStatus",
+    "BrowserPostCommand",
+    "BrowserPostCommandAckRequest",
+    "BrowserPostCommandListPayload",
+    "BrowserPostCommandRequest",
+    "BrowserPostCommandStatus",
+    "BrowserPostEnqueuedPayload",
+    "BrowserPostProvider",
+    "BrowserPostTarget",
     "looks_like_browser_capture",
 ]

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -435,6 +435,14 @@ class BrowserPostDisabledError(RuntimeError):
     """Raised when a post command is requested while posting is disabled."""
 
 
+class BrowserPostCommandConflictError(RuntimeError):
+    """Raised when a queued post command id would overwrite an existing command."""
+
+
+class BrowserPostCommandStateError(RuntimeError):
+    """Raised when an ack targets a command state that cannot be acked."""
+
+
 def browser_post_enabled() -> bool:
     """Return whether outbound posting is enabled via the env safety flag."""
     return os.environ.get(BROWSER_POST_ENABLED_ENV, "") == "1"
@@ -492,6 +500,8 @@ def enqueue_post_command(
         raise BrowserPostDisabledError(f"outbound posting is disabled; set {BROWSER_POST_ENABLED_ENV}=1 to enable")
     root = post_command_queue_root(spool_path)
     command_id = _safe_token(request.command_id) if request.command_id else uuid4().hex
+    if _post_command_path(root, command_id).exists():
+        raise BrowserPostCommandConflictError(f"post command already exists: {command_id}")
     now = datetime.now(UTC).isoformat()
     command = BrowserPostCommand(
         command_id=command_id,
@@ -554,6 +564,10 @@ def ack_post_command(
     command = _read_post_command(path)
     if command is None:
         return None
+    if command.status in {"submitted", "failed"}:
+        return command
+    if command.status != "dispatched":
+        raise BrowserPostCommandStateError(f"cannot ack post command in {command.status!r} state")
     now = datetime.now(UTC).isoformat()
     command.status = ack.status
     command.detail = ack.detail
@@ -569,6 +583,8 @@ __all__ = [
     "POST_COMMAND_QUEUE_DIRNAME",
     "BrowserCaptureReceiverConfig",
     "BrowserCaptureWriteResult",
+    "BrowserPostCommandConflictError",
+    "BrowserPostCommandStateError",
     "BrowserPostDisabledError",
     "ack_post_command",
     "browser_post_enabled",

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import sqlite3
 import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import uuid4
 
 import orjson
 
@@ -18,12 +20,24 @@ from polylogue.browser_capture.models import (
     BrowserCaptureArchiveStatePayload,
     BrowserCaptureEnvelope,
     BrowserCaptureReceiverStatusPayload,
+    BrowserPostCommand,
+    BrowserPostCommandAckRequest,
+    BrowserPostCommandRequest,
 )
 from polylogue.core.hashing import hash_text_short
 from polylogue.paths import archive_root as default_archive_root
 from polylogue.paths import browser_capture_spool_root
 
 _SAFE_TOKEN = re.compile(r"[^A-Za-z0-9._-]+")
+
+#: Environment flag that must equal ``"1"`` before the receiver will enqueue or
+#: dispatch any outbound post command. Default OFF: the posting capability is a
+#: high-authority action (it writes into a live ChatGPT/Claude thread through the
+#: extension), so it cannot fire by accident — an operator must opt in explicitly.
+BROWSER_POST_ENABLED_ENV = "POLYLOGUE_BROWSER_POST_ENABLED"
+
+#: Subdirectory of the capture spool that holds queued post commands.
+POST_COMMAND_QUEUE_DIRNAME = "post-commands"
 
 
 @dataclass(frozen=True, slots=True)
@@ -417,14 +431,155 @@ def existing_capture_state(
     ).model_dump(mode="json", exclude_none=True)
 
 
+class BrowserPostDisabledError(RuntimeError):
+    """Raised when a post command is requested while posting is disabled."""
+
+
+def browser_post_enabled() -> bool:
+    """Return whether outbound posting is enabled via the env safety flag."""
+    return os.environ.get(BROWSER_POST_ENABLED_ENV, "") == "1"
+
+
+def post_command_queue_root(spool_path: Path | None = None) -> Path:
+    """Return the directory that holds queued outbound post commands."""
+    root = spool_path if spool_path is not None else BrowserCaptureReceiverConfig.default().spool_path
+    return root / POST_COMMAND_QUEUE_DIRNAME
+
+
+def _post_command_path(root: Path, command_id: str) -> Path:
+    return root / f"{_safe_token(command_id)}.json"
+
+
+def _atomic_write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
+    with tempfile.NamedTemporaryFile("wb", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+        temp_path = Path(handle.name)
+        handle.write(raw)
+        handle.write(b"\n")
+    temp_path.replace(path)
+
+
+def _write_post_command(root: Path, command: BrowserPostCommand) -> Path:
+    target = _post_command_path(root, command.command_id)
+    _atomic_write_json(target, command.model_dump(mode="json", exclude_none=True))
+    return target
+
+
+def _read_post_command(path: Path) -> BrowserPostCommand | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return BrowserPostCommand.model_validate(payload)
+    except Exception:
+        return None
+
+
+def enqueue_post_command(
+    request: BrowserPostCommandRequest,
+    *,
+    spool_path: Path | None = None,
+) -> BrowserPostCommand:
+    """Persist an outbound post command in the queue.
+
+    Raises :class:`BrowserPostDisabledError` unless the
+    ``POLYLOGUE_BROWSER_POST_ENABLED=1`` safety flag is set, so the capability
+    cannot fire by accident.
+    """
+    if not browser_post_enabled():
+        raise BrowserPostDisabledError(f"outbound posting is disabled; set {BROWSER_POST_ENABLED_ENV}=1 to enable")
+    root = post_command_queue_root(spool_path)
+    command_id = _safe_token(request.command_id) if request.command_id else uuid4().hex
+    now = datetime.now(UTC).isoformat()
+    command = BrowserPostCommand(
+        command_id=command_id,
+        provider=request.provider,
+        target=request.target,
+        text=request.text,
+        submit=request.submit,
+        status="pending",
+        created_at=now,
+        updated_at=now,
+    )
+    _write_post_command(root, command)
+    return command
+
+
+def poll_post_commands(
+    *,
+    provider: str | None = None,
+    spool_path: Path | None = None,
+    claim: bool = True,
+) -> list[BrowserPostCommand]:
+    """Return pending post commands, optionally claiming them (pending -> dispatched).
+
+    Returns an empty list when posting is disabled, so a manually-placed queue
+    file is never dispatched while the safety flag is off. Claiming a command
+    prevents a subsequent poll from re-dispatching it; an unacked dispatched
+    command is intentionally not auto-retried.
+    """
+    if not browser_post_enabled():
+        return []
+    root = post_command_queue_root(spool_path)
+    if not root.exists():
+        return []
+    commands: list[BrowserPostCommand] = []
+    for path in sorted(root.glob("*.json")):
+        command = _read_post_command(path)
+        if command is None or command.status != "pending":
+            continue
+        if provider is not None and command.provider != provider:
+            continue
+        if claim:
+            now = datetime.now(UTC).isoformat()
+            command.status = "dispatched"
+            command.dispatched_at = now
+            command.updated_at = now
+            _write_post_command(root, command)
+        commands.append(command)
+    return commands
+
+
+def ack_post_command(
+    command_id: str,
+    ack: BrowserPostCommandAckRequest,
+    *,
+    spool_path: Path | None = None,
+) -> BrowserPostCommand | None:
+    """Record the extension's result for a dispatched post command."""
+    root = post_command_queue_root(spool_path)
+    path = _post_command_path(root, command_id)
+    command = _read_post_command(path)
+    if command is None:
+        return None
+    now = datetime.now(UTC).isoformat()
+    command.status = ack.status
+    command.detail = ack.detail
+    command.observed_url = ack.observed_url
+    command.acked_at = now
+    command.updated_at = now
+    _write_post_command(root, command)
+    return command
+
+
 __all__ = [
+    "BROWSER_POST_ENABLED_ENV",
+    "POST_COMMAND_QUEUE_DIRNAME",
     "BrowserCaptureReceiverConfig",
     "BrowserCaptureWriteResult",
+    "BrowserPostDisabledError",
+    "ack_post_command",
+    "browser_post_enabled",
     "capture_artifact_ref",
     "capture_response_id",
     "_is_extension_origin_pattern",
     "capture_artifact_path",
+    "enqueue_post_command",
     "existing_capture_state",
+    "poll_post_commands",
+    "post_command_queue_root",
     "receiver_status_payload",
     "write_capture_envelope",
 ]

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -12,7 +12,14 @@ from dataclasses import dataclass
 from typing import Literal
 
 BrowserCaptureAuthPolicy = Literal["extension_origin", "bearer_if_web_origin", "bearer_if_configured"]
-BrowserCaptureRouteKind = Literal["status", "archive_state", "capture_ingest"]
+BrowserCaptureRouteKind = Literal[
+    "status",
+    "archive_state",
+    "capture_ingest",
+    "post_command_enqueue",
+    "post_command_poll",
+    "post_command_ack",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +62,39 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "BrowserCaptureEnvelope",
         "BrowserCaptureAcceptedPayload | BrowserCaptureErrorPayload",
         "Accepts captures and returns a receiver-local artifact ref; extra web origins require bearer auth.",
+    ),
+    BrowserCaptureRouteContract(
+        "POST",
+        "/v1/post-commands",
+        "post_command_enqueue",
+        "bearer_if_web_origin",
+        "BrowserPostCommandRequest",
+        "BrowserPostEnqueuedPayload | BrowserCaptureErrorPayload",
+        (
+            "Enqueues an outbound post command. Refused with 403 unless "
+            "POLYLOGUE_BROWSER_POST_ENABLED=1 (default OFF safety guard)."
+        ),
+    ),
+    BrowserCaptureRouteContract(
+        "GET",
+        "/v1/post-commands",
+        "post_command_poll",
+        "bearer_if_configured",
+        "optional provider query parameter",
+        "BrowserPostCommandListPayload",
+        (
+            "Extension polls for pending post commands and claims them "
+            "(pending -> dispatched). Returns an empty command list when posting is disabled."
+        ),
+    ),
+    BrowserCaptureRouteContract(
+        "POST",
+        "/v1/post-commands/{command_id}/ack",
+        "post_command_ack",
+        "bearer_if_web_origin",
+        "BrowserPostCommandAckRequest",
+        "BrowserPostAckPayload | BrowserCaptureErrorPayload",
+        "Extension reports the post result (submitted|failed); updates the queued command.",
     ),
 )
 

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -100,13 +100,28 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
 
 
 def browser_capture_route_contract_for(method: str, path: str) -> BrowserCaptureRouteContract | None:
-    """Return the receiver route contract for an exact method/path pair."""
+    """Return the receiver route contract for a method/path pair."""
 
     method_upper = method.upper()
     for contract in BROWSER_CAPTURE_ROUTE_CONTRACTS:
-        if contract.method == method_upper and contract.pattern == path:
+        if contract.method == method_upper and _route_pattern_matches(contract.pattern, path):
             return contract
     return None
+
+
+def _route_pattern_matches(pattern: str, path: str) -> bool:
+    pattern_parts = pattern.strip("/").split("/")
+    path_parts = path.strip("/").split("/")
+    if len(pattern_parts) != len(path_parts):
+        return False
+    for pattern_part, path_part in zip(pattern_parts, path_parts, strict=True):
+        if pattern_part.startswith("{") and pattern_part.endswith("}"):
+            if not path_part:
+                return False
+            continue
+        if pattern_part != path_part:
+            return False
+    return True
 
 
 __all__ = [

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -18,11 +18,21 @@ from polylogue.browser_capture.models import (
     BrowserCaptureAcceptedPayload,
     BrowserCaptureEnvelope,
     BrowserCaptureErrorPayload,
+    BrowserPostAckPayload,
+    BrowserPostCommandAckRequest,
+    BrowserPostCommandListPayload,
+    BrowserPostCommandRequest,
+    BrowserPostEnqueuedPayload,
 )
 from polylogue.browser_capture.receiver import (
     BrowserCaptureReceiverConfig,
+    BrowserPostDisabledError,
+    ack_post_command,
+    browser_post_enabled,
     capture_response_id,
+    enqueue_post_command,
     existing_capture_state,
+    poll_post_commands,
     receiver_status_payload,
     write_capture_envelope,
 )
@@ -204,30 +214,57 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 ),
             )
             return
+        if parsed.path == "/v1/post-commands":
+            params = parse_qs(parsed.query)
+            post_provider = params.get("provider", [""])[0] or None
+            commands = poll_post_commands(provider=post_provider, spool_path=self.server.config.spool_path)
+            self._send_json(
+                HTTPStatus.OK,
+                BrowserPostCommandListPayload(
+                    post_enabled=browser_post_enabled(),
+                    commands=commands,
+                ).model_dump(mode="json", exclude_none=True),
+            )
+            return
         self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
 
     def do_POST(self) -> None:
         self._observe_request("POST", self._do_post)
 
-    def _do_post(self) -> None:
-        if self._reject_origin() or self._reject_token():
-            return
-        if urlparse(self.path).path != "/v1/browser-captures":
-            self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
-            return
+    def _read_json_body(self) -> object | None:
+        """Read and parse a JSON request body, sending an error and returning None on failure."""
         try:
             length = int(self.headers.get("Content-Length", "0"))
         except ValueError:
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_content_length")
-            return
+            return None
         if length <= 0 or length > MAX_BROWSER_CAPTURE_BODY_BYTES:
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_body_size")
-            return
+            return None
         try:
-            payload = json.loads(self.rfile.read(length))
+            parsed: object = json.loads(self.rfile.read(length))
         except json.JSONDecodeError:
             logger.warning("browser_capture.invalid_json", request_id=self._request_id())
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_json")
+            return None
+        return parsed
+
+    def _do_post(self) -> None:
+        if self._reject_origin() or self._reject_token():
+            return
+        path = urlparse(self.path).path
+        if path == "/v1/post-commands":
+            self._post_command_enqueue()
+            return
+        if path.startswith("/v1/post-commands/") and path.endswith("/ack"):
+            command_id = path[len("/v1/post-commands/") : -len("/ack")]
+            self._post_command_ack(command_id)
+            return
+        if path != "/v1/browser-captures":
+            self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
+            return
+        payload = self._read_json_body()
+        if payload is None:
             return
         try:
             envelope = BrowserCaptureEnvelope.model_validate(payload)
@@ -260,6 +297,73 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 bytes_written=result.bytes_written,
                 replaced=result.replaced,
             ).model_dump(mode="json"),
+        )
+
+    def _post_command_enqueue(self) -> None:
+        payload = self._read_json_body()
+        if payload is None:
+            return
+        try:
+            request = BrowserPostCommandRequest.model_validate(payload)
+        except ValidationError:
+            logger.warning("browser_capture.invalid_post_command", request_id=self._request_id())
+            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_post_command")
+            return
+        try:
+            command = enqueue_post_command(request, spool_path=self.server.config.spool_path)
+        except BrowserPostDisabledError:
+            logger.warning("browser_capture.post_disabled", request_id=self._request_id())
+            self._safe_error(HTTPStatus.FORBIDDEN, "post_disabled")
+            return
+        except OSError as exc:
+            logger.warning("browser_capture.post_enqueue_failed", request_id=self._request_id(), error=repr(exc))
+            self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
+            return
+        logger.debug(
+            "browser_capture.post_command_enqueued",
+            request_id=self._request_id(),
+            command_id=command.command_id,
+            provider=command.provider,
+            submit=command.submit,
+        )
+        self._send_json(
+            HTTPStatus.ACCEPTED,
+            BrowserPostEnqueuedPayload(
+                command_id=command.command_id,
+                provider=command.provider,
+                status=command.status,
+                submit=command.submit,
+            ).model_dump(mode="json"),
+        )
+
+    def _post_command_ack(self, command_id: str) -> None:
+        payload = self._read_json_body()
+        if payload is None:
+            return
+        try:
+            ack = BrowserPostCommandAckRequest.model_validate(payload)
+        except ValidationError:
+            logger.warning("browser_capture.invalid_post_ack", request_id=self._request_id())
+            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_post_ack")
+            return
+        try:
+            command = ack_post_command(command_id, ack, spool_path=self.server.config.spool_path)
+        except OSError as exc:
+            logger.warning("browser_capture.post_ack_failed", request_id=self._request_id(), error=repr(exc))
+            self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
+            return
+        if command is None:
+            self._safe_error(HTTPStatus.NOT_FOUND, "unknown_command")
+            return
+        logger.debug(
+            "browser_capture.post_command_acked",
+            request_id=self._request_id(),
+            command_id=command.command_id,
+            status=command.status,
+        )
+        self._send_json(
+            HTTPStatus.OK,
+            BrowserPostAckPayload(command_id=command.command_id, status=command.status).model_dump(mode="json"),
         )
 
 

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -26,6 +26,8 @@ from polylogue.browser_capture.models import (
 )
 from polylogue.browser_capture.receiver import (
     BrowserCaptureReceiverConfig,
+    BrowserPostCommandConflictError,
+    BrowserPostCommandStateError,
     BrowserPostDisabledError,
     ack_post_command,
     browser_post_enabled,
@@ -217,7 +219,12 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/post-commands":
             params = parse_qs(parsed.query)
             post_provider = params.get("provider", [""])[0] or None
-            commands = poll_post_commands(provider=post_provider, spool_path=self.server.config.spool_path)
+            try:
+                commands = poll_post_commands(provider=post_provider, spool_path=self.server.config.spool_path)
+            except OSError as exc:
+                logger.warning("browser_capture.post_poll_failed", request_id=self._request_id(), error=repr(exc))
+                self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
+                return
             self._send_json(
                 HTTPStatus.OK,
                 BrowserPostCommandListPayload(
@@ -315,6 +322,10 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             logger.warning("browser_capture.post_disabled", request_id=self._request_id())
             self._safe_error(HTTPStatus.FORBIDDEN, "post_disabled")
             return
+        except BrowserPostCommandConflictError:
+            logger.warning("browser_capture.post_command_conflict", request_id=self._request_id())
+            self._safe_error(HTTPStatus.CONFLICT, "duplicate_post_command")
+            return
         except OSError as exc:
             logger.warning("browser_capture.post_enqueue_failed", request_id=self._request_id(), error=repr(exc))
             self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
@@ -348,6 +359,10 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             return
         try:
             command = ack_post_command(command_id, ack, spool_path=self.server.config.spool_path)
+        except BrowserPostCommandStateError:
+            logger.warning("browser_capture.post_ack_invalid_state", request_id=self._request_id())
+            self._safe_error(HTTPStatus.CONFLICT, "invalid_post_command_state")
+            return
         except OSError as exc:
             logger.warning("browser_capture.post_ack_failed", request_id=self._request_id(), error=repr(exc))
             self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")

--- a/polylogue/daemon/browser_capture.py
+++ b/polylogue/daemon/browser_capture.py
@@ -6,6 +6,13 @@ from pathlib import Path
 
 import click
 
+from polylogue.browser_capture.models import BrowserPostCommandRequest, BrowserPostTarget
+from polylogue.browser_capture.receiver import (
+    BROWSER_POST_ENABLED_ENV,
+    BrowserPostDisabledError,
+    browser_post_enabled,
+    enqueue_post_command,
+)
 from polylogue.browser_capture.server import make_server
 from polylogue.core.json import dumps
 from polylogue.daemon.status import browser_capture_status_payload
@@ -49,4 +56,65 @@ def serve_command(host: str, port: int, spool_path: Path | None) -> None:
         server.server_close()
 
 
-__all__ = ["browser_capture_command", "serve_command", "status_command"]
+@browser_capture_command.command("post")
+@click.option("--provider", type=click.Choice(["chatgpt", "claude"]), required=True)
+@click.option(
+    "--conversation-id",
+    "conversation_id",
+    default="new",
+    show_default=True,
+    help='Provider-native conversation id, or "new" to request a fresh thread.',
+)
+@click.option("--project-ref", "project_ref", default=None, help="Optional provider project/workspace ref.")
+@click.option("--text", required=True, help="Prompt text to post into the conversation.")
+@click.option("--command-id", "command_id", default=None, help="Optional explicit command id.")
+@click.option(
+    "--submit/--no-submit",
+    "submit",
+    default=False,
+    show_default=True,
+    help="Request the extension to actually click send. Default is a dry-run that fills the composer only.",
+)
+@click.option("--spool", "spool_path", type=click.Path(path_type=Path), default=None)
+@click.option("--format", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
+def post_command(
+    provider: str,
+    conversation_id: str,
+    project_ref: str | None,
+    text: str,
+    command_id: str | None,
+    submit: bool,
+    spool_path: Path | None,
+    output_format: str | None,
+) -> None:
+    """Enqueue an outbound post command for the extension to deliver.
+
+    Safety: refused unless POLYLOGUE_BROWSER_POST_ENABLED=1 is set. The command
+    is only queued here; the running receiver serves it to the extension via
+    GET /v1/post-commands.
+    """
+    request = BrowserPostCommandRequest(
+        provider=provider,  # type: ignore[arg-type]
+        target=BrowserPostTarget(conversation_id=conversation_id, project_ref=project_ref),
+        text=text,
+        command_id=command_id,
+        submit=submit,
+    )
+    try:
+        command = enqueue_post_command(request, spool_path=spool_path)
+    except BrowserPostDisabledError:
+        raise click.ClickException(
+            f"Outbound posting is disabled. Set {BROWSER_POST_ENABLED_ENV}=1 to enable (default OFF safety guard)."
+        ) from None
+    payload = command.model_dump(mode="json", exclude_none=True)
+    if output_format == "json":
+        click.echo(dumps(payload))
+        return
+    click.echo(f"Queued post command {command.command_id}")
+    click.echo(f"Provider: {command.provider}  target: {command.target.conversation_id}")
+    click.echo(f"Submit (click send): {command.submit}")
+    if not browser_post_enabled():  # pragma: no cover - defensive; enqueue would have raised
+        click.echo(f"WARNING: {BROWSER_POST_ENABLED_ENV} is not set")
+
+
+__all__ = ["browser_capture_command", "post_command", "serve_command", "status_command"]

--- a/polylogue/daemon/browser_capture.py
+++ b/polylogue/daemon/browser_capture.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import get_args
 
 import click
+from pydantic import ValidationError
 
-from polylogue.browser_capture.models import BrowserPostCommandRequest, BrowserPostTarget
+from polylogue.browser_capture.models import BrowserPostCommandRequest, BrowserPostProvider, BrowserPostTarget
 from polylogue.browser_capture.receiver import (
     BROWSER_POST_ENABLED_ENV,
     BrowserPostDisabledError,
@@ -57,7 +59,7 @@ def serve_command(host: str, port: int, spool_path: Path | None) -> None:
 
 
 @browser_capture_command.command("post")
-@click.option("--provider", type=click.Choice(["chatgpt", "claude"]), required=True)
+@click.option("--provider", type=click.Choice(list(get_args(BrowserPostProvider))), required=True)
 @click.option(
     "--conversation-id",
     "conversation_id",
@@ -93,15 +95,17 @@ def post_command(
     is only queued here; the running receiver serves it to the extension via
     GET /v1/post-commands.
     """
-    request = BrowserPostCommandRequest(
-        provider=provider,  # type: ignore[arg-type]
-        target=BrowserPostTarget(conversation_id=conversation_id, project_ref=project_ref),
-        text=text,
-        command_id=command_id,
-        submit=submit,
-    )
     try:
+        request = BrowserPostCommandRequest(
+            provider=provider,  # type: ignore[arg-type]
+            target=BrowserPostTarget(conversation_id=conversation_id, project_ref=project_ref),
+            text=text,
+            command_id=command_id,
+            submit=submit,
+        )
         command = enqueue_post_command(request, spool_path=spool_path)
+    except ValidationError as exc:
+        raise click.ClickException(str(exc)) from None
     except BrowserPostDisabledError:
         raise click.ClickException(
             f"Outbound posting is disabled. Set {BROWSER_POST_ENABLED_ENV}=1 to enable (default OFF safety guard)."

--- a/tests/unit/browser_capture/test_post_commands.py
+++ b/tests/unit/browser_capture/test_post_commands.py
@@ -1,0 +1,213 @@
+"""Tests for the browser-capture outbound post-command queue and routes."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http import HTTPStatus
+from http.client import HTTPConnection, HTTPResponse
+from pathlib import Path
+from threading import Thread
+from typing import cast
+
+import pytest
+
+from polylogue.browser_capture.models import (
+    BrowserPostCommandAckRequest,
+    BrowserPostCommandRequest,
+    BrowserPostTarget,
+)
+from polylogue.browser_capture.receiver import (
+    BROWSER_POST_ENABLED_ENV,
+    BrowserPostDisabledError,
+    ack_post_command,
+    browser_post_enabled,
+    enqueue_post_command,
+    poll_post_commands,
+    post_command_queue_root,
+)
+from polylogue.browser_capture.route_contracts import (
+    BROWSER_CAPTURE_ROUTE_CONTRACTS,
+    browser_capture_route_contract_for,
+)
+from polylogue.browser_capture.server import make_server
+
+_EXTENSION_ORIGIN = "chrome-extension://polylogue-test"
+
+
+@pytest.fixture
+def post_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(BROWSER_POST_ENABLED_ENV, "1")
+
+
+@pytest.fixture
+def post_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(BROWSER_POST_ENABLED_ENV, raising=False)
+
+
+def _request_obj(provider: str = "chatgpt", conversation_id: str = "conv-1") -> BrowserPostCommandRequest:
+    return BrowserPostCommandRequest(
+        provider=provider,  # type: ignore[arg-type]
+        target=BrowserPostTarget(conversation_id=conversation_id),
+        text="Please research X.",
+    )
+
+
+# ---- queue-level lifecycle ------------------------------------------------
+
+
+def test_enqueue_requires_env_flag(tmp_path: Path, post_disabled: None) -> None:
+    assert browser_post_enabled() is False
+    with pytest.raises(BrowserPostDisabledError):
+        enqueue_post_command(_request_obj(), spool_path=tmp_path)
+    assert not post_command_queue_root(tmp_path).exists()
+
+
+def test_enqueue_poll_ack_lifecycle(tmp_path: Path, post_enabled: None) -> None:
+    command = enqueue_post_command(_request_obj(), spool_path=tmp_path)
+    assert command.status == "pending"
+    assert command.submit is False
+
+    # Poll claims the command: pending -> dispatched.
+    polled = poll_post_commands(provider="chatgpt", spool_path=tmp_path)
+    assert [c.command_id for c in polled] == [command.command_id]
+    assert polled[0].status == "dispatched"
+
+    # A second poll does not re-dispatch a claimed command.
+    assert poll_post_commands(provider="chatgpt", spool_path=tmp_path) == []
+
+    acked = ack_post_command(
+        command.command_id,
+        BrowserPostCommandAckRequest(
+            status="submitted", detail="dry_run_filled_not_sent", observed_url="https://chatgpt.com/c/conv-1"
+        ),
+        spool_path=tmp_path,
+    )
+    assert acked is not None
+    assert acked.status == "submitted"
+    assert acked.observed_url == "https://chatgpt.com/c/conv-1"
+
+
+def test_poll_returns_empty_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(BROWSER_POST_ENABLED_ENV, "1")
+    enqueue_post_command(_request_obj(), spool_path=tmp_path)
+    # Even with a queued command on disk, disabling posting hides it.
+    monkeypatch.delenv(BROWSER_POST_ENABLED_ENV, raising=False)
+    assert poll_post_commands(spool_path=tmp_path) == []
+
+
+def test_poll_filters_by_provider(tmp_path: Path, post_enabled: None) -> None:
+    enqueue_post_command(_request_obj(provider="chatgpt"), spool_path=tmp_path)
+    enqueue_post_command(_request_obj(provider="claude"), spool_path=tmp_path)
+    claude = poll_post_commands(provider="claude", spool_path=tmp_path)
+    assert [c.provider for c in claude] == ["claude"]
+
+
+def test_ack_unknown_command(tmp_path: Path, post_enabled: None) -> None:
+    assert (
+        ack_post_command("does-not-exist", BrowserPostCommandAckRequest(status="failed"), spool_path=tmp_path) is None
+    )
+
+
+# ---- HTTP route surface ---------------------------------------------------
+
+
+@contextmanager
+def _running_receiver(tmp_path: Path) -> Iterator[tuple[str, int]]:
+    server = make_server("127.0.0.1", 0, spool_path=tmp_path)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = cast(tuple[str, int], server.server_address[:2])
+    try:
+        yield host, port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _request(
+    host: str, port: int, method: str, path: str, *, body: object | None = None
+) -> tuple[int, dict[str, object]]:
+    conn = HTTPConnection(host, port)
+    headers = {"Origin": _EXTENSION_ORIGIN}
+    payload: str | None = None
+    if body is not None:
+        payload = json.dumps(body)
+        headers["Content-Type"] = "application/json"
+    conn.request(method, path, body=payload, headers=headers)
+    response: HTTPResponse = conn.getresponse()
+    raw = response.read()
+    conn.close()
+    parsed = json.loads(raw) if raw else {}
+    return response.status, parsed
+
+
+def test_route_contracts_registered() -> None:
+    kinds = {c.kind for c in BROWSER_CAPTURE_ROUTE_CONTRACTS}
+    assert {"post_command_enqueue", "post_command_poll", "post_command_ack"} <= kinds
+    assert browser_capture_route_contract_for("POST", "/v1/post-commands") is not None
+    assert browser_capture_route_contract_for("GET", "/v1/post-commands") is not None
+
+
+def test_http_enqueue_disabled_returns_403(tmp_path: Path, post_disabled: None) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(host, port, "POST", "/v1/post-commands", body={"provider": "chatgpt", "text": "hi"})
+    assert status == HTTPStatus.FORBIDDEN
+    assert body["error"] == "post_disabled"
+
+
+def test_http_post_command_full_lifecycle(tmp_path: Path, post_enabled: None) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, enq = _request(
+            host,
+            port,
+            "POST",
+            "/v1/post-commands",
+            body={
+                "provider": "chatgpt",
+                "target": {"conversation_id": "conv-9"},
+                "text": "Research X",
+                "submit": False,
+            },
+        )
+        assert status == HTTPStatus.ACCEPTED
+        command_id = cast(str, enq["command_id"])
+        assert enq["status"] == "pending"
+
+        status, poll = _request(host, port, "GET", "/v1/post-commands?provider=chatgpt")
+        assert status == HTTPStatus.OK
+        assert poll["post_enabled"] is True
+        commands = cast(list[dict[str, object]], poll["commands"])
+        assert [c["command_id"] for c in commands] == [command_id]
+        assert commands[0]["status"] == "dispatched"
+
+        status, ack = _request(
+            host,
+            port,
+            "POST",
+            f"/v1/post-commands/{command_id}/ack",
+            body={"status": "submitted", "detail": "dry_run_filled_not_sent"},
+        )
+        assert status == HTTPStatus.OK
+        assert ack["status"] == "submitted"
+
+        # The claimed+acked command is no longer pending for the extension.
+        status, poll2 = _request(host, port, "GET", "/v1/post-commands?provider=chatgpt")
+        assert cast(list[object], poll2["commands"]) == []
+
+
+def test_http_poll_empty_when_disabled(tmp_path: Path, post_disabled: None) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(host, port, "GET", "/v1/post-commands")
+    assert status == HTTPStatus.OK
+    assert body["post_enabled"] is False
+    assert body["commands"] == []
+
+
+def test_http_ack_unknown_command_404(tmp_path: Path, post_enabled: None) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(host, port, "POST", "/v1/post-commands/nope/ack", body={"status": "failed"})
+    assert status == HTTPStatus.NOT_FOUND
+    assert body["error"] == "unknown_command"

--- a/tests/unit/browser_capture/test_post_commands.py
+++ b/tests/unit/browser_capture/test_post_commands.py
@@ -12,6 +12,7 @@ from threading import Thread
 from typing import cast
 
 import pytest
+from click.testing import CliRunner
 
 from polylogue.browser_capture.models import (
     BrowserPostCommandAckRequest,
@@ -20,6 +21,8 @@ from polylogue.browser_capture.models import (
 )
 from polylogue.browser_capture.receiver import (
     BROWSER_POST_ENABLED_ENV,
+    BrowserPostCommandConflictError,
+    BrowserPostCommandStateError,
     BrowserPostDisabledError,
     ack_post_command,
     browser_post_enabled,
@@ -32,6 +35,7 @@ from polylogue.browser_capture.route_contracts import (
     browser_capture_route_contract_for,
 )
 from polylogue.browser_capture.server import make_server
+from polylogue.daemon.cli import main as daemon_cli
 
 _EXTENSION_ORIGIN = "chrome-extension://polylogue-test"
 
@@ -110,6 +114,41 @@ def test_ack_unknown_command(tmp_path: Path, post_enabled: None) -> None:
     )
 
 
+def test_enqueue_rejects_duplicate_normalized_command_id(tmp_path: Path, post_enabled: None) -> None:
+    enqueue_post_command(_request_obj().model_copy(update={"command_id": "manual/id"}), spool_path=tmp_path)
+
+    with pytest.raises(BrowserPostCommandConflictError):
+        enqueue_post_command(_request_obj().model_copy(update={"command_id": "manual id"}), spool_path=tmp_path)
+
+
+def test_ack_requires_dispatched_state(tmp_path: Path, post_enabled: None) -> None:
+    command = enqueue_post_command(_request_obj(), spool_path=tmp_path)
+
+    with pytest.raises(BrowserPostCommandStateError):
+        ack_post_command(command.command_id, BrowserPostCommandAckRequest(status="submitted"), spool_path=tmp_path)
+
+
+def test_ack_terminal_state_is_idempotent(tmp_path: Path, post_enabled: None) -> None:
+    command = enqueue_post_command(_request_obj(), spool_path=tmp_path)
+    [dispatched] = poll_post_commands(provider="chatgpt", spool_path=tmp_path)
+    acked = ack_post_command(
+        dispatched.command_id,
+        BrowserPostCommandAckRequest(status="submitted", detail="first", observed_url="https://chatgpt.com/c/conv-1"),
+        spool_path=tmp_path,
+    )
+    repeated = ack_post_command(
+        command.command_id,
+        BrowserPostCommandAckRequest(status="failed", detail="second", observed_url="https://chatgpt.com/c/conv-2"),
+        spool_path=tmp_path,
+    )
+
+    assert acked is not None
+    assert repeated is not None
+    assert repeated.status == "submitted"
+    assert repeated.detail == "first"
+    assert repeated.observed_url == "https://chatgpt.com/c/conv-1"
+
+
 # ---- HTTP route surface ---------------------------------------------------
 
 
@@ -149,6 +188,7 @@ def test_route_contracts_registered() -> None:
     assert {"post_command_enqueue", "post_command_poll", "post_command_ack"} <= kinds
     assert browser_capture_route_contract_for("POST", "/v1/post-commands") is not None
     assert browser_capture_route_contract_for("GET", "/v1/post-commands") is not None
+    assert browser_capture_route_contract_for("POST", "/v1/post-commands/abc123/ack") is not None
 
 
 def test_http_enqueue_disabled_returns_403(tmp_path: Path, post_disabled: None) -> None:
@@ -211,3 +251,46 @@ def test_http_ack_unknown_command_404(tmp_path: Path, post_enabled: None) -> Non
         status, body = _request(host, port, "POST", "/v1/post-commands/nope/ack", body={"status": "failed"})
     assert status == HTTPStatus.NOT_FOUND
     assert body["error"] == "unknown_command"
+
+
+def test_http_ack_pending_command_returns_conflict(tmp_path: Path, post_enabled: None) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, enq = _request(
+            host,
+            port,
+            "POST",
+            "/v1/post-commands",
+            body={"provider": "chatgpt", "target": {"conversation_id": "conv-9"}, "text": "Research X"},
+        )
+        assert status == HTTPStatus.ACCEPTED
+        command_id = cast(str, enq["command_id"])
+
+        status, body = _request(
+            host,
+            port,
+            "POST",
+            f"/v1/post-commands/{command_id}/ack",
+            body={"status": "submitted"},
+        )
+
+    assert status == HTTPStatus.CONFLICT
+    assert body["error"] == "invalid_post_command_state"
+
+
+def test_daemon_post_command_reports_empty_text_cleanly(tmp_path: Path, post_enabled: None) -> None:
+    result = CliRunner().invoke(
+        daemon_cli,
+        [
+            "browser-capture",
+            "post",
+            "--provider",
+            "chatgpt",
+            "--text",
+            "   ",
+            "--spool",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "post command text must not be empty" in result.output


### PR DESCRIPTION
## Summary

Adds a gated outbound post-command path for the browser-capture extension and fixes the ChatGPT send-button selector used by the live capture flow.

## Problem

Browser capture needed a controlled way to send provider-page commands from the capture controller without treating manual browser interaction as the only reliable actuation path. The ChatGPT send selector had also drifted, making the browser-capture flow brittle on the current page shape.

## Solution

The branch adds post-command plumbing behind an explicit gate, wires the extension-side handlers, and updates the ChatGPT content script selector. The implementation keeps page actuation inside the browser-capture surface instead of creating a separate ad hoc automation path.

## Verification

- `devtools test tests/unit/browser_capture/test_post_commands.py -q` -> 10 passed.
- `node --check browser-extension/src/background.js browser-extension/src/common.js browser-extension/src/content/chatgpt.js browser-extension/src/content/claude.js`.
- `ruff format --check`, `ruff check`, and `mypy` on the touched Python/test files.
- `devtools render all --check`.
- `devtools verify --quick` -> all quick gates passed after refreshing generated `AGENTS.md`.

Live selector behavior was checked as local DOM evidence; the automated gate is the unit/static/quick verification above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new browser posting flow that can queue replies locally and send them to supported chat sites.
  * Introduced a command to create outgoing posts from the local tooling, with optional auto-send support.
  * Added new API endpoints for listing, creating, and confirming queued posts.

* **Bug Fixes**
  * Improved reliability of reply injection and send-button handling across supported chat interfaces.

* **Documentation**
  * Expanded schema versioning notes and added a new benchmarking command entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->