### PR TITLE
fix(embeddings): preserve unknown status counts

### DIFF
--- a/polylogue/operations/archive_debt.py
+++ b/polylogue/operations/archive_debt.py
@@ -937,7 +937,8 @@ def _embedding_rows(index_db: Path) -> list[ArchiveDebtRowPayload]:
     has_key = _bool_value(info.get("embedding_has_voyage_key"))
     enabled = _bool_value(info.get("embedding_enabled"))
     pending = _int_value(info.get("embedding_pending_count")) or 0
-    pending_messages = _int_value(info.get("embedding_pending_message_count")) or 0
+    pending_messages = _int_value(info.get("embedding_pending_message_count"))
+    pending_messages_exact = _bool_value(info.get("embedding_pending_message_count_exact"))
     stale = _int_value(info.get("embedding_stale_count")) or 0
     failures = _int_value(info.get("embedding_failure_count")) or 0
 
@@ -981,6 +982,12 @@ def _embedding_rows(index_db: Path) -> list[ArchiveDebtRowPayload]:
             )
         )
     if pending or stale:
+        if pending_messages_exact and pending_messages is not None:
+            details = f"Pending messages: {pending_messages}; stale messages: {stale}."
+            caveats: tuple[str, ...] = ()
+        else:
+            details = "Pending and stale message counts are unknown in the bounded debt projection."
+            caveats = ("Run `polylogue ops embed status --detail` for bounded exact-count attempts.",)
         rows.append(
             ArchiveDebtRowPayload(
                 debt_ref="debt:embedding:catchup:backlog",
@@ -991,8 +998,9 @@ def _embedding_rows(index_db: Path) -> list[ArchiveDebtRowPayload]:
                 status="actionable" if enabled else "blocked",
                 owner="daemon",
                 summary=f"{pending} session(s) pending embedding catch-up",
-                details=f"Pending messages: {pending_messages}; stale messages: {stale}.",
+                details=details,
                 evidence_refs=(f"archive-tier:{index_db.with_name('embeddings.db')}",),
+                caveats=caveats,
                 actions=(
                     ArchiveDebtActionPayload(
                         label="Run embedding backfill",

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -394,9 +394,10 @@ def _archive_embedding_session_state_summary(
         conn,
         f"""
         SELECT COUNT(*)
-        FROM {status_table}
-        WHERE COALESCE(needs_reindex, 0) = 0
-          AND error_message IS NULL
+        FROM {status_table} AS e
+        JOIN sessions AS s ON s.session_id = e.session_id
+        WHERE COALESCE(e.needs_reindex, 0) = 0
+          AND e.error_message IS NULL
         """,
     )
     pending_sessions = max(total_sessions - embedded_sessions, 0)
@@ -666,7 +667,11 @@ def _archive_embedding_status_payload(
         if has_status:
             embedded_messages = _scalar_int(
                 conn,
-                f"SELECT COALESCE(SUM(message_count_embedded), 0) FROM {status_table}",
+                f"""
+                SELECT COALESCE(SUM(e.message_count_embedded), 0)
+                FROM {status_table} AS e
+                JOIN sessions AS s ON s.session_id = e.session_id
+                """,
             )
         elif has_meta:
             exact_embedded_messages = _scalar_int_with_timeout(
@@ -681,7 +686,15 @@ def _archive_embedding_status_payload(
         else:
             embedded_messages = 0
         failure_count = (
-            _scalar_int(conn, f"SELECT COUNT(*) FROM {status_table} WHERE error_message IS NOT NULL")
+            _scalar_int(
+                conn,
+                f"""
+                SELECT COUNT(*)
+                FROM {status_table} AS e
+                JOIN sessions AS s ON s.session_id = e.session_id
+                WHERE e.error_message IS NOT NULL
+                """,
+            )
             if has_status
             else 0
         )

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -365,8 +365,13 @@ def _coverage_percent(*, embedded_sessions: int, eligible_sessions: int, total_s
     return embedded_sessions / eligible_sessions * 100
 
 
-def _message_coverage_percent(*, embedded_messages: int, candidate_prose_messages: int | None) -> float | None:
-    if candidate_prose_messages is None:
+def _message_coverage_percent(
+    *,
+    embedded_messages: int,
+    candidate_prose_messages: int | None,
+    candidate_prose_messages_exact: bool,
+) -> float | None:
+    if candidate_prose_messages is None or not candidate_prose_messages_exact:
         return None
     if candidate_prose_messages <= 0:
         return 100.0 if embedded_messages > 0 else 0.0
@@ -560,6 +565,7 @@ def _payload_from_stats(
     message_coverage = _message_coverage_percent(
         embedded_messages=stats.embedded_messages,
         candidate_prose_messages=stats.candidate_prose_messages,
+        candidate_prose_messages_exact=stats.candidate_prose_messages_exact,
     )
     return {
         "config_enabled": config_enabled,

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -214,7 +214,7 @@ def test_status_json_reports_archive_embedding_metadata_without_detail(tmp_path:
     assert payload["newest_embedded_at"] is None
 
 
-def test_status_json_detail_uses_analyzed_prose_index_for_candidate_count(tmp_path: Path) -> None:
+def test_status_json_detail_does_not_derive_coverage_from_analyzed_prose_estimate(tmp_path: Path) -> None:
     db_anchor = tmp_path / "custom.sqlite"
     index_db = tmp_path / "index.db"
     _seed_archive_file_set_from_archive_tiers(index_db)
@@ -235,7 +235,43 @@ def test_status_json_detail_uses_analyzed_prose_index_for_candidate_count(tmp_pa
 
     assert payload["candidate_prose_messages"] == 3
     assert payload["candidate_prose_messages_exact"] is False
-    assert payload["message_coverage_percent"] == 33.3
+    assert payload["message_coverage_percent"] is None
+
+
+def test_status_json_does_not_report_over_100_percent_from_retained_embedding_rows(tmp_path: Path) -> None:
+    db_anchor = tmp_path / "custom.sqlite"
+    index_db = tmp_path / "index.db"
+    _seed_archive_file_set_from_archive_tiers(index_db)
+    with sqlite3.connect(index_db) as conn:
+        conn.executescript(
+            """
+            CREATE INDEX idx_messages_embedding_prose
+            ON messages(session_id, message_id)
+            WHERE message_type = 'message'
+              AND role IN ('user', 'assistant')
+              AND material_origin IN ('human_authored', 'assistant_authored')
+              AND word_count > 0;
+            ANALYZE idx_messages_embedding_prose;
+            """
+        )
+    with sqlite3.connect(tmp_path / "embeddings.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO message_embeddings_meta VALUES (
+                'orphaned-by-index-rebuild', 'voyage-4', 1024, 1767225700000, x'ff', 0
+            )
+            """
+        )
+        conn.execute(
+            "UPDATE embedding_status SET message_count_embedded = 4 WHERE session_id = 'codex-session:complete'"
+        )
+
+    payload = _run_status(db_anchor, "--detail", cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
+
+    assert payload["embedded_messages"] == 4
+    assert payload["candidate_prose_messages"] == 3
+    assert payload["candidate_prose_messages_exact"] is False
+    assert payload["message_coverage_percent"] is None
 
 
 def test_status_json_default_does_not_exact_count_archive_session_state(

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -265,10 +265,24 @@ def test_status_json_does_not_report_over_100_percent_from_retained_embedding_ro
         conn.execute(
             "UPDATE embedding_status SET message_count_embedded = 4 WHERE session_id = 'codex-session:complete'"
         )
+        conn.executemany(
+            """
+            INSERT INTO embedding_status (
+                session_id, origin, message_count_embedded, needs_reindex, error_message
+            ) VALUES (?, 'codex-session', ?, 0, ?)
+            """,
+            [
+                ("orphaned-clean-status", 7, None),
+                ("orphaned-error-status", 0, "Embedding generation failed: HTTP 400"),
+            ],
+        )
 
     payload = _run_status(db_anchor, "--detail", cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
 
+    assert payload["embedded_sessions"] == 1
+    assert payload["pending_sessions"] == 1
     assert payload["embedded_messages"] == 4
+    assert payload["failure_count"] == 0
     assert payload["candidate_prose_messages"] == 3
     assert payload["candidate_prose_messages_exact"] is False
     assert payload["message_coverage_percent"] is None

--- a/tests/unit/operations/test_archive_debt.py
+++ b/tests/unit/operations/test_archive_debt.py
@@ -180,6 +180,7 @@ def test_archive_debt_converts_embedding_and_fts_readiness(
             "embedding_has_voyage_key": True,
             "embedding_pending_count": 3,
             "embedding_pending_message_count": 30,
+            "embedding_pending_message_count_exact": True,
             "embedding_stale_count": 1,
             "embedding_failure_count": 2,
         },
@@ -211,6 +212,35 @@ def test_archive_debt_converts_embedding_and_fts_readiness(
     assert "debt:fts:messages_fts" in refs
     assert payload.totals.total == 3
     assert payload.totals.critical == 2
+
+
+def test_archive_debt_preserves_unknown_embedding_message_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_current_tier_files(tmp_path)
+    monkeypatch.setattr(
+        module,
+        "embedding_readiness_info",
+        lambda _path, detail=False: {
+            "embedding_config_enabled": True,
+            "embedding_enabled": True,
+            "embedding_has_voyage_key": True,
+            "embedding_pending_count": 3,
+            "embedding_pending_message_count": None,
+            "embedding_pending_message_count_exact": False,
+            "embedding_stale_count": 0,
+            "embedding_failure_count": 0,
+        },
+    )
+
+    payload = archive_debt_list(archive_root=tmp_path, kinds=("embedding",))
+
+    assert payload.totals.total == 1
+    row = payload.rows[0]
+    assert row.debt_ref == "debt:embedding:catchup:backlog"
+    assert row.details == "Pending and stale message counts are unknown in the bounded debt projection."
+    assert row.caveats == ("Run `polylogue ops embed status --detail` for bounded exact-count attempts.",)
 
 
 def _init_raw_materialization_fixture(root: Path) -> tuple[Path, Path, Path]:


### PR DESCRIPTION
## Summary

Preserve unknownness in bounded embedding debt and suppress message coverage when its candidate denominator is only an analyzed-index estimate.

Ref polylogue-b2r9.

## Problem

Live source-v4 dogfooding reported 430 pending sessions as `Pending messages: 0` even though the bounded status payload explicitly returned `pending_messages=null` and `pending_messages_exact=false`. Detailed status also divided 675,724 embedded messages by a stale `sqlite_stat1` estimate of 652,760 candidate messages, publishing an impossible 103.5% coverage value.

The archive contains 11,348 retained embedding metadata rows whose message IDs are absent from the rebuilt index, so an approximate denominator and historical numerator do not even describe the same set.

## Solution

- Derive `message_coverage_percent` only when `candidate_prose_messages_exact` is true.
- Keep the candidate estimate visible with its existing exactness flag, but do not turn it into false precision.
- Render pending/stale message counts as unknown in bounded archive debt and point operators to the detailed status attempt instead of coercing `None` to zero.
- Add a retained-orphan synthetic fixture that would produce coverage above 100% before this change.

Terminal HTTP-400 exclusions and orphan reconciliation remain separate lifecycle work; this PR does not change the no-retry behavior shipped for polylogue-n846.

## Verification

- `devtools test tests/unit/cli/test_embed_status_fast.py tests/unit/operations/test_archive_debt.py` -> 48 passed in 6.80s.
- `devtools verify --quick` -> 13/13 steps passed, run `20260710T164654Z-quick-1311820-e24d14c7`.
- Pre-push quick gate -> 13/13 steps passed, run `20260710T164750Z-quick-1312562-bed58221`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented message coverage from being reported when candidate message counts are estimates rather than exact values.
  * Avoided coverage percentages exceeding 100% in embedding status details.
  * Clarified embedding backlog details when pending or stale message counts cannot be determined exactly.

* **CLI**
  * Added clearer guidance to run detailed status checks when exact embedding counts are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->