### PR TITLE
fix(embed): expose preflight min-message floor

### DIFF
--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -357,6 +357,12 @@ def disable_subcommand(env: AppEnv) -> None:
     help="Estimate only the next approximate cost window.",
 )
 @click.option(
+    "--min-messages",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Skip sessions below this eligible-message floor in the estimate.",
+)
+@click.option(
     "--rebuild",
     is_flag=True,
     help="Estimate re-embedding every session, not just pending ones.",
@@ -375,6 +381,7 @@ def preflight_subcommand(
     max_sessions: int | None,
     max_messages: int | None,
     max_cost_usd: float | None,
+    min_messages: int | None,
     rebuild: bool,
     output_format: str,
 ) -> None:
@@ -389,6 +396,7 @@ def preflight_subcommand(
         max_sessions=max_sessions,
         max_messages=max_messages,
         max_cost_usd=max_cost_usd,
+        min_messages=min_messages,
     )
     if output_format == "json":
         _render_preflight_json(report)

--- a/polylogue/storage/embeddings/preflight.py
+++ b/polylogue/storage/embeddings/preflight.py
@@ -289,6 +289,8 @@ def preflight_backfill_args(report: PreflightReport) -> list[str] | None:
         args.extend(["--max-messages", str(report.max_messages)])
     if report.max_cost_usd is not None:
         args.extend(["--max-cost-usd", f"{report.max_cost_usd:.4f}".rstrip("0").rstrip(".")])
+    if report.min_messages is not None:
+        args.extend(["--min-messages", str(report.min_messages)])
     return args
 
 

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -296,7 +296,17 @@ class TestPreflightCommand:
         with patch("polylogue.cli.commands.embed._build_preflight_report", fake_preflight):
             result = cli_runner.invoke(
                 embed_command,
-                ["preflight", "--max-sessions", "2", "--max-messages", "7", "--max-cost-usd", "0.10"],
+                [
+                    "preflight",
+                    "--max-sessions",
+                    "2",
+                    "--max-messages",
+                    "7",
+                    "--max-cost-usd",
+                    "0.10",
+                    "--min-messages",
+                    "5",
+                ],
                 obj=stub_env,
             )
 
@@ -304,6 +314,7 @@ class TestPreflightCommand:
         assert fake_preflight.call_args.kwargs["max_sessions"] == 2
         assert fake_preflight.call_args.kwargs["max_messages"] == 7
         assert fake_preflight.call_args.kwargs["max_cost_usd"] == 0.10
+        assert fake_preflight.call_args.kwargs["min_messages"] == 5
 
     def test_preflight_json_emits_machine_readable_window_plan(self, cli_runner: CliRunner, stub_env: Any) -> None:
         report = _make_report(
@@ -315,6 +326,7 @@ class TestPreflightCommand:
             max_sessions=3,
             max_messages=2000,
             max_cost_usd=0.10,
+            min_messages=5,
         )
         with _patch_preflight(report):
             result = cli_runner.invoke(embed_command, ["preflight", "--format", "json"], obj=stub_env)
@@ -338,10 +350,12 @@ class TestPreflightCommand:
             "2000",
             "--max-cost-usd",
             "0.1",
+            "--min-messages",
+            "5",
         ]
         assert (
             payload["backfill_command"]
-            == "polylogue ops embed backfill --yes --max-sessions 3 --max-messages 2000 --max-cost-usd 0.1"
+            == "polylogue ops embed backfill --yes --max-sessions 3 --max-messages 2000 --max-cost-usd 0.1 --min-messages 5"
         )
 
     def test_preflight_json_omits_backfill_command_when_backlog_empty(


### PR DESCRIPTION
## Summary

Expose the existing embedding backfill `--min-messages` selector on `polylogue ops embed preflight`, and include it in generated backfill args/commands when present.

## Problem

Cost-bounded embedding backfills already support skipping sessions below a minimum eligible-message count, which is useful for early paid runs where tiny sessions add overhead without much semantic-search value. The preflight command could estimate cost windows, but it could not model that same floor or print a faithful suggested backfill command.

## Solution

- Add `--min-messages` to `polylogue ops embed preflight`.
- Pass the value through to the existing preflight report builder.
- Include the floor in generated `backfill_args` and `backfill_command` output.
- Extend CLI tests for option forwarding and JSON command rendering.

## Verification

- `devtools test tests/unit/cli/test_embed_activation.py -k 'preflight_passes_bounded_window_options or preflight_json_emits_machine_readable_window_plan' -q` → `2 passed, 35 deselected`
- `polylogue ops embed preflight --max-cost-usd 1 --min-messages 20 --format json` → emitted `--min-messages 20` in `backfill_args` and `backfill_command`
- `devtools verify --quick` → all quick gates passed
