### PR TITLE
fix(docs): repair generated pages links

### DIFF
--- a/devtools/pages_builder.py
+++ b/devtools/pages_builder.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import os
+import posixpath
 import shutil
 import sqlite3
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import tomllib
 from jinja2 import DictLoader, Environment, select_autoescape
@@ -22,6 +25,14 @@ from polylogue.rendering.renderers.html import PygmentsHighlighter
 from polylogue.rendering.renderers.html_sanitizer import sanitize_html
 
 ROOT = _get_root()
+GITHUB_BLOB_BASE = "https://github.com/Sinity/polylogue/blob/master/"
+
+
+@dataclass(frozen=True)
+class BrokenSiteLink:
+    page: str
+    href: str
+    target: str
 
 
 def _default_config_path() -> Path:
@@ -98,10 +109,110 @@ def _build_env() -> Environment:
     return env
 
 
-def _render_markdown(content: str) -> str:
+def _page_output_rel(page_path: str) -> str:
+    rel = page_path.lstrip("/")
+    if not rel:
+        return "index.html"
+    if rel.endswith("/"):
+        return f"{rel}index.html"
+    if rel.endswith(".html"):
+        return rel
+    return f"{rel}/index.html"
+
+
+def _relative_href_from_output(current_output_rel: str, target_output_rel: str) -> str:
+    start = posixpath.dirname(current_output_rel) or "."
+    href = posixpath.relpath(target_output_rel, start=start)
+    if href == ".":
+        return "./"
+    if href == "index.html":
+        return "./"
+    if href.endswith("/index.html"):
+        href = href[: -len("index.html")]
+    return href
+
+
+def _href_between_pages(current_page_path: str, target_page_path: str) -> str:
+    return _relative_href_from_output(_page_output_rel(current_page_path), _page_output_rel(target_page_path))
+
+
+def _source_to_page_map(pages: list[PageEntry]) -> dict[str, str]:
+    return {Path(page.source).as_posix(): page.path for page in pages if page.source}
+
+
+def _source_relative_path(source: str, href_path: str) -> str | None:
+    if href_path.startswith("/"):
+        rel = posixpath.normpath(href_path.lstrip("/"))
+        return None if rel.startswith("../") else rel
+    source_dir = posixpath.dirname(source)
+    rel = posixpath.normpath(posixpath.join(source_dir, href_path))
+    if rel.startswith("../"):
+        return None
+    return rel
+
+
+def _rewrite_markdown_href(
+    href: str,
+    *,
+    source: str,
+    current_page_path: str,
+    source_to_page: dict[str, str],
+) -> str:
+    parsed = urlparse(href)
+    if parsed.scheme or parsed.netloc or href.startswith("#"):
+        return href
+    if not parsed.path:
+        return href
+    target_source = _source_relative_path(source, parsed.path)
+    if target_source is None:
+        return href
+    target_page_path = source_to_page.get(target_source)
+    if target_page_path:
+        rewritten = _href_between_pages(current_page_path, target_page_path)
+    elif (ROOT / target_source).exists():
+        rewritten = f"{GITHUB_BLOB_BASE}{target_source}"
+    else:
+        return href
+    if parsed.query:
+        rewritten = f"{rewritten}?{parsed.query}"
+    if parsed.fragment:
+        rewritten = f"{rewritten}#{parsed.fragment}"
+    return rewritten
+
+
+def _render_markdown(
+    content: str,
+    *,
+    source: str,
+    current_page_path: str,
+    source_to_page: dict[str, str],
+) -> str:
     from markdown_it import MarkdownIt
 
-    md: MarkdownIt = MarkdownIt("gfm-like", {"highlight": None})
+    md: MarkdownIt = MarkdownIt("gfm-like", {"highlight": None, "linkify": False})
+    md.disable("linkify")
+
+    renderer: Any = md.renderer
+    default_link_open = renderer.rules.get("link_open")
+
+    def _link_open(tokens: Any, idx: int, options: Any, env: Any) -> str:
+        token = tokens[idx]
+        href = token.attrGet("href")
+        if href:
+            token.attrSet(
+                "href",
+                _rewrite_markdown_href(
+                    href,
+                    source=source,
+                    current_page_path=current_page_path,
+                    source_to_page=source_to_page,
+                ),
+            )
+        if default_link_open is not None:
+            return str(default_link_open(tokens, idx, options, env))
+        return str(renderer.renderToken(tokens, idx, options, env))
+
+    renderer.rules["link_open"] = _link_open
     result: str = md.render(content)
     return result
 
@@ -117,9 +228,61 @@ def _find_prev_next(page: PageEntry, all_pages: list[PageEntry]) -> tuple[dict[s
     idx = next((i for i, p in enumerate(all_pages) if p.path == page.path), -1)
     prev_entry = all_pages[idx - 1] if idx > 0 else None
     next_entry = all_pages[idx + 1] if idx >= 0 and idx < len(all_pages) - 1 else None
-    prev_dict: dict[str, str] | None = {"label": prev_entry.title, "path": prev_entry.path} if prev_entry else None
-    next_dict: dict[str, str] | None = {"label": next_entry.title, "path": next_entry.path} if next_entry else None
+    prev_dict: dict[str, str] | None = (
+        {"label": prev_entry.title, "path": prev_entry.path, "href": _href_between_pages(page.path, prev_entry.path)}
+        if prev_entry
+        else None
+    )
+    next_dict: dict[str, str] | None = (
+        {"label": next_entry.title, "path": next_entry.path, "href": _href_between_pages(page.path, next_entry.path)}
+        if next_entry
+        else None
+    )
     return prev_dict, next_dict
+
+
+def _nav_data_for_page(config: PagesConfig, page: PageEntry) -> list[dict[str, Any]]:
+    return [
+        {
+            "title": sec.title,
+            "entries": [
+                {
+                    "label": item.label,
+                    "path": item.path,
+                    "href": _href_between_pages(page.path, item.path),
+                }
+                for item in sec.items
+            ],
+        }
+        for sec in config.nav
+    ]
+
+
+def _home_links_for_page(page: PageEntry, page_paths: set[str]) -> list[dict[str, str]]:
+    candidates = [
+        ("Get started", "/docs/getting-started/"),
+        ("Search", "/docs/search/"),
+        ("Architecture", "/architecture/rings/"),
+        ("Verifiability", "/verifiability/coverage/"),
+    ]
+    return [
+        {"label": label, "href": _href_between_pages(page.path, target), "suffix": "->"}
+        for label, target in candidates
+        if target in page_paths
+    ]
+
+
+def _validate_site_config(config: PagesConfig) -> None:
+    page_paths = {page.path for page in config.pages}
+    missing_nav = [
+        f"{section.title}: {item.label} -> {item.path}"
+        for section in config.nav
+        for item in section.items
+        if item.path not in page_paths
+    ]
+    if missing_nav:
+        joined = "\n".join(f"- {item}" for item in missing_nav)
+        raise ValueError(f"Navigation entries point at unbuilt pages:\n{joined}")
 
 
 def _site_archive_stats() -> dict[str, Any]:
@@ -184,16 +347,11 @@ def build_site(config_path: Path | None = None, output_dir: Path | None = None) 
         output_dir = ROOT / ".cache" / "site"
 
     config = load_pages_config(config_path)
+    _validate_site_config(config)
     env = _build_env()
     highlighter = PygmentsHighlighter()
-
-    nav_data: list[dict[str, Any]] = [
-        {
-            "title": sec.title,
-            "entries": [{"label": item.label, "path": item.path} for item in sec.items],
-        }
-        for sec in config.nav
-    ]
+    source_to_page = _source_to_page_map(config.pages)
+    page_paths = {page.path for page in config.pages}
 
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -219,7 +377,12 @@ def build_site(config_path: Path | None = None, output_dir: Path | None = None) 
         if page.source:
             raw = _read_source(page.source)
             if page.source.endswith(".md"):
-                content_html = _render_markdown(raw)
+                content_html = _render_markdown(
+                    raw,
+                    source=page.source,
+                    current_page_path=page.path,
+                    source_to_page=source_to_page,
+                )
             else:
                 content_html = f"<pre><code>{sanitize_html(raw)}</code></pre>"
 
@@ -227,10 +390,13 @@ def build_site(config_path: Path | None = None, output_dir: Path | None = None) 
         template_data: dict[str, Any] = {
             "title": page.title,
             "style": PAGES_STYLE + "\n" + highlighter.get_css(),
-            "nav": nav_data,
+            "nav": _nav_data_for_page(config, page),
             "current_path": page.path,
             "content": content_html,
             "stats": stats,
+            "site_root": _href_between_pages(page.path, "/index.html"),
+            "search_href": _href_between_pages(page.path, "/docs/search/") if "/docs/search/" in page_paths else "",
+            "home_links": _home_links_for_page(page, page_paths),
             "updated_at": "",
             **data,
         }
@@ -246,6 +412,59 @@ def build_site(config_path: Path | None = None, output_dir: Path | None = None) 
         out_path.write_text(html)
 
     return output_dir
+
+
+class _SiteLinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = dict(attrs)
+        if tag == "a" and attr_map.get("href"):
+            self.links.append(attr_map["href"] or "")
+        elif tag in {"img", "script"} and attr_map.get("src"):
+            self.links.append(attr_map["src"] or "")
+        elif tag == "link" and attr_map.get("href"):
+            self.links.append(attr_map["href"] or "")
+
+
+def _local_link_target(page_path: Path, site_dir: Path, href: str) -> Path | None:
+    parsed = urlparse(href)
+    if parsed.scheme or parsed.netloc or href.startswith("#"):
+        return None
+    if parsed.path in {"", "#"}:
+        return None
+    path = parsed.path
+    target = site_dir / path.lstrip("/") if path.startswith("/") else page_path.parent / path
+    target = target.resolve()
+    try:
+        target.relative_to(site_dir.resolve())
+    except ValueError:
+        return None
+    if target.is_dir() or path.endswith("/"):
+        return target / "index.html"
+    if target.suffix:
+        return target
+    return target / "index.html"
+
+
+def validate_site_links(site_dir: Path) -> list[BrokenSiteLink]:
+    broken: list[BrokenSiteLink] = []
+    for page in sorted(site_dir.rglob("*.html")):
+        parser = _SiteLinkParser()
+        parser.feed(page.read_text(encoding="utf-8"))
+        for href in parser.links:
+            target = _local_link_target(page, site_dir, href)
+            if target is not None and not target.exists():
+                broken.append(
+                    BrokenSiteLink(
+                        page=page.relative_to(site_dir).as_posix(),
+                        href=href,
+                        target=target.relative_to(site_dir).as_posix(),
+                    )
+                )
+    return broken
 
 
 def build_site_with_pagefind(config_path: Path | None = None, output_dir: Path | None = None) -> Path:

--- a/devtools/pages_templates.py
+++ b/devtools/pages_templates.py
@@ -15,7 +15,7 @@ BASE_TEMPLATE = """<!DOCTYPE html>
 </head>
 <body>
     <header class="site-header">
-        <a href="/polylogue/" class="logo">poly<span>logue</span></a>
+        <a href="{{ site_root }}" class="logo">poly<span>logue</span></a>
         <div class="search-bar">
             <input type="search" placeholder="Search docs..." id="search-input">
         </div>
@@ -30,7 +30,7 @@ BASE_TEMPLATE = """<!DOCTYPE html>
             <div class="nav-section">
                 <div class="nav-section-title">{{ section.title }}</div>
                 {% for item in section.entries %}
-                <a href="/polylogue{{ item.path }}" {% if item.path == current_path %}class="active"{% endif %}>
+                <a href="{{ item.href }}" {% if item.path == current_path %}class="active"{% endif %}>
                     {{ item.label }}
                 </a>
                 {% endfor %}
@@ -69,7 +69,7 @@ HOME_TEMPLATE = """{% extends "base.html" %}
     <p class="tagline">Your AI memory</p>
     <div class="hero-search">
         <input type="search" placeholder="Search your archive..."
-               onkeydown="if(event.key==='Enter'){window.location='/polylogue/docs/search/?q='+encodeURIComponent(this.value)}">
+               onkeydown="if(event.key==='Enter' && '{{ search_href }}'){window.location='{{ search_href }}?q='+encodeURIComponent(this.value)}">
     </div>
     <div class="card-grid">
         <div class="stat-card">
@@ -86,10 +86,9 @@ HOME_TEMPLATE = """{% extends "base.html" %}
         </div>
     </div>
     <div class="home-links">
-        <a href="/polylogue/docs/getting-started/">Get started \u2192</a>
-        <a href="/polylogue/docs/">Documentation \u2192</a>
-        <a href="/polylogue/architecture/">Architecture \u2192</a>
-        <a href="/polylogue/verifiability/">Verifiability \u2192</a>
+        {% for link in home_links %}
+        <a href="{{ link.href }}">{{ link.label }} {{ link.suffix }}</a>
+        {% endfor %}
     </div>
 </div>
 {% endblock %}
@@ -100,8 +99,8 @@ DOC_TEMPLATE = """{% extends "base.html" %}
 {{ content | safe }}
 <hr style="margin: 3rem 0 1rem; border-color: var(--border);">
 <nav style="display: flex; justify-content: space-between; font-size: 0.9rem;">
-    {% if prev %}<a href="/polylogue{{ prev.path }}">\u2190 {{ prev.label }}</a>{% else %}<span></span>{% endif %}
-    {% if next %}<a href="/polylogue{{ next.path }}">{{ next.label }} \u2192</a>{% else %}<span></span>{% endif %}
+    {% if prev %}<a href="{{ prev.href }}">\u2190 {{ prev.label }}</a>{% else %}<span></span>{% endif %}
+    {% if next %}<a href="{{ next.href }}">{{ next.label }} \u2192</a>{% else %}<span></span>{% endif %}
 </nav>
 {% endblock %}
 """

--- a/devtools/render_pages.py
+++ b/devtools/render_pages.py
@@ -6,7 +6,7 @@ through Jinja2 templates, runs Pagefind, writes .cache/site/.
 Usage:
     devtools render pages              Build .cache/site/
     devtools render pages --serve      Build and serve locally
-    devtools render pages --check      Verify .cache/site/ matches sources
+    devtools render pages --check      Verify sources render and links resolve
     devtools render pages --watch      Rebuild on source changes
 """
 
@@ -39,7 +39,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify .cache/site/ is in sync with sources (exit non-zero on drift).",
+        help="Verify the site sources render and generated local links resolve.",
     )
     parser.add_argument(
         "--watch",
@@ -94,17 +94,6 @@ def _run_render_commands(verbose: bool = False) -> None:
             print(f"  Warning: devtools {name} failed with exit code {result}", file=sys.stderr)
 
 
-def _hash_directory(dir_path: Path) -> str:
-    """Compute a rough hash of directory contents for drift detection."""
-    import hashlib
-
-    hasher = hashlib.sha256()
-    for f in sorted(dir_path.rglob("*")):
-        if f.is_file() and "pagefind" not in f.parts:
-            hasher.update(f.read_bytes())
-    return hasher.hexdigest()
-
-
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
@@ -118,18 +107,18 @@ def main(argv: list[str] | None = None) -> int:
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp) / "_site"
-            from devtools.pages_builder import build_site
+            from devtools.pages_builder import build_site, validate_site_links
 
             build_site(config_path=config_path, output_dir=tmp_dir)
-            new_hash = _hash_directory(tmp_dir)
-            if not args.output.exists():
-                print(f"OK: {args.output} is absent; sources render successfully.")
-                return 0
-            current_hash = _hash_directory(args.output)
-            if current_hash != new_hash:
-                print(f"Error: {args.output} is out of sync with sources. Run: devtools render pages", file=sys.stderr)
+            broken_links = validate_site_links(tmp_dir)
+            if broken_links:
+                print("Error: generated site has broken local links:", file=sys.stderr)
+                for link in broken_links[:20]:
+                    print(f"  {link.page}: {link.href} -> {link.target}", file=sys.stderr)
+                if len(broken_links) > 20:
+                    print(f"  ... and {len(broken_links) - 20} more", file=sys.stderr)
                 return 1
-            print(f"OK: {args.output} matches sources.")
+            print("OK: site sources render and generated local links resolve.")
             return 0
 
     print("Building GitHub Pages site...", file=sys.stderr)

--- a/docs/site/pages.toml
+++ b/docs/site/pages.toml
@@ -55,9 +55,6 @@ path = "/architecture/contributing/"
 [[nav]]
 title = "Verifiability"
 [[nav.items]]
-label = "Catalog"
-path = "/verifiability/catalog/"
-[[nav.items]]
 label = "Coverage"
 path = "/verifiability/coverage/"
 [[nav.items]]
@@ -140,6 +137,16 @@ source = "docs/cli-reference.md"
 path = "/reference/mcp/"
 title = "MCP Reference"
 source = "docs/mcp-reference.md"
+
+[[pages]]
+path = "/reference/api/"
+title = "Library API"
+source = "docs/library-api.md"
+
+[[pages]]
+path = "/reference/config/"
+title = "Configuration"
+source = "docs/configuration.md"
 
 [[pages]]
 path = "/architecture/rings/"

--- a/tests/unit/site/test_renderer_behavior.py
+++ b/tests/unit/site/test_renderer_behavior.py
@@ -35,6 +35,7 @@ from devtools.pages_builder import (
     PagesConfig,
     build_site,
     load_pages_config,
+    validate_site_links,
 )
 
 _MINIMAL_CONFIG = """
@@ -88,10 +89,14 @@ def synthetic_site(
     """
     fake_root = tmp_path / "repo"
     fake_root.mkdir()
+    (fake_root / "README.md").write_text("# Repo README\n", encoding="utf-8")
     docs = fake_root / "docs"
     docs.mkdir()
     (docs / "getting-started.md").write_text(
-        "# Getting Started\n\nWelcome to the synthetic site.\n",
+        "# Getting Started\n\n"
+        "Welcome to the synthetic site.\n\n"
+        "[Search docs](search.md) and [repo README](../README.md).\n\n"
+        "Plain file names such as CLAUDE.md should not become external links.\n",
         encoding="utf-8",
     )
     (docs / "search.md").write_text(
@@ -189,7 +194,9 @@ def test_navigation_section_rendered_on_every_page(synthetic_site: Path) -> None
     """Each emitted page contains every nav entry from pages.toml.
 
     Items are rendered as ``<a href="...">\\n   Label\\n</a>``, so we
-    normalize whitespace before substring-checking.
+    normalize whitespace before substring-checking. Links are relative to
+    the current HTML file so the same artifact can be deployed under
+    ``/main/``, ``/pr/N/``, ``/latest/``, or served from disk.
     """
     for rel in (
         "index.html",
@@ -199,8 +206,7 @@ def test_navigation_section_rendered_on_every_page(synthetic_site: Path) -> None
         html = _read(synthetic_site / rel)
         normalized = re.sub(r"\s+", " ", html)
         assert ">Docs<" in normalized, rel
-        assert "/polylogue/docs/getting-started/" in normalized, rel
-        assert "/polylogue/docs/search/" in normalized, rel
+        assert 'href="/polylogue' not in normalized, rel
         assert "> Getting Started <" in normalized or ">Getting Started<" in normalized, rel
         assert "> Search <" in normalized or ">Search<" in normalized, rel
 
@@ -208,27 +214,35 @@ def test_navigation_section_rendered_on_every_page(synthetic_site: Path) -> None
 def test_navigation_links_resolve_to_built_pages(synthetic_site: Path) -> None:
     """Every nav-sidebar link maps to a built page in the output.
 
-    The base template emits sidebar entries as ``/polylogue<path>`` for
-    each ``[[nav.items]]`` entry in ``pages.toml``. We extract only those
-    links (not body links from rendered markdown / home-page hero) and
-    require each one to resolve to an emitted file.
+    We extract only sidebar links (not body links from rendered markdown /
+    home-page hero) and require each one to resolve to an emitted file from
+    the current page location.
     """
-    html = _read(synthetic_site / "docs" / "getting-started" / "index.html")
+    page = synthetic_site / "docs" / "getting-started" / "index.html"
+    html = _read(page)
     nav_block_match = re.search(r'<nav class="site-nav"[^>]*>(.*?)</nav>', html, re.DOTALL)
     assert nav_block_match, "site-nav block not found"
-    nav_hrefs = re.findall(r'href="(/polylogue[^"]+)"', nav_block_match.group(1))
+    nav_hrefs = re.findall(r'href="([^"]+)"', nav_block_match.group(1))
     assert nav_hrefs, "expected at least one sidebar link"
     for href in nav_hrefs:
-        rel = href[len("/polylogue") :].lstrip("/")
-        if not rel:
-            target = synthetic_site / "index.html"
-        elif rel.endswith("/"):
-            target = synthetic_site / rel / "index.html"
-        elif rel.endswith(".html"):
-            target = synthetic_site / rel
-        else:
-            target = synthetic_site / rel / "index.html"
+        target = (page.parent / href).resolve()
+        if href.endswith("/") or target.is_dir():
+            target = target / "index.html"
         assert target.exists(), f"nav href {href!r} points at missing file {target}"
+
+
+def test_generated_local_links_resolve(synthetic_site: Path) -> None:
+    """The site-level link verifier catches local broken links."""
+    assert validate_site_links(synthetic_site) == []
+
+
+def test_markdown_links_rewritten_for_site_and_repo_files(synthetic_site: Path) -> None:
+    """Markdown links point at built site pages or stable source blobs."""
+    html = _read(synthetic_site / "docs" / "getting-started" / "index.html")
+    hrefs = _collect_links(html).hrefs
+    assert "../search/" in hrefs
+    assert "https://github.com/Sinity/polylogue/blob/master/README.md" in hrefs
+    assert "http://CLAUDE.md" not in hrefs
 
 
 def test_no_unresolved_template_placeholders(synthetic_site: Path) -> None:


### PR DESCRIPTION
## Summary

Repair the generated GitHub Pages site so the same artifact works under the deployment directories used by the repo (`main/`, `pr/N/`, releases, and `latest/`). The builder now emits page-relative local links, rewrites Markdown links into either built site routes or GitHub source links, validates navigation targets, and makes `devtools render pages --check` prove that generated local links resolve.

## Problem

The pages builder hard-coded `/polylogue/` into nav, logo, home, search, and previous/next links, but the workflows deploy `.cache/site` below subdirectories such as `main/` and `pr/<number>/`. That made otherwise-built pages navigate to the wrong root. The config also advertised unbuilt routes (`/reference/api/`, `/reference/config/`, `/verifiability/catalog/`), and Markdown links to `.md` files were emitted as local site links even when those files were not part of the curated Pages artifact.

## Solution

The site builder now computes relative hrefs from each emitted page to its targets and passes those hrefs into the templates instead of reconstructing `/polylogue` URLs there. Markdown rendering disables fuzzy linkification for plain file names and rewrites links: configured docs pages become relative site routes, while repo files outside the curated site become GitHub source URLs. Navigation config is validated against built pages, API/config pages were added from existing docs, and the unbuilt catalog nav entry was removed. `render pages --check` now builds into a temporary directory and runs a local link verifier instead of comparing against a potentially stale ignored `.cache/site` snapshot.

## Verification

- `devtools test tests/unit/site/test_renderer_behavior.py` -> 17 passed
- `devtools render pages --check` -> `OK: site sources render and generated local links resolve.`
- `devtools verify --quick` -> all 13 quick-gate steps passed
- `git push -u origin feature/docs/pages-site-audit` -> pre-push reran `devtools verify --quick` and passed
