### PR TITLE
feat(chatgpt): record assistant sandbox file links as unfetchable attachments

### DIFF
--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 
 from polylogue.archive.message.artifacts import classify_material_origin, classify_text_message_type
@@ -240,6 +241,25 @@ def _non_negative_int(value: object) -> int | None:
     return None
 
 
+_SANDBOX_FILE_RE = re.compile(r"sandbox:(/mnt/data/[^\s)\]\"'>]+)")
+
+
+def _sandbox_file_paths(text: str) -> list[str]:
+    """Ordered, deduplicated ``/mnt/data`` paths linked in assistant text.
+
+    Trailing prose punctuation is stripped so ``(sandbox:/mnt/data/kit.zip).``
+    yields ``/mnt/data/kit.zip``. Directory links keep their trailing slash in
+    the returned path.
+    """
+
+    seen: dict[str, None] = {}
+    for match in _SANDBOX_FILE_RE.finditer(text):
+        path = match.group(1).rstrip(".,;:!?*`")
+        if path != "/mnt/data/":
+            seen.setdefault(path)
+    return list(seen)
+
+
 def _extract_content_text(content: Mapping[str, object]) -> str:
     """Extract message text from a ChatGPT content block.
 
@@ -348,6 +368,26 @@ def extract_messages_from_mapping(
                                 upload_origin="oauth",
                             )
                         )
+
+        # Assistant-generated downloadable files (#sandbox links). Code
+        # Interpreter deliverables surface only as `sandbox:/mnt/data/...`
+        # links inside assistant prose; the export/capture carries no bytes
+        # and no metadata attachment row for them, and the links expire with
+        # the sandbox container. Record each as an unfetchable attachment so
+        # the archive knows the file existed, its name, and which message
+        # produced it. attachment_kind="sandbox_file" keeps every acquisition
+        # path away from it (there is nothing local to fetch).
+        if role is Role.ASSISTANT and text:
+            for sandbox_path in _sandbox_file_paths(text):
+                attachments.append(
+                    ParsedAttachment(
+                        provider_attachment_id=f"sandbox:{msg_id}:{sandbox_path}",
+                        message_provider_id=str(msg_id),
+                        name=sandbox_path.rsplit("/", 1)[-1] or None,
+                        attachment_kind="sandbox_file",
+                        source_url=f"sandbox:{sandbox_path}",
+                    )
+                )
 
         model_slug: object = None
         duration_raw: object = None

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1110,3 +1110,64 @@ def test_code_interpreter_content_is_preserved() -> None:
     assert any(b.type == BlockType.CODE for b in code_msg.blocks)
     out_msg = next(m for m in conv.messages if m.text == "1\n")
     assert any(b.type == BlockType.TOOL_RESULT for b in out_msg.blocks)
+
+
+# SANDBOX FILE LINKS (assistant-generated downloadable deliverables)
+
+
+def test_sandbox_links_become_unfetchable_attachments() -> None:
+    text = (
+        "Kit delivered.\n\n"
+        "**[Download the ZIP](sandbox:/mnt/data/compiler-kit.zip)**\n"
+        "[Checksum](sandbox:/mnt/data/compiler-kit.zip.sha256): `abc`\n"
+        "Also see [the prompts dir](sandbox:/mnt/data/compiler-kit/prompts/) "
+        "and again [the ZIP](sandbox:/mnt/data/compiler-kit.zip)."
+    )
+    mapping = {
+        "node1": make_chatgpt_node("msg1", "assistant", [text]),
+    }
+
+    _messages, attachments = extract_messages_from_mapping(mapping)
+
+    sandbox = [a for a in attachments if a.attachment_kind == "sandbox_file"]
+    assert [a.name for a in sandbox] == [
+        "compiler-kit.zip",
+        "compiler-kit.zip.sha256",
+        None,  # directory link keeps trailing slash; no file name
+    ]
+    assert [a.source_url for a in sandbox] == [
+        "sandbox:/mnt/data/compiler-kit.zip",
+        "sandbox:/mnt/data/compiler-kit.zip.sha256",
+        "sandbox:/mnt/data/compiler-kit/prompts/",
+    ]
+    assert all(a.message_provider_id == "msg1" for a in sandbox)
+    # Duplicate link in the same message is recorded once.
+    assert len(sandbox) == 3
+
+
+def test_sandbox_links_in_user_messages_are_not_attachments() -> None:
+    mapping = {
+        "node1": make_chatgpt_node("msg1", "user", ["please regenerate sandbox:/mnt/data/old.zip"]),
+    }
+
+    _messages, attachments = extract_messages_from_mapping(mapping)
+
+    assert not [a for a in attachments if a.attachment_kind == "sandbox_file"]
+
+
+def test_sandbox_link_trailing_punctuation_is_stripped() -> None:
+    mapping = {
+        "node1": make_chatgpt_node(
+            "msg1",
+            "assistant",
+            ["Saved to sandbox:/mnt/data/report.md. Enjoy, or see sandbox:/mnt/data/data.csv,"],
+        ),
+    }
+
+    _messages, attachments = extract_messages_from_mapping(mapping)
+
+    sandbox = [a for a in attachments if a.attachment_kind == "sandbox_file"]
+    assert [a.source_url for a in sandbox] == [
+        "sandbox:/mnt/data/report.md",
+        "sandbox:/mnt/data/data.csv",
+    ]


### PR DESCRIPTION
## Summary
Assistant-generated Code Interpreter deliverables (`sandbox:/mnt/data/...` links) become first-class attachment rows with `attachment_kind="sandbox_file"`, honest non-acquired status, and `source_url` carrying the sandbox path. One parser change covers both export files and browser captures (native payloads route through `chatgpt.parse`).

## Problem
Ten GPT-Pro fork conversations captured 2026-07-10 each end with a kit ZIP deliverable reachable only through expiring sandbox links. The archive recorded nothing: no attachment row, no name, no queryable trace that the files ever existed. Bytes are unrecoverable post-expiry; even the *existence* was invisible.

## Solution
- `_sandbox_file_paths`: ordered, per-message-deduplicated extraction of `/mnt/data` paths from assistant text (markdown links and bare mentions; trailing prose punctuation stripped; user-message mentions ignored).
- Emitted as `ParsedAttachment(provider_attachment_id="sandbox:<msg>:<path>", attachment_kind="sandbox_file", source_url="sandbox:<path>")` — the existing #2468 acquisition plumbing records them as non-acquired without fabricating hashes.
- Byte acquisition at capture time (authenticated fetch in the extension) is deliberately out of scope — tracked in beads (`polylogue-ptx` extension lane); this slice gives it stable rows to fill.

## Verification
- `tests/unit/sources/test_parsers_chatgpt.py` → **85 passed** (3 new: extraction/dedup/shape, user-message negative control, punctuation stripping).
- Real fork capture (`Sinex Proof Obligation Compiler` conversation) parsed through the new code → **87 `sandbox_file` attachments** including the kit ZIP + checksum.
- `devtools verify --quick` green (89.9s).

Ref polylogue-ptx (extension attachments lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU