### PR TITLE
fix(embed): count only prose in embedding stats

### DIFF
--- a/polylogue/storage/embeddings/embedding_stats.py
+++ b/polylogue/storage/embeddings/embedding_stats.py
@@ -10,6 +10,7 @@ import aiosqlite
 from polylogue.storage.embeddings.models import EmbeddingStatsSnapshot
 from polylogue.storage.embeddings.sql import (
     DIMENSION_COUNTS_SQL,
+    ELIGIBLE_SESSIONS_SQL,
     EMBEDDED_AT_BOUNDS_SQL,
     EMBEDDED_SESSIONS_SQL,
     EMBEDDING_FAILURE_COUNT_SQL,
@@ -142,86 +143,94 @@ def _dimension_counts(rows: list[sqlite3.Row]) -> dict[int, int]:
 
 def _base_parts_sync(conn: sqlite3.Connection, *, detail: bool) -> _EmbeddingStatsParts:
     sessions_exist = table_exists_sync(conn, "sessions")
+    status_exists = table_exists_sync(conn, "embedding_status")
     if not detail:
         return _EmbeddingStatsParts(
             bounds=None,
             model_rows=[],
             dimension_rows=[],
-            embedded_sessions=optional_count_sync(conn, EMBEDDED_SESSIONS_SQL),
+            embedded_sessions=optional_count_sync(conn, EMBEDDED_SESSIONS_SQL) if status_exists else 0,
             embedded_messages=embedded_message_count_sync(conn),
-            pending_sessions=optional_count_sync(conn, PENDING_SESSIONS_SQL),
+            pending_sessions=(
+                optional_count_sync(conn, PENDING_SESSIONS_SQL)
+                if status_exists
+                else optional_count_sync(conn, ELIGIBLE_SESSIONS_SQL)
+            ),
             pending_messages=0,
             stale_messages=0,
             missing_provenance=0,
             sessions_exist=sessions_exist,
-            failure_count=optional_count_sync(conn, EMBEDDING_FAILURE_COUNT_SQL),
+            failure_count=optional_count_sync(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,
             total_message_count=0,
         )
+    total_messages = optional_count_sync(conn, TOTAL_MESSAGES_SQL)
     return _EmbeddingStatsParts(
         bounds=optional_row_sync(conn, EMBEDDED_AT_BOUNDS_SQL),
         model_rows=optional_rows_sync(conn, MODEL_COUNTS_SQL),
         dimension_rows=optional_rows_sync(conn, DIMENSION_COUNTS_SQL),
-        embedded_sessions=optional_count_sync(conn, EMBEDDED_SESSIONS_SQL),
+        embedded_sessions=optional_count_sync(conn, EMBEDDED_SESSIONS_SQL) if status_exists else 0,
         embedded_messages=embedded_message_count_sync(conn),
-        pending_sessions=optional_count_sync(conn, PENDING_SESSIONS_SQL),
-        pending_messages=optional_count_sync(conn, PENDING_MESSAGES_SQL),
+        pending_sessions=(
+            optional_count_sync(conn, PENDING_SESSIONS_SQL)
+            if status_exists
+            else optional_count_sync(conn, ELIGIBLE_SESSIONS_SQL)
+        ),
+        pending_messages=optional_count_sync(conn, PENDING_MESSAGES_SQL) if status_exists else total_messages,
         stale_messages=optional_count_sync(conn, STALE_MESSAGES_SQL),
         missing_provenance=optional_count_sync(conn, MISSING_META_MESSAGES_SQL),
         sessions_exist=sessions_exist,
-        failure_count=optional_count_sync(conn, EMBEDDING_FAILURE_COUNT_SQL),
-        total_message_count=optional_count_sync(conn, TOTAL_MESSAGES_SQL),
+        failure_count=optional_count_sync(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,
+        total_message_count=total_messages,
     )
 
 
 async def _base_parts_async(conn: aiosqlite.Connection, *, detail: bool) -> _EmbeddingStatsParts:
     sessions_exist = await table_exists_async(conn, "sessions")
+    status_exists = await table_exists_async(conn, "embedding_status")
     if not detail:
         return _EmbeddingStatsParts(
             bounds=None,
             model_rows=[],
             dimension_rows=[],
-            embedded_sessions=await optional_count_async(conn, EMBEDDED_SESSIONS_SQL),
+            embedded_sessions=await optional_count_async(conn, EMBEDDED_SESSIONS_SQL) if status_exists else 0,
             embedded_messages=await embedded_message_count_async(conn),
-            pending_sessions=await optional_count_async(conn, PENDING_SESSIONS_SQL),
+            pending_sessions=(
+                await optional_count_async(conn, PENDING_SESSIONS_SQL)
+                if status_exists
+                else await optional_count_async(conn, ELIGIBLE_SESSIONS_SQL)
+            ),
             pending_messages=0,
             stale_messages=0,
             missing_provenance=0,
             sessions_exist=sessions_exist,
-            failure_count=await optional_count_async(conn, EMBEDDING_FAILURE_COUNT_SQL),
+            failure_count=await optional_count_async(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,
             total_message_count=0,
         )
+    total_messages = await optional_count_async(conn, TOTAL_MESSAGES_SQL)
     return _EmbeddingStatsParts(
         bounds=await optional_row_async(conn, EMBEDDED_AT_BOUNDS_SQL),
         model_rows=await optional_rows_async(conn, MODEL_COUNTS_SQL),
         dimension_rows=await optional_rows_async(conn, DIMENSION_COUNTS_SQL),
-        embedded_sessions=await optional_count_async(conn, EMBEDDED_SESSIONS_SQL),
+        embedded_sessions=await optional_count_async(conn, EMBEDDED_SESSIONS_SQL) if status_exists else 0,
         embedded_messages=await embedded_message_count_async(conn),
-        pending_sessions=await optional_count_async(conn, PENDING_SESSIONS_SQL),
-        pending_messages=await optional_count_async(conn, PENDING_MESSAGES_SQL),
+        pending_sessions=(
+            await optional_count_async(conn, PENDING_SESSIONS_SQL)
+            if status_exists
+            else await optional_count_async(conn, ELIGIBLE_SESSIONS_SQL)
+        ),
+        pending_messages=await optional_count_async(conn, PENDING_MESSAGES_SQL) if status_exists else total_messages,
         stale_messages=await optional_count_async(conn, STALE_MESSAGES_SQL),
         missing_provenance=await optional_count_async(conn, MISSING_META_MESSAGES_SQL),
         sessions_exist=sessions_exist,
-        failure_count=await optional_count_async(conn, EMBEDDING_FAILURE_COUNT_SQL),
-        total_message_count=await optional_count_async(conn, TOTAL_MESSAGES_SQL),
+        failure_count=await optional_count_async(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,
+        total_message_count=total_messages,
     )
 
 
 def _with_total_sessions(parts: _EmbeddingStatsParts, total_sessions: int) -> _EmbeddingStatsParts:
-    pending_sessions = max(
-        parts.pending_sessions,
-        total_sessions - parts.embedded_sessions,
-    )
-    pending_messages = parts.pending_messages
-    if parts.total_message_count > 0:
-        pending_messages = max(
-            parts.pending_messages,
-            parts.total_message_count - parts.embedded_messages if pending_sessions > 0 else 0,
-        )
     return replace(
         parts,
         total_sessions=total_sessions,
-        pending_sessions=pending_sessions,
-        pending_messages=pending_messages,
     )
 
 

--- a/polylogue/storage/embeddings/sql.py
+++ b/polylogue/storage/embeddings/sql.py
@@ -2,14 +2,49 @@
 
 from __future__ import annotations
 
+EMBEDDABLE_MESSAGE_WHERE = """
+    m.message_type = 'message'
+    AND m.role IN ('user', 'assistant')
+    AND m.material_origin IN ('human_authored', 'assistant_authored')
+    AND m.word_count > 0
+"""
+ELIGIBLE_SESSIONS_SQL = f"""
+    SELECT COUNT(*)
+    FROM (
+        SELECT m.session_id
+        FROM messages m
+        WHERE {EMBEDDABLE_MESSAGE_WHERE}
+        GROUP BY m.session_id
+    ) eligible_sessions
+"""
 EMBEDDED_SESSIONS_SQL = "SELECT COUNT(*) FROM embedding_status WHERE needs_reindex = 0"
-PENDING_SESSIONS_SQL = "SELECT COUNT(*) FROM embedding_status WHERE needs_reindex = 1"
+PENDING_SESSIONS_SQL = f"""
+    WITH eligible_sessions AS (
+        SELECT m.session_id, COUNT(*) AS message_count
+        FROM messages m
+        WHERE {EMBEDDABLE_MESSAGE_WHERE}
+        GROUP BY m.session_id
+    )
+    SELECT COUNT(*)
+    FROM eligible_sessions es
+    LEFT JOIN embedding_status e ON e.session_id = es.session_id
+    WHERE e.session_id IS NULL
+       OR e.needs_reindex = 1
+       OR e.message_count_embedded < es.message_count
+"""
 PENDING_MESSAGES_SQL = """
     SELECT COUNT(*)
     FROM messages m
     JOIN sessions c ON c.session_id = m.session_id
     LEFT JOIN embedding_status e ON e.session_id = c.session_id
-    WHERE e.session_id IS NULL OR e.needs_reindex = 1
+    WHERE (
+            e.session_id IS NULL
+         OR e.needs_reindex = 1
+    )
+      AND m.message_type = 'message'
+      AND m.role IN ('user', 'assistant')
+      AND m.material_origin IN ('human_authored', 'assistant_authored')
+      AND m.word_count > 0
 """
 EMBEDDED_MESSAGES_SQL = "SELECT COUNT(*) FROM message_embeddings"
 MISSING_META_MESSAGES_SQL = """
@@ -25,8 +60,14 @@ STALE_MESSAGES_SQL = """
     JOIN messages m ON m.message_id = me.message_id
     LEFT JOIN message_embeddings_meta em
       ON em.message_id = me.message_id
-    WHERE em.message_id IS NULL
-       OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
+    WHERE (
+            em.message_id IS NULL
+         OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
+    )
+      AND m.message_type = 'message'
+      AND m.role IN ('user', 'assistant')
+      AND m.material_origin IN ('human_authored', 'assistant_authored')
+      AND m.word_count > 0
 """
 EMBEDDED_AT_BOUNDS_SQL = """
     SELECT MIN(embedded_at_ms) AS oldest_embedded_at, MAX(embedded_at_ms) AS newest_embedded_at
@@ -53,5 +94,9 @@ STORED_MODEL_SQL = """
 """
 TOTAL_MESSAGES_SQL = """
     SELECT COUNT(*) AS message_count
-    FROM messages
+    FROM messages m
+    WHERE m.message_type = 'message'
+      AND m.role IN ('user', 'assistant')
+      AND m.material_origin IN ('human_authored', 'assistant_authored')
+      AND m.word_count > 0
 """

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -421,11 +421,12 @@ def test_embedding_status_lifecycle(
 
         # Seed embedding_status rows
         for conv_id, last_embedded, needs_reindex, error_msg in seed_rows:
+            message_count_embedded = 1 if last_embedded is not None and needs_reindex == 0 and error_msg is None else 0
             conn.execute(
                 "INSERT INTO embedding_status "
-                "(session_id, last_embedded_at, needs_reindex, error_message) "
-                "VALUES (?, ?, ?, ?)",
-                (conv_id, last_embedded, needs_reindex, error_msg),
+                "(session_id, message_count_embedded, last_embedded_at, needs_reindex, error_message) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (conv_id, message_count_embedded, last_embedded, needs_reindex, error_msg),
             )
         conn.commit()
 

--- a/tests/unit/storage/test_embedding_stats.py
+++ b/tests/unit/storage/test_embedding_stats.py
@@ -15,10 +15,82 @@ from polylogue.storage.embeddings.embedding_stats import (
 from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
 
 
+def _create_embedding_stats_tables(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE embedding_status (
+            session_id TEXT PRIMARY KEY,
+            message_count_embedded INTEGER NOT NULL DEFAULT 0,
+            needs_reindex INTEGER NOT NULL,
+            error_message TEXT
+        );
+        CREATE TABLE message_embeddings (message_id TEXT);
+        CREATE TABLE sessions (session_id TEXT PRIMARY KEY);
+        CREATE TABLE messages (
+            message_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            message_type TEXT NOT NULL,
+            material_origin TEXT NOT NULL,
+            word_count INTEGER NOT NULL,
+            content_hash BLOB
+        );
+        """
+    )
+
+
+def _insert_prose_message(conn: sqlite3.Connection, session_id: str, message_id: str) -> None:
+    conn.execute("INSERT OR IGNORE INTO sessions (session_id) VALUES (?)", (session_id,))
+    conn.execute(
+        """
+        INSERT INTO messages (
+            message_id, session_id, role, message_type, material_origin, word_count, content_hash
+        ) VALUES (?, ?, 'user', 'message', 'human_authored', 6, zeroblob(32))
+        """,
+        (message_id, session_id),
+    )
+
+
+async def _create_embedding_stats_tables_async(conn: aiosqlite.Connection) -> None:
+    await conn.executescript(
+        """
+        CREATE TABLE embedding_status (
+            session_id TEXT PRIMARY KEY,
+            message_count_embedded INTEGER NOT NULL DEFAULT 0,
+            needs_reindex INTEGER NOT NULL,
+            error_message TEXT
+        );
+        CREATE TABLE message_embeddings (message_id TEXT);
+        CREATE TABLE sessions (session_id TEXT PRIMARY KEY);
+        CREATE TABLE messages (
+            message_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            message_type TEXT NOT NULL,
+            material_origin TEXT NOT NULL,
+            word_count INTEGER NOT NULL,
+            content_hash BLOB
+        );
+        """
+    )
+
+
+async def _insert_prose_message_async(conn: aiosqlite.Connection, session_id: str, message_id: str) -> None:
+    await conn.execute("INSERT OR IGNORE INTO sessions (session_id) VALUES (?)", (session_id,))
+    await conn.execute(
+        """
+        INSERT INTO messages (
+            message_id, session_id, role, message_type, material_origin, word_count, content_hash
+        ) VALUES (?, ?, 'user', 'message', 'human_authored', 6, zeroblob(32))
+        """,
+        (message_id, session_id),
+    )
+
+
 def test_read_embedding_stats_sync_missing_tables_returns_zeroes() -> None:
     conn = sqlite3.connect(":memory:")
     try:
-        stats = read_embedding_stats_sync(conn)
+        stats = read_embedding_stats_sync(conn, include_retrieval_bands=False)
     finally:
         conn.close()
 
@@ -30,13 +102,13 @@ def test_read_embedding_stats_sync_missing_tables_returns_zeroes() -> None:
 def test_read_embedding_stats_sync_counts_available_tables() -> None:
     conn = sqlite3.connect(":memory:")
     try:
-        conn.execute(
-            "CREATE TABLE embedding_status (session_id TEXT, needs_reindex INTEGER NOT NULL, error_message TEXT)"
-        )
-        conn.execute("CREATE TABLE message_embeddings (message_id TEXT)")
+        _create_embedding_stats_tables(conn)
+        _insert_prose_message(conn, "conv-1", "msg-1")
+        _insert_prose_message(conn, "conv-2", "msg-2")
+        _insert_prose_message(conn, "conv-3", "msg-3")
         conn.executemany(
-            "INSERT INTO embedding_status (session_id, needs_reindex) VALUES (?, ?)",
-            [("conv-1", 0), ("conv-2", 0), ("conv-3", 1)],
+            "INSERT INTO embedding_status (session_id, message_count_embedded, needs_reindex) VALUES (?, ?, ?)",
+            [("conv-1", 1, 0), ("conv-2", 1, 0), ("conv-3", 0, 1)],
         )
         conn.executemany(
             "INSERT INTO message_embeddings (message_id) VALUES (?)",
@@ -44,13 +116,42 @@ def test_read_embedding_stats_sync_counts_available_tables() -> None:
         )
         conn.commit()
 
-        stats = read_embedding_stats_sync(conn)
+        stats = read_embedding_stats_sync(conn, include_retrieval_bands=False)
     finally:
         conn.close()
 
     assert stats.embedded_sessions == 2
     assert stats.embedded_messages == 3
     assert stats.pending_sessions == 1
+
+
+def test_read_embedding_stats_counts_only_authored_prose_candidates() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        _create_embedding_stats_tables(conn)
+        _insert_prose_message(conn, "conv-prose", "msg-prose")
+        conn.execute("INSERT OR IGNORE INTO sessions (session_id) VALUES ('conv-tool')")
+        conn.executemany(
+            """
+            INSERT INTO messages (
+                message_id, session_id, role, message_type, material_origin, word_count, content_hash
+            ) VALUES (?, 'conv-tool', ?, ?, ?, ?, zeroblob(32))
+            """,
+            [
+                ("tool-use", "assistant", "tool_use", "assistant_authored", 10),
+                ("tool-result", "tool", "tool_result", "tool_generated", 2000),
+                ("protocol-context", "user", "message", "runtime_generated", 2000),
+            ],
+        )
+        conn.commit()
+
+        stats = read_embedding_stats_sync(conn, include_retrieval_bands=False)
+    finally:
+        conn.close()
+
+    assert stats.pending_sessions == 1
+    assert stats.pending_messages == 1
+    assert stats.total_estimated_cost_usd == 0.0
 
 
 def test_read_embedding_stats_sync_propagates_non_missing_operational_errors() -> None:
@@ -90,9 +191,28 @@ def test_read_embedding_stats_sync_exposes_retrieval_bands_when_archive_tables_e
     conn = sqlite3.connect(":memory:")
     try:
         conn.execute("CREATE TABLE sessions (session_id TEXT)")
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                message_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                message_type TEXT NOT NULL,
+                material_origin TEXT NOT NULL,
+                word_count INTEGER NOT NULL
+            )
+            """
+        )
         conn.executemany(
             "INSERT INTO sessions (session_id) VALUES (?)",
             [("conv-1",), ("conv-2",)],
+        )
+        conn.executemany(
+            """
+            INSERT INTO messages (message_id, session_id, role, message_type, material_origin, word_count)
+            VALUES (?, ?, 'user', 'message', 'human_authored', 6)
+            """,
+            [("msg-1", "conv-1"), ("msg-2", "conv-2")],
         )
         conn.commit()
 
@@ -152,9 +272,28 @@ def test_read_embedding_stats_sync_can_skip_retrieval_band_status(
     conn = sqlite3.connect(":memory:")
     try:
         conn.execute("CREATE TABLE sessions (session_id TEXT)")
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                message_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                message_type TEXT NOT NULL,
+                material_origin TEXT NOT NULL,
+                word_count INTEGER NOT NULL
+            )
+            """
+        )
         conn.executemany(
             "INSERT INTO sessions (session_id) VALUES (?)",
             [("conv-1",), ("conv-2",)],
+        )
+        conn.executemany(
+            """
+            INSERT INTO messages (message_id, session_id, role, message_type, material_origin, word_count)
+            VALUES (?, ?, 'user', 'message', 'human_authored', 6)
+            """,
+            [("msg-1", "conv-1"), ("msg-2", "conv-2")],
         )
         conn.commit()
 
@@ -171,13 +310,12 @@ def test_read_embedding_stats_sync_can_skip_retrieval_band_status(
 @pytest.mark.asyncio
 async def test_read_embedding_stats_async_counts_available_tables() -> None:
     async with aiosqlite.connect(":memory:") as conn:
-        await conn.execute(
-            "CREATE TABLE embedding_status (session_id TEXT, needs_reindex INTEGER NOT NULL, error_message TEXT)"
-        )
-        await conn.execute("CREATE TABLE message_embeddings (message_id TEXT)")
+        await _create_embedding_stats_tables_async(conn)
+        await _insert_prose_message_async(conn, "conv-1", "msg-1")
+        await _insert_prose_message_async(conn, "conv-2", "msg-2")
         await conn.executemany(
-            "INSERT INTO embedding_status (session_id, needs_reindex) VALUES (?, ?)",
-            [("conv-1", 0), ("conv-2", 1)],
+            "INSERT INTO embedding_status (session_id, message_count_embedded, needs_reindex) VALUES (?, ?, ?)",
+            [("conv-1", 1, 0), ("conv-2", 0, 1)],
         )
         await conn.executemany(
             "INSERT INTO message_embeddings (message_id) VALUES (?)",
@@ -185,7 +323,7 @@ async def test_read_embedding_stats_async_counts_available_tables() -> None:
         )
         await conn.commit()
 
-        stats = await read_embedding_stats_async(conn)
+        stats = await read_embedding_stats_async(conn, include_retrieval_bands=False)
 
     assert stats.embedded_sessions == 1
     assert stats.embedded_messages == 2
@@ -203,7 +341,7 @@ async def test_read_embedding_stats_async_missing_tables_returns_zeroes() -> Non
 
 
 @pytest.mark.asyncio
-async def test_read_embedding_stats_async_derives_pending_from_total_sessions(
+async def test_read_embedding_stats_async_does_not_derive_pending_from_session_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def fake_session_status(_conn: object) -> SessionInsightStatusSnapshot:
@@ -241,9 +379,9 @@ async def test_read_embedding_stats_async_derives_pending_from_total_sessions(
 
         stats = await read_embedding_stats_async(conn)
 
-    assert stats.pending_sessions == 3
-    assert stats.retrieval_bands["transcript_embeddings"]["pending_documents"] == 3
-    assert "pending 3" in str(stats.retrieval_bands["transcript_embeddings"]["detail"])
+    assert stats.pending_sessions == 0
+    assert stats.retrieval_bands["transcript_embeddings"]["pending_documents"] == 0
+    assert "pending 0" in str(stats.retrieval_bands["transcript_embeddings"]["detail"])
 
 
 @pytest.mark.asyncio
@@ -255,9 +393,28 @@ async def test_read_embedding_stats_async_can_skip_retrieval_band_status(
 
     async with aiosqlite.connect(":memory:") as conn:
         await conn.execute("CREATE TABLE sessions (session_id TEXT)")
+        await conn.execute(
+            """
+            CREATE TABLE messages (
+                message_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                message_type TEXT NOT NULL,
+                material_origin TEXT NOT NULL,
+                word_count INTEGER NOT NULL
+            )
+            """
+        )
         await conn.executemany(
             "INSERT INTO sessions (session_id) VALUES (?)",
             [("conv-1",), ("conv-2",)],
+        )
+        await conn.executemany(
+            """
+            INSERT INTO messages (message_id, session_id, role, message_type, material_origin, word_count)
+            VALUES (?, ?, 'user', 'message', 'human_authored', 6)
+            """,
+            [("msg-1", "conv-1"), ("msg-2", "conv-2")],
         )
         await conn.commit()
 


### PR DESCRIPTION
## Summary

Tighten embedding statistics so backlog and cost accounting use the same authored-prose eligibility model as paid embedding materialization. Tool calls, tool results, protocol/context rows, and generated runtime messages no longer inflate generic embedding stats.

## Problem

The archive materializer already sends only authored user/assistant prose text blocks to the embedding provider, but the generic stats SQL still counted every session/message row as backlog. That made fallback status/cost estimates preserve an all-message assumption even after the paid pipeline had moved to selective embedding.

## Solution

`polylogue/storage/embeddings/sql.py` now defines one embeddable-message predicate for generic stats: standard `message` rows from `user`/`assistant` roles with `human_authored` or `assistant_authored` material origin and positive word count. Pending session, pending message, stale message, and total cost counts use that predicate.

`polylogue/storage/embeddings/embedding_stats.py` now treats a fresh archive with no `embedding_status` table as “all eligible prose pending” rather than “all sessions pending,” and it no longer derives pending sessions/messages from raw total session counts.

Tests now seed canonical message fields for stats fixtures, record embedded-message coverage in lifecycle status rows, and include regression coverage proving tool/protocol/generated rows do not affect pending embedding cost.

## Verification

- `devtools test tests/unit/storage/test_embedding_stats.py tests/unit/storage/test_embedding_contracts.py -q` → 38 passed.
- `ruff format --check polylogue/storage/embeddings/sql.py polylogue/storage/embeddings/embedding_stats.py tests/unit/storage/test_embedding_stats.py tests/unit/storage/test_embedding_contracts.py` → 4 files already formatted.
- `ruff check polylogue/storage/embeddings/sql.py polylogue/storage/embeddings/embedding_stats.py tests/unit/storage/test_embedding_stats.py tests/unit/storage/test_embedding_contracts.py` → all checks passed.
- `mypy polylogue/storage/embeddings/sql.py polylogue/storage/embeddings/embedding_stats.py tests/unit/storage/test_embedding_stats.py tests/unit/storage/test_embedding_contracts.py` → success.
- `devtools verify --quick` → all 13 steps passed.
- Live archive `/home/sinity/.local/share/polylogue`, index schema v21: `polylogue ops embed status --detail --format json` reported `pending_messages=719288`, `embedded_messages=59357`, `retrieval_ready=true`, `stale_messages=0`, `messages_missing_provenance=0`.
- Live preflight: `polylogue ops embed preflight --max-messages 20000 --min-messages 20 --max-cost-usd 1.1 --format json` reported the next bounded window as 40 sessions / 19,891 eligible messages / estimated cost `$0.99455`.
- `devtools verify` static/generated steps passed; pytest-testmon selected a broad run and was aborted at ~35% after 2,224 passes / 39 failures in unrelated query/parser/MCP/FTS surfaces. The embedding-focused tests in that same run were passing, including `test_archive_embedding_only_sends_authored_prose_to_provider` and `test_archive_pending_window_and_embedding_success`.
