### PR TITLE
fix: classify blockless thinking messages as reasoning

### DIFF
--- a/polylogue/archive/message/model_runtime.py
+++ b/polylogue/archive/message/model_runtime.py
@@ -162,7 +162,7 @@ class MessageRuntimeMixin:
         if text:
             match = re.search(r"<(?:antml:)?thinking>(.*?)</(?:antml:)?thinking>", text, re.DOTALL)
             if match:
-                return match.group(1).strip()
+                return match.group(1).strip() or None
 
         return None
 

--- a/polylogue/archive/semantic/content_projection.py
+++ b/polylogue/archive/semantic/content_projection.py
@@ -224,6 +224,8 @@ def _segments_for_message(
 
 def _whole_message_kind(message: Message, *, has_content_blocks: bool) -> ContentKind | None:
     message_type = MessageType.normalize(getattr(message, "message_type", MessageType.MESSAGE))
+    if message_type is MessageType.THINKING:
+        return None
     if not has_content_blocks and (message_type == MessageType.TOOL_RESULT or message.role == Role.TOOL):
         return ContentKind.TOOL_OUTPUT
     if (
@@ -274,6 +276,14 @@ def _segments_from_text(message: Message) -> list[_Segment]:
     text = (message.text or "").strip()
     if not text:
         return []
+    message_type = MessageType.normalize(getattr(message, "message_type", MessageType.MESSAGE))
+    if message_type is MessageType.THINKING:
+        thinking = message.extract_thinking()
+        if thinking:
+            return [_Segment(ContentKind.REASONING, thinking)]
+        if _THINKING_PATTERN.search(text):
+            return []
+        return [_Segment(ContentKind.REASONING, text)]
     if message.role == Role.TOOL or message.is_tool_use:
         return [_Segment(ContentKind.TOOL_OUTPUT, text)]
     if not message.is_authored_prose:
@@ -282,7 +292,7 @@ def _segments_from_text(message: Message) -> list[_Segment]:
         return [_Segment(ContentKind.SYSTEM_NOISE, text)]
 
     segments = _segments_from_inline_text(text)
-    if segments:
+    if segments or _THINKING_PATTERN.search(text):
         return segments
 
     if message.is_thinking:

--- a/tests/unit/core/test_content_projection.py
+++ b/tests/unit/core/test_content_projection.py
@@ -81,6 +81,32 @@ def test_prose_only_uses_text_fallback_and_preserves_order() -> None:
     assert message.text == "Alpha\n\nOmega"
 
 
+def test_reasoning_projection_drops_empty_inline_thinking_wrapper() -> None:
+    message = make_msg(id="empty-thinking", role=Role.ASSISTANT, text="<thinking></thinking>")
+
+    projected = project_message_content([message], ContentProjectionSpec(include_reasoning=False))
+
+    assert projected == []
+
+
+def test_reasoning_projection_uses_typed_message_without_blocks() -> None:
+    message = make_msg(
+        id="typed-thinking",
+        role=Role.TOOL,
+        text="private reasoning",
+        message_type=MessageType.THINKING,
+    )
+
+    without_reasoning = project_message_content([message], ContentProjectionSpec(include_reasoning=False))
+    only_reasoning = project_message_content(
+        [message],
+        ContentProjectionSpec.from_params({"include_content_kinds": [ContentKind.REASONING]}),
+    )
+
+    assert without_reasoning == []
+    assert [projected.text for projected in only_reasoning] == ["private reasoning"]
+
+
 def test_projection_filters_structured_code_and_tool_outputs_without_losing_prose() -> None:
     session = make_conv(
         messages=[

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -117,3 +117,9 @@ def test_without_noise_idempotent(conv: Session) -> None:
 def test_extract_thinking_never_empty_string(msg: Message) -> None:
     result = msg.extract_thinking()
     assert result is None or len(result.strip()) > 0
+
+
+def test_extract_thinking_empty_wrapper_returns_none() -> None:
+    msg = Message(id="empty-thinking", role=Role.ASSISTANT, text="<thinking></thinking>")
+
+    assert msg.extract_thinking() is None


### PR DESCRIPTION
## Summary

Prevents reasoning-excluding and prose-only projections from retaining persisted thinking messages that have no blocks, and removes empty inline thinking wrappers instead of falling back to prose.

## Problem

The shared content projector classified role/tool state before the persisted `message_type`. A blockless `message_type=thinking` row could therefore survive as tool output or system noise. Empty `<thinking></thinking>` wrappers also produced no parsed segments and then fell back to the unfiltered source text. Both defects were observed while validating the private PolyDrop export.

## Solution

- Classify persisted `THINKING` message types before role-based fallbacks.
- Distinguish an inline projection match from no inline syntax, so empty wrappers yield empty content.
- Keep `extract_thinking()` honest by returning `None` for empty wrappers.
- Add focused cases for blockless tool-role thinking and empty inline wrappers.

`polylogue-395j` remains adjacent: it concerns default renderer presentation of legitimate structured zero-content thinking blocks, not filtered-projection leakage.

## Verification

- Focused content-projection and message-law selection -> `26 passed`
- `devtools verify --quick` -> 13/13 steps passed in 38.25s
