### PR TITLE
feat(demo): Incident 14:32 constructs — source outage, cross-material duplicate, compaction omission

### DIFF
--- a/docs/plans/demo-corpus-construct-audit.md
+++ b/docs/plans/demo-corpus-construct-audit.md
@@ -15,14 +15,14 @@ This datasheet is generated from the deterministic demo family registry, the dec
 
 | Fact | Current |
 | --- | ---: |
-| Sessions | 13 |
-| Messages | 55 indexed |
-| Blocks | 99 |
-| Session profiles | 13 |
+| Sessions | 15 |
+| Messages | 62 indexed |
+| Blocks | 106 |
+| Session profiles | 15 |
 | Origins | aistudio-drive, chatgpt-export, claude-ai-export, claude-code-session, codex-session |
-| Run rows | 14 |
-| Observed-event rows | 45 |
-| Context-snapshot rows | 14 |
+| Run rows | 16 |
+| Observed-event rows | 49 |
+| Context-snapshot rows | 16 |
 
 ## Declared Source Families
 
@@ -31,11 +31,12 @@ This datasheet is generated from the deterministic demo family registry, the dec
 | `chatgpt-dialogue` | `chatgpt` | `chatgpt/demo-00.json` | `multi_origin_sessions`<br>`session_profiles` | `true` |
 | `claude-code-tools` | `claude-code` | `claude-code/demo-00.jsonl` | `tool_use_blocks`<br>`tool_result_blocks`<br>`failed_tool_results`<br>`provider_usage_messages`<br>`run_projection_rows`<br>`observed_event_rows`<br>`context_snapshot_rows` | `true` |
 | `claude-ai-temporary` | `claude-ai` | `claude-ai/temporary-demo.json` | `temporary_session_rows`<br>`token_budget_web_constructs` | `false` |
-| `browser-capture-gap` | `browser-capture` | `browser-capture/chatgpt-raw-provider.json`<br>`browser-capture/chatgpt-dom-fallback.json` | `capture_gap_events`<br>`browser_capture_raw_variants`<br>`browser_capture_coalesced_session` | `false` |
+| `browser-capture-gap` | `browser-capture` | `browser-capture/chatgpt-raw-provider.json`<br>`browser-capture/chatgpt-dom-fallback.json` | `capture_gap_events`<br>`browser_capture_raw_variants`<br>`browser_capture_coalesced_session`<br>`source_outage_interval_events` | `false` |
+| `cross-material-duplicate` | `chatgpt` | `chatgpt/duplicate-source-export.json`<br>`browser-capture/duplicate-capture.json` | `ambiguous_cross_material_duplicate` | `false` |
 | `codex-tools` | `codex` | `codex/demo-00.jsonl` | `tool_use_blocks`<br>`tool_result_blocks`<br>`failed_tool_results` | `true` |
 | `evidence-lab-receipts` | `codex` | `codex/receipts.jsonl`<br>`codex/anti-grep-control.jsonl` | `receipts_failed_test_action`<br>`receipts_successful_recovery_action`<br>`receipts_conflicting_claim`<br>`anti_grep_control` | `false` |
 | `gemini-attachments` | `gemini` | `gemini/demo-00.json` | `attachment_rows`<br>`acquired_attachment_rows` | `true` |
-| `agent-lineage-matrix` | `mixed-agent` | `codex/lineage-parent.jsonl`<br>`codex/lineage-fork.jsonl`<br>`codex/lineage-subagent.jsonl`<br>`codex/terminal-error.jsonl`<br>`claude-code/agent-acompact-demo.jsonl`<br>`claude-code/lineage-sidechain.jsonl` | `session_link_rows`<br>`generic_branch_links`<br>`prefix_sharing_links`<br>`continuation_links`<br>`subagent_links`<br>`sidechain_sessions`<br>`compaction_events`<br>`subagent_context_snapshots`<br>`subagent_run_rows`<br>`unfinished_terminal_state_rows`<br>`error_terminal_state_rows` | `false` |
+| `agent-lineage-matrix` | `mixed-agent` | `codex/lineage-parent.jsonl`<br>`codex/lineage-fork.jsonl`<br>`codex/lineage-subagent.jsonl`<br>`codex/terminal-error.jsonl`<br>`claude-code/agent-acompact-demo.jsonl`<br>`claude-code/lineage-sidechain.jsonl` | `session_link_rows`<br>`generic_branch_links`<br>`prefix_sharing_links`<br>`continuation_links`<br>`subagent_links`<br>`sidechain_sessions`<br>`compaction_events`<br>`subagent_context_snapshots`<br>`subagent_run_rows`<br>`unfinished_terminal_state_rows`<br>`error_terminal_state_rows`<br>`compaction_omits_failed_attempt` | `false` |
 | `embedding-lane-prose` | `derived-embedding` | `claude-code/demo-00.jsonl`<br>`embeddings.db` | `embedding_candidate_prose_messages`<br>`synthetic_message_embedding_rows`<br>`embedding_status_rows` | `false` |
 
 ## Declared Construct Coverage
@@ -43,10 +44,10 @@ This datasheet is generated from the deterministic demo family registry, the dec
 | Construct | Observed | Minimum | Status |
 | --- | ---: | ---: | --- |
 | Multi-origin sessions (`multi_origin_sessions`) | 5 | 3 | `ok` |
-| Session profiles (`session_profiles`) | 13 | 3 | `ok` |
-| Tool-use blocks (`tool_use_blocks`) | 23 | 1 | `ok` |
-| Tool-result blocks (`tool_result_blocks`) | 25 | 1 | `ok` |
-| Failed tool results (`failed_tool_results`) | 6 | 1 | `ok` |
+| Session profiles (`session_profiles`) | 15 | 3 | `ok` |
+| Tool-use blocks (`tool_use_blocks`) | 24 | 1 | `ok` |
+| Tool-result blocks (`tool_result_blocks`) | 26 | 1 | `ok` |
+| Failed tool results (`failed_tool_results`) | 7 | 1 | `ok` |
 | Provider usage messages (`provider_usage_messages`) | 7 | 1 | `ok` |
 | Attachment rows (`attachment_rows`) | 1 | 1 | `ok` |
 | Acquired attachment rows (`acquired_attachment_rows`) | 1 | 1 | `ok` |
@@ -55,6 +56,9 @@ This datasheet is generated from the deterministic demo family registry, the dec
 | Capture-gap events (`capture_gap_events`) | 1 | 1 | `ok` |
 | Browser-capture raw variants (`browser_capture_raw_variants`) | 3 | 3 | `ok` |
 | Browser-capture coalesced session (`browser_capture_coalesced_session`) | 1 | 1 | `ok` |
+| Source-outage interval events (`source_outage_interval_events`) | 1 | 1 | `ok` |
+| Ambiguous cross-material duplicate (`ambiguous_cross_material_duplicate`) | 2 | 1 | `ok` |
+| Compaction omits a failed attempt (`compaction_omits_failed_attempt`) | 1 | 1 | `ok` |
 | Session-link rows (`session_link_rows`) | 3 | 1 | `ok` |
 | Generic branch links (`generic_branch_links`) | 1 | 1 | `ok` |
 | Prefix-sharing lineage links (`prefix_sharing_links`) | 1 | 1 | `ok` |
@@ -62,18 +66,18 @@ This datasheet is generated from the deterministic demo family registry, the dec
 | Subagent links (`subagent_links`) | 1 | 1 | `ok` |
 | Sidechain sessions (`sidechain_sessions`) | 1 | 1 | `ok` |
 | Compaction events (`compaction_events`) | 1 | 1 | `ok` |
-| Run projection rows (`run_projection_rows`) | 14 | 1 | `ok` |
-| Observed-event rows (`observed_event_rows`) | 45 | 1 | `ok` |
-| Context snapshot rows (`context_snapshot_rows`) | 14 | 1 | `ok` |
+| Run projection rows (`run_projection_rows`) | 16 | 1 | `ok` |
+| Observed-event rows (`observed_event_rows`) | 49 | 1 | `ok` |
+| Context snapshot rows (`context_snapshot_rows`) | 16 | 1 | `ok` |
 | Subagent context snapshots (`subagent_context_snapshots`) | 1 | 1 | `ok` |
 | Subagent run rows (`subagent_run_rows`) | 1 | 1 | `ok` |
-| Unfinished terminal-state rows (`unfinished_terminal_state_rows`) | 3 | 1 | `ok` |
+| Unfinished terminal-state rows (`unfinished_terminal_state_rows`) | 5 | 1 | `ok` |
 | Error terminal-state rows (`error_terminal_state_rows`) | 2 | 1 | `ok` |
 | Receipts failed test action (`receipts_failed_test_action`) | 1 | 1 | `ok` |
 | Receipts successful recovery action (`receipts_successful_recovery_action`) | 1 | 1 | `ok` |
 | Receipts conflicting claim (`receipts_conflicting_claim`) | 1 | 1 | `ok` |
 | Anti-grep negative control (`anti_grep_control`) | 1 | 1 | `ok` |
-| Embedding candidate prose messages (`embedding_candidate_prose_messages`) | 31 | 1 | `ok` |
+| Embedding candidate prose messages (`embedding_candidate_prose_messages`) | 36 | 1 | `ok` |
 | Synthetic message embedding rows (`synthetic_message_embedding_rows`) | 2 | 1 | `ok` |
 | Embedding status rows (`embedding_status_rows`) | 1 | 1 | `ok` |
 

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -71,6 +71,21 @@ class BrowserCaptureTurn(BaseModel):
         return self
 
 
+class BrowserCaptureInterruption(BaseModel):
+    """A source-declared interval during which the capture adapter was not observing the page.
+
+    Extensions can legitimately detect and report their own non-observation
+    windows (the host was suspended, the tab was backgrounded, auth expired
+    mid-session, etc). This is distinct from ordinary conversational silence,
+    which leaves no signal in the archive at all — a declared interruption is
+    positive evidence of a coverage gap, not an absence of evidence.
+    """
+
+    started_at: str
+    ended_at: str
+    reason: str
+
+
 class BrowserCaptureProvenance(BaseModel):
     """How and where the capture was observed."""
 
@@ -82,6 +97,7 @@ class BrowserCaptureProvenance(BaseModel):
     adapter_name: str
     adapter_version: str | None = None
     capture_mode: Literal["snapshot", "tail"] = "snapshot"
+    capture_interruption: BrowserCaptureInterruption | None = None
     provider_meta: dict[str, object] = Field(default_factory=dict)
 
     @field_validator("provider_meta", mode="before")
@@ -357,6 +373,7 @@ __all__ = [
     "BrowserCaptureAttachment",
     "BrowserCaptureEnvelope",
     "BrowserCaptureErrorPayload",
+    "BrowserCaptureInterruption",
     "BrowserCaptureProvenance",
     "BrowserCaptureReceiverStatusPayload",
     "BrowserCaptureSession",

--- a/polylogue/demo/constructs.py
+++ b/polylogue/demo/constructs.py
@@ -162,6 +162,29 @@ DEMO_CONSTRUCTS: tuple[DemoConstruct, ...] = (
         """,
     ),
     DemoConstruct(
+        construct_id="ambiguous_cross_material_duplicate",
+        label="Ambiguous cross-material duplicate",
+        description=(
+            "The same logical conversation content arrives via two materials that do not share a "
+            "native id, so occurrence-identity tooling must resolve the duplicate from content."
+        ),
+        sql="""
+            SELECT COUNT(*)
+            FROM (
+                SELECT DISTINCT b1.text
+                FROM blocks AS b1
+                JOIN messages AS m1 ON m1.message_id = b1.message_id AND m1.session_id = b1.session_id
+                JOIN blocks AS b2
+                  ON b2.text = b1.text
+                 AND b2.block_type = 'text'
+                JOIN messages AS m2 ON m2.message_id = b2.message_id AND m2.session_id = b2.session_id
+                WHERE b1.block_type = 'text'
+                  AND m1.session_id = 'chatgpt-export:cross-material-duplicate-01'
+                  AND m2.session_id = 'chatgpt-export:cross-material-duplicate-02'
+            )
+        """,
+    ),
+    DemoConstruct(
         construct_id="session_link_rows",
         label="Session-link rows",
         description="At least one parser-declared parent relationship is persisted.",

--- a/polylogue/demo/constructs.py
+++ b/polylogue/demo/constructs.py
@@ -185,6 +185,31 @@ DEMO_CONSTRUCTS: tuple[DemoConstruct, ...] = (
         """,
     ),
     DemoConstruct(
+        construct_id="compaction_omits_failed_attempt",
+        label="Compaction omits a failed attempt",
+        description=(
+            "A structurally failed tool result precedes a compaction boundary whose summary text "
+            "omits any mention of the failure, so compaction-honesty demos must diff full session "
+            "evidence against the summary rather than trusting the summary alone."
+        ),
+        sql="""
+            SELECT CASE WHEN
+                EXISTS (
+                    SELECT 1 FROM actions
+                    WHERE session_id = 'claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6:agent-acompact-demo'
+                      AND is_error = 1
+                )
+                AND EXISTS (
+                    SELECT 1 FROM session_events
+                    WHERE session_id = 'claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6:agent-acompact-demo'
+                      AND event_type = 'compaction'
+                      AND LOWER(summary) NOT LIKE '%fail%'
+                      AND LOWER(summary) NOT LIKE '%error%'
+                )
+            THEN 1 ELSE 0 END
+        """,
+    ),
+    DemoConstruct(
         construct_id="session_link_rows",
         label="Session-link rows",
         description="At least one parser-declared parent relationship is persisted.",

--- a/polylogue/demo/constructs.py
+++ b/polylogue/demo/constructs.py
@@ -147,6 +147,21 @@ DEMO_CONSTRUCTS: tuple[DemoConstruct, ...] = (
         """,
     ),
     DemoConstruct(
+        construct_id="source_outage_interval_events",
+        label="Source-outage interval events",
+        description=(
+            "A capture adapter declares a bounded interval during which it was not observing the "
+            "session, distinct from ordinary conversational silence, which leaves no signal at all."
+        ),
+        sql="""
+            SELECT COUNT(*)
+            FROM session_events
+            WHERE event_type = 'source_outage'
+              AND json_extract(payload_json, '$.started_at') IS NOT NULL
+              AND json_extract(payload_json, '$.ended_at') IS NOT NULL
+        """,
+    ),
+    DemoConstruct(
         construct_id="session_link_rows",
         label="Session-link rows",
         description="At least one parser-declared parent relationship is persisted.",

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -66,6 +66,7 @@ def materialize_demo_source(root: Path, *, force: bool = False) -> Path:
     )
     _write_demo_temporary_sources(source_root)
     _write_demo_browser_capture_gap_sources(source_root)
+    _write_demo_cross_material_duplicate_sources(source_root)
     _write_demo_lineage_sources(source_root)
     _write_demo_receipts_sources(source_root)
     return source_root
@@ -243,6 +244,105 @@ def _write_demo_browser_capture_gap_sources(source_root: Path) -> None:
                     }
                 ],
             },
+        },
+    )
+
+
+def _write_demo_cross_material_duplicate_sources(source_root: Path) -> None:
+    """Write two materials reporting the same content under unrelated native ids.
+
+    A direct ChatGPT export and a browser capture of the same conversation
+    arrive with different native ids (the extension observed the page before
+    the provider had assigned the export's canonical conversation id), so the
+    archive keeps two distinct sessions instead of silently coalescing them.
+    This is the ambiguous cross-material duplicate / occurrence-identity
+    anchor: the duplication is only discoverable from content, not from the
+    origin/native-id identity key (#polylogue-212.11).
+    """
+
+    export_id = "cross-material-duplicate-01"
+    capture_id = "cross-material-duplicate-02"
+    title = "Flaky clock test fix summary"
+    shared_user_text = "Summarize the one-sentence fix for the flaky clock test."
+    shared_assistant_text = "The fixture used a shared clock instance; switching to an isolated clock fixed it."
+
+    def _mapping_payload(*, conversation_id: str, user_id: str, assistant_id: str) -> dict[str, object]:
+        return {
+            "conversation_id": conversation_id,
+            "title": title,
+            "create_time": 1783158900.0,
+            "update_time": 1783158903.0,
+            "current_node": "assistant-node",
+            "mapping": {
+                "root": {"id": "root", "message": None, "parent": None, "children": ["user-node"]},
+                "user-node": {
+                    "id": "user-node",
+                    "parent": "root",
+                    "children": ["assistant-node"],
+                    "message": {
+                        "id": user_id,
+                        "author": {"role": "user"},
+                        "create_time": 1783158901.0,
+                        "content": {"content_type": "text", "parts": [shared_user_text]},
+                        "metadata": {},
+                    },
+                },
+                "assistant-node": {
+                    "id": "assistant-node",
+                    "parent": "user-node",
+                    "children": [],
+                    "message": {
+                        "id": assistant_id,
+                        "author": {"role": "assistant"},
+                        "create_time": 1783158902.0,
+                        "content": {"content_type": "text", "parts": [shared_assistant_text]},
+                        "metadata": {"model_slug": "gpt-5-demo"},
+                    },
+                },
+            },
+        }
+
+    _write_json(
+        source_root / "chatgpt" / "duplicate-source-export.json",
+        _mapping_payload(
+            conversation_id=export_id,
+            user_id="duplicate-export-u0",
+            assistant_id="duplicate-export-a1",
+        ),
+    )
+    _write_json(
+        source_root / "browser-capture" / "duplicate-capture.json",
+        {
+            "polylogue_capture_kind": "browser_llm_session",
+            "schema_version": 1,
+            "capture_id": f"chatgpt:{capture_id}:ambiguous-material",
+            "provenance": {
+                "source_url": f"https://chatgpt.com/c/{capture_id}",
+                "page_title": title,
+                "captured_at": "2026-07-04T09:56:00Z",
+                "adapter_name": "chatgpt-browser-native-v1",
+                "capture_mode": "snapshot",
+            },
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": capture_id,
+                "title": title,
+                "updated_at": "2026-07-04T09:56:00Z",
+                "model": "gpt-5-demo",
+                "turns": [
+                    {
+                        "provider_turn_id": "duplicate-capture-placeholder-u0",
+                        "role": "user",
+                        "text": shared_user_text,
+                        "ordinal": 0,
+                    }
+                ],
+            },
+            "raw_provider_payload": _mapping_payload(
+                conversation_id=capture_id,
+                user_id="duplicate-capture-u0",
+                assistant_id="duplicate-capture-a1",
+            ),
         },
     )
 

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -395,7 +395,7 @@ def _claude_code_record(
     session_id: str,
     timestamp: str,
     role: str,
-    content: str,
+    content: str | list[dict[str, object]],
     is_sidechain: bool = False,
 ) -> dict[str, object]:
     record: dict[str, object] = {
@@ -470,13 +470,59 @@ def _write_demo_lineage_sources(source_root: Path) -> None:
                 session_id=claude_parent_id,
                 timestamp="2026-07-04T10:03:01Z",
                 role="user",
-                content="Summarize the parent context before continuing the demo lineage audit.",
+                content="Fix the flaky clock test before continuing the demo lineage audit.",
+            ),
+            # A structurally failed attempt precedes the compaction boundary below.
+            # The compaction summary deliberately omits it (#polylogue-212.11
+            # compaction-honesty anchor) — a reader trusting the summary alone
+            # would never learn the first edit failed.
+            _claude_code_record(
+                record_type="assistant",
+                uuid="acompact-fail-a0",
+                session_id=claude_parent_id,
+                timestamp="2026-07-04T10:03:02Z",
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_acompact_fail",
+                        "name": "Edit",
+                        "input": {
+                            "file_path": "tests/fixtures/shared_clock.py",
+                            "old_string": "class SharedClock",
+                            "new_string": "class IsolatedClock",
+                        },
+                    }
+                ],
+            ),
+            _claude_code_record(
+                record_type="user",
+                uuid="acompact-fail-r0",
+                session_id=claude_parent_id,
+                timestamp="2026-07-04T10:03:03Z",
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_acompact_fail",
+                        "content": "F tests/test_clock.py::test_uses_monotonic_clock\n1 failed in 0.21s",
+                        "is_error": True,
+                    }
+                ],
+            ),
+            _claude_code_record(
+                record_type="assistant",
+                uuid="acompact-fail-a1",
+                session_id=claude_parent_id,
+                timestamp="2026-07-04T10:03:04Z",
+                role="assistant",
+                content="All tests pass now; the clock fix is complete.",
             ),
             _claude_code_record(
                 record_type="summary",
                 uuid="acompact-s1",
                 session_id=claude_parent_id,
-                timestamp="2026-07-04T10:03:02Z",
+                timestamp="2026-07-04T10:03:05Z",
                 role="system",
                 content="Compacted demo lineage context: parent, branch, subagent, and caveats.",
             ),

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -149,6 +149,14 @@ def _write_demo_browser_capture_gap_sources(source_root: Path) -> None:
                 "captured_at": "2026-07-04T09:54:00Z",
                 "adapter_name": "chatgpt-browser-native-v1",
                 "capture_mode": "snapshot",
+                # Declared source-outage interval (#polylogue-212.11): the extension
+                # host was suspended before this snapshot, so it has positive
+                # evidence of a coverage gap distinct from mere silence.
+                "capture_interruption": {
+                    "started_at": "2026-07-04T09:50:00Z",
+                    "ended_at": "2026-07-04T09:53:30Z",
+                    "reason": "extension host suspended while the tab was backgrounded",
+                },
             },
             "session": {
                 "provider": "chatgpt",

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -48,6 +48,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     BrowserCapturePrecedence,
     browser_capture_precedence,
     record_capture_gap_event,
+    record_source_outage_events,
     session_has_parser_ingest_flag,
     stored_message_count,
 )
@@ -448,10 +449,19 @@ def _write_session(
                     incoming_message_count=payload.message_count,
                 )
                 counts["session_events"] = 1
+            # Twin of the ArchiveStore skip path: a capture that loses the
+            # content merge can still truthfully declare when it was NOT
+            # observing the page — that outage telemetry survives the skip.
+            outage_events = record_source_outage_events(
+                conn,
+                session_id=payload.session_id,
+                events=payload.parsed_session.session_events,
+            )
+            counts["session_events"] = counts.get("session_events", 0) + outage_events
             counts["skipped_sessions"] = 1
             counts["skipped_messages"] = payload.message_count
             counts["skipped_attachments"] = payload.attachment_count
-            counts["skipped_session_events"] = len(payload.parsed_session.session_events)
+            counts["skipped_session_events"] = len(payload.parsed_session.session_events) - outage_events
             return False, counts
 
     incoming_freshness_ms = _timestamp_ms(session_to_write.updated_at) or _timestamp_ms(session_to_write.created_at)

--- a/polylogue/scenarios/__init__.py
+++ b/polylogue/scenarios/__init__.py
@@ -10,6 +10,8 @@ from .cli_surfaces import (
     build_cli_surface_memory_budget_variants,
 )
 from .corpus import (
+    DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
+    DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
     DEMO_CHATGPT_SESSION_ID,
     DEMO_CLAUDE_AI_TEMPORARY_SESSION_ID,
     DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,
@@ -135,6 +137,8 @@ __all__ = [
     "DEMO_EMBEDDING_PROSE_SESSION_ID",
     "DEMO_GEMINI_SESSION_ID",
     "DEMO_CHATGPT_SESSION_ID",
+    "DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID",
+    "DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID",
     "DEMO_SESSION_IDS",
     "DemoUserOverlayResult",
     "compile_projection_entries",

--- a/polylogue/scenarios/corpus.py
+++ b/polylogue/scenarios/corpus.py
@@ -63,6 +63,11 @@ DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID = (
     "claude-code-session:63705dcc-f3e5-4378-8118-8bc21e53bbb6:agent-acompact-demo"
 )
 DEMO_CLAUDE_CODE_LINEAGE_SIDECHAIN_SESSION_ID = "claude-code-session:demo-lineage-sidechain"
+# Two materials (a direct export and a browser capture) reporting the same
+# logical conversation under unrelated native ids — the ambiguous
+# cross-material duplicate / occurrence-identity anchor (#polylogue-212.11).
+DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID = "chatgpt-export:cross-material-duplicate-01"
+DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID = "chatgpt-export:cross-material-duplicate-02"
 DEMO_EMBEDDING_PROSE_SESSION_ID = DEMO_CLAUDE_CODE_SESSION_ID
 DEMO_SESSION_IDS = (
     DEMO_CHATGPT_SESSION_ID,
@@ -78,6 +83,8 @@ DEMO_SESSION_IDS = (
     DEMO_CODEX_ANTI_GREP_SESSION_ID,
     DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,
     DEMO_CLAUDE_CODE_LINEAGE_SIDECHAIN_SESSION_ID,
+    DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
+    DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
 )
 
 
@@ -194,6 +201,22 @@ DEMO_CORPUS_FAMILIES: tuple[DemoCorpusFamily, ...] = (
         source_paths=(
             "browser-capture/chatgpt-raw-provider.json",
             "browser-capture/chatgpt-dom-fallback.json",
+        ),
+        synthetic=False,
+    ),
+    DemoCorpusFamily(
+        family_id="cross-material-duplicate",
+        label="Cross-material duplicate occurrence",
+        provider="chatgpt",
+        construct_ids=("ambiguous_cross_material_duplicate",),
+        description=(
+            "The same logical conversation content arrives through two independent materials — a "
+            "direct ChatGPT export and a browser capture with an unrelated native id — so occurrence-"
+            "identity tooling must resolve the duplicate from content, not from identity keys."
+        ),
+        source_paths=(
+            "chatgpt/duplicate-source-export.json",
+            "browser-capture/duplicate-capture.json",
         ),
         synthetic=False,
     ),

--- a/polylogue/scenarios/corpus.py
+++ b/polylogue/scenarios/corpus.py
@@ -183,10 +183,13 @@ DEMO_CORPUS_FAMILIES: tuple[DemoCorpusFamily, ...] = (
             "capture_gap_events",
             "browser_capture_raw_variants",
             "browser_capture_coalesced_session",
+            "source_outage_interval_events",
         ),
         description=(
             "Native-payload and lower-precedence DOM browser captures for an existing ChatGPT session, "
-            "proving source evidence remains durable while the indexed session stays canonical."
+            "proving source evidence remains durable while the indexed session stays canonical. The "
+            "native capture also declares a bounded pre-capture interval during which the extension "
+            "adapter reported no observation, distinct from ordinary conversational silence."
         ),
         source_paths=(
             "browser-capture/chatgpt-raw-provider.json",

--- a/polylogue/scenarios/corpus.py
+++ b/polylogue/scenarios/corpus.py
@@ -279,10 +279,13 @@ DEMO_CORPUS_FAMILIES: tuple[DemoCorpusFamily, ...] = (
             "subagent_run_rows",
             "unfinished_terminal_state_rows",
             "error_terminal_state_rows",
+            "compaction_omits_failed_attempt",
         ),
         description=(
             "Explicit parent, prefix-sharing branch, spawned subagent, sidechain, compaction, and "
-            "structural unfinished/error terminal-state source files."
+            "structural unfinished/error terminal-state source files. The compaction fixture also "
+            "precedes its summary with a structurally failed tool result that the summary text omits, "
+            "proving compaction honesty must be checked against full session evidence."
         ),
         source_paths=(
             "codex/lineage-parent.jsonl",

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -19,7 +19,12 @@ from polylogue.browser_capture.models import (
     looks_like_browser_capture,
 )
 from polylogue.core.enums import Provider, SessionKind
-from polylogue.sources.parsers.base_models import ParsedAttachment, ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base_models import (
+    ParsedAttachment,
+    ParsedMessage,
+    ParsedSession,
+    ParsedSessionEvent,
+)
 
 
 def _legacy_native_id(provider: Provider, provider_session_id: str | None) -> str | None:
@@ -183,6 +188,44 @@ def _merge_envelope_attachments(parsed: ParsedSession, envelope: BrowserCaptureE
     return parsed.model_copy(update={"attachments": list(merged.values())})
 
 
+def _capture_interruption_session_events(envelope: BrowserCaptureEnvelope) -> list[ParsedSessionEvent]:
+    """Turn a source-declared capture interruption into a session event.
+
+    Distinct from the ``capture_gap`` event recorded when a lower-precedence
+    DOM capture is skipped during write (an artifact of merge precedence): this
+    is a positive, source-reported claim that observation stopped for a bounded
+    interval, so it is preserved as its own ``source_outage`` event even when
+    this capture otherwise wins outright.
+    """
+
+    interruption = envelope.provenance.capture_interruption
+    if interruption is None:
+        return []
+    summary = (
+        f"{envelope.provenance.adapter_name} reported no observation of this session "
+        f"from {interruption.started_at} to {interruption.ended_at}: {interruption.reason}."
+    )
+    return [
+        ParsedSessionEvent(
+            event_type="source_outage",
+            timestamp=interruption.ended_at,
+            payload={
+                "summary": summary,
+                "started_at": interruption.started_at,
+                "ended_at": interruption.ended_at,
+                "reason": interruption.reason,
+            },
+        )
+    ]
+
+
+def _merge_envelope_session_events(parsed: ParsedSession, envelope: BrowserCaptureEnvelope) -> ParsedSession:
+    events = _capture_interruption_session_events(envelope)
+    if not events:
+        return parsed
+    return parsed.model_copy(update={"session_events": [*parsed.session_events, *events]})
+
+
 def parse(payload: object, fallback_id: str) -> ParsedSession:
     """Parse a browser-capture envelope into the canonical parser contract."""
     envelope = BrowserCaptureEnvelope.model_validate(payload)
@@ -192,20 +235,26 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
     if envelope.session.provider is Provider.CHATGPT and _has_chatgpt_native_payload(raw_provider_payload):
         from polylogue.sources.parsers.chatgpt import parse as parse_chatgpt
 
-        return _apply_browser_capture_session_kind(
-            _merge_envelope_attachments(parse_chatgpt(raw_provider_payload, provider_session_id), envelope),
+        return _merge_envelope_session_events(
+            _apply_browser_capture_session_kind(
+                _merge_envelope_attachments(parse_chatgpt(raw_provider_payload, provider_session_id), envelope),
+                envelope,
+                provider_session_id,
+                has_native_payload=True,
+            ),
             envelope,
-            provider_session_id,
-            has_native_payload=True,
         )
     if envelope.session.provider is Provider.CLAUDE_AI and _has_claude_ai_native_payload(raw_provider_payload):
         from polylogue.sources.parsers.claude.ai_parser import parse_ai as parse_claude_ai
 
-        return _apply_browser_capture_session_kind(
-            _merge_envelope_attachments(parse_claude_ai(raw_provider_payload, provider_session_id), envelope),
+        return _merge_envelope_session_events(
+            _apply_browser_capture_session_kind(
+                _merge_envelope_attachments(parse_claude_ai(raw_provider_payload, provider_session_id), envelope),
+                envelope,
+                provider_session_id,
+                has_native_payload=True,
+            ),
             envelope,
-            provider_session_id,
-            has_native_payload=True,
         )
 
     seen_turns: set[str] = set()
@@ -265,6 +314,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
         attachments=attachments,
+        session_events=_capture_interruption_session_events(envelope),
         ingest_flags=[
             *dict.fromkeys(
                 [

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -124,6 +124,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     BrowserCapturePrecedence,
     browser_capture_precedence,
     record_capture_gap_event,
+    record_source_outage_events,
     session_has_parser_ingest_flag,
     stored_message_count,
 )
@@ -991,6 +992,11 @@ class ArchiveStore:
                         incoming_message_count=len(session.messages),
                     )
                     session_event_count = 1
+                session_event_count += record_source_outage_events(
+                    self._conn,
+                    session_id=session_id,
+                    events=session.session_events,
+                )
                 if manage_transaction:
                     self._conn.commit()
                 return ArchiveRawParsedWriteResult(

--- a/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
+++ b/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
+from collections.abc import Sequence
 from typing import Literal
+
+from polylogue.core.timestamps import parse_timestamp
+from polylogue.sources.parsers.base_models import ParsedSessionEvent
 
 BrowserCapturePrecedence = Literal["default", "replace", "skip"]
 
@@ -109,10 +114,72 @@ def record_capture_gap_event(
     )
 
 
+def record_source_outage_events(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    events: Sequence[ParsedSessionEvent],
+) -> int:
+    """Persist source-outage telemetry a capture declares about itself even
+    when its message content loses the browser-capture precedence merge and
+    is otherwise discarded.
+
+    A capture that loses the content merge can still be telling the truth
+    about when it was not observing the page: that claim does not depend on
+    whether its transcript content wins. Mirrors ``record_capture_gap_event``:
+    a lightweight write survives the skip path instead of the whole incoming
+    session's evidence being silently dropped alongside its discarded
+    messages.
+    """
+    outage_events = [event for event in events if event.event_type == "source_outage"]
+    if not outage_events:
+        return 0
+    row = conn.execute(
+        """
+        SELECT MAX(position) + 1
+        FROM (
+            SELECT position FROM session_events WHERE session_id = ?
+            UNION ALL
+            SELECT position FROM session_agent_policies WHERE session_id = ?
+            UNION ALL
+            SELECT position FROM session_provider_usage_events WHERE session_id = ?
+        )
+        """,
+        (session_id, session_id, session_id),
+    ).fetchone()
+    position = int(row[0] or 0) if row is not None else 0
+    for event in outage_events:
+        summary = str(event.payload.get("summary") or "")
+        occurred_at_ms: int | None = None
+        if event.timestamp:
+            parsed_timestamp = parse_timestamp(event.timestamp)
+            if parsed_timestamp is not None:
+                occurred_at_ms = int(parsed_timestamp.timestamp() * 1000)
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO session_events (
+                session_id, source_message_id, source_message_provider_id,
+                position, event_type, summary, payload_json, occurred_at_ms
+            ) VALUES (?, NULL, NULL, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                position,
+                event.event_type,
+                summary,
+                json.dumps(event.payload, sort_keys=True, ensure_ascii=False),
+                occurred_at_ms,
+            ),
+        )
+        position += 1
+    return len(outage_events)
+
+
 __all__ = [
     "BrowserCapturePrecedence",
     "browser_capture_precedence",
     "record_capture_gap_event",
+    "record_source_outage_events",
     "session_has_parser_ingest_flag",
     "stored_message_count",
 ]

--- a/tests/unit/demo/test_demo_construct_anti_vacuity.py
+++ b/tests/unit/demo/test_demo_construct_anti_vacuity.py
@@ -18,6 +18,10 @@ from pathlib import Path
 import pytest
 
 from polylogue.demo import evaluate_demo_constructs, seed_demo_archive
+from polylogue.scenarios import (
+    DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
+    DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
+)
 
 
 def _coverage_for(archive_root: Path, construct_id: str) -> bool:
@@ -39,3 +43,35 @@ async def test_source_outage_interval_construct_goes_red_when_event_withheld(tmp
     assert deleted >= 1
 
     assert _coverage_for(archive_root, "source_outage_interval_events") is False
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_cross_material_duplicate_construct_goes_red_when_content_diverges(
+    tmp_path: Path,
+) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    assert _coverage_for(archive_root, "ambiguous_cross_material_duplicate") is True
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks SET text = 'no longer the same logical content'
+            WHERE session_id = ? AND block_type = 'text'
+            """,
+            (DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 1
+
+    assert _coverage_for(archive_root, "ambiguous_cross_material_duplicate") is False
+
+    # Sanity: the sibling material and its session both remain, proving the
+    # construct genuinely depends on content equality, not session presence.
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
+            (DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID, DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID),
+        ).fetchone()[0]
+    assert remaining == 2

--- a/tests/unit/demo/test_demo_construct_anti_vacuity.py
+++ b/tests/unit/demo/test_demo_construct_anti_vacuity.py
@@ -1,0 +1,41 @@
+"""Anti-vacuity witnesses for the Incident 14:32 proof-world constructs (#polylogue-212.11).
+
+Per docs/design/incident-1432-proof-world.md's anti-circularity rule: for every
+declared construct there must be a test that withholds or deletes the evidence
+and asserts the dependent construct check goes red. A verifier that stays green
+when its proof is removed validates shape, not reality. Each test below seeds
+the real demo archive through the real provider parsers, confirms the new
+construct is green, mutates the archive to remove exactly the evidence the
+construct depends on, and re-measures to confirm the construct goes red while
+the seeding path itself is untouched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.demo import evaluate_demo_constructs, seed_demo_archive
+
+
+def _coverage_for(archive_root: Path, construct_id: str) -> bool:
+    coverage = evaluate_demo_constructs(archive_root)
+    (row,) = (row for row in coverage if row.construct_id == construct_id)
+    return row.ok
+
+
+@pytest.mark.asyncio
+async def test_source_outage_interval_construct_goes_red_when_event_withheld(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    assert _coverage_for(archive_root, "source_outage_interval_events") is True
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        deleted = conn.execute("DELETE FROM session_events WHERE event_type = 'source_outage'").rowcount
+        conn.commit()
+    assert deleted >= 1
+
+    assert _coverage_for(archive_root, "source_outage_interval_events") is False

--- a/tests/unit/demo/test_demo_construct_anti_vacuity.py
+++ b/tests/unit/demo/test_demo_construct_anti_vacuity.py
@@ -21,6 +21,7 @@ from polylogue.demo import evaluate_demo_constructs, seed_demo_archive
 from polylogue.scenarios import (
     DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
     DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
+    DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,
 )
 
 
@@ -75,3 +76,60 @@ async def test_ambiguous_cross_material_duplicate_construct_goes_red_when_conten
             (DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID, DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID),
         ).fetchone()[0]
     assert remaining == 2
+
+
+@pytest.mark.asyncio
+async def test_compaction_omission_construct_goes_red_when_failed_attempt_withheld(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    assert _coverage_for(archive_root, "compaction_omits_failed_attempt") is True
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        deleted = conn.execute(
+            """
+            DELETE FROM blocks
+            WHERE session_id = ? AND block_type = 'tool_result' AND tool_result_is_error = 1
+            """,
+            (DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert deleted >= 1
+
+    assert _coverage_for(archive_root, "compaction_omits_failed_attempt") is False
+
+    # Sanity: the compaction event itself survives — the construct is
+    # specifically about the omission relative to a real failure, not about
+    # compaction existing at all (guarded separately by "compaction_events").
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        compaction_rows = conn.execute(
+            "SELECT COUNT(*) FROM session_events WHERE session_id = ? AND event_type = 'compaction'",
+            (DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,),
+        ).fetchone()[0]
+    assert compaction_rows == 1
+    assert _coverage_for(archive_root, "compaction_events") is True
+
+
+@pytest.mark.asyncio
+async def test_compaction_omission_construct_goes_red_if_summary_names_the_failure(tmp_path: Path) -> None:
+    """The construct also fails closed if a future fixture edit stops omitting
+    the failure — proving the check is sensitive to the summary text, not just
+    to the presence of a compaction event."""
+
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    assert _coverage_for(archive_root, "compaction_omits_failed_attempt") is True
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE session_events SET summary = 'Compacted context; noted the earlier failed attempt.'
+            WHERE session_id = ? AND event_type = 'compaction'
+            """,
+            (DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated == 1
+
+    assert _coverage_for(archive_root, "compaction_omits_failed_attempt") is False

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -7,6 +7,8 @@ import pytest
 
 from polylogue.core.json import JSONDocument
 from polylogue.scenarios import (
+    DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
+    DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
     DEMO_CHATGPT_SESSION_ID,
     DEMO_CLAUDE_AI_TEMPORARY_SESSION_ID,
     DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,
@@ -206,12 +208,15 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
         DEMO_CODEX_ANTI_GREP_SESSION_ID,
         DEMO_CLAUDE_CODE_LINEAGE_COMPACTION_SESSION_ID,
         DEMO_CLAUDE_CODE_LINEAGE_SIDECHAIN_SESSION_ID,
+        DEMO_CHATGPT_DUPLICATE_EXPORT_SESSION_ID,
+        DEMO_CHATGPT_DUPLICATE_CAPTURE_SESSION_ID,
     )
     assert tuple(family.family_id for family in DEMO_CORPUS_FAMILIES) == (
         "chatgpt-dialogue",
         "claude-code-tools",
         "claude-ai-temporary",
         "browser-capture-gap",
+        "cross-material-duplicate",
         "codex-tools",
         "evidence-lab-receipts",
         "gemini-attachments",
@@ -234,6 +239,13 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
         "browser_capture_coalesced_session",
         "source_outage_interval_events",
     )
+    cross_material_family = DEMO_CORPUS_FAMILIES[4]
+    assert cross_material_family.synthetic is False
+    assert cross_material_family.source_paths == (
+        "chatgpt/duplicate-source-export.json",
+        "browser-capture/duplicate-capture.json",
+    )
+    assert cross_material_family.construct_ids == ("ambiguous_cross_material_duplicate",)
     assert DEMO_CORPUS_FAMILIES[-1].synthetic is False
     assert set(DEMO_CORPUS_FAMILIES[-1].construct_ids) == {
         "embedding_candidate_prose_messages",

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -266,6 +266,7 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
         "subagent_run_rows",
         "unfinished_terminal_state_rows",
         "error_terminal_state_rows",
+        "compaction_omits_failed_attempt",
     }
     assert "codex/terminal-error.jsonl" in lineage_family.source_paths
     assert tuple(spec.style for spec in specs) == (

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -232,6 +232,7 @@ def test_build_demo_corpus_specs_declares_release_fixture_world() -> None:
         "capture_gap_events",
         "browser_capture_raw_variants",
         "browser_capture_coalesced_session",
+        "source_outage_interval_events",
     )
     assert DEMO_CORPUS_FAMILIES[-1].synthetic is False
     assert set(DEMO_CORPUS_FAMILIES[-1].construct_ids) == {


### PR DESCRIPTION
## Summary
Lane C of the parallel-lanes effort (Sonnet-implemented, coordinator-reviewed): advances bead `polylogue-212.11` with three new deterministic-corpus constructs, each with an independently-authored oracle row and an anti-vacuity witness proving red→green. Declared constructs 34 → **37**, demo sessions 13 → 15. Plus one coordinator-found twin-path fix.

## Problem
The Incident 14:32 proof world (docs/design/incident-1432-proof-world.md) requires constructs the corpus lacked: a declared source-outage interval (coverage honesty), an ambiguous cross-material duplicate (occurrence identity), and a compaction summary that omits a failed attempt (compaction honesty).

## Solution
- **Source-outage interval**: `BrowserCaptureInterruption` on capture provenance → `source_outage` session events; survival-write (`record_source_outage_events`, mirroring `record_capture_gap_event`) keeps the telemetry even when the capture loses the browser-capture precedence merge.
- **Cross-material duplicate**: new `cross-material-duplicate` family — identical block text arriving via a real export parse AND a browser-capture parse under unrelated native ids; construct matches on content, not identity keys.
- **Compaction omission**: the acompact fixture now contains a structurally failed pytest (`is_error=true`) + a false "all tests pass" claim before the unchanged compaction summary; construct requires both the failure and a summary silent about it.
- **Coordinator addition (found in integration review)**: the production daemon skip path (`ingest_batch/_core.py`) dropped ALL session events on precedence skip — the sync-path survival write was added by the lane but its daemon twin was missing (the repo's known twin-path hazard). Mirrored, with honest skip counts.
- Deferred with written design sketch (in branch commit): parser v1/v2 dual-interpretation construct — needs a real semantics-versioning primitive, not a fixture hack.

## Verification
- Anti-vacuity witnesses (4 tests, `test_demo_construct_anti_vacuity.py`): each construct proven to go red when its evidence is withheld/diverged, incl. a control where the compaction summary names the failure.
- Integration re-run after rebase: demo/scenarios/cli/browser-capture/storage/pipeline battery → **168 passed**; lane's own post-rebase run 301/301.
- Live `polylogue demo tour`: **37/37 constructs**, 14.6s (budget 420s).
- `docs/plans/demo-corpus-construct-audit.md` regenerated via its owning command; ruff/mypy clean; `devtools verify --quick` green.

Ref polylogue-212.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeVDxsVhLuoG5w7bp5cmNU