### PR TITLE
perf(pipeline): report raw ingest batch starts

### DIFF
--- a/polylogue/pipeline/services/parsing_workflow.py
+++ b/polylogue/pipeline/services/parsing_workflow.py
@@ -59,6 +59,37 @@ def _raw_batch_bytes(headers_by_raw_id: dict[str, int], batch_ids: Iterable[str]
     return sum(max(int(headers_by_raw_id.get(raw_id, 0)), 0) for raw_id in batch_ids)
 
 
+def _emit_ingest_batch_start(
+    *,
+    batch: int,
+    batch_ids: list[str],
+    processed_raw: int,
+    total_raw: int,
+    raw_blob_sizes: dict[str, int],
+    progress_callback: ProgressCallback | None,
+) -> int:
+    batch_blob_bytes = _raw_batch_bytes(raw_blob_sizes, batch_ids)
+    batch_blob_mb = batch_blob_bytes / (1024 * 1024)
+    if progress_callback is not None:
+        progress_callback(
+            0,
+            desc=(
+                f"Ingesting batch {batch} "
+                f"({processed_raw:,}/{total_raw:,} raw, "
+                f"batch {len(batch_ids):,} raw, {batch_blob_mb:.1f} MiB)"
+            ),
+        )
+    logger.info(
+        "ingest_batch_start",
+        batch=batch,
+        size=len(batch_ids),
+        processed_raw=processed_raw,
+        total_raw=total_raw,
+        blob_mb=round(batch_blob_mb, 1),
+    )
+    return batch_blob_bytes
+
+
 def _append_unique_raw_ids(
     target: list[str],
     *,
@@ -296,6 +327,15 @@ async def parse_from_raw(
             max_records=service.raw_batch_size,
             max_blob_bytes=service.raw_batch_blob_limit_bytes,
         ):
+            next_batch = batches_processed + 1
+            batch_blob_bytes = _emit_ingest_batch_start(
+                batch=next_batch,
+                batch_ids=batch_ids,
+                processed_raw=processed_so_far,
+                total_raw=total,
+                raw_blob_sizes=raw_blob_sizes,
+                progress_callback=progress_callback,
+            )
             t_batch = time.perf_counter()
             batch_observation = await process_ingest_batch(
                 service,
@@ -305,7 +345,7 @@ async def parse_from_raw(
                 progress_callback,
                 force_write=force_write,
                 repair_message_fts=repair_message_fts,
-                suspend_fts_triggers=_raw_batch_bytes(raw_blob_sizes, batch_ids) >= _BULK_FTS_RAW_BATCH_BYTES,
+                suspend_fts_triggers=batch_blob_bytes >= _BULK_FTS_RAW_BATCH_BYTES,
             )
             batches_processed += 1
             batch_elapsed = time.perf_counter() - t_batch
@@ -339,6 +379,15 @@ async def parse_from_raw(
             max_records=service.raw_batch_size,
             max_blob_bytes=service.raw_batch_blob_limit_bytes,
         ):
+            next_batch = batches_processed + 1
+            batch_blob_bytes = _emit_ingest_batch_start(
+                batch=next_batch,
+                batch_ids=batch_ids,
+                processed_raw=processed_so_far,
+                total_raw=total,
+                raw_blob_sizes=raw_blob_sizes,
+                progress_callback=progress_callback,
+            )
             t_batch = time.perf_counter()
             batch_observation = await process_ingest_batch(
                 service,
@@ -348,7 +397,7 @@ async def parse_from_raw(
                 progress_callback,
                 force_write=force_write,
                 repair_message_fts=repair_message_fts,
-                suspend_fts_triggers=_raw_batch_bytes(raw_blob_sizes, batch_ids) >= _BULK_FTS_RAW_BATCH_BYTES,
+                suspend_fts_triggers=batch_blob_bytes >= _BULK_FTS_RAW_BATCH_BYTES,
             )
             batches_processed += 1
             processed_so_far += len(batch_ids)

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -468,18 +468,24 @@ class TestParsingServiceStreaming:
         )
         config = Config(archive_root=tmp_path / "archive", render_root=tmp_path / "render", sources=[])
         service = ParsingService(repository=repository, archive_root=config.archive_root, config=config)
+        progress_events: list[str] = []
 
         with patch(
             "polylogue.pipeline.services.ingest_batch.process_ingest_batch",
             new=AsyncMock(side_effect=[None, None]),
         ) as mock_process:
-            await service.parse_from_raw(raw_ids=["raw-1", "raw-2", "raw-3"])
+            await service.parse_from_raw(
+                raw_ids=["raw-1", "raw-2", "raw-3"],
+                progress_callback=lambda _amount, desc=None: progress_events.append(desc or ""),
+            )
 
         repository.get_raw_blob_sizes.assert_awaited_once_with(["raw-1", "raw-2", "raw-3"])
         assert mock_process.await_args_list[0].args[2] == ["raw-1"]
         assert mock_process.await_args_list[1].args[2] == ["raw-2", "raw-3"]
         assert mock_process.await_args_list[0].kwargs["suspend_fts_triggers"] is True
         assert mock_process.await_args_list[1].kwargs["suspend_fts_triggers"] is True
+        assert "Ingesting batch 1 (0/3 raw, batch 1 raw, 96.0 MiB)" in progress_events
+        assert "Ingesting batch 2 (1/3 raw, batch 2 raw, 104.0 MiB)" in progress_events
 
     async def test_parse_from_raw_splits_streamed_backlog_by_blob_budget(self, tmp_path: Path) -> None:
         backend = MagicMock()
@@ -497,16 +503,22 @@ class TestParsingServiceStreaming:
         repository.iter_raw_headers = MagicMock(return_value=raw_headers())
         config = Config(archive_root=tmp_path / "archive", render_root=tmp_path / "render", sources=[])
         service = ParsingService(repository=repository, archive_root=config.archive_root, config=config)
+        progress_events: list[str] = []
 
         with patch(
             "polylogue.pipeline.services.ingest_batch.process_ingest_batch",
             new=AsyncMock(side_effect=[None, None]),
         ) as mock_process:
-            await service.parse_from_raw(provider="chatgpt")
+            await service.parse_from_raw(
+                provider="chatgpt",
+                progress_callback=lambda _amount, desc=None: progress_events.append(desc or ""),
+            )
 
         repository.iter_raw_headers.assert_called_once_with(source_name="chatgpt")
         assert mock_process.await_args_list[0].args[2] == ["raw-1"]
         assert mock_process.await_args_list[1].args[2] == ["raw-2", "raw-3"]
+        assert "Ingesting batch 1 (0/3 raw, batch 1 raw, 96.0 MiB)" in progress_events
+        assert "Ingesting batch 2 (1/3 raw, batch 2 raw, 104.0 MiB)" in progress_events
 
     async def test_parse_from_raw_closes_header_stream_before_writing_batches(self, tmp_path: Path) -> None:
         backend = MagicMock()


### PR DESCRIPTION
## Summary

Emit a structured `ingest_batch_start` log and progress description before every raw ingest batch begins. The signal includes batch number, processed/total raw rows, batch size, and batch blob MiB, so long `rebuild-index` runs expose which weighted batch is currently executing instead of going silent until completion.

## Problem

The live v24 rebuild can spend minutes inside CPU-bound raw replay without a fresh log line. Completion-only `ingest_batch` / `slow_batch` logs explain what happened after the fact, but they do not identify the in-flight weighted batch while the process is burning CPU. That makes current ETA and hang diagnosis weaker than the weighted planning work from the previous slices.

## Solution

`parse_from_raw` now computes each batch's blob bytes once before calling `process_ingest_batch`. The value is used both for the new progress/log signal and for the existing FTS-trigger suspension decision. Both explicit raw-id rebuilds and streamed raw backlog replays use the same helper.

Tests extend the existing parsing-service batch-budget coverage to assert the pre-batch progress strings for explicit and streamed raw replay.

## Verification

- `ruff format --check polylogue/pipeline/services/parsing_workflow.py tests/unit/pipeline/test_parsing_service.py && ruff check polylogue/pipeline/services/parsing_workflow.py tests/unit/pipeline/test_parsing_service.py`
- `mypy polylogue/pipeline/services/parsing_workflow.py tests/unit/pipeline/test_parsing_service.py`
- `devtools test tests/unit/pipeline/test_parsing_service.py -k 'parse_from_raw_splits_explicit_raw_ids_by_blob_budget or parse_from_raw_splits_streamed_backlog_by_blob_budget'` -> 2 passed, 24 deselected
- `devtools verify --quick` -> exit_code 0
- Pre-push `devtools verify --quick` -> exit_code 0

A full `devtools verify` was attempted first, but pytest-testmon expanded into a broad run, showed multiple failures by 29%, and was aborted. Static/generated gates had already passed before pytest. The focused tests above cover the changed surface.

Ref polylogue-3wb