### PR TITLE
fix(logging): forward exc_info/extra in stdlib logger shim

### DIFF
--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -10,7 +10,7 @@ import logging
 import sys
 from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import TYPE_CHECKING, BinaryIO, Protocol, TextIO
+from typing import TYPE_CHECKING, Any, BinaryIO, Protocol, TextIO
 
 from polylogue.config import load_polylogue_config
 
@@ -151,19 +151,24 @@ class _StdlibBoundLogger:
         return self  # no-op: stdlib doesn't support structured context
 
     def debug(self, message: str, *args: object, **event_kw: object) -> None:
-        self._logger.debug(message, *args)
+        self._logger.debug(message, *args, **_stdlib_log_kwargs(event_kw))
 
     def info(self, message: str, *args: object, **event_kw: object) -> None:
-        self._logger.info(message, *args)
+        self._logger.info(message, *args, **_stdlib_log_kwargs(event_kw))
 
     def warning(self, message: str, *args: object, **event_kw: object) -> None:
-        self._logger.warning(message, *args)
+        self._logger.warning(message, *args, **_stdlib_log_kwargs(event_kw))
 
     def error(self, message: str, *args: object, **event_kw: object) -> None:
-        self._logger.error(message, *args)
+        self._logger.error(message, *args, **_stdlib_log_kwargs(event_kw))
 
     def exception(self, message: str, *args: object, **event_kw: object) -> None:
-        self._logger.exception(message, *args)
+        self._logger.exception(message, *args, **_stdlib_log_kwargs(event_kw))
+
+
+def _stdlib_log_kwargs(event_kw: dict[str, object]) -> dict[str, Any]:
+    """Forward stdlib-supported logging kwargs from structlog-style calls."""
+    return {key: value for key, value in event_kw.items() if key in {"exc_info", "stack_info", "stacklevel", "extra"}}
 
 
 def get_logger(name: str | None = None) -> BoundLoggerLike:

--- a/tests/unit/test_logging_runtime.py
+++ b/tests/unit/test_logging_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import sys
 from typing import Any, cast
 from unittest.mock import patch
@@ -178,3 +179,27 @@ def test_configure_logging_accepts_typed_force_plain_config() -> None:
         logging_mod.configure_logging(verbose=False, json_logs=False)
 
     console_renderer.assert_called_once_with(colors=False)
+
+
+def test_stdlib_bound_logger_forwards_exc_info_before_structlog_configured() -> None:
+    """Callers pass exc_info/extra structlog-style before configure_logging() runs.
+
+    Previously these kwargs were silently dropped, so a `logger.warning(...,
+    exc_info=True)` call made before structlog configuration (e.g. daemon
+    convergence probe failure paths) lost the traceback entirely.
+    """
+    captured: dict[str, object] = {}
+
+    def _record(message: str, *args: object, **kwargs: object) -> None:
+        captured["message"] = message
+        captured["kwargs"] = kwargs
+
+    stdlib_logger = logging.getLogger("polylogue.tests.exc-forwarding")
+    stdlib_logger.warning = _record  # type: ignore[assignment]
+
+    with patch("polylogue.logging.logging.getLogger", return_value=stdlib_logger):
+        bound = logging_mod.get_logger("polylogue.tests.exc-forwarding")
+
+    bound.warning("probe failed", exc_info=True, extra={"stage": "fts"}, unsupported_kw="dropped")
+
+    assert captured["kwargs"] == {"exc_info": True, "extra": {"stage": "fts"}}


### PR DESCRIPTION
## Summary
- `_StdlibBoundLogger` (used before `configure_logging()` switches to structlog) dropped every structlog-style kwarg, so `logger.warning(..., exc_info=True)` calls made pre-configuration silently lost their traceback.

## Problem
Extracted while auditing a stray unmerged local branch (`feature/fix/convergence-probes-fail-open`) during a repo-wide branch cleanup. That branch's `convergence_stages.py` probe-fail-toward-work fix and tests turned out to already be superseded by master (landed via #2543 + the `da8d2ca73`/`733b789d0` regression-test/bead-close pair — confirmed `except Exception: ... return True` already present in `convergence_stages.py`). But its `polylogue/logging.py` change was a real, still-present gap: those very probe-failure `logger.warning(..., exc_info=True)` calls lose the traceback whenever they fire before structlog is configured (the common case for daemon startup and plain CLI invocations).

## Solution
- `polylogue/logging.py`: `_StdlibBoundLogger.{debug,info,warning,error,exception}` now forward `exc_info`/`stack_info`/`stacklevel`/`extra` to the underlying stdlib call via a small allow-list helper (`_stdlib_log_kwargs`); other structlog-only kwargs remain dropped since stdlib logging doesn't accept them.
- `tests/unit/test_logging_runtime.py`: added a regression test asserting `exc_info`/`extra` are forwarded and unsupported kwargs are dropped.

## Verification
- `devtools test tests/unit/test_logging_runtime.py` — 5 passed
- `mypy --strict polylogue/logging.py tests/unit/test_logging_runtime.py` — clean
- `devtools verify --quick` — exit 0 (ruff format/check, mypy, render all, topology/layering/closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, test-infra-currency, test-clock-hygiene)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standard logging now preserves supported keyword arguments like exception details, stack info, stack level, and extra context when messages are sent before advanced logging is configured.
  * Improved consistency so log calls behave more like the standard library logger in these early logging scenarios.

* **Tests**
  * Added coverage for forwarding logging context correctly before full logging configuration is in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->