### PR TITLE
feat(capture): acquire assistant-produced file bytes at capture time

### DIFF
--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -72,7 +72,8 @@
     createdAt = null,
     updatedAt = null,
     providerMeta = {},
-    rawProviderPayload = null
+    rawProviderPayload = null,
+    attachments = []
   }) {
     const sourceUrl = window.location.href;
     const urlSessionId = providerSessionId || sessionIdFromUrl(provider, sourceUrl);
@@ -132,7 +133,8 @@
           parent_turn_id: turn.parent_turn_id || null,
           attachments: Array.isArray(turn.attachments) ? turn.attachments : [],
           provider_meta: turn.provider_meta || {}
-        }))
+        })),
+        attachments: Array.isArray(attachments) ? attachments : []
       }
     };
     if (rawProviderPayload && typeof rawProviderPayload === "object") {

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -347,7 +347,168 @@
     return null;
   }
 
-  function buildNativeEnvelope(payload) {
+  // --- Assistant-produced asset acquisition (sandbox + file-service) ------
+  //
+  // Deliverable files surface only as expiring links; the conversation JSON
+  // never carries bytes. Fetch them through the page bridge (authenticated
+  // session) at capture time and ship them as envelope attachments. Failures
+  // are normal (links expire with the sandbox container) and must never fail
+  // the capture itself — per-asset outcomes are disclosed in provider_meta.
+  const assetFetchRequestMessage = "polylogue.chatgpt.assetFetchRequest";
+  const assetFetchResponseMessage = "polylogue.chatgpt.assetFetchResponse";
+  const assetFetchTimeoutMs = 35000;
+  const assetMaxBytesPerFile = 25 * 1024 * 1024;
+  const assetMaxBytesTotal = 75 * 1024 * 1024;
+  const assetResponses = new Map();
+  const sandboxLinkPattern = /sandbox:(\/mnt\/data\/[^\s)\]"'>]+)/g;
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type !== assetFetchResponseMessage || !data.requestId) return;
+    const pending = assetResponses.get(data.requestId);
+    if (!pending) return;
+    assetResponses.delete(data.requestId);
+    pending.resolve({ asset: data.asset || null, error: data.error || null });
+  });
+
+  function requestAssetFromPage(request) {
+    const requestId = `polylogue-asset-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responsePromise = new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        assetResponses.delete(requestId);
+        resolve({ asset: null, error: "timeout" });
+      }, assetFetchTimeoutMs);
+      assetResponses.set(requestId, {
+        resolve(value) {
+          window.clearTimeout(timeout);
+          resolve(value);
+        }
+      });
+    });
+    window.postMessage({ type: assetFetchRequestMessage, requestId, request }, window.location.origin);
+    return responsePromise;
+  }
+
+  function sandboxPathsFromText(text) {
+    const paths = [];
+    for (const match of String(text).matchAll(sandboxLinkPattern)) {
+      const path = match[1].replace(/[.,;:!?*`]+$/, "");
+      if (path !== "/mnt/data/" && !paths.includes(path)) paths.push(path);
+    }
+    return paths;
+  }
+
+  function collectAssetDescriptors(payload) {
+    const mapping = payload && payload.mapping;
+    if (!mapping || typeof mapping !== "object") return [];
+    const descriptors = [];
+    const seen = new Set();
+    const add = (descriptor) => {
+      if (descriptor.provider_attachment_id && !seen.has(descriptor.provider_attachment_id)) {
+        seen.add(descriptor.provider_attachment_id);
+        descriptors.push(descriptor);
+      }
+    };
+    for (const [nodeId, node] of Object.entries(mapping)) {
+      const message = node && node.message;
+      if (!message) continue;
+      const messageId = String(message.id || node.id || nodeId);
+      const metadata = message.metadata && typeof message.metadata === "object" ? message.metadata : {};
+      for (const attachment of Array.isArray(metadata.attachments) ? metadata.attachments : []) {
+        if (attachment && attachment.id) {
+          add({
+            kind: "file",
+            fileId: String(attachment.id),
+            provider_attachment_id: String(attachment.id),
+            message_provider_id: messageId,
+            name: attachment.name ? String(attachment.name) : null,
+            mime_type: attachment.mime_type ? String(attachment.mime_type) : null
+          });
+        }
+      }
+      const content = message.content;
+      const parts = content && Array.isArray(content.parts) ? content.parts : [];
+      const role = message.author && message.author.role;
+      for (const part of parts) {
+        if (part && typeof part === "object" && typeof part.asset_pointer === "string" && part.asset_pointer) {
+          const pointer = part.asset_pointer;
+          const pointerPath = pointer.includes("://") ? pointer.split("://").at(-1) : pointer;
+          const fileIdMatch = pointerPath.match(/file[-_][A-Za-z0-9]+/);
+          if (fileIdMatch) {
+            add({
+              kind: "file",
+              fileId: fileIdMatch[0],
+              provider_attachment_id: pointer,
+              message_provider_id: messageId,
+              name: null,
+              mime_type: null
+            });
+          }
+        }
+        if (typeof part === "string" && role === "assistant") {
+          for (const path of sandboxPathsFromText(part)) {
+            add({
+              kind: "sandbox",
+              sandboxPath: path,
+              provider_attachment_id: `sandbox:${messageId}:${path}`,
+              message_provider_id: messageId,
+              name: path.replace(/\/+$/, "").split("/").at(-1) || null,
+              mime_type: null
+            });
+          }
+        }
+      }
+    }
+    return descriptors;
+  }
+
+  async function acquireAssets(payload, conversationId) {
+    const descriptors = collectAssetDescriptors(payload);
+    const outcome = { attempted: descriptors.length, acquired: 0, failed: [], skipped_over_budget: 0 };
+    const attachments = [];
+    let totalBytes = 0;
+    for (const descriptor of descriptors) {
+      if (totalBytes >= assetMaxBytesTotal) {
+        outcome.skipped_over_budget += 1;
+        continue;
+      }
+      const request = {
+        kind: descriptor.kind,
+        conversationId,
+        messageId: descriptor.message_provider_id,
+        sandboxPath: descriptor.sandboxPath || null,
+        fileId: descriptor.fileId || null,
+        maxBytes: Math.min(assetMaxBytesPerFile, assetMaxBytesTotal - totalBytes)
+      };
+      const result = await requestAssetFromPage(request);
+      if (result.asset && result.asset.base64) {
+        totalBytes += result.asset.size_bytes || 0;
+        outcome.acquired += 1;
+        attachments.push({
+          provider_attachment_id: descriptor.provider_attachment_id,
+          message_provider_id: descriptor.message_provider_id,
+          name: result.asset.name || descriptor.name,
+          mime_type: result.asset.mime_type || descriptor.mime_type,
+          size_bytes: result.asset.size_bytes || null,
+          inline_base64: result.asset.base64,
+          provider_meta: {
+            capture_source: "chatgpt_page_asset_fetch",
+            asset_kind: descriptor.kind,
+            sandbox_path: descriptor.sandboxPath || null
+          }
+        });
+      } else {
+        outcome.failed.push({
+          provider_attachment_id: descriptor.provider_attachment_id,
+          error: result.error || "unknown"
+        });
+      }
+    }
+    return { attachments, outcome };
+  }
+
+  function buildNativeEnvelope(payload, assetAcquisition = null) {
     const turns = collectNativeTurns(payload);
     if (!turns.length) return null;
     return window.polylogueCapture.buildEnvelope({
@@ -365,15 +526,31 @@
         current_node: payload.current_node || null,
         mapping_node_count: payload.mapping ? Object.keys(payload.mapping).length : 0,
         is_temporary: payload.is_temporary === true,
-        session_kind: payload.is_temporary === true ? "temporary" : null
+        session_kind: payload.is_temporary === true ? "temporary" : null,
+        asset_acquisition: assetAcquisition ? assetAcquisition.outcome : null
       },
-      rawProviderPayload: payload
+      rawProviderPayload: payload,
+      attachments: assetAcquisition ? assetAcquisition.attachments : []
     });
   }
 
   async function capture() {
     const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
-    const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
+    let assetAcquisition = null;
+    if (nativePayload) {
+      try {
+        assetAcquisition = await acquireAssets(
+          nativePayload,
+          String(nativePayload.conversation_id || nativePayload.id || conversationIdFromUrl())
+        );
+      } catch (error) {
+        assetAcquisition = {
+          attachments: [],
+          outcome: { attempted: 0, acquired: 0, failed: [{ provider_attachment_id: null, error: String(error && error.message ? error.message : error) }], skipped_over_budget: 0 }
+        };
+      }
+    }
+    const envelope = nativePayload ? buildNativeEnvelope(nativePayload, assetAcquisition) : null;
     const fallbackEnvelope = () => {
       const turns = collectTurns();
       if (!turns.length) return null;

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -104,6 +104,95 @@
     }
   });
 
+  // Asset acquisition: fetch assistant-produced files (Code Interpreter
+  // sandbox deliverables, file-service uploads/outputs) through the page's
+  // own authenticated session. Both endpoints return a JSON envelope with a
+  // signed download_url; the bytes are then fetched from that URL directly.
+  const assetFetchRequestMessage = "polylogue.chatgpt.assetFetchRequest";
+  const assetFetchResponseMessage = "polylogue.chatgpt.assetFetchResponse";
+  const assetFetchTimeoutMs = 30000;
+
+  function assetTimeoutError(label) {
+    const error = new Error(`${label}_timeout_after_${assetFetchTimeoutMs}ms`);
+    error.name = "PolylogueTimeoutError";
+    return error;
+  }
+
+  function arrayBufferToBase64(buffer) {
+    const bytes = new Uint8Array(buffer);
+    const chunkSize = 0x8000;
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(offset, offset + chunkSize));
+    }
+    return window.btoa(binary);
+  }
+
+  async function fetchWithAbort(url, options, label) {
+    const controller = new globalThis.AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(assetTimeoutError(label)), assetFetchTimeoutMs);
+    try {
+      return await originalFetch.call(window, url, { ...options, signal: controller.signal });
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }
+
+  async function fetchAssetBytes(request) {
+    let metaUrl;
+    if (request.kind === "sandbox") {
+      metaUrl = new URL(
+        `/backend-api/conversation/${encodeURIComponent(String(request.conversationId))}/interpreter/download`,
+        currentOrigin
+      );
+      metaUrl.searchParams.set("message_id", String(request.messageId));
+      metaUrl.searchParams.set("sandbox_path", String(request.sandboxPath));
+    } else if (request.kind === "file") {
+      metaUrl = new URL(`/backend-api/files/${encodeURIComponent(String(request.fileId))}/download`, currentOrigin);
+    } else {
+      throw new Error(`unsupported_asset_kind_${request.kind}`);
+    }
+    const metaResponse = await fetchWithAbort(
+      metaUrl.href,
+      { credentials: "include", cache: "no-store", headers: authHeaders() },
+      "asset_meta_fetch"
+    );
+    if (!metaResponse.ok) throw new Error(`asset_meta_status_${metaResponse.status}`);
+    const meta = await metaResponse.json();
+    const downloadUrl = meta && (meta.download_url || meta.downloadUrl || meta.url);
+    if (typeof downloadUrl !== "string" || !downloadUrl) throw new Error("asset_meta_missing_download_url");
+    const fileResponse = await fetchWithAbort(downloadUrl, { credentials: "omit", cache: "no-store" }, "asset_bytes_fetch");
+    if (!fileResponse.ok) throw new Error(`asset_bytes_status_${fileResponse.status}`);
+    const buffer = await fileResponse.arrayBuffer();
+    const maxBytes = Number(request.maxBytes) > 0 ? Number(request.maxBytes) : 25 * 1024 * 1024;
+    if (buffer.byteLength > maxBytes) throw new Error(`asset_too_large_${buffer.byteLength}`);
+    return {
+      base64: arrayBufferToBase64(buffer),
+      size_bytes: buffer.byteLength,
+      mime_type: fileResponse.headers.get("content-type") || null,
+      name: (meta && (meta.file_name || meta.fileName)) || null
+    };
+  }
+
+  window.addEventListener("message", async (event) => {
+    if (event.source !== window || event.origin !== currentOrigin) return;
+    const data = event.data || {};
+    if (data.type !== assetFetchRequestMessage || !data.requestId || !data.request) return;
+    try {
+      const asset = await fetchAssetBytes(data.request);
+      window.postMessage({ type: assetFetchResponseMessage, requestId: data.requestId, asset }, currentOrigin);
+    } catch (error) {
+      window.postMessage(
+        {
+          type: assetFetchResponseMessage,
+          requestId: data.requestId,
+          error: String(error && error.message ? error.message : error)
+        },
+        currentOrigin
+      );
+    }
+  });
+
   window.fetch = async function polylogueFetch(input) {
     const response = await originalFetch.apply(this, arguments);
     try {

--- a/browser-extension/tests/content/chatgpt.test.js
+++ b/browser-extension/tests/content/chatgpt.test.js
@@ -400,3 +400,146 @@ describe("chatgpt fetchNativePayloadOnDemand", () => {
     ).resolves.toBe(null);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Extracted from src/content/chatgpt.js — keep in sync (asset acquisition)
+// ---------------------------------------------------------------------------
+
+const sandboxLinkPattern = /sandbox:(\/mnt\/data\/[^\s)\]"'>]+)/g;
+
+function sandboxPathsFromText(text) {
+  const paths = [];
+  for (const match of String(text).matchAll(sandboxLinkPattern)) {
+    const path = match[1].replace(/[.,;:!?*`]+$/, "");
+    if (path !== "/mnt/data/" && !paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
+function collectAssetDescriptors(payload) {
+  const mapping = payload && payload.mapping;
+  if (!mapping || typeof mapping !== "object") return [];
+  const descriptors = [];
+  const seen = new Set();
+  const add = (descriptor) => {
+    if (descriptor.provider_attachment_id && !seen.has(descriptor.provider_attachment_id)) {
+      seen.add(descriptor.provider_attachment_id);
+      descriptors.push(descriptor);
+    }
+  };
+  for (const [nodeId, node] of Object.entries(mapping)) {
+    const message = node && node.message;
+    if (!message) continue;
+    const messageId = String(message.id || node.id || nodeId);
+    const metadata = message.metadata && typeof message.metadata === "object" ? message.metadata : {};
+    for (const attachment of Array.isArray(metadata.attachments) ? metadata.attachments : []) {
+      if (attachment && attachment.id) {
+        add({
+          kind: "file",
+          fileId: String(attachment.id),
+          provider_attachment_id: String(attachment.id),
+          message_provider_id: messageId,
+          name: attachment.name ? String(attachment.name) : null,
+          mime_type: attachment.mime_type ? String(attachment.mime_type) : null
+        });
+      }
+    }
+    const content = message.content;
+    const parts = content && Array.isArray(content.parts) ? content.parts : [];
+    const role = message.author && message.author.role;
+    for (const part of parts) {
+      if (part && typeof part === "object" && typeof part.asset_pointer === "string" && part.asset_pointer) {
+        const pointer = part.asset_pointer;
+        const pointerPath = pointer.includes("://") ? pointer.split("://").at(-1) : pointer;
+        const fileIdMatch = pointerPath.match(/file[-_][A-Za-z0-9]+/);
+        if (fileIdMatch) {
+          add({
+            kind: "file",
+            fileId: fileIdMatch[0],
+            provider_attachment_id: pointer,
+            message_provider_id: messageId,
+            name: null,
+            mime_type: null
+          });
+        }
+      }
+      if (typeof part === "string" && role === "assistant") {
+        for (const path of sandboxPathsFromText(part)) {
+          add({
+            kind: "sandbox",
+            sandboxPath: path,
+            provider_attachment_id: `sandbox:${messageId}:${path}`,
+            message_provider_id: messageId,
+            name: path.replace(/\/+$/, "").split("/").at(-1) || null,
+            mime_type: null
+          });
+        }
+      }
+    }
+  }
+  return descriptors;
+}
+
+describe("asset descriptor collection", () => {
+  it("collects sandbox links, upload ids, and asset pointers with parser-matching ids", () => {
+    const payload = {
+      mapping: {
+        n1: {
+          id: "n1",
+          message: {
+            id: "msg-a",
+            author: { role: "assistant" },
+            content: {
+              parts: [
+                "Kit ready: [zip](sandbox:/mnt/data/kit.zip) and [sum](sandbox:/mnt/data/kit.zip.sha256). Again sandbox:/mnt/data/kit.zip."
+              ]
+            },
+            metadata: {}
+          }
+        },
+        n2: {
+          id: "n2",
+          message: {
+            id: "msg-b",
+            author: { role: "user" },
+            content: { parts: ["please use sandbox:/mnt/data/ignored.zip"] },
+            metadata: { attachments: [{ id: "file-UP1", name: "input.csv", mime_type: "text/csv" }] }
+          }
+        },
+        n3: {
+          id: "n3",
+          message: {
+            id: "msg-c",
+            author: { role: "assistant" },
+            content: {
+              parts: [{ content_type: "image_asset_pointer", asset_pointer: "file-service://file-IMG9" }]
+            },
+            metadata: {}
+          }
+        }
+      }
+    };
+
+    const descriptors = collectAssetDescriptors(payload);
+    const ids = descriptors.map((d) => d.provider_attachment_id);
+    expect(ids).toEqual([
+      "sandbox:msg-a:/mnt/data/kit.zip",
+      "sandbox:msg-a:/mnt/data/kit.zip.sha256",
+      "file-UP1",
+      "file-service://file-IMG9"
+    ]);
+    const sandbox = descriptors[0];
+    expect(sandbox.kind).toBe("sandbox");
+    expect(sandbox.sandboxPath).toBe("/mnt/data/kit.zip");
+    expect(sandbox.name).toBe("kit.zip");
+    const pointer = descriptors[3];
+    expect(pointer.kind).toBe("file");
+    expect(pointer.fileId).toBe("file-IMG9");
+  });
+
+  it("strips trailing punctuation and dedupes sandbox paths", () => {
+    expect(sandboxPathsFromText("see sandbox:/mnt/data/a.md. and sandbox:/mnt/data/a.md,")).toEqual([
+      "/mnt/data/a.md"
+    ]);
+  });
+});

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -145,6 +145,44 @@ def _browser_capture_parsed_attachment(
     )
 
 
+def _merge_envelope_attachments(parsed: ParsedSession, envelope: BrowserCaptureEnvelope) -> ParsedSession:
+    """Fold envelope attachments into a native-payload-delegated session.
+
+    When a capture carries a provider-native payload the session structure is
+    parsed from that payload, but the envelope may still carry attachments the
+    extension acquired itself (e.g. sandbox/file-service bytes fetched through
+    the authenticated page). Without this merge those bytes are silently
+    dropped. Envelope rows win on id collision when they carry inline bytes —
+    the native payload never does.
+    """
+
+    envelope_attachments = [
+        _browser_capture_parsed_attachment(attachment, message_provider_id=attachment.message_provider_id)
+        for attachment in (
+            *(a for turn in envelope.session.turns for a in turn.attachments),
+            *envelope.session.attachments,
+        )
+    ]
+    if not envelope_attachments:
+        return parsed
+    merged: dict[str, ParsedAttachment] = {a.provider_attachment_id: a for a in parsed.attachments}
+    for candidate in envelope_attachments:
+        existing = merged.get(candidate.provider_attachment_id)
+        if existing is None:
+            merged[candidate.provider_attachment_id] = candidate
+        elif candidate.inline_bytes is not None:
+            merged[candidate.provider_attachment_id] = candidate.model_copy(
+                update={
+                    "name": candidate.name or existing.name,
+                    "mime_type": candidate.mime_type or existing.mime_type,
+                    "message_provider_id": candidate.message_provider_id or existing.message_provider_id,
+                    "source_url": candidate.source_url or existing.source_url,
+                    "attachment_kind": existing.attachment_kind,
+                }
+            )
+    return parsed.model_copy(update={"attachments": list(merged.values())})
+
+
 def parse(payload: object, fallback_id: str) -> ParsedSession:
     """Parse a browser-capture envelope into the canonical parser contract."""
     envelope = BrowserCaptureEnvelope.model_validate(payload)
@@ -155,7 +193,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         from polylogue.sources.parsers.chatgpt import parse as parse_chatgpt
 
         return _apply_browser_capture_session_kind(
-            parse_chatgpt(raw_provider_payload, provider_session_id),
+            _merge_envelope_attachments(parse_chatgpt(raw_provider_payload, provider_session_id), envelope),
             envelope,
             provider_session_id,
             has_native_payload=True,
@@ -164,7 +202,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         from polylogue.sources.parsers.claude.ai_parser import parse_ai as parse_claude_ai
 
         return _apply_browser_capture_session_kind(
-            parse_claude_ai(raw_provider_payload, provider_session_id),
+            _merge_envelope_attachments(parse_claude_ai(raw_provider_payload, provider_session_id), envelope),
             envelope,
             provider_session_id,
             has_native_payload=True,

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -76,17 +76,30 @@ def _construct_from_reference(
     group_id: str | None = None,
     group_title: str | None = None,
 ) -> ParsedWebConstruct:
+    # File-search citation rows nest their source identity one or two levels
+    # down (item.metadata carries the file name/id/source, item.metadata.extra
+    # carries cited_message_id, library_file_id, source_url, ...). Consult the
+    # nested layers whenever the top level misses — otherwise a file citation
+    # keeps only its answer-side anchor span and loses which document it cites.
+    metadata = item.get("metadata")
+    nested = metadata if isinstance(metadata, Mapping) else {}
+    extra_value = nested.get("extra")
+    extra = extra_value if isinstance(extra_value, Mapping) else {}
+
+    def pick(*keys: str) -> str | None:
+        return _string_value(item, *keys) or _string_value(nested, *keys) or _string_value(extra, *keys)
+
     return ParsedWebConstruct(
         construct_type=construct_type,
         provider_key=provider_key,
-        title=_string_value(item, "title", "name", "source_name"),
-        url=_string_value(item, "url", "link", "source_url"),
-        text=_string_value(item, "snippet", "text", "content", "description"),
-        source_id=_string_value(item, "id", "source_id", "ref_id", "attribution_id", "textdoc_id"),
+        title=pick("title", "name", "source_name", "source_label"),
+        url=pick("url", "link", "source_url", "cloud_doc_url"),
+        text=pick("snippet", "text", "content", "description", "quote"),
+        source_id=pick("id", "source_id", "ref_id", "attribution_id", "textdoc_id", "library_file_id"),
         group_id=group_id,
         group_title=group_title,
-        asset_pointer=_string_value(item, "asset_pointer"),
-        mime_type=_string_value(item, "mime_type", "media_type"),
+        asset_pointer=pick("asset_pointer"),
+        mime_type=pick("mime_type", "media_type"),
         rank=rank if rank is not None else _int_value(item, "rank", "index"),
         start_index=_int_value(item, "start_index", "start_idx", "start_ix", "start"),
         end_index=_int_value(item, "end_index", "end_idx", "end_ix", "end"),
@@ -250,6 +263,7 @@ def _non_negative_int(value: object) -> int | None:
 # glyphs into search text and rendered transcripts; the untouched original
 # remains in the source-tier raw payload.
 _CITATION_MARKER_RE = re.compile("\ue200.*?\ue201|[\ue200\ue201\ue202]")
+_CITATION_MARKER_SPAN_RE = re.compile("\ue200(.*?)\ue201")
 
 
 def _strip_citation_markers(text: str) -> str:
@@ -297,15 +311,15 @@ def _extract_content_text(content: Mapping[str, object]) -> str:
                     text_parts.append(t)
                 # Skip image_asset_pointer and other non-text dicts
         if text_parts:
-            return _strip_citation_markers("\n".join(text_parts))
+            return "\n".join(text_parts)
     # Non-parts content shapes: code / execution_output carry top-level text;
     # browsing display carries a result string.
     top_text = content.get("text")
     if isinstance(top_text, str) and top_text:
-        return _strip_citation_markers(top_text)
+        return top_text
     result = content.get("result")
     if isinstance(result, str) and result:
-        return _strip_citation_markers(result)
+        return result
     return ""
 
 
@@ -329,7 +343,8 @@ def extract_messages_from_mapping(
         if not isinstance(content, dict):
             continue
         parts = content.get("parts") or []
-        text = _extract_content_text(content)
+        raw_text = _extract_content_text(content)
+        text = _strip_citation_markers(raw_text)
         # Role is required - skip messages without one
         author = msg.get("author")
         raw_role = author.get("role") if isinstance(author, dict) else None
@@ -542,6 +557,23 @@ def extract_messages_from_mapping(
                     )
 
         web_constructs = _constructs_from_chatgpt_metadata(msg_metadata)
+        # Inline citation anchors are stripped from stored text (invisible
+        # glyphs), but their reference tokens — turn/file pointers and line
+        # ranges like "filecite turn3file14 L180-L293" — carry source-location
+        # detail the metadata rows sometimes lack (line_range is often null).
+        # Preserve each span as a construct anchored at its original-text
+        # offset, the same coordinate system the citation rows' start_ix/
+        # end_ix use.
+        web_constructs.extend(
+            ParsedWebConstruct(
+                construct_type=WebConstructType.CONTENT_REFERENCE,
+                provider_key="inline_citation_marker",
+                text=" ".join(token for token in marker.group(1).split("\ue202") if token),
+                start_index=marker.start(),
+                end_index=marker.end(),
+            )
+            for marker in _CITATION_MARKER_SPAN_RE.finditer(raw_text)
+        )
         if web_constructs:
             if not content_blocks:
                 content_blocks.append(ParsedContentBlock(type=BlockType.TEXT))

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -849,3 +849,88 @@ async def test_browser_capture_raw_payload_coalesces_with_claude_ai_export(
     assert rows[0]["native_id"] == "claude-conv-123"
     assert rows[0]["title"] == "Claude browser title"
     assert rows[0]["message_count"] == 2
+
+
+def test_native_payload_delegation_keeps_envelope_acquired_assets() -> None:
+    """Extension-acquired bytes must survive the native-payload parse path.
+
+    The session structure comes from raw_provider_payload, but the envelope
+    carries attachments the extension fetched through the authenticated page
+    (sandbox deliverables). Regression: these were silently dropped.
+    """
+
+    import base64 as _b64
+
+    payload = _capture_payload()
+    payload["session"]["attachments"] = [  # type: ignore[index]
+        {
+            "provider_attachment_id": "sandbox:native-a1:/mnt/data/kit.zip",
+            "message_provider_id": "native-a1",
+            "name": "kit.zip",
+            "mime_type": "application/zip",
+            "inline_base64": _b64.b64encode(b"PK\x03\x04demo-bytes").decode("ascii"),
+            "provider_meta": {"capture_source": "chatgpt_page_asset_fetch", "asset_kind": "sandbox"},
+        }
+    ]
+    payload["raw_provider_payload"] = {
+        "id": "native-conv",
+        "title": "Native ChatGPT title",
+        "mapping": {
+            "assistant-node": {
+                "id": "assistant-node",
+                "parent": None,
+                "children": [],
+                "message": {
+                    "id": "native-a1",
+                    "author": {"role": "assistant"},
+                    "create_time": 1781442880.0,
+                    "content": {
+                        "content_type": "text",
+                        "parts": ["Kit ready: [zip](sandbox:/mnt/data/kit.zip)"],
+                    },
+                    "metadata": {},
+                },
+            },
+        },
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")
+
+    assert len(parsed) == 1
+    session = parsed[0]
+    by_id = {attachment.provider_attachment_id: attachment for attachment in session.attachments}
+    acquired = by_id["sandbox:native-a1:/mnt/data/kit.zip"]
+    assert acquired.inline_bytes == b"PK\x03\x04demo-bytes"
+    assert acquired.name == "kit.zip"
+    # The parser-derived sandbox row and the envelope row share one id: the
+    # envelope's byte-carrying version wins while keeping the parser's kind.
+    assert acquired.attachment_kind == "sandbox_file"
+    assert len([a for a in session.attachments if a.provider_attachment_id.startswith("sandbox:")]) == 1
+
+
+def test_native_payload_delegation_without_envelope_attachments_is_unchanged() -> None:
+    payload = _capture_payload()
+    payload["session"]["attachments"] = []  # type: ignore[index]
+    for turn in payload["session"]["turns"]:  # type: ignore[index]
+        turn.pop("attachments", None)
+    payload["raw_provider_payload"] = {
+        "id": "native-conv",
+        "mapping": {
+            "assistant-node": {
+                "id": "assistant-node",
+                "parent": None,
+                "children": [],
+                "message": {
+                    "id": "native-a1",
+                    "author": {"role": "assistant"},
+                    "content": {"content_type": "text", "parts": ["plain answer"]},
+                    "metadata": {},
+                },
+            },
+        },
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")
+
+    assert len(parsed) == 1
+    assert parsed[0].attachments == []

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1270,3 +1270,78 @@ def test_model_editable_context_memory_payload_is_kept_and_empty_is_dropped() ->
     assert messages[0].message_type is MessageType.CONTEXT
     assert messages[0].text is not None
     assert "Prefers rigorous verification" in messages[0].text
+
+
+def test_file_citation_nested_metadata_is_surfaced() -> None:
+    mapping = {
+        "node1": {
+            "id": "node1",
+            "message": {
+                "id": "msg1",
+                "author": {"role": "assistant"},
+                "content": {"parts": ["Cited claim."]},
+                "metadata": {
+                    "citations": [
+                        {
+                            "citation_format_type": "berry_file_search",
+                            "start_ix": 0,
+                            "end_ix": 12,
+                            "metadata": {
+                                "id": "file_00000000b074",
+                                "name": "06-strategy-falsification.md",
+                                "source": "my_files",
+                                "type": "file",
+                                "extra": {
+                                    "cited_message_id": "bd889688",
+                                    "library_file_id": "libfile_9eba",
+                                    "source_url": None,
+                                },
+                            },
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    constructs = [c for b in messages[0].blocks for c in b.web_constructs if c.provider_key == "citations"]
+    assert len(constructs) == 1
+    citation = constructs[0]
+    # Source identity lives one level down (metadata) and two levels down
+    # (metadata.extra); losing it reduces a file citation to a bare span.
+    assert citation.title == "06-strategy-falsification.md"
+    assert citation.source_id == "file_00000000b074"
+    assert citation.start_index == 0
+    assert citation.end_index == 12
+
+
+def test_inline_citation_marker_tokens_become_anchored_constructs() -> None:
+    marked = "Claim text. \ue200filecite\ue202turn3file14\ue202L180-L293\ue201 More."
+    mapping = {
+        "node1": {
+            "id": "node1",
+            "message": {
+                "id": "msg1",
+                "author": {"role": "assistant"},
+                "content": {"parts": [marked]},
+                "metadata": {},
+            },
+        },
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    message = messages[0]
+    assert message.text is not None
+    assert "\ue200" not in message.text
+    markers = [c for b in message.blocks for c in b.web_constructs if c.provider_key == "inline_citation_marker"]
+    assert len(markers) == 1
+    marker = markers[0]
+    # Line ranges often exist ONLY in the marker tokens (metadata line_range
+    # is frequently null) — the construct must retain them.
+    assert marker.text == "filecite turn3file14 L180-L293"
+    # Anchored in ORIGINAL-text coordinates, matching citation start_ix/end_ix.
+    assert marker.start_index == marked.index("\ue200")
+    assert marker.end_index == marked.index("\ue201") + 1


### PR DESCRIPTION
## Summary
Implements `polylogue-5k5l`: the browser extension now fetches assistant-produced files (Code Interpreter sandbox deliverables, file-service assets) through the authenticated page session at capture time and ships the bytes as envelope attachments; the parser merges them onto the attachment rows it already derives, landing them in the content-addressed blob store with `acquired` status. Also deepens ChatGPT citation fidelity: file citations keep their cited-document identity, and inline citation markers are preserved as anchored constructs.

## Problem
Ten GPT-Pro fork conversations captured 2026-07-10 each delivered a kit ZIP reachable only through `sandbox:` links that expire with the container — the archive recorded links (after #2666), never bytes. Worse, on the native-payload parse path (the path every rich capture takes), envelope attachments were **silently dropped**, so even extension-acquired bytes could never have landed. Separately, file citations were flattened to bare spans (source identity nests under `metadata`/`extra`), and stripped citation markers (#2668) discarded turn/file/line-range tokens that metadata often lacks (`line_range` is frequently null).

## Solution
- **Extension**: page-bridge asset fetch (interpreter/download + files/download → signed URL → bytes), descriptor collection from the native payload with parser-matching ids (`sandbox:<msg>:<path>`, upload ids, asset pointers), 25MB/file / 75MB/capture budget, per-asset outcome disclosure in `provider_meta.asset_acquisition`; failures never fail the capture — expired links are normal.
- **Parser**: `_merge_envelope_attachments` folds envelope rows into native-delegated sessions; byte-carrying rows win on id collision while preserving `attachment_kind`, so bytes land on the same row the sandbox-link extractor creates.
- **Citations**: nested `metadata`/`extra` lookup (document name, file id, source, cloud URL); inline markers become `inline_citation_marker` constructs anchored in original-text coordinates — the same system as citation `start_ix`/`end_ix`, so anchors correlate.

## Verification
- Extension vitest **93 passed**; new descriptor tests caught a real bug pre-merge (`file-service://` scheme matched as the file id); eslint clean.
- `test_browser_capture.py` **31 passed** (merge regression + no-envelope-attachments no-op); `test_parsers_chatgpt.py` **90 passed**; mypy clean on all changed Python.
- Real fork capture re-parsed: **11/11 file citations** carry source name + file id; **50 inline markers** preserved, spans aligned with citation anchors.
- `devtools verify --quick` green.
- Not run: live end-to-end browser capture with the updated extension (requires reloading the unpacked extension in the agent browser — noted for the capture owner; the bridge endpoints mirror the page's own download flow).

Ref polylogue-5k5l.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU