### PR TITLE
fix(daemon): default /api/provider-usage to headline detail, not full

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2782,10 +2782,18 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         unhandled ``AttributeError`` (polylogue-g9j6). Mirrors the MCP
         ``provider_usage`` tool, which is a thin wrapper over the same
         ``Polylogue.provider_usage_report`` API method.
+
+        Defaults to ``detail=headline``, NOT ``full`` (unlike the MCP
+        tool): ``full`` walks ``session_provider_usage_events`` with a
+        Python-side scan-and-compare with no row cap, measured to exceed
+        90s on the live archive — a synchronous HTTP request thread is a
+        much worse place to block on that than a CLI call a human can
+        interrupt (polylogue-dlmv). Callers that want the full
+        diagnostics can still request ``?detail=full`` explicitly.
         """
         origin = self._get_param(params, "origin")
         limit = self._get_int(params, "limit", 25)
-        detail = self._get_param(params, "detail", "full") or "full"
+        detail = self._get_param(params, "detail", "headline") or "headline"
 
         async def _get(poly: Polylogue) -> object:
             report = await poly.provider_usage_report(origin=origin, limit=limit, detail=detail)

--- a/tests/unit/daemon/test_provider_usage_endpoint.py
+++ b/tests/unit/daemon/test_provider_usage_endpoint.py
@@ -92,6 +92,22 @@ def test_returns_200_with_origin_usage_for_seeded_session(workspace_env: dict[st
     assert "pricing_lanes" in payload
 
 
+def test_default_detail_is_headline_not_full(workspace_env: dict[str, Path]) -> None:
+    """polylogue-dlmv: detail=full does an unbounded Python-side scan over
+    session_provider_usage_events, measured to exceed 90s on the live
+    archive. A synchronous HTTP request thread must not default into that
+    path — headline is fast (SQL-side rollups only) and the MCP tool's
+    detail="full" default is deliberately NOT mirrored here."""
+    handler = _make_handler()
+    send_json = _capture_json(handler)
+
+    handler.do_GET()
+
+    status, payload = send_json.call_args.args
+    assert status == HTTPStatus.OK
+    assert payload["detail_level"] == "headline"
+
+
 def test_respects_detail_and_limit_query_params(workspace_env: dict[str, Path]) -> None:
     handler = _make_handler("/api/provider-usage?detail=headline&limit=5")
     send_json = _capture_json(handler)


### PR DESCRIPTION
## Summary
Dogfood-discovered while smoke-testing the kwsb.1/g9j6 deploy against the live 26GB archive: `GET /api/provider-usage` hung past 90s because it defaulted to `detail=full`, which walks `session_provider_usage_events` with an unbounded Python-side scan-and-compare. Defaults the daemon handler to `headline` instead.

## Problem
`polylogue analyze usage --detail full` against the live archive (`/home/sinity/.local/share/polylogue`) took >90s (killed by `timeout`); `--detail headline` on the same archive returned in ~2s. This confirms the slow path is a pre-existing query-cost bug (`_stale_provider_rollup_stats`/`_expected_provider_model_rollups` in `polylogue/storage/usage.py:797`), not something specific to the daemon — tracked separately as **polylogue-dlmv**. But my `_handle_provider_usage` handler (landed in #2559 to fix the missing-handler crash, polylogue-g9j6) defaulted to `full` to mirror the MCP `provider_usage` tool, meaning any client hitting the endpoint with no params blocks a daemon HTTP thread for 90+ seconds — much worse than a CLI call a human can interrupt.

## Solution
- `_handle_provider_usage` now defaults to `detail=headline` (SQL-side rollups only). `?detail=full` is still available for callers that explicitly want it.
- Added a test pinning the default (`test_default_detail_is_headline_not_full`).

The underlying query-cost bug stays open as polylogue-dlmv — this PR is a footgun mitigation for the entry point I just shipped, not a fix for the query itself.

## Verification
- `devtools test tests/unit/daemon/test_provider_usage_endpoint.py` → 4 passed
- `mypy` → clean
- `devtools verify --quick` → exit 0

Ref polylogue-dlmv, polylogue-g9j6.