### PR TITLE
perf(maintenance): batch raw materialization replay

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1369,29 +1369,21 @@ def repair_raw_materialization(
         try:
             service = ParsingService(repository=repository, archive_root=config.archive_root, config=config)
             total = len(executable_raw_ids)
-            for index, raw_id in enumerate(executable_raw_ids, start=1):
-                raw_size = candidates.raw_blob_bytes.get(raw_id, 0)
-                size_suffix = f" size={_format_bytes(raw_size)}" if raw_size else ""
-                if progress_callback is not None:
-                    progress_callback(
-                        index - 1,
-                        desc=f"raw_materialization: parsing raw {index}/{total} {raw_id[:12]}{size_suffix}",
-                    )
-                result = await service.parse_from_raw(
-                    raw_ids=[raw_id],
-                    progress_callback=progress_callback,
-                    force_write=False,
-                    repair_message_fts=False,
+            if progress_callback is not None:
+                progress_callback(0, desc=f"raw_materialization: parsing {total:,} raw rows")
+            result = await service.parse_from_raw(
+                raw_ids=executable_raw_ids,
+                progress_callback=progress_callback,
+                force_write=False,
+                repair_message_fts=False,
+            )
+            processed_total += len(result.processed_ids)
+            failure_total += result.parse_failures
+            if progress_callback is not None:
+                progress_callback(
+                    total,
+                    desc=f"raw_materialization: parsed {total:,} raw rows changed={processed_total}",
                 )
-                processed_total += len(result.processed_ids)
-                failure_total += result.parse_failures
-                if progress_callback is not None:
-                    progress_callback(
-                        index,
-                        desc=(
-                            f"raw_materialization: parsed raw {index}/{total} {raw_id[:12]} changed={processed_total}"
-                        ),
-                    )
             return processed_total, failure_total
         finally:
             await repository.close()

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -4,6 +4,7 @@ import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -262,6 +263,70 @@ def test_raw_materialization_replays_parsed_rows_when_index_is_empty(tmp_path: P
     assert result.metrics["raw_materialization_candidate_count"] == 1.0
     assert result.metrics["raw_materialization_already_parsed_count"] == 1.0
     assert "already parsed but not materialized" in result.detail
+
+
+def test_raw_materialization_replay_uses_batch_parse_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    first_raw_id, first_size = blob_store.write_from_bytes(b'{"mapping":{"first":{}}}')
+    second_raw_id, second_size = blob_store.write_from_bytes(b'{"mapping":{"second":{}}}')
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.executemany(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                (
+                    first_raw_id,
+                    "chatgpt-export",
+                    "native-first",
+                    "first.json",
+                    0,
+                    bytes.fromhex(first_raw_id),
+                    first_size,
+                    1,
+                ),
+                (
+                    second_raw_id,
+                    "chatgpt-export",
+                    "native-second",
+                    "second.json",
+                    0,
+                    bytes.fromhex(second_raw_id),
+                    second_size,
+                    2,
+                ),
+            ),
+        )
+        source_conn.commit()
+
+    calls: list[list[str]] = []
+
+    class FakeParsingService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def parse_from_raw(self, *, raw_ids: list[str], **_kwargs: object) -> object:
+            calls.append(list(raw_ids))
+            return SimpleNamespace(processed_ids=set(raw_ids), parse_failures=0)
+
+    import polylogue.pipeline.services.parsing as parsing_module
+
+    monkeypatch.setattr(parsing_module, "ParsingService", FakeParsingService)
+
+    result = repair_mod.repair_raw_materialization(config)
+
+    assert result.success is True
+    assert result.repaired_count == 2
+    assert calls == [[second_raw_id, first_raw_id]]
 
 
 def test_raw_materialization_raw_artifact_filter_counts_only_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Raw-materialization repair now delegates full replay batches to the existing `parse_from_raw` batcher instead of invoking it once per raw row.

## Problem

The repair target already had a record/byte batching primitive beneath it, but the maintenance layer wrapped that primitive in a one-row loop. Full index rebuilds repeated service setup, blob-size lookup, progress output, and parse summary logging thousands of times, making reset recovery much slower and much noisier than necessary.

## Solution

`repair_raw_materialization` now passes the executable raw-id list to `parse_from_raw` once. The parsing workflow still owns the actual split by `DEFAULT_RAW_BATCH_SIZE` and raw blob byte limits, so memory/WAL behavior remains bounded by the existing ingest policy.

A regression test monkeypatches the parsing service and asserts that repair passes multiple replayable raw ids in one call rather than degrading back to per-row parse invocations.

## Verification

- `devtools test tests/unit/storage/test_repair.py -k 'raw_materialization_replay_uses_batch_parse_call or raw_materialization_replays_parsed_rows_when_index_is_empty or raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs' -q` -> `3 passed, 22 deselected`
- `devtools verify --quick` -> exit 0, total duration 17.36s

## Changelog

Skipped: maintenance performance improvement, no user-facing CLI shape change.

## Risks and Follow-ups

The repair target now produces coarser repair-level progress text, while the underlying parse workflow still emits batch-level progress and observations. The already-running live replay was started before this patch and is unaffected.
