### PR TITLE
perf(embed): constrain archive block text lookup

### DIFF
--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -582,8 +582,9 @@ def embed_archive_session_sync(
             SELECT m.message_id, m.role, m.content_hash, m.material_origin, m.message_type,
                    GROUP_CONCAT(b.text, char(10) || char(10)) AS text
             FROM {messages_ref}
-            LEFT JOIN blocks b
-              ON b.message_id = m.message_id
+            LEFT JOIN blocks AS b INDEXED BY idx_blocks_session_position
+              ON b.session_id = m.session_id
+             AND b.message_id = m.message_id
              AND b.block_type = 'text'
              AND b.text IS NOT NULL
             WHERE m.session_id = ?


### PR DESCRIPTION
## Summary

Constrain archive embedding text extraction to the selected session by using the existing `idx_blocks_session_position` index for the `messages → blocks` join.

## Problem

After the embedding window selector was fixed, the first selected session still read tens of GB before any provider call or progress output. The text extraction query joined `blocks` only on `message_id`, so SQLite chose the global `idx_blocks_type_tool` path for `block_type = 'text'` and scanned text blocks across the archive.

## Solution

`embed_archive_session_sync` now joins blocks on both `session_id` and `message_id` and forces `idx_blocks_session_position`. That matches the query's real shape: extract text blocks for one already-selected session. No schema change is needed.

## Verification

- `devtools test tests/unit/storage/test_embedding_contracts.py -k 'archive_pending_window_and_embedding_success or archive_embedding_only_sends_authored_prose_to_provider or archive_embedding_error_records_retryable_status'` → 3 passed, 21 deselected.
- `devtools verify --quick` → passed all 13 quick-gate steps.
- Live first selected session from the `$1 / min_messages=20` window: text extraction returned 89 rows in 0.001s.
- `EXPLAIN QUERY PLAN` now shows `SEARCH b USING INDEX idx_blocks_session_position (session_id=? AND message_id=?)`.