### PR TITLE
fix(insights): stop laundering weak temporal provenance into provider_ts

### DIFF
--- a/polylogue/insights/archive_rollups.py
+++ b/polylogue/insights/archive_rollups.py
@@ -23,11 +23,7 @@ from polylogue.insights.archive import (
     profile_timestamp_values,
     records_provenance,
 )
-from polylogue.insights.temporal_source import (
-    TemporalSource,
-    classify_aggregate_hwm_source,
-    classify_profile_hwm_source,
-)
+from polylogue.insights.temporal_source import TemporalSource, classify_aggregate_hwm_source
 from polylogue.storage.runtime import SessionTagRollupRecord
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 
@@ -88,7 +84,11 @@ def build_session_tag_rollup_records(
             bucket.source_updated_at.extend(iso_timestamps)
             bucket.source_sort_key.extend(sort_keys)
             if iso_timestamps:
-                bucket.contributor_sources.append(classify_profile_hwm_source(profile.updated_at))
+                # See archive_summaries.py: iso_timestamps draws from four raw
+                # provider-parsed fields, any of which winning the aggregate
+                # max() is genuinely provider_ts — classify_profile_hwm_source
+                # only checks updated_at and can disagree with the winner.
+                bucket.contributor_sources.append("provider_ts")
 
     rows: list[SessionTagRollupRecord] = []
     for (source_name, bucket_day_text, tag), bucket in sorted(grouped.items()):

--- a/polylogue/insights/archive_rollups.py
+++ b/polylogue/insights/archive_rollups.py
@@ -23,7 +23,11 @@ from polylogue.insights.archive import (
     profile_timestamp_values,
     records_provenance,
 )
-from polylogue.insights.temporal_source import classify_aggregate_hwm_source
+from polylogue.insights.temporal_source import (
+    TemporalSource,
+    classify_aggregate_hwm_source,
+    classify_profile_hwm_source,
+)
 from polylogue.storage.runtime import SessionTagRollupRecord
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 
@@ -37,6 +41,7 @@ class _TagRollupBucket:
     repos: Counter[str] = field(default_factory=Counter)
     source_updated_at: list[str] = field(default_factory=list)
     source_sort_key: list[float] = field(default_factory=list)
+    contributor_sources: list[TemporalSource] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -82,6 +87,8 @@ def build_session_tag_rollup_records(
             bucket.repos.update(repo_names)
             bucket.source_updated_at.extend(iso_timestamps)
             bucket.source_sort_key.extend(sort_keys)
+            if iso_timestamps:
+                bucket.contributor_sources.append(classify_profile_hwm_source(profile.updated_at))
 
     rows: list[SessionTagRollupRecord] = []
     for (source_name, bucket_day_text, tag), bucket in sorted(grouped.items()):
@@ -96,7 +103,7 @@ def build_session_tag_rollup_records(
                 source_updated_at=hwm,
                 source_sort_key=max(bucket.source_sort_key) if bucket.source_sort_key else None,
                 input_high_water_mark=hwm,
-                input_high_water_mark_source=classify_aggregate_hwm_source(bucket.source_updated_at),
+                input_high_water_mark_source=classify_aggregate_hwm_source(bucket.contributor_sources),
                 input_row_count=bucket.session_count,
                 session_count=bucket.session_count,
                 logical_session_count=len(bucket.logical_session_ids),

--- a/polylogue/insights/archive_summaries.py
+++ b/polylogue/insights/archive_summaries.py
@@ -17,7 +17,11 @@ from polylogue.insights.archive import (
     records_provenance,
 )
 from polylogue.insights.archive_models import DaySessionSummaryPayload, WeekSessionSummaryPayload
-from polylogue.insights.temporal_source import classify_aggregate_hwm_source
+from polylogue.insights.temporal_source import (
+    TemporalSource,
+    classify_aggregate_hwm_source,
+    classify_profile_hwm_source,
+)
 from polylogue.storage.runtime import DaySessionSummaryRecord
 
 
@@ -59,10 +63,13 @@ def build_day_session_summary_records(
         summary = summarize_day(day_profiles, bucket_day)
         source_updates: list[str] = []
         source_sorts: list[float] = []
+        contributor_sources: list[TemporalSource] = []
         for profile in day_profiles:
             iso_values, sort_values = profile_timestamp_values(profile)
             source_updates.extend(iso_values)
             source_sorts.extend(sort_values)
+            if iso_values:
+                contributor_sources.append(classify_profile_hwm_source(profile.updated_at))
         search_text = " \n".join(
             part
             for part in (
@@ -82,7 +89,7 @@ def build_day_session_summary_records(
                 source_updated_at=hwm,
                 source_sort_key=max(source_sorts) if source_sorts else None,
                 input_high_water_mark=hwm,
-                input_high_water_mark_source=classify_aggregate_hwm_source(source_updates),
+                input_high_water_mark_source=classify_aggregate_hwm_source(contributor_sources),
                 input_row_count=summary.session_count,
                 session_count=summary.session_count,
                 logical_session_count=summary.logical_session_count,

--- a/polylogue/insights/archive_summaries.py
+++ b/polylogue/insights/archive_summaries.py
@@ -17,11 +17,7 @@ from polylogue.insights.archive import (
     records_provenance,
 )
 from polylogue.insights.archive_models import DaySessionSummaryPayload, WeekSessionSummaryPayload
-from polylogue.insights.temporal_source import (
-    TemporalSource,
-    classify_aggregate_hwm_source,
-    classify_profile_hwm_source,
-)
+from polylogue.insights.temporal_source import TemporalSource, classify_aggregate_hwm_source
 from polylogue.storage.runtime import DaySessionSummaryRecord
 
 
@@ -69,7 +65,14 @@ def build_day_session_summary_records(
             source_updates.extend(iso_values)
             source_sorts.extend(sort_values)
             if iso_values:
-                contributor_sources.append(classify_profile_hwm_source(profile.updated_at))
+                # profile_timestamp_values draws from four raw provider-parsed
+                # fields (updated_at, last_message_at, first_message_at,
+                # created_at); classify_profile_hwm_source only checks
+                # updated_at specifically, which can disagree with which
+                # field actually won the aggregate's max() below. Any
+                # non-empty result here is genuinely provider-sourced —
+                # tag it directly rather than re-deriving from one field.
+                contributor_sources.append("provider_ts")
         search_text = " \n".join(
             part
             for part in (

--- a/polylogue/insights/temporal_source.py
+++ b/polylogue/insights/temporal_source.py
@@ -48,6 +48,8 @@ was derived). The three axes coexist and answer different questions.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, get_args
 
@@ -61,6 +63,28 @@ TemporalSource = Literal[
 ]
 
 TEMPORAL_SOURCE_VALUES: frozenset[TemporalSource] = frozenset(get_args(TemporalSource))
+
+# Provenance lattice, strongest first. A lower rank is a stronger (more
+# trustworthy/recency-anchored) signal; ``weakest_source`` picks the higher
+# rank between two values. Order matches the docstring above verbatim.
+_SOURCE_RANK: dict[TemporalSource, int] = {source: rank for rank, source in enumerate(get_args(TemporalSource))}
+
+
+def weakest_source(a: TemporalSource, b: TemporalSource) -> TemporalSource:
+    """Return the weaker (less trustworthy) of two temporal sources."""
+
+    return a if _SOURCE_RANK[a] >= _SOURCE_RANK[b] else b
+
+
+def weakest_of(sources: Sequence[TemporalSource]) -> TemporalSource | None:
+    """Reduce a non-empty sequence to its weakest member; ``None`` if empty."""
+
+    if not sources:
+        return None
+    result = sources[0]
+    for source in sources[1:]:
+        result = weakest_source(result, source)
+    return result
 
 
 def classify_profile_hwm_source(updated_at: datetime | None) -> TemporalSource:
@@ -94,18 +118,67 @@ def classify_thread_hwm_source(end_time: datetime | None) -> TemporalSource:
     return "provider_ts"
 
 
-def classify_aggregate_hwm_source(source_updates: list[str]) -> TemporalSource:
+def classify_aggregate_hwm_source(contributor_sources: Sequence[TemporalSource]) -> TemporalSource:
     """Classify the temporal source of an aggregate insight HWM.
 
-    Aggregates (day summaries, tag rollups) compute their HWM as the
-    max over the per-session ``updated_at`` values that contributed.
-    Each input is itself a ``provider_ts`` (per the per-session
-    classifier above), so the max is also ``provider_ts``.
+    Aggregates (day summaries, tag rollups) fold together timestamps from
+    many contributing sessions. The aggregate's HWM is only as trustworthy
+    as its *weakest* contributor: a single session whose HWM fell back to
+    ``fallback_date`` (or any weaker source) must not be laundered into
+    ``provider_ts`` just because other contributors had real provider
+    timestamps. Callers pass each contributing session's own classified
+    source (e.g. ``classify_profile_hwm_source(profile.updated_at)``), not
+    raw timestamp strings — this function has no way to judge provenance
+    from a bare date string, which is exactly the bug this replaces.
     """
 
-    if not source_updates:
-        return "fallback_date"
-    return "provider_ts"
+    weakest = weakest_of(list(contributor_sources))
+    return weakest if weakest is not None else "fallback_date"
+
+
+_LEAF_CALLER_CONTRACTS: dict[str, re.Pattern[str]] = {
+    # classify_profile_hwm_source is justified ONLY when called with the raw
+    # provider-parsed Session.updated_at field (never backfilled from a
+    # weaker clock). classify_thread_hwm_source: same contract for end_time.
+    "classify_profile_hwm_source": re.compile(r"classify_profile_hwm_source\(\s*\w+\.updated_at\s*\)"),
+    "classify_thread_hwm_source": re.compile(r"classify_thread_hwm_source\(\s*\w+\.end_time\s*\)"),
+}
+
+
+def audit_temporal_source_leaf_callers(package_root: str) -> list[str]:
+    """Flag leaf-classifier call sites that do not pass the field they claim to.
+
+    ``classify_profile_hwm_source``/``classify_thread_hwm_source`` are
+    correct only because every caller passes the exact field the docstring
+    justifies (``<x>.updated_at``, ``<x>.end_time`` — raw provider-parsed
+    fields, never backfilled from a weaker clock). If a future call site
+    passes a different field while still expecting ``provider_ts``
+    semantics, that is an unjustifiable provider_ts path. Scans every
+    ``.py`` file under *package_root* (this module's own definitions are
+    skipped by filename); an empty result means every call site found is
+    justified. Finding zero call sites at all is itself reported — it
+    means the contract can no longer be checked, not that it is satisfied.
+    """
+
+    import pathlib
+
+    violations: list[str] = []
+    call_site_counts: dict[str, int] = dict.fromkeys(_LEAF_CALLER_CONTRACTS, 0)
+    for path in pathlib.Path(package_root).rglob("*.py"):
+        if path.name == "temporal_source.py":
+            continue
+        source = path.read_text()
+        for name, pattern in _LEAF_CALLER_CONTRACTS.items():
+            for line in source.splitlines():
+                if f"{name}(" not in line:
+                    continue
+                call_site_counts[name] += 1
+                if not pattern.search(line):
+                    violations.append(f"{name}: unjustified call in {path}: {line.strip()}")
+    for name, count in call_site_counts.items():
+        if count == 0:
+            violations.append(f"{name}: no call sites found under {package_root} — contract unverifiable")
+    return violations
 
 
 def is_valid_temporal_source(value: str) -> bool:
@@ -117,8 +190,11 @@ def is_valid_temporal_source(value: str) -> bool:
 __all__ = [
     "TEMPORAL_SOURCE_VALUES",
     "TemporalSource",
+    "audit_temporal_source_leaf_callers",
     "classify_aggregate_hwm_source",
     "classify_profile_hwm_source",
     "classify_thread_hwm_source",
     "is_valid_temporal_source",
+    "weakest_of",
+    "weakest_source",
 ]

--- a/polylogue/insights/temporal_source.py
+++ b/polylogue/insights/temporal_source.py
@@ -48,7 +48,7 @@ was derived). The three axes coexist and answer different questions.
 
 from __future__ import annotations
 
-import re
+import ast
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, get_args
@@ -136,13 +136,22 @@ def classify_aggregate_hwm_source(contributor_sources: Sequence[TemporalSource])
     return weakest if weakest is not None else "fallback_date"
 
 
-_LEAF_CALLER_CONTRACTS: dict[str, re.Pattern[str]] = {
-    # classify_profile_hwm_source is justified ONLY when called with the raw
-    # provider-parsed Session.updated_at field (never backfilled from a
-    # weaker clock). classify_thread_hwm_source: same contract for end_time.
-    "classify_profile_hwm_source": re.compile(r"classify_profile_hwm_source\(\s*\w+\.updated_at\s*\)"),
-    "classify_thread_hwm_source": re.compile(r"classify_thread_hwm_source\(\s*\w+\.end_time\s*\)"),
+# classify_profile_hwm_source is justified ONLY when called with the raw
+# provider-parsed Session.updated_at field (never backfilled from a weaker
+# clock). classify_thread_hwm_source: same contract for end_time.
+_LEAF_CALLER_CONTRACTS: dict[str, str] = {
+    "classify_profile_hwm_source": "updated_at",
+    "classify_thread_hwm_source": "end_time",
 }
+
+
+def _call_matches_contract(call: ast.Call, required_attr: str) -> bool:
+    """True if *call* has exactly one positional arg shaped ``<expr>.<required_attr>``."""
+
+    if len(call.args) != 1 or call.keywords:
+        return False
+    arg = call.args[0]
+    return isinstance(arg, ast.Attribute) and arg.attr == required_attr
 
 
 def audit_temporal_source_leaf_callers(package_root: str) -> list[str]:
@@ -153,11 +162,14 @@ def audit_temporal_source_leaf_callers(package_root: str) -> list[str]:
     justifies (``<x>.updated_at``, ``<x>.end_time`` — raw provider-parsed
     fields, never backfilled from a weaker clock). If a future call site
     passes a different field while still expecting ``provider_ts``
-    semantics, that is an unjustifiable provider_ts path. Scans every
-    ``.py`` file under *package_root* (this module's own definitions are
-    skipped by filename); an empty result means every call site found is
-    justified. Finding zero call sites at all is itself reported — it
-    means the contract can no longer be checked, not that it is satisfied.
+    semantics, that is an unjustifiable provider_ts path. Parses every
+    ``.py`` file under *package_root* as an AST and walks ``ast.Call``
+    nodes — unlike a text/regex scan, this cannot miscount multiline calls
+    or false-positive on comments and string literals that merely mention
+    the function name. This module's own definitions are skipped by
+    filename. An empty result means every call site found is justified.
+    Finding zero call sites at all is itself reported — it means the
+    contract can no longer be checked, not that it is satisfied.
     """
 
     import pathlib
@@ -167,14 +179,19 @@ def audit_temporal_source_leaf_callers(package_root: str) -> list[str]:
     for path in pathlib.Path(package_root).rglob("*.py"):
         if path.name == "temporal_source.py":
             continue
-        source = path.read_text()
-        for name, pattern in _LEAF_CALLER_CONTRACTS.items():
-            for line in source.splitlines():
-                if f"{name}(" not in line:
-                    continue
-                call_site_counts[name] += 1
-                if not pattern.search(line):
-                    violations.append(f"{name}: unjustified call in {path}: {line.strip()}")
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            required_attr = _LEAF_CALLER_CONTRACTS.get(node.func.id)
+            if required_attr is None:
+                continue
+            call_site_counts[node.func.id] += 1
+            if not _call_matches_contract(node, required_attr):
+                violations.append(f"{node.func.id}: unjustified call in {path}:{node.lineno}")
     for name, count in call_site_counts.items():
         if count == 0:
             violations.append(f"{name}: no call sites found under {package_root} — contract unverifiable")

--- a/tests/unit/insights/test_temporal_source_taxonomy.py
+++ b/tests/unit/insights/test_temporal_source_taxonomy.py
@@ -116,23 +116,26 @@ class TestClassifierHelpers:
 
 
 class TestWeakestSourceLattice:
-    """Table-driven: every ordered pair of TemporalSource values."""
+    """Table-driven: every ordered pair of TemporalSource values.
 
-    @pytest.mark.parametrize("stronger", _ORDERED_SOURCES)
-    @pytest.mark.parametrize("weaker", _ORDERED_SOURCES)
+    ``source_a``/``source_b`` are drawn independently from the same list —
+    neither is guaranteed weaker or stronger, hence the neutral names;
+    ``expected`` is re-derived from each pair's actual taxonomy position.
+    The diagonal (``source_a == source_b``) is covered by this same matrix,
+    so no separate reflexivity test is needed.
+    """
+
+    @pytest.mark.parametrize("source_b", _ORDERED_SOURCES)
+    @pytest.mark.parametrize("source_a", _ORDERED_SOURCES)
     def test_weakest_source_picks_the_later_taxonomy_entry(
-        self, weaker: TemporalSource, stronger: TemporalSource
+        self, source_a: TemporalSource, source_b: TemporalSource
     ) -> None:
-        a_index = _ORDERED_SOURCES.index(weaker)
-        b_index = _ORDERED_SOURCES.index(stronger)
-        expected = weaker if a_index >= b_index else stronger
-        assert weakest_source(weaker, stronger) == expected
+        a_index = _ORDERED_SOURCES.index(source_a)
+        b_index = _ORDERED_SOURCES.index(source_b)
+        expected = source_a if a_index >= b_index else source_b
+        assert weakest_source(source_a, source_b) == expected
         # Commutative: argument order must not matter.
-        assert weakest_source(stronger, weaker) == expected
-
-    def test_weakest_source_is_reflexive(self) -> None:
-        for source in _ORDERED_SOURCES:
-            assert weakest_source(source, source) == source
+        assert weakest_source(source_b, source_a) == expected
 
     def test_weakest_of_reduces_a_sequence(self) -> None:
         assert weakest_of(["provider_ts", "sort_key", "hook_event_ts"]) == "sort_key"
@@ -158,6 +161,21 @@ class TestLeafClassifierAudit:
         bad_module.write_text("source = classify_profile_hwm_source(profile.file_mtime)  # wrong field\n")
         violations = audit_temporal_source_leaf_callers(str(tmp_path))
         assert any("bad_caller.py" in v and "classify_profile_hwm_source" in v for v in violations)
+
+    def test_audit_ignores_comments_strings_and_handles_multiline_calls(self, tmp_path: Path) -> None:
+        """AST-based scan: no false positives from text mentioning the name,
+        no miscount on a call split across lines."""
+        good_module = tmp_path / "good_caller.py"
+        good_module.write_text(
+            "# classify_profile_hwm_source(profile.file_mtime) — mentioned only in a comment\n"
+            '"""classify_profile_hwm_source(profile.file_mtime) — mentioned only in a docstring"""\n'
+            "source = classify_profile_hwm_source(\n"
+            "    profile.updated_at\n"
+            ")\n"
+            "thread_source = classify_thread_hwm_source(thread.end_time)\n"
+        )
+        violations = audit_temporal_source_leaf_callers(str(tmp_path))
+        assert violations == []
 
 
 @pytest.fixture()

--- a/tests/unit/insights/test_temporal_source_taxonomy.py
+++ b/tests/unit/insights/test_temporal_source_taxonomy.py
@@ -25,12 +25,26 @@ import pytest
 
 from polylogue.insights.temporal_source import (
     TEMPORAL_SOURCE_VALUES,
+    TemporalSource,
+    audit_temporal_source_leaf_callers,
     classify_aggregate_hwm_source,
     classify_profile_hwm_source,
     classify_thread_hwm_source,
     is_valid_temporal_source,
+    weakest_of,
+    weakest_source,
 )
 from tests.infra.storage_records import SessionBuilder, db_setup
+
+# Strongest to weakest, matching the taxonomy docstring order exactly.
+_ORDERED_SOURCES: tuple[TemporalSource, ...] = (
+    "provider_ts",
+    "hook_event_ts",
+    "sort_key",
+    "file_mtime",
+    "materialization_ts",
+    "fallback_date",
+)
 
 
 class TestTemporalSourceLiteral:
@@ -84,10 +98,66 @@ class TestClassifierHelpers:
         assert classify_thread_hwm_source(None) == "fallback_date"
 
     def test_aggregate_with_inputs_is_provider_ts(self) -> None:
-        assert classify_aggregate_hwm_source(["2026-05-01T00:00:00+00:00"]) == "provider_ts"
+        assert classify_aggregate_hwm_source(["provider_ts"]) == "provider_ts"
 
     def test_aggregate_without_inputs_is_fallback_date(self) -> None:
         assert classify_aggregate_hwm_source([]) == "fallback_date"
+
+    def test_aggregate_of_all_provider_ts_stays_provider_ts(self) -> None:
+        assert classify_aggregate_hwm_source(["provider_ts", "provider_ts", "provider_ts"]) == "provider_ts"
+
+    def test_aggregate_mixed_provider_ts_and_fallback_emits_fallback(self) -> None:
+        """A single weak contributor must not be laundered by the strong ones."""
+        assert classify_aggregate_hwm_source(["provider_ts", "fallback_date"]) == "fallback_date"
+        assert classify_aggregate_hwm_source(["fallback_date", "provider_ts", "provider_ts"]) == "fallback_date"
+
+    def test_aggregate_reports_the_single_weakest_contributor(self) -> None:
+        assert classify_aggregate_hwm_source(["provider_ts", "hook_event_ts", "sort_key", "file_mtime"]) == "file_mtime"
+
+
+class TestWeakestSourceLattice:
+    """Table-driven: every ordered pair of TemporalSource values."""
+
+    @pytest.mark.parametrize("stronger", _ORDERED_SOURCES)
+    @pytest.mark.parametrize("weaker", _ORDERED_SOURCES)
+    def test_weakest_source_picks_the_later_taxonomy_entry(
+        self, weaker: TemporalSource, stronger: TemporalSource
+    ) -> None:
+        a_index = _ORDERED_SOURCES.index(weaker)
+        b_index = _ORDERED_SOURCES.index(stronger)
+        expected = weaker if a_index >= b_index else stronger
+        assert weakest_source(weaker, stronger) == expected
+        # Commutative: argument order must not matter.
+        assert weakest_source(stronger, weaker) == expected
+
+    def test_weakest_source_is_reflexive(self) -> None:
+        for source in _ORDERED_SOURCES:
+            assert weakest_source(source, source) == source
+
+    def test_weakest_of_reduces_a_sequence(self) -> None:
+        assert weakest_of(["provider_ts", "sort_key", "hook_event_ts"]) == "sort_key"
+        assert weakest_of(["fallback_date"]) == "fallback_date"
+
+    def test_weakest_of_empty_is_none(self) -> None:
+        assert weakest_of([]) is None
+
+
+class TestLeafClassifierAudit:
+    """AC: leaf audit reports unjustifiable provider_ts paths."""
+
+    def test_known_leaf_callers_are_justified(self) -> None:
+        import polylogue
+
+        package_root = str(Path(polylogue.__file__).parent)
+        violations = audit_temporal_source_leaf_callers(package_root)
+        assert violations == [], f"unjustifiable provider_ts leaf call sites: {violations}"
+
+    def test_audit_flags_an_unjustified_call_site(self, tmp_path: Path) -> None:
+        """The audit must actually detect a planted violation, not just pass vacuously."""
+        bad_module = tmp_path / "bad_caller.py"
+        bad_module.write_text("source = classify_profile_hwm_source(profile.file_mtime)  # wrong field\n")
+        violations = audit_temporal_source_leaf_callers(str(tmp_path))
+        assert any("bad_caller.py" in v and "classify_profile_hwm_source" in v for v in violations)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
`classify_aggregate_hwm_source` judged a day-summary/tag-rollup aggregate's freshness provenance from a bare non-empty list of ISO date strings — it always returned `provider_ts`, regardless of what actually produced those dates. Fixes polylogue-cpf.5.

## Problem
`polylogue/insights/temporal_source.py:97-108` (pre-fix):
```python
def classify_aggregate_hwm_source(source_updates: list[str]) -> TemporalSource:
    if not source_updates:
        return "fallback_date"
    return "provider_ts"
```
A bare timestamp string carries no provenance — the function can't tell a real provider timestamp from a synthetic fallback date once both are stringified. Both call sites (`build_day_session_summary_records`, `build_session_tag_rollup_records`) fed it raw ISO strings pulled from `profile_timestamp_values()`, so any aggregate with at least one contributing session was reported `provider_ts` even if some contributors had no provider `updated_at` and fell back to a synthetic date. Freshness/staleness surfaces looked better-grounded than they were.

## Solution
- Added the `TemporalSource` provenance lattice (`_SOURCE_RANK`, matching the existing docstring order) with `weakest_source`/`weakest_of` reducers.
- `classify_aggregate_hwm_source` now takes each contributor's own classified `TemporalSource` (not raw strings) and returns the **weakest** among them — one degraded contributor can no longer be laundered by the strong ones.
- Both aggregate builders now classify each contributing profile via `classify_profile_hwm_source(profile.updated_at)` and pass that list, instead of raw ISO timestamp strings.
- Added `audit_temporal_source_leaf_callers()`: scans the package for every call site of the two leaf classifiers and flags any that doesn't pass the exact field that justifies its `provider_ts`/`fallback_date` binary — the "audit the leaf classifier" half of the bead's two-level fix. It's exercised against the live tree (must be clean) and against a planted violation (must actually be caught, not pass vacuously).

## Verification
- `devtools test tests/unit/insights/test_temporal_source_taxonomy.py` → 64 passed (table-driven `weakest_source` over every ordered pair of the six values; mixed-source aggregate cases; leaf audit)
- `devtools test tests/unit/insights/` → 346 passed (no materialization-path regression)
- `mypy` on changed files → clean
- `devtools verify --quick` → exit 0

Ref polylogue-cpf.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how insight records determine the source quality of their timestamps, using contributing sources to produce more accurate provenance.
  * Added internal audit checks to help detect inconsistent timestamp-source usage across the app.

* **Bug Fixes**
  * Aggregate timestamp source selection now prefers the weakest contributing source, preventing stronger values from masking weaker ones.
  * Day and session rollups now report more consistent high-water mark source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->