### PR TITLE
fix(storage): route ops-doctor orphan-blob repair through the safe GC planner

### DIFF
--- a/polylogue/storage/blob_repair.py
+++ b/polylogue/storage/blob_repair.py
@@ -90,34 +90,46 @@ def count_orphaned_blobs_sync(conn: sqlite3.Connection, *, db_path: Path | str |
 
 
 def repair_orphaned_blobs_data(config: Config, dry_run: bool = False) -> BlobRepairOutcome:
-    from polylogue.storage.blob_store import get_blob_store
+    """Delete orphaned blobs via the lease/ref/generation-safe GC planner.
 
-    blob_store = get_blob_store()
-    with sqlite3.connect(f"file:{config.db_path}?mode=ro", uri=True) as conn:
-        referenced_hashes, surfaces = _referenced_blob_hashes(conn, db_path=config.db_path)
+    Previously this called ``BlobStore.detect_orphans``/``cleanup_orphans``
+    directly, comparing disk hashes only against committed ``raw_sessions``/
+    ``blob_refs`` rows. A blob with an active operation lease
+    (``pending_blob_refs`` — acquired but not yet committed) has no
+    committed reference yet by design, so it was misclassified as an
+    orphan and deleted: the exact in-flight-ingest race the lease
+    mechanism exists to close (polylogue-8jg9.4). ``run_blob_gc_report``
+    already applies all three safety invariants (committed reference,
+    active lease, generation-age floor); routing the doctor repair path
+    through it closes the race without duplicating that safety logic.
+    """
+    from polylogue.paths import blob_store_root
+    from polylogue.storage.blob_gc import run_blob_gc_report
 
-    surface_detail = _surface_detail(surfaces)
-    detect_result = blob_store.detect_orphans(referenced_hashes)
-    if detect_result.orphan_count == 0:
-        return BlobRepairOutcome(0, True, f"No orphaned blobs found ({surface_detail})")
-
-    orphan_hashes = {h for h in blob_store.iter_all() if h not in referenced_hashes}
-    cleanup_result = blob_store.cleanup_orphans(orphan_hashes, dry_run=dry_run)
+    report = run_blob_gc_report(
+        config.db_path,
+        blob_store_root(),
+        max_batch=100_000,
+        dry_run=dry_run,
+    )
+    protected_detail = (
+        f"; skipped {report.skipped_referenced} referenced, {report.skipped_leased} leased"
+        if (report.skipped_referenced or report.skipped_leased)
+        else ""
+    )
     if dry_run:
         return BlobRepairOutcome(
-            cleanup_result.would_delete_count,
+            report.would_delete_count,
             True,
-            (
-                f"Would: delete {cleanup_result.would_delete_count} orphaned blobs "
-                f"({cleanup_result.would_delete_bytes:,} bytes; {surface_detail})"
-            ),
+            f"Would: delete {report.would_delete_count} orphaned blobs{protected_detail}",
         )
+    errors = report.skipped_unlink_error
     return BlobRepairOutcome(
-        cleanup_result.deleted_count,
-        cleanup_result.errors == 0,
+        report.deleted_count,
+        errors == 0,
         (
-            f"Deleted {cleanup_result.deleted_count} orphaned blobs ({cleanup_result.deleted_bytes:,} bytes)"
-            f" ({surface_detail})" + (f" with {cleanup_result.errors} errors" if cleanup_result.errors else "")
+            f"Deleted {report.deleted_count} orphaned blobs ({report.reclaimed_bytes:,} bytes)"
+            f"{protected_detail}" + (f" with {errors} errors" if errors else "")
         ),
     )
 

--- a/tests/unit/storage/test_blob_gc_concurrency.py
+++ b/tests/unit/storage/test_blob_gc_concurrency.py
@@ -353,3 +353,89 @@ def test_helpers_reflect_lease_lifecycle(tmp_path: Path) -> None:
         assert _has_active_lease(conn, blob) is False
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Ops-doctor repair path (polylogue-8jg9.4)
+# ---------------------------------------------------------------------------
+#
+# repair_orphaned_blobs_data previously called BlobStore.detect_orphans /
+# cleanup_orphans directly, comparing disk hashes only against committed
+# raw_sessions/blob_refs rows — with zero awareness of pending_blob_refs
+# (leases) or the generation-age floor. A blob acquired-but-not-yet-committed
+# has no committed reference yet by design, so the doctor path classified it
+# an orphan and deleted it: the exact in-flight-ingest race the lease
+# mechanism exists to close. The fix routes the doctor path through
+# run_blob_gc_report, the same safe planner run_blob_gc already uses.
+
+
+def test_doctor_repair_path_respects_active_lease(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A leased-uncommitted blob survives the ops-doctor repair path."""
+    from polylogue.config import Config
+    from polylogue.storage.blob_repair import repair_orphaned_blobs_data
+
+    db_path = tmp_path / "archive.db"
+    blob_root = tmp_path / "blobs"
+    blob_store = BlobStore(blob_root)
+    _make_db(db_path).close()
+
+    blob_hash, _ = blob_store.write_from_bytes(b"in-flight doctor payload")
+    _age_blob(blob_store, blob_hash, seconds=MIN_AGE_S + 5)
+    acquire_blob_leases(db_path, [blob_hash], operation_id="op-doctor-write")
+
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: blob_root)
+    config = Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=db_path)
+
+    outcome = repair_orphaned_blobs_data(config, dry_run=False)
+
+    assert blob_store.exists(blob_hash), (
+        "ops-doctor repair deleted a blob held by an in-flight lease — "
+        "the acquire-then-commit window is no longer protected on this path"
+    )
+    assert outcome.repaired_count == 0
+
+
+def test_doctor_repair_path_deletes_unreferenced_unleased_blob(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An old, unreferenced, lease-free blob is still collectable via the doctor path."""
+    from polylogue.config import Config
+    from polylogue.storage.blob_repair import repair_orphaned_blobs_data
+
+    db_path = tmp_path / "archive.db"
+    blob_root = tmp_path / "blobs"
+    blob_store = BlobStore(blob_root)
+    _make_db(db_path).close()
+
+    blob_hash, _ = blob_store.write_from_bytes(b"truly abandoned payload")
+    _age_blob(blob_store, blob_hash, seconds=MIN_AGE_S + 5)
+
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: blob_root)
+    config = Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=db_path)
+
+    outcome = repair_orphaned_blobs_data(config, dry_run=False)
+
+    assert not blob_store.exists(blob_hash)
+    assert outcome.repaired_count == 1
+    assert outcome.success is True
+
+
+def test_doctor_repair_path_dry_run_never_deletes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """dry_run=True reports the count without touching disk, on the doctor path too."""
+    from polylogue.config import Config
+    from polylogue.storage.blob_repair import repair_orphaned_blobs_data
+
+    db_path = tmp_path / "archive.db"
+    blob_root = tmp_path / "blobs"
+    blob_store = BlobStore(blob_root)
+    _make_db(db_path).close()
+
+    blob_hash, _ = blob_store.write_from_bytes(b"dry run candidate")
+    _age_blob(blob_store, blob_hash, seconds=MIN_AGE_S + 5)
+
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: blob_root)
+    config = Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=db_path)
+
+    outcome = repair_orphaned_blobs_data(config, dry_run=True)
+
+    assert blob_store.exists(blob_hash)
+    assert outcome.repaired_count == 1
+    assert outcome.success is True


### PR DESCRIPTION
## Summary
`BlobStore.detect_orphans`/`cleanup_orphans` (the ops-doctor's orphan-blob repair path) had zero awareness of the lease mechanism that `run_blob_gc` already respects — an in-flight, acquired-but-not-yet-committed blob could be deleted out from under a concurrent ingest. Fixes polylogue-8jg9.4 ("the real #818").

## Problem
`repair_orphaned_blobs_data` computed "referenced" hashes from committed `raw_sessions`/`blob_refs` rows only, then deleted everything else. A blob acquired via `acquire_blob_leases` (written to `pending_blob_refs`) but not yet committed has **no committed reference by design** — that's the whole point of the lease, to bridge the acquire→commit window. The doctor path classified that blob an orphan and deleted it: exactly the race the lease design exists to close. Verified live 2026-07-06 (per the bead): `blob_store.py` has zero references to `pending_blob_refs`/`blob_refs`/`gc_generations`.

## Solution
Route `repair_orphaned_blobs_data` through `run_blob_gc_report` — the same lease + committed-reference + generation-age-safe planner `run_blob_gc` already uses — instead of the raw `detect_orphans`/`cleanup_orphans` pair. This closes the race without duplicating safety logic in two places. External signature and `BlobRepairOutcome` shape are unchanged, so `repair.py`/`preview.py` callers needed no changes. `count_orphaned_blobs_sync` (read-only, never deletes) is intentionally left as-is — the race only matters on the destructive path.

## Verification
Three new fixture-race tests in `test_blob_gc_concurrency.py`, mirroring the existing `run_blob_gc` lease-visibility test but driving the doctor path:
- a leased-uncommitted blob survives `repair_orphaned_blobs_data`
- an unreferenced, unleased, aged blob is still collected
- `dry_run=True` never touches disk

```
devtools test tests/unit/storage/test_blob_gc_concurrency.py tests/unit/storage/test_blob_gc.py \
  tests/unit/storage/test_blob_gc_lease_recovery.py tests/unit/storage/test_blob_store_contracts.py \
  tests/unit/storage/test_repair.py tests/unit/maintenance/test_preview.py \
  tests/unit/maintenance/test_idempotency.py
-> 106 passed
```
mypy clean; `devtools verify --quick` → exit 0.

Ref polylogue-8jg9.4.