### PR TITLE
perf(storage): use session-scoped block lookup for signatures

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -3355,7 +3355,7 @@ def _own_db_signatures(conn: sqlite3.Connection, session_id: str) -> list[tuple[
         SELECT m.message_id, m.position, m.role,
                b.block_type, b.text, b.tool_name, b.tool_input
         FROM messages m
-        LEFT JOIN blocks b ON b.message_id = m.message_id
+        LEFT JOIN blocks b ON b.session_id = m.session_id AND b.message_id = m.message_id
         WHERE m.session_id = ? AND m.variant_index = 0
         ORDER BY m.position, b.position
         """,

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -2605,6 +2605,26 @@ def test_graph_resolve_records_late_parent_substage_timings(tmp_path: Path) -> N
     assert "append.index.graph_resolve" in timings
 
 
+def test_own_db_signatures_uses_session_scoped_block_lookup(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    plan_rows = conn.execute(
+        """
+        EXPLAIN QUERY PLAN
+        SELECT m.message_id, m.position, m.role,
+               b.block_type, b.text, b.tool_name, b.tool_input
+        FROM messages m
+        LEFT JOIN blocks b ON b.session_id = m.session_id AND b.message_id = m.message_id
+        WHERE m.session_id = ? AND m.variant_index = 0
+        ORDER BY m.position, b.position
+        """,
+        ("session:planner",),
+    ).fetchall()
+    plan = "\n".join(str(row[3]) for row in plan_rows)
+
+    assert "idx_blocks_session_position" in plan
+    assert "sqlite_autoindex_blocks_2" not in plan
+
+
 def test_graph_resolve_shares_projection_refresh_seen_set_for_late_children(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Constrain the DB-signature block join by both `session_id` and `message_id`, so graph-resolution signature composition uses the session-position block index instead of the message-id-only autoindex.

## Problem

`_own_db_signatures` is called during prefix-sharing graph resolution. On the active archive, the old query shape over `codex-session:019d1c2a-6f18-7f20-8b77-7012c34d619a` returned 81,454 rows but took 12.94s because SQLite searched blocks by `message_id` alone. The same query constrained by `b.session_id = m.session_id` returned the same row count in 0.06s and planned through `idx_blocks_session_position`.

## Solution

Update `_own_db_signatures` to join blocks on `(session_id, message_id)`. Add a planner regression that asserts the query uses `idx_blocks_session_position` and does not fall back to `sqlite_autoindex_blocks_2`.

## Verification

- Live read-only active archive timing: old query shape 12.94s; session-scoped join 0.06s for the 81k-message Codex root.
- `ruff format --check polylogue/storage/sqlite/archive_tiers/write.py tests/unit/storage/test_archive_tiers_write.py && ruff check polylogue/storage/sqlite/archive_tiers/write.py tests/unit/storage/test_archive_tiers_write.py`
- `mypy polylogue/storage/sqlite/archive_tiers/write.py tests/unit/storage/test_archive_tiers_write.py`
- `devtools test tests/unit/storage/test_archive_tiers_write.py -k 'own_db_signatures_uses_session_scoped_block_lookup or graph_resolve_records_late_parent_substage_timings'` -> 2 passed, 56 deselected
- `devtools verify --quick` -> exit_code 0
- Pre-push `devtools verify --quick` -> exit_code 0

Ref polylogue-3wb