### PR TITLE
feat(mcp): add agent query cookbook prompts

### DIFF
--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -7,6 +7,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from itertools import islice
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from typing_extensions import TypedDict
@@ -400,6 +401,106 @@ Your task:
 Session summaries:
 {json.dumps(summaries, indent=2)}
 """
+
+    @mcp.prompt()
+    async def resume_context(repo: str = "", limit: int = 5) -> str:
+        """Rebuild working context for the current repo from the archive."""
+        repo_name, cwd = _repo_context(repo)
+        return f"""Rebuild working context for repo '{repo_name}' from the Polylogue archive.
+
+Call sequence:
+1. find_resume_candidates(repo_path="{cwd}", limit={limit}) — ranked resumable logical sessions for this checkout.
+2. get_resume_brief(session_id=<top candidate>) — typed brief: goals, open threads, next actions, provenance refs.
+3. agent_coordination_brief(view="self") — check concurrent agents/worktrees before claiming work.
+4. blackboard_list(scope_repo="{repo_name}", unresolved=True) — unresolved notes/handoffs addressed to agents here.
+
+Rules:
+- Cite refs (session_id, message_id) instead of pasting transcripts; fetch full text only for messages you will act on.
+- Empty results usually mean a wrong archive root: the harness must point POLYLOGUE_ARCHIVE_ROOT at the live archive, not a sandbox default.
+"""
+
+    @mcp.prompt()
+    async def postmortem_last(repo: str = "", since: str = "14d") -> str:
+        """Postmortem the most recent failed or abandoned session for a repo."""
+        repo_name, cwd = _repo_context(repo)
+        return f"""Postmortem the most recent failed or abandoned session for repo '{repo_name}'.
+
+Call sequence:
+1. find_abandoned_sessions(repo_path="{cwd}", since="{since}") and find_stuck_sessions(since="{since}") — candidates with dangling work or stuck tool calls.
+2. Pick the most recent relevant session; orient with get_session_summary(id=<session_id>).
+3. get_postmortem_bundle(repo="{repo_name}", since="{since}") — forensic bundle: timeline, decisions, tool errors.
+4. get_pathologies(repo="{repo_name}", since="{since}") — detected anti-patterns in the same window.
+
+Report: what was attempted, where it failed (cite tool_result errors by ref), what remained undone, and the smallest next action.
+"""
+
+    @mcp.prompt()
+    async def decisions_about(topic: str, limit: int = 20) -> str:
+        """Find what was decided about a topic, recorded and inferred."""
+        return f"""Find what was decided about '{topic}'.
+
+Call sequence:
+1. list_assertion_claims(kinds="decision,judgment,lesson", statuses="active,candidate", limit={limit}) — recorded decisions (authoritative when user-authored).
+2. query_units(expression='assertions where kind:decision AND text:"{topic}"') — targeted assertion search.
+3. search(query='near:"{topic}"', limit=10) — decision discussions never recorded as assertions.
+
+Rules:
+- Recorded assertions outrank inferred prose; label each finding as recorded vs inferred.
+- status:candidate rows are agent-proposed and unreviewed — never present them as settled.
+"""
+
+    @mcp.prompt()
+    async def unacknowledged_failures(repo: str = "", since: str = "7d") -> str:
+        """Surface recent failures that nobody acknowledged."""
+        repo_name, _cwd = _repo_context(repo)
+        return f"""Surface failures in '{repo_name}' since {since} that were never acknowledged.
+
+Call sequence:
+1. query_units(expression='sessions where repo:{repo_name} since:{since} AND exists action(output:failed)', limit=20) — sessions containing failed tool actions.
+2. find_stuck_sessions(since="{since}") — sessions whose provider tool calls are bounded as stuck.
+3. For each hit: list_marks(session_id=<session_id>) and list_annotations for that session — an existing mark/annotation means acknowledged.
+
+Report only sessions with failures and no acknowledgment; cite the failing action refs (tool, path, error).
+"""
+
+    @mcp.prompt()
+    async def sessions_touching_file(path: str, repo: str = "") -> str:
+        """Find sessions that edited or referenced a file path."""
+        repo_name, _cwd = _repo_context(repo)
+        repo_clause = f"repo:{repo_name} AND " if repo_name else ""
+        return f"""Find sessions that touched file path '{path}'.
+
+Call sequence:
+1. query_units(expression='sessions where {repo_clause}exists file(action:file_edit AND path:{path})', limit=20) — sessions that edited the path.
+2. query_units(expression='files where path:{path}', limit=20) — per-file action rows (edits, reads, shell references).
+3. search(query='"{path}"', limit=10) — mentions in prose that never became edits.
+4. get_session_summary(id=<session_id>) on each hit for orientation.
+
+Rules: path matching is substring — prefer repo-relative fragments (e.g. polylogue/mcp/server_prompts.py) over bare filenames.
+"""
+
+    @mcp.prompt()
+    async def cost_of(since: str = "30d", limit: int = 10) -> str:
+        """Report cost/usage for a time window with honest accounting."""
+        return f"""Report cost/usage for the last {since}, with honest accounting.
+
+Call sequence:
+1. cost_rollups(since="{since}") — aggregate spend by model.
+2. session_costs(since="{since}", limit={limit}) — top sessions by cost.
+3. provider_usage(detail="summary") — usage accounting diagnostics without billing estimates.
+4. For one repo's sessions: search(query='repo:<repo> since:{since}') then session_costs(session_id=<id>) per hit — cost tools have no repo filter.
+
+Rules:
+- cost_usd is API-list-equivalent; on subscription plans report the subscription-credit view separately (cache reads are ~free on Claude Max/Pro).
+- Codex 'input' includes cached tokens and 'output' includes reasoning — treat lanes as disjoint, never sum naively.
+"""
+
+
+def _repo_context(repo: str) -> tuple[str, str]:
+    cwd = Path.cwd()
+    if repo:
+        return repo, str(cwd)
+    return cwd.name, str(cwd)
 
 
 __all__ = ["register_prompts"]

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -129,6 +129,12 @@ EXPECTED_PROMPT_NAMES = {
     "compare_sessions",
     "extract_patterns",
     "agent_coordination_brief",
+    "resume_context",
+    "postmortem_last",
+    "decisions_about",
+    "unacknowledged_failures",
+    "sessions_touching_file",
+    "cost_of",
 }
 
 SurfaceResult = TypeVar("SurfaceResult")

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -1131,6 +1131,77 @@ class TestPromptSurfaces:
         assert '"provider"' not in result
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("prompt_name", "kwargs", "expected_tools"),
+        [
+            (
+                "resume_context",
+                {},
+                ("find_resume_candidates", "get_resume_brief", "agent_coordination_brief", "blackboard_list"),
+            ),
+            (
+                "postmortem_last",
+                {},
+                ("find_abandoned_sessions", "find_stuck_sessions", "get_postmortem_bundle", "get_pathologies"),
+            ),
+            (
+                "decisions_about",
+                {"topic": "schema versioning"},
+                ("list_assertion_claims", "query_units", "search"),
+            ),
+            (
+                "unacknowledged_failures",
+                {},
+                ("query_units", "find_stuck_sessions", "list_marks"),
+            ),
+            (
+                "sessions_touching_file",
+                {"path": "polylogue/mcp/server.py"},
+                ("query_units", "search", "get_session_summary"),
+            ),
+            (
+                "cost_of",
+                {},
+                ("cost_rollups", "session_costs", "provider_usage"),
+            ),
+        ],
+    )
+    async def test_cookbook_prompts_render_tool_recipes(
+        self: object,
+        mcp_server: MCPServerUnderTest,
+        prompt_name: str,
+        kwargs: dict[str, object],
+        expected_tools: tuple[str, ...],
+    ) -> None:
+        result = await invoke_surface_async(mcp_server._prompt_manager._prompts[prompt_name].fn, **kwargs)
+        for tool in expected_tools:
+            assert tool in result, f"{prompt_name} recipe must name tool {tool}"
+
+    @pytest.mark.asyncio
+    async def test_cookbook_prompts_prefill_repo_context(self: object, mcp_server: MCPServerUnderTest) -> None:
+        prompts = mcp_server._prompt_manager._prompts
+        cwd = Path.cwd()
+
+        resume = await invoke_surface_async(prompts["resume_context"].fn)
+        assert str(cwd) in resume
+        assert cwd.name in resume
+        assert "POLYLOGUE_ARCHIVE_ROOT" in resume
+        assert "refs" in resume.lower()
+
+        override = await invoke_surface_async(prompts["resume_context"].fn, repo="sinex")
+        assert "'sinex'" in override
+
+        touching = await invoke_surface_async(
+            prompts["sessions_touching_file"].fn, path="polylogue/cli/click_app.py", repo="polylogue"
+        )
+        assert "path:polylogue/cli/click_app.py" in touching
+        assert "repo:polylogue" in touching
+
+        decisions = await invoke_surface_async(prompts["decisions_about"].fn, topic="lineage")
+        assert 'near:"lineage"' in decisions
+        assert "candidate" in decisions
+
+    @pytest.mark.asyncio
     async def test_compare_sessions_prompt_reads_archive_file_set(
         self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
Six intent-named MCP recipe prompts — `resume_context`, `postmortem_last`, `decisions_about`, `unacknowledged_failures`, `sessions_touching_file`, `cost_of` — that teach agents which tools matter for the common archive intents, with cwd/repo prefilled. First layer of polylogue-pj8 (the MCP-native discoverability channel).

## Problem
The MCP server exposes ~96 tools; agent usage is dominated by `search`/`get_session` because nothing surfaces the right tool sequence per intent (pj8: "agents use what is in their face and skip what requires invention"). `server_prompts.py` had 6 prompts, mostly data-dump style.

## Solution
- Recipe prompts are **pure text expansion** — no archive I/O, no new query machinery. Each names a concrete 3–4 step tool-call sequence with prefilled arguments (`find_resume_candidates(repo_path="<cwd>")`, `query_units(expression='sessions where repo:<repo> … exists action(output:failed)')`, …) and embeds the rules agents get wrong: refs over dumps, `POLYLOGUE_ARCHIVE_ROOT`, recorded assertions outrank inferred prose, `status:candidate` is unreviewed, API-equivalent vs subscription-credit cost lanes, Codex token lane disjointness.
- Coordination intents intentionally stay on the existing `agent_coordination_brief` views (status/self/work-item/conflicts/handoff); addressed messages route through `blackboard_list` in the resume recipe — the envelope has no messages field yet.
- `cost_of` is honest about a real gap: cost tools have no `repo` filter, so the recipe gives the two-step fallback.
- Contract: `EXPECTED_PROMPT_NAMES` extended to 12; DSL expressions in recipes use only documented fields (`docs/search.md`: `path:`, `output:failed`, `exists file/action(...)`, `kind:decision`).

## Verification
- `devtools test tests/unit/mcp/test_server_surfaces.py` → 75 passed (includes new parametrized recipe/prefill tests and the prompt-set equality contract)
- `devtools verify --quick` → exit 0 (format, lint, mypy --strict, render all --check, topology, layering)

## Remaining pj8 scope
Harness-side `polylogue` skill (sinnix repo), SessionStart preamble affordance index (blocked on 37t.4), and the affordance-usage diversity evidence are outside this PR; tracked on the bead.

Ref polylogue-pj8.