### PR TITLE
fix(cli): honor JSON format for select

### DIFF
--- a/devtools/cli_surface_audit.py
+++ b/devtools/cli_surface_audit.py
@@ -206,8 +206,13 @@ def _json_top_level_bytes(text: str) -> dict[str, int] | None:
         payload = json.loads(text)
     except json.JSONDecodeError:
         return None
+    if isinstance(payload, list):
+        return {
+            "$array_bytes": len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()),
+            "$array_items": len(payload),
+        }
     if not isinstance(payload, dict):
-        return None
+        return {"$scalar_bytes": len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode())}
     return {
         key: len(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
         for key, value in sorted(payload.items())

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -362,7 +362,8 @@ Options:
   -n, --limit INTEGER RANGE  Max candidate sessions.  [default: 20; x>=1]
   --print [id|title|origin]  Field to print for selected or candidate
                              sessions.  [default: id]
-  --json                     Print selected or candidate sessions as JSON.
+  --json                     Shortcut for --format json.
+  -f, --format [json]
   --help                     Show this message and exit.
 ```
 

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -762,19 +762,25 @@ def _summary_all_output_param(destination: str, out_path: str | None) -> str | N
     show_default=True,
     help="Field to print for selected or candidate sessions.",
 )
-@click.option("--json", "json_output", is_flag=True, help="Print selected or candidate sessions as JSON.")
+@click.option("--json", "output_format", flag_value="json", default=None, help="Shortcut for --format json.")
+@click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
 @click.pass_context
-def select_verb(ctx: click.Context, limit: int, print_field: str, json_output: bool) -> None:
+def select_verb(ctx: click.Context, limit: int, print_field: str, output_format: str | None) -> None:
     """Select one matched session or print bounded candidate identities."""
     from polylogue.cli.select import run_select
 
-    field: SelectPrintField = "json" if json_output else cast("SelectPrintField", print_field)
     request = _parent_request(ctx)
+    root_format = request.params.get("output_format")
+    effective_format = (
+        output_format if output_format is not None else root_format if isinstance(root_format, str) else None
+    )
+    field: SelectPrintField = "json" if effective_format == "json" else cast("SelectPrintField", print_field)
     if _explain_terminal_action(
         request,
         action="select",
         limit=limit,
         print_field=field,
+        format=effective_format or "default",
     ):
         return
     run_select(ctx.obj, request, limit=limit, print_field=field)

--- a/polylogue/cli/select.py
+++ b/polylogue/cli/select.py
@@ -81,6 +81,8 @@ def render_select_row(row: SelectSessionRow, print_field: SelectPrintField) -> s
 
 def render_select_rows(rows: list[SelectSessionRow], print_field: SelectPrintField) -> str:
     """Render one or more selector rows for noninteractive output."""
+    if print_field == "json":
+        return dumps([row.to_json() for row in rows])
     return "\n".join(render_select_row(row, print_field) for row in rows)
 
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -206,7 +206,7 @@ def test_select_verb_invokes_query_backed_selector() -> None:
     assert callable(wrapped)
 
     with patch("polylogue.cli.select.run_select") as run_select:
-        wrapped(child, 7, "title", False)
+        wrapped(child, 7, "title", None)
 
     request = run_select.call_args.args[1]
     assert run_select.call_args.args[0] is child.obj
@@ -216,13 +216,24 @@ def test_select_verb_invokes_query_backed_selector() -> None:
     assert run_select.call_args.kwargs == {"limit": 7, "print_field": "title"}
 
 
-def test_select_verb_json_flag_overrides_print_field() -> None:
+def test_select_verb_format_json_overrides_print_field() -> None:
     _, child = _context_pair(query_terms=("alpha",))
     wrapped = getattr(query_verbs.select_verb.callback, "__wrapped__", None)
     assert callable(wrapped)
 
     with patch("polylogue.cli.select.run_select") as run_select:
-        wrapped(child, 5, "id", True)
+        wrapped(child, 5, "id", "json")
+
+    assert run_select.call_args.kwargs == {"limit": 5, "print_field": "json"}
+
+
+def test_select_verb_inherits_root_json_format() -> None:
+    _, child = _context_pair(params={"output_format": "json"}, query_terms=("alpha",))
+    wrapped = getattr(query_verbs.select_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.select.run_select") as run_select:
+        wrapped(child, 5, "id", None)
 
     assert run_select.call_args.kwargs == {"limit": 5, "print_field": "json"}
 

--- a/tests/unit/cli/test_select.py
+++ b/tests/unit/cli/test_select.py
@@ -108,9 +108,24 @@ def test_render_select_rows_emits_one_row_per_line() -> None:
     rows = [_row(1), _row(2)]
 
     assert render_select_rows(rows, "id") == "conv-1\nconv-2"
-    assert render_select_rows(rows, "json").splitlines() == [
-        '{"id":"conv-1","origin":"claude-code-session","title":"Session 1","date":"2026-05-02"}',
-        '{"id":"conv-2","origin":"claude-code-session","title":"Session 2","date":"2026-05-02"}',
+
+
+def test_render_select_rows_json_emits_single_array() -> None:
+    rows = [_row(1), _row(2)]
+
+    assert json.loads(render_select_rows(rows, "json")) == [
+        {
+            "id": "conv-1",
+            "origin": "claude-code-session",
+            "title": "Session 1",
+            "date": "2026-05-02",
+        },
+        {
+            "id": "conv-2",
+            "origin": "claude-code-session",
+            "title": "Session 2",
+            "date": "2026-05-02",
+        },
     ]
 
 

--- a/tests/unit/devtools/test_cli_surface_audit.py
+++ b/tests/unit/devtools/test_cli_surface_audit.py
@@ -71,6 +71,15 @@ def test_cli_surface_audit_prunes_stale_unbounded_output_by_default(
     assert "`status_plain`" in readme
 
 
+def test_cli_surface_audit_records_json_array_shape() -> None:
+    payload = [{"id": "s1"}, {"id": "s2"}]
+
+    assert cli_surface_audit._json_top_level_bytes(json.dumps(payload)) == {
+        "$array_bytes": len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()),
+        "$array_items": 2,
+    }
+
+
 def test_cli_surface_audit_can_include_unbounded_diagnostic(
     tmp_path: Path,
     monkeypatch: Any,


### PR DESCRIPTION
## Summary

Make `find ... then select` honor JSON output contracts. The selector now accepts `select --format json`, inherits root `polylogue --format json`, and emits multi-row selector output as one JSON array instead of plain newline ids.

## Problem

The current CLI surface audit captured `polylogue --plain --format json find repo:polylogue then select --limit 3` exiting successfully while printing plain session ids. That made the root output contract false and left the current demo shelf preserving a sample that was named JSON but could not be parsed as JSON.

## Solution

`polylogue/cli/query_verbs.py` now resolves an effective selector format from the local `select --format/--json` option or the root `--format` option. `polylogue/cli/select.py` renders multi-row JSON as one array of selector row objects. The CLI surface audit in `devtools/cli_surface_audit.py` now records JSON array and scalar shapes instead of treating non-object JSON as opaque text, so the regenerated demo matrix can represent selector JSON honestly. `docs/cli-reference.md` was regenerated for the new selector option.

## Verification

- `devtools test tests/unit/cli/test_select.py tests/unit/cli/test_query_verbs_runtime.py::test_select_verb_invokes_query_backed_selector tests/unit/cli/test_query_verbs_runtime.py::test_select_verb_format_json_overrides_print_field tests/unit/cli/test_query_verbs_runtime.py::test_select_verb_inherits_root_json_format tests/unit/devtools/test_cli_surface_audit.py -q` -> `19 passed`.
- `ruff check ... && ruff format --check ... && mypy ...` on touched files -> clean.
- `devtools render all --check` -> clean.
- Live archive proof: `polylogue --plain --format json find repo:polylogue then select --limit 3 | python -m json.tool` parsed a three-row JSON array against `/home/sinity/.local/share/polylogue`.
- `devtools workspace cli-surface-audit --out-dir .agent/demos/cli-surface-audit/current --json` regenerated the current demo; `find_select_json` now records `$array_items: 3`.
- `devtools verify` reached the pytest-testmon phase after all static/generated gates passed, but selected a broad suite and produced unrelated failures outside this selector/audit slice. The focused selector and audit tests above exercise the changed behavior directly.

## Changelog

Skipped. The release policy says routine PRs should not edit `CHANGELOG.md`; release-please derives release notes from the squash title/body.

## Risks and Follow-ups

The broader CLI audit still shows several commands in the 2-3s range on the live archive. That is useful follow-up product evidence, but separate from this format-contract fix.
