### PR TITLE
fix(embed): keep partial vectors retrieval-ready

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -288,6 +288,26 @@ SESSION_TERMINAL_ACTIONS: frozenset[SessionTerminalAction] = frozenset(
 )
 
 
+def _session_terminal_action(action: str) -> SessionTerminalAction:
+    if action == "read":
+        return "read"
+    if action == "analyze":
+        return "analyze"
+    if action == "select":
+        return "select"
+    if action == "mark":
+        return "mark"
+    if action == "delete":
+        return "delete"
+    if action == "continue":
+        return "continue"
+    supported = ", ".join(sorted(SESSION_TERMINAL_ACTIONS))
+    raise UnsupportedSessionTerminalActionError(
+        f"unsupported session terminal action: {action!r}; supported actions: {supported}",
+        field=None,
+    )
+
+
 @dataclass(frozen=True)
 class QueryUnitSessionScopeStage:
     """Session-source stage in a terminal query-unit pipeline."""
@@ -2870,15 +2890,9 @@ def build_session_terminal_pipeline(
     predicate: QueryPredicate | None = None,
 ) -> SessionQueryPipeline:
     """Build a typed session-source pipeline for a root query terminal verb."""
-    if action not in SESSION_TERMINAL_ACTIONS:
-        supported = ", ".join(sorted(SESSION_TERMINAL_ACTIONS))
-        raise UnsupportedSessionTerminalActionError(
-            f"unsupported session terminal action: {action!r}; supported actions: {supported}",
-            field=None,
-        )
     return SessionQueryPipeline(
         predicate=predicate,
-        terminal=SessionQueryTerminalStage(action=action, args=args),
+        terminal=SessionQueryTerminalStage(action=_session_terminal_action(action), args=args),
     )
 
 

--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -268,6 +268,7 @@ def _raw_materialization_rows(archive_root: Path) -> list[ArchiveDebtRowPayload]
         embedded_coverage: dict[str, tuple[int, int]] = {}
         grouped: dict[tuple[str, str], list[sqlite3.Row]] = {}
         for row in candidate_rows:
+            category: str
             if row["parse_error"]:
                 category = _raw_materialization_category(conn, row, archive_root)
             elif _raw_materialized_by_native_id(conn, row) or _raw_materialized_by_source_path_native(conn, row):

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -346,9 +346,11 @@ def _archive_embedding_status_payload(
         if embeddings_db.exists():
             conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
             status_table = _attached_table_name(conn, "embeddings", "embedding_status")
+            vector_table = _attached_table_name(conn, "embeddings", "message_embeddings")
             meta_table = _attached_table_name(conn, "embeddings", "message_embeddings_meta")
         else:
             status_table = ""
+            vector_table = ""
             meta_table = ""
         has_messages = _table_exists(conn, "messages")
         has_status = bool(status_table)
@@ -408,31 +410,31 @@ def _archive_embedding_status_payload(
             else:
                 pending_messages = total_messages
             if has_meta and embedded_messages == 0:
-                missing_provenance = total_messages
-                stale_messages = total_messages
+                missing_provenance = 0
+                stale_messages = 0
             elif has_meta:
                 meta_join = "ON em.message_id = m.message_id"
                 meta_missing_column = "em.message_id"
-                missing_provenance = _scalar_int(
-                    conn,
-                    f"""
-                    SELECT COUNT(*)
-                    FROM {messages_ref}
-                    LEFT JOIN {meta_table} em {meta_join}
-                    WHERE {embeddable_where}
-                      AND {meta_missing_column} IS NULL
-                    """,
-                )
+                if vector_table:
+                    missing_provenance = _scalar_int(
+                        conn,
+                        f"""
+                        SELECT COUNT(*)
+                        FROM {vector_table} me
+                        LEFT JOIN {meta_table} em
+                          ON em.message_id = me.message_id
+                        WHERE em.message_id IS NULL
+                        """,
+                    )
                 stale_messages = _scalar_int(
                     conn,
                     f"""
                     SELECT COUNT(*)
                     FROM {messages_ref}
-                    LEFT JOIN {meta_table} em {meta_join}
+                    JOIN {meta_table} em {meta_join}
                     WHERE {embeddable_where}
                       AND (
-                        {meta_missing_column} IS NULL
-                        OR COALESCE(em.needs_reindex, 0) = 1
+                        COALESCE(em.needs_reindex, 0) = 1
                         OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
                       )
                     """,

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -187,6 +187,9 @@ def test_status_json_reads_archive_file_set_from_archive_index(tmp_path: Path) -
     assert payload["embedded_messages"] == 1
     assert payload["pending_messages"] == 2
     assert payload["pending_messages_exact"] is True
+    assert payload["stale_messages"] == 0
+    assert payload["retrieval_ready"] is True
+    assert payload["freshness_status"] == "partial"
     assert payload["embedding_coverage_percent"] == 50.0
     assert payload["embedding_models"] == {"voyage-4": 1}
     assert payload["embedding_dimensions"] == {"1024": 1} or payload["embedding_dimensions"] == {1024: 1}


### PR DESCRIPTION
## Summary

Fix archive-file-set embedding status so partial vector coverage remains retrieval-ready when existing vectors are current and the remaining archive messages are pending backlog.

## Problem

After the second cost-bounded embedding batch on the active archive, semantic search worked and `polylogue ops status` reported `retrieval_ready=true`, but `polylogue ops embed status --detail` reported `freshness_status=stale` and `retrieval_ready=false`. The detailed status path was counting every unembedded archive message as both pending and stale/missing provenance. That made a partial opt-in embedding rollout look broken even though the embedded subset was queryable.

GitHub's Python 3.13 typecheck also surfaced two unrelated narrowing ambiguities while validating the PR: root session terminal actions depended on membership narrowing, and one raw-materialization category assignment looked possibly undefined to that checker.

## Solution

The archive-file-set status reader now keeps the concepts separate:

- pending messages are embeddable archive messages without current vectors;
- stale messages are existing vector metadata rows that need reindexing or whose content hash no longer matches;
- missing provenance is scoped to vector rows that lack metadata, matching the shared embedding stats contract.

A regression assertion covers the partial archive-file-set case: one embedded session plus one pending session reports `stale_messages=0`, `retrieval_ready=true`, and `freshness_status=partial`.

The follow-up typing hardening makes the root session terminal action normalization explicit and initializes the raw-materialization category type before branching. These do not change runtime behavior; they make the CI type contract unambiguous.

## Verification

- `devtools test tests/unit/cli/test_embed_status_fast.py -q` -> 13 passed.
- `devtools test tests/unit/cli/test_embed_status_fast.py tests/unit/daemon/test_embedding_readiness.py tests/unit/cli/test_status.py -k 'embedding or embed' -q` -> 26 passed, 29 deselected.
- `uv run mypy polylogue/` -> success, 851 source files checked.
- `devtools verify --quick` -> passed in pre-push for `f60fe3d48`.
- Live active archive after the second embedding batch reports `embedded_messages=19755`, `embedded_sessions=163`, `freshness_status=partial`, `retrieval_ready=true`, `stale_messages=0`, and `messages_missing_provenance=0`.
- Live semantic smoke: `polylogue --semantic --limit 3 --format json find "senior reliability auditor Polylogue daemon"` returned semantic-lane matches.
