### PR TITLE
test: collect fuzz modules in normal pytest discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ path = "packaging/hatch_build.py"
 [tool.pytest.ini_options]
 addopts = "-rfE --tb=line --benchmark-disable --benchmark-storage=file://./.cache/pytest-benchmark"
 testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py", "fuzz_*.py"]
 asyncio_mode = "auto"
 xfail_strict = true
 cache_dir = ".cache/pytest"


### PR DESCRIPTION
## Summary

Include `fuzz_*.py` in pytest module discovery so the existing deterministic fuzz cases participate in ordinary collection.

## Problem

The fuzz README says pytest mode runs in the normal suite, but pytest used only its default `test_*.py`/`*_test.py` patterns. `tests/fuzz/` therefore collected zero modules by default even though its four targets contain 418 pytest cases.

## Solution

Declare the two established pytest filename patterns plus `fuzz_*.py` in `[tool.pytest.ini_options]`. No target code or campaign-mode behavior changes.

Ref `polylogue-kj22`.

## Verification

- `python -m pytest --collect-only tests/fuzz -q` -> `418 tests collected in 0.05s`
- `python -m pytest tests/fuzz -q` -> `418 passed in 1.95s`
- `devtools verify --quick` -> all 13 steps passed, run `20260710T182346Z-quick-1387773-f5afc345`
- Pre-push `devtools verify --quick` at `e74f00888` -> all 13 steps passed, run `20260710T183420Z-quick-1415815-893cff80`
