### PR TITLE
fix: stamp focused test runs with git head

### DIFF
--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -40,7 +40,7 @@ from devtools.verify import (
     _clear_pytest_report,
     _run,
 )
-from devtools.verify_runs import VerifyRun
+from devtools.verify_runs import VerifyRun, git_head
 
 ROOT = Path(__file__).resolve().parent.parent
 _LOCK_PATH = ROOT / ".cache" / "test-run.lock"
@@ -135,7 +135,7 @@ def main(argv: list[str] | None = None) -> int:
     no_lock = os.environ.get("POLYLOGUE_TEST_NO_LOCK") == "1"
     with _run_lock(enabled=not no_lock):
         _clear_pytest_report(cmd)
-        run = VerifyRun(tier="focused-test", argv=selection, git_head=None, root=ROOT)
+        run = VerifyRun(tier="focused-test", argv=selection, git_head=git_head(ROOT), root=ROOT)
         started = time.monotonic()
         rc, _elapsed, metadata = _run("pytest focused", cmd, cwd=str(ROOT), run=run)
         run.finish(exit_code=rc, duration_s=time.monotonic() - started, diagnosis=metadata.get("diagnosis"))

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -85,6 +85,29 @@ def git_dirty() -> bool:
     return bool(result.stdout.strip())
 
 
+def git_head(cwd: Path | None = None) -> str | None:
+    """Return the current checkout HEAD, or ``None`` when git is unavailable.
+
+    Verification artifacts are evidence, not a reason to fail the user's test
+    run. Keep the probe bounded and nullable so non-git archives, missing git
+    executables, and wedged git commands preserve honest ``null`` metadata.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    head = result.stdout.strip()
+    return head or None
+
+
 @dataclass(frozen=True)
 class PytestStepArtifacts:
     step_id: str

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,7 @@ import pytest
 
 from devtools import run_tests
 from devtools.verify import PYTEST_EVENTS_PATH, PYTEST_SELECTION_PATH, PYTEST_SUMMARY_PATH
+from devtools.verify_runs import git_head
 
 
 def test_build_pytest_cmd_defaults_to_single_process() -> None:
@@ -57,11 +59,14 @@ def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run", _fake_run)
+    monkeypatch.setattr("devtools.run_tests.git_head", lambda _root: "abc123")
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
     assert captured["label"] == "pytest focused"
     assert captured["run"].run_id
+    assert captured["run"]._payload["git_head"] == "abc123"
+    assert isinstance(captured["run"]._payload["git_dirty"], bool)
 
 
 def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -72,6 +77,33 @@ def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
+
+
+def test_git_head_records_checkout_head(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert cmd == ["git", "rev-parse", "HEAD"]
+        assert kwargs["cwd"] == tmp_path
+        assert kwargs["timeout"] == 5
+        return subprocess.CompletedProcess(cmd, 0, stdout="deadbeef\n", stderr="")
+
+    monkeypatch.setattr("devtools.verify_runs.subprocess.run", _fake_run)
+    assert git_head(tmp_path) == "deadbeef"
+
+
+def test_git_head_degrades_to_none_without_git(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="not a git repository")
+
+    monkeypatch.setattr("devtools.verify_runs.subprocess.run", _fake_run)
+    assert git_head(tmp_path) is None
+
+
+def test_git_head_degrades_to_none_when_probe_cannot_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise OSError("git missing")
+
+    monkeypatch.setattr("devtools.verify_runs.subprocess.run", _fake_run)
+    assert git_head(tmp_path) is None
 
 
 def test_managed_env_sets_repo_roots() -> None:


### PR DESCRIPTION
## Summary

Stamp `devtools test` focused-run artifacts with the checkout HEAD using a bounded nullable git probe. Ref polylogue-k6fm.

## Problem

Focused runs carry per-test events but recorded `git_head: null`, so the flakiness ledger cannot distinguish same-commit pass/fail evidence. Other verification tiers already record commit identity.

## Solution

- add a bounded `git_head()` probe that degrades to `None` for non-git, missing-git, or stalled probes;
- pass the checkout-root HEAD into focused `VerifyRun` records;
- cover successful, non-git, and missing-git probes plus payload stamping and the existing boolean dirty field.

This was the first task executed through the new Codex Cloud `polylogue` environment. The cloud result was recovered through `codex cloud diff/apply`, reviewed locally, and published through the normal feature-branch flow.

## Verification

- `devtools test tests/unit/devtools/test_run_tests.py` -> `10 passed in 1.04s`
- focused artifact `20260710T052156Z-focused-test-372579-e0424b4c/run.json` -> `git_head=c68585b8bf3a8e83f57faa364fff108a23ed504a`, `git_dirty=true`, `status=success`
- `devtools verify --quick` -> all 13 steps passed; run `20260710T052207Z-quick-373416-37501139`
- pre-push `devtools verify --quick` on commit `6f3de88ee` -> all 13 steps passed; run `20260710T052551Z-quick-387837-bcf8cb36`

The cloud sandbox's quick gate was not accepted as proof: a plain executable resolved outside the synced uv environment and produced inherited mypy/sqlite-extension failures. Local managed verification is green, and future cloud packets now require `uv run devtools ...`.