### PR TITLE
perf(embed): index authored prose selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1204,6 +1204,15 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 21 adds `idx_messages_embedding_prose`, a partial
+  covering index for authored prose messages eligible for paid embeddings:
+  standard `message` rows from `user`/`assistant` roles, with
+  `human_authored`/`assistant_authored` material origin and positive word
+  count. Embedding preflight, status detail, and archive-session embedding
+  reads use this index when present so cost windows do not scan unrelated tool,
+  protocol, context-pack, or runtime rows in large archives. Existing index
+  tiers must be rebuilt from source evidence
+  (`polylogue ops reset --index && polylogued run`).
 - Index schema version 20 adds `idx_blocks_type_tool`, an expression index on
   `(block_type, COALESCE(NULLIF(LOWER(tool_name), ''), 'unknown'))`, so tool
   family rollups can resolve exact tool names and MCP-server prefixes without

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -106,6 +106,15 @@ schema shape:
 - Schema bumps are deletes-then-defines, never deltas. A schema change
   edits the owning tier DDL/version and documents the re-ingest expectation.
   No upgrade helpers are added for the bump.
+- Index schema version 21 adds `idx_messages_embedding_prose`, a partial
+  covering index for authored prose messages eligible for paid embeddings:
+  standard `message` rows from `user`/`assistant` roles, with
+  `human_authored`/`assistant_authored` material origin and positive word
+  count. Embedding preflight, status detail, and archive-session embedding
+  reads use this index when present so cost windows do not scan unrelated tool,
+  protocol, context-pack, or runtime rows in large archives. Existing index
+  tiers must be rebuilt from source evidence
+  (`polylogue ops reset --index && polylogued run`).
 - Index schema version 20 adds `idx_blocks_type_tool`, an expression index on
   `(block_type, COALESCE(NULLIF(LOWER(tool_name), ''), 'unknown'))`, so tool
   family rollups can resolve exact tool names and MCP-server prefixes without

--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -271,11 +271,16 @@ def select_pending_archive_session_window(
 
     if status_table is None:
         status_table = "embedding_status" if _table_exists(conn, "embedding_status") else ""
+    aggregate_expr = _archive_session_embeddable_count_expression(conn)
     status_select = "e.session_id, e.needs_reindex, e.message_count_embedded" if status_table else "NULL, NULL, NULL"
     join_clause = f"LEFT JOIN {status_table} e ON e.session_id = s.session_id" if status_table else ""
+    if aggregate_expr is None:
+        count_select = "NULL AS estimated_message_count"
+    else:
+        count_select = f"{aggregate_expr} AS estimated_message_count"
     cursor = conn.execute(
         f"""
-        SELECT s.session_id, s.title, {status_select}
+        SELECT s.session_id, s.title, {status_select}, {count_select}
         FROM sessions s
         {join_clause}
         WHERE 1 = 1
@@ -295,6 +300,11 @@ def select_pending_archive_session_window(
             status_session_id = _row_value(row, 2, "status_session_id")
             needs_reindex = _row_int(row, 3, "needs_reindex") if status_session_id is not None else 0
             embedded_count = _row_int(row, 4, "message_count_embedded") if status_session_id is not None else 0
+            estimated_count = _row_int(row, 5, "estimated_message_count")
+            if estimated_count <= 0:
+                continue
+            if min_messages is not None and estimated_count < min_messages:
+                continue
             message_count = count_archive_session_embeddable_messages(conn, session_id)
             if message_count <= 0:
                 continue
@@ -324,11 +334,7 @@ def count_archive_session_embeddable_messages(conn: sqlite3.Connection, session_
 
     if not _table_exists(conn, "messages"):
         return 0
-    messages_ref = (
-        "messages AS m INDEXED BY idx_messages_session_material_origin"
-        if _index_exists(conn, "idx_messages_session_material_origin")
-        else archive_messages_table_ref(conn, alias="m")
-    )
+    messages_ref = archive_embedding_messages_table_ref(conn, alias="m")
     row = conn.execute(
         f"""
         SELECT COUNT(*)
@@ -414,6 +420,41 @@ def archive_messages_table_ref(conn: sqlite3.Connection, *, alias: str) -> str:
     if _index_exists(conn, "idx_messages_message_type"):
         return f"messages AS {alias} INDEXED BY idx_messages_message_type"
     return f"messages AS {alias}"
+
+
+def archive_embedding_messages_table_ref(conn: sqlite3.Connection, *, alias: str) -> str:
+    if _index_exists(conn, "idx_messages_embedding_prose"):
+        return f"messages AS {alias} INDEXED BY idx_messages_embedding_prose"
+    if _index_exists(conn, "idx_messages_session_material_origin"):
+        return f"messages AS {alias} INDEXED BY idx_messages_session_material_origin"
+    return archive_messages_table_ref(conn, alias=alias)
+
+
+def _archive_session_embeddable_count_expression(conn: sqlite3.Connection) -> str | None:
+    """Return a cheap session-level estimate for authored prose candidates.
+
+    The canonical index stores authored-user and assistant message aggregates on
+    ``sessions``. Those counts are the right first-order selector for paid
+    embedding windows: they exclude protocol/tool/context messages without
+    walking the multi-million-row ``messages`` table. Minimal legacy test
+    fixtures may only have ``message_count``; in that case the caller can still
+    use the coarse aggregate or fall back to exact message scans.
+    """
+
+    columns = _table_columns(conn, "sessions")
+    if {"authored_user_message_count", "assistant_message_count"}.issubset(columns):
+        return "COALESCE(s.authored_user_message_count, 0) + COALESCE(s.assistant_message_count, 0)"
+    if "message_count" in columns:
+        return "COALESCE(s.message_count, 0)"
+    return None
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    except sqlite3.Error:
+        return set()
+    return {str(row[1]) for row in rows}
 
 
 def mark_all_archive_sessions_needs_reindex(index_db_path: Path) -> None:
@@ -522,11 +563,7 @@ def embed_archive_session_sync(
         ).fetchone()
         if session is None:
             return EmbedSessionOutcome(status="not_found", session_id=session_id)
-        messages_ref = (
-            "messages AS m INDEXED BY idx_messages_session_material_origin"
-            if _index_exists(index_conn, "idx_messages_session_material_origin")
-            else archive_messages_table_ref(index_conn, alias="m")
-        )
+        messages_ref = archive_embedding_messages_table_ref(index_conn, alias="m")
         rows = index_conn.execute(
             f"""
             SELECT m.message_id, m.role, m.content_hash, m.material_origin, m.message_type,
@@ -797,6 +834,7 @@ __all__ = [
     "EmbedSingleStatus",
     "PendingSession",
     "archive_embeddable_message_where",
+    "archive_embedding_messages_table_ref",
     "archive_messages_table_ref",
     "count_archive_embedding_session_state",
     "count_archive_session_embeddable_messages",

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -16,7 +16,7 @@ from typing_extensions import TypedDict
 
 from polylogue.storage.embeddings.materialization import (
     archive_embeddable_message_where,
-    archive_messages_table_ref,
+    archive_embedding_messages_table_ref,
     count_archive_embedding_session_state,
 )
 from polylogue.storage.embeddings.models import EmbeddingStatsSnapshot
@@ -380,7 +380,7 @@ def _archive_embedding_status_payload(
         model_counts: dict[str, int] = {}
         dimension_counts: dict[int, int] = {}
         if include_detail and has_messages:
-            messages_ref = archive_messages_table_ref(conn, alias="m")
+            messages_ref = archive_embedding_messages_table_ref(conn, alias="m")
             embeddable_where = archive_embeddable_message_where("m")
             total_messages = _scalar_int(conn, f"SELECT COUNT(*) FROM {messages_ref} WHERE {embeddable_where}")
             if has_meta and embedded_messages == 0:

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -33,7 +33,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
     nullable_check,
 )
 
-INDEX_SCHEMA_VERSION = 20
+INDEX_SCHEMA_VERSION = 21
 
 INDEX_DDL = f"""
 CREATE TABLE IF NOT EXISTS sessions (
@@ -158,6 +158,18 @@ ON messages(message_type);
 
 CREATE INDEX IF NOT EXISTS idx_messages_material_origin
 ON messages(material_origin);
+
+-- Serves the paid embedding selector and status/preflight counts. The predicate
+-- matches authored prose only: user/assistant message rows with human- or
+-- assistant-authored material and positive word count. Keeping this as a
+-- partial index avoids scanning tool, protocol, context-pack, and generated
+-- runtime rows when computing cost windows over large archives.
+CREATE INDEX IF NOT EXISTS idx_messages_embedding_prose
+ON messages(session_id, position, variant_index, message_id, content_hash)
+WHERE message_type = 'message'
+  AND role IN ('user', 'assistant')
+  AND material_origin IN ('human_authored', 'assistant_authored')
+  AND word_count > 0;
 
 CREATE INDEX IF NOT EXISTS idx_messages_active_path
 ON messages(session_id, is_active_path, position)

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -327,6 +327,24 @@ def test_archive_tiers_messages_have_role_leading_facet_index(tmp_path: Path) ->
     assert columns == ["role"]
 
 
+def test_archive_tiers_messages_have_embedding_prose_index(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    _apply_tier(conn, ArchiveTier.INDEX)
+
+    indexes = {row["name"] for row in conn.execute("PRAGMA index_list('messages')").fetchall()}
+    assert "idx_messages_embedding_prose" in indexes
+
+    columns = [row["name"] for row in conn.execute("PRAGMA index_info('idx_messages_embedding_prose')").fetchall()]
+    assert columns == ["session_id", "position", "variant_index", "message_id", "content_hash"]
+    ddl = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_messages_embedding_prose'"
+    ).fetchone()[0]
+    assert "message_type = 'message'" in ddl
+    assert "role IN ('user', 'assistant')" in ddl
+    assert "material_origin IN ('human_authored', 'assistant_authored')" in ddl
+    assert "word_count > 0" in ddl
+
+
 def test_archive_tiers_blocks_have_tool_family_index(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     _apply_tier(conn, ArchiveTier.INDEX)

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -794,7 +794,7 @@ def test_archive_embedding_only_sends_authored_prose_to_provider(tmp_path: Path)
 
 def test_archive_embedding_error_records_retryable_status(tmp_path: Path) -> None:
     from polylogue.archive.message.roles import Role
-    from polylogue.core.enums import BlockType, Provider
+    from polylogue.core.enums import BlockType, MaterialOrigin, Provider
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
@@ -815,6 +815,7 @@ def test_archive_embedding_error_records_retryable_status(tmp_path: Path) -> Non
                         role=Role.USER,
                         text=long_text,
                         blocks=[ParsedContentBlock(type=BlockType.TEXT, text=long_text)],
+                        material_origin=MaterialOrigin.HUMAN_AUTHORED,
                     )
                 ],
             )


### PR DESCRIPTION
## Summary

Add an index-tier v21 partial covering index for authored-prose embedding candidates, and route embedding preflight/backfill/status-detail reads through it when present.

## Problem

Embedding cost windows must count only authored user/assistant prose. On the active 23 GB archive, a correct one-dollar preflight window took about 46 seconds, and an initial backfill scan read gigabytes before writing any embedding rows. A tempting session-aggregate shortcut was fast but over-counted assistant/runtime material, so exact message semantics need an index rather than an approximate report.

## Solution

- Bump `INDEX_SCHEMA_VERSION` to 21.
- Add `idx_messages_embedding_prose`, a partial covering index over `messages` for standard user/assistant authored prose with positive word count.
- Prefer that index for archive embedding message counts and archive embedding reads when available.
- Keep final preflight/backfill message counts exact; session aggregates are used only as a coarse prefilter before exact candidate counting.
- Document the rebuild requirement in `docs/internals.md` and update rendered `AGENTS.md`.

## Compatibility

Existing index tiers must be rebuilt from source evidence with:

```bash
polylogue ops reset --index && polylogued run
```

This is an index-tier rebuild. It does not migrate `source.db`, `user.db`, `ops.db`, or `embeddings.db` in place.

## Verification

- `devtools test tests/unit/storage/test_embedding_contracts.py tests/unit/daemon/test_embedding_readiness.py tests/unit/storage/test_archive_tiers_ddl.py -q` → `59 passed`
- `devtools verify --quick` → all quick gates passed
