### PR TITLE
fix(embed): keep backfill windows under message cap

### DIFF
--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -226,6 +226,8 @@ def select_pending_session_window(
             message_count = _row_int(row, 2, "message_count")
             if max_sessions is not None and len(pending) >= max_sessions:
                 return pending
+            if max_messages is not None and message_count > max_messages:
+                continue
             if max_messages is not None and pending and message_total + message_count > max_messages:
                 return pending
             pending.append(
@@ -325,6 +327,8 @@ def select_pending_archive_session_window(
                 continue
             if max_sessions is not None and len(pending) >= max_sessions:
                 return pending
+            if max_messages is not None and estimated_count > max_messages:
+                continue
             if max_messages is not None and pending and message_total + estimated_count > max_messages:
                 return pending
             pending.append(PendingSession(session_id=session_id, title=title, message_count=estimated_count))

--- a/polylogue/storage/embeddings/preflight.py
+++ b/polylogue/storage/embeddings/preflight.py
@@ -315,6 +315,7 @@ def preflight_payload(report: PreflightReport) -> dict[str, object]:
         "max_sessions": report.max_sessions,
         "max_messages": report.max_messages,
         "max_cost_usd": report.max_cost_usd,
+        "min_messages": report.min_messages,
         "pricing": {
             "estimated_tokens_per_message": ESTIMATED_TOKENS_PER_MESSAGE,
             "cost_usd_per_1m_tokens": VOYAGE_4_COST_PER_1M_TOKENS,

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -339,6 +339,7 @@ class TestPreflightCommand:
         assert payload["monthly_cost_cap_usd"] == 5.0
         assert payload["effective_cost_cap_usd"] == 0.10
         assert payload["pricing"]["approximate"] is True
+        assert payload["min_messages"] == 5
         assert payload["backfill_args"] == [
             "ops",
             "embed",

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -502,6 +502,22 @@ def test_pending_window_honors_max_messages() -> None:
         conn.close()
 
 
+def test_pending_window_skips_session_larger_than_max_messages() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        _setup_minimal_embedding_db(conn)
+        _insert_session(conn, "conv-oversize", message_count=5)
+        _insert_session(conn, "conv-fit", message_count=2)
+        conn.commit()
+
+        pending = select_pending_session_window(conn, max_messages=3)
+
+        assert [item.session_id for item in pending] == ["conv-fit"]
+        assert sum(item.message_count for item in pending) == 2
+    finally:
+        conn.close()
+
+
 def test_pending_window_uses_sessions_message_count() -> None:
     conn = sqlite3.connect(":memory:")
     try:
@@ -549,6 +565,25 @@ def test_pending_archive_window_honors_min_messages() -> None:
         pending = select_pending_archive_session_window(conn, status_table="", min_messages=3)
 
         assert [item.session_id for item in pending] == ["substantial"]
+    finally:
+        conn.close()
+
+
+def test_pending_archive_window_skips_session_larger_than_max_messages() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        _setup_minimal_embedding_db(conn)
+        conn.execute("ALTER TABLE sessions ADD COLUMN sort_key_ms INTEGER")
+        _insert_session(conn, "oversize", message_count=5)
+        _insert_session(conn, "fit", message_count=2)
+        conn.execute("UPDATE sessions SET sort_key_ms = 2 WHERE session_id = 'oversize'")
+        conn.execute("UPDATE sessions SET sort_key_ms = 1 WHERE session_id = 'fit'")
+        conn.commit()
+
+        pending = select_pending_archive_session_window(conn, status_table="", max_messages=3)
+
+        assert [item.session_id for item in pending] == ["fit"]
+        assert sum(item.message_count for item in pending) == 2
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Make embedding backfill message windows respect `--max-messages` as a hard cost-control bound and include `min_messages` in machine-readable preflight output.

## Problem

During live dogfood after the third cost-bounded embedding batch, the next preflight planned one pending session with 32,469 eligible messages while invoked as `polylogue ops embed preflight --max-messages 20000 --min-messages 20 --format json`. That violates the operator meaning of `--max-messages`: a provider-cost planning flag must not silently select a single session larger than the cap.

The same preflight JSON also omitted `min_messages`, even though `PreflightReport` and the generated `backfill_command` carried the value. Machine consumers saw `null` for a bound that was actually active.

## Solution

Both pending-session selectors now skip sessions whose eligible message count exceeds `max_messages`, including the archive-tier selector used by current embedding backfill. Oversize sessions remain pending for an explicit larger window; small bounded runs no longer exceed their stated cap.

`preflight_payload()` now emits `min_messages`, so text, JSON, and generated command surfaces agree.

## Verification

- `devtools test tests/unit/cli/test_embed_activation.py tests/unit/storage/test_embedding_contracts.py -k 'preflight_json_emits_machine_readable_window_plan or pending_window_honors_max_messages or pending_window_skips_session_larger_than_max_messages or pending_archive_window_skips_session_larger_than_max_messages or pending_archive_window_honors_min_messages' -q` -> 5 passed, 59 deselected.
- `uv run mypy polylogue/storage/embeddings/preflight.py polylogue/storage/embeddings/materialization.py` -> success.
- `ruff format --check polylogue/storage/embeddings/preflight.py polylogue/storage/embeddings/materialization.py tests/unit/storage/test_embedding_contracts.py tests/unit/cli/test_embed_activation.py` -> already formatted.
- `ruff check polylogue/storage/embeddings/preflight.py polylogue/storage/embeddings/materialization.py tests/unit/storage/test_embedding_contracts.py tests/unit/cli/test_embed_activation.py` -> all checks passed.
- `devtools verify --quick` -> passed locally and in the pre-push hook for `7626d9c96`.
- Live active archive preflight after the fix reports `pending_sessions=60`, `pending_messages=19949`, `max_messages=20000`, and `min_messages=20` for the same command shape.
