### PR TITLE
fix(web): render truthful loading/stale/error states, not false emptiness

### DIFF
--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -89,6 +89,24 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .insight-section-header .insight-toggle { display: inline-block; width: 10px; color: var(--text-dim); }
 .inspector-field .value.muted { color: var(--text-dim); font-style: italic; }
 .muted { color: var(--text-dim); }
+/* Collapsed developer-idiom disclosure (polylogue-bby.1): the fallback curl
+   command is an escape hatch for operators comfortable outside the shell,
+   not primary product copy -- keep it out of the default reading flow. */
+.route-debug { margin-top: 4px; }
+.route-debug summary { cursor: pointer; color: var(--text-dim); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.route-debug code { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 10px;
+  color: var(--text-muted); word-break: break-all; white-space: pre-wrap; }
+/* Global daemon-liveness banner (polylogue-bby.1): one probe (/api/health)
+   gates a single, unmissable "everything you see may be stale/failed"
+   notice instead of forcing the operator to notice N independent per-panel
+   "Failed to fetch" strings scattered across the shell. */
+#daemon-banner { display: none; position: fixed; top: 36px; left: 0; right: 0; z-index: 60;
+  background: var(--err-bg); border-bottom: 1px solid var(--err); color: var(--err);
+  padding: 6px 12px; font-size: var(--small); align-items: center; gap: 10px; }
+#daemon-banner.visible { display: flex; }
+#daemon-banner .daemon-banner-msg { flex: 1; }
+#daemon-banner .route-debug { margin-top: 0; }
+#daemon-banner .route-debug summary { color: var(--err); opacity: 0.8; }
 
 #sidebar { grid-column: 1; grid-row: 2; display: flex; flex-direction: column;
   background: var(--panel); border-right: 1px solid var(--border); overflow: hidden; }
@@ -280,6 +298,7 @@ __COORDINATION_CSS__
     <span class="chip" id="status-api-debug" title="Latest API request" style="display:none">api: --</span>
     <span class="chip" id="status-live" title="Realtime channel">live: --</span>
   </div>
+  <div id="daemon-banner" role="alert"></div>
   <div id="sidebar">
     <div id="search-box">
       <input type="text" id="search" placeholder="Search sessions..." autofocus>
@@ -350,7 +369,7 @@ __SELECTION_PREVIEW_HTML__
 <script>
 var API = '';
 var state = {
-  sessions: [], selected: null, selectedRaw: null,
+  sessions: [], selected: null, selectedRaw: null, selectedRawError: null,
   origin: '', query: '', offset: 0, limit: 100, total: 0,
   status: {}, facets: null, inspectorTab: 'info',
   facetError: '',
@@ -548,6 +567,15 @@ function fallbackCommand(route) {
   return 'curl -fsS http://127.0.0.1:8766' + route;
 }
 
+// Operator escape hatch (polylogue-bby.1). The fallback curl command is a
+// developer idiom, not a primary product surface -- keep it behind a
+// collapsed <details> disclosure everywhere a route-state notice renders it,
+// rather than printing a literal shell command inline in the product panel.
+function debugDisclosure(cmd) {
+  if (!cmd) return '';
+  return '<details class="route-debug"><summary>debug</summary><code>' + esc(cmd) + '</code></details>';
+}
+
 function routeErrorDetails(e, route) {
   var message = String((e && (e.response_summary || e.message)) || e || 'unavailable');
   return {
@@ -590,7 +618,7 @@ function renderRouteStateNotice(name, label, retryJs) {
   var html = '<div class="sidebar-state q-' + escAttr(quality) + '" data-route-state-name="' + escAttr(name)
     + '" data-route-state="' + escAttr(rs.state || '') + '"><div class="state-icon">!</div>'
     + '<div><strong>' + esc(title) + '</strong><br>' + esc(parts.join(' · ') || 'checking route')
-    + '<br><code>' + esc(rs.fallback || (rs.route ? fallbackCommand(rs.route) : 'polylogue daemon status')) + '</code></div>';
+    + debugDisclosure(rs.fallback || (rs.route ? fallbackCommand(rs.route) : 'polylogue daemon status')) + '</div>';
   if (retryJs) html += '<button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
   html += '</div>';
   return html;
@@ -606,8 +634,27 @@ function renderInlineRouteFailure(title, details, retryJs) {
   if (details.stale_available) bits.push('stale data available');
   var html = '<div class="main-empty q-unavailable"><h3>' + esc(title) + '</h3>'
     + '<p>' + esc(bits.join(' · ') || 'Route unavailable') + '</p>'
-    + '<p><code>' + esc(details.fallback || (route ? fallbackCommand(route) : 'polylogue daemon status')) + '</code></p>';
+    + debugDisclosure(details.fallback || (route ? fallbackCommand(route) : 'polylogue daemon status'))
+    + '</div>';
   if (retryJs) html += '<button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
+  html += '</div>';
+  return html;
+}
+
+// Compact panel-scoped failure notice for inspector tabs (Insights/Cost/
+// Evidence/Raw) that previously collapsed every fetch failure into a
+// static "<X> surface unavailable" string with no reason, no route, and no
+// retry -- indistinguishable from a route that legitimately has zero rows.
+function renderInlinePanelFailure(title, details, retryJs) {
+  details = details || {};
+  var bits = [];
+  if (details.route) bits.push('route ' + details.route);
+  if (details.status) bits.push('status ' + details.status);
+  if (details.error) bits.push(details.error);
+  var html = '<div class="inspector-empty q-unavailable"><strong>' + esc(title) + '</strong><br>'
+    + esc(bits.join(' · ') || 'Route unavailable')
+    + debugDisclosure(details.fallback || (details.route ? fallbackCommand(details.route) : ''));
+  if (retryJs) html += '<br><button class="user-action" onclick="' + escAttr(retryJs) + '">Retry</button>';
   html += '</div>';
   return html;
 }
@@ -661,7 +708,7 @@ window.addEventListener('popstate', function() {
   if (route) { loadWorkspaceRoute(route, false); return; }
   var cid = getSessionIdFromURL();
   if (cid) selectSession(cid, false);
-  else { state.mode = 'single'; state.selected = null; state.selectedRaw = null; renderMain(); renderInspector(); renderSessions(); }
+  else { state.mode = 'single'; state.selected = null; state.selectedRaw = null; state.selectedRawError = null; renderMain(); renderInspector(); renderSessions(); }
 });
 
 async function loadSessions(opts) {
@@ -699,9 +746,14 @@ async function loadSessions(opts) {
     });
     if (state.routeStates.status && state.routeStates.status.state !== 'ready') updateStatusCountsUnknown('degraded');
   } catch(e) {
-    state.sessions = [];
-    state.total = null;
-    setRouteState('sessionList', Object.assign({state: 'failed', stale_available: false}, routeErrorDetails(e, route)));
+    // Preserve the last-known session rows and total (polylogue-bby.1): a
+    // failed refresh must never present as "0 conversations" when a prior
+    // successful load populated the list. The route-state banner rendered
+    // above the (still-stale) rows in renderSessions() carries the failure.
+    setRouteState('sessionList', Object.assign(
+      {state: 'failed', stale_available: !!(state.sessions && state.sessions.length)},
+      routeErrorDetails(e, route)
+    ));
   }
   renderSessions();
   // After render, animate rows that are newly present (either flagged by
@@ -796,10 +848,18 @@ function loadSessionFromError() {
 }
 
 async function loadSessionRaw(id) {
+  var route = '/api/sessions/' + encodeURIComponent(id) + '/provenance';
   try {
-    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/provenance', {timeoutMs: 5000});
+    var data = await fetchJSON(route, {timeoutMs: 5000});
     state.selectedRaw = data;
-  } catch(e) { state.selectedRaw = null; }
+    state.selectedRawError = null;
+  } catch(e) {
+    // Distinguish "the fetch failed" from "the fetch succeeded with
+    // genuinely zero raw artifacts" (polylogue-bby.1) -- loadRawData()
+    // previously collapsed both into the same generic empty message.
+    state.selectedRaw = null;
+    state.selectedRawError = routeErrorDetails(e, route);
+  }
 }
 
 async function loadFacets(opts) {
@@ -837,6 +897,52 @@ async function loadFacets(opts) {
   renderFacets();
 }
 
+// Global daemon-liveness gate (polylogue-bby.1). /api/health is the single
+// probe that decides whether the daemon is reachable at all; every other
+// panel's independent "Failed to fetch" is a symptom of the same root
+// cause, so this owns one visible banner plus an automatic reconnect loop
+// (exponential backoff, capped) instead of leaving the operator to notice
+// N separately-degraded widgets and manually refresh each one.
+var daemonRetryTimer = null;
+var daemonRetryDelayMs = 3000;
+var DAEMON_RETRY_MAX_MS = 30000;
+
+function renderDaemonBanner() {
+  var el = document.getElementById('daemon-banner');
+  if (!el) return;
+  var rs = state.routeStates.health;
+  if (!rs || rs.state !== 'error') {
+    el.classList.remove('visible');
+    el.innerHTML = '';
+    return;
+  }
+  var bits = ['daemon unreachable'];
+  if (rs.status) bits.push('status ' + rs.status);
+  if (rs.error) bits.push(rs.error);
+  var retryNote = daemonRetryTimer
+    ? ('retrying automatically in ' + Math.round(daemonRetryDelayMs / 1000) + 's')
+    : 'retrying now';
+  el.innerHTML = '<span class="daemon-banner-msg">' + esc(bits.join(' · '))
+    + ' — every panel below may show loading/stale/failed states until this clears (' + esc(retryNote) + ').</span>'
+    + debugDisclosure(rs.fallback || fallbackCommand(rs.route || '/api/health'))
+    + '<button class="user-action" onclick="retryDaemonHealth()">Retry now</button>';
+  el.classList.add('visible');
+}
+
+function retryDaemonHealth() {
+  if (daemonRetryTimer) { clearTimeout(daemonRetryTimer); daemonRetryTimer = null; }
+  loadStatus();
+}
+
+function scheduleDaemonRetry() {
+  if (daemonRetryTimer) clearTimeout(daemonRetryTimer);
+  daemonRetryTimer = setTimeout(function() {
+    daemonRetryTimer = null;
+    loadStatus();
+  }, daemonRetryDelayMs);
+  daemonRetryDelayMs = Math.min(daemonRetryDelayMs * 2, DAEMON_RETRY_MAX_MS);
+}
+
 async function loadStatus() {
   var healthRoute = '/api/health';
   setRouteState('health', {state: 'loading', route: healthRoute, error: '', status: ''});
@@ -848,11 +954,19 @@ async function loadStatus() {
     var dbGB = ((h.db_size_bytes || 0) / 1073741824).toFixed(1);
     document.getElementById('status-db').textContent = 'index DB: ' + dbGB + ' GB';
     setRouteState('health', {state: h.ok ? 'ready' : 'error', route: healthRoute, status: '200', error: h.ok ? '' : (h.quick_check || 'issues')});
+    if (h.ok) {
+      daemonRetryDelayMs = 3000;
+      if (daemonRetryTimer) { clearTimeout(daemonRetryTimer); daemonRetryTimer = null; }
+    } else {
+      scheduleDaemonRetry();
+    }
   } catch(e) {
     document.getElementById('status-dot').className = 'dot err';
     document.getElementById('status-label').textContent = 'offline';
     setRouteState('health', Object.assign({state: 'error'}, routeErrorDetails(e, healthRoute)));
+    scheduleDaemonRetry();
   }
+  renderDaemonBanner();
   var statusRoute = '/api/status';
   setRouteState('status', {state: 'loading', route: statusRoute, error: '', status: ''});
   try {
@@ -1114,7 +1228,14 @@ function renderSessions() {
     }
     return;
   }
-  el.innerHTML = items.map(function(c) {
+  // Rows exist (possibly stale from a prior successful load). If the most
+  // recent /api/sessions refresh is loading/degraded/failed, prepend a
+  // truthful banner above the still-visible rows instead of either hiding
+  // them or silently pretending the refresh succeeded (polylogue-bby.1).
+  // renderRouteStateNotice() is a no-op ('') for idle/ready, so this is
+  // safe to call unconditionally.
+  var staleBanner = renderRouteStateNotice('sessionList', 'Sessions', 'loadSessions()');
+  el.innerHTML = staleBanner + items.map(function(c) {
     var sel = state.selected && state.selected.id === c.id ? ' selected' : '';
     var selectionSel = isSelectionSelected(c.id) ? ' selection-selected' : '';
     var title = esc((c.title || 'Untitled').substring(0, 100));
@@ -1631,15 +1752,21 @@ function renderInspector() {
 // kind with no materialized row is rendered with an explicit q-missing
 // chip and a "no rows recorded" body.
 async function loadInsightsPanel(id) {
+  var route = '/api/insights/sessions/' + encodeURIComponent(id);
   try {
-    var data = await fetchJSON('/api/insights/sessions/' + encodeURIComponent(id), {timeoutMs: 8000});
+    var data = await fetchJSON(route, {timeoutMs: 8000});
     state.insightsPanels[id] = data;
   } catch(e) {
-    state.insightsPanels[id] = {error: String(e)};
+    state.insightsPanels[id] = {error: true, details: routeErrorDetails(e, route)};
   }
   if (state.selected && state.selected.id === id && state.inspectorTab === 'insights') {
     renderInspector();
   }
+}
+
+function retryInsightsPanel(id) {
+  delete state.insightsPanels[id];
+  renderInspector();
 }
 
 function insightSectionKey(convId, kind) { return convId + ':' + kind; }
@@ -1769,7 +1896,7 @@ function renderInspectorInsights(el, c) {
     return;
   }
   if (data && data.error) {
-    el.innerHTML = '<div class="inspector-empty">Insights surface unavailable</div>';
+    el.innerHTML = renderInlinePanelFailure('Insights unavailable', data.details, "retryInsightsPanel('" + escJsAttr(c.id) + "')");
     return;
   }
   var kinds = data.kinds || {};
@@ -1794,15 +1921,21 @@ function renderInspectorInsights(el, c) {
 // driven by the MK3 q-* vocabulary returned by the daemon (q-canonical /
 // q-estimated / q-heuristic / q-unavailable).
 async function loadCostPanel(id) {
+  var route = '/api/sessions/' + encodeURIComponent(id) + '/cost';
   try {
-    var data = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/cost', {timeoutMs: 8000});
+    var data = await fetchJSON(route, {timeoutMs: 8000});
     state.costPanels[id] = data;
   } catch(e) {
-    state.costPanels[id] = {error: String(e)};
+    state.costPanels[id] = {error: true, details: routeErrorDetails(e, route)};
   }
   if (state.selected && state.selected.id === id && state.inspectorTab === 'cost') {
     renderInspector();
   }
+}
+
+function retryCostPanel(id) {
+  delete state.costPanels[id];
+  renderInspector();
 }
 
 function formatUsd(value) {
@@ -1825,7 +1958,7 @@ function renderInspectorCost(el, c) {
     return;
   }
   if (cost && cost.error) {
-    el.innerHTML = '<div class="inspector-empty">Cost surface unavailable</div>';
+    el.innerHTML = renderInlinePanelFailure('Cost unavailable', cost.details, "retryCostPanel('" + escJsAttr(c.id) + "')");
     return;
   }
   var tag = cost.confidence_tag || 'q-unavailable';
@@ -1905,16 +2038,23 @@ function renderInspectorCost(el, c) {
 }
 
 async function loadEvidencePanel(id) {
+  var route = '/api/sessions/' + encodeURIComponent(id) + '/read?view=context-image&format=json&include_messages=0';
   try {
-    var context = await fetchJSON('/api/sessions/' + encodeURIComponent(id) + '/read?view=context-image&format=json&include_messages=0', {timeoutMs: 10000});
-    var assertions = await fetchJSON('/api/assertions?target_ref=' + encodeURIComponent('session:' + id) + '&limit=20', {timeoutMs: 10000});
+    var context = await fetchJSON(route, {timeoutMs: 10000});
+    route = '/api/assertions?target_ref=' + encodeURIComponent('session:' + id) + '&limit=20';
+    var assertions = await fetchJSON(route, {timeoutMs: 10000});
     state.evidencePanels[id] = {context: context, assertions: assertions};
   } catch(e) {
-    state.evidencePanels[id] = {error: String(e)};
+    state.evidencePanels[id] = {error: true, details: routeErrorDetails(e, route)};
   }
   if (state.selected && state.selected.id === id && state.inspectorTab === 'evidence') {
     renderInspector();
   }
+}
+
+function retryEvidencePanel(id) {
+  delete state.evidencePanels[id];
+  renderInspector();
 }
 
 function renderRefList(refs) {
@@ -1936,7 +2076,7 @@ function renderInspectorEvidence(el, c) {
     return;
   }
   if (!panel || panel.error) {
-    el.innerHTML = '<div class="inspector-empty">Evidence surface unavailable</div>';
+    el.innerHTML = renderInlinePanelFailure('Evidence unavailable', panel && panel.details, "retryEvidencePanel('" + escJsAttr(c.id) + "')");
     return;
   }
   var contextPayload = (panel.context && panel.context.payload) || {};
@@ -2244,6 +2384,10 @@ async function loadRawData() {
   area.innerHTML = '<div style="color:var(--text-dim);font-size:var(--small);padding:8px 0">Loading artifact list...</div>';
   try {
     await loadSessionRaw(id);
+    if (state.selectedRawError) {
+      area.innerHTML = renderInlinePanelFailure('Raw artifact list unavailable', state.selectedRawError, 'loadRawData()');
+      return;
+    }
     var raw = state.selectedRaw;
     if (!raw) { area.innerHTML = '<div class="inspector-empty">No raw artifact metadata available</div>'; return; }
     var artifacts = raw.raw_artifacts || ((raw.raw_id || raw.content_hash) ? [raw] : []);

--- a/tests/visual/test_route_state_interaction_smoke.py
+++ b/tests/visual/test_route_state_interaction_smoke.py
@@ -1,0 +1,431 @@
+"""Truthful route-state interaction smoke evidence (polylogue-bby.1).
+
+Live-probe finding: the web shell rendered a populated session list under
+status chips claiming "checking / 0 convs / 0 msgs", a facets panel stuck
+showing a literal developer curl command in the product panel, and every
+widget independently degrading to "Failed to fetch" with no single visible
+"the daemon is unreachable" signal when the daemon died mid-session.
+
+Two evidence tiers, matching the established pattern in
+``tests/unit/daemon/test_web_shell_xss_escaping.py``:
+
+- Browserless DOM contract (always runs): the served shell HTML must carry
+  the truthful-state building blocks (``#daemon-banner``, the collapsed
+  ``route-debug`` disclosure, the panel-failure helper, the reconnect loop).
+- Best-effort real JS execution (skipped if ``node`` is not on PATH): the
+  ACTUAL extracted ``loadSessions``/``renderSessions``/``loadStatus``/
+  ``renderDaemonBanner``/``renderInlinePanelFailure`` from the real,
+  assembled ``WEB_SHELL_HTML`` are driven through a harness that fakes
+  ``document``/``fetch`` and proves the real runtime behavior, not a
+  hand-copied mirror of the logic:
+
+  1. ``test_session_list_survives_daemon_failure_seeded`` -- seeds a real
+     archive, captures a REAL ``/api/sessions`` envelope from the running
+     daemon HTTP server (contract fidelity), replays it as the shell's
+     first fetch, then fails the second fetch (daemon died mid-session).
+     Asserts the previously-rendered session rows are still visible (not
+     blanked to "0 convs") and a truthful failed-route banner is now
+     prepended above them.
+  2. ``test_daemon_banner_gates_on_health_probe`` -- every fetch fails from
+     the start; asserts the single ``/api/health`` probe drives one visible
+     "daemon unreachable" banner with a reason, a collapsed debug
+     disclosure (not an inline curl command), and an automatic reconnect
+     timer -- the negative control for "slow/missing routes degrade
+     visibly".
+  3. ``test_panel_failure_carries_reason_and_retry`` -- proves the
+     Insights/Cost/Evidence panel failure renderer now carries the route,
+     status, and failure reason plus a retry action instead of the old
+     static "<X> surface unavailable" string.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from tests.visual.conftest import (
+    READER_C1,
+    ReaderWorkspace,
+    assert_no_private_paths,
+    get_json,
+    get_text,
+    parse_dom,
+    running_reader_server,
+)
+
+WEB_SHELL_MODULE_DIR = Path(__file__).resolve().parents[2] / "polylogue" / "daemon"
+_NODE = shutil.which("node")
+
+
+# ---------------------------------------------------------------------------
+# Browserless DOM contract (always runs, no node dependency)
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_route_state_contract_in_served_shell(
+    reader_workspace: ReaderWorkspace,
+) -> None:
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, body = get_text(base_url, "/")
+
+    assert status == 200
+    assert "text/html" in content_type
+    assert_no_private_paths(body, context="reader shell HTML")
+
+    dom = parse_dom(body)
+    assert "daemon-banner" in dom.ids
+
+    for phrase in (
+        # Global daemon-liveness gate + reconnect loop.
+        "renderDaemonBanner",
+        "scheduleDaemonRetry",
+        "retryDaemonHealth",
+        "daemon unreachable",
+        # Curl fallback collapsed behind a debug disclosure, not printed
+        # inline in the primary product panel.
+        "function debugDisclosure",
+        'class="route-debug"',
+        "<summary>debug</summary>",
+        # Panel-scoped failure renderer with route/status/reason + retry,
+        # replacing the old static "<X> surface unavailable" strings.
+        "function renderInlinePanelFailure",
+        "retryInsightsPanel",
+        "retryCostPanel",
+        "retryEvidencePanel",
+        # loadSessions() no longer blanks state on a failed refresh.
+        "Preserve the last-known session rows",
+    ):
+        assert phrase in body, f"missing truthful-route-state marker: {phrase!r}"
+
+    # Regression guard: the fallback curl command must never be printed as a
+    # bare inline <code> sibling of a route-state notice again -- it must
+    # always be routed through debugDisclosure()'s collapsed <details>.
+    assert "'<br><code>' + esc(rs.fallback" not in body
+    assert "'<p><code>' + esc(details.fallback" not in body
+
+
+# ---------------------------------------------------------------------------
+# Real JS execution against the actual extracted functions
+# ---------------------------------------------------------------------------
+
+
+def _extract_function(source: str, name: str) -> str:
+    for prefix in (f"async function {name}(", f"function {name}("):
+        idx = source.find(prefix)
+        if idx == -1:
+            continue
+        brace_start = source.index("{", idx)
+        depth = 0
+        i = brace_start
+        while True:
+            ch = source[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return source[idx : i + 1]
+            i += 1
+    raise AssertionError(f"could not locate function {name} in WEB_SHELL_HTML")
+
+
+def _extract_functions(source: str, names: list[str]) -> str:
+    return "\n".join(_extract_function(source, name) for name in names)
+
+
+def _extract_var_block(source: str, start_marker: str, end_marker: str) -> str:
+    start = source.index(start_marker)
+    end = source.index(end_marker, start) + len(end_marker)
+    return source[start:end]
+
+
+_DOM_HARNESS_PRELUDE = r"""
+var API = '';
+var elements = {};
+function makeElement(id) {
+  var classes = [];
+  return {
+    id: id, innerHTML: '', textContent: '', className: '', title: '', style: {}, dataset: {},
+    classList: {
+      add: function(c) { if (classes.indexOf(c) === -1) classes.push(c); },
+      remove: function(c) { var i = classes.indexOf(c); if (i !== -1) classes.splice(i, 1); },
+      toggle: function(c, force) {
+        var has = classes.indexOf(c) !== -1;
+        var want = force === undefined ? !has : !!force;
+        if (want && !has) classes.push(c);
+        if (!want && has) classes.splice(classes.indexOf(c), 1);
+      },
+      contains: function(c) { return classes.indexOf(c) !== -1; }
+    },
+    addEventListener: function() {},
+    querySelectorAll: function() { return []; }
+  };
+}
+var document = {
+  getElementById: function(id) { if (!elements[id]) elements[id] = makeElement(id); return elements[id]; },
+  querySelector: function() { return null; },
+  querySelectorAll: function() { return []; },
+  addEventListener: function() {}
+};
+var window = { performance: { now: function() { return Date.now(); } } };
+"""
+
+_SESSION_LIST_FUNCS = [
+    "esc",
+    "escAttr",
+    "escJsAttr",
+    "nowMs",
+    "nextApiRequestId",
+    "summarizeApiBody",
+    "renderApiDebugChip",
+    "rememberApiDebug",
+    "requestJSON",
+    "fetchJSON",
+    "fallbackCommand",
+    "debugDisclosure",
+    "routeErrorDetails",
+    "setRouteState",
+    "routeStateQuality",
+    "renderRouteStateNotice",
+    "updateStatusCountsUnknown",
+    "setChipQuality",
+    "markSetFor",
+    "hasMark",
+    "sessionsFromListPayload",
+    "renderSidebarState",
+    "renderSessions",
+    "isSelectionSelected",
+    "selectionSelectedIds",
+    "selectionSelectedCount",
+    "renderSelectionToolbar",
+    "renderSelectionStatus",
+    "cssEscape",
+    "maybeAnimateExistingRow",
+    "loadSessions",
+]
+
+
+@pytest.mark.skipif(_NODE is None, reason="node not on PATH (not a declared flake dependency)")
+def test_session_list_survives_daemon_failure_seeded(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    """Seed a real archive, capture the REAL /api/sessions envelope from the
+    running daemon, then prove the actual shipped loadSessions()/
+    renderSessions() keep the previously-rendered rows visible (with a
+    truthful failed-route banner) when a second refresh's fetch fails --
+    the exact live-probe regression named in polylogue-bby.1."""
+    assert _NODE is not None
+    from polylogue.daemon.web_shell import WEB_SHELL_HTML
+
+    with running_reader_server(reader_workspace) as (_, base_url):
+        captured = cast(dict[str, object], get_json(base_url, "/api/sessions?limit=100&offset=0"))
+
+    assert isinstance(captured, dict)
+    items = cast(list[dict[str, object]], captured.get("items") or [])
+    assert items, "seeded reader archive must yield at least one session row"
+    assert any(item.get("id") == READER_C1 for item in items)
+
+    functions_src = _extract_functions(WEB_SHELL_HTML, _SESSION_LIST_FUNCS)
+    harness = f"""
+{_DOM_HARNESS_PRELUDE}
+var state = {{
+  sessions: [], selected: null, origin: '', query: '', offset: 0, limit: 100, total: 0,
+  routeStates: {{}}, marks: {{}}, selectionSet: {{}}, lastSelectionResult: null,
+  apiDebug: {{counter: 0, last: null}}, actionAffordances: []
+}};
+{functions_src}
+
+var CAPTURED_PAYLOAD = {json.dumps(captured)};
+var fetchCallCount = 0;
+global.fetch = function(url, opts) {{
+  fetchCallCount += 1;
+  if (fetchCallCount === 1) {{
+    return Promise.resolve({{
+      ok: true, status: 200,
+      headers: {{ get: function() {{ return ''; }} }},
+      text: function() {{ return Promise.resolve(JSON.stringify(CAPTURED_PAYLOAD)); }}
+    }});
+  }}
+  return Promise.reject(new TypeError('fetch failed'));
+}};
+
+(async function() {{
+  await loadSessions();
+  var afterFirstHtml = document.getElementById('conv-list').innerHTML;
+  var sessionsAfterFirst = (state.sessions || []).length;
+
+  await loadSessions();
+  var afterSecondHtml = document.getElementById('conv-list').innerHTML;
+  var sessionsAfterSecond = (state.sessions || []).length;
+
+  console.log(JSON.stringify({{
+    after_first_html: afterFirstHtml,
+    after_second_html: afterSecondHtml,
+    sessions_after_first: sessionsAfterFirst,
+    sessions_after_second: sessionsAfterSecond,
+    route_state: state.routeStates.sessionList
+  }}));
+  process.exit(0);
+}})();
+"""
+    (tmp_path / "harness.js").write_text(harness, encoding="utf-8")
+    proc = subprocess.run([_NODE, str(tmp_path / "harness.js")], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    result = json.loads(proc.stdout)
+
+    first_title = "MK3 reader target contract"
+    assert first_title in result["after_first_html"], "first successful load must render seeded session rows"
+    assert result["sessions_after_first"] == len(items)
+
+    # The core regression: a failed refresh must not blank previously-loaded
+    # rows to a false "0 conversations" state.
+    assert result["sessions_after_second"] == len(items), (
+        "loadSessions() must retain the last-known session rows on a failed refresh"
+    )
+    assert first_title in result["after_second_html"], "stale rows must remain visible after a failed refresh"
+    assert "No sessions in archive" not in result["after_second_html"]
+    assert "0 sessions" not in result["after_second_html"]
+
+    # A truthful failed-route banner must be visible above the stale rows.
+    assert 'data-route-state-name="sessionList"' in result["after_second_html"]
+    assert 'data-route-state="failed"' in result["after_second_html"]
+    assert "q-unavailable" in result["after_second_html"]
+    assert result["route_state"]["state"] == "failed"
+    assert result["route_state"]["stale_available"] is True
+
+
+_STATUS_FUNCS = [
+    "esc",
+    "escAttr",
+    "escJsAttr",
+    "nowMs",
+    "nextApiRequestId",
+    "summarizeApiBody",
+    "renderApiDebugChip",
+    "rememberApiDebug",
+    "requestJSON",
+    "fetchJSON",
+    "fallbackCommand",
+    "debugDisclosure",
+    "routeErrorDetails",
+    "setRouteState",
+    "routeStateQuality",
+    "renderRouteStateNotice",
+    "updateStatusCountsUnknown",
+    "setChipQuality",
+    "renderFacets",
+    "renderDevLoopChip",
+    "renderDaemonBanner",
+    "retryDaemonHealth",
+    "scheduleDaemonRetry",
+    "loadStatus",
+]
+
+
+@pytest.mark.skipif(_NODE is None, reason="node not on PATH (not a declared flake dependency)")
+def test_daemon_banner_gates_on_health_probe(tmp_path: Path) -> None:
+    """Negative control: every route fails from the start (daemon fully
+    unreachable). Proves the single /api/health probe drives one visible
+    banner with a reason and a collapsed debug disclosure, plus schedules
+    an automatic reconnect -- not N independent silent per-widget
+    failures."""
+    assert _NODE is not None
+    from polylogue.daemon.web_shell import WEB_SHELL_HTML
+
+    daemon_retry_block = _extract_var_block(
+        WEB_SHELL_HTML, "var daemonRetryTimer = null;", "var DAEMON_RETRY_MAX_MS = 30000;"
+    )
+    functions_src = _extract_functions(WEB_SHELL_HTML, _STATUS_FUNCS)
+    harness = f"""
+{_DOM_HARNESS_PRELUDE}
+var state = {{
+  routeStates: {{}}, facets: null, total: 0, apiDebug: {{counter: 0, last: null}}
+}};
+{daemon_retry_block}
+{functions_src}
+
+global.fetch = function() {{ return Promise.reject(new TypeError('fetch failed')); }};
+
+(async function() {{
+  await loadStatus();
+  var banner = document.getElementById('daemon-banner');
+  console.log(JSON.stringify({{
+    banner_visible: banner.classList.contains('visible'),
+    banner_html: banner.innerHTML,
+    health_state: state.routeStates.health,
+    retry_scheduled: daemonRetryTimer !== null,
+    retry_delay_ms: daemonRetryDelayMs
+  }}));
+  process.exit(0);
+}})();
+"""
+    (tmp_path / "harness.js").write_text(harness, encoding="utf-8")
+    proc = subprocess.run([_NODE, str(tmp_path / "harness.js")], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    result = json.loads(proc.stdout)
+
+    assert result["banner_visible"] is True
+    assert "daemon unreachable" in result["banner_html"]
+    assert "Retry now" in result["banner_html"]
+    # The fallback curl hint is present but collapsed, not printed inline.
+    assert '<details class="route-debug">' in result["banner_html"]
+    assert "curl -fsS" in result["banner_html"]
+    assert result["health_state"]["state"] == "error"
+    # An automatic reconnect must be scheduled -- no silent dead end.
+    assert result["retry_scheduled"] is True
+    assert result["retry_delay_ms"] == 6000  # doubled from the 3000ms base after the first failure
+
+
+_PANEL_FAILURE_FUNCS = [
+    "esc",
+    "escAttr",
+    "fallbackCommand",
+    "debugDisclosure",
+    "routeErrorDetails",
+    "renderInlinePanelFailure",
+]
+
+
+@pytest.mark.skipif(_NODE is None, reason="node not on PATH (not a declared flake dependency)")
+def test_panel_failure_carries_reason_and_retry(tmp_path: Path) -> None:
+    """Insights/Cost/Evidence/Raw panel failures used to collapse into a
+    static "<X> surface unavailable" string -- indistinguishable from a
+    route that legitimately returned zero rows. Proves the real
+    renderInlinePanelFailure() now surfaces route, status, and reason, a
+    retry action, and keeps the curl fallback collapsed."""
+    assert _NODE is not None
+    from polylogue.daemon.web_shell import WEB_SHELL_HTML
+
+    functions_src = _extract_functions(WEB_SHELL_HTML, _PANEL_FAILURE_FUNCS)
+    harness = f"""
+{functions_src}
+var err = new Error('500');
+err.status = 500;
+err.response_summary = 'materialization backlog exceeded budget';
+err.request_id = 'web-abc123';
+var details = routeErrorDetails(err, '/api/insights/sessions/example-session');
+var html = renderInlinePanelFailure('Insights unavailable', details, "retryInsightsPanel('example-session')");
+console.log(JSON.stringify({{details: details, html: html}}));
+"""
+    proc = subprocess.run([_NODE, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    result = json.loads(proc.stdout)
+    html = result["html"]
+
+    assert "Insights unavailable" in html
+    assert "route /api/insights/sessions/example-session" in html
+    assert "status 500" in html
+    assert "materialization backlog exceeded budget" in html
+    assert (
+        'onclick="retryInsightsPanel(&#39;example-session&#39;)"' in html
+        or "retryInsightsPanel('example-session')" in html
+    )
+    assert "Retry" in html
+    # The curl fallback must be collapsed behind the debug disclosure, not a
+    # bare inline <code> line in the panel body.
+    assert '<details class="route-debug">' in html
+    assert re.search(r"<p><code>|<br><code>", html) is None


### PR DESCRIPTION
## Summary
Implements bead `polylogue-bby.1` (Lane B of the parallel-lanes effort, Sonnet-implemented, coordinator-reviewed and rebased): the web shell never again renders a confident empty state while a request is pending or failed. Stale data stays visible under a truthful degradation banner; a global daemon-unreachable banner with backoff reconnect replaces per-widget "Failed to fetch" scatter.

## Problem
The exact live-probe bug in the bead: `/api/sessions` failure blanked a populated list to a false "0 conversations"; daemon death mid-session degraded every widget independently with no global signal; panel failures (`Insights/Cost/Evidence`) collapsed to reason-less "surface unavailable" strings indistinguishable from legitimately-empty results; a literal `curl` fallback command leaked inline into the product surface.

## Solution (route/panel audit → fix, full table in the branch commits)
- `loadSessions` failure no longer clears state; stale rows render under a `renderRouteStateNotice` degradation banner.
- Global `#daemon-banner` gated on the health route with exponential-backoff reconnect (3s→30s).
- Panel failures carry route/status/reason + a Retry action (`renderInlinePanelFailure`); raw-artifact fetch failure is now distinct from genuinely-empty metadata.
- Debug curl commands collapsed behind a `<details>` disclosure.
- Audited-and-already-correct routes documented (facets, session detail, read views, user overlays).

## Verification
- `devtools test tests/visual tests/unit/daemon/test_web_shell_xss_escaping.py` → **36 passed** (re-run at integration after rebase onto current master).
- 4 new smoke tests run real extracted JS from `WEB_SHELL_HTML` via Node (repo-established pattern), including a seeded daemon-death replay and a proven regression catch: reverting the `loadSessions` fix makes `test_session_list_survives_daemon_failure_seeded` fail (`assert 0 == 3`).
- ruff + mypy clean on changed files; `devtools verify --quick` green.

Deferred (documented, out of lane scope): same generic-error pattern in `web_shell_similar/lineage/provenance.py`; write-path error strings; Playwright fault injection belongs to bead `1ilk`.

Ref polylogue-bby.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU