### PR TITLE
fix(coordination): compact agent status projections (#2656)

### DIFF
--- a/polylogue/cli/commands/agents.py
+++ b/polylogue/cli/commands/agents.py
@@ -27,6 +27,11 @@ def _format_options(func: F) -> F:
     )
     func = click.option("--json", "json_output", is_flag=True, help="Emit JSON.")(func)
     func = click.option(
+        "--detail",
+        is_flag=True,
+        help="Include bounded evidence details omitted from the compact default.",
+    )(func)
+    func = click.option(
         "--format",
         "-f",
         "output_format",
@@ -38,8 +43,15 @@ def _format_options(func: F) -> F:
     return func
 
 
-def _emit(view: CoordinationView, cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
-    payload = build_coordination_envelope(view=view, cwd=cwd, limit=limit)
+def _emit(
+    view: CoordinationView,
+    cwd: Path | None,
+    limit: int,
+    json_output: bool,
+    output_format: str,
+    detail: bool,
+) -> None:
+    payload = build_coordination_envelope(view=view, cwd=cwd, limit=limit, detail=detail)
     if json_output or output_format == "json":
         click.echo(payload.to_json(exclude_none=True))
         return
@@ -62,51 +74,51 @@ def agents_command(ctx: click.Context) -> None:
 
 @agents_command.command("status")
 @_format_options
-def status_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
-    """Show the full bounded coordination envelope."""
-    _emit("status", cwd, limit, json_output, output_format)
+def status_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
+    """Show the compact bounded coordination envelope."""
+    _emit("status", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("self")
 @_format_options
-def self_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
+def self_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Show this agent's repo, process, and current work-item projection."""
-    _emit("self", cwd, limit, json_output, output_format)
+    _emit("self", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("work-item")
 @_format_options
-def work_item_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
+def work_item_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Show the current work item projection."""
-    _emit("work-item", cwd, limit, json_output, output_format)
+    _emit("work-item", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("current")
 @_format_options
-def current_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
+def current_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Alias for ``work-item``."""
-    _emit("work-item", cwd, limit, json_output, output_format)
+    _emit("work-item", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("conflicts")
 @_format_options
-def conflicts_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
+def conflicts_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Show overlap/resource awareness; same-file activity is not a blocker."""
-    _emit("conflicts", cwd, limit, json_output, output_format)
+    _emit("conflicts", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("overlap")
 @_format_options
-def overlap_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
+def overlap_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Alias for ``conflicts``."""
-    _emit("conflicts", cwd, limit, json_output, output_format)
+    _emit("conflicts", cwd, limit, json_output, output_format, detail)
 
 
 @agents_command.command("handoff")
 @_format_options
-def handoff_command(cwd: Path | None, limit: int, json_output: bool, output_format: str) -> None:
-    """Show handoff and active-loop references for the current repo."""
-    _emit("handoff", cwd, limit, json_output, output_format)
+def handoff_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
+    """Show supported live handoff references for the current repo."""
+    _emit("handoff", cwd, limit, json_output, output_format, detail)
 
 
 __all__ = ["agents_command"]

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -781,19 +781,25 @@ def _logical_peer_payloads(
 ) -> tuple[CoordinationPeerPayload, ...]:
     by_pid = {row.pid: row for row in rows}
     candidate_kinds = {row.pid: kind for row in rows if (kind := _agent_kind_for_process(row)) is not None}
+    logical_kinds = {pid: kind for pid, kind in candidate_kinds.items() if not _is_agent_component(by_pid[pid])}
     roots: dict[int, list[_ProcessRow]] = {}
+    component_ancestors: dict[int, set[int]] = {}
     for row in rows:
-        if row.pid not in candidate_kinds or row.pid == os.getpid():
+        if row.pid not in logical_kinds or row.pid == os.getpid():
             continue
         root_pid = row.pid
         parent_pid = row.ppid
         seen = {row.pid}
+        ancestors: set[int] = set()
         while parent_pid in by_pid and parent_pid not in seen:
             seen.add(parent_pid)
-            if parent_pid in candidate_kinds:
+            if parent_pid in logical_kinds:
                 root_pid = parent_pid
+            elif parent_pid in candidate_kinds:
+                ancestors.add(parent_pid)
             parent_pid = by_pid[parent_pid].ppid
         roots.setdefault(root_pid, []).append(row)
+        component_ancestors.setdefault(root_pid, set()).update(ancestors)
 
     peers: list[CoordinationPeerPayload] = []
     for root_pid, agent_rows in sorted(roots.items()):
@@ -804,9 +810,17 @@ def _logical_peer_payloads(
         ):
             continue
         descendants = tuple(row.pid for row in rows if row.pid != root_pid and _descends_from(row, root_pid, by_pid))
-        kind = candidate_kinds[root_pid]
+        kind = logical_kinds[root_pid]
         session_ref = _session_ref(root.command)
-        component_pids = tuple(sorted({*(row.pid for row in agent_rows if row.pid != root_pid), *descendants}))
+        component_pids = tuple(
+            sorted(
+                {
+                    *(row.pid for row in agent_rows if row.pid != root_pid),
+                    *descendants,
+                    *component_ancestors.get(root_pid, set()),
+                }
+            )
+        )
         peers.append(
             CoordinationPeerPayload(
                 pid=root_pid,
@@ -844,7 +858,11 @@ def _agent_kind_for_process(row: _ProcessRow) -> str | None:
 
 def _is_agent_component(row: _ProcessRow) -> bool:
     text = f"{row.comm} {row.command}".lower()
-    return any(marker in text for marker in ("mcp-server", "--spare-daemon", "code-mode-host", "claude-code-acp"))
+    executable = _executable_name(row.command)
+    wrapper = any(executable.endswith(suffix) for suffix in ("-browser", "-deepseek", "-full", "-lean", "-local"))
+    return wrapper or any(
+        marker in text for marker in ("mcp-server", "--spare-daemon", "code-mode-host", "claude-code-acp")
+    )
 
 
 def _descends_from(row: _ProcessRow, ancestor_pid: int, by_pid: dict[int, _ProcessRow]) -> bool:

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -27,6 +29,7 @@ from polylogue.coordination.payloads import (
     CoordinationLimitsPayload,
     CoordinationOverlapPayload,
     CoordinationPeerPayload,
+    CoordinationProjectionPayload,
     CoordinationProofRefPayload,
     CoordinationProvenancePayload,
     CoordinationRepoPayload,
@@ -45,9 +48,25 @@ CommandRunner = Callable[[Sequence[str], Path | None], "CommandResult"]
 
 _COMMAND_CHARS = 220
 _CHANGED_PATH_LIMIT = 40
-_PROCESS_COMMAND = ("ps", "-eo", "pid,ppid,comm,args", "--no-headers")
+# Leave headroom for the MCP brief's fixed instructions while keeping the
+# complete default response below the bead's 8 KiB transport ceiling.
+_COMPACT_BYTE_BUDGET = 7_600
+_PROCESS_COMMAND = ("ps", "-eo", "pid=,ppid=,comm=,cgroup=,args=")
 _AGENT_NAMES = ("codex", "claude", "gemini")
-_RESOURCE_NAMES = ("polylogued", "pytest", "python", "uv", "nix", "cargo", "rustc", "node")
+_SYSTEM_RESOURCE_NAMES = frozenset(
+    {
+        "below",
+        "dbus-daemon",
+        "earlyoom",
+        "nix-daemon",
+        "systemd-oomd",
+        "systemd-resolved",
+        "systemd-timesyncd",
+        "systemd-udevd",
+    }
+)
+_WORK_SCOPE_RE = re.compile(r"(?:sinnix-(?:background|build|nix-build)|polylogue[^/]*(?:rebuild|verify|test))")
+_SESSION_ARG_RE = re.compile(r"(?:--session-id|--resume|--thread-id)(?:=|\s+)([^\s]+)")
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,11 +77,21 @@ class CommandResult:
     stderr: str
 
 
+@dataclass(frozen=True, slots=True)
+class _ProcessRow:
+    pid: int
+    ppid: int
+    comm: str
+    cgroup: str
+    command: str
+
+
 def build_coordination_envelope(
     *,
     view: CoordinationView = "status",
     cwd: Path | None = None,
     limit: int = 10,
+    detail: bool = False,
     runner: CommandRunner | None = None,
 ) -> AgentCoordinationPayload:
     """Return a bounded, JSON-first coordination envelope for agents."""
@@ -77,9 +106,11 @@ def build_coordination_envelope(
     self_payload = _self_payload(root_cwd, repo)
     work_item = _work_item_payload(root_cwd, repo, command_runner)
     beads = _beads_payload(root_cwd, repo, command_runner)
-    peers, resources = _process_payloads(command_runner, root_cwd, peer_limit=peer_limit, resource_limit=resource_limit)
-    handoff = _handoff_payloads(repo.root or str(root_cwd))
+    all_peers, all_resources = _process_payloads(command_runner, root_cwd)
+    peers = all_peers[:peer_limit]
+    resources = all_resources[:resource_limit]
     archive = _archive_payload(resources)
+    handoff = _handoff_payloads(repo.root or str(root_cwd), archive=archive, limit=peer_limit)
     session_trees, activity_episodes, subagent_exchanges, proof_refs, context_flow_refs = _archive_evidence_payloads(
         repo,
         self_payload,
@@ -113,9 +144,19 @@ def build_coordination_envelope(
             changed_path_limit=_CHANGED_PATH_LIMIT,
             command_chars=_COMMAND_CHARS,
         ),
+        projection=CoordinationProjectionPayload(detail=detail),
         provenance=provenance,
     )
-    return project_coordination_envelope(payload, view)
+    projected = project_coordination_envelope(payload, view)
+    total_counts = _coordination_counts(projected)
+    total_counts["peers"] = len(all_peers)
+    total_counts["resource_episodes"] = len(all_resources)
+    total_counts["peer_components"] = sum(peer.component_count for peer in all_peers)
+    total_counts["resource_components"] = sum(episode.component_count for episode in all_resources)
+    total_counts["resource_refs"] = sum(episode.resource_count for episode in all_resources)
+    if detail:
+        return _finalize_projection(projected, total_counts=total_counts, detail=True)
+    return _compact_coordination_payload(projected, total_counts=total_counts)
 
 
 def project_coordination_envelope(
@@ -161,6 +202,251 @@ def project_coordination_envelope(
             }
         )
     return payload
+
+
+_COUNTED_FAMILIES = (
+    "peers",
+    "resource_episodes",
+    "overlaps",
+    "handoff",
+    "session_trees",
+    "activity_episodes",
+    "subagent_exchanges",
+    "proof_refs",
+    "context_flow_refs",
+    "advisories",
+    "provenance",
+)
+
+
+def _coordination_counts(payload: AgentCoordinationPayload) -> dict[str, int]:
+    counts = {name: len(cast(Sequence[object], getattr(payload, name))) for name in _COUNTED_FAMILIES}
+    counts["changed_paths"] = len(payload.repo.changed_paths)
+    counts["work_item_fields"] = len(payload.work_item.fields)
+    if payload.beads is not None:
+        counts["beads_hooks"] = len(payload.beads.hooks)
+        counts["beads_gates"] = len(payload.beads.gates)
+        counts["beads_merge_waiters"] = len(payload.beads.merge_slot.waiters) if payload.beads.merge_slot else 0
+    if payload.archive is not None:
+        counts["archive_hook_states"] = len(payload.archive.hook_flow_states)
+        counts["archive_hook_gaps"] = len(payload.archive.hook_flow_gaps)
+        counts["archive_daemon_processes"] = len(payload.archive.daemon_processes)
+    counts["session_tree_nodes"] = sum(len(tree.nodes) for tree in payload.session_trees)
+    counts["session_tree_edges"] = sum(len(tree.edges) for tree in payload.session_trees)
+    counts["peer_components"] = sum(len(peer.component_pids) for peer in payload.peers)
+    counts["resource_components"] = sum(len(episode.component_pids) for episode in payload.resource_episodes)
+    counts["resource_refs"] = sum(len(episode.resources) for episode in payload.resource_episodes)
+    counts["activity_refs"] = sum(len(episode.refs) for episode in payload.activity_episodes)
+    counts["proof_evidence_refs"] = sum(len(proof.evidence_refs) for proof in payload.proof_refs)
+    counts["context_segment_refs"] = sum(len(ref.segment_refs) for ref in payload.context_flow_refs)
+    counts["context_evidence_refs"] = sum(len(ref.evidence_refs) for ref in payload.context_flow_refs)
+    return counts
+
+
+def _compact_coordination_payload(
+    payload: AgentCoordinationPayload,
+    *,
+    total_counts: dict[str, int],
+) -> AgentCoordinationPayload:
+    repo = payload.repo.model_copy(
+        update={
+            "changed_paths": payload.repo.changed_paths[:8],
+            "provenance": _compact_provenance(payload.repo.provenance),
+        }
+    )
+    self_payload = payload.self.model_copy(update={"provenance": _compact_provenance(payload.self.provenance)})
+    work_item = payload.work_item.model_copy(
+        update={"fields": {}, "provenance": _compact_provenance(payload.work_item.provenance, keep_note=True)}
+    )
+    peers = tuple(
+        peer.model_copy(
+            update={
+                "command": _short_to(peer.command, 120),
+                "component_pids": peer.component_pids[:4],
+                "provenance": _compact_provenance(peer.provenance),
+            }
+        )
+        for peer in payload.peers[:4]
+    )
+    resources = tuple(
+        episode.model_copy(
+            update={
+                "command": _short_to(episode.command, 140),
+                "resources": episode.resources[:3],
+                "component_pids": episode.component_pids[:4],
+                "provenance": _compact_provenance(episode.provenance),
+            }
+        )
+        for episode in payload.resource_episodes[:4]
+    )
+    overlaps = tuple(
+        overlap.model_copy(update={"refs": overlap.refs[:4], "provenance": _compact_provenance(overlap.provenance)})
+        for overlap in payload.overlaps[:4]
+    )
+    handoff = tuple(
+        item.model_copy(update={"provenance": _compact_provenance(item.provenance)}) for item in payload.handoff[:3]
+    )
+    session_trees = tuple(
+        tree.model_copy(
+            update={
+                "nodes": tuple(
+                    node.model_copy(update={"title": _short_to(node.title, 100) if node.title else None})
+                    for node in tree.nodes[:3]
+                ),
+                "edges": tree.edges[:3],
+                "provenance": _compact_provenance(tree.provenance),
+            }
+        )
+        for tree in payload.session_trees[:1]
+    )
+    activity = tuple(
+        item.model_copy(
+            update={
+                "summary": _short_to(item.summary, 140) if item.summary else None,
+                "refs": item.refs[:2],
+                "provenance": _compact_provenance(item.provenance),
+            }
+        )
+        for item in payload.activity_episodes[:2]
+    )
+    proofs = tuple(
+        item.model_copy(
+            update={
+                "summary": _short_to(item.summary, 140) if item.summary else None,
+                "evidence_refs": item.evidence_refs[:2],
+                "provenance": _compact_provenance(item.provenance),
+            }
+        )
+        for item in payload.proof_refs[:2]
+    )
+    context_refs = tuple(
+        item.model_copy(
+            update={
+                "segment_refs": item.segment_refs[:2],
+                "evidence_refs": item.evidence_refs[:2],
+                "provenance": _compact_provenance(item.provenance),
+            }
+        )
+        for item in payload.context_flow_refs[:2]
+    )
+    archive = payload.archive
+    if archive is not None:
+        archive = archive.model_copy(
+            update={
+                "hook_flow_states": dict(tuple(sorted(archive.hook_flow_states.items()))[:6]),
+                "hook_flow_gaps": archive.hook_flow_gaps[:4],
+                "daemon_processes": (),
+                "provenance": _compact_provenance(archive.provenance),
+            }
+        )
+    beads = payload.beads
+    if beads is not None:
+        merge_slot = beads.merge_slot
+        if merge_slot is not None:
+            merge_slot = merge_slot.model_copy(update={"waiters": merge_slot.waiters[:3]})
+        beads = beads.model_copy(
+            update={
+                "hooks": beads.hooks[:3],
+                "gates": beads.gates[:2],
+                "merge_slot": merge_slot,
+                "provenance": _compact_provenance(beads.provenance),
+            }
+        )
+    compact = payload.model_copy(
+        update={
+            "repo": repo,
+            "self": self_payload,
+            "work_item": work_item,
+            "peers": peers,
+            "resource_episodes": resources,
+            "overlaps": overlaps,
+            "handoff": handoff,
+            "archive": archive,
+            "session_trees": session_trees,
+            "activity_episodes": activity,
+            "subagent_exchanges": (),
+            "proof_refs": proofs,
+            "context_flow_refs": context_refs,
+            "advisories": tuple(_short_to(item, 180) for item in payload.advisories[:3]),
+            "provenance": (),
+        }
+    )
+    compact = _finalize_projection(compact, total_counts=total_counts, detail=False)
+    for family in ("context_flow_refs", "activity_episodes", "proof_refs", "session_trees", "handoff"):
+        if _serialized_size(compact) <= _COMPACT_BYTE_BUDGET:
+            break
+        compact = compact.model_copy(update={family: ()})
+        compact = _finalize_projection(compact, total_counts=total_counts, detail=False)
+    if _serialized_size(compact) > _COMPACT_BYTE_BUDGET and compact.beads is not None:
+        compact = compact.model_copy(
+            update={"beads": compact.beads.model_copy(update={"hooks": (), "gates": (), "merge_slot": None})}
+        )
+        compact = _finalize_projection(compact, total_counts=total_counts, detail=False)
+    if _serialized_size(compact) > _COMPACT_BYTE_BUDGET and compact.archive is not None:
+        compact = compact.model_copy(
+            update={
+                "archive": compact.archive.model_copy(update={"hook_flow_states": {}, "hook_flow_gaps": ()}),
+                "overlaps": (),
+                "advisories": (),
+            }
+        )
+        compact = _finalize_projection(compact, total_counts=total_counts, detail=False)
+    if _serialized_size(compact) > _COMPACT_BYTE_BUDGET:
+        compact = compact.model_copy(
+            update={"peers": compact.peers[:1], "resource_episodes": compact.resource_episodes[:1]}
+        )
+        compact = _finalize_projection(compact, total_counts=total_counts, detail=False)
+    return compact
+
+
+def _compact_provenance(
+    provenance: CoordinationProvenancePayload,
+    *,
+    keep_note: bool = False,
+) -> CoordinationProvenancePayload:
+    return provenance.model_copy(update={"command": (), "note": provenance.note if keep_note else None})
+
+
+def _short_to(value: str, limit: int) -> str:
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1] + "…"
+
+
+def _finalize_projection(
+    payload: AgentCoordinationPayload,
+    *,
+    total_counts: dict[str, int],
+    detail: bool,
+) -> AgentCoordinationPayload:
+    visible = _coordination_counts(payload)
+    omitted = {
+        name: total - visible.get(name, 0)
+        for name, total in sorted(total_counts.items())
+        if total > visible.get(name, 0)
+    }
+    projection = CoordinationProjectionPayload(
+        detail=detail,
+        byte_budget=None if detail else _COMPACT_BYTE_BUDGET,
+        serialized_bytes=0,
+        total_counts=dict(sorted(total_counts.items())),
+        omitted_counts=omitted,
+        detail_hint=None if detail else "CLI: --detail; MCP: detail=true",
+    )
+    finalized = payload.model_copy(update={"projection": projection})
+    for _ in range(3):
+        size = _serialized_size(finalized)
+        if finalized.projection.serialized_bytes == size:
+            break
+        finalized = finalized.model_copy(
+            update={"projection": finalized.projection.model_copy(update={"serialized_bytes": size})}
+        )
+    return finalized
+
+
+def _serialized_size(payload: AgentCoordinationPayload) -> int:
+    return len(payload.to_json(exclude_none=True).encode("utf-8"))
 
 
 def _run_command(args: Sequence[str], cwd: Path | None) -> CommandResult:
@@ -451,84 +737,241 @@ def _bool_or_none(value: object) -> bool | None:
 def _process_payloads(
     runner: CommandRunner,
     cwd: Path,
-    *,
-    peer_limit: int,
-    resource_limit: int,
 ) -> tuple[tuple[CoordinationPeerPayload, ...], tuple[CoordinationResourceEpisodePayload, ...]]:
     result = runner(_PROCESS_COMMAND, None)
     if result.returncode != 0:
         return (), ()
-    peers: list[CoordinationPeerPayload] = []
-    resources: list[CoordinationResourceEpisodePayload] = []
-    for row in result.stdout.splitlines():
-        parsed = _parse_ps_row(row)
-        if parsed is None:
-            continue
-        pid, comm, command = parsed
-        comm_lower = comm.lower()
-        command_lower = command.lower()
-        if (
-            pid != os.getpid()
-            and any(name in comm_lower or name in command_lower for name in _AGENT_NAMES)
-            and len(peers) < peer_limit
-        ):
-            peers.append(
-                CoordinationPeerPayload(
-                    pid=pid,
-                    kind=_classify_agent(comm_lower, command_lower),
-                    command=_short(command),
-                    cwd=_proc_cwd(pid),
-                    provenance=_prov("process-table", command=result.args, confidence=0.65),
-                )
-            )
-        if (
-            any(name in comm_lower or name in command_lower for name in _RESOURCE_NAMES)
-            and len(resources) < resource_limit
-        ):
-            resources.append(
-                CoordinationResourceEpisodePayload(
-                    pid=pid,
-                    kind=_classify_resource(comm_lower, command_lower),
-                    command=_short(command),
-                    status="running",
-                    scope=str(cwd),
-                    provenance=_prov("process-table", command=result.args, confidence=0.6),
-                )
-            )
-    return tuple(peers), tuple(resources)
+    rows = tuple(parsed for line in result.stdout.splitlines() if (parsed := _parse_ps_row(line)) is not None)
+    return _logical_peer_payloads(rows, result), _resource_scope_payloads(rows, result, cwd)
 
 
-def _parse_ps_row(row: str) -> tuple[int, str, str] | None:
-    parts = row.strip().split(None, 3)
-    if len(parts) < 4:
+def _parse_ps_row(row: str) -> _ProcessRow | None:
+    parts = row.strip().split(None, 4)
+    if len(parts) < 5:
         return None
     try:
         pid = int(parts[0])
+        ppid = int(parts[1])
     except ValueError:
         return None
-    return pid, parts[2], parts[3]
+    return _ProcessRow(pid=pid, ppid=ppid, comm=parts[2], cgroup=parts[3], command=parts[4])
 
 
-def _classify_agent(comm: str, command: str) -> str:
+def _logical_peer_payloads(
+    rows: tuple[_ProcessRow, ...],
+    result: CommandResult,
+) -> tuple[CoordinationPeerPayload, ...]:
+    by_pid = {row.pid: row for row in rows}
+    candidate_kinds = {row.pid: kind for row in rows if (kind := _agent_kind_for_process(row)) is not None}
+    roots: dict[int, list[_ProcessRow]] = {}
+    for row in rows:
+        if row.pid not in candidate_kinds or row.pid == os.getpid():
+            continue
+        root_pid = row.pid
+        parent_pid = row.ppid
+        seen = {row.pid}
+        while parent_pid in by_pid and parent_pid not in seen:
+            seen.add(parent_pid)
+            if parent_pid in candidate_kinds:
+                root_pid = parent_pid
+            parent_pid = by_pid[parent_pid].ppid
+        roots.setdefault(root_pid, []).append(row)
+
+    peers: list[CoordinationPeerPayload] = []
+    for root_pid, agent_rows in sorted(roots.items()):
+        root = by_pid[root_pid]
+        current = by_pid.get(os.getpid())
+        if _is_agent_component(root) or (
+            current is not None and (current.pid == root_pid or _descends_from(current, root_pid, by_pid))
+        ):
+            continue
+        descendants = tuple(row.pid for row in rows if row.pid != root_pid and _descends_from(row, root_pid, by_pid))
+        kind = candidate_kinds[root_pid]
+        session_ref = _session_ref(root.command)
+        component_pids = tuple(sorted({*(row.pid for row in agent_rows if row.pid != root_pid), *descendants}))
+        peers.append(
+            CoordinationPeerPayload(
+                pid=root_pid,
+                kind=kind,
+                logical_id=f"{kind}:{session_ref or root_pid}",
+                session_ref=session_ref,
+                command=_short(root.command),
+                cwd=_proc_cwd(root_pid),
+                component_count=len(component_pids),
+                component_pids=component_pids[:50],
+                provenance=_prov(
+                    "process-tree",
+                    command=result.args,
+                    confidence=0.8,
+                    note="launcher/host/MCP/spare descendants collapsed into one logical peer",
+                ),
+            )
+        )
+    return tuple(peers)
+
+
+def _agent_kind_for_process(row: _ProcessRow) -> str | None:
+    comm = Path(row.comm).name.lower()
+    executable = _executable_name(row.command)
     for name in _AGENT_NAMES:
-        if name in comm or name in command:
+        if comm == name or comm.startswith(f"{name}-") or executable == name or executable.startswith(f"{name}-"):
             return name
-    return "agent"
+    command = row.command.lower()
+    if "@anthropic-ai/claude-code" in command:
+        return "claude"
+    if "@openai/codex" in command:
+        return "codex"
+    return None
 
 
-def _classify_resource(comm: str, command: str) -> str:
-    text = f"{comm} {command}"
-    if "polylogued" in text:
+def _is_agent_component(row: _ProcessRow) -> bool:
+    text = f"{row.comm} {row.command}".lower()
+    return any(marker in text for marker in ("mcp-server", "--spare-daemon", "code-mode-host", "claude-code-acp"))
+
+
+def _descends_from(row: _ProcessRow, ancestor_pid: int, by_pid: dict[int, _ProcessRow]) -> bool:
+    parent_pid = row.ppid
+    seen = {row.pid}
+    while parent_pid in by_pid and parent_pid not in seen:
+        if parent_pid == ancestor_pid:
+            return True
+        seen.add(parent_pid)
+        parent_pid = by_pid[parent_pid].ppid
+    return False
+
+
+def _resource_scope_payloads(
+    rows: tuple[_ProcessRow, ...],
+    result: CommandResult,
+    repo_cwd: Path,
+) -> tuple[CoordinationResourceEpisodePayload, ...]:
+    by_unit: dict[str, list[_ProcessRow]] = {}
+    direct: list[_ProcessRow] = []
+    for row in rows:
+        kind = _classify_resource(row)
+        if kind is None:
+            continue
+        unit = _systemd_unit(row.cgroup)
+        if unit and _WORK_SCOPE_RE.search(unit.lower()):
+            by_unit.setdefault(unit, []).append(row)
+        else:
+            direct.append(row)
+
+    episodes: list[CoordinationResourceEpisodePayload] = []
+    for unit, unit_rows in sorted(by_unit.items()):
+        representative = min(unit_rows, key=lambda row: row.pid)
+        kind = _classify_resource(representative) or "work"
+        episodes.append(_resource_payload(representative, unit_rows, kind, result, repo_cwd, unit=unit))
+    scoped_pids = {row.pid for unit_rows in by_unit.values() for row in unit_rows}
+    for row in direct:
+        if row.pid in scoped_pids:
+            continue
+        kind = _classify_resource(row)
+        if kind is not None:
+            episodes.append(_resource_payload(row, [row], kind, result, repo_cwd, unit=_systemd_unit(row.cgroup)))
+    return tuple(sorted(episodes, key=lambda episode: (episode.unit or "", episode.pid)))
+
+
+def _resource_payload(
+    representative: _ProcessRow,
+    rows: Sequence[_ProcessRow],
+    kind: str,
+    result: CommandResult,
+    repo_cwd: Path,
+    *,
+    unit: str | None,
+) -> CoordinationResourceEpisodePayload:
+    process_cwd = _proc_cwd(representative.pid)
+    resources = _command_resource_refs(representative.command, process_cwd, repo_cwd)
+    return CoordinationResourceEpisodePayload(
+        pid=representative.pid,
+        kind=kind,
+        command=_short(representative.command),
+        status="running",
+        scope=representative.cgroup,
+        unit=unit,
+        cwd=process_cwd,
+        resource_count=len(resources),
+        resources=resources[:50],
+        component_count=max(0, len(rows) - 1),
+        component_pids=tuple(sorted(row.pid for row in rows if row.pid != representative.pid))[:50],
+        provenance=_prov("process-cgroup", command=result.args, confidence=0.85 if unit else 0.75),
+    )
+
+
+def _classify_resource(row: _ProcessRow) -> str | None:
+    comm = Path(row.comm).name.lower()
+    executable = _executable_name(row.command)
+    unit = (_systemd_unit(row.cgroup) or "").lower()
+    if comm in _SYSTEM_RESOURCE_NAMES or executable in _SYSTEM_RESOURCE_NAMES or "/system.slice/" in row.cgroup:
+        return None
+    if _WORK_SCOPE_RE.search(unit):
+        if "rebuild" in unit or "nix-build" in unit or "build" in unit:
+            return "build"
+        if "test" in unit or "verify" in unit:
+            return "test"
+        return "work"
+    if executable == "polylogued" or comm == "polylogued":
         return "daemon"
-    if "pytest" in text:
+    if executable == "pytest" or comm == "pytest" or _python_module(row.command) == "pytest":
         return "test"
-    if "nix" in text:
+    if executable in {"nix", "cargo", "rustc"} or comm in {"cargo", "rustc"}:
         return "build"
-    if "cargo" in text or "rustc" in text:
-        return "build"
-    if "uv" in text or "python" in text:
-        return "python"
-    return "process"
+    if executable == "uv" and any(token in row.command for token in ("pytest", "devtools verify", "devtools test")):
+        return "test"
+    return None
+
+
+def _executable_name(command: str) -> str:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    if not tokens:
+        return ""
+    return Path(tokens[0]).name.lower()
+
+
+def _python_module(command: str) -> str | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    for index, token in enumerate(tokens[:-1]):
+        if token == "-m":
+            return tokens[index + 1].lower()
+    return None
+
+
+def _systemd_unit(cgroup: str) -> str | None:
+    for segment in reversed(cgroup.split("/")):
+        if segment.endswith((".service", ".scope")):
+            return segment
+    return None
+
+
+def _session_ref(command: str) -> str | None:
+    match = _SESSION_ARG_RE.search(command)
+    return match.group(1) if match else None
+
+
+def _command_resource_refs(command: str, process_cwd: str | None, repo_cwd: Path) -> tuple[str, ...]:
+    refs: list[str] = []
+    if process_cwd:
+        refs.append(process_cwd)
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    for token in tokens:
+        candidate = token.split("=", 1)[-1]
+        if candidate.startswith("/") and (
+            candidate.startswith(str(repo_cwd))
+            or "/polylogue" in candidate
+            or candidate.startswith("/realm/tmp/worktrees/")
+        ):
+            refs.append(candidate)
+    return tuple(dict.fromkeys(refs))
 
 
 def _short(command: str) -> str:
@@ -545,27 +988,116 @@ def _proc_cwd(pid: int) -> str | None:
         return None
 
 
-def _handoff_payloads(root: str) -> tuple[CoordinationHandoffPayload, ...]:
+def _handoff_payloads(
+    root: str,
+    *,
+    archive: CoordinationArchivePayload | None,
+    limit: int,
+) -> tuple[CoordinationHandoffPayload, ...]:
     repo_root = Path(root)
-    refs = (
-        (repo_root / ".agent" / "conductor-devloop" / "ACTIVE-LOOP.md", "active-loop"),
-        (repo_root / ".agent" / "conductor-devloop" / "HANDOFF-LATEST.md", "handoff"),
-        (repo_root / ".agent" / "conductor-devloop" / "OPERATING-LOG.md", "operating-log"),
-    )
     payloads: list[CoordinationHandoffPayload] = []
-    for path, kind in refs:
-        stat = path.stat() if path.exists() else None
+    scratch = repo_root / ".agent" / "scratch"
+    paths = sorted(
+        (
+            path
+            for pattern in ("*handoff*.md", "*coordination-message*.md")
+            for path in scratch.rglob(pattern)
+            if path.is_file()
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    for path in paths[: max(1, limit)]:
+        stat = path.stat()
         payloads.append(
             CoordinationHandoffPayload(
+                ref=str(path),
                 path=str(path),
-                kind=kind,
-                exists=stat is not None,
-                updated_at=(datetime.fromtimestamp(stat.st_mtime, UTC).isoformat() if stat else None),
-                bytes=(stat.st_size if stat else None),
-                provenance=_prov("filesystem", path=str(path), confidence=0.8 if stat else 0.5),
+                kind="scratch-handoff",
+                exists=True,
+                updated_at=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+                bytes=stat.st_size,
+                provenance=_prov("scratch", path=str(path), confidence=0.8),
             )
         )
-    return tuple(payloads)
+    remaining = max(0, limit - len(payloads))
+    if remaining and archive is not None:
+        payloads.extend(
+            _assertion_handoff_payloads(
+                Path(archive.index_db).with_name("user.db"),
+                repo_root=repo_root,
+                limit=remaining,
+            )
+        )
+    return tuple(payloads[: max(1, limit)])
+
+
+def _assertion_handoff_payloads(
+    user_db: Path,
+    *,
+    repo_root: Path,
+    limit: int,
+) -> tuple[CoordinationHandoffPayload, ...]:
+    if not user_db.exists() or limit <= 0:
+        return ()
+    try:
+        with closing(sqlite3.connect(f"file:{user_db}?mode=ro", uri=True, timeout=0.2)) as conn:
+            tables = {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+            if "assertions" not in tables:
+                return ()
+            rows = conn.execute(
+                """
+                SELECT assertion_id, kind, body_text, scope_ref, target_ref, updated_at_ms
+                FROM assertions
+                WHERE status = 'active'
+                  AND (kind = 'handoff' OR (kind = 'note' AND body_text LIKE '[handoff]%'))
+                ORDER BY updated_at_ms DESC
+                LIMIT ?
+                """,
+                (limit * 4,),
+            ).fetchall()
+    except sqlite3.Error:
+        return ()
+    repo_tokens = {str(repo_root), repo_root.name}
+    scoped_rows = [
+        row
+        for row in rows
+        if _handoff_matches_repo(
+            body=str(row[2] or ""),
+            scope_ref=str(row[3] or ""),
+            target_ref=str(row[4] or ""),
+            repo_tokens=repo_tokens,
+        )
+    ][:limit]
+    return tuple(
+        CoordinationHandoffPayload(
+            ref=f"assertion:{row[0]}",
+            path=f"user.db:assertions:{row[0]}",
+            kind="assertion-handoff",
+            exists=True,
+            updated_at=datetime.fromtimestamp(int(row[5]) / 1000, UTC).isoformat(),
+            bytes=len(str(row[2] or "").encode()),
+            provenance=_prov(
+                "user-assertion",
+                path=f"user.db:assertions:{row[0]}",
+                confidence=0.9,
+            ),
+        )
+        for row in scoped_rows
+    )
+
+
+def _handoff_matches_repo(*, body: str, scope_ref: str, target_ref: str, repo_tokens: set[str]) -> bool:
+    body_scope = next(
+        (line.removeprefix("scope_repo: ").strip() for line in body.splitlines() if line.startswith("scope_repo: ")),
+        None,
+    )
+    if body_scope is not None:
+        return body_scope in repo_tokens
+    explicit_refs = {value for value in (scope_ref, target_ref) if value}
+    if not explicit_refs:
+        return True
+    return bool(explicit_refs & repo_tokens) or any(token in ref for ref in explicit_refs for token in repo_tokens)
 
 
 def _archive_payload(resources: tuple[CoordinationResourceEpisodePayload, ...]) -> CoordinationArchivePayload | None:
@@ -797,7 +1329,7 @@ def _session_tree_payload(
         CoordinationSessionTreeNodePayload(
             session_id=str(row["session_id"]),
             source_name=_str_or_none(row["origin"]),
-            title=_str_or_none(row["title"]),
+            title=(_short_to(str(row["title"]), 500) if row["title"] is not None else None),
             depth=depth_by_id.get(str(row["session_id"]), 0),
             is_target=bool(row["is_target"]),
         )
@@ -1095,7 +1627,7 @@ def _activity_payload_from_row(row: sqlite3.Row) -> CoordinationActivityEpisodeP
         run_ref=_str_or_none(row["run_ref"]),
         kind=str(row["kind"]),
         status=_str_or_none(row["status"]),
-        summary=_str_or_none(row["summary"]),
+        summary=(_short_to(str(row["summary"]), 1_000) if row["summary"] is not None else None),
         occurred_at=_str_or_none(row["occurred_at"]),
         refs=_json_str_tuple(row["refs_json"], limit=10),
         provenance=_prov(
@@ -1112,7 +1644,7 @@ def _proof_payload_from_row(row: sqlite3.Row) -> CoordinationProofRefPayload:
         session_id=str(row["session_id"]),
         kind=str(row["kind"]),
         status=status,
-        summary=_str_or_none(row["summary"]),
+        summary=(_short_to(str(row["summary"]), 1_000) if row["summary"] is not None else None),
         evidence_refs=_json_str_tuple(row["evidence_refs_json"], limit=10),
         provenance=_prov("archive-proof-outcome", path="index.db:session_observed_events", confidence=0.7),
     )
@@ -1127,8 +1659,10 @@ def _subagent_exchange_payload_from_row(row: sqlite3.Row) -> CoordinationSubagen
         session_id=str(row["session_id"]),
         run_ref=str(row["run_ref"]),
         agent_ref=_str_or_none(row["agent_ref"]),
-        dispatch_prompt=_str_or_none(row["dispatch_prompt"]),
-        returned_final_message=_str_or_none(row["returned_final_message"]),
+        dispatch_prompt=(_short_to(str(row["dispatch_prompt"]), 1_000) if row["dispatch_prompt"] is not None else None),
+        returned_final_message=(
+            _short_to(str(row["returned_final_message"]), 1_000) if row["returned_final_message"] is not None else None
+        ),
         status=_str_or_none(row["status"]),
         child_session_id=_str_or_none(row["native_session_id"]),
         context_snapshot_ref=_str_or_none(row["context_snapshot_ref"]),

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -106,7 +106,11 @@ def build_coordination_envelope(
     self_payload = _self_payload(root_cwd, repo)
     work_item = _work_item_payload(root_cwd, repo, command_runner)
     beads = _beads_payload(root_cwd, repo, command_runner)
-    all_peers, all_resources = _process_payloads(command_runner, root_cwd)
+    all_peers, all_resources = _process_payloads(
+        command_runner,
+        root_cwd,
+        archive_resource=_configured_archive_resource(),
+    )
     peers = all_peers[:peer_limit]
     resources = all_resources[:resource_limit]
     archive = _archive_payload(resources)
@@ -737,12 +741,26 @@ def _bool_or_none(value: object) -> bool | None:
 def _process_payloads(
     runner: CommandRunner,
     cwd: Path,
+    *,
+    archive_resource: str | None,
 ) -> tuple[tuple[CoordinationPeerPayload, ...], tuple[CoordinationResourceEpisodePayload, ...]]:
     result = runner(_PROCESS_COMMAND, None)
     if result.returncode != 0:
         return (), ()
     rows = tuple(parsed for line in result.stdout.splitlines() if (parsed := _parse_ps_row(line)) is not None)
-    return _logical_peer_payloads(rows, result), _resource_scope_payloads(rows, result, cwd)
+    return _logical_peer_payloads(rows, result), _resource_scope_payloads(
+        rows,
+        result,
+        cwd,
+        archive_resource=archive_resource,
+    )
+
+
+def _configured_archive_resource() -> str | None:
+    try:
+        return str(archive_root().resolve())
+    except Exception:
+        return None
 
 
 def _parse_ps_row(row: str) -> _ProcessRow | None:
@@ -844,6 +862,8 @@ def _resource_scope_payloads(
     rows: tuple[_ProcessRow, ...],
     result: CommandResult,
     repo_cwd: Path,
+    *,
+    archive_resource: str | None,
 ) -> tuple[CoordinationResourceEpisodePayload, ...]:
     by_unit: dict[str, list[_ProcessRow]] = {}
     direct: list[_ProcessRow] = []
@@ -861,14 +881,34 @@ def _resource_scope_payloads(
     for unit, unit_rows in sorted(by_unit.items()):
         representative = min(unit_rows, key=lambda row: row.pid)
         kind = _classify_resource(representative) or "work"
-        episodes.append(_resource_payload(representative, unit_rows, kind, result, repo_cwd, unit=unit))
+        episodes.append(
+            _resource_payload(
+                representative,
+                unit_rows,
+                kind,
+                result,
+                repo_cwd,
+                unit=unit,
+                archive_resource=archive_resource,
+            )
+        )
     scoped_pids = {row.pid for unit_rows in by_unit.values() for row in unit_rows}
     for row in direct:
         if row.pid in scoped_pids:
             continue
         kind = _classify_resource(row)
         if kind is not None:
-            episodes.append(_resource_payload(row, [row], kind, result, repo_cwd, unit=_systemd_unit(row.cgroup)))
+            episodes.append(
+                _resource_payload(
+                    row,
+                    [row],
+                    kind,
+                    result,
+                    repo_cwd,
+                    unit=_systemd_unit(row.cgroup),
+                    archive_resource=archive_resource,
+                )
+            )
     return tuple(sorted(episodes, key=lambda episode: (episode.unit or "", episode.pid)))
 
 
@@ -880,9 +920,12 @@ def _resource_payload(
     repo_cwd: Path,
     *,
     unit: str | None,
+    archive_resource: str | None,
 ) -> CoordinationResourceEpisodePayload:
     process_cwd = _proc_cwd(representative.pid)
     resources = _command_resource_refs(representative.command, process_cwd, repo_cwd)
+    if archive_resource and _resource_owns_archive(representative, unit):
+        resources = tuple(dict.fromkeys((*resources, archive_resource)))
     return CoordinationResourceEpisodePayload(
         pid=representative.pid,
         kind=kind,
@@ -897,6 +940,11 @@ def _resource_payload(
         component_pids=tuple(sorted(row.pid for row in rows if row.pid != representative.pid))[:50],
         provenance=_prov("process-cgroup", command=result.args, confidence=0.85 if unit else 0.75),
     )
+
+
+def _resource_owns_archive(row: _ProcessRow, unit: str | None) -> bool:
+    text = f"{unit or ''} {row.comm} {row.command}".lower()
+    return "polylogued" in text or "polylogue-index-rebuild" in text or "rebuild-index" in text
 
 
 def _classify_resource(row: _ProcessRow) -> str | None:

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -51,7 +51,7 @@ _CHANGED_PATH_LIMIT = 40
 # Leave headroom for the MCP brief's fixed instructions while keeping the
 # complete default response below the bead's 8 KiB transport ceiling.
 _COMPACT_BYTE_BUDGET = 7_600
-_PROCESS_COMMAND = ("ps", "-eo", "pid=,ppid=,comm=,cgroup=,args=")
+_PROCESS_COMMAND = ("ps", "ww", "-eo", "pid=,ppid=,comm=,cgroup:200=,args=")
 _AGENT_NAMES = ("codex", "claude", "gemini")
 _SYSTEM_RESOURCE_NAMES = frozenset(
     {

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -943,7 +943,7 @@ def _resource_payload(
     process_cwd = _proc_cwd(representative.pid)
     resources = _command_resource_refs(representative.command, process_cwd, repo_cwd)
     if archive_resource and _resource_owns_archive(representative, unit):
-        resources = tuple(dict.fromkeys((*resources, archive_resource)))
+        resources = tuple(dict.fromkeys((archive_resource, *resources)))
     return CoordinationResourceEpisodePayload(
         pid=representative.pid,
         kind=kind,

--- a/polylogue/coordination/payloads.py
+++ b/polylogue/coordination/payloads.py
@@ -56,6 +56,10 @@ class CoordinationPeerPayload(SurfacePayloadModel):
     kind: str
     command: str
     cwd: str | None = None
+    logical_id: str | None = None
+    session_ref: str | None = None
+    component_count: int = 0
+    component_pids: tuple[int, ...] = ()
     provenance: CoordinationProvenancePayload
 
 
@@ -65,6 +69,12 @@ class CoordinationResourceEpisodePayload(SurfacePayloadModel):
     command: str
     status: str
     scope: str | None = None
+    unit: str | None = None
+    cwd: str | None = None
+    resource_count: int = 0
+    resources: tuple[str, ...] = ()
+    component_count: int = 0
+    component_pids: tuple[int, ...] = ()
     provenance: CoordinationProvenancePayload
 
 
@@ -81,6 +91,7 @@ class CoordinationHandoffPayload(SurfacePayloadModel):
     path: str
     kind: str
     exists: bool
+    ref: str | None = None
     updated_at: str | None = None
     bytes: int | None = None
     provenance: CoordinationProvenancePayload
@@ -215,6 +226,15 @@ class CoordinationLimitsPayload(SurfacePayloadModel):
     command_chars: int
 
 
+class CoordinationProjectionPayload(SurfacePayloadModel):
+    detail: bool = False
+    byte_budget: int | None = None
+    serialized_bytes: int | None = None
+    total_counts: dict[str, int] = Field(default_factory=dict)
+    omitted_counts: dict[str, int] = Field(default_factory=dict)
+    detail_hint: str | None = None
+
+
 class AgentCoordinationPayload(SurfacePayloadModel):
     view: CoordinationView
     generated_at: str
@@ -234,4 +254,5 @@ class AgentCoordinationPayload(SurfacePayloadModel):
     beads: CoordinationBeadsPayload | None = None
     advisories: tuple[str, ...] = ()
     limits: CoordinationLimitsPayload
+    projection: CoordinationProjectionPayload = Field(default_factory=CoordinationProjectionPayload)
     provenance: tuple[CoordinationProvenancePayload, ...] = ()

--- a/polylogue/coordination/rendering.py
+++ b/polylogue/coordination/rendering.py
@@ -31,6 +31,14 @@ def _beads_summary(payload: AgentCoordinationPayload) -> str:
     )
 
 
+def _projection_summary(payload: AgentCoordinationPayload) -> str:
+    projection = payload.projection
+    omissions = ", ".join(f"{name}={count}" for name, count in projection.omitted_counts.items()) or "none"
+    return (
+        f"detail={str(projection.detail).lower()} bytes={projection.serialized_bytes or 'unknown'} omitted={omissions}"
+    )
+
+
 def render_coordination_text(payload: AgentCoordinationPayload) -> str:
     """Render a compact text view for humans; JSON remains the primary contract."""
 
@@ -40,6 +48,7 @@ def render_coordination_text(payload: AgentCoordinationPayload) -> str:
         f"  branch: {payload.repo.branch or 'n/a'} head={payload.repo.head or 'n/a'} dirty={payload.repo.dirty}",
         f"  self: {payload.self.agent_kind} pid={payload.self.pid}",
         "  work item: " + _work_item_label(payload),
+        "  projection: " + _projection_summary(payload),
     ]
     if payload.peers:
         lines.append(f"  peers: {len(payload.peers)}")
@@ -58,7 +67,7 @@ def render_coordination_text(payload: AgentCoordinationPayload) -> str:
         lines.append("  handoff refs:")
         for handoff_ref in payload.handoff:
             state = "present" if handoff_ref.exists else "missing"
-            lines.append(f"    - {handoff_ref.kind}: {state} {handoff_ref.path}")
+            lines.append(f"    - {handoff_ref.kind}: {state} {handoff_ref.ref or handoff_ref.path}")
     if payload.archive:
         lines.append(
             "  archive: "
@@ -124,6 +133,7 @@ def render_coordination_markdown(payload: AgentCoordinationPayload) -> str:
         f"- Agent: `{payload.self.agent_kind}` pid `{payload.self.pid}`",
         f"- Work item: `{_work_item_label(payload)}`",
         f"- Beads: `{_beads_summary(payload)}`",
+        f"- Projection: `{_projection_summary(payload)}`",
     ]
     if payload.archive:
         lines.extend(
@@ -215,7 +225,7 @@ def render_coordination_markdown(payload: AgentCoordinationPayload) -> str:
     if payload.handoff:
         for handoff_ref in payload.handoff:
             state = "present" if handoff_ref.exists else "missing"
-            lines.append(f"- `{handoff_ref.kind}` {state}: `{handoff_ref.path}`")
+            lines.append(f"- `{handoff_ref.kind}` {state}: `{handoff_ref.ref or handoff_ref.path}`")
     else:
         lines.append("- No handoff refs in this projection.")
     if payload.advisories:
@@ -235,6 +245,7 @@ def render_coordination_tree(payload: AgentCoordinationPayload) -> str:
         f"+- self {payload.self.agent_kind} pid={payload.self.pid}",
         f"+- work {payload.work_item.ref or 'none'} source={payload.work_item.source} confidence={payload.work_item.confidence:.2f}",
         f"+- beads {_beads_summary(payload)}",
+        f"+- projection {_projection_summary(payload)}",
     ]
     if payload.archive:
         lines.append(f"+- archive schema={payload.archive.index_user_version} root={payload.archive.archive_root}")

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -221,7 +221,7 @@ def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     """Register MCP prompts on the given server."""
 
     @mcp.prompt()
-    async def agent_coordination_brief(view: str = "status", limit: int = 10) -> str:
+    async def agent_coordination_brief(view: str = "status", limit: int = 10, detail: bool = False) -> str:
         from polylogue.coordination import CoordinationView, build_coordination_envelope
 
         normalized_view: CoordinationView
@@ -229,7 +229,11 @@ def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             normalized_view = cast(CoordinationView, view)
         else:
             normalized_view = "status"
-        payload = build_coordination_envelope(view=normalized_view, limit=hooks.clamp_limit(limit))
+        payload = build_coordination_envelope(
+            view=normalized_view,
+            limit=hooks.clamp_limit(limit),
+            detail=detail,
+        )
         return f"""Use this bounded coordination envelope to decide the next agent action.
 
 Rules:

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -1031,12 +1031,18 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         view: Literal["status", "self", "work-item", "conflicts", "handoff"] = "status",
         cwd: str | None = None,
         limit: MCPToolLimit = 10,
+        detail: bool = False,
     ) -> str:
-        """Return the bounded shared coordination envelope for agents."""
+        """Return the compact shared envelope; opt into bounded evidence detail."""
 
         async def run() -> str:
             path = Path(cwd).expanduser().resolve() if cwd else None
-            payload = build_coordination_envelope(view=view, cwd=path, limit=hooks.clamp_limit(limit))
+            payload = build_coordination_envelope(
+                view=view,
+                cwd=path,
+                limit=hooks.clamp_limit(limit),
+                detail=detail,
+            )
             return hooks.json_payload(payload, exclude_none=True)
 
         return await hooks.async_safe_call("agent_coordination", run)

--- a/tests/unit/cli/test_agents_command.py
+++ b/tests/unit/cli/test_agents_command.py
@@ -59,10 +59,10 @@ def _payload(view: str = "status") -> AgentCoordinationPayload:
 
 
 def test_agents_status_json_uses_shared_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, Path | None, int]] = []
+    calls: list[tuple[str, Path | None, int, bool]] = []
 
-    def fake_build(*, view: str, cwd: Path | None, limit: int) -> AgentCoordinationPayload:
-        calls.append((view, cwd, limit))
+    def fake_build(*, view: str, cwd: Path | None, limit: int, detail: bool) -> AgentCoordinationPayload:
+        calls.append((view, cwd, limit, detail))
         return _payload(view)
 
     monkeypatch.setattr("polylogue.cli.commands.agents.build_coordination_envelope", fake_build)
@@ -77,7 +77,22 @@ def test_agents_status_json_uses_shared_envelope(monkeypatch: pytest.MonkeyPatch
     body = json.loads(result.output)
     assert body["view"] == "status"
     assert body["work_item"]["ref"] == "polylogue-s7ae.1"
-    assert calls == [("status", Path("/repo"), 3)]
+    assert calls == [("status", Path("/repo"), 3, False)]
+
+
+def test_agents_status_detail_is_explicitly_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[bool] = []
+
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    monkeypatch.setattr("polylogue.cli.commands.agents.build_coordination_envelope", fake_build)
+
+    result = CliRunner().invoke(agents_command, ["status", "--detail", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert calls == [True]
 
 
 def test_agents_work_item_text_is_compact(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -445,7 +445,8 @@ def test_process_projection_collapses_components_and_uses_real_work_scopes(
     system = "0::/system.slice"
     rows = "\n".join(
         (
-            "101 1 codex 0::/user.slice/user@1000.service/app.slice/codex.scope codex --session-id session-1",
+            "100 1 node 0::/user.slice/user@1000.service/app.slice/codex.scope node @openai/codex code-mode-host",
+            "101 100 codex 0::/user.slice/user@1000.service/app.slice/codex.scope codex --session-id session-1",
             "102 101 node 0::/user.slice/user@1000.service/app.slice/codex.scope node code-mode-host",
             "103 101 claude-mcp 0::/user.slice/user@1000.service/app.slice/codex.scope claude-mcp mcp-server",
             "104 1 claude 0::/user.slice/user@1000.service/app.slice/claude-spare.service claude --spare-daemon",
@@ -470,8 +471,8 @@ def test_process_projection_collapses_components_and_uses_real_work_scopes(
     )
 
     assert [(peer.kind, peer.session_ref) for peer in payload.peers] == [("codex", "session-1")]
-    assert payload.peers[0].component_count >= 2
-    assert {102, 103} <= set(payload.peers[0].component_pids)
+    assert payload.peers[0].component_count >= 3
+    assert {100, 102, 103} <= set(payload.peers[0].component_pids)
     assert len(payload.resource_episodes) == 1
     rebuild = payload.resource_episodes[0]
     assert rebuild.kind == "build"

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -213,7 +213,7 @@ class FakeRunner:
                 json.dumps(self.merge_slot or {"id": "polylogue-merge-slot", "available": False, "error": "not found"}),
                 "",
             )
-        if key == ("ps", "-eo", "pid=,ppid=,comm=,cgroup=,args="):
+        if key == ("ps", "ww", "-eo", "pid=,ppid=,comm=,cgroup:200=,args="):
             return CommandResult(
                 key,
                 0,

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -481,6 +481,9 @@ def test_process_projection_collapses_components_and_uses_real_work_scopes(
     assert str(archive) in rebuild.resources
     assert all(name not in rebuild.command for name in ("timesyncd", "resolved", "udevd", "oomd", "earlyoom"))
 
+    compact = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None, process_rows=rows))
+    assert compact.resource_episodes[0].resources[0] == str(archive)
+
 
 def test_compact_projection_is_byte_bounded_and_detail_recovers_omitted_peers(
     tmp_path: Path,

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -158,11 +158,13 @@ class FakeRunner:
         beads_rows: list[dict[str, object]] | None,
         gates: list[dict[str, object]] | None = None,
         merge_slot: dict[str, object] | None = None,
+        process_rows: str | None = None,
     ) -> None:
         self.root = root
         self.beads_rows = beads_rows
         self.gates = gates
         self.merge_slot = merge_slot
+        self.process_rows = process_rows
 
     def __call__(self, args: Sequence[str], cwd: Path | None) -> CommandResult:
         key = tuple(args)
@@ -211,11 +213,17 @@ class FakeRunner:
                 json.dumps(self.merge_slot or {"id": "polylogue-merge-slot", "available": False, "error": "not found"}),
                 "",
             )
-        if key == ("ps", "-eo", "pid,ppid,comm,args", "--no-headers"):
+        if key == ("ps", "-eo", "pid=,ppid=,comm=,cgroup=,args="):
             return CommandResult(
                 key,
                 0,
-                "101 1 codex codex --profile full\n202 1 polylogued polylogued run --api-port 8766\n",
+                self.process_rows
+                or (
+                    "101 1 codex 0::/user.slice/user@1000.service/app.slice/codex.scope "
+                    "codex --profile full\n"
+                    "202 1 polylogued 0::/user.slice/user@1000.service/app.slice/polylogued.service "
+                    "polylogued run --api-port 8766\n"
+                ),
                 "",
             )
         return CommandResult(key, 1, "", "unexpected command")
@@ -342,7 +350,7 @@ def test_coordination_envelope_composes_archive_evidence(
     monkeypatch.setattr("polylogue.coordination.envelope.active_index_db_path", lambda: index)
     monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
 
-    payload = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), limit=4)
+    payload = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), limit=4, detail=True)
 
     assert len(payload.session_trees) == 1
     tree = payload.session_trees[0]
@@ -416,3 +424,145 @@ def test_coordination_view_projection_is_bounded(tmp_path: Path, monkeypatch: py
     assert payload.overlaps == ()
     assert payload.archive is not None
     assert payload.beads is not None
+
+
+def test_process_projection_collapses_components_and_uses_real_work_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    index = archive / "index.db"
+    index.touch()
+    monkeypatch.setattr("polylogue.coordination.envelope.archive_root", lambda: archive)
+    monkeypatch.setattr("polylogue.coordination.envelope.active_index_db_path", lambda: index)
+    monkeypatch.setattr(
+        "polylogue.coordination.envelope._proc_cwd",
+        lambda pid: str(root) if pid in {101, 102, 103, 300} else None,
+    )
+    system = "0::/system.slice"
+    rows = "\n".join(
+        (
+            "101 1 codex 0::/user.slice/user@1000.service/app.slice/codex.scope codex --session-id session-1",
+            "102 101 node 0::/user.slice/user@1000.service/app.slice/codex.scope node code-mode-host",
+            "103 101 claude-mcp 0::/user.slice/user@1000.service/app.slice/codex.scope claude-mcp mcp-server",
+            "104 1 claude 0::/user.slice/user@1000.service/app.slice/claude-spare.service claude --spare-daemon",
+            f"201 1 systemd-timesyncd {system}/systemd-timesyncd.service /nix/store/hash/systemd-timesyncd",
+            f"202 1 systemd-resolved {system}/systemd-resolved.service /nix/store/hash/systemd-resolved",
+            f"203 1 systemd-udevd {system}/systemd-udevd.service /nix/store/hash/systemd-udevd",
+            f"204 1 systemd-oomd {system}/systemd-oomd.service /nix/store/hash/systemd-oomd",
+            f"205 1 dbus-daemon {system}/dbus.service /nix/store/hash/dbus-daemon --system",
+            f"206 1 earlyoom {system}/earlyoom.service /nix/store/hash/earlyoom",
+            f"207 1 below {system}/below.service /nix/store/hash/below record",
+            "208 2 nvidia_uvm 0::/ [nvidia_uvm]",
+            "300 1 python 0::/user.slice/user@1000.service/background.slice/"
+            "sinnix-background-polylogue-index-rebuild-v30.scope python rebuild-index "
+            f"--archive-root={archive}",
+        )
+    )
+
+    payload = build_coordination_envelope(
+        cwd=root,
+        runner=FakeRunner(root, beads_rows=None, process_rows=rows),
+        detail=True,
+    )
+
+    assert [(peer.kind, peer.session_ref) for peer in payload.peers] == [("codex", "session-1")]
+    assert payload.peers[0].component_count >= 2
+    assert {102, 103} <= set(payload.peers[0].component_pids)
+    assert len(payload.resource_episodes) == 1
+    rebuild = payload.resource_episodes[0]
+    assert rebuild.kind == "build"
+    assert rebuild.unit == "sinnix-background-polylogue-index-rebuild-v30.scope"
+    assert rebuild.cwd == str(root)
+    assert str(archive) in rebuild.resources
+    assert all(name not in rebuild.command for name in ("timesyncd", "resolved", "udevd", "oomd", "earlyoom"))
+
+
+def test_compact_projection_is_byte_bounded_and_detail_recovers_omitted_peers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    index = archive / "index.db"
+    index.touch()
+    monkeypatch.setattr("polylogue.coordination.envelope.archive_root", lambda: archive)
+    monkeypatch.setattr("polylogue.coordination.envelope.active_index_db_path", lambda: index)
+    rows = "\n".join(
+        f"{100 + index} 1 codex 0::/user.slice/user@1000.service/app.slice/codex-{index}.scope "
+        f"codex --session-id session-{index} --config {'x' * 180}"
+        for index in range(20)
+    )
+    runner = FakeRunner(root, beads_rows=None, process_rows=rows)
+
+    compact = build_coordination_envelope(cwd=root, runner=runner, limit=20)
+    detailed = build_coordination_envelope(cwd=root, runner=runner, limit=20, detail=True)
+
+    compact_bytes = len(compact.to_json(exclude_none=True).encode())
+    assert compact_bytes <= 8 * 1024
+    assert compact.projection.serialized_bytes == compact_bytes
+    assert compact.projection.omitted_counts["peers"] == 16
+    assert compact.projection.detail_hint == "CLI: --detail; MCP: detail=true"
+    assert len(detailed.peers) == 20
+    assert detailed.projection.detail is True
+    assert detailed.projection.omitted_counts == {}
+    assert len(detailed.to_json(exclude_none=True).encode()) > compact_bytes
+
+
+def test_handoff_projection_uses_supported_live_sources_or_empty_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    index = archive / "index.db"
+    index.touch()
+    monkeypatch.setattr("polylogue.coordination.envelope.archive_root", lambda: archive)
+    monkeypatch.setattr("polylogue.coordination.envelope.active_index_db_path", lambda: index)
+
+    empty = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), detail=True)
+    assert empty.handoff == ()
+    assert "conductor-devloop" not in empty.to_json(exclude_none=True)
+
+    scratch = root / ".agent" / "scratch"
+    scratch.mkdir(parents=True)
+    handoff = scratch / "2026-07-10-agent-handoff.md"
+    handoff.write_text("handoff evidence", encoding="utf-8")
+    populated = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), detail=True)
+
+    assert len(populated.handoff) == 1
+    assert populated.handoff[0].ref == str(handoff)
+    assert populated.handoff[0].kind == "scratch-handoff"
+    assert populated.handoff[0].exists is True
+
+    with sqlite3.connect(archive / "user.db") as conn:
+        conn.executescript(
+            """
+            CREATE TABLE assertions (
+                assertion_id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                body_text TEXT,
+                scope_ref TEXT,
+                target_ref TEXT NOT NULL,
+                status TEXT NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            ) STRICT;
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO assertions
+                (assertion_id, kind, body_text, scope_ref, target_ref, status, updated_at_ms)
+            VALUES (?, 'note', ?, ?, 'blackboard:handoff', 'active', 1783700000000)
+            """,
+            ("blackboard-note:handoff-1", f"[handoff] Ready\n\nscope_repo: {root.name}", str(root)),
+        )
+    with_assertion = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), detail=True)
+    assert {item.kind for item in with_assertion.handoff} == {"scratch-handoff", "assertion-handoff"}

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -459,7 +459,7 @@ def test_process_projection_collapses_components_and_uses_real_work_scopes(
             "208 2 nvidia_uvm 0::/ [nvidia_uvm]",
             "300 1 python 0::/user.slice/user@1000.service/background.slice/"
             "sinnix-background-polylogue-index-rebuild-v30.scope python rebuild-index "
-            f"--archive-root={archive}",
+            "--workers=4",
         )
     )
 

--- a/tests/unit/mcp/test_agent_coordination.py
+++ b/tests/unit/mcp/test_agent_coordination.py
@@ -88,11 +88,20 @@ def test_agent_coordination_tool_returns_shared_payload(
     mcp_server: MCPServerUnderTest,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        "polylogue.mcp.server_tools.build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"])
-    )
+    calls: list[bool] = []
 
-    raw = invoke_surface(mcp_server._tool_manager._tools["agent_coordination"].fn, view="work-item", limit=5)
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    monkeypatch.setattr("polylogue.mcp.server_tools.build_coordination_envelope", fake_build)
+
+    raw = invoke_surface(
+        mcp_server._tool_manager._tools["agent_coordination"].fn,
+        view="work-item",
+        limit=5,
+        detail=True,
+    )
     body = json.loads(raw)
 
     assert body["view"] == "work-item"
@@ -102,16 +111,29 @@ def test_agent_coordination_tool_returns_shared_payload(
     assert body["activity_episodes"][0]["kind"] == "run"
     assert body["proof_refs"][0]["status"] == "passed"
     assert body["context_flow_refs"][0]["boundary"] == "session_start"
+    assert calls == [True]
 
 
 def test_agent_coordination_prompt_embeds_bounded_envelope(
     mcp_server: MCPServerUnderTest,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("polylogue.coordination.build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"]))
+    calls: list[bool] = []
 
-    raw = invoke_surface(mcp_server._prompt_manager._prompts["agent_coordination_brief"].fn, view="conflicts", limit=5)
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    monkeypatch.setattr("polylogue.coordination.build_coordination_envelope", fake_build)
+
+    raw = invoke_surface(
+        mcp_server._prompt_manager._prompts["agent_coordination_brief"].fn,
+        view="conflicts",
+        limit=5,
+        detail=True,
+    )
 
     assert "bounded coordination envelope" in raw
     assert '"view": "conflicts"' in raw
     assert "Treat overlaps as awareness" in raw
+    assert calls == [True]


### PR DESCRIPTION
## Summary

Make agent coordination status compact by default while retaining bounded,
explicit detail. Logical agent process trees now collapse launcher, host, MCP,
and spare-daemon plumbing into one peer; resource episodes use executable and
full cgroup/unit identity; handoffs come from supported scratch/assertion
sources instead of retired conductor paths.

Ref polylogue-s7ae.7.

## Problem

Live dogfooding falsified the shipped boundedness and classification claims.
`polylogue agents status --json` at the ordinary limit emitted 20,671 bytes,
reported process plumbing as ten peers, classified ordinary system services as
resource work, missed the active named index-rebuild scope, and returned three
nonexistent `.agent/conductor-devloop` handoff paths.

## Solution

- Add a typed projection contract with detail state, byte budget, serialized
  bytes, total counts, omitted counts, and a transport-specific detail hint.
- Keep compact CLI/MCP status below 8 KiB and expose bounded evidence with
  `--detail` / `detail=true`.
- Build logical peers from process trees and keep agent-branded component
  ancestors attached without allowing them to replace the real session root.
- Request an explicit 200-character cgroup column from procps, exclude ordinary
  system services, group named Sinnix/Polylogue work scopes, and prioritize the
  archive/repo resources those scopes own.
- Resolve live handoffs from scoped scratch files and active user assertions;
  return an empty typed list when no supported evidence exists.

## Acceptance Matrix

| Criterion | Status | Evidence |
| --- | --- | --- |
| Default CLI and MCP status <=8 KiB | Satisfied | High-process fixture; publish-head live CLI/MCP compact responses both 7,539 bytes |
| Detail exposes omitted evidence/counts/refs | Satisfied | Publish-head live detail responses 12,485 bytes; compact metadata lists omitted families |
| One logical peer per Codex/Claude tree | Satisfied | Host-above-session + MCP/spare component fixture |
| Ordinary services excluded; named work scope retained | Satisfied | timesyncd/resolved/udevd/oomd/UVM/dbus/earlyoom/below exclusion fixture; rebuild-scope fixture |
| Work scope reports unit, command, repo/archive resources, liveness | Satisfied | Explicit-width cgroup fixture and archive-resource priority assertion |
| No active retired-conductor handoffs; absent evidence is empty | Satisfied | Scratch/assertion/empty-source mutation fixture and source grep |
| Mutation-grade regression proof | Satisfied | Focused coordination, CLI, and MCP tests |
| Live MCP dogfood artifact | Satisfied | `.local/coordination/s7ae7-20260710T152753Z.json`, SHA-256 `8f953ee2d2ee831e9b93e05ba07738a8330b3e889b7656140bfd6aa95b156a55` |

## Verification

- `devtools test tests/unit/coordination/test_envelope.py tests/unit/cli/test_agents_command.py tests/unit/mcp/test_agent_coordination.py` -> 15 passed in 1.87s after rebase.
- `devtools test tests/unit/coordination/test_envelope.py` -> 9 passed in 1.22s.
- `mypy --strict polylogue/coordination/payloads.py polylogue/coordination/envelope.py polylogue/coordination/rendering.py polylogue/cli/commands/agents.py polylogue/mcp/server_tools.py polylogue/mcp/server_prompts.py` -> success, no issues in 6 files.
- `devtools verify --quick` -> 13/13 steps passed in 22.34s on publish head; run `20260710T152951Z-quick-1238499-ee44422c`.
- Live CLI compact: 7,539 bytes / est. 1,884 tokens / 13,199.206 ms.
- Live CLI detail: 12,485 bytes / est. 3,121 tokens / 13,155.585 ms.
- Live MCP compact: 7,539 bytes / est. 1,884 tokens / 16,632.985 ms.
- Live MCP detail: 12,485 bytes / est. 3,121 tokens / 13,641.836 ms.
- Private live artifact: `.local/coordination/s7ae7-20260710T152753Z.json`, 56,188 bytes, SHA-256 `8f953ee2d2ee831e9b93e05ba07738a8330b3e889b7656140bfd6aa95b156a55`.

## Residual Risk

Process identity remains observational rather than a scheduler or ownership
lock. Unknown process and scope shapes intentionally remain absent/unknown
instead of being guessed from broad command substrings.

Byte compactness did not make collection responsive: the publish-head four-call
sequence measured 13.2-16.6 seconds. Follow-up `polylogue-s7ae.8` owns a stage-timed,
measurement-first latency reduction; this PR does not claim a latency fix.
