### PR TITLE
fix(security): harden blob hash validation, drop misleading symlink check

### DIFF
--- a/polylogue/core/security.py
+++ b/polylogue/core/security.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-from pathlib import Path
 
 from polylogue.logging import get_logger
 
@@ -23,28 +22,16 @@ def sanitize_path(v: str | None) -> str | None:
     # Remove control characters (ASCII < 32 and 127)
     v = "".join(c for c in v if ord(c) >= 32 and ord(c) != 127)
 
-    # Detect threats:
-    # 1. Traversal attempts (..)
-    # 2. Symlinks in path (potential traversal bypass)
+    # Detect traversal attempts (..). A prior symlink check here
+    # (Path(v).is_symlink() walked against the process's own CWD) was
+    # removed: this value is provider-reported attachment path metadata that
+    # is never opened relative to CWD, so the check tested an unrelated
+    # filesystem location and could never catch a real traversal-via-symlink
+    # (jsy). Traversal and control-character stripping remain the real guard.
     has_traversal = ".." in original_v
 
-    # Check for symlinks in the path by checking path components.
-    # On any filesystem error (PermissionError, OSError) treat the path as
-    # suspicious — this guard sits in front of traversal protection and a
-    # silent skip would let unreadable directories mask a real attack.
-    has_symlink = False
-    try:
-        p = Path(v)
-        for parent in [p] + list(p.parents):
-            if parent.is_symlink():
-                has_symlink = True
-                break
-    except OSError as exc:
-        logger.warning("symlink check failed for path %r: %s; treating as suspicious", v, exc)
-        has_symlink = True
-
-    # If traversal or symlinks were detected, hash to prevent re-assembly
-    if has_traversal or has_symlink:
+    # If traversal was detected, hash to prevent re-assembly
+    if has_traversal:
         original_hash = hashlib.sha256(original_v.encode()).hexdigest()[:12]
         return f"_blocked_{original_hash}"
 

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -31,8 +31,12 @@ logger = logging.getLogger(__name__)
 
 _CHUNK_SIZE = 1024 * 1024  # 1 MiB
 
-# Valid blob hash: lowercase hex only
-_VALID_HEX = re.compile(r"^[0-9a-f]+$")
+# Valid blob hash: exactly 64 lowercase hex chars (a SHA-256 digest). Matched
+# with fullmatch (not the former match() + trailing-`$`, which also accepts a
+# trailing newline and any length >=1) so a truncated, over-long, or
+# newline-suffixed hash is rejected at the boundary rather than silently
+# accepted (jsy).
+_VALID_HEX = re.compile(r"[0-9a-f]{64}")
 
 Heartbeat = Callable[[], None]
 
@@ -55,7 +59,7 @@ class BlobStore:
 
     def blob_path(self, hash_hex: str) -> Path:
         """Return the filesystem path for a blob by its hex digest."""
-        if not _VALID_HEX.match(hash_hex):
+        if not _VALID_HEX.fullmatch(hash_hex):
             raise ValueError(f"invalid blob hash: {hash_hex!r} — expected lowercase hex string")
         return self.root / hash_hex[:2] / hash_hex[2:]
 
@@ -403,7 +407,7 @@ class BlobStore:
             would_delete_count = 0
             would_delete_bytes = 0
             for hash_hex in orphan_hashes:
-                if not _VALID_HEX.match(hash_hex):
+                if not _VALID_HEX.fullmatch(hash_hex):
                     continue
                 path = self.blob_path(hash_hex)
                 if path.exists():
@@ -426,7 +430,7 @@ class BlobStore:
         error_details: list[str] = []
 
         for hash_hex in orphan_hashes:
-            if not _VALID_HEX.match(hash_hex):
+            if not _VALID_HEX.fullmatch(hash_hex):
                 errors += 1
                 error_details.append(f"invalid hash: {hash_hex[:32]}...")
                 continue

--- a/tests/unit/security/test_path_sanitization.py
+++ b/tests/unit/security/test_path_sanitization.py
@@ -84,16 +84,24 @@ class TestSanitizePathTraversal:
     def test_none_returns_none(self) -> None:
         assert sanitize_path(None) is None
 
-    def test_symlink_check_oserror_treats_path_as_suspicious(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Filesystem errors during symlink probing must not silently bypass the guard."""
+    def test_relative_path_is_not_symlink_probed_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """jsy: sanitize_path no longer probes Path(v).is_symlink() against the
+        process CWD -- that check tested an unrelated filesystem location
+        (the value is provider-reported attachment metadata, never opened
+        relative to CWD) and could never catch a real traversal-via-symlink.
+        A relative path that happens to collide with a real symlink under the
+        process's actual CWD is no longer specially blocked for that reason;
+        only traversal (..) and absolute-path rules apply."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "real_target").mkdir()
+        (tmp_path / "sessions").symlink_to(tmp_path / "real_target")
 
-        def _raise_permission_error(self: Path) -> bool:
-            raise PermissionError("simulated unreadable directory")
-
-        monkeypatch.setattr(Path, "is_symlink", _raise_permission_error)
-        result = sanitize_path("/some/safe/looking/path")
+        result = sanitize_path("sessions/chatgpt/export.json")
         assert result is not None
-        assert result.startswith("_blocked_")
+        assert not result.startswith("_blocked_")
+        assert "sessions" in result
 
 
 # =============================================================================

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -414,6 +414,42 @@ def test_blob_path_rejects_uppercase(tmp_path: Path) -> None:
         blob.blob_path("AABBCCDDEEFF0011223344556677889900AABBCCDD")
 
 
+def test_blob_path_rejects_truncated_hash(tmp_path: Path) -> None:
+    """jsy: a 63-char (one short of a real SHA-256 digest) hash must be
+    rejected, not silently accepted as if length didn't matter."""
+    blob = BlobStore(tmp_path)
+    import pytest
+
+    with pytest.raises(ValueError, match="invalid blob hash"):
+        blob.blob_path("a" * 63)
+
+
+def test_blob_path_rejects_over_long_hash(tmp_path: Path) -> None:
+    """jsy: a 65-char hash (one over) must be rejected, not truncated/accepted."""
+    blob = BlobStore(tmp_path)
+    import pytest
+
+    with pytest.raises(ValueError, match="invalid blob hash"):
+        blob.blob_path("a" * 65)
+
+
+def test_blob_path_rejects_trailing_newline(tmp_path: Path) -> None:
+    """jsy: the former `^[0-9a-f]+$` pattern (via .match, not .fullmatch)
+    accepted a trailing newline since bare `$` matches just before one --
+    fullmatch on a fixed-length pattern must reject it."""
+    blob = BlobStore(tmp_path)
+    import pytest
+
+    with pytest.raises(ValueError, match="invalid blob hash"):
+        blob.blob_path("a" * 64 + "\n")
+
+
+def test_blob_path_accepts_exactly_64_hex_chars(tmp_path: Path) -> None:
+    blob = BlobStore(tmp_path)
+    path = blob.blob_path("a" * 64)
+    assert path == tmp_path / "aa" / ("a" * 62)
+
+
 # ---------------------------------------------------------------------------
 # Content-addressing invariant
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Defense-in-depth hardening (gh#2483): neither issue is currently exploitable, but both weaken the intended guard.

## Problem
1. `blob_store._VALID_HEX = re.compile(r"^[0-9a-f]+$")` matched via `.match()`, not `.fullmatch()` — the bare `$` accepts a trailing newline, and `+` accepts any length ≥ 1, not exactly 64. A truncated, over-long, or newline-suffixed value could pass where only a real SHA-256 digest should.
2. `core/security.sanitize_path` ran `Path(v).is_symlink()` per path component against the process's own CWD. The value is provider-reported attachment metadata that is never opened relative to CWD, so the check tested an unrelated filesystem location and could never catch a real traversal-via-symlink — it only added a false sense of coverage.

## Solution
- `_VALID_HEX` is now `re.compile(r"[0-9a-f]{64}")`, matched with `.fullmatch()` at all three call sites (`blob_path`, `cleanup_orphans` x2).
- Removed the symlink-probing loop and its OSError-suspicious-fallback from `sanitize_path`; kept traversal (`..`) detection and control-character stripping, which are the checks that actually guard this boundary.
- `decoder_zip`'s per-entry 10GiB cap already exists; an aggregate/entry-count budget was left out per the bead's own design note ("add one only if untrusted zips become an input class") — not currently the case.

## Verification
- New fixtures per malformed class: truncated (63 chars), over-long (65), trailing-newline, and the accept-boundary case (exactly 64) in `tests/unit/storage/test_blob_store.py`.
- Replaced the obsolete symlink-OSError test in `tests/unit/security/test_path_sanitization.py` with one proving a relative path colliding with a REAL symlink under the process's actual CWD is no longer specially blocked — locking in the intentional removal rather than leaving a silent gap.
- `devtools test` across `test_blob_store.py`, `test_path_sanitization.py`, `test_blob_gc.py`, `test_blob_integrity.py`: 101 passed.
- `mypy --strict` on changed files: clean. `devtools render all --check`: clean.

Ref polylogue-jsy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)