### PR TITLE
fix: make partial resume profiles explicit

### DIFF
--- a/polylogue/insights/resume.py
+++ b/polylogue/insights/resume.py
@@ -542,6 +542,9 @@ def _next_steps(
     if last_message is not None and last_message.role == "user" and last_message.preview:
         steps.append(f"Respond to latest user request: {last_message.preview}")
 
+    if not steps and last_message is not None and last_message.role == "assistant" and last_message.preview:
+        steps.append(f"Continue from latest assistant state: {last_message.preview}")
+
     if not steps and inferences.intent_summary:
         steps.append(f"Continue intent: {inferences.intent_summary}")
     if not steps and inferences.outcome_summary:
@@ -578,6 +581,23 @@ async def build_resume_brief(
                 detail="session_insights not materialized for this session; run rebuild_insights",
             )
         )
+    elif profile is not None:
+        missing_profile_parts = tuple(
+            name
+            for name, value in (
+                ("evidence", profile.evidence),
+                ("inference", profile.inference),
+                ("enrichment", profile.enrichment),
+            )
+            if value is None
+        )
+        if missing_profile_parts:
+            uncertainties.append(
+                ResumeUncertainty(
+                    source="session_profile",
+                    detail=f"merged session profile is missing: {', '.join(missing_profile_parts)}",
+                )
+            )
 
     events: list[SessionWorkEventInsight] = []
     try:

--- a/tests/unit/core/test_resume.py
+++ b/tests/unit/core/test_resume.py
@@ -38,11 +38,15 @@ def _seed_resume_sessions(db_path: Path) -> None:
             timestamp="2026-04-20T10:05:00+00:00",
             blocks=[
                 {
+                    "type": "text",
+                    "text": "I will inspect command wiring and insight surfaces.",
+                },
+                {
                     "type": "tool_use",
                     "tool_name": "Read",
                     "semantic_type": "file_read",
                     "input": {"path": "/workspace/polylogue/polylogue/cli/click_app.py"},
-                }
+                },
             ],
         )
         .save()
@@ -68,11 +72,15 @@ def _seed_resume_sessions(db_path: Path) -> None:
             timestamp="2026-04-20T11:15:00+00:00",
             blocks=[
                 {
+                    "type": "text",
+                    "text": "Continuing implementation and running pytest for resume tests.",
+                },
+                {
                     "type": "tool_use",
                     "tool_name": "Bash",
                     "semantic_type": "shell",
                     "input": {"command": "pytest -q tests/unit/core/test_resume.py"},
-                }
+                },
             ],
         )
         .save()

--- a/tests/unit/core/test_resume.py
+++ b/tests/unit/core/test_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -174,6 +175,38 @@ async def test_resume_brief_degrades_when_insights_are_unavailable(cli_workspace
     # store, so it does not degrade — only the profile-derived projections do.
     assert {uncertainty.source for uncertainty in brief.uncertainties} >= {"session_profile"}
     assert all("session_insights" in uncertainty.detail for uncertainty in brief.uncertainties)
+    assert brief.next_steps == (
+        "Continue from latest assistant state: I will inspect command wiring and insight surfaces.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_brief_flags_partial_merged_profile(
+    cli_workspace: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_resume_sessions(db_path)
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    await archive.rebuild_insights()
+    profile = await archive.get_session_profile_insight(ROOT_ID)
+    assert profile is not None
+    partial_profile = profile.model_copy(
+        update={"evidence": None, "inference": None, "enrichment": None},
+    )
+    monkeypatch.setattr(
+        archive,
+        "get_session_profile_insight",
+        AsyncMock(return_value=partial_profile),
+    )
+
+    brief = await archive.resume_brief(ROOT_ID)
+
+    assert brief is not None
+    assert [uncertainty.detail for uncertainty in brief.uncertainties if uncertainty.source == "session_profile"] == [
+        "merged session profile is missing: evidence, inference, enrichment",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes resume briefs expose partial merged-profile uncertainty and continue from an actionable assistant state when no stronger work-event, user request, or inferred next step exists.

## Problem

A merged session profile with missing evidence, inference, or enrichment looked authoritative. Separately, a session ending on assistant state could degrade to a generic instruction even when the archived assistant prose provided a concrete continuation point.

## Solution

- Emit one bounded `session_profile` uncertainty listing every absent merged-profile component.
- Prefer the latest assistant preview before intent/outcome and generic fallbacks when no higher-priority step exists.
- Make the mixed prose/tool fixture production-shaped with explicit typed text blocks; the focused test initially caught that unattached message-column prose is correctly discarded by the writer.

## Verification

- `devtools test tests/unit/core/test_resume.py` -> `6 passed in 14.48s`
- `devtools verify --quick` -> 13/13 steps passed in 38.24s
