### PR TITLE
perf(embed): avoid exact scans during window selection

### DIFF
--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -276,8 +276,24 @@ def select_pending_archive_session_window(
     join_clause = f"LEFT JOIN {status_table} e ON e.session_id = s.session_id" if status_table else ""
     if aggregate_expr is None:
         count_select = "NULL AS estimated_message_count"
+        floor_filter = ""
+        pending_filter = ""
     else:
         count_select = f"{aggregate_expr} AS estimated_message_count"
+        floor_filter = f"AND {aggregate_expr} >= ?" if min_messages is not None else ""
+        if min_messages is not None:
+            params.append(min_messages)
+        pending_filter = (
+            ""
+            if rebuild or not status_table
+            else f"""
+              AND (
+                    e.session_id IS NULL
+                 OR e.needs_reindex = 1
+                 OR COALESCE(e.message_count_embedded, 0) < {aggregate_expr}
+              )
+            """
+        )
     cursor = conn.execute(
         f"""
         SELECT s.session_id, s.title, {status_select}, {count_select}
@@ -285,6 +301,8 @@ def select_pending_archive_session_window(
         {join_clause}
         WHERE 1 = 1
           {id_filter}
+          {floor_filter}
+          {pending_filter}
         ORDER BY (s.sort_key_ms IS NULL), s.sort_key_ms DESC, s.session_id
         """,
         tuple(params),
@@ -305,25 +323,20 @@ def select_pending_archive_session_window(
                 continue
             if min_messages is not None and estimated_count < min_messages:
                 continue
-            message_count = count_archive_session_embeddable_messages(conn, session_id)
-            if message_count <= 0:
-                continue
-            if min_messages is not None and message_count < min_messages:
-                continue
             if not (
                 rebuild
                 or not status_table
                 or status_session_id is None
                 or needs_reindex == 1
-                or embedded_count < message_count
+                or embedded_count < estimated_count
             ):
                 continue
             if max_sessions is not None and len(pending) >= max_sessions:
                 return pending
-            if max_messages is not None and pending and message_total + message_count > max_messages:
+            if max_messages is not None and pending and message_total + estimated_count > max_messages:
                 return pending
-            pending.append(PendingSession(session_id=session_id, title=title, message_count=message_count))
-            message_total += message_count
+            pending.append(PendingSession(session_id=session_id, title=title, message_count=estimated_count))
+            message_total += estimated_count
             if max_messages is not None and message_total >= max_messages:
                 return pending
     return pending


### PR DESCRIPTION
## Summary

Switch archive embedding window selection to use the session-level authored/assistant aggregate as the cost-window estimate. Exact text extraction still happens in the per-session embedding step after the bounded window has already been chosen.

## Problem

A bounded operator backfill intended to embed the next ~$1 of substantial prose (`polylogue ops embed backfill --yes --max-messages 20000 --max-cost-usd 1 --min-messages 20`) read about 58 GB from the active `index.db` and still had not written any embeddings. The selector was ordering sessions and then exact-counting embeddable messages one session at a time before provider work began.

## Solution

`select_pending_archive_session_window` now treats `sessions.authored_user_message_count + sessions.assistant_message_count` as the archive-tier selector and budget estimate. The same aggregate is used for the min-message floor and pending-state comparison, so completed sessions can be skipped without scanning `messages`. The expensive message/text work remains inside `embed_archive_session_sync`, where it is limited to already-selected sessions.

## Verification

- `devtools test tests/unit/storage/test_embedding_contracts.py -k 'pending_archive_window or pending_window'` → 6 passed, 18 deselected.
- `devtools verify --quick` → passed all 13 quick-gate steps.
- Push pre-hook `devtools verify --quick` on `4d387eeea` → passed all 13 quick-gate steps.
- Live active archive selector check: `$1 / min_messages=20` window returns 76 sessions / 19,991 estimated messages in 0.011s.
- Live `polylogue ops embed preflight --max-cost-usd 1 --min-messages 20 --format json` returns 76 sessions / 19,991 messages / estimated cost `$0.99955` without the previous stall.