### PR TITLE
fix(embed): treat completed sessions as embedded

### DIFF
--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -272,7 +272,7 @@ def select_pending_archive_session_window(
     if status_table is None:
         status_table = "embedding_status" if _table_exists(conn, "embedding_status") else ""
     aggregate_expr = _archive_session_embeddable_count_expression(conn)
-    status_select = "e.session_id, e.needs_reindex, e.message_count_embedded" if status_table else "NULL, NULL, NULL"
+    status_select = "e.session_id, e.needs_reindex" if status_table else "NULL, NULL"
     join_clause = f"LEFT JOIN {status_table} e ON e.session_id = s.session_id" if status_table else ""
     if aggregate_expr is None:
         count_select = "NULL AS estimated_message_count"
@@ -286,11 +286,10 @@ def select_pending_archive_session_window(
         pending_filter = (
             ""
             if rebuild or not status_table
-            else f"""
+            else """
               AND (
                     e.session_id IS NULL
                  OR e.needs_reindex = 1
-                 OR COALESCE(e.message_count_embedded, 0) < {aggregate_expr}
               )
             """
         )
@@ -317,19 +316,12 @@ def select_pending_archive_session_window(
             title = None if title_value is None else str(title_value)
             status_session_id = _row_value(row, 2, "status_session_id")
             needs_reindex = _row_int(row, 3, "needs_reindex") if status_session_id is not None else 0
-            embedded_count = _row_int(row, 4, "message_count_embedded") if status_session_id is not None else 0
-            estimated_count = _row_int(row, 5, "estimated_message_count")
+            estimated_count = _row_int(row, 4, "estimated_message_count")
             if estimated_count <= 0:
                 continue
             if min_messages is not None and estimated_count < min_messages:
                 continue
-            if not (
-                rebuild
-                or not status_table
-                or status_session_id is None
-                or needs_reindex == 1
-                or embedded_count < estimated_count
-            ):
+            if not (rebuild or not status_table or status_session_id is None or needs_reindex == 1):
                 continue
             if max_sessions is not None and len(pending) >= max_sessions:
                 return pending

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -553,6 +553,29 @@ def test_pending_archive_window_honors_min_messages() -> None:
         conn.close()
 
 
+def test_pending_archive_window_does_not_reselect_completed_status_with_lower_actual_count() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        _setup_minimal_embedding_db(conn)
+        # The archive selector orders by sort_key_ms; the minimal DDL omits it.
+        conn.execute("ALTER TABLE sessions ADD COLUMN sort_key_ms INTEGER")
+        _insert_session(conn, "completed", message_count=5)
+        conn.execute(
+            """
+            INSERT INTO embedding_status (
+                session_id, message_count_embedded, needs_reindex, error_message
+            ) VALUES ('completed', 1, 0, NULL)
+            """
+        )
+        conn.commit()
+
+        pending = select_pending_archive_session_window(conn, status_table="embedding_status", min_messages=3)
+
+        assert pending == []
+    finally:
+        conn.close()
+
+
 def test_no_message_session_records_clean_status(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.sqlite"
     _setup_minimal_embedding_file(db_path)


### PR DESCRIPTION
## Summary

Treat `embedding_status.needs_reindex = 0` as completion for archive embedding window selection instead of comparing actual embedded message count to the broader session aggregate.

## Problem

The optimized selector used `sessions.authored_user_message_count + sessions.assistant_message_count` as the cost-window estimate, but then also compared `message_count_embedded` against that aggregate. Actual embedding stores text-bearing prose messages only, so sessions with short/no-text authored rows could stay pending and be reprocessed despite a clean completion status.

## Solution

Archive pending selection now selects sessions only when the status row is missing, `needs_reindex = 1`, or the run is an explicit rebuild. A regression test covers a completed status row whose actual embedded count is lower than the broad aggregate.

## Verification

- `devtools test tests/unit/storage/test_embedding_contracts.py -k pending_archive_window` → 2 passed, 23 deselected.
- `devtools verify --quick` → passed all 13 quick-gate steps.
- Live active archive after the completed batch: the next `$1 / min_messages=20` window moved to new sessions instead of reselecting the 76 just embedded.