### PR TITLE
fix(chatgpt): strip inline citation markers; keep injected context messages

### DIFF
--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -241,6 +241,21 @@ def _non_negative_int(value: object) -> int | None:
     return None
 
 
+# ChatGPT embeds inline citation anchors in assistant text as private-use
+# unicode spans: U+E200 opens, U+E202 separates reference tokens, U+E201
+# closes (e.g. "\ue200filecite\ue202turn3file14\ue202L180-L293\ue201").
+# The span carries no human-readable text -- the resolvable citation rows
+# live in message metadata (`citations`/`content_references`) and are
+# preserved as web constructs. The raw markers otherwise leak invisible
+# glyphs into search text and rendered transcripts; the untouched original
+# remains in the source-tier raw payload.
+_CITATION_MARKER_RE = re.compile("\ue200.*?\ue201|[\ue200\ue201\ue202]")
+
+
+def _strip_citation_markers(text: str) -> str:
+    return _CITATION_MARKER_RE.sub("", text)
+
+
 _SANDBOX_FILE_RE = re.compile(r"sandbox:(/mnt/data/[^\s)\]\"'>]+)")
 
 
@@ -282,15 +297,15 @@ def _extract_content_text(content: Mapping[str, object]) -> str:
                     text_parts.append(t)
                 # Skip image_asset_pointer and other non-text dicts
         if text_parts:
-            return "\n".join(text_parts)
+            return _strip_citation_markers("\n".join(text_parts))
     # Non-parts content shapes: code / execution_output carry top-level text;
     # browsing display carries a result string.
     top_text = content.get("text")
     if isinstance(top_text, str) and top_text:
-        return top_text
+        return _strip_citation_markers(top_text)
     result = content.get("result")
     if isinstance(result, str) and result:
-        return result
+        return _strip_citation_markers(result)
     return ""
 
 
@@ -420,6 +435,7 @@ def extract_messages_from_mapping(
 
         # Build structured content blocks
         content_blocks: list[ParsedContentBlock] = []
+        forced_message_type: MessageType | None = None
         content_type = content.get("content_type", "text")
         if tool_call_input is not None:
             # Recipient-addressed tool call whose content is a JSON payload
@@ -461,10 +477,35 @@ def extract_messages_from_mapping(
                     metadata={"content_type": content_type},
                 )
             )
+        elif content_type in ("user_editable_context", "model_editable_context"):
+            # System-injected conversation context (#runtime evidence): custom
+            # instructions / user profile (`user_editable_context`) and the
+            # ChatGPT memory payload (`model_set_context`). These carry no
+            # `parts`, so without this branch the messages are dropped and the
+            # archive loses what context the provider injected. Empty payloads
+            # (e.g. memory feature on but no memories) still drop.
+            context_fields = (
+                ("user_profile", "user_instructions")
+                if content_type == "user_editable_context"
+                else ("model_set_context",)
+            )
+            context_texts = [
+                value for key in context_fields if isinstance(value := content.get(key), str) and value.strip()
+            ]
+            if context_texts:
+                text = "\n\n".join(context_texts)
+                forced_message_type = MessageType.CONTEXT
+                content_blocks.append(
+                    ParsedContentBlock(
+                        type=BlockType.TEXT,
+                        text=text,
+                        metadata={"content_type": content_type},
+                    )
+                )
         elif parts:
             for part in parts:
                 if isinstance(part, str) and part:
-                    content_blocks.append(ParsedContentBlock(type=BlockType.TEXT, text=part))
+                    content_blocks.append(ParsedContentBlock(type=BlockType.TEXT, text=_strip_citation_markers(part)))
                 elif isinstance(part, dict) and part.get("content_type") == "image_asset_pointer":
                     content_blocks.append(
                         ParsedContentBlock(
@@ -512,7 +553,7 @@ def extract_messages_from_mapping(
         status_val = msg.get("status")
         end_turn_val = msg.get("end_turn")
         user_context_val = msg_metadata.get("user_context_message_data") if isinstance(msg_metadata, Mapping) else None
-        message_type = classify_text_message_type(text) or MessageType.MESSAGE
+        message_type = forced_message_type or classify_text_message_type(text) or MessageType.MESSAGE
         parsed = ParsedMessage(
             provider_message_id=str(msg_id),
             role=role,

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1203,12 +1203,14 @@ def test_citation_markers_are_stripped_but_citations_survive() -> None:
 
     assert len(messages) == 1
     message = messages[0]
-    assert "\ue200" not in message.text
-    assert "\ue201" not in message.text
-    assert "\ue202" not in message.text
-    assert "filecite" not in message.text
-    assert message.text.startswith("Per the brief.")
-    assert message.text.endswith("end.")
+    text = message.text
+    assert text is not None
+    assert "\ue200" not in text
+    assert "\ue201" not in text
+    assert "\ue202" not in text
+    assert "filecite" not in text
+    assert text.startswith("Per the brief.")
+    assert text.endswith("end.")
     assert all("\ue200" not in (block.text or "") for block in message.blocks)
     constructs = [c for block in message.blocks for c in block.web_constructs]
     assert any(c.provider_key == "citations" for c in constructs)
@@ -1237,6 +1239,7 @@ def test_user_editable_context_becomes_runtime_context_message() -> None:
     message = messages[0]
     assert message.message_type is MessageType.CONTEXT
     assert message.material_origin is MaterialOrigin.RUNTIME_CONTEXT
+    assert message.text is not None
     assert "Profile: local-first archivist." in message.text
     assert "Always answer with evidence refs." in message.text
     assert message.blocks[0].metadata == {"content_type": "user_editable_context"}
@@ -1265,4 +1268,5 @@ def test_model_editable_context_memory_payload_is_kept_and_empty_is_dropped() ->
 
     assert [m.provider_message_id for m in messages] == ["msg1"]
     assert messages[0].message_type is MessageType.CONTEXT
+    assert messages[0].text is not None
     assert "Prefers rigorous verification" in messages[0].text

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1171,3 +1171,98 @@ def test_sandbox_link_trailing_punctuation_is_stripped() -> None:
         "sandbox:/mnt/data/report.md",
         "sandbox:/mnt/data/data.csv",
     ]
+
+
+# CITATION MARKER HYGIENE + SYSTEM-INJECTED CONTEXT
+
+
+def test_citation_markers_are_stripped_but_citations_survive() -> None:
+    marked = "Per the brief. \ue200filecite\ue202turn0file0\ue201 More text \ue200cite\ue202turn1search2\ue202L10-L20\ue201 end."
+    mapping = {
+        "node1": {
+            "id": "node1",
+            "message": {
+                "id": "msg1",
+                "author": {"role": "assistant"},
+                "content": {"parts": [marked]},
+                "metadata": {
+                    "citations": [
+                        {
+                            "citation_format_type": "berry_file_search",
+                            "start_ix": 15,
+                            "end_ix": 43,
+                            "metadata": {"title": "brief.md", "url": "https://example.test/brief"},
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    assert len(messages) == 1
+    message = messages[0]
+    assert "\ue200" not in message.text
+    assert "\ue201" not in message.text
+    assert "\ue202" not in message.text
+    assert "filecite" not in message.text
+    assert message.text.startswith("Per the brief.")
+    assert message.text.endswith("end.")
+    assert all("\ue200" not in (block.text or "") for block in message.blocks)
+    constructs = [c for block in message.blocks for c in block.web_constructs]
+    assert any(c.provider_key == "citations" for c in constructs)
+
+
+def test_user_editable_context_becomes_runtime_context_message() -> None:
+    mapping = {
+        "node1": {
+            "id": "node1",
+            "message": {
+                "id": "msg1",
+                "author": {"role": "user"},
+                "content": {
+                    "content_type": "user_editable_context",
+                    "user_profile": "Profile: local-first archivist.",
+                    "user_instructions": "Always answer with evidence refs.",
+                },
+                "metadata": {"is_visually_hidden_from_conversation": True},
+            },
+        },
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    assert len(messages) == 1
+    message = messages[0]
+    assert message.message_type is MessageType.CONTEXT
+    assert message.material_origin is MaterialOrigin.RUNTIME_CONTEXT
+    assert "Profile: local-first archivist." in message.text
+    assert "Always answer with evidence refs." in message.text
+    assert message.blocks[0].metadata == {"content_type": "user_editable_context"}
+
+
+def test_model_editable_context_memory_payload_is_kept_and_empty_is_dropped() -> None:
+    def node(msg_id: str, model_set_context: str) -> dict[str, object]:
+        return {
+            "id": msg_id,
+            "message": {
+                "id": msg_id,
+                "author": {"role": "assistant"},
+                "content": {
+                    "content_type": "model_editable_context",
+                    "model_set_context": model_set_context,
+                },
+            },
+        }
+
+    mapping = {
+        "node1": node("msg1", "1. Prefers rigorous verification.\n2. Runs Polylogue."),
+        "node2": node("msg2", ""),
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    assert [m.provider_message_id for m in messages] == ["msg1"]
+    assert messages[0].message_type is MessageType.CONTEXT
+    assert "Prefers rigorous verification" in messages[0].text


### PR DESCRIPTION
## Summary
Closes the two fidelity gaps found while auditing ChatGPT citation/deep-research handling against 18 real browser captures (3,069 messages): invisible inline citation-anchor glyphs polluting parsed text, and system-injected context messages (custom instructions + ChatGPT memory payload) being dropped entirely.

## Problem
- Assistant text embeds citation anchors as private-use unicode spans (`U+E200 filecite U+E202 turn3file14 U+E202 L180-L293 U+E201`). The resolvable citation rows live in metadata and were already captured as web constructs — but the raw markers stayed in message text, leaking invisible glyphs into FTS `search_text` and rendered transcripts (27 affected messages in the sample corpus).
- `content_type: user_editable_context` (custom instructions/user profile) and `model_editable_context` (`model_set_context`, the memory payload) carry no `parts`, so text extraction produced nothing and the messages were silently dropped — the archive lost what context the provider injected.

## Solution
- `_strip_citation_markers` applied at text extraction (message text and per-part blocks); original bytes remain in the source-tier raw payload; citation web constructs untouched.
- New content-type branch parses both editable-context shapes into `MessageType.CONTEXT` text blocks → `material_origin=runtime_context` via the existing classifier. Empty payloads still drop.
- Audit result recorded in the commit: all other citation/deep-research surfaces (`citations`, `content_references`, `_cite_metadata`, `search_queries`, `search_result_groups`, `selected_sources`, `image_results`, `canvas`, `async_task`, `aggregate_result`, tether quotes/browsing display) confirmed already handled.

## Verification
- `tests/unit/sources/test_parsers_chatgpt.py` → **88 passed** (3 new: marker stripping with citations surviving, user context → runtime_context, memory payload kept/empty dropped); mypy clean.
- Real capture re-parsed through new code: marker-polluted messages **27 → 0**, **+1 runtime_context** message (user profile), **36 web constructs intact**.
- `devtools verify --quick` green.

Semantic-reparse note: existing archived sessions gain these fixes on their next reprocess/rebuild; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU