### PR TITLE
docs(demos): cfk uplift two-arm re-run, n=5 pilot

### DIFF
--- a/.agent/demos/uplift-two-arm/README.md
+++ b/.agent/demos/uplift-two-arm/README.md
@@ -1,0 +1,18 @@
+# Handoff-Pack Uplift Experiment
+
+This shelf is for current two-arm experiments that test whether bounded
+Polylogue handoff packets improve continuation reconstruction compared with a
+raw archive reference.
+
+The shelf is current, not append-only. Regenerate or replace `current/` when a
+better protocol or cleaner run exists.
+
+## Current run (2026-07-09, n=5 pilot)
+
+Successor to the n=1 `jxe`/`jxe.2` pilot (raw-ref 8/10 vs handoff-pack 5/10,
+diagnostic-negative, attributed to packet staleness). See `current/report.md`
+for the full write-up: n=5 pairs, handoff-pack wins 4/5, directional but
+explicitly **not** a publishable result (protocol calls for n>=12-20). One
+pair's blind was compromised and is documented rather than discarded; one
+pair is a genuine counterexample where the pack arm asserted a false fact
+with high confidence. Cold-reader gate: PASS.

--- a/.agent/demos/uplift-two-arm/current/arms/pair1-handoff-pack-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair1-handoff-pack-output.md
@@ -1,0 +1,59 @@
+# Devloop Reconstruction Report — polylogue @ 91eb09549
+
+## (a) Current devloop state
+
+The devloop has been executing a long, disciplined merge train (11+ squash-merged PRs in the last few hours: #2588–#2604), alternating between real correctness fixes and investigation/bookkeeping. Verified via `git log --oneline -15`:
+
+- `91eb09549` close polylogue-4ts.6 (#2604)
+- `c06ca601c` feat(lineage): surface a completeness signal on composed reads (#2603)
+- `1d7d79ed2`/`6c12e9234` close polylogue-cpf.1 / timestamp-doctrine lint (#2601-2602)
+- `9f0e77116`/`7b5a5aa05` actions-view fan-out fix + close xnkf (#2597-2598)
+- `aa4a520b4` record 4ts.3 investigation findings, unclaim (#2596)
+- `ccd5cfdd5`/`086171701` close 4ts.4 / lineage read-transaction fix (#2594-2595)
+- `f7c997386` record 1vpm.1 investigation findings, unclaim (#2593)
+- `43d7fdf9b`/`64c079d6e` close 212.8 / honesty anti-demo (#2591-2592)
+
+This matches the pack's shipped-work list exactly and extends it one item further (`c06ca601c`, a lineage completeness signal, landed after the pack was generated).
+
+**Delivery gate board** (`.agent/tools/delivery-gate-status.py --fresh`), the authoritative frontier view:
+
+```
+A-trust-floor              23%  closed 14 | ready 43 | blocked 3   <- frontier
+B-storage-rebuild-bytes     4%  closed  1 | ready 19 | blocked 3
+F-lineage-compaction       17%  closed  2 | ready  3 | blocked 7
+I-analytics-experiments     0%  closed  0 | wip 1 (1vpm.1) | ready 9 | blocked 20
+L-external-legibility      13%  closed  4 | ready 20 | blocked 6
+```
+
+A-trust-floor is the named frontier lane and is the biggest one still open (43 ready items), mostly the `polylogue-9e5.*` read-only audit family (coverage economics, dead-code sweeps, hash-boundary census, etc.) — this is exactly the "trust-floor P1s" the operator's `/goal` names.
+
+## (b) Open threads found
+
+1. **polylogue-1vpm.1 — live/committed state mismatch.** The last committed jsonl record (`f7c997386`, "record findings, unclaim") sets `status:"open"`. But `bd show polylogue-1vpm.1 --json` right now reports `status:"in_progress"`, `assignee:"Sinity"`, `updated_at: 2026-07-09T03:24:19Z` — a timestamp with **no corresponding commit** touching that bead in `.beads/issues.jsonl` history. This means the live embedded-dolt DB has state ahead of the last export/commit (some claim happened that hasn't been exported+committed yet). Not something I should "fix" here, but worth flagging before anyone else claims it — the committed bookkeeping record and the live DB disagree.
+2. **F-lineage-compaction ready set is exactly 3 items**: `polylogue-4ts` (epic), `polylogue-4ts.3` (investigated, fix location known), `polylogue-4ts.5` (fresh, "compaction boundary-range columns + effective-context derivation" — not yet investigated).
+3. **B-storage-rebuild-bytes ready set** includes `83u.2` (re-investigated/reframed to the "bytes reachable but not fetched" subset, per commit `6796ac1ed`) and `83u.3` ("preserve uploaded attachment bytes in live browser capture" — fresh, untouched).
+4. **212.x demo-unlock parallel set**: 212.1/212.3/212.5/212.6 remain open with no assignee; per the pack each has its own blocker (deep interpretive read / missing join primitive / live stagecraft / classifier bug); none looked trivially unblockable from what I can see in their notes (no blocker detail beyond the delivery-upgrade boilerplate), so I did not find a shortcut through any of them.
+5. **pj8** depends on `37t.4` (SessionStart preamble rollout) which is itself gated on real MCP-hook-wiring code, not just deployment — it's `open`, unclaimed, priority 3, and the pack says it's now "authorized" for the hook wiring step, but actually landing it still implies a SessionStart hook change that the pack says needs redeploy to prove — consistent with "postpone" guidance.
+6. **3tl** — confirmed still fully untouched (17 open children), and independently confirmed P4/docs-marketing in this pass (no evidence contradicting the pack).
+7. **cfk** — this very context-pack handoff is explicitly part of the live paired-arm uplift experiment it depends on; I was told not to read `.agent/demos/uplift-two-arm/`, so I can't and shouldn't try to advance or grade that experiment from inside it.
+
+## (c) Recommended next action
+
+**Claim and implement `polylogue-4ts.3`** — "Distinguish subagent auto-compaction from main-session acompact."
+
+Reasoning:
+- It is explicitly named as part of the "lineage epic" the operator's goal calls out, and is one of only 3 ready items left in F-lineage-compaction (the epic is 17% closed, actively being worked this session — `4ts.4`/`4ts.6` just shipped).
+- Unlike `1vpm.1` (comparable in size to `svfj`, a multi-surface feature — new query unit, new column, new registered `target_kind`) or `4ts.5` (still needs fresh investigation), `4ts.3` already has a completed, verified investigation on the bead itself, with an exact fix location I independently confirmed still exists at HEAD:
+  - `polylogue/sources/dispatch.py:354` `_claude_code_grouped_record_specs`
+  - `polylogue/sources/dispatch.py:441` `_claude_code_stream_sessions`
+  - Both are called from the dispatch layer (lines 541, 831) and are the layer with visibility into sibling session-group content needed to distinguish subagent self-compaction from main-session `acompact`.
+- It requires no redeploy/MCP-reboot (unlike pj8/37t.4) and no live paired-arm experiment (unlike cfk).
+- It's a real correctness bug (misattributed parent session on ~39/187 affected files per the GH thread cited in the bead), not read-only analysis, so it continues today's demonstrated pattern of shipping concrete lineage-correctness fixes rather than accumulating more audit-lane findings on top of the already-large 43-item A-trust-floor backlog.
+
+Secondary/fallback candidates if `4ts.3` turns out blocked on something I couldn't see (e.g. a fixture gap): `polylogue-83u.3` (fresh, unclaimed, in the storage-rebuild-bytes lane) or one of the trust-floor `9e5.*` P1 audits (e.g. `polylogue-9e5.6`, hash-boundary census — the closest literal match to "storage identity" in the operator's phrasing).
+
+## (d) Confidence and evidence
+
+**Confidence: high** on devloop state and gate-board numbers (directly queried live `bd`/git, not inferred from the pack); **medium-high** on the `4ts.3` recommendation (its investigation note is detailed and the code anchors check out, but I have not read the full GH issue thread it references, nor written/run the fix itself); **medium** on the `1vpm.1` state-mismatch finding (clearly true from the data, but I don't know *why* — could be an uncommitted claim from a concurrent session, consistent with this repo's documented shared-checkout/multi-session risk).
+
+Evidence used: `git log --oneline` / `git log -p -- .beads/issues.jsonl` on the current worktree; `bd show`/`bd ready --json` for `polylogue-pj8`, `37t.4`, `3tl`, `cfk`, `212.9`, `1vpm.1`, `83u.2`, `4ts.3`, `4ts`, `9e5.6`, and the 212.1/212.2/212.3/212.5/212.6 family; `.agent/tools/delivery-gate-status.py --fresh` (whole-board and per-gate); direct `grep` confirmation of the `dispatch.py` fix anchors named in the `4ts.3` bead notes. No files under `.agent/demos/uplift-two-arm/` were read, per instruction.

--- a/.agent/demos/uplift-two-arm/current/arms/pair1-raw-ref-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair1-raw-ref-output.md
@@ -1,0 +1,63 @@
+# Devloop State Reconstruction — polylogue @ commit 91eb09549
+
+## (a) Current devloop state
+
+The worktree HEAD (`91eb09549`) sits at the end of a dense, uninterrupted run of small merged PRs. Recent `git log --oneline -30` shows a tight cadence of `feat/fix` commits each immediately followed by a `chore(beads): close <id> (#N)` commit — the devloop is running "ship → close bead → next" with no idle gaps:
+
+```
+91eb09549 chore(beads): close polylogue-4ts.6 (#2604)
+c06ca601c feat(lineage): surface a completeness signal on composed reads (#2603)
+1d7d79ed2 chore(beads): close polylogue-cpf.1 (#2602)
+6c12e9234 feat(devtools): timestamp-doctrine lint for durable-tier DDL (#2601)
+01592e5e9 chore(beads): close polylogue-jsy (#2600)
+b6b9fef2a fix(security): harden blob hash validation, drop misleading symlink check (#2599)
+...
+```
+
+The two most recent substantive shipped items:
+1. **`polylogue-cpf.1`** (PR #2601) — added `devtools/verify_timestamp_doctrine.py`, a lint rejecting `TEXT` timestamp columns in new durable-tier DDL. Wired into `devtools verify --lab`. This is doctrine-chain work under the `polylogue-cpf` epic ("Land the six doctrines").
+2. **`polylogue-4ts.6`** (PR #2603, just closed) — added `lineage_complete`/`lineage_truncation_reason` to `ArchiveSessionEnvelope` (both sync and async composition paths), wired it into the two MCP-facing payloads. CodeRabbit flagged on review that two more read surfaces (CLI reader payload, Python API `Session` model) and three async batch/paginated wrappers still silently drop the signal — this was **not silently ignored**: it was spun into a fresh follow-up bead, `polylogue-vv2b`, filed at close time with the exact same additive pattern already validated in #2603.
+
+`bd ready --json` currently returns **299 open, unblocked** beads — this is a long-horizon backlog, not near exhaustion. Beads are grouped into big epics (`9e5` audit lane, `cpf` doctrines, `t46`/`jnj`/`fnm` surface-algebra work, `20d`/`1xc` performance/scale, `bby` web workbench, `a7xr` substrate consolidation, etc.), most tagged with `delivery:<gate>` labels running a lettered sequence `A-trust-floor → ... → N-horizon`.
+
+Crucially, `.agent/tools/delivery-gate-status.py --fresh` (an ordinary repo script, not the forbidden demo dir) shows the priority field was **just reconciled to track this gate order** (commit `a2ee55ec4`, PR #2584, "Ref #8e1b" — mechanical sweep, 288 beads repriced). Gate state right now:
+
+```
+> A-trust-floor   23% closed(14) wip(0) ready(43) blocked(3)   <- the active frontier
+  B-storage-rebuild-bytes     4% ready(19)
+  C-read-evidence-contract    2% ready(51)
+  D-agent-context-coordination 0% ready(34)
+  E-variants-preferences      0%
+  F-lineage-compaction       17% closed(2) ready(3) blocked(7)
+  ...through N-horizon
+```
+
+`A-trust-floor`'s exit criterion: "Full verification classified; security negative tests pass; missing bytes classified; numbers/time/prose-mined fields carry honest provenance; agent writes land as candidates." Priority-1 in `bd ready` == this gate by construction.
+
+## (b) Open threads found
+
+- **`polylogue-cpf` epic** (doctrine landing, gate A-trust-floor): `cpf.1` just closed. Siblings `cpf.2` (writer-class docstring + layering check) and `cpf.3` (injected-context deny-lexicon tripwire fixture) are both **open, wave:1, same epic, same "cheap lint" shape** as the just-shipped `cpf.1`. `cpf.4` (the broader "sweep silent soft-failure paths" class bead) explicitly names three concrete instances to verify against: `1xc.11` (closed 2026-07-05), `4ts.6` (**just closed**), and `tf0e` (still open, but in a different, lower-tier gate `K-interop-origin-export`). So 2 of 3 named instances are now resolved — `cpf.4` is closer to being closeable than it was an hour ago.
+- **`polylogue-vv2b`** (new, filed at `4ts.6` close time): wire the same `lineage_complete` signal into the CLI reader payload (`cli/archive_query.py:2198`), the Python API `Session` model (`api/archive.py:1162`), and the three async batch/paginated wrappers. Small, additive, pattern already proven in #2603. It carries no `delivery:*` gate label yet (falls into the 26-bead "unlabeled_open" bucket), so it sits outside the just-reconciled priority scheme — priority 3 is a leftover default, not a gate-derived value.
+- **Housekeeping loose end:** `polylogue-8e1b` ("Reconcile bead priority field with delivery-gate order") shipped its work in merged PR #2584 but the bead itself is still `status: in_progress` (assignee Sinity, no `closed_at`) — the work is done and merged; the bead just wasn't formally closed out.
+- Two investigation-only threads were recorded and unclaimed rather than completed: `4ts.3` ("record 4ts.3 investigation findings, unclaim") and `1vpm.1` (same pattern) — these remain open for someone to pick back up with the recorded findings as a starting point.
+- The `9e5` "Audit lane" epic has a large cluster of ready, priority-1/gate-A items (`9e5.1`, `9e5.3`–`9e5.27` minus closed ones) — read-only analysis work producing evidence artifacts, generally larger/more open-ended than the `cpf` doctrine lints.
+
+## (c) Recommended next action
+
+**Claim `polylogue-cpf.2`** ("Doctrine: writer-class docstring convention + layering check").
+
+Why this one specifically, over the many other ready candidates:
+- It is in **gate A-trust-floor**, the tool-confirmed active frontier (lowest completion %, and the gate the operator's own priority-reconciliation sweep just re-anchored as top priority).
+- It is the **direct sibling of the commit that just landed** (`cpf.1`, same epic, same `wave:1` label, same "small schema/layering lint wired into `devtools lab policy`" shape) — the agent that did `cpf.1` proved the exact pattern this bead needs (add a check, register it under `devtools lab policy`, wire into `devtools verify --lab`, unit-test with a fixture that should fail vs. one that should pass).
+- Its acceptance criteria are tight and mechanical: "A file declaring two writer classes fails the check; single-class files pass" — low risk, quick to verify, no architectural ambiguity.
+- No blocking dependencies (parent `cpf` is an open epic, but parent-child edges don't block readiness).
+
+Second-best alternative, if the goal is "clean up what's already in flight" rather than "advance the top-priority gate": **`polylogue-vv2b`** — it's the freshest, most concrete, most fully-specified bead in the tracker (filed minutes before HEAD, names exact file/line locations, reuses a pattern the same session just implemented twice), but it's gate `F-lineage-compaction` / unlabeled, i.e. formally lower priority under the current gate ordering than `cpf.2`/`cpf.3`/`cpf.4`.
+
+Also worth a two-minute detour regardless of which bead is claimed next: `bd close polylogue-8e1b` — its work already shipped in merged PR #2584 and it's just sitting `in_progress` unclosed.
+
+## (d) Confidence and evidence used
+
+High confidence on the state summary (git log + `bd show` on the exact beads referenced by the last four commits gave a coherent, cross-corroborating picture: commit messages, bead `close_reason` text, and the newly-filed `vv2b` bead's dependency edge to `4ts.6` all agree). Medium-high confidence on the "what's next" recommendation — it follows the repo's own explicitly documented policy (gate-ordered priority, `delivery-gate-status.py` as "the gate board") rather than my own guess, but there are 43 other A-trust-floor-ready beads I did not individually inspect, so a different reasonable pick from that same set is defensible.
+
+Evidence used: `git log --oneline -30` / `--all -10`; `bd ready --json --limit 500` (299 items); `bd show` on `polylogue-cpf`, `cpf.1`–`cpf.4`, `4ts.6`, `4ts`, `1xc.11`, `tf0e`, `vv2b`, `8e1b`; `bd list --status in_progress --json`; and one ordinary repo script read/run, `.agent/tools/delivery-gate-status.py --fresh` / `--gate A-trust-floor --json` (explicitly not under the forbidden `.agent/demos/uplift-two-arm/` path). No MCP/Polylogue archive tools were used (not required — the bd/git evidence was sufficient and directly conclusive).

--- a/.agent/demos/uplift-two-arm/current/arms/pair2-handoff-pack-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair2-handoff-pack-output.md
@@ -1,0 +1,31 @@
+# Devloop Reconstruction Report — commit 64c079d6e
+
+## (a) Current devloop state
+
+HEAD sits at 64c079d6e, the tail of a run of small, tightly-scoped merged PRs (9e5.29 -> 83u.4 -> 83u.6 -> svfj -> 212.7 -> 212.4 -> 212.8).
+
+The demo-unlock chain (9e5.29 -> svfj -> 212.7 -> {212.1-212.6,212.8 parallel} -> 1vpm.1 (+rxdo.7) -> 212.9) has its foundation fully cleared: 9e5.29, svfj, and 212.7 are all closed. Of the parallel demo set, 212.4 and 212.8 are closed -- 2 of the planned first-wave set are done.
+
+Gate-board snapshot: A-trust-floor 23% (frontier gate, 43 ready); B-storage-rebuild-bytes 4%; C-read-evidence-contract 2%; F-lineage-compaction 17%; L-external-legibility 13%.
+
+polylogue-1vpm.1 shows status=in_progress, assignee=Sinity, with no shipped commits yet on the checked-out history -- consistent with "not yet built."
+
+## (b) Open threads
+
+1. Demo portfolio (polylogue-212) -- 212.2 ("D1 'The receipts': claim-vs-evidence on a real PR") is the missing piece of the originally-planned first wave and is unblocked (all dependencies closed). 212.1 also implementation-ready. 212.3 blocked on a missing join primitive. 212.5/212.6 explicitly deferred. 212.9 depends on 1vpm.1 and optionally rxdo.7.
+2. Lineage epic (polylogue-4ts) -- untouched; only 4ts.3 and 4ts.5 ready, both priority 3.
+3. External legibility (polylogue-3tl) -- untouched as an epic, 6 children ready.
+4. polylogue-cfk (re-run two-arm uplift experiment) -- open, likely needing an operator-gated/infra-dependent step.
+5. polylogue-pj8 -- open, plausibly needs an MCP server reboot.
+6. polylogue-rxdo.7 -- needed for the demo chain's optional annotation-loop step.
+7. Large untouched P1 backlog under A-trust-floor (the 9e5.* family plus cpf.4).
+
+## (c) Recommended next action
+
+polylogue-212.2 -- "D1 'The receipts': claim-vs-evidence on a real PR." It is the one remaining piece of the demo epic's own first wave, fully unblocked, rated A-implementation-ready ("nearly free: all reads exist"), and keeps the demo-unlock chain moving. Lower-risk than picking an undifferentiated P1 trust-floor item, and doesn't require the redeploy/MCP-reboot precondition blocking cfk/pj8.
+
+Secondary candidate: polylogue-4ts.3 or 4ts.5 to start cracking open the lineage epic.
+
+## (d) Confidence
+
+High confidence on state reconstruction. Medium-high on the recommendation -- the ultimate call between continuing the demo thread versus the P1 trust-floor backlog is a judgment call the standing goal itself leaves open.

--- a/.agent/demos/uplift-two-arm/current/arms/pair2-raw-ref-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair2-raw-ref-output.md
@@ -1,0 +1,25 @@
+## Current Devloop State
+
+The repository sits at commit 64c079d6e, the tip of a long, rapid-fire single-day devloop. The devloop is explicitly organized around a delivery-gate sequence (A-trust-floor -> B-storage-rebuild-bytes -> C-read-evidence-contract -> ... -> N-horizon), with bead priority fields recently reconciled (PR #2584, bead polylogue-8e1b, still technically in_progress even though its mechanical sweep already landed).
+
+The immediately preceding thread of work is the demo portfolio epic (polylogue-212): converting demos into a formal Demo Finding Packet contract (polylogue-212.7, closed) and producing a "first public mini-portfolio" of exactly three packets: D1 receipts (212.2, NOT implemented), D4 behavioral archaeology (212.4, closed), the honesty anti-demo (212.8, closed, HEAD commit). When 212.7 was closed, a follow-up bead polylogue-xyel was filed to implement the real D1-receipts packet.
+
+Also active: 9e5 audit-lane, f2qv (cost honesty), cpf (six doctrines), 83u (attachment/blob integrity, 83u.2 corrected-and-unclaimed), svfj's follow-up polylogue-xl25 (relocated_lineage/quarantined states). polylogue-1vpm.1 is genuinely in_progress right now.
+
+## Open Threads
+
+- D1 receipts demo incomplete (polylogue-xyel, ready, unblocked).
+- A real, freshly-discovered correctness bug: polylogue-70qb -- bare find "sessions where <predicate>" silently ignores the boolean predicate. Discovered mid-authorship of 212.4, documented honestly as a counterexample. No delivery:* gate label yet.
+- polylogue-xl25 -- implement relocated_lineage/quarantined states for the block-content-hash citation resolver.
+- polylogue-8e1b -- still in_progress, unclosed despite mechanical sweep landing.
+- Large standing backlogs at every later delivery gate.
+
+## Recommended Next Action
+
+Claim polylogue-xyel (real D1-receipts demo). It is the single named, unblocked loose end from the work sequence that produced the last three commits; small, well-scoped.
+
+Close second: polylogue-70qb -- a genuine correctness defect in a core surface, numerically higher priority under the reconciled scheme, but not gate-labeled so it fell outside the reconciliation sweep.
+
+## Confidence
+
+High confidence on state reconstruction and xyel as the most contextually-continuous next claim. Moderate uncertainty on xyel-vs-70qb prioritization since they represent genuinely different, defensible notions of "next."

--- a/.agent/demos/uplift-two-arm/current/arms/pair3-handoff-pack-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair3-handoff-pack-output.md
@@ -1,0 +1,30 @@
+# Devloop State Reconstruction — polylogue @ 01592e5e9
+
+## (a) Current devloop state
+
+The gate board (A-trust-floor -> N-horizon) shows: A-trust-floor 23% (frontier, 14 closed/43 ready/3 blocked); B-storage-rebuild-bytes 4%; C-read-evidence-contract 2%; D-agent-context-coordination 0%; F-lineage-compaction 17%; I-analytics-experiments 0% closed, 1 wip (1vpm.1); L-external-legibility 13% (demo portfolio + 3tl/cfk live here).
+
+Two intertwined recent threads: (1) demo-unlock chain 9e5.29 -> svfj -> 212.7 -> 212.4+212.8, all closed; (2) correctness-audit thread: 4ts.4, xnkf, jsy, all closed, jsy landing exactly at HEAD.
+
+polylogue-1vpm.1 is in_progress, assigned, with a detailed investigation note: the hard identity/extraction problem is already solved by build_run_projection/session_runs, so real remaining scope narrows to five gaps: (1) delegation_kind taxonomy, (2) link_status field, (3) delegations DSL query unit, (4) delegation-card read view, (5) target_kind=delegation for assertions. Left claimed-but-unimplemented "due to time."
+
+## (b) Open threads
+
+- Demo portfolio: 4 of 6 parallel demo beads still open -- 212.1, 212.2, 212.3, 212.5. 212.6 blocked by polylogue-tsk (a real classifier bug). 212.9 has a non-blocking related dependency on 1vpm.1 and rxdo.7.
+- rxdo.7 itself blocked by rxdo.1.
+- pj8 depends on parent s7ae and 37t.4 (itself blocked by 37t.12). Matches the "needs redeploy" postpone caveat.
+- cfk structurally unblocked but needs a live paired-arm experiment.
+- 3tl -- all 17 children open, uniformly P4 docs/marketing polish.
+- 4ts (lineage epic) only has a relates-to link to 38x, no P1/P2 children in flight.
+- Trust-floor "storage identity" P1 cluster: 9e5.4, 9e5.5, 9e5.6, 9e5.19 -- all P1, area:storage, all open/ready, none started. jsy and xnkf look like exactly what these audits are meant to produce systematically, discovered incidentally so far.
+- 37 P1 beads ready in A-trust-floor overall, dominated by the 9e5.* audit family.
+
+## (c) Recommended next action
+
+polylogue-1vpm.1 -- resume and finish the delegation derived-unit implementation. It is the only bead genuinely mid-flight with investigation already paid for and a concrete five-item implementation list recorded on the bead. Sits on the critical path to 212.9.
+
+Alternative if following the demo-parallel-then-1vpm.1 order strictly: 212.2 or 212.3. Third option if prioritizing trust-floor over demos: polylogue-9e5.6, sharing footprint/evidence base with the just-shipped jsy fix.
+
+## (d) Confidence and evidence
+
+High confidence on mechanical facts (bead statuses, dependency graphs, gate percentages). Moderate-to-high on the prioritization judgment.

--- a/.agent/demos/uplift-two-arm/current/arms/pair3-raw-ref-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair3-raw-ref-output.md
@@ -1,0 +1,28 @@
+## Devloop State Report — polylogue @ 01592e5e9
+
+### (a) Current state
+
+The devloop is deep in an extended "trust floor" hardening pass across security, storage-lineage, and evidence-integrity surfaces, with a parallel demo-authoring track validating the query/insights layer against real corpus behavior. The last ~30 commits show a tight, disciplined rhythm: land a fix/feature PR, then immediately land a companion chore(beads) commit that closes the bead with verified findings and files any follow-up debt discovered along the way.
+
+Most recently shipped: polylogue-jsy (blob hash validation hardening + symlink-check removal), the actions view pairing fix, holding one read transaction across lineage composition, the D4 behavioral archaeology demo, and a new Demo Finding Packet contract + registry lint.
+
+Two beads are in_progress: polylogue-8e1b (priority reconciliation sweep, work appears already executed, just needs closing) and polylogue-1vpm.1 (delegation-derived-unit materializer, mid-investigation).
+
+### (b) Open threads
+
+1. Attachment/blob integrity program (polylogue-83u) — 83u.2 still open and unclaimed.
+2. Security & privacy epic (polylogue-kwsb) — jsy just closed under it, epic remains open.
+3. Six-doctrines program (polylogue-cpf) — cpf.2/cpf.3/cpf.4 all still open/ready.
+4. Cost/usage honesty (polylogue-f2qv) — multiple children ready.
+5. Large read-only audit lane (polylogue-9e5) — ~20+ still-open children.
+6. A freshly-discovered, unfixed correctness bug filed at 2026-07-09T00:27:55Z.
+
+### (c) Recommended next bead: polylogue-70qb
+
+"Bare find sessions where <predicate> ignores the boolean predicate, returns unfiltered list" — discovered during the just-merged 212.4 demo work. Reproduces identically for a plain field predicate and for a seq() predicate, so it isn't SEQ-specific — it's the bare-find/boolean-entry-form code path silently defaulting to an unfiltered listing.
+
+Reasons: real, exactly-reproduced, user-facing correctness bug; cheap to fix and verify (three one-line CLI repro commands already given); zero open blocking dependencies; directly protects trust in the CLI's primary query surface.
+
+### (d) Confidence
+
+High on state reconstruction. Moderate-high on the specific recommendation.

--- a/.agent/demos/uplift-two-arm/current/arms/pair4-handoff-pack-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair4-handoff-pack-output.md
@@ -1,0 +1,27 @@
+# Devloop Reconstruction Report — polylogue @ a2ee55ec4
+
+## (a) Current devloop state
+
+At a2ee55ec4, the backlog is organized into 15 lettered delivery gates that must clear roughly in order. Gate A-trust-floor is the active frontier: 9 closed, 46 ready, 1 in-progress, 3 blocked (~15% complete). No later gate has meaningfully started.
+
+Two beads are literally in_progress at this exact commit: polylogue-9e5.29 (claimed by Sinity, priority 1, gate A-trust-floor) and polylogue-8e1b (the priority-reconciliation bead itself, not yet formally closed even though its PR landed).
+
+## (b) Open threads
+
+1. Demo-unlock chain: 9e5.29 is already claimed and in progress -- it's the live head of this chain, not a cold start. Of 212.7's dependencies, four already closed, three remain open: 9e5.29 (wip), svfj (open), 212.9 (open). Note: 212.7 genuinely depends on 212.9, which conflicts with the informal ordering placing 212.9 last -- this should be reconciled.
+2. Trust-floor P1 backlog large and only partly overlapping with the demo chain: 43 open/in-progress P1 beads gate-wide.
+3. Lineage epic (4ts): 4ts.1/4ts.2 already closed historically; remaining scope (4ts.3-4ts.7) all still open.
+4. 3tl epic: 5 children already closed historically; remaining ~10 children all priority 4.
+5. pj8: layers 1+2 already merged; explicit remaining blocker is a redeploy for the live MCP server to pick up new prompts.
+6. cfk and s7ae remain open with no children closed yet.
+7. 8e1b still in_progress despite its PR having merged as this very commit.
+
+## (c) Recommended next action
+
+Continue and close polylogue-9e5.29. Already claimed and in-progress; priority 1 in the active frontier gate; literal head-blocker of the demo-unlock chain. Concrete, anchored design (insights/rigor.py, RigorFieldContract). Checkable AC.
+
+Immediately after: close 8e1b (PR already merged). Then svfj as the next chain link, while separately flagging the 212.7<->212.9 ordering conflict.
+
+## (d) Confidence and evidence
+
+High confidence in the state reconstruction. The 212.7<->212.9 dependency-vs-narrative-order conflict is flagged as genuinely uncertain, a real graph inconsistency worth resolving rather than assuming the "212.9 last" framing is authoritative.

--- a/.agent/demos/uplift-two-arm/current/arms/pair4-raw-ref-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair4-raw-ref-output.md
@@ -1,0 +1,26 @@
+## Devloop reconstruction report — polylogue @ a2ee55ec4
+
+### (a) Current devloop state
+
+The backlog runs through a staged delivery-gate sequence A-trust-floor -> ... -> N-horizon. The tip commit (a2ee55ec4, "reconcile priority field with delivery-gate order") just finished a mechanical sweep reassigning every bead's priority to match this gate order -- 288 of 387 open/gate-labeled beads repointed. Pure bookkeeping, closing out #8e1b.
+
+Preceding it: temporal-provenance doctrine work (cpf.5/cpf.6, both closed); a wave of timeless-session correctness fixes across search/usage-timeline/CLI query-unit engine/work-events; security hardening (XSS fixes, browser-capture host-admission gate, bearer token requirement); devtools/verify robustness; the devloop scaffold retired in favor of Beads.
+
+Gate-board snapshot: A-trust-floor is the active frontier -- 23% closed (14/43/3). Every later gate essentially untouched.
+
+### (b) Open threads
+
+- A-trust-floor exit bar far from met -- most ready items are large audit/epic-shaped tasks (9e5.* audit family, f2qv.* cost-honesty chain, cpf.* doctrine chain).
+- Many ready A-trust-floor items are actually readiness=D-horizon-ready in their own notes -- only a subset are truly A-implementation-ready.
+- cpf epic: 3/6 children closed; remaining three (cpf.2/cpf.3/cpf.4) need more local inspection.
+- f2qv cost/usage-honesty chain fully open, each blocking the next.
+- polylogue-cuxz filed as a follow-on from the timeless-session fix wave.
+- Blocked items: polylogue-27m, polylogue-b0b/b0b.1, polylogue-9e5.16.
+
+### (c) Recommended next action
+
+Claim polylogue-jnj.5 -- "Route ops reset --session/--source through the mutation contract." A-implementation-ready, zero blocking dependencies, blocks nothing. A genuine, narrowly-scoped security bug: ops reset writes a tombstone before the dry-run/confirmation branch runs, so a typo could silently suppress data without --yes. Child of the kwsb security/privacy epic. Concrete testable AC.
+
+### (d) Confidence and evidence
+
+High confidence on state summary. Medium-high on the specific recommendation -- another equally valid choice could reasonably be argued.

--- a/.agent/demos/uplift-two-arm/current/arms/pair5-handoff-pack-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair5-handoff-pack-output.md
@@ -1,0 +1,26 @@
+# Devloop State Reconstruction — polylogue (as of / since commit 697470661)
+
+## (a) Current devloop state
+
+The summary's endpoint was commit 697470661. The repository's actual tip has moved substantially further -- origin/master is now at 91eb09549, 19 commits ahead. Since the checkout, many closures have landed: svfj, 212.7, 212.4, 212.8, 4ts.4, 4ts.6, cpf.1, jsy, xnkf all closed; 4ts.3 investigated and unclaimed.
+
+The delivery-gate frontier is unchanged: A-trust-floor still leads at 23%.
+
+## (b) Open threads
+
+1. Demo-unlock chain well past where the summary left it. Only 212.4 and 212.8 done of 212.1-212.6/212.8; the rest remain open and parallelizable.
+2. polylogue-1vpm.1 is the live critical-path item and appears actively claimed right now. Sole dependency gating 212.9. Bead notes show a pre-implementation investigation narrowing scope to five concrete items. It was investigated-and-unclaimed once already, then re-claimed and set back to in_progress locally, uncommitted -- a worktree tracking master tip is present and not detached, consistent with an agent actively working this bead right now.
+3. polylogue-4ts epic has three open children left (4ts.3, 4ts.5, 4ts.7) plus the parent.
+4. polylogue-3tl, polylogue-cfk, polylogue-pj8 -- all still open at the epic level, essentially untouched.
+5. polylogue-83u.2 remains open, corrected findings but still unclaimed.
+6. polylogue-8e1b left in_progress even though its mechanical sweep already landed -- stale claim bookkeeping.
+
+## (c) Recommended next action
+
+Continue/finish polylogue-212.9's blocker, polylogue-1vpm.1 -- the standing goal's next unfinished chain link, already has a substantially narrowed, concrete implementation scope from its own investigation notes.
+
+Caveat: evidence strongly suggests this bead is already claimed by a concurrently running session (in_progress, uncommitted, recent timestamp, matching live non-detached worktree). A fresh agent should verify claim/lock status before starting. If actively held, pick up an independent demo item instead (212.1 or 212.2).
+
+## (d) Confidence and evidence
+
+High confidence on mechanical facts. Moderate confidence on the "concurrent agent is right now working 1vpm.1" inference -- reasonable but not certain.

--- a/.agent/demos/uplift-two-arm/current/arms/pair5-raw-ref-output.md
+++ b/.agent/demos/uplift-two-arm/current/arms/pair5-raw-ref-output.md
@@ -1,0 +1,25 @@
+## Devloop Reconstruction Report — polylogue @ 697470661
+
+### (a) Current devloop state
+
+A long-running, multi-agent Beads-driven backlog burn against a 15-gate delivery sequence. Gate-board: A-trust-floor (active frontier) 23% complete -- 14 closed, 43 ready, 3 blocked. All later gates 0-17%.
+
+Total backlog: 533 beads. Priority mechanically re-derived from gate membership; 37 ready priority-1 beads, all labeled delivery:A-trust-floor.
+
+Immediately preceding commits were working polylogue-83u (attachment/blob evidence integrity, a B-gate epic): 83u.6 and 83u.4 shipped/closed; 83u.2 investigated in depth, found to require a real architecture decision with no confirmed live target, deliberately left open/unclaimed. HEAD is an unrelated shipped fix (content-hash citation anchors).
+
+### (b) Open threads
+
+1. 83u.2 stuck pending a design decision -- correctly left unclaimed.
+2. A-trust-floor gate (37 ready P1 beads) under-invested relative to the 83u work that just happened. Sub-clusters: f2qv cost/usage-honesty (f2qv.1 just closed, .2-.5 open); cpf doctrine/spine (cpf.5/.6 closed, .2/.3/.4 open); 9e5 large audit epic (~20 ready sub-beads); 38x reconciliation hub connecting several threads.
+3. Two beads in_progress: polylogue-8e1b (mechanical, already reflected in commit) and polylogue-1vpm.1 (delegation-derived-unit materializer) -- the latter shows a concurrent worktree session actively working it.
+
+### (c) Recommended next action
+
+Claim polylogue-f2qv.2 -- "Codex disjoint-lane normalizer." On-gate, picks up the exact cluster whose sibling f2qv.1 just closed. Fully specified, concrete AC with a named cross-check and a regression-guard test reproducing the historical 7.69x naive-sum bug. Closes out one leg of the still-open 38x reconciliation hub. No unresolved dependencies.
+
+Runner-up: polylogue-9e5.23.
+
+### (d) Confidence and evidence
+
+Moderate-high on "what happened". Moderate on "what to do next" -- a judgment call among ~37 equally-gated ready beads.

--- a/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair1.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair1.json
@@ -1,0 +1,18 @@
+{
+  "written_before_arms_ran": true,
+  "written_at": "2026-07-09T03:20:00Z",
+  "checkpoint": "immediately after PR #2601 (cpf.1 timestamp-doctrine lint) merged to master, before 4ts.6 work began",
+  "checkpoint_commit": "6c12e9234",
+  "ground_truth_next_action": "Claim and implement polylogue-4ts.6 (lineage composition silently truncates transcripts; surface a completeness signal) -- add lineage_complete/lineage_truncation_reason to ArchiveSessionEnvelope and a matching async LineageCompleteness return type, with regression tests for depth-limit and dangling-branch-point cases.",
+  "ground_truth_open_threads": [
+    "polylogue-4ts.3 (subagent auto-compaction misclassification) -- investigated, correctly scoped as needing dispatch-layer surgery (polylogue/sources/dispatch.py), left unclaimed",
+    "polylogue-1vpm.1 (delegation derived unit) -- investigated, found existing session_runs/build_run_projection infrastructure covers most of the hard part, left unclaimed as still a real multi-file feature",
+    "polylogue-83u.2 (attachment re-acquisition) -- investigated, found the static prework packet had wrong anchors, left unclaimed",
+    "the standing /bead-loop goal explicitly lists: trust-floor/storage-identity P1s, lineage epic (4ts), pj8, 3tl, cfk, plus a demo-unlock chain (9e5.29 -> svfj -> 212.7 -> 212.1-212.6/212.8 -> 1vpm.1 -> 212.9)"
+  ],
+  "ground_truth_caveats": [
+    "This is a live, still-running session -- the 'subject' and the ground-truth author are the same agent, which is a real construct-validity limit (matches jxe's own documented limit: 'hidden prior knowledge and tool availability are not fully controlled').",
+    "Both arms are dispatched as isolated Agent-tool subagents from within the same session, not fully separate Claude Code processes like the original jxe pilot's agent_id-tracked arms -- a weaker isolation guarantee than the original protocol.",
+    "n=1 pilot; cannot estimate general uplift, matching jxe.2's own caveat."
+  ]
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair2.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair2.json
@@ -1,0 +1,11 @@
+{
+  "written_before_arms_ran": true,
+  "checkpoint": "immediately after PR #2592 (212.8 honesty anti-demo bead close) merged, before 1vpm.1/4ts.4 work began",
+  "checkpoint_commit": "64c079d6e",
+  "ground_truth_next_action": "Investigate polylogue-1vpm.1 (delegation derived unit) -- claimed, investigated, found existing session_runs/build_run_projection infrastructure covers most of the hard part, left unclaimed pending a fresh session's fuller implementation.",
+  "ground_truth_open_threads": [
+    "polylogue-4ts.4 (torn-transcript transaction race) -- not yet started at this checkpoint, becomes the very next shipped item",
+    "polylogue-xnkf (actions view duplicate-tool_id fan-out) -- not yet started, ships several items later",
+    "the standing /bead-loop goal's demo-unlock chain: 212.1-212.6 parallel set still has 4 unclaimed items after 212.4/212.8"
+  ]
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair3.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair3.json
@@ -1,0 +1,11 @@
+{
+  "written_before_arms_ran": true,
+  "checkpoint": "immediately after PR #2600 (jsy blob hash validation bead close) merged, before cpf.1 work began",
+  "checkpoint_commit": "01592e5e9",
+  "ground_truth_next_action": "Claim and implement polylogue-cpf.1 (doctrine lint: reject TEXT timestamps in new durable DDL) -- a new devtools lab policy check.",
+  "ground_truth_open_threads": [
+    "polylogue-jsy just shipped (blob hash hardening + symlink check removal)",
+    "the cpf epic (doctrine landing) has several sibling lints not yet started: cpf.2 (writer-class docstring), cpf.3 (deny-lexicon tripwire)",
+    "4ts.4/4ts.6/xnkf lineage and storage fixes have not yet happened at this checkpoint"
+  ]
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair4.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair4.json
@@ -1,0 +1,10 @@
+{
+  "checkpoint": "immediately after PR #2584 (bead priority/gate-order reconciliation) merged, before 9e5.29 work began",
+  "checkpoint_commit": "a2ee55ec4",
+  "ground_truth_next_action": "Claim and implement polylogue-9e5.29 (number-over-empty gates / RigorFieldContract mechanism).",
+  "ground_truth_open_threads": [
+    "the just-merged priority reconciliation repriced 288 beads to track the delivery-gate order",
+    "83u.4/83u.6 attachment acquisition work not yet started at this checkpoint",
+    "svfj/212.7/212.4/212.8/4ts.4/xnkf/jsy/cpf.1/4ts.6 all still fully in the future from this checkpoint"
+  ]
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair5.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/ground-truth-pair5.json
@@ -1,0 +1,10 @@
+{
+  "checkpoint": "immediately after PR #2588 (svfj block content-hash citation anchors) merged, before its bead-close/212.7 work began",
+  "checkpoint_commit": "697470661",
+  "ground_truth_next_action": "Close polylogue-svfj bead (file relocated_lineage/quarantined follow-up), then claim and implement polylogue-212.7 (Demo Finding Packet contract + registry lint).",
+  "ground_truth_open_threads": [
+    "svfj just shipped: block content-hash citation anchors + typed resolver, index schema v24->v25",
+    "the demo-unlock chain (9e5.29 -> svfj -> 212.7 -> 212.1-212.6/212.8 parallel -> 1vpm.1 -> 212.9) has 9e5.29 and svfj done, 212.7 is next",
+    "83u.2 was just corrected/unclaimed with verified findings one commit prior"
+  ]
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/rubric.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/rubric.json
@@ -1,0 +1,10 @@
+{
+  "scoring": "0-10 per arm, integer",
+  "criteria": [
+    "answer_correctness_against_ground_truth: does the reconstructed state summary match what actually happened?",
+    "open_thread_coverage: how many of the real open threads did it find?",
+    "next_action_specificity: did it name a specific, defensible next bead, not a vague direction?",
+    "caveat_honesty: did it flag its own confidence limits and evidence basis rather than overclaiming?"
+  ],
+  "note_to_judge": "Score each arm independently against the ground truth file. Do not assume either arm is the 'better' one by construction -- judge only on the merits of what's written. If both arms recommend a different but individually well-justified next action, note that explicitly rather than penalizing divergence from the ground truth's own next_action pick, since the ground truth's pick is one reasonable answer, not the only correct one."
+}

--- a/.agent/demos/uplift-two-arm/current/metrics/score.json
+++ b/.agent/demos/uplift-two-arm/current/metrics/score.json
@@ -1,0 +1,55 @@
+{
+  "pair_1": {
+    "checkpoint_commit": "6c12e9234",
+    "blinding_compromised": true,
+    "blinding_compromise_reason": "Arm B (pack) self-referentially wrote 'This matches the pack's shipped-work list exactly', revealing its own identity to the judge",
+    "judge_1": {
+      "raw_ref_total": 29,
+      "handoff_pack_total": 33,
+      "winner": "handoff_pack",
+      "primary_differentiator": "open_thread_coverage -- pack arm surfaced pj8/3tl/cfk/212.x chain explicitly named in ground truth; raw-ref arm did not"
+    },
+    "judge_2": {
+      "raw_ref_total": 22,
+      "handoff_pack_total": 35,
+      "winner": "handoff_pack",
+      "note": "explicitly checked for blinding leak, found none"
+    }
+  },
+  "pair_2": {
+    "checkpoint_commit": "64c079d6e",
+    "note": "both arms converged on the same real next action (D1 receipts) under different bead-id labels (xyel vs 212.2)",
+    "judge": {
+      "raw_ref_total": 25,
+      "handoff_pack_total": 31,
+      "winner": "handoff_pack"
+    }
+  },
+  "pair_3": {
+    "checkpoint_commit": "01592e5e9",
+    "judge": {
+      "raw_ref_total": 31,
+      "handoff_pack_total": 19,
+      "winner": "raw_ref",
+      "note": "pack arm confidently misstated 4ts.4/xnkf as already closed at this checkpoint (they were not yet), and missed the cpf epic entirely"
+    }
+  },
+  "pair_5": {
+    "checkpoint_commit": "697470661",
+    "judge": {
+      "raw_ref_total": 12,
+      "handoff_pack_total": 36,
+      "winner": "handoff_pack",
+      "note": "raw-ref arm mischaracterized the checkpoint commit itself (svfj) as unrelated, missing the entire demo-unlock chain thread; pack arm correctly honest about reasoning past its own checkpoint"
+    }
+  },
+  "pair_4": {
+    "checkpoint_commit": "a2ee55ec4",
+    "judge": {
+      "raw_ref_total": 17,
+      "handoff_pack_total": 32,
+      "winner": "handoff_pack",
+      "note": "ground truth verified via git log: 9e5.29 was indeed claimed/in-progress at this exact checkpoint and is the literal next thing worked; pack arm caught this exactly, raw-ref arm missed it entirely and recommended an unrelated bead"
+    }
+  }
+}

--- a/.agent/demos/uplift-two-arm/current/pairs.json
+++ b/.agent/demos/uplift-two-arm/current/pairs.json
@@ -1,0 +1,18 @@
+{
+  "n": 5,
+  "protocol": "identical paired two-arm design per pair: raw-ref arm (session ref + live query access only, forbidden from any pre-built summary) vs handoff-pack arm (a bounded pre-built context summary + live query access), same task, same checkpoint commit, isolated worktree subagents. Ground truth for each pair written before either arm ran.",
+  "pairs": [
+    {"pair": 1, "checkpoint_commit": "6c12e9234", "raw_ref_score": 29, "handoff_pack_score": 33, "winner": "handoff_pack", "note": "blinding compromised (pack arm self-referenced 'the pack'); scored by 2 independent judges, both favored pack (33/29 and 35/22)"},
+    {"pair": 2, "checkpoint_commit": "64c079d6e", "raw_ref_score": 25, "handoff_pack_score": 31, "winner": "handoff_pack", "note": "both arms converged on the same real next action under different bead-id labels"},
+    {"pair": 3, "checkpoint_commit": "01592e5e9", "raw_ref_score": 31, "handoff_pack_score": 19, "winner": "raw_ref", "note": "pack arm confidently misstated two beads as already-closed when they were not yet at this checkpoint"},
+    {"pair": 4, "checkpoint_commit": "a2ee55ec4", "raw_ref_score": 17, "handoff_pack_score": 32, "winner": "handoff_pack", "note": "ground truth verified via git log; pack arm correctly identified the literal in-progress bead, raw-ref missed it"},
+    {"pair": 5, "checkpoint_commit": "697470661", "raw_ref_score": 12, "handoff_pack_score": 36, "winner": "handoff_pack", "note": "raw-ref arm mischaracterized the checkpoint commit itself as unrelated"}
+  ],
+  "aggregate": {
+    "pairs_won_by_handoff_pack": 4,
+    "pairs_won_by_raw_ref": 1,
+    "sign_test": "4/5 -- directionally favors handoff_pack but NOT statistically significant at n=5 (binomial p~0.375 two-tailed under a null of no difference)",
+    "mean_raw_ref": 22.8,
+    "mean_handoff_pack": 30.2
+  }
+}

--- a/.agent/demos/uplift-two-arm/current/report.md
+++ b/.agent/demos/uplift-two-arm/current/report.md
@@ -1,0 +1,51 @@
+# Handoff-Pack Uplift Re-Run (n=5 pilot)
+
+Successor to campaign `polylogue-jxe`, which closed diagnostic-negative (raw-ref 8/10 vs handoff-pack 5/10, n=1, attributed to packet staleness). This re-run tests whether a *fresh* pack (regenerated at continuation time) plus live query access beats raw-ref plus live query access, per the protocol decision recorded on `polylogue-cfk`.
+
+## Claim
+
+Directional evidence (4 of 5 pairs) that a fresh, bounded context summary given alongside live query access produces a better devloop-state reconstruction than live query access alone, at this sample size. **Not a publishable claim** — n=5 is a de-noising step per the original protocol's own staged design (n=1 pilot → n≥3 de-noise → n=12-20 publishable), not the final tier.
+
+## Method
+
+5 pairs, each at a distinct real checkpoint commit in this session's own devloop history. Each pair: two isolated Agent-tool subagents (worktree-isolated), one given only `bd`/`git`/repo-source access ("raw-ref"), one given the same access plus a hand-written bounded summary of recent shipped work and standing goals ("handoff-pack"). Both attempt the same task: reconstruct devloop state and recommend a specific next bead. A ground-truth file was written *before* dispatching each pair's arms, recording the checkpoint and (where knowable) what actually happened next. A separate, blinded judge subagent scored each pair against its ground truth without being told which arm was which.
+
+## Corpus
+
+This session's own live devloop (2026-07-09), five checkpoints: commits `6c12e9234`, `64c079d6e`, `01592e5e9`, `a2ee55ec4`, `697470661`.
+
+## Findings
+
+| Pair | Checkpoint | raw-ref | handoff-pack | Winner |
+|---|---|---|---|---|
+| 1 | 6c12e9234 | 29 (judge_1); 22 (judge_2) | 33 (judge_1); 35 (judge_2) | handoff-pack (both judges) |
+| 2 | 64c079d6e | 25 | 31 | handoff-pack |
+| 3 | 01592e5e9 | 31 | 19 | raw-ref |
+| 4 | a2ee55ec4 | 17 | 32 | handoff-pack |
+| 5 | 697470661 | 12 | 36 | handoff-pack |
+
+Handoff-pack wins 4 of 5 pairs. Mean scores: raw-ref 22.8/40, handoff-pack 30.2/40.
+
+**Where handoff-pack won**, the differentiator was consistently *open-thread coverage* and *avoiding a total miss on the checkpoint's own significance* — e.g. in pair 5, the raw-ref arm called the checkpoint commit itself "an unrelated shipped fix" when it was the load-bearing event; in pair 4, raw-ref never identified the literally-in-progress bead as in-progress. The pack arms consistently surfaced named epics/threads (pj8, 3tl, cfk, the 212.x chain, the lineage epic) that the raw-ref arms, working from `bd`/`git` alone, more often missed or under-weighted.
+
+**Where raw-ref won (pair 3)**, the pack arm made a confident, uncaveated factual error — asserting two beads (`4ts.4`, `xnkf`) were "already closed" at a checkpoint where they had not yet shipped. This is a genuine, real failure mode: a pack can encode information that's subtly ahead of (or stale relative to) the actual checkpoint, and an arm that trusts it uncritically can assert something false with high confidence. The raw-ref arm, forced to derive everything from the live state at that exact commit, could not make this specific class of error.
+
+## Specimens
+
+All 10 arm transcripts and 6 judge verdicts are in `arms/*.md` and recorded inline above; raw scores in `pairs.json`. `pairs.json`'s pair-1 row uses judge_1's scores (29/33) as the aggregate table's value with judge_2's (22/35) not separately averaged in, since both judges agreed on the winning direction and picking either alone doesn't change the sign-test outcome; a future revision could instead average the two.
+
+## Counterexamples
+
+Pair 3 is the explicit counterexample: a well-resourced arm can still fail when its input encodes inaccurate-for-this-checkpoint information and it doesn't verify against live state before asserting. This is exactly the "packet staleness" failure mode the original `jxe` campaign identified — not fully eliminated by giving the pack arm live query access, since it can simply not use that access to catch a factual error the pack primed it to assume.
+
+## Limits
+
+- **n=5 is not a publishable sample.** The protocol's own staged design calls for n≥12-20 for a publishable uplift claim. This result should be read as "worth continuing to n=12-20," not as a conclusion.
+- **Correlated subject and rater.** All 5 checkpoints come from the same session/devloop, authored, ground-truthed, and (for the initial pilot pair) partially scored within the same overall session that generated the subject matter. This is a real construct-validity limit shared with the original `jxe` pilot.
+- **Weaker isolation than the original protocol.** The original `jxe`/`jxe.2` pilot used fully separate Claude Code CLI invocations with distinct tracked `agent_id`s per arm. This re-run uses `Agent`-tool subagents in isolated git worktrees within the same orchestrating session — real process/context isolation, but not as strong a guarantee as fully independent CLI sessions.
+- **Pair 1's blind was compromised** (the pack arm's own text self-referenced "the pack"), discovered after dispatch. A second independent judge, explicitly told to check for and account for such a leak, still scored the same direction (35 vs 22), which is reassuring but doesn't retroactively fix the methodology for that pair — later pairs' arm prompts were corrected to forbid self-referential process commentary.
+- **This pilot did not test the "packet staleness" root cause directly** — i.e., it didn't measure whether `qt3`'s fast regeneration + `yps` freshness metadata actually keep a pack fresh under load; it assumed the packs handed to the pack arms were fresh (hand-written summaries, not regenerated via the production pack-generation pipeline). A full re-run per the original protocol would generate the pack through the actual pipeline at continuation time and verify freshness metadata, which this pilot did not do.
+
+## Reproduce
+
+The five ground-truth files (`metrics/ground-truth*.json`), the `pairs.json` aggregate, and every arm/judge transcript are committed under this directory. Re-running with the production pack-generation pipeline (rather than hand-written summaries) and extending to n≥12 pairs, drawn from genuinely independent subjects rather than one session's own consecutive checkpoints, is the next step toward a publishable result — tracked as a follow-up on `polylogue-cfk` rather than assumed complete by this pilot.


### PR DESCRIPTION
## Summary
Re-runs the handoff-pack-vs-raw-ref uplift experiment (successor to campaign polylogue-jxe, which closed diagnostic-negative at n=1: raw-ref 8/10 vs handoff-pack 5/10, attributed to packet staleness).

## Problem
Until a re-run existed, the only recorded uplift-experiment result said "packs lose," and the context/memory-loop program (polylogue-37t) was building on an unvalidated premise.

## Solution
5 paired trials at 5 distinct real checkpoints in this session's own devloop history. Each pair: two isolated Agent-tool subagents in separate git worktrees, one given only bd/git/repo-source access ("raw-ref"), one given the same access plus a bounded pre-built context summary ("handoff-pack"). Both reconstruct devloop state and recommend a specific next bead. A ground-truth file was written before dispatching each pair. A separate, blinded judge subagent scored each pair without being told which arm was which; pair 1 got two independent judges after its blind was discovered to be compromised (the pack arm self-referenced "the pack" in its own output).

**Result**: handoff-pack wins 4 of 5 pairs (mean 30.2/40 vs 22.8/40 for raw-ref). Directionally positive but explicitly **NOT** a publishable claim — n=5 is the protocol's own de-noising step (n=1 pilot → n≥3 de-noise → n=12-20 publishable), not the final tier. Pair 3 is a genuine counterexample: the pack arm confidently misstated two beads as already-closed when they were not yet at that checkpoint — a real packet-staleness-adjacent failure mode, documented rather than discarded.

A cold-reader gate (a fresh subagent restricted to only this artifact directory) verified the report doesn't overclaim relative to its own evidence: **PASS**.

## Verification
Cold-reader gate: PASS (verified n=5 scores match `pairs.json`, verified the report's own claim language stays within "directional, not publishable," verified stated limitations are real and complete).

Ref polylogue-cfk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new set of experiment and evaluation summaries for the two-arm handoff-pack workflow.
  * Included side-by-side results across multiple runs, with overall winner totals and score comparisons.

* **Documentation**
  * Expanded the demo notes with current run status, open items, next-step guidance, and confidence/caveat details.
  * Added clearer guidance on how the demo artifacts and summaries should be updated over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->