### PR TITLE
feat(browser-extension): capture retry queue, receiver health probe, popup outcomes

### DIFF
--- a/browser-extension/eslint.config.js
+++ b/browser-extension/eslint.config.js
@@ -18,6 +18,7 @@ export default [
         URL: "readonly",
         URLSearchParams: "readonly",
         fetch: "readonly",
+        TextEncoder: "readonly",
       },
     },
     rules: {

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Polylogue Browser Capture",
   "version": "0.1.0",
   "description": "Capture supported web LLM sessions into the local Polylogue inbox.",
-  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "permissions": ["activeTab", "alarms", "scripting", "storage", "tabs"],
   "host_permissions": [
     "https://chatgpt.com/*",
     "https://claude.ai/*",

--- a/browser-extension/scripts/validate-manifest.mjs
+++ b/browser-extension/scripts/validate-manifest.mjs
@@ -22,6 +22,7 @@ const EXT_ROOT = resolve(__dirname, "..");
 
 const ALLOWED_PERMISSIONS = new Set([
   "activeTab",
+  "alarms",
   "scripting",
   "storage",
   "tabs",

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -13,6 +13,26 @@ const inFlightPostCommands = new Set();
 const pendingPostCommandAcks = new Map();
 let postPollTimer = 0;
 
+// ---- Capture retry queue --------------------------------------------------
+//
+// When the receiver is unreachable or returns a 5xx/429, a capture envelope
+// is durable-queued in chrome.storage.local instead of being dropped. A
+// background alarm drains the queue with per-entry exponential backoff. The
+// queue is intentionally bounded (both by entry count and serialized byte
+// size) — a wedged/offline receiver must not let this grow unbounded; the
+// oldest entries are evicted first and counted in `dropped_count`.
+const CAPTURE_QUEUE_KEY = "polylogueCaptureQueue";
+const CAPTURE_QUEUE_MAX_ENTRIES = 20;
+const CAPTURE_QUEUE_MAX_BYTES = 40 * 1024 * 1024;
+const CAPTURE_QUEUE_EMPTY = Object.freeze({ entries: [], dropped_count: 0 });
+const CAPTURE_RETRY_ALARM = "polylogueCaptureRetry";
+const CAPTURE_RETRY_BASE_DELAY_MS = 30000;
+const CAPTURE_RETRY_MAX_DELAY_MS = 30 * 60 * 1000;
+const CAPTURE_RETRY_ALARM_PERIOD_MINUTES = 1;
+// In-memory mirror of the queue length so badge rendering never needs an
+// extra storage round trip; reloaded from storage once at SW startup.
+let cachedQueueLength = 0;
+
 function timeoutError(label, timeoutMs) {
   const error = new Error(`${label}_timeout_after_${timeoutMs}ms`);
   error.name = "PolylogueTimeoutError";
@@ -83,6 +103,228 @@ function sessionKey(provider, providerSessionId) {
   return `${provider || "unknown"}:${providerSessionId || "unknown"}`;
 }
 
+function retryDelayForAttempt(attempts) {
+  const delay = CAPTURE_RETRY_BASE_DELAY_MS * 2 ** Math.max(0, attempts);
+  return Math.min(delay, CAPTURE_RETRY_MAX_DELAY_MS);
+}
+
+function byteLength(value) {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+function envelopeSessionSummary(envelope) {
+  const session = envelope?.session || {};
+  return {
+    provider: session.provider || null,
+    providerSessionId: session.provider_session_id || null,
+    captureMode: session.provider_meta?.capture_fidelity || null,
+    assetAcquisition: session.provider_meta?.asset_acquisition || null,
+    turnCount: Array.isArray(session.turns) ? session.turns.length : null,
+    attachmentCount: Array.isArray(session.turns)
+      ? session.turns.reduce((count, turn) => count + (Array.isArray(turn.attachments) ? turn.attachments.length : 0), 0)
+      : null,
+  };
+}
+
+async function getCaptureQueue() {
+  const stored = await chrome.storage.local.get({ [CAPTURE_QUEUE_KEY]: CAPTURE_QUEUE_EMPTY });
+  const queue = stored[CAPTURE_QUEUE_KEY];
+  if (!queue || !Array.isArray(queue.entries)) return { entries: [], dropped_count: 0 };
+  return { entries: queue.entries, dropped_count: queue.dropped_count || 0 };
+}
+
+async function refreshQueueBadge() {
+  const stored = await chrome.storage.local.get({ polylogueState: {} });
+  const badge = badgeForState(stored.polylogueState || {});
+  await chrome.action.setBadgeText({ text: badge.text });
+  await chrome.action.setBadgeBackgroundColor({ color: badge.color });
+}
+
+async function saveCaptureQueue(queue) {
+  await chrome.storage.local.set({ [CAPTURE_QUEUE_KEY]: queue });
+  cachedQueueLength = queue.entries.length;
+  await refreshQueueBadge();
+  return queue;
+}
+
+async function ensureRetryAlarm() {
+  if (!chrome.alarms?.create) return;
+  await chrome.alarms.create(CAPTURE_RETRY_ALARM, {
+    delayInMinutes: CAPTURE_RETRY_ALARM_PERIOD_MINUTES,
+    periodInMinutes: CAPTURE_RETRY_ALARM_PERIOD_MINUTES,
+  });
+}
+
+async function clearRetryAlarm() {
+  if (!chrome.alarms?.clear) return;
+  await chrome.alarms.clear(CAPTURE_RETRY_ALARM);
+}
+
+function isRetryableCaptureError(error) {
+  if (!error) return false;
+  if (typeof error.status === "number") return error.status >= 500 || error.status === 429;
+  // No HTTP status means fetch itself rejected (offline, DNS failure, refused
+  // connection, CORS) rather than the receiver answering with an error body.
+  return true;
+}
+
+async function enqueueCaptureForRetry({ envelope, reason, error }) {
+  const entry = {
+    id: buildReceiverRequestId(),
+    envelope,
+    reason: reason || "content_script_capture",
+    enqueued_at: new Date().toISOString(),
+    attempts: 0,
+    next_attempt_at: new Date(Date.now() + retryDelayForAttempt(0)).toISOString(),
+    last_error: String(error?.message || error || "unknown"),
+  };
+  if (byteLength(entry) > CAPTURE_QUEUE_MAX_BYTES) {
+    // A single envelope over budget can never fit; queueing it would only
+    // evict every other pending retry to make room for one that still won't
+    // fit. Surface it as an immediate drop instead.
+    const queue = await getCaptureQueue();
+    await saveCaptureQueue({ entries: queue.entries, dropped_count: (queue.dropped_count || 0) + 1 });
+    await appendCaptureLog({
+      ok: false,
+      reason: "capture_queue_entry_over_budget",
+      error: entry.last_error,
+    });
+    return getCaptureQueue();
+  }
+  const queue = await getCaptureQueue();
+  let entries = [...queue.entries, entry];
+  let droppedCount = queue.dropped_count || 0;
+  while (entries.length > CAPTURE_QUEUE_MAX_ENTRIES || byteLength(entries) > CAPTURE_QUEUE_MAX_BYTES) {
+    entries = entries.slice(1);
+    droppedCount += 1;
+  }
+  const nextQueue = { entries, dropped_count: droppedCount };
+  await saveCaptureQueue(nextQueue);
+  await ensureRetryAlarm();
+  await appendCaptureLog({
+    ok: false,
+    reason: "capture_queued_for_retry",
+    queued_id: entry.id,
+    error: entry.last_error,
+    queue_length: entries.length,
+  });
+  return nextQueue;
+}
+
+async function drainCaptureQueue(trigger = "alarm") {
+  const queue = await getCaptureQueue();
+  if (!queue.entries.length) {
+    await clearRetryAlarm();
+    return { drained: 0, remaining: 0 };
+  }
+  const now = Date.now();
+  const remaining = [];
+  let drained = 0;
+  for (const entry of queue.entries) {
+    const dueAt = Date.parse(entry.next_attempt_at || "") || 0;
+    if (dueAt > now) {
+      remaining.push(entry);
+      continue;
+    }
+    const summary = envelopeSessionSummary(entry.envelope);
+    try {
+      const result = await postJson("/v1/browser-captures", entry.envelope);
+      drained += 1;
+      await updateSessionLedger({
+        provider: summary.provider || result.provider,
+        providerSessionId: summary.providerSessionId || result.provider_session_id,
+        patch: {
+          capture_mode: summary.captureMode,
+          asset_acquisition: summary.assetAcquisition,
+          turn_count: summary.turnCount,
+          attachment_count: summary.attachmentCount,
+          receiver_request_id: result.receiver_request_id || null,
+          artifact_ref: result.artifact_ref || null,
+          last_error: null,
+        },
+      });
+      await appendCaptureLog({
+        ok: true,
+        reason: "capture_retry_drained",
+        provider: summary.provider || result.provider,
+        provider_session_id: summary.providerSessionId || result.provider_session_id,
+        capture_mode: summary.captureMode,
+        receiver_request_id: result.receiver_request_id || null,
+        artifact_ref: result.artifact_ref || null,
+        queued_id: entry.id,
+        attempts: entry.attempts,
+      });
+      await setState({
+        online: true,
+        captured: true,
+        last_capture: result,
+        provider: summary.provider || result.provider,
+        provider_session_id: summary.providerSessionId || result.provider_session_id,
+        capture_mode: summary.captureMode,
+        asset_acquisition: summary.assetAcquisition,
+        turn_count: summary.turnCount,
+        attachment_count: summary.attachmentCount,
+        last_receiver_request_id: result.receiver_request_id || null,
+      });
+    } catch (error) {
+      const attempts = entry.attempts + 1;
+      remaining.push({
+        ...entry,
+        attempts,
+        last_error: String(error.message || error),
+        next_attempt_at: new Date(now + retryDelayForAttempt(attempts)).toISOString(),
+      });
+      await appendCaptureLog({
+        ok: false,
+        reason: "capture_retry_failed",
+        queued_id: entry.id,
+        attempts,
+        error: String(error.message || error),
+      });
+    }
+  }
+  const nextQueue = { entries: remaining, dropped_count: queue.dropped_count || 0 };
+  await saveCaptureQueue(nextQueue);
+  if (!remaining.length) {
+    await clearRetryAlarm();
+  } else if (trigger === "alarm") {
+    await appendDebugLog({ stage: "capture_retry_drain", drained, remaining: remaining.length });
+  }
+  return { drained, remaining: remaining.length };
+}
+
+async function loadCaptureQueueIntoCache() {
+  const queue = await getCaptureQueue();
+  cachedQueueLength = queue.entries.length;
+  if (queue.entries.length) await ensureRetryAlarm();
+  return queue;
+}
+
+async function checkReceiverHealth() {
+  const settings = await receiverSettings();
+  const requestId = buildReceiverRequestId();
+  try {
+    const response = await fetch(`${settings.baseUrl}/api/health`, {
+      headers: await requestHeaders({ requestId }),
+    });
+    const body = await response.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return { ok: false, status: "unreachable", detail: "non_json_response" };
+    }
+    if (body.error === "unauthorized") {
+      return { ok: true, status: "unauthorized", detail: body.error };
+    }
+    if (body.ok === true) {
+      return { ok: true, status: "ok", detail: null };
+    }
+    // Any other well-formed JSON body still proves the receiver answered —
+    // report it as reachable with whatever error detail it supplied.
+    return { ok: true, status: "error", detail: body.error || `http_${response.status}` };
+  } catch (error) {
+    return { ok: false, status: "unreachable", detail: String(error.message || error) };
+  }
+}
+
 async function appendCaptureLog(entry) {
   const stored = await chrome.storage.local.get({ polylogueCaptureLog: [] });
   const prior = Array.isArray(stored.polylogueCaptureLog) ? stored.polylogueCaptureLog : [];
@@ -149,6 +391,9 @@ async function updateSessionLedger({ provider, providerSessionId, patch }) {
 }
 
 function badgeForState(state) {
+  if (cachedQueueLength > 0) {
+    return { text: cachedQueueLength > 99 ? "99+" : String(cachedQueueLength), color: "#9a5b00" };
+  }
   if (!state.online) return { text: "off", color: "#9b2c2c" };
   const archiveState = state.archive_state?.state;
   if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
@@ -208,6 +453,7 @@ async function postJson(path, payload) {
     if (!response.ok) {
       const error = new Error(body.error || `HTTP ${response.status}`);
       error.receiverRequestId = receiverRequestId;
+      error.status = response.status;
       throw error;
     }
     return { ...body, receiver_request_id: receiverRequestId };
@@ -350,6 +596,8 @@ async function captureTab(tab, reason = "background") {
         provider,
         provider_session_id: providerSessionId,
         capture_mode: envelopeSession.provider_meta?.capture_fidelity || null,
+        asset_acquisition: envelopeSession.provider_meta?.asset_acquisition || null,
+        turn_count: Array.isArray(envelopeSession.turns) ? envelopeSession.turns.length : null,
         last_receiver_request_id:
           resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null
       });
@@ -641,6 +889,13 @@ function stopPostPolling() {
 }
 
 void startPostPolling();
+void loadCaptureQueueIntoCache();
+
+chrome.alarms?.onAlarm?.addListener((alarm) => {
+  if (alarm?.name === CAPTURE_RETRY_ALARM) {
+    void drainCaptureQueue("alarm");
+  }
+});
 
 chrome.runtime.onInstalled?.addListener(() => {
   void refreshCurrentActiveTab("extension_installed");
@@ -672,17 +927,39 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       return;
     }
     if (message.type === "polylogue.capture") {
-      const result = await postJson("/v1/browser-captures", message.envelope);
-      const session = message.envelope?.session || {};
+      const summary = envelopeSessionSummary(message.envelope);
+      let result;
+      try {
+        result = await postJson("/v1/browser-captures", message.envelope);
+      } catch (error) {
+        if (isRetryableCaptureError(error)) {
+          await enqueueCaptureForRetry({ envelope: message.envelope, reason: message.reason, error });
+          await setState({
+            online: false,
+            captured: false,
+            provider: summary.provider,
+            provider_session_id: summary.providerSessionId,
+            error: String(error.message || error),
+            last_receiver_request_id: error.receiverRequestId || null,
+          });
+          sendResponse({
+            ok: false,
+            queued: true,
+            error: String(error.message || error),
+            receiver_request_id: error.receiverRequestId || null,
+          });
+          return;
+        }
+        throw error;
+      }
       await updateSessionLedger({
-        provider: session.provider || result.provider,
-        providerSessionId: session.provider_session_id || result.provider_session_id,
+        provider: summary.provider || result.provider,
+        providerSessionId: summary.providerSessionId || result.provider_session_id,
         patch: {
-          capture_mode: session.provider_meta?.capture_fidelity || null,
-          turn_count: Array.isArray(session.turns) ? session.turns.length : null,
-          attachment_count: Array.isArray(session.turns)
-            ? session.turns.reduce((count, turn) => count + (Array.isArray(turn.attachments) ? turn.attachments.length : 0), 0)
-            : null,
+          capture_mode: summary.captureMode,
+          asset_acquisition: summary.assetAcquisition,
+          turn_count: summary.turnCount,
+          attachment_count: summary.attachmentCount,
           receiver_request_id: result.receiver_request_id || null,
           artifact_ref: result.artifact_ref || null,
           last_error: null,
@@ -691,9 +968,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       await appendCaptureLog({
         ok: true,
         reason: message.reason || "content_script_capture",
-        provider: session.provider || result.provider,
-        provider_session_id: session.provider_session_id || result.provider_session_id,
-        capture_mode: session.provider_meta?.capture_fidelity || null,
+        provider: summary.provider || result.provider,
+        provider_session_id: summary.providerSessionId || result.provider_session_id,
+        capture_mode: summary.captureMode,
         receiver_request_id: result.receiver_request_id || null,
         artifact_ref: result.artifact_ref || null,
       });
@@ -701,12 +978,46 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         online: true,
         captured: true,
         last_capture: result,
-        provider: session.provider || result.provider,
-        provider_session_id: session.provider_session_id || result.provider_session_id,
-        capture_mode: session.provider_meta?.capture_fidelity || null,
+        provider: summary.provider || result.provider,
+        provider_session_id: summary.providerSessionId || result.provider_session_id,
+        capture_mode: summary.captureMode,
+        asset_acquisition: summary.assetAcquisition,
+        turn_count: summary.turnCount,
+        attachment_count: summary.attachmentCount,
         last_receiver_request_id: result.receiver_request_id || null
       });
+      // Receiver just proved reachable — flush anything queued from earlier
+      // outages before returning this capture's result.
+      void drainCaptureQueue("post_success");
       sendResponse(result);
+      return;
+    }
+    if (message.type === "polylogue.getCaptureQueue") {
+      const queue = await getCaptureQueue();
+      sendResponse({
+        ok: true,
+        dropped_count: queue.dropped_count,
+        entries: queue.entries.map((entry) => ({
+          id: entry.id,
+          reason: entry.reason,
+          enqueued_at: entry.enqueued_at,
+          attempts: entry.attempts,
+          next_attempt_at: entry.next_attempt_at,
+          last_error: entry.last_error,
+          provider: entry.envelope?.session?.provider || null,
+          provider_session_id: entry.envelope?.session?.provider_session_id || null,
+        })),
+      });
+      return;
+    }
+    if (message.type === "polylogue.retryCaptureQueue") {
+      const outcome = await drainCaptureQueue("manual");
+      sendResponse({ ok: true, ...outcome });
+      return;
+    }
+    if (message.type === "polylogue.checkReceiverHealth") {
+      const health = await checkReceiverHealth();
+      sendResponse(health);
       return;
     }
     if (message.type === "polylogue.archiveState") {

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -295,10 +295,13 @@
         <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
         <div class="row"><span class="label">Archive</span><span id="archive" class="value">Not checked</span></div>
         <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
+        <div class="row"><span class="label">Fidelity</span><span id="fidelity" class="value">--</span></div>
         <div class="row"><span class="label">Turns</span><span id="turns" class="value">--</span></div>
+        <div class="row"><span class="label">Assets</span><span id="assets" class="value">--</span></div>
         <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
         <div class="row"><span class="label">Updated</span><span id="updated" class="value">--</span></div>
       </section>
+      <div id="asset-failures" class="log-meta"></div>
 
       <section>
         <p id="state">Checking receiver...</p>
@@ -309,7 +312,20 @@
           <button id="sync-open-tabs"><span class="button-label">Sync open tabs</span><span class="button-status"></span></button>
           <button id="copy-ref"><span class="button-label">Copy ref</span><span class="button-status"></span></button>
           <button id="open-polylogue"><span class="button-label">Open in Polylogue</span><span class="button-status"></span></button>
+          <button id="check-receiver"><span class="button-label">Check receiver</span><span class="button-status"></span></button>
         </div>
+      </section>
+
+      <section>
+        <div class="row"><span class="label">Receiver health</span><span id="receiver-health" class="value">--</span></div>
+      </section>
+
+      <section>
+        <div class="section-head">
+          <span class="label">Queued retries</span>
+          <span id="queue-count" class="value">0</span>
+        </div>
+        <div id="queue-log" class="log"></div>
       </section>
 
       <section>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -257,6 +257,86 @@ function renderLog(items) {
     .join("");
 }
 
+function fidelityLabel(captureMode) {
+  if (captureMode === "native_full") return "Native";
+  if (captureMode === "dom_degraded") return "DOM fallback";
+  return captureMode || "--";
+}
+
+function truncateForDisplay(value, limit = 200) {
+  const text = String(value ?? "");
+  return text.length > limit ? `${text.slice(0, limit - 3)}...` : text;
+}
+
+function renderAssetAcquisition(assetAcquisition) {
+  const summaryNode = document.getElementById("assets");
+  const detailNode = document.getElementById("asset-failures");
+  if (!assetAcquisition || typeof assetAcquisition !== "object") {
+    summaryNode.textContent = "--";
+    detailNode.textContent = "";
+    return;
+  }
+  const attempted = Number(assetAcquisition.attempted) || 0;
+  const acquired = Number(assetAcquisition.acquired) || 0;
+  const failed = Array.isArray(assetAcquisition.failed) ? assetAcquisition.failed : [];
+  const skipped = Number(assetAcquisition.skipped_over_budget) || 0;
+  if (!attempted) {
+    summaryNode.textContent = "none";
+    detailNode.textContent = "";
+    return;
+  }
+  const parts = [`${acquired} acquired`, `${failed.length} failed`];
+  if (skipped) parts.push(`${skipped} skipped`);
+  summaryNode.textContent = parts.join(" · ");
+  const shown = failed.slice(0, 5);
+  const overflow = failed.length - shown.length;
+  detailNode.textContent = shown.length
+    ? shown
+        .map((item) => `${item.provider_attachment_id || "asset"}: ${truncateForDisplay(item.error || "unknown")}`)
+        .join("; ") + (overflow > 0 ? `; +${overflow} more` : "")
+    : "";
+}
+
+function renderQueue(queue) {
+  const countNode = document.getElementById("queue-count");
+  const listNode = document.getElementById("queue-log");
+  const entries = Array.isArray(queue?.entries) ? queue.entries : [];
+  const droppedCount = Number(queue?.dropped_count) || 0;
+  countNode.textContent = droppedCount ? `${entries.length} (+${droppedCount} dropped)` : String(entries.length);
+  if (!entries.length) {
+    listNode.innerHTML = '<div class="log-meta">No captures queued for retry.</div>';
+    return;
+  }
+  listNode.innerHTML = entries
+    .map((entry) => {
+      const session = entry.envelope?.session || {};
+      const provider = session.provider || "unknown";
+      const providerSessionId = session.provider_session_id || "";
+      const title = `${provider} ${providerSessionId}`.trim();
+      const meta = [
+        `attempt ${entry.attempts || 0}`,
+        entry.next_attempt_at ? `next in ${relativeAge(entry.next_attempt_at)}` : null,
+        entry.last_error,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      return `<div class="log-item"><div class="log-time">${escapeHtml(relativeAge(entry.enqueued_at))}</div><div><div class="log-title">${providerLogo(provider)} ${escapeHtml(title)}</div><div class="log-meta">${escapeHtml(meta)}</div></div></div>`;
+    })
+    .join("");
+}
+
+function renderReceiverHealth(health) {
+  const node = document.getElementById("receiver-health");
+  if (!health) {
+    node.textContent = "--";
+    node.title = "";
+    return;
+  }
+  const labels = { ok: "OK", unauthorized: "Unauthorized", unreachable: "Unreachable", error: "Error" };
+  node.textContent = labels[health.status] || health.status || "--";
+  node.title = health.detail || "";
+}
+
 function renderDebugLog(items) {
   const debug = document.getElementById("debug-log");
   const safeItems = Array.isArray(items) ? items.slice(0, 24) : [];
@@ -314,12 +394,14 @@ async function render() {
   const stored = await chrome.storage.local.get({
     polylogueCaptureLog: [],
     polylogueDebugLog: [],
+    polylogueCaptureQueue: { entries: [], dropped_count: 0 },
     polylogueState: null,
     receiverAuthToken: "",
     receiverBaseUrl: DEFAULT_RECEIVER
   });
   renderLog(stored.polylogueCaptureLog);
   renderDebugLog(stored.polylogueDebugLog);
+  renderQueue(stored.polylogueCaptureQueue);
   document.getElementById("receiver-url").value = stored.receiverBaseUrl;
   document.getElementById("receiver-token").value = stored.receiverAuthToken || "";
   document.getElementById("receiver").textContent = stored.receiverBaseUrl;
@@ -333,9 +415,11 @@ async function render() {
   const updatedNode = document.getElementById("updated");
   requestNode.textContent = state?.last_receiver_request_id || "--";
   modeNode.textContent = state?.capture_mode || state?.archive_state?.state || "--";
+  document.getElementById("fidelity").textContent = fidelityLabel(state?.capture_mode);
+  renderAssetAcquisition(state?.asset_acquisition);
   const lastSession = state?.last_capture || {};
-  const turnCount = state?.archive_state?.indexed_message_count || lastSession.turn_count || "--";
-  const attachmentCount = state?.archive_state?.attachment_count || lastSession.attachment_count || null;
+  const turnCount = state?.archive_state?.indexed_message_count ?? state?.turn_count ?? lastSession.turn_count ?? "--";
+  const attachmentCount = state?.archive_state?.attachment_count ?? state?.attachment_count ?? lastSession.attachment_count ?? null;
   turnsNode.textContent = attachmentCount === null ? String(turnCount) : `${turnCount} / ${attachmentCount} files`;
   updatedNode.textContent = state?.updated_at ? `${relativeAge(state.updated_at)} ago` : "--";
 
@@ -381,6 +465,24 @@ document.getElementById("open-polylogue").addEventListener("click", async () => 
     const url = `${String(stored.receiverBaseUrl || DEFAULT_RECEIVER).replace(/\/+$/, "")}/?q=${encodeURIComponent(providerSessionId || "")}`;
     await chrome.tabs.create({ url });
   }, { busy: "Opening" });
+});
+
+document.getElementById("check-receiver").addEventListener("click", async () => {
+  try {
+    await withAction(
+      "check-receiver",
+      async () => {
+        const health = await chrome.runtime.sendMessage({ type: "polylogue.checkReceiverHealth" });
+        renderReceiverHealth(health);
+        if (health?.status === "unreachable") throw new Error(health?.detail || "unreachable");
+      },
+      { busy: "Checking", ok: "Checked", bad: "Unreachable" },
+    );
+  } catch {
+    // withAction already reflects the failure via button state + renderReceiverHealth;
+    // swallow here so a genuinely unreachable receiver doesn't surface as an
+    // unhandled rejection from this click listener.
+  }
 });
 
 document.getElementById("save").addEventListener("click", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -4,6 +4,7 @@ let messageListener;
 let installedListener;
 let activatedListener;
 let updatedListener;
+let alarmListener;
 let stored;
 let fetchCalls;
 let tabs;
@@ -17,12 +18,22 @@ function installChromeMock() {
   installedListener = null;
   activatedListener = null;
   updatedListener = null;
+  alarmListener = null;
   fetchCalls = [];
   tabs = [{ id: 42, url: "https://chatgpt.com/?temporary-chat=true", title: "ChatGPT" }];
   globalThis.chrome = {
     action: {
       setBadgeBackgroundColor: vi.fn(async () => undefined),
       setBadgeText: vi.fn(async () => undefined),
+    },
+    alarms: {
+      create: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+      onAlarm: {
+        addListener: vi.fn((fn) => {
+          alarmListener = fn;
+        }),
+      },
     },
     runtime: {
       onInstalled: {
@@ -270,5 +281,190 @@ describe("background receiver diagnostics", () => {
       target: { tabId: 77 },
       files: ["src/common.js", "src/content/grok.js"],
     });
+  });
+});
+
+describe("capture retry queue", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await loadBackground();
+  });
+
+  it("queues a capture for retry when the receiver is unreachable, sets a badge, then drains on the next alarm", async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      callCount += 1;
+      fetchCalls.push({ url });
+      if (callCount === 1) throw new TypeError("Failed to fetch");
+      return responseJson({
+        ok: true,
+        provider: "chatgpt",
+        provider_session_id: "conv-9",
+        artifact_ref: "chatgpt/conv-9.json",
+      });
+    });
+
+    const envelope = {
+      session: {
+        provider: "chatgpt",
+        provider_session_id: "conv-9",
+        provider_meta: { capture_fidelity: "native_full" },
+        turns: [{ role: "user" }, { role: "assistant" }],
+      },
+    };
+
+    const response = await sendRuntimeMessage({ type: "polylogue.capture", envelope, reason: "content_script_capture" });
+
+    expect(response).toEqual({ ok: false, queued: true, error: "Failed to fetch", receiver_request_id: null });
+    expect(stored.polylogueCaptureQueue.entries).toHaveLength(1);
+    expect(stored.polylogueCaptureQueue.entries[0].envelope.session.provider_session_id).toBe("conv-9");
+    expect(stored.polylogueCaptureQueue.entries[0].attempts).toBe(0);
+    expect(globalThis.chrome.alarms.create).toHaveBeenCalledWith(
+      "polylogueCaptureRetry",
+      expect.objectContaining({ periodInMinutes: 1 }),
+    );
+    const lastBadgeCall = globalThis.chrome.action.setBadgeText.mock.calls.at(-1);
+    expect(lastBadgeCall[0]).toEqual({ text: "1" });
+
+    // Force the queued entry's backoff window to be due, then simulate the
+    // retry alarm firing (real Chrome would deliver this on its own timer).
+    stored.polylogueCaptureQueue.entries[0].next_attempt_at = new Date(Date.now() - 1000).toISOString();
+    expect(alarmListener).toBeTypeOf("function");
+    alarmListener({ name: "polylogueCaptureRetry" });
+
+    await vi.waitFor(() => expect(stored.polylogueCaptureQueue.entries).toHaveLength(0));
+    expect(callCount).toBe(2);
+    expect(globalThis.chrome.alarms.clear).toHaveBeenCalledWith("polylogueCaptureRetry");
+    expect(stored.polylogueCaptureLog[0].reason).toBe("capture_retry_drained");
+    expect(stored.polylogueState.captured).toBe(true);
+    expect(stored.polylogueState.provider_session_id).toBe("conv-9");
+  });
+
+  it("does not queue a capture rejected with a client error", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({ error: "invalid_envelope" }, { ok: false, status: 400 }));
+
+    const response = await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-1" } },
+    });
+
+    expect(response).toEqual({ ok: false, error: "invalid_envelope", receiver_request_id: "receiver-request-1" });
+    expect(stored.polylogueCaptureQueue).toBeUndefined();
+    expect(globalThis.chrome.alarms.create).not.toHaveBeenCalled();
+  });
+
+  it("retries a 503 receiver response but bounds the queue at 20 entries with a drop counter", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({ error: "unavailable" }, { ok: false, status: 503 }));
+
+    for (let i = 0; i < 22; i += 1) {
+      await sendRuntimeMessage({
+        type: "polylogue.capture",
+        envelope: { session: { provider: "chatgpt", provider_session_id: `conv-${i}` } },
+      });
+    }
+
+    expect(stored.polylogueCaptureQueue.entries).toHaveLength(20);
+    expect(stored.polylogueCaptureQueue.dropped_count).toBe(2);
+    expect(stored.polylogueCaptureQueue.entries[0].envelope.session.provider_session_id).toBe("conv-2");
+    expect(stored.polylogueCaptureQueue.entries.at(-1).envelope.session.provider_session_id).toBe("conv-21");
+  });
+
+  it("summarizes the retry queue for the popup without leaking full envelope internals", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("offline");
+    });
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: {
+        session: { provider: "chatgpt", provider_session_id: "conv-5", turns: [{ role: "user", text: "secret" }] },
+      },
+    });
+
+    const response = await sendRuntimeMessage({ type: "polylogue.getCaptureQueue" });
+
+    expect(response.ok).toBe(true);
+    expect(response.dropped_count).toBe(0);
+    expect(response.entries).toHaveLength(1);
+    expect(response.entries[0]).toMatchObject({ provider: "chatgpt", provider_session_id: "conv-5", attempts: 0 });
+    expect(response.entries[0].envelope).toBeUndefined();
+  });
+
+  it("drains the retry queue once a subsequent capture proves the receiver is reachable again", async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) throw new TypeError("Failed to fetch");
+      return responseJson({ ok: true, provider: "chatgpt", provider_session_id: "conv-7" });
+    });
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-7" } },
+    });
+    expect(stored.polylogueCaptureQueue.entries).toHaveLength(1);
+
+    // Make the queued entry due, then drive a second capture that succeeds —
+    // its success should trigger a queue drain as a side effect.
+    stored.polylogueCaptureQueue.entries[0].next_attempt_at = new Date(Date.now() - 1000).toISOString();
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-8" } },
+    });
+
+    await vi.waitFor(() => expect(stored.polylogueCaptureQueue.entries).toHaveLength(0));
+  });
+});
+
+describe("receiver health probe", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await loadBackground();
+  });
+
+  it("reports the receiver as reachable and authorized when /api/health returns ok:true", async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      fetchCalls.push({ url });
+      return responseJson({ ok: true });
+    });
+
+    const response = await sendRuntimeMessage({ type: "polylogue.checkReceiverHealth" });
+
+    expect(response).toEqual({ ok: true, status: "ok", detail: null });
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:8875/api/health");
+  });
+
+  it("reports the receiver as reachable but unauthorized when no valid token is configured", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({ ok: false, error: "unauthorized" }));
+
+    const response = await sendRuntimeMessage({ type: "polylogue.checkReceiverHealth" });
+
+    expect(response).toEqual({ ok: true, status: "unauthorized", detail: "unauthorized" });
+  });
+
+  it("reports the receiver as unreachable when the fetch itself fails", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    const response = await sendRuntimeMessage({ type: "polylogue.checkReceiverHealth" });
+
+    expect(response).toEqual({ ok: false, status: "unreachable", detail: "Failed to fetch" });
+  });
+
+  it("reports the receiver as unreachable when the response body is not JSON", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      headers: { get: vi.fn(() => null) },
+      json: vi.fn(async () => {
+        throw new Error("not json");
+      }),
+      ok: true,
+      status: 200,
+    }));
+
+    const response = await sendRuntimeMessage({ type: "polylogue.checkReceiverHealth" });
+
+    expect(response).toEqual({ ok: false, status: "unreachable", detail: "non_json_response" });
   });
 });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -26,10 +26,17 @@ function installDom() {
       <button id="sync-open-tabs"><span class="button-status"></span></button>
       <button id="copy-ref"><span class="button-status"></span></button>
       <button id="open-polylogue"><span class="button-status"></span></button>
+      <button id="check-receiver"><span class="button-status"></span></button>
       <button id="debug-toggle"><span class="button-status"></span></button>
       <button id="debug-export"><span class="button-status"></span></button>
       <span id="mode"></span>
+      <span id="fidelity"></span>
       <span id="turns"></span>
+      <span id="assets"></span>
+      <div id="asset-failures"></div>
+      <span id="receiver-health"></span>
+      <span id="queue-count"></span>
+      <div id="queue-log"></div>
       <span id="log-count"></span>
       <span id="debug-count"></span>
       <div id="log"></div>
@@ -240,5 +247,110 @@ describe("popup capture", () => {
 
     globalThis.document.getElementById("debug-export").click();
     await vi.waitFor(() => expect(globalThis.URL.createObjectURL).toHaveBeenCalled());
+  });
+
+  it("renders capture fidelity and asset acquisition outcome from the last capture", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: true,
+        capture_mode: "native_full",
+        turn_count: 12,
+        asset_acquisition: {
+          attempted: 3,
+          acquired: 2,
+          failed: [{ provider_attachment_id: "file-abc", error: "timeout" }],
+          skipped_over_budget: 0,
+        },
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(globalThis.document.getElementById("fidelity").textContent).toBe("Native");
+    expect(globalThis.document.getElementById("turns").textContent).toBe("12");
+    expect(globalThis.document.getElementById("assets").textContent).toBe("2 acquired · 1 failed");
+    expect(globalThis.document.getElementById("asset-failures").textContent).toContain("file-abc: timeout");
+  });
+
+  it("renders DOM-fallback fidelity and a no-assets state distinctly", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: true,
+        capture_mode: "dom_degraded",
+        asset_acquisition: { attempted: 0, acquired: 0, failed: [], skipped_over_budget: 0 },
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(globalThis.document.getElementById("fidelity").textContent).toBe("DOM fallback");
+    expect(globalThis.document.getElementById("assets").textContent).toBe("none");
+    expect(globalThis.document.getElementById("asset-failures").textContent).toBe("");
+  });
+
+  it("renders queued retry entries with attempt and backoff detail", async () => {
+    await loadPopup({
+      polylogueCaptureQueue: {
+        entries: [
+          {
+            id: "polylogue-ext-1",
+            envelope: { session: { provider: "chatgpt", provider_session_id: "conv-9" } },
+            attempts: 2,
+            enqueued_at: new Date(Date.now() - 60000).toISOString(),
+            next_attempt_at: new Date(Date.now() + 120000).toISOString(),
+            last_error: "HTTP 503",
+          },
+        ],
+        dropped_count: 1,
+      },
+    });
+
+    expect(globalThis.document.getElementById("queue-count").textContent).toBe("1 (+1 dropped)");
+    expect(globalThis.document.getElementById("queue-log").textContent).toContain("chatgpt conv-9");
+    expect(globalThis.document.getElementById("queue-log").textContent).toContain("attempt 2");
+    expect(globalThis.document.getElementById("queue-log").textContent).toContain("HTTP 503");
+  });
+
+  it("renders an empty queue as an explicit no-op state", async () => {
+    await loadPopup();
+
+    expect(globalThis.document.getElementById("queue-count").textContent).toBe("0");
+    expect(globalThis.document.getElementById("queue-log").textContent).toContain("No captures queued for retry.");
+  });
+
+  it("checks receiver health and shows a reachable-but-unauthorized result", async () => {
+    await loadPopup();
+    globalThis.chrome.runtime.sendMessage = vi.fn(async (message) => {
+      if (message.type === "polylogue.checkReceiverHealth") {
+        return { ok: true, status: "unauthorized", detail: "unauthorized" };
+      }
+      return { ok: true };
+    });
+
+    globalThis.document.getElementById("check-receiver").click();
+
+    await vi.waitFor(() =>
+      expect(globalThis.document.getElementById("receiver-health").textContent).toBe("Unauthorized"),
+    );
+    expect(globalThis.chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "polylogue.checkReceiverHealth" });
+  });
+
+  it("checks receiver health and shows an unreachable result as a failed action", async () => {
+    await loadPopup();
+    globalThis.chrome.runtime.sendMessage = vi.fn(async (message) => {
+      if (message.type === "polylogue.checkReceiverHealth") {
+        return { ok: false, status: "unreachable", detail: "Failed to fetch" };
+      }
+      return { ok: true };
+    });
+
+    globalThis.document.getElementById("check-receiver").click();
+
+    await vi.waitFor(() =>
+      expect(globalThis.document.getElementById("receiver-health").textContent).toBe("Unreachable"),
+    );
+    await vi.waitFor(() =>
+      expect(globalThis.document.getElementById("check-receiver").dataset.state).toBe("bad"),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Extension reliability hardening (Lane A of the 2026-07-10 parallel-lanes effort, Sonnet-implemented, integrated after review): failed capture POSTs now survive receiver outages in a bounded retry queue; the popup surfaces capture fidelity, asset-acquisition outcomes, queued retries, and a receiver health probe.

## Problem
A capture POSTed while the receiver is down/unreachable was silently lost — exactly the failure mode that stranded today's 10 fork captures in a temp spool. And the new asset-acquisition outcomes (#2669) were invisible to the operator.

## Solution
- Bounded `chrome.storage.local` retry queue (20 entries / 40MB, oldest-evicted with `dropped_count`; single oversized envelope dropped rather than evicting the queue), per-entry exponential backoff (30s→30min) drained by a `chrome.alarms` periodic alarm; network-level failures and 5xx/429 queue, 4xx keeps the existing error path; badge shows queue depth.
- Popup: fidelity (native/DOM), asset acquired/failed/skipped counts with truncated failure reasons, queued-retry inspection, and a "check receiver" probe that treats any parseable JSON as reachable (the production receiver answers 200 `{"ok":false,"error":"unauthorized"}` without a token).
- Found+fixed during testing: unhandled promise rejection in the popup click handler for the unreachable case.

## Verification
- vitest: **108 passed** (was 93; +15 covering queue/backoff/health/popup), re-run independently at integration.
- eslint clean; `node scripts/validate-manifest.mjs` ok (alarms permission added + allowlisted).
- `devtools verify --quick` green on the branch.

Ref polylogue-5k5l (capture pipeline reliability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU