### PR TITLE
fix(ingest): publish full results after raw completion

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1309,6 +1309,10 @@ class LiveBatchProcessor:
                             error=ValueError("parsed raw payload produced no sessions"),
                         )
                         continue
+                    record_raw_id = source_raw_id
+                    record_session_ids: list[str] = []
+                    record_session_count = 0
+                    record_message_count = 0
                     for session in sessions:
                         raw_id, session_id = archive.write_parsed_for_retained_raw(
                             session,
@@ -1320,11 +1324,15 @@ class LiveBatchProcessor:
                             stage_timing_prefix="full",
                             finalize_raw_parse=False,
                         )
-                        result.raw_ids[record.raw_id] = raw_id
-                        result.session_ids.append(session_id)
-                        result.session_count += 1
-                        result.message_count += len(session.messages)
+                        record_raw_id = raw_id
+                        record_session_ids.append(session_id)
+                        record_session_count += 1
+                        record_message_count += len(session.messages)
                     archive.mark_raw_parse_succeeded(source_raw_id, provider=provider)
+                    result.raw_ids[record.raw_id] = record_raw_id
+                    result.session_ids.extend(record_session_ids)
+                    result.session_count += record_session_count
+                    result.message_count += record_message_count
                     _accumulate_stage_timings(result.stage_timings_s, record_timings)
                 except Exception as exc:
                     if provider is not None and source_raw_id is not None:

--- a/polylogue/storage/sqlite/raw_state_update.py
+++ b/polylogue/storage/sqlite/raw_state_update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.core.sources import origin_from_provider
 from polylogue.storage.raw.models import UNSET, RawSessionStateUpdate, _RawStateUnset
@@ -50,7 +52,7 @@ def compile_raw_state_update(
     if state.detection_warnings is not UNSET:
         warnings = state.detection_warnings
         set_clauses.append("detection_warnings_json = ?")
-        params.append((warnings[:2000] if isinstance(warnings, str) else warnings) or "[]")
+        params.append(json.dumps([warnings[:2000]]) if isinstance(warnings, str) and warnings else "[]")
     if state.validation_status is not UNSET or state.validation_error is not UNSET:
         set_clauses.append("validated_at_ms = ?")
         params.append(now_ms)

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -12,7 +12,7 @@ import pytest
 from polylogue.core.enums import Provider
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.append_ingest import ingest_append_plans
-from polylogue.sources.live.batch import _MAX_APPEND_PLAN_PAYLOAD_BYTES, LiveBatchProcessor
+from polylogue.sources.live.batch import _MAX_APPEND_PLAN_PAYLOAD_BYTES, LiveBatchProcessor, _ArchiveFullWriteResult
 from polylogue.sources.live.batch_support import (
     _DEFER_APPEND,
     _AppendPlan,
@@ -26,6 +26,7 @@ from polylogue.storage.raw.models import UNSET
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.source_write import read_archive_raw_session_envelope
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 
 
@@ -1231,6 +1232,11 @@ def test_append_parse_failure_retains_typed_raw_failure(
     assert parsed_at_ms is None
     assert isinstance(parse_error, str) and "injected append parse failure" in parse_error
     assert len(parse_error) <= 2000
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        raw_id = str(conn.execute("SELECT raw_id FROM raw_sessions").fetchone()[0])
+        envelope = read_archive_raw_session_envelope(conn, raw_id)
+    assert envelope.parse_error == parse_error
+    assert envelope.detection_warnings == (parse_error[:500],)
     with sqlite3.connect(tmp_path / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
 
@@ -1332,6 +1338,78 @@ def test_append_multi_session_failure_does_not_finalize_after_first(
     assert isinstance(parse_error, str) and "second-session index failure" in parse_error
     with sqlite3.connect(tmp_path / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+
+def test_full_multi_session_failure_retries_without_success_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    source = root / "full-multi.jsonl"
+    source.write_bytes(b"{}\n")
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+    sessions = [
+        ParsedSession(source_name=Provider.CODEX, provider_session_id="full-multi-1", messages=[]),
+        ParsedSession(source_name=Provider.CODEX, provider_session_id="full-multi-2", messages=[]),
+    ]
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr("polylogue.sources.live.batch.parse_stream_payload", lambda *_args, **_kwargs: sessions)
+    original_write = ArchiveStore._write_parsed_precedence_result
+    write_count = 0
+
+    def fail_second_index(
+        archive: ArchiveStore,
+        session: ParsedSession,
+        **kwargs: object,
+    ) -> object:
+        nonlocal write_count
+        write_count += 1
+        if write_count == 2:
+            raise sqlite3.IntegrityError("injected full second-session index failure")
+        return original_write(archive, session, **cast(Any, kwargs))
+
+    monkeypatch.setattr(ArchiveStore, "_write_parsed_precedence_result", fail_second_index)
+    archive_results: list[_ArchiveFullWriteResult] = []
+    original_full_write = processor._ingest_full_records_archive
+
+    def capture_full_write(*args: Any, **kwargs: Any) -> _ArchiveFullWriteResult:
+        outcome = original_full_write(*args, **kwargs)
+        archive_results.append(outcome)
+        return outcome
+
+    monkeypatch.setattr(processor, "_ingest_full_records_archive", capture_full_write)
+
+    first = processor._ingest_full_paths_sync([source], source_name="codex")
+
+    assert first.succeeded == []
+    assert source in first.failed
+    assert archive_results[0].raw_ids == {}
+    parsed_at_ms, parse_error = _raw_parse_state(tmp_path)
+    assert parsed_at_ms is None
+    assert isinstance(parse_error, str) and "full second-session index failure" in parse_error
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+    retry = processor._ingest_full_paths_sync([source], source_name="codex")
+
+    assert retry.succeeded == [source]
+    assert retry.failed == []
+    assert archive_results[1].raw_ids
+    parsed_at_ms, parse_error = _raw_parse_state(tmp_path)
+    assert parsed_at_ms is not None
+    assert parse_error is None
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
 
 
 def test_append_crash_after_index_commit_repairs_idempotently(


### PR DESCRIPTION
## Summary

Keep full-route result publication atomic at the raw-payload boundary and encode typed detection warnings as valid JSON.

## Problem

PR #2663 finalized source parse state only after every session derived from a raw payload indexed, but `_ArchiveFullWriteResult` was still mutated inside the per-session loop. If session 1 committed and session 2 failed, `raw_ids` retained a success mapping; the caller could classify the path as cursor-eligible and suppress retry despite the source row being marked failed.

The same failure path passed plain warning text through the shared compiler into `detection_warnings_json`. Source-envelope reads call `json.loads` on that column, so the failure evidence could make its own readback fail.

## Solution

- Accumulate per-record raw/session/message results locally and publish them only after every session indexes and `mark_raw_parse_succeeded` completes.
- Encode a non-empty typed detection warning as a JSON string list at the canonical SQLite compiler boundary.
- Exercise a real full-route two-session failure: the first session remains durable, no raw success mapping escapes, the source marker is bounded and readable, and an idempotent retry indexes the second session and finalizes success.

Ref polylogue-kwlu.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k 'writes_archive_with_route_observability or writes_archive_file_set_through_archive_tiers or typed_raw_failure or never_marks_raw_success or multi_session_failure or repairs_idempotently'` — 8 passed, 24 deselected.
- `devtools test tests/unit/storage/test_parse_tracking.py tests/unit/storage/test_raw.py` — 49 passed.
- `devtools verify --quick` — 13/13 steps passed; run `20260710T173207Z-quick-1347732-1f24162d`.

## Residual

No live archive or service was mutated. The owning bead remains open for the sanitized live catch-up proof.
