### PR TITLE
refactor(mcp): retire duplicate get_session tool

### DIFF
--- a/docs/design/session-lineage-model.md
+++ b/docs/design/session-lineage-model.md
@@ -193,7 +193,7 @@ Status as of the prefix-inheritance slices (index schema **v12**):
    acquisition.
 3. **Done (prefix-inheritance)** — both read paths compose: the async
    `get_messages` query and the sync `read_archive_session_envelope` (used by MCP
-   `get_session` / CLI `read`) prepend the parent transcript up to the branch
+   `get_session_summary` / CLI `read`) prepend the parent transcript up to the branch
    point. Effective-context derivation lands with the compaction slice.
 4. Optimize ingest, then re-ingest the real archive.
 5. Validate against authoritative stores (`state_5.sqlite`, `stats-cache.json`):

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -51,7 +51,7 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 |------|-------------|
 | `search` | Search sessions by text query with optional provider/date filters; returns session summaries plus match rank, lane, surface, message id, and snippet evidence. Drive/Gemini provider attachment ids and stored `provider_id`, `id`, `fileId`, or `driveId` metadata return `match_surface=attachment` hits. |
 | `list_sessions` | List recent sessions, optionally filtered |
-| `get_session` | Get a single session by ID (supports prefix matching) |
+| `get_session_summary` | Get a single session summary by ID (supports prefix matching) |
 | `stats` | Archive statistics: totals, provider breakdown, database size |
 | `get_postmortem_bundle` | Distilled postmortem bundle over a matched scope (#2380): top sessions by cost, repos touched, tool/work-kind rollups, failure signals. Read-only. |
 | `get_pathologies` | Deterministic agent-workflow pathology distribution over a matched scope (#2383): consecutive failure-streak and stale-context findings with drillable evidence. Read-only. |

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -9,7 +9,7 @@ CLI or Python API for agent-facing recall, corrections, and context assembly.
 ~100 tools registered across `polylogue/mcp/server_*.py`, gated by capability role (see
 Configuration below). A representative sample by category:
 
-- **Search / list / get**: `search`, `list_sessions`, `get_session`, `get_messages`,
+- **Search / list / get**: `search`, `list_sessions`, `get_messages`,
   `get_session_tree`, `get_session_summary`, `get_logical_session`, `facets`.
 - **Insights**: `get_stats_by`, `session_costs`, `cost_rollups`, `usage_timeline`,
   `tool_usage`, `workflow_shape_distribution`, `session_latency_profile`.

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -344,22 +344,6 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("compile_context", run)
 
     @mcp.tool()
-    async def get_session(
-        id: str,
-    ) -> str:
-        async def run() -> str:
-            config = hooks.get_config()
-            try:
-                with ArchiveStore.open_existing(mcp_archive_root(config)) as archive:
-                    session_id = archive.resolve_session_id(id)
-                    archive_summary = archive.read_summary(session_id)
-                    return hooks.json_payload(archive_summary_payload(archive_summary))
-            except (KeyError, ValueError, sqlite3.OperationalError):
-                return hooks.error_json(f"Session not found: {id}", code="not_found")
-
-        return await hooks.async_safe_call("get_session", run)
-
-    @mcp.tool()
     async def archive_list_sessions(
         origin: str | None = None,
         exclude_origin: str | None = None,

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -1389,22 +1389,6 @@
     }
   },
   {
-    "name": "get_session",
-    "parameters": {
-      "properties": {
-        "id": {
-          "title": "Id",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "title": "get_sessionArguments",
-      "type": "object"
-    }
-  },
-  {
     "name": "get_session_summary",
     "parameters": {
       "properties": {

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -23,7 +23,6 @@ EXPECTED_TOOL_NAMES = {
     "blackboard_list",
     "blackboard_post",
     "list_assertion_claims",
-    "get_session",
     "neighbor_candidates",
     "stats",
     "embedding_status",

--- a/tests/unit/mcp/test_contract_evidence.py
+++ b/tests/unit/mcp/test_contract_evidence.py
@@ -145,7 +145,7 @@ class TestToolErrorEnvelopes:
         body = _structured_error(result)
         assert "requires id or query" in body["message"], f"unexpected error message: {body}"
 
-    def test_get_session_missing_returns_not_found_envelope(
+    def test_get_session_summary_missing_returns_not_found_envelope(
         self,
         mcp_server: MCPServerUnderTest,
     ) -> None:
@@ -154,7 +154,7 @@ class TestToolErrorEnvelopes:
             mock_poly.get_session_summary = AsyncMock(return_value=None)
             mock_get_polylogue.return_value = mock_poly
 
-            result = invoke_surface(mcp_server._tool_manager._tools["get_session"].fn, id="missing")
+            result = invoke_surface(mcp_server._tool_manager._tools["get_session_summary"].fn, id="missing")
 
         body = _structured_error(result)
         assert body.get("code") == "not_found", f"expected code='not_found', got {body!r}"
@@ -190,23 +190,6 @@ class TestToolErrorEnvelopes:
             result = invoke_surface(
                 mcp_server._tool_manager._tools["raw_artifacts"].fn,
                 session_id="missing",
-            )
-
-        body = _structured_error(result)
-        assert body.get("code") == "not_found", f"expected code='not_found', got {body!r}"
-
-    def test_get_session_summary_missing_returns_not_found_envelope(
-        self,
-        mcp_server: MCPServerUnderTest,
-    ) -> None:
-        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
-            mock_poly = make_polylogue_mock()
-            mock_poly.get_session_summary = AsyncMock(return_value=None)
-            mock_get_polylogue.return_value = mock_poly
-
-            result = invoke_surface(
-                mcp_server._tool_manager._tools["get_session_summary"].fn,
-                id="missing",
             )
 
         body = _structured_error(result)

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -86,7 +86,6 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "list_recall_packs": ("envelope", frozenset({"items", "total"})),
     "list_workspaces": ("envelope", frozenset({"items", "total"})),
     # ------- single record -------
-    "get_session": "single_object",
     "get_session_summary": "single_object",
     "compile_context": "single_object",
     "archive_get_session": "single_object",
@@ -575,7 +574,6 @@ class TestNativeReadSurfaceHonorsContract:
             ("search", {"query": "needle", "limit": 10}),
             ("query_units", {"expression": "messages where text:needle", "limit": 10}),
             ("list_sessions", {"limit": 10}),
-            ("get_session", {}),  # id filled from seeded session
             ("get_session_summary", {}),
             ("get_messages", {}),  # session_id filled from seeded session
             ("stats", {}),
@@ -596,7 +594,7 @@ class TestNativeReadSurfaceHonorsContract:
         archive_root = tmp_path / "archive"
         session_id = self._seed(archive_root)
         call_kwargs = dict(kwargs)
-        if tool_name in {"get_session", "get_session_summary"}:
+        if tool_name == "get_session_summary":
             call_kwargs["id"] = session_id
         if tool_name == "get_messages":
             call_kwargs["session_id"] = session_id

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -850,7 +850,7 @@ class TestArchiveGenericToolSurfaces:
         assert payload["tool"] == "query_units"
         assert payload["code"] == "invalid_query"
 
-    def test_get_session_tools_read_archive_file_set(
+    def test_get_session_summary_tool_reads_archive_file_set(
         self: object, mcp_server: MCPServerUnderTest, tmp_path: Path
     ) -> None:
         archive_root = tmp_path / "archive"
@@ -869,17 +869,14 @@ class TestArchiveGenericToolSurfaces:
                 archive_root=archive_root,
                 db_path=archive_root / "index.db",
             )
-            mock_get_polylogue.side_effect = AssertionError("get tools must not open Polylogue facade")
-            result = invoke_surface(mcp_server._tool_manager._tools["get_session"].fn, id=session_id[:12])
-            summary_result = invoke_surface(
+            mock_get_polylogue.side_effect = AssertionError("get_session_summary must not open Polylogue facade")
+            result = invoke_surface(
                 mcp_server._tool_manager._tools["get_session_summary"].fn,
-                id=session_id,
+                id=session_id[:12],
             )
 
         payload = json.loads(result)
-        summary_payload = json.loads(summary_result)
         assert payload["id"] == session_id
-        assert summary_payload["id"] == session_id
 
     def test_get_messages_tool_reads_archive_file_set(
         self: object, mcp_server: MCPServerUnderTest, tmp_path: Path

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -1,7 +1,7 @@
 """Unit contracts for MCP tool surfaces backed by the store.
 
-Read-heavy MCP tools (``search``, ``list_sessions``, ``get_session``,
-``get_session_summary``, ``get_messages``, ``stats``) route unconditionally
+Read-heavy MCP tools (``search``, ``list_sessions``, ``get_session_summary``,
+``get_messages``, ``stats``) route unconditionally
 through ``ArchiveStore`` over the archive. These tests
 seed a archive on disk, point the MCP ``_get_config`` seam at it, and
 assert against the archive tool output. Monolithic ``_get_archive_ops`` and ``_get_polylogue`` seams are no longer on these read paths.
@@ -792,8 +792,8 @@ class TestArchiveTools:
         assert payload["messages"][0]["blocks"][0]["text"] == "hello from mcp"
 
 
-class TestGetSessionTool:
-    def test_get_returns_session(self, tmp_path: Path, mcp_server: MCPServerUnderTest) -> None:
+class TestGetSessionSummaryTool:
+    def test_get_summary_returns_session(self, tmp_path: Path, mcp_server: MCPServerUnderTest) -> None:
         archive_root = tmp_path / "archive"
         session_id = _seed_archive(
             archive_root,
@@ -803,7 +803,7 @@ class TestGetSessionTool:
         )
 
         with _archive_config(archive_root):
-            result = invoke_surface(mcp_server._tool_manager._tools["get_session"].fn, id=session_id)
+            result = invoke_surface(mcp_server._tool_manager._tools["get_session_summary"].fn, id=session_id)
 
         conv = json.loads(result)
         assert conv["id"] == session_id
@@ -816,7 +816,7 @@ class TestGetSessionTool:
             mock_poly.get_session_summary = AsyncMock(return_value=None)
             mock_get_polylogue.return_value = mock_poly
 
-            result = invoke_surface(mcp_server._tool_manager._tools["get_session"].fn, id="nonexistent")
+            result = invoke_surface(mcp_server._tool_manager._tools["get_session_summary"].fn, id="nonexistent")
 
         parsed = json.loads(result)
         assert "message" in parsed
@@ -1040,7 +1040,7 @@ class TestGetSessionTool:
             mock_get_polylogue.return_value = mock_poly
 
             result = await invoke_surface_async(
-                mcp_server._tool_manager._tools["get_session"].fn, id="nonexistent-id-xyz"
+                mcp_server._tool_manager._tools["get_session_summary"].fn, id="nonexistent-id-xyz"
             )
 
         assert isinstance(json.loads(result), dict)

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -31,7 +31,6 @@ _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "resolve_ref": {"ref": f"session:{_SYNTHETIC_CONV_ID}"},
     "compile_context": {"seed_ref": f"session:{_SYNTHETIC_CONV_ID}", "read_views": "messages"},
     "blackboard_list": {},
-    "get_session": {"id": _SYNTHETIC_CONV_ID},
     "get_session_summary": {"id": _SYNTHETIC_CONV_ID},
     "get_messages": {"session_id": _SYNTHETIC_CONV_ID, "limit": 1},
     "get_session_tree": {"session_id": _SYNTHETIC_CONV_ID},
@@ -159,7 +158,7 @@ def test_all_read_tools_discovered() -> None:
         "stats",
         "facets",
         "readiness_check",
-        "get_session",
+        "get_session_summary",
         "build_context_image",
     ]:
         assert expected in _READ_TOOL_NAMES, f"missing expected read tool: {expected}"

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -134,7 +134,7 @@ def test_prefix_sharing_child_stores_only_tail_and_composes(tmp_path: Path) -> N
     assert link["branch_point_message_id"] is not None
     assert link["resolved_dst_session_id"] == parent_id
 
-    # The sync envelope read (MCP get_session / CLI read) also composes.
+    # The sync envelope read (MCP get_session_summary / CLI read) also composes.
     envelope = read_archive_session_envelope(conn, child_id)
     assert ["".join(block.text or "" for block in message.blocks) for message in envelope.messages] == [
         "hello",


### PR DESCRIPTION
## Summary

Removes the unused `get_session` MCP alias and leaves `get_session_summary` as the sole agent-facing summary read.

## Problem

The two MCP tools had byte-for-byte equivalent implementations, while affordance-usage evidence found no captured `get_session` use. Keeping both increased discovery payload and duplicated contracts without adding capability.

## Solution

Remove the redundant registration and update expected-tool inventories, schema witnesses, MCP contract tests, lineage tests, and generated/reference documentation. This does not remove the Python repository/API `get_session` operation; only the duplicate MCP tool is retired.

Ref `polylogue-v6vy`.

## Verification

- Focused changed MCP/storage selection -> `294 passed`, exit status 0
- `devtools verify --quick` -> 13/13 steps passed in 16.04s
- `git diff --check origin/master...HEAD` -> clean
