### PR TITLE
fix: harden cloud bootstrap for sandbox lanes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,9 @@
   "env": {
     "POLYLOGUE_ARCHIVE_ROOT": "/tmp/polylogue-archive",
     "POLYLOGUE_FORCE_PLAIN": "1",
-    "HYPOTHESIS_PROFILE": "ci"
+    "HYPOTHESIS_PROFILE": "ci",
+    "POLYLOGUE_PYTEST_WORKERS": "2",
+    "POLYLOGUE_PYTEST_BASETEMP_ROOT": "/tmp/polylogue-pytest"
   },
   "permissions": {
     "allow": [

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -13,8 +13,14 @@ fi
 uv sync --extra dev --frozen
 
 # Pre-warm: render checks so the docs surface compiles cleanly.
-# Non-fatal so a render mismatch does not block the sandbox starting.
-uv run devtools render-all --check 2>/dev/null || true
+# Non-fatal so a render mismatch does not block the sandbox starting, but the
+# failure must stay visible — a silent pre-warm is worse than none.
+if ! uv run devtools render all --check; then
+  echo "WARNING: 'devtools render all --check' exited nonzero — inspect the output" >&2
+  echo "WARNING: above; branch verification will classify the failure." >&2
+fi
 
-# Workspace dirs (matches POLYLOGUE_ARCHIVE_ROOT in .claude/settings.json).
+# Workspace dirs (matches POLYLOGUE_ARCHIVE_ROOT and
+# POLYLOGUE_PYTEST_BASETEMP_ROOT in .claude/settings.json).
 mkdir -p /tmp/polylogue-archive/inbox /tmp/polylogue-archive/blob
+mkdir -p /tmp/polylogue-pytest

--- a/docs/cloud-agents.md
+++ b/docs/cloud-agents.md
@@ -61,11 +61,13 @@ Codex Cloud reads `AGENTS.md` for repo-scoped guidance, but its sandbox env
 vars are configured outside the repo, in the Codex Cloud environment-settings
 panel. Mirror the values from `.claude/settings.json` there:
 
-| Variable                    | Value                     | Why                                               |
-| --------------------------- | ------------------------- | ------------------------------------------------- |
-| `POLYLOGUE_ARCHIVE_ROOT`    | `/tmp/polylogue-archive`  | Keeps writes inside the sandbox tmpfs.            |
-| `POLYLOGUE_FORCE_PLAIN`     | `1`                       | Disables Rich pretty-printers (matches CI).       |
-| `HYPOTHESIS_PROFILE`        | `ci`                      | Bounded property-test budget.                     |
+| Variable                          | Value                     | Why                                                          |
+| --------------------------------- | ------------------------- | ------------------------------------------------------------ |
+| `POLYLOGUE_ARCHIVE_ROOT`          | `/tmp/polylogue-archive`  | Keeps writes inside the sandbox tmpfs.                        |
+| `POLYLOGUE_FORCE_PLAIN`           | `1`                       | Disables Rich pretty-printers (matches CI).                   |
+| `HYPOTHESIS_PROFILE`              | `ci`                      | Bounded property-test budget.                                 |
+| `POLYLOGUE_PYTEST_WORKERS`        | `2`                       | Caps xdist workers for ~4-vCPU/16 GB sandboxes.               |
+| `POLYLOGUE_PYTEST_BASETEMP_ROOT`  | `/tmp/polylogue-pytest`   | Pytest temp DBs in sandbox tmp, not the local `/realm/tmp`.   |
 
 If Codex Cloud supports a per-environment bootstrap script, point it at
 `.claude/setup.sh` (or paste its contents) so `uv` is installed and dev deps


### PR DESCRIPTION
## Summary
Repairs the three cloud-runway defects found in the 2026-07-10 audit so Claude Code Web / Codex Cloud lanes can launch against a truthful bootstrap: real render command with visible (cause-neutral) failure, bounded pytest workers/basetemp for 4-vCPU/16 GB sandboxes, and the basetemp dir created at setup.

## Problem
`.claude/setup.sh` invoked a nonexistent `devtools render-all --check` and swallowed the failure (`2>/dev/null || true`) — the pre-warm claimed success for a command that never ran. `.claude/settings.json` left pytest xdist unbounded in small sandboxes and inherited the local `/realm/tmp` basetemp convention; setup never created the pytest temp root.

## Solution
- `.claude/setup.sh`: correct command form `devtools render all --check`; nonfatal but prints an explicit cause-neutral WARNING on nonzero exit (per review: render can fail for reasons other than drift — branch verification classifies it); `mkdir -p /tmp/polylogue-pytest`.
- `.claude/settings.json`: `POLYLOGUE_PYTEST_WORKERS=2`, `POLYLOGUE_PYTEST_BASETEMP_ROOT=/tmp/polylogue-pytest` (consumed by `devtools/verify.py:128`, `devtools/verify_runs.py:370`).
- `docs/cloud-agents.md`: Codex Cloud env-mirror table gains both variables.

Deliberately excluded: automatic testmon seeding (needs a measured sandbox benchmark first).

Bead: polylogue-ooqh. Executor packet `/realm/inbox/gpt-pro-sol/polylogue-cloud/04-cloud-bootstrap-hardening.md` is superseded by this local fix.

## Verification
- `bash -n .claude/setup.sh` — pass
- `python3 -c "json.load(...)"` asserts both new env keys — pass
- `grep` confirms no `2>/dev/null` on the render check; correct command form present
- `uv run devtools verify --quick` in the worktree — exit 0 (13 steps, 39.4s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring parallel test workers and a dedicated temporary test directory in cloud development environments.

* **Chores**
  * Improved environment setup checks with visible warnings when pre-warming fails.
  * Added automatic creation of the dedicated test workspace directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->