### PR TITLE
fix(web-shell): correct total_sessions path, clear stuck status notice

### DIFF
--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -841,12 +841,15 @@ async function loadStatus() {
   try {
     var s = await fetchJSON(statusRoute, {timeoutMs: 5000});
     var readiness = s.component_readiness || {};
+    var profileCounts = (readiness.session_profiles && readiness.session_profiles.counts) || {};
+    var totalSessions = s.total_sessions != null ? s.total_sessions : profileCounts.total_sessions;
+    var totalMessages = s.total_messages != null ? s.total_messages : null;
     var convs = document.getElementById('status-convs');
     var msgs = document.getElementById('status-msgs');
-    convs.textContent = (s.total_sessions != null ? Number(s.total_sessions).toLocaleString() : 'unknown') + ' convs';
-    msgs.textContent = (s.total_messages != null ? Number(s.total_messages).toLocaleString() : 'unknown') + ' msgs';
-    setChipQuality(convs, s.total_sessions != null ? 'canonical' : 'partial');
-    setChipQuality(msgs, s.total_messages != null ? 'canonical' : 'partial');
+    convs.textContent = (totalSessions != null ? Number(totalSessions).toLocaleString() : 'unknown') + ' convs';
+    msgs.textContent = (totalMessages != null ? Number(totalMessages).toLocaleString() : 'unknown') + ' msgs';
+    setChipQuality(convs, totalSessions != null ? 'canonical' : 'partial');
+    setChipQuality(msgs, totalMessages != null ? 'canonical' : 'partial');
     renderFtsChip(readiness.search || null, s.fts_readiness || {});
     renderMaterializationChip(readiness.raw_materialization || null, s.raw_materialization_readiness || {});
     renderSemanticChip(readiness.embeddings || null);
@@ -854,6 +857,7 @@ async function loadStatus() {
     renderIngestChip(readiness.daemon_ingest || null, s.live || {});
     renderBrowserCaptureChip(readiness.browser_capture || null, s.browser_capture || {});
     setRouteState('status', {state: 'ready', route: statusRoute, status: '200', error: ''});
+    renderFacets();
   } catch(e) {
     updateStatusCountsUnknown('degraded');
     setRouteState('status', Object.assign({state: 'error', stale_available: false}, routeErrorDetails(e, statusRoute)));

--- a/tests/unit/daemon/test_daemon_http_contracts.py
+++ b/tests/unit/daemon/test_daemon_http_contracts.py
@@ -645,6 +645,26 @@ class TestPrivacyContract:
 
         assert sentinel not in WEB_SHELL_HTML
 
+    def test_load_status_success_path_clears_the_status_route_notice(self) -> None:
+        """Dogfood regression (2026-07-08): loadStatus()'s success path set
+        state.routeStates.status to 'ready' but never called renderFacets(),
+        so a "Status: loading" notice rendered from an earlier snapshot
+        stayed stuck in the sidebar forever — verified live against the
+        real archive daemon. The error path already called renderFacets();
+        the success path must too, or any future edit that reintroduces
+        this asymmetry regresses silently (there is no JS-executing test
+        for this file's inline script, so this is a structural string
+        check on the success-path source, not a DOM assertion)."""
+        from polylogue.daemon.web_shell import WEB_SHELL_HTML
+
+        anchor = "setRouteState('status', {state: 'ready', route: statusRoute, status: '200', error: ''});"
+        idx = WEB_SHELL_HTML.index(anchor)
+        following = WEB_SHELL_HTML[idx + len(anchor) : idx + len(anchor) + 200]
+        assert "renderFacets();" in following, (
+            "loadStatus() success path must call renderFacets() to clear any "
+            "stale 'Status: loading' notice rendered before this route became ready"
+        )
+
     def test_get_session_does_not_leak_adjacent_sessions(
         self,
         workspace_env: dict[str, Path],


### PR DESCRIPTION
## Summary
Two dogfood-discovered web UI bugs, found by driving the live daemon's web shell against the real archive via CDP browser automation after the kwsb.1 deploy.

## Problem
1. **"unknown convs" / "unknown msgs" header chips**, always, on the real archive. `loadStatus()` read `s.total_sessions` at the top level of `/api/status`, but the field actually lives at `component_readiness.session_profiles.counts.total_sessions` (confirmed: 16996, matching the sidebar's own session count).
2. **"Status: loading" sidebar notice stuck permanently**, even once the route genuinely reached `ready` (confirmed live: `state.routeStates.status.state === "ready"` while the DOM still showed the loading banner). Root cause: `loadStatus()`'s success path updated the route state but never called `renderFacets()` to re-render the notice area — only the error path did.

## Solution
- Read `total_sessions` from the correct nested path, with a graceful fallback. `total_messages` has no backend equivalent anywhere in the payload — left honestly "unknown" (out of scope: would need a new server-side field).
- Added the missing `renderFacets()` call on `loadStatus()`'s success path, mirroring what the error path already did.
- Added a structural regression test (`test_load_status_success_path_clears_the_status_route_notice`) since this file's inline JS has no execution-level test harness (`tests/visual/test_reader_dom_smoke.py` parses served HTML, not post-JS DOM state).

## Verification
- Both bugs verified live via CDP browser automation against the real daemon (`http://127.0.0.1:8766/`) and real 26GB archive — not just unit tests.
- `devtools test tests/unit/daemon/test_daemon_http_contracts.py tests/visual/test_reader_dom_smoke.py` → 100 passed
- `devtools verify --quick` → exit 0