### PR TITLE
fix(maintenance): resume interrupted raw materialization

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -91,10 +91,11 @@ def _raw_materialization_candidate_ids(
     Raw evidence is the durable source of truth, but a raw row whose
     content-addressed blob is absent cannot be reparsed without outside
     evidence. Keep those rows as debt instead of mutating or deleting them.
-    Broad repair only queues acquired-but-unparsed rows. An explicit scope
-    (raw artifact, provider/origin, source family, or source root) may queue
-    already-parsed non-materialized rows because that is a deliberate bounded
-    replay, not a blind archive-wide retry.
+    Broad repair queues raw rows that are not materialized in the attached
+    index tier, including rows whose raw evidence was parsed before an index
+    reset or interrupted replay. Parse failures, intentionally skipped rows,
+    missing blobs, and source-path/native-id aliases remain excluded or counted
+    as debt instead of being blindly retried.
     """
     source_db = config.archive_root / "source.db"
     index_db = config.archive_root / "index.db"
@@ -128,16 +129,6 @@ def _raw_materialization_candidate_ids(
             normalized_root = str(source_root).rstrip("/")
             source_root_filter = " AND (r.source_path = ? OR r.source_path LIKE ?)"
             params.extend((normalized_root, f"{normalized_root}/%"))
-        index_session_count = 0
-        try:
-            row = conn.execute("SELECT COUNT(*) FROM index_tier.sessions").fetchone()
-            index_session_count = int(row[0] or 0) if row is not None else 0
-        except sqlite3.Error:
-            index_session_count = 0
-        include_already_parsed = index_session_count == 0 or any(
-            value is not None for value in (raw_artifact_id, provider_origin, source_family, source_root)
-        )
-        parsed_filter = "" if include_already_parsed else "AND r.parsed_at_ms IS NULL"
         rows = conn.execute(
             f"""
             SELECT r.raw_id, r.origin, r.native_id, r.source_path, r.blob_hash, r.blob_size, r.parsed_at_ms
@@ -150,7 +141,6 @@ def _raw_materialization_candidate_ids(
             WHERE s_by_raw.raw_id IS NULL
               AND s_by_native.native_id IS NULL
               AND r.parse_error IS NULL
-              {parsed_filter}
               AND NOT (
                 COALESCE(r.validation_status, '') = 'skipped'
                 AND r.parsed_at_ms IS NOT NULL

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -265,6 +265,68 @@ def test_raw_materialization_replays_parsed_rows_when_index_is_empty(tmp_path: P
     assert "already parsed but not materialized" in result.detail
 
 
+def test_raw_materialization_replays_parsed_rows_after_interrupted_index_rebuild(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    remaining_raw_id, remaining_size = blob_store.write_from_bytes(b'{"mapping":{"remaining":{}}}')
+    done_raw_id, done_size = blob_store.write_from_bytes(b'{"mapping":{"done":{}}}')
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.executemany(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, parsed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                (
+                    remaining_raw_id,
+                    "chatgpt-export",
+                    "native-remaining",
+                    "remaining.json",
+                    0,
+                    bytes.fromhex(remaining_raw_id),
+                    remaining_size,
+                    1,
+                    2,
+                ),
+                (
+                    done_raw_id,
+                    "chatgpt-export",
+                    "native-done",
+                    "done.json",
+                    0,
+                    bytes.fromhex(done_raw_id),
+                    done_size,
+                    3,
+                    4,
+                ),
+            ),
+        )
+        source_conn.commit()
+
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        index_conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, raw_id, title, content_hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("native-done", "chatgpt-export", done_raw_id, "done", bytes(32)),
+        )
+        index_conn.commit()
+
+    result = repair_mod.repair_raw_materialization(config, dry_run=True)
+
+    assert result.repaired_count == 1
+    assert result.success is True
+    assert result.metrics["raw_materialization_candidate_count"] == 1.0
+    assert result.metrics["raw_materialization_already_parsed_count"] == 1.0
+    assert "already parsed but not materialized" in result.detail
+
+
 def test_raw_materialization_replay_uses_batch_parse_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Raw-materialization repair now resumes interrupted index rebuilds by treating parsed-but-unmaterialized raw rows as actionable archive debt even after the index tier is partially populated.

## Problem

The previous empty-index fix handled a fresh reset, but not an interrupted rebuild. Once `index.db` contained any sessions, broad repair again filtered out rows with `parsed_at_ms`, so the remaining parsed raw evidence was invisible even though it had no matching materialized index session.

## Solution

Candidate selection is now defined by absence from the attached index tier, not by whether `source.db.raw_sessions.parsed_at_ms` is set. Parse failures, intentionally skipped rows, missing blobs, and source-path/native-id aliases remain excluded or reported as debt.

The regression suite now covers both shapes: a completely empty reset index and a partially rebuilt non-empty index with remaining parsed raw rows.

## Verification

- `devtools test tests/unit/storage/test_repair.py -k 'raw_materialization_replays_parsed_rows_after_interrupted_index_rebuild or raw_materialization_replay_uses_batch_parse_call or raw_materialization_replays_parsed_rows_when_index_is_empty or raw_materialization_preview_counts_replayable_rows_without_erasing_missing_blobs' -q` -> `4 passed, 22 deselected`
- Active archive dry-run after interrupt -> `raw_materialization_candidate_count = 9219`, `raw_materialization_already_parsed_count = 9219`, `raw_materialization_missing_blob_count = 0`
- `devtools verify --quick` -> exit 0, total duration 17.03s

## Changelog

Skipped: maintenance repair correctness fix, no user-facing CLI shape change.

## Risks and Follow-ups

The broader candidate definition may replay more parsed-but-unmaterialized raw evidence during broad repair, but those rows are exactly the raw-materialization debt class and still pass the existing alias/error/skipped/missing-blob guards.
