### PR TITLE
fix(maintenance): replay parsed raw rows after index reset

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -128,7 +128,13 @@ def _raw_materialization_candidate_ids(
             normalized_root = str(source_root).rstrip("/")
             source_root_filter = " AND (r.source_path = ? OR r.source_path LIKE ?)"
             params.extend((normalized_root, f"{normalized_root}/%"))
-        include_already_parsed = any(
+        index_session_count = 0
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM index_tier.sessions").fetchone()
+            index_session_count = int(row[0] or 0) if row is not None else 0
+        except sqlite3.Error:
+            index_session_count = 0
+        include_already_parsed = index_session_count == 0 or any(
             value is not None for value in (raw_artifact_id, provider_origin, source_family, source_root)
         )
         parsed_filter = "" if include_already_parsed else "AND r.parsed_at_ms IS NULL"

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -226,6 +226,44 @@ def test_raw_materialization_preview_counts_replayable_rows_without_erasing_miss
     assert "1 raw rows blocked by missing blobs" in result.detail
 
 
+def test_raw_materialization_replays_parsed_rows_when_index_is_empty(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    raw_id, blob_size = blob_store.write_from_bytes(b'{"mapping":{"already-parsed":{}}}')
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, parsed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "chatgpt-export",
+                "native-reset-replay",
+                "reset-replay.json",
+                0,
+                bytes.fromhex(raw_id),
+                blob_size,
+                1,
+                2,
+            ),
+        )
+        source_conn.commit()
+
+    result = repair_mod.repair_raw_materialization(config, dry_run=True)
+
+    assert result.repaired_count == 1
+    assert result.success is True
+    assert result.metrics["raw_materialization_candidate_count"] == 1.0
+    assert result.metrics["raw_materialization_already_parsed_count"] == 1.0
+    assert "already parsed but not materialized" in result.detail
+
+
 def test_raw_materialization_raw_artifact_filter_counts_only_target(tmp_path: Path) -> None:
     config = _config(tmp_path)
     initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)


### PR DESCRIPTION
## Summary

Raw-materialization repair now recognizes an empty rebuilt index tier as needing a full replay from preserved `source.db` evidence, including raw rows that were already parsed before the reset.

## Problem

After the v21 index reset, `source.db` still correctly had `parsed_at_ms` for existing raw rows, while the new `index.db` was empty. The broad raw-materialization repair filtered out those already-parsed rows unless a narrow raw/source filter was supplied, so it reported zero candidates and could not rebuild the reset index tier from source evidence.

## Solution

`polylogue/storage/repair.py` now checks the attached index tier session count. If the index tier is empty, broad raw-materialization candidate selection includes already-parsed rows; non-empty broad repairs retain the prior unparsed-only behavior, and explicit scoped repairs continue to include already-parsed targets.

A regression test covers the reset shape by seeding a parsed raw row in `source.db`, initializing an empty `index.db`, and asserting that dry-run repair queues the row with the already-parsed metric and detail text.

## Verification

- `devtools test tests/unit/storage/test_repair.py -k 'raw_materialization_replays_parsed_rows_when_index_is_empty or raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs' -q` -> `2 passed, 22 deselected`
- `devtools verify --quick` -> exit 0, total duration 21.53s

## Changelog

Skipped: maintenance repair correctness fix, no user-facing CLI shape change.

## Risks and Follow-ups

Low risk. The broadened replay only happens when the attached index tier has zero sessions, or when an explicit scoped repair already requested already-parsed row inclusion.
