### PR TITLE
fix(embed): emit structured backfill results

### DIFF
--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -22,7 +22,7 @@ import os
 import sqlite3
 import time
 from pathlib import Path
-from typing import cast
+from typing import TypedDict, cast
 
 import click
 
@@ -134,6 +134,33 @@ def _preflight_payload(report: PreflightReport) -> dict[str, object]:
 
 def _render_preflight_json(report: PreflightReport) -> None:
     click.echo(json.dumps(_preflight_payload(report), indent=2, sort_keys=True))
+
+
+class BackfillSessionPayload(TypedDict):
+    index: int
+    total: int
+    session_id: str
+    title: str | None
+    status: str
+    embedded_message_count: int
+    estimated_cost_usd: float
+    error: str | None
+
+
+class BackfillResultPayload(TypedDict):
+    status: str
+    embedded_sessions: int
+    error_count: int
+    estimated_cost_usd: float
+    stopped_reason: str | None
+    candidate_sessions: int
+    processed_sessions: int
+    preflight: dict[str, object]
+    sessions: list[BackfillSessionPayload]
+
+
+def _render_backfill_json(payload: BackfillResultPayload) -> None:
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 # ---------------------------------------------------------------------------
@@ -452,6 +479,14 @@ def preflight_subcommand(
     is_flag=True,
     help="Skip the cost confirmation prompt.",
 )
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format.",
+)
 @click.pass_obj
 def backfill_subcommand(
     env: AppEnv,
@@ -463,6 +498,7 @@ def backfill_subcommand(
     rebuild: bool,
     yes: bool,
     min_messages: int | None,
+    output_format: str,
 ) -> None:
     """Run the first embedding batch with per-session cost feedback.
 
@@ -471,6 +507,9 @@ def backfill_subcommand(
     user can interrupt before the soft monthly cap kicks in.
     """
     from polylogue.storage.search_providers import create_vector_provider
+
+    if output_format == "json" and not yes:
+        raise click.UsageError("backfill --format json requires --yes so stdout stays machine-readable.")
 
     key = _resolve_voyage_key(env, None)
     if not key:
@@ -488,7 +527,8 @@ def backfill_subcommand(
         max_cost_usd=max_cost_usd,
         min_messages=min_messages,
     )
-    _render_preflight(env, report)
+    if output_format == "text":
+        _render_preflight(env, report)
     if not yes and not click.confirm("\nProceed with backfill?", default=False):
         click.echo("Cancelled.")
         return
@@ -520,7 +560,7 @@ def backfill_subcommand(
         click.echo("Error: vector provider unavailable (sqlite-vec or voyage init failed).", err=True)
         raise click.Abort()
 
-    _run_archive_backfill(
+    payload = _run_archive_backfill(
         env,
         index_db,
         vec_provider,
@@ -530,7 +570,10 @@ def backfill_subcommand(
         stop_after_seconds=stop_after_seconds,
         max_errors=max_errors,
         min_messages=min_messages,
+        output_format=output_format,
     )
+    if output_format == "json":
+        _render_backfill_json(payload)
 
 
 def _run_archive_backfill(
@@ -544,7 +587,8 @@ def _run_archive_backfill(
     stop_after_seconds: int | None,
     max_errors: int | None,
     min_messages: int | None = None,
-) -> None:
+    output_format: str = "text",
+) -> BackfillResultPayload:
     from polylogue.protocols import VectorProvider
     from polylogue.storage.embeddings.materialization import (
         embed_archive_session_sync,
@@ -575,13 +619,27 @@ def _run_archive_backfill(
     finally:
         conn.close()
     if not pending:
-        click.echo("All sessions are already embedded.")
-        return
+        payload: BackfillResultPayload = {
+            "status": "complete",
+            "embedded_sessions": 0,
+            "error_count": 0,
+            "estimated_cost_usd": 0.0,
+            "stopped_reason": None,
+            "candidate_sessions": 0,
+            "processed_sessions": 0,
+            "preflight": _preflight_payload(report),
+            "sessions": [],
+        }
+        if output_format == "text":
+            click.echo("All sessions are already embedded.")
+        return payload
 
     cap = _effective_cost_cap(report.cost_cap_usd, report.max_cost_usd)
     cumulative_cost = 0.0
     embedded = 0
     errors = 0
+    processed = 0
+    session_payloads: list[BackfillSessionPayload] = []
     console = env.ui.console
     started_at = time.monotonic()
     stopped_reason: str | None = None
@@ -592,35 +650,68 @@ def _run_archive_backfill(
             stopped_reason = f"time limit reached ({stop_after_seconds}s)"
             break
         outcome = embed_archive_session_sync(index_db, typed_provider, item.session_id)
+        processed += 1
+        batch_cost = 0.0
         if outcome.status == "embedded":
             embedded += 1
             batch_cost = (
                 outcome.embedded_message_count * ESTIMATED_TOKENS_PER_MESSAGE * VOYAGE_4_COST_PER_1M_TOKENS / 1_000_000
             )
             cumulative_cost += batch_cost
-            console.print(
-                f"  [{index}/{len(pending)}] {item.title or item.session_id[:12]}: "
-                f"{outcome.embedded_message_count} msgs (~${batch_cost:.4f}, cumulative ~${cumulative_cost:.4f})"
-            )
+            if output_format == "text":
+                console.print(
+                    f"  [{index}/{len(pending)}] {item.title or item.session_id[:12]}: "
+                    f"{outcome.embedded_message_count} msgs (~${batch_cost:.4f}, cumulative ~${cumulative_cost:.4f})"
+                )
             if cap > 0 and cumulative_cost > cap:
                 stopped_reason = f"cost cap reached (~${cumulative_cost:.4f} > ${cap:.2f})"
-                console.print(
-                    f"[yellow]Cost cap reached (~${cumulative_cost:.4f} > ${cap:.2f}). "
-                    f"Stopping after {embedded} sessions.[/yellow]"
-                )
-                break
+                if output_format == "text":
+                    console.print(
+                        f"[yellow]Cost cap reached (~${cumulative_cost:.4f} > ${cap:.2f}). "
+                        f"Stopping after {embedded} sessions.[/yellow]"
+                    )
         elif outcome.status in {"no_messages", "no_embeddable_messages"}:
-            console.print(f"  [{index}/{len(pending)}] {item.title or item.session_id[:12]}: no embeddable messages")
+            if output_format == "text":
+                console.print(
+                    f"  [{index}/{len(pending)}] {item.title or item.session_id[:12]}: no embeddable messages"
+                )
         elif outcome.status == "error":
             errors += 1
-            console.print(f"  [{index}/{len(pending)}] {item.session_id}: error {outcome.error}")
+            if output_format == "text":
+                console.print(f"  [{index}/{len(pending)}] {item.session_id}: error {outcome.error}")
             if max_errors is not None and errors >= max_errors:
                 stopped_reason = f"max errors reached ({max_errors})"
-                break
+        session_payloads.append(
+            {
+                "index": index,
+                "total": len(pending),
+                "session_id": item.session_id,
+                "title": item.title,
+                "status": outcome.status,
+                "embedded_message_count": outcome.embedded_message_count,
+                "estimated_cost_usd": round(batch_cost, 8),
+                "error": outcome.error,
+            }
+        )
+        if stopped_reason:
+            break
 
-    click.echo(f"\nBackfill complete. Embedded {embedded}, errors {errors}, est. cost ~${cumulative_cost:.4f}.")
-    if stopped_reason:
-        click.echo(f"Stopped early: {stopped_reason}.")
+    payload = {
+        "status": "stopped" if stopped_reason else "complete",
+        "embedded_sessions": embedded,
+        "error_count": errors,
+        "estimated_cost_usd": round(cumulative_cost, 8),
+        "stopped_reason": stopped_reason,
+        "candidate_sessions": len(pending),
+        "processed_sessions": processed,
+        "preflight": _preflight_payload(report),
+        "sessions": session_payloads,
+    }
+    if output_format == "text":
+        click.echo(f"\nBackfill complete. Embedded {embedded}, errors {errors}, est. cost ~${cumulative_cost:.4f}.")
+        if stopped_reason:
+            click.echo(f"Stopped early: {stopped_reason}.")
+    return payload
 
 
 @embed_command.command("status")

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -519,6 +519,76 @@ class TestBackfillCommand:
         fake_embed.assert_called_once_with(index_db, fake_provider, "codex-session:v1")
         old_iter.assert_not_called()
 
+    def test_backfill_json_outputs_structured_result(
+        self,
+        cli_runner: CliRunner,
+        stub_env: Any,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VOYAGE_API_KEY", "pa-test")
+        from polylogue.storage.embeddings.materialization import (
+            EmbedSessionOutcome,
+            PendingSession,
+        )
+
+        index_db = tmp_path / "index.db"
+        sqlite3.connect(index_db).close()
+        pending = [PendingSession(session_id="codex-session:v1", title="v1", message_count=2)]
+        with (
+            _patch_preflight(_make_report(pending_sessions=1, pending_messages=2, max_messages=2)),
+            patch("polylogue.cli.commands.embed._active_archive_index_path", return_value=index_db),
+            patch("polylogue.storage.search_providers.create_vector_provider", return_value=MagicMock()),
+            patch(
+                "polylogue.storage.embeddings.materialization.select_pending_archive_session_window",
+                return_value=pending,
+            ),
+            patch(
+                "polylogue.storage.embeddings.materialization.embed_archive_session_sync",
+                return_value=EmbedSessionOutcome(
+                    status="embedded",
+                    session_id="codex-session:v1",
+                    embedded_message_count=2,
+                ),
+            ),
+        ):
+            result = cli_runner.invoke(embed_command, ["backfill", "--yes", "--format", "json"], obj=stub_env)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "complete"
+        assert payload["embedded_sessions"] == 1
+        assert payload["error_count"] == 0
+        assert payload["candidate_sessions"] == 1
+        assert payload["processed_sessions"] == 1
+        assert payload["estimated_cost_usd"] == 0.0001
+        assert payload["preflight"]["pending_messages"] == 2
+        assert payload["sessions"] == [
+            {
+                "embedded_message_count": 2,
+                "error": None,
+                "estimated_cost_usd": 0.0001,
+                "index": 1,
+                "session_id": "codex-session:v1",
+                "status": "embedded",
+                "title": "v1",
+                "total": 1,
+            }
+        ]
+
+    def test_backfill_json_requires_yes_for_clean_stdout(
+        self,
+        cli_runner: CliRunner,
+        stub_env: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VOYAGE_API_KEY", "pa-test")
+
+        result = cli_runner.invoke(embed_command, ["backfill", "--format", "json"], obj=stub_env)
+
+        assert result.exit_code != 0
+        assert "requires --yes" in result.output
+
     def test_backfill_stop_after_seconds_stops_before_next_session(
         self,
         cli_runner: CliRunner,


### PR DESCRIPTION
## Summary

Add structured JSON output for `polylogue ops embed backfill`. The costful embedding operation now composes with the existing structured `preflight` and `status` surfaces instead of requiring transcript scraping.

## Problem

The live sixth embedding batch produced useful evidence, but the command that actually spends provider budget was text-only. Agents could capture preflight and status as JSON, but completion details required parsing terminal prose, which is brittle for demos, supervision, and future automation.

## Solution

`backfill --format json --yes` now emits one machine-readable payload containing the preflight, candidate/processed counts, per-session outcomes, embedded/error totals, estimated cost, and stop reason. Text remains the default and keeps the existing progress output. `backfill --format json` without `--yes` now fails immediately with a structured usage error so stdout is never mixed with a prompt or preflight text.

## Verification

- `devtools test tests/unit/cli/test_embed_activation.py::TestBackfillCommand -q` -> `9 passed`.
- `ruff check polylogue/cli/commands/embed.py tests/unit/cli/test_embed_activation.py && ruff format --check ... && mypy ...` -> clean.
- `devtools render all --check` -> clean.
- `devtools verify --quick` -> all 13 quick steps passed.
- Live guard proof: `polylogue ops embed backfill --format json` exits in about one second with a structured `invalid_arguments` payload requiring `--yes`, without running a preflight scan.

## Changelog

Skipped. Release notes are generated from the squash title/body by release-please.

## Risks and Follow-ups

The JSON mode intentionally suppresses per-session progress until the final payload so stdout stays parseable. If streaming supervision becomes important, add an explicit NDJSON mode rather than overloading `--format json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output for the backfill command, alongside the existing text output.
  * Backfill results now include structured session details, counts, estimated cost, and stop reasons.
  * Added support for reporting completed, pending, and processed session totals.

* **Bug Fixes**
  * Prevented non-machine-readable output in JSON mode by requiring confirmation before running.
  * Improved behavior when no sessions need processing, returning a clear completion result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->