### PR TITLE
fix(test): repair full-verify baseline drift from 2026-07-05 commit batch

### DIFF
--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -561,6 +561,7 @@
             "raw_id_join_gap": 0,
             "skipped": 0,
             "parse_failed": 0,
+            "raw_parse_failed": 0,
             "parsed_without_index_session": 0
           },
           "source_family_counts": {},
@@ -1077,6 +1078,7 @@
         "raw_id_join_gap": 0,
         "skipped": 0,
         "parse_failed": 0,
+        "raw_parse_failed": 0,
         "parsed_without_index_session": 0
       },
       "source_family_counts": {}
@@ -1085,6 +1087,8 @@
       "available": true,
       "candidate_count": 0,
       "missing_blob_count": 0,
+      "missing_blob_source_available_count": 0,
+      "missing_blob_source_missing_count": 0,
       "already_parsed_count": 0,
       "total_blob_bytes": 0,
       "max_blob_bytes": 0,

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -46,28 +46,32 @@ _STORAGE_ROOT: Final = Path("polylogue/storage")
 _AUDITED_SITES: Final[dict[tuple[str, int], str]] = {
     (
         "polylogue/storage/embeddings/status_payload.py",
-        624,
+        626,
     ): 'conn.execute(f"PRAGMA busy_timeout = {STATUS_READ_BUSY_TIMEOUT_MS}") uses an internal integer constant.',
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
-        4972,
+        5172,
     ): "query_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL plus closed predicate/order fragments; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
-        5023,
+        5223,
     ): "query_session_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL, placeholders, and closed order direction; ids are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
-        5501,
+        5701,
     ): "query_runs interpolates run_relation_sql() and closed predicate/order fragments; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
-        5552,
+        5752,
     ): "query_observed_events interpolates observed_event_relation_sql() and closed predicate/order fragments; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
-        5607,
+        5807,
     ): "query_context_snapshots interpolates context_snapshot_relation_sql() and closed predicate/order fragments; user values are bound.",
+    (
+        "polylogue/storage/sqlite/archive_tiers/archive.py",
+        1605,
+    ): "cost_rollup no-usage leg interpolates a closed WHERE fragment list built in-function; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/ops_write.py",
         585,

--- a/tests/unit/test_logging_runtime.py
+++ b/tests/unit/test_logging_runtime.py
@@ -6,6 +6,8 @@ import sys
 from typing import Any, cast
 from unittest.mock import patch
 
+import pytest
+
 from polylogue import logging as logging_mod
 from polylogue.logging import BoundLoggerLike
 
@@ -181,7 +183,9 @@ def test_configure_logging_accepts_typed_force_plain_config() -> None:
     console_renderer.assert_called_once_with(colors=False)
 
 
-def test_stdlib_bound_logger_forwards_exc_info_before_structlog_configured() -> None:
+def test_stdlib_bound_logger_forwards_exc_info_before_structlog_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Callers pass exc_info/extra structlog-style before configure_logging() runs.
 
     Previously these kwargs were silently dropped, so a `logger.warning(...,
@@ -196,6 +200,10 @@ def test_stdlib_bound_logger_forwards_exc_info_before_structlog_configured() -> 
 
     stdlib_logger = logging.getLogger("polylogue.tests.exc-forwarding")
     stdlib_logger.warning = _record  # type: ignore[assignment]
+
+    # An earlier test in the same worker may have run configure_logging();
+    # this test is specifically about the pre-configuration stdlib path.
+    monkeypatch.setattr(logging_mod, "_structlog_configured", False)
 
     with patch("polylogue.logging.logging.getLogger", return_value=stdlib_logger):
         bound = logging_mod.get_logger("polylogue.tests.exc-forwarding")


### PR DESCRIPTION
## Summary
Test-only repairs for the 4 failures in the first clean full `devtools verify --all` baseline, recorded for the polylogue-s7ae.6 deploy gate. All 4 were introduced by the 2026-07-05 commit batch; none by the coordination commit 32ff31651.

## Problem
`devtools verify --all` on master (`848658dc3`) completed with 12725 passed / 4 failed (log: `.agent/reports/verify-full-2026-07-07.log`, 187s). Classification:

| Test | Cause | Class |
|---|---|---|
| `test_no_string_interpolated_sql::test_audited_sites_are_real_violations` | bb2f84ff8 shifted `archive.py` ~+200 lines; `status_payload.py` +2 | pre-existing drift (audit line numbers) |
| `test_no_string_interpolated_sql::test_no_unaudited_string_interpolated_sql` | bb2f84ff8 added a cost-rollup no-usage SQL leg (`archive.py:1605`) | pre-existing (new unaudited site) |
| `test_plain_cli_snapshots::test_json_status_snapshot` | 884efb5f9 (`raw_parse_failed`) + raw-blob span counts extended status payload | pre-existing (stale snapshot) |
| `test_logging_runtime::test_stdlib_bound_logger_forwards_exc_info_before_structlog_configured` | ee1a51cb6 test assumes `_structlog_configured` is False; order-dependent under xdist | pre-existing (test isolation) |

## Solution
- `_AUDITED_SITES`: line numbers updated; new cost-rollup site audited — it interpolates a closed in-function WHERE fragment list, user values bound via `?` (inspected `archive.py:1571-1627`).
- Snapshot regenerated (`raw_parse_failed`, `missing_blob_source_available_count`, `missing_blob_source_missing_count` additions only).
- Logging test now monkeypatches `_structlog_configured=False` so it deterministically exercises the pre-configuration stdlib path.

## Verification
- `devtools test tests/unit/storage/test_no_string_interpolated_sql.py` → 2 passed
- `devtools test tests/unit/test_logging_runtime.py` → 4 passed
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py` → 22 passed, 15 snapshots passed
- Failure reproduction: all 4 nodes failed deterministically together pre-fix; logging node passed alone (isolation proof)

Ref polylogue-s7ae.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI status output coverage to reflect additional diagnostic counters, including parsing failures and backlog details.
  * Strengthened logging behavior checks to ensure exception information is preserved before logging is fully initialized.
* **Tests**
  * Updated automated checks for SQL safety and CLI snapshots to match the latest expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->