### PR TITLE
test(devtools): add real storage correctness scenarios

### DIFF
--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -4,33 +4,28 @@ from __future__ import annotations
 
 import argparse
 import json
-import sqlite3
 import subprocess
 import sys
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Protocol, TextIO
 
 from devtools import repo_root as _get_root
 from devtools.cli_boundary import invoke_polylogue_cli
+from devtools.storage_correctness_scenario import (
+    STORAGE_CORRECTNESS_SCENARIO_NAME,
+    run_storage_correctness,
+    storage_correctness_scenario_entry,
+)
 from devtools.visual_artifacts import (
     READER_VISUAL_SMOKE_PYTEST_COMMAND,
     reader_visual_artifact_payloads,
 )
-from polylogue.archive.message.roles import Role
-from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import BlockType, Provider
 from polylogue.core.outcomes import OutcomeStatus
-from polylogue.pipeline.ids import session_content_hash
 from polylogue.scenarios import AssertionSpec, ExecutionSpec, polylogue_execution
-from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
-from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.storage.sqlite.archive_tiers.write import read_archive_session_envelope
 
-_SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke", "storage-correctness")
+_SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke", STORAGE_CORRECTNESS_SCENARIO_NAME)
 _ARCHIVE_SMOKE_TIER = 0
 
 
@@ -123,42 +118,6 @@ def get_archive_smoke_checks() -> tuple[ArchiveSmokeCheck, ...]:
     return _ARCHIVE_SMOKE_CHECKS
 
 
-@dataclass(frozen=True, slots=True)
-class StorageCorrectnessCheckResult:
-    name: str
-    passed: bool
-    duration_ms: float
-    details: dict[str, object]
-    error: str | None = None
-
-
-class StorageCorrectnessResult:
-    """Result wrapper for the archive-backed storage-correctness scenario."""
-
-    scenario_name = "storage-correctness"
-
-    def __init__(
-        self,
-        *,
-        check_results: list[StorageCorrectnessCheckResult],
-        report_dir: Path | None,
-    ) -> None:
-        self.check_results = check_results
-        self.report_dir = report_dir
-
-    @property
-    def all_passed(self) -> bool:
-        return not self.failed_stages()
-
-    def stage_statuses(self) -> dict[str, OutcomeStatus]:
-        return {
-            result.name: OutcomeStatus.OK if result.passed else OutcomeStatus.ERROR for result in self.check_results
-        }
-
-    def failed_stages(self) -> tuple[str, ...]:
-        return tuple(result.name for result in self.check_results if not result.passed)
-
-
 def run_tier_0() -> dict[str, str]:
     """Run direct archive-smoke checks and return output by check name."""
     checks = get_archive_smoke_checks()
@@ -211,11 +170,7 @@ def list_scenarios(*, as_json: bool) -> int:
             "command": " ".join((sys.executable, *READER_VISUAL_SMOKE_PYTEST_COMMAND[1:])),
             "artifact_count": len(reader_visual_artifact_payloads()),
         },
-        {
-            "name": "storage-correctness",
-            "kind": "archive-storage",
-            "check_count": len(_STORAGE_CORRECTNESS_CHECKS),
-        },
+        storage_correctness_scenario_entry(),
     ]
     payload = {"scenarios": scenarios}
     if as_json:
@@ -322,302 +277,10 @@ def _scenario_payload(result: _ScenarioResult) -> dict[str, object]:
         "ok": not failed_stages,
         "report_dir": str(result.report_dir) if result.report_dir is not None else None,
     }
-    if isinstance(result, StorageCorrectnessResult):
-        payload["checks"] = [
-            {
-                "name": check.name,
-                "passed": check.passed,
-                "duration_ms": round(check.duration_ms, 1),
-                "details": check.details,
-                "error": check.error,
-            }
-            for check in result.check_results
-        ]
+    extra_payload = getattr(result, "extra_payload", None)
+    if callable(extra_payload):
+        payload.update(extra_payload())
     return payload
-
-
-def _parsed_message(provider_id: str, role: Role, text: str, position: int) -> ParsedMessage:
-    return ParsedMessage(
-        provider_message_id=provider_id,
-        role=role,
-        text=text,
-        position=position,
-        variant_index=0,
-        is_active_path=True,
-        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
-    )
-
-
-def _parsed_session(
-    native_id: str,
-    messages: tuple[ParsedMessage, ...],
-    *,
-    title: str,
-    parent_native_id: str | None = None,
-    branch_type: BranchType | None = None,
-) -> ParsedSession:
-    return ParsedSession(
-        source_name=Provider.CODEX,
-        provider_session_id=native_id,
-        title=title,
-        updated_at="2026-01-01T00:00:00Z",
-        parent_session_provider_id=parent_native_id,
-        branch_type=branch_type,
-        messages=list(messages),
-    )
-
-
-def _storage_archive_root() -> TemporaryDirectory[str]:
-    return TemporaryDirectory(prefix="polylogue-storage-correctness-")
-
-
-def _row_count(conn: sqlite3.Connection, table: str, where: str = "", params: tuple[object, ...] = ()) -> int:
-    clause = f" WHERE {where}" if where else ""
-    row = conn.execute(f"SELECT COUNT(*) FROM {table}{clause}", params).fetchone()
-    return int(row[0] if row is not None else 0)
-
-
-def _storage_idempotent_reingest_check() -> dict[str, object]:
-    session = _parsed_session(
-        "storage-idempotent",
-        (
-            _parsed_message("m0", Role.USER, "idempotent user storage token", 0),
-            _parsed_message("m1", Role.ASSISTANT, "idempotent assistant storage token", 1),
-        ),
-        title="Storage idempotent",
-    )
-    with _storage_archive_root() as temp_root:
-        root = Path(temp_root)
-        with ArchiveStore(root) as archive:
-            first = archive.write_raw_and_parsed_result(
-                session,
-                payload=b'{"session":"storage-idempotent","version":1}',
-                source_path="/scenario/storage-idempotent.json",
-                acquired_at_ms=1_767_000_000_000,
-            )
-            second = archive.write_raw_and_parsed_result(
-                session,
-                payload=b'{"session":"storage-idempotent","version":1}',
-                source_path="/scenario/storage-idempotent-repeat.json",
-                acquired_at_ms=1_767_000_000_001,
-            )
-        with sqlite3.connect(root / "index.db") as conn:
-            conn.row_factory = sqlite3.Row
-            session_row = conn.execute(
-                "SELECT content_hash, raw_id FROM sessions WHERE session_id = ?",
-                (first.session_id,),
-            ).fetchone()
-            if session_row is None:
-                raise AssertionError("idempotent scenario did not persist a session row")
-            derived_counts = {
-                "sessions": _row_count(conn, "sessions", "session_id = ?", (first.session_id,)),
-                "messages": _row_count(conn, "messages", "session_id = ?", (first.session_id,)),
-                "blocks": _row_count(conn, "blocks", "session_id = ?", (first.session_id,)),
-                "message_fts": _row_count(conn, "messages_fts"),
-            }
-        with sqlite3.connect(root / "source.db") as source_conn:
-            raw_count = _row_count(source_conn, "raw_sessions")
-    expected_hash = str(session_content_hash(session))
-    stored_hash = session_row["content_hash"]
-    stored_hash_hex = stored_hash.hex() if isinstance(stored_hash, bytes) else str(stored_hash)
-    if first.content_changed is not True:
-        raise AssertionError("first ingest should write the derived session")
-    if second.content_changed is not False or second.counts["skipped_sessions"] != 1:
-        raise AssertionError(f"repeat ingest should skip unchanged content, got {second.counts}")
-    if derived_counts != {"sessions": 1, "messages": 2, "blocks": 2, "message_fts": 2}:
-        raise AssertionError(f"repeat ingest changed derived row counts: {derived_counts}")
-    if raw_count != 2:
-        raise AssertionError(f"raw acquisition evidence should retain both captures, got {raw_count}")
-    if stored_hash_hex != expected_hash:
-        raise AssertionError("stored content_hash does not match session_content_hash")
-    return {
-        "first_counts": first.counts,
-        "repeat_counts": second.counts,
-        "derived_counts": derived_counts,
-        "raw_sessions": raw_count,
-        "content_hash": stored_hash_hex,
-    }
-
-
-def _storage_fts_trigger_drift_check() -> dict[str, object]:
-    session = _parsed_session(
-        "storage-fts",
-        (_parsed_message("m0", Role.USER, "stable fts repair sentinel", 0),),
-        title="Storage FTS",
-    )
-    with _storage_archive_root() as temp_root:
-        root = Path(temp_root)
-        with ArchiveStore(root) as archive:
-            first = archive.write_raw_and_parsed_result(
-                session,
-                payload=b'{"session":"storage-fts","version":1}',
-                source_path="/scenario/storage-fts.json",
-                acquired_at_ms=1_767_000_000_000,
-            )
-        with sqlite3.connect(root / "index.db") as conn:
-            before = _row_count(conn, "messages_fts")
-            conn.execute("DELETE FROM messages_fts")
-            conn.commit()
-            drifted = _row_count(conn, "messages_fts")
-        with ArchiveStore(root) as archive:
-            repeat = archive.write_raw_and_parsed_result(
-                session,
-                payload=b'{"session":"storage-fts","version":1}',
-                source_path="/scenario/storage-fts-repeat.json",
-                acquired_at_ms=1_767_000_000_001,
-            )
-            search_hits = archive.search_blocks("sentinel")
-        with sqlite3.connect(root / "index.db") as conn:
-            after = _row_count(conn, "messages_fts")
-    if first.content_changed is not True:
-        raise AssertionError("first FTS scenario ingest should write content")
-    if before != 1 or drifted != 0:
-        raise AssertionError(f"FTS drift setup failed: before={before}, drifted={drifted}")
-    if repeat.content_changed is not False or repeat.counts.get("_fts_repair") != 1:
-        raise AssertionError(f"unchanged ingest should repair FTS drift, got {repeat.counts}")
-    if after != 1 or len(search_hits) != 1:
-        raise AssertionError(f"FTS repair did not restore searchable row: after={after}, hits={search_hits}")
-    return {
-        "before_fts_rows": before,
-        "drifted_fts_rows": drifted,
-        "after_fts_rows": after,
-        "repeat_counts": repeat.counts,
-        "search_hits": search_hits,
-    }
-
-
-def _storage_lineage_composition_check() -> dict[str, object]:
-    parent = _parsed_session(
-        "storage-parent",
-        (
-            _parsed_message("p0", Role.USER, "hello", 0),
-            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
-            _parsed_message("p2", Role.USER, "parent continues alone", 2),
-        ),
-        title="Storage parent",
-    )
-    child = _parsed_session(
-        "storage-child",
-        (
-            _parsed_message("c0", Role.USER, "hello", 0),
-            _parsed_message("c1", Role.ASSISTANT, "hi there", 1),
-            _parsed_message("cx", Role.USER, "child diverges here", 2),
-            _parsed_message("cy", Role.ASSISTANT, "child reply", 3),
-        ),
-        title="Storage child",
-        parent_native_id="storage-parent",
-        branch_type=BranchType.FORK,
-    )
-    parent_grown = _parsed_session(
-        "storage-parent",
-        (
-            _parsed_message("p0", Role.USER, "hello", 0),
-            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
-            _parsed_message("p2", Role.USER, "parent continues alone", 2),
-            _parsed_message("p3", Role.ASSISTANT, "parent grows later", 3),
-        ),
-        title="Storage parent",
-    )
-    with _storage_archive_root() as temp_root:
-        root = Path(temp_root)
-        with ArchiveStore(root) as archive:
-            parent_id = archive.write_parsed(parent, content_hash=str(session_content_hash(parent)))
-            child_id = archive.write_parsed(child, content_hash=str(session_content_hash(child)))
-            archive.write_parsed(parent_grown, content_hash=str(session_content_hash(parent_grown)))
-            archive.commit()
-        with sqlite3.connect(root / "index.db") as conn:
-            conn.row_factory = sqlite3.Row
-            stored_positions = [
-                int(row["position"])
-                for row in conn.execute(
-                    "SELECT position FROM messages WHERE session_id = ? ORDER BY position",
-                    (child_id,),
-                ).fetchall()
-            ]
-            link = conn.execute(
-                """
-                SELECT resolved_dst_session_id, inheritance, branch_point_message_id
-                FROM session_links
-                WHERE src_session_id = ?
-                """,
-                (child_id,),
-            ).fetchone()
-            envelope = read_archive_session_envelope(conn, child_id)
-            composed_texts = ["".join(block.text or "" for block in message.blocks) for message in envelope.messages]
-    if parent_id != "codex-session:storage-parent":
-        raise AssertionError(f"unexpected parent id: {parent_id}")
-    if stored_positions != [2, 3]:
-        raise AssertionError(f"child should physically store only divergent tail, got {stored_positions}")
-    if link is None:
-        raise AssertionError("prefix-sharing child did not persist a session_links row")
-    if link["resolved_dst_session_id"] != parent_id:
-        raise AssertionError(f"lineage link did not resolve to parent: {dict(link)}")
-    if link["inheritance"] != "prefix-sharing" or not link["branch_point_message_id"]:
-        raise AssertionError(f"lineage link did not capture prefix-sharing branch point: {dict(link)}")
-    expected_texts = ["hello", "hi there", "child diverges here", "child reply"]
-    if composed_texts != expected_texts:
-        raise AssertionError(f"child did not compose the logical transcript: {composed_texts}")
-    return {
-        "parent_id": parent_id,
-        "child_id": child_id,
-        "stored_child_positions": stored_positions,
-        "lineage": dict(link),
-        "composed_texts": composed_texts,
-    }
-
-
-_STORAGE_CORRECTNESS_CHECKS: tuple[tuple[str, Callable[[], dict[str, object]]], ...] = (
-    ("idempotent-reingest", _storage_idempotent_reingest_check),
-    ("fts-trigger-drift", _storage_fts_trigger_drift_check),
-    ("lineage-composition", _storage_lineage_composition_check),
-)
-
-
-def run_storage_correctness(*, report_dir: Path | None) -> StorageCorrectnessResult:
-    """Run archive-backed storage correctness checks."""
-    results: list[StorageCorrectnessCheckResult] = []
-    for name, check in _STORAGE_CORRECTNESS_CHECKS:
-        started = time.monotonic()
-        try:
-            details = check()
-            passed = True
-            error = None
-        except Exception as exc:
-            details = {}
-            passed = False
-            error = f"{type(exc).__name__}: {exc}"
-        results.append(
-            StorageCorrectnessCheckResult(
-                name=name,
-                passed=passed,
-                duration_ms=(time.monotonic() - started) * 1000,
-                details=details,
-                error=error,
-            )
-        )
-    result = StorageCorrectnessResult(check_results=results, report_dir=report_dir)
-    _write_storage_correctness_report(result)
-    return result
-
-
-def _write_storage_correctness_report(result: StorageCorrectnessResult) -> None:
-    if result.report_dir is None:
-        return
-    result.report_dir.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "scenario": result.scenario_name,
-        "checks": [
-            {
-                "name": check.name,
-                "passed": check.passed,
-                "duration_ms": round(check.duration_ms, 1),
-                "details": check.details,
-                "error": check.error,
-            }
-            for check in result.check_results
-        ],
-    }
-    (result.report_dir / "storage-correctness.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def _run_archive_smoke_check(check: ArchiveSmokeCheck) -> ArchiveSmokeCheckResult:

--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Protocol, TextIO
 
 from devtools import repo_root as _get_root
@@ -17,15 +20,25 @@ from devtools.visual_artifacts import (
     READER_VISUAL_SMOKE_PYTEST_COMMAND,
     reader_visual_artifact_payloads,
 )
+from polylogue.archive.message.roles import Role
+from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.outcomes import OutcomeStatus
+from polylogue.pipeline.ids import session_content_hash
 from polylogue.scenarios import AssertionSpec, ExecutionSpec, polylogue_execution
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.write import read_archive_session_envelope
 
-_SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke")
+_SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke", "storage-correctness")
 _ARCHIVE_SMOKE_TIER = 0
 
 
 class _ScenarioResult(Protocol):
     report_dir: Path | None
+
+    @property
+    def scenario_name(self) -> str: ...
 
     def stage_statuses(self) -> dict[str, OutcomeStatus]: ...
 
@@ -84,6 +97,10 @@ class ArchiveSmokeResult:
         self.unsupported_reason = unsupported_reason
 
     @property
+    def scenario_name(self) -> str:
+        return "archive-smoke"
+
+    @property
     def all_passed(self) -> bool:
         return not self.failed_stages()
 
@@ -104,6 +121,42 @@ class ArchiveSmokeResult:
 def get_archive_smoke_checks() -> tuple[ArchiveSmokeCheck, ...]:
     """Return direct CLI checks for the archive-smoke lab smoke."""
     return _ARCHIVE_SMOKE_CHECKS
+
+
+@dataclass(frozen=True, slots=True)
+class StorageCorrectnessCheckResult:
+    name: str
+    passed: bool
+    duration_ms: float
+    details: dict[str, object]
+    error: str | None = None
+
+
+class StorageCorrectnessResult:
+    """Result wrapper for the archive-backed storage-correctness scenario."""
+
+    scenario_name = "storage-correctness"
+
+    def __init__(
+        self,
+        *,
+        check_results: list[StorageCorrectnessCheckResult],
+        report_dir: Path | None,
+    ) -> None:
+        self.check_results = check_results
+        self.report_dir = report_dir
+
+    @property
+    def all_passed(self) -> bool:
+        return not self.failed_stages()
+
+    def stage_statuses(self) -> dict[str, OutcomeStatus]:
+        return {
+            result.name: OutcomeStatus.OK if result.passed else OutcomeStatus.ERROR for result in self.check_results
+        }
+
+    def failed_stages(self) -> tuple[str, ...]:
+        return tuple(result.name for result in self.check_results if not result.passed)
 
 
 def run_tier_0() -> dict[str, str]:
@@ -158,6 +211,11 @@ def list_scenarios(*, as_json: bool) -> int:
             "command": " ".join((sys.executable, *READER_VISUAL_SMOKE_PYTEST_COMMAND[1:])),
             "artifact_count": len(reader_visual_artifact_payloads()),
         },
+        {
+            "name": "storage-correctness",
+            "kind": "archive-storage",
+            "check_count": len(_STORAGE_CORRECTNESS_CHECKS),
+        },
     ]
     payload = {"scenarios": scenarios}
     if as_json:
@@ -167,6 +225,9 @@ def list_scenarios(*, as_json: bool) -> int:
         name = str(entry["name"])
         if name == "reader-visual-smoke":
             print(f"{name:<20s}  command: {entry['command']}")
+            continue
+        if name == "storage-correctness":
+            print(f"{name:<20s}  checks: {entry['check_count']}")
             continue
         print(f"{name:<20s}  tier-0 checks: {entry['tier_0_check_count']}")
     return 0
@@ -254,13 +315,309 @@ def _scenario_payload(result: _ScenarioResult) -> dict[str, object]:
     """Return the direct lab smoke payload without report wrapping."""
     stage_statuses = result.stage_statuses()
     failed_stages = result.failed_stages()
-    return {
-        "scenario": "archive-smoke",
+    payload: dict[str, object] = {
+        "scenario": result.scenario_name,
         "stages": {name: status.value for name, status in stage_statuses.items()},
         "failed_stages": list(failed_stages),
         "ok": not failed_stages,
         "report_dir": str(result.report_dir) if result.report_dir is not None else None,
     }
+    if isinstance(result, StorageCorrectnessResult):
+        payload["checks"] = [
+            {
+                "name": check.name,
+                "passed": check.passed,
+                "duration_ms": round(check.duration_ms, 1),
+                "details": check.details,
+                "error": check.error,
+            }
+            for check in result.check_results
+        ]
+    return payload
+
+
+def _parsed_message(provider_id: str, role: Role, text: str, position: int) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=provider_id,
+        role=role,
+        text=text,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+    )
+
+
+def _parsed_session(
+    native_id: str,
+    messages: tuple[ParsedMessage, ...],
+    *,
+    title: str,
+    parent_native_id: str | None = None,
+    branch_type: BranchType | None = None,
+) -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=native_id,
+        title=title,
+        updated_at="2026-01-01T00:00:00Z",
+        parent_session_provider_id=parent_native_id,
+        branch_type=branch_type,
+        messages=list(messages),
+    )
+
+
+def _storage_archive_root() -> TemporaryDirectory[str]:
+    return TemporaryDirectory(prefix="polylogue-storage-correctness-")
+
+
+def _row_count(conn: sqlite3.Connection, table: str, where: str = "", params: tuple[object, ...] = ()) -> int:
+    clause = f" WHERE {where}" if where else ""
+    row = conn.execute(f"SELECT COUNT(*) FROM {table}{clause}", params).fetchone()
+    return int(row[0] if row is not None else 0)
+
+
+def _storage_idempotent_reingest_check() -> dict[str, object]:
+    session = _parsed_session(
+        "storage-idempotent",
+        (
+            _parsed_message("m0", Role.USER, "idempotent user storage token", 0),
+            _parsed_message("m1", Role.ASSISTANT, "idempotent assistant storage token", 1),
+        ),
+        title="Storage idempotent",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            first = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-idempotent","version":1}',
+                source_path="/scenario/storage-idempotent.json",
+                acquired_at_ms=1_767_000_000_000,
+            )
+            second = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-idempotent","version":1}',
+                source_path="/scenario/storage-idempotent-repeat.json",
+                acquired_at_ms=1_767_000_000_001,
+            )
+        with sqlite3.connect(root / "index.db") as conn:
+            conn.row_factory = sqlite3.Row
+            session_row = conn.execute(
+                "SELECT content_hash, raw_id FROM sessions WHERE session_id = ?",
+                (first.session_id,),
+            ).fetchone()
+            if session_row is None:
+                raise AssertionError("idempotent scenario did not persist a session row")
+            derived_counts = {
+                "sessions": _row_count(conn, "sessions", "session_id = ?", (first.session_id,)),
+                "messages": _row_count(conn, "messages", "session_id = ?", (first.session_id,)),
+                "blocks": _row_count(conn, "blocks", "session_id = ?", (first.session_id,)),
+                "message_fts": _row_count(conn, "messages_fts"),
+            }
+        with sqlite3.connect(root / "source.db") as source_conn:
+            raw_count = _row_count(source_conn, "raw_sessions")
+    expected_hash = str(session_content_hash(session))
+    stored_hash = session_row["content_hash"]
+    stored_hash_hex = stored_hash.hex() if isinstance(stored_hash, bytes) else str(stored_hash)
+    if first.content_changed is not True:
+        raise AssertionError("first ingest should write the derived session")
+    if second.content_changed is not False or second.counts["skipped_sessions"] != 1:
+        raise AssertionError(f"repeat ingest should skip unchanged content, got {second.counts}")
+    if derived_counts != {"sessions": 1, "messages": 2, "blocks": 2, "message_fts": 2}:
+        raise AssertionError(f"repeat ingest changed derived row counts: {derived_counts}")
+    if raw_count != 2:
+        raise AssertionError(f"raw acquisition evidence should retain both captures, got {raw_count}")
+    if stored_hash_hex != expected_hash:
+        raise AssertionError("stored content_hash does not match session_content_hash")
+    return {
+        "first_counts": first.counts,
+        "repeat_counts": second.counts,
+        "derived_counts": derived_counts,
+        "raw_sessions": raw_count,
+        "content_hash": stored_hash_hex,
+    }
+
+
+def _storage_fts_trigger_drift_check() -> dict[str, object]:
+    session = _parsed_session(
+        "storage-fts",
+        (_parsed_message("m0", Role.USER, "stable fts repair sentinel", 0),),
+        title="Storage FTS",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            first = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-fts","version":1}',
+                source_path="/scenario/storage-fts.json",
+                acquired_at_ms=1_767_000_000_000,
+            )
+        with sqlite3.connect(root / "index.db") as conn:
+            before = _row_count(conn, "messages_fts")
+            conn.execute("DELETE FROM messages_fts")
+            conn.commit()
+            drifted = _row_count(conn, "messages_fts")
+        with ArchiveStore(root) as archive:
+            repeat = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-fts","version":1}',
+                source_path="/scenario/storage-fts-repeat.json",
+                acquired_at_ms=1_767_000_000_001,
+            )
+            search_hits = archive.search_blocks("sentinel")
+        with sqlite3.connect(root / "index.db") as conn:
+            after = _row_count(conn, "messages_fts")
+    if first.content_changed is not True:
+        raise AssertionError("first FTS scenario ingest should write content")
+    if before != 1 or drifted != 0:
+        raise AssertionError(f"FTS drift setup failed: before={before}, drifted={drifted}")
+    if repeat.content_changed is not False or repeat.counts.get("_fts_repair") != 1:
+        raise AssertionError(f"unchanged ingest should repair FTS drift, got {repeat.counts}")
+    if after != 1 or len(search_hits) != 1:
+        raise AssertionError(f"FTS repair did not restore searchable row: after={after}, hits={search_hits}")
+    return {
+        "before_fts_rows": before,
+        "drifted_fts_rows": drifted,
+        "after_fts_rows": after,
+        "repeat_counts": repeat.counts,
+        "search_hits": search_hits,
+    }
+
+
+def _storage_lineage_composition_check() -> dict[str, object]:
+    parent = _parsed_session(
+        "storage-parent",
+        (
+            _parsed_message("p0", Role.USER, "hello", 0),
+            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("p2", Role.USER, "parent continues alone", 2),
+        ),
+        title="Storage parent",
+    )
+    child = _parsed_session(
+        "storage-child",
+        (
+            _parsed_message("c0", Role.USER, "hello", 0),
+            _parsed_message("c1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("cx", Role.USER, "child diverges here", 2),
+            _parsed_message("cy", Role.ASSISTANT, "child reply", 3),
+        ),
+        title="Storage child",
+        parent_native_id="storage-parent",
+        branch_type=BranchType.FORK,
+    )
+    parent_grown = _parsed_session(
+        "storage-parent",
+        (
+            _parsed_message("p0", Role.USER, "hello", 0),
+            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("p2", Role.USER, "parent continues alone", 2),
+            _parsed_message("p3", Role.ASSISTANT, "parent grows later", 3),
+        ),
+        title="Storage parent",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            parent_id = archive.write_parsed(parent, content_hash=str(session_content_hash(parent)))
+            child_id = archive.write_parsed(child, content_hash=str(session_content_hash(child)))
+            archive.write_parsed(parent_grown, content_hash=str(session_content_hash(parent_grown)))
+            archive.commit()
+        with sqlite3.connect(root / "index.db") as conn:
+            conn.row_factory = sqlite3.Row
+            stored_positions = [
+                int(row["position"])
+                for row in conn.execute(
+                    "SELECT position FROM messages WHERE session_id = ? ORDER BY position",
+                    (child_id,),
+                ).fetchall()
+            ]
+            link = conn.execute(
+                """
+                SELECT resolved_dst_session_id, inheritance, branch_point_message_id
+                FROM session_links
+                WHERE src_session_id = ?
+                """,
+                (child_id,),
+            ).fetchone()
+            envelope = read_archive_session_envelope(conn, child_id)
+            composed_texts = ["".join(block.text or "" for block in message.blocks) for message in envelope.messages]
+    if parent_id != "codex-session:storage-parent":
+        raise AssertionError(f"unexpected parent id: {parent_id}")
+    if stored_positions != [2, 3]:
+        raise AssertionError(f"child should physically store only divergent tail, got {stored_positions}")
+    if link is None:
+        raise AssertionError("prefix-sharing child did not persist a session_links row")
+    if link["resolved_dst_session_id"] != parent_id:
+        raise AssertionError(f"lineage link did not resolve to parent: {dict(link)}")
+    if link["inheritance"] != "prefix-sharing" or not link["branch_point_message_id"]:
+        raise AssertionError(f"lineage link did not capture prefix-sharing branch point: {dict(link)}")
+    expected_texts = ["hello", "hi there", "child diverges here", "child reply"]
+    if composed_texts != expected_texts:
+        raise AssertionError(f"child did not compose the logical transcript: {composed_texts}")
+    return {
+        "parent_id": parent_id,
+        "child_id": child_id,
+        "stored_child_positions": stored_positions,
+        "lineage": dict(link),
+        "composed_texts": composed_texts,
+    }
+
+
+_STORAGE_CORRECTNESS_CHECKS: tuple[tuple[str, Callable[[], dict[str, object]]], ...] = (
+    ("idempotent-reingest", _storage_idempotent_reingest_check),
+    ("fts-trigger-drift", _storage_fts_trigger_drift_check),
+    ("lineage-composition", _storage_lineage_composition_check),
+)
+
+
+def run_storage_correctness(*, report_dir: Path | None) -> StorageCorrectnessResult:
+    """Run archive-backed storage correctness checks."""
+    results: list[StorageCorrectnessCheckResult] = []
+    for name, check in _STORAGE_CORRECTNESS_CHECKS:
+        started = time.monotonic()
+        try:
+            details = check()
+            passed = True
+            error = None
+        except Exception as exc:
+            details = {}
+            passed = False
+            error = f"{type(exc).__name__}: {exc}"
+        results.append(
+            StorageCorrectnessCheckResult(
+                name=name,
+                passed=passed,
+                duration_ms=(time.monotonic() - started) * 1000,
+                details=details,
+                error=error,
+            )
+        )
+    result = StorageCorrectnessResult(check_results=results, report_dir=report_dir)
+    _write_storage_correctness_report(result)
+    return result
+
+
+def _write_storage_correctness_report(result: StorageCorrectnessResult) -> None:
+    if result.report_dir is None:
+        return
+    result.report_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "scenario": result.scenario_name,
+        "checks": [
+            {
+                "name": check.name,
+                "passed": check.passed,
+                "duration_ms": round(check.duration_ms, 1),
+                "details": check.details,
+                "error": check.error,
+            }
+            for check in result.check_results
+        ],
+    }
+    (result.report_dir / "storage-correctness.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def _run_archive_smoke_check(check: ArchiveSmokeCheck) -> ArchiveSmokeCheckResult:
@@ -356,14 +713,18 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"unknown action: {args.action}")
     if args.scenario == "reader-visual-smoke":
         return run_reader_visual_smoke(report_dir=args.report_dir, as_json=bool(args.json))
-    result = run_archive_smoke(
-        live=bool(args.live),
-        tier=args.tier,
-        report_dir=args.report_dir,
-        verbose=bool(args.verbose),
-        fail_fast=bool(args.fail_fast),
-        as_json=bool(args.json),
-    )
+    result: _ScenarioResult
+    if args.scenario == "storage-correctness":
+        result = run_storage_correctness(report_dir=args.report_dir)
+    else:
+        result = run_archive_smoke(
+            live=bool(args.live),
+            tier=args.tier,
+            report_dir=args.report_dir,
+            verbose=bool(args.verbose),
+            fail_fast=bool(args.fail_fast),
+            as_json=bool(args.json),
+        )
     if args.json:
         print(json.dumps(_scenario_payload(result), indent=2))
     else:

--- a/devtools/storage_correctness_scenario.py
+++ b/devtools/storage_correctness_scenario.py
@@ -1,0 +1,516 @@
+"""Archive-backed storage correctness lab scenario."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from polylogue.archive.message.roles import Role
+from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.enums import BlockType, Provider
+from polylogue.core.outcomes import OutcomeStatus
+from polylogue.daemon.convergence_stages import repair_messages_fts_surface
+from polylogue.errors import DatabaseError
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.blob_gc import MIN_AGE_S, read_gc_history, run_blob_gc_report
+from polylogue.storage.blob_publication import ArchiveBlobPublisher
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.fts.fts_lifecycle import FTS_TRIGGER_NAMES, message_fts_readiness_sync
+from polylogue.storage.search_providers.fts5 import FTS5Provider
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.write import read_archive_session_envelope
+
+STORAGE_CORRECTNESS_SCENARIO_NAME = "storage-correctness"
+STORAGE_CORRECTNESS_SCOPE_ADJUDICATION = {
+    "blob_gc": (
+        "The old blob-lease scope was stale: no production writer populated it. "
+        "This scenario instead exercises publication reservation and durable "
+        "reference survival, the gc_generations age gate, and typed reclaim evidence."
+    )
+}
+
+_MESSAGE_FTS_TRIGGER_NAMES = tuple(name for name in FTS_TRIGGER_NAMES if name.startswith("messages_fts_"))
+
+
+@dataclass(frozen=True, slots=True)
+class StorageCorrectnessCheckResult:
+    name: str
+    passed: bool
+    duration_ms: float
+    details: dict[str, object]
+    error: str | None = None
+
+
+class StorageCorrectnessResult:
+    """Result wrapper for the archive-backed storage-correctness scenario."""
+
+    scenario_name = STORAGE_CORRECTNESS_SCENARIO_NAME
+
+    def __init__(
+        self,
+        *,
+        check_results: list[StorageCorrectnessCheckResult],
+        report_dir: Path | None,
+    ) -> None:
+        self.check_results = check_results
+        self.report_dir = report_dir
+
+    @property
+    def all_passed(self) -> bool:
+        return not self.failed_stages()
+
+    def stage_statuses(self) -> dict[str, OutcomeStatus]:
+        return {
+            result.name: OutcomeStatus.OK if result.passed else OutcomeStatus.ERROR for result in self.check_results
+        }
+
+    def failed_stages(self) -> tuple[str, ...]:
+        return tuple(result.name for result in self.check_results if not result.passed)
+
+    def extra_payload(self) -> dict[str, object]:
+        return {
+            "checks": [
+                {
+                    "name": check.name,
+                    "passed": check.passed,
+                    "duration_ms": round(check.duration_ms, 1),
+                    "details": check.details,
+                    "error": check.error,
+                }
+                for check in self.check_results
+            ],
+            "scope_adjudication": STORAGE_CORRECTNESS_SCOPE_ADJUDICATION,
+        }
+
+
+def storage_correctness_scenario_entry() -> dict[str, object]:
+    return {
+        "name": STORAGE_CORRECTNESS_SCENARIO_NAME,
+        "kind": "archive-storage",
+        "check_count": len(_STORAGE_CORRECTNESS_CHECKS),
+        "scope_adjudication": STORAGE_CORRECTNESS_SCOPE_ADJUDICATION,
+    }
+
+
+def _parsed_message(provider_id: str, role: Role, text: str, position: int) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=provider_id,
+        role=role,
+        text=text,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+    )
+
+
+def _parsed_session(
+    native_id: str,
+    messages: tuple[ParsedMessage, ...],
+    *,
+    title: str,
+    parent_native_id: str | None = None,
+    branch_type: BranchType | None = None,
+) -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=native_id,
+        title=title,
+        updated_at="2026-01-01T00:00:00Z",
+        parent_session_provider_id=parent_native_id,
+        branch_type=branch_type,
+        messages=list(messages),
+    )
+
+
+def _storage_archive_root() -> TemporaryDirectory[str]:
+    return TemporaryDirectory(prefix="polylogue-storage-correctness-")
+
+
+def _row_count(conn: sqlite3.Connection, table: str, where: str = "", params: tuple[object, ...] = ()) -> int:
+    clause = f" WHERE {where}" if where else ""
+    row = conn.execute(f"SELECT COUNT(*) FROM {table}{clause}", params).fetchone()
+    return int(row[0] if row is not None else 0)
+
+
+def _message_fts_trigger_set(conn: sqlite3.Connection) -> tuple[str, ...]:
+    rows = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'trigger' AND name IN (?, ?, ?)
+        ORDER BY name
+        """,
+        _MESSAGE_FTS_TRIGGER_NAMES,
+    ).fetchall()
+    return tuple(str(row[0]) for row in rows)
+
+
+def _storage_idempotent_reingest_check() -> dict[str, object]:
+    session = _parsed_session(
+        "storage-idempotent",
+        (
+            _parsed_message("m0", Role.USER, "idempotent user storage token", 0),
+            _parsed_message("m1", Role.ASSISTANT, "idempotent assistant storage token", 1),
+        ),
+        title="Storage idempotent",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            first = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-idempotent","version":1}',
+                source_path="/scenario/storage-idempotent.json",
+                acquired_at_ms=1_767_000_000_000,
+            )
+            second = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-idempotent","version":1}',
+                source_path="/scenario/storage-idempotent-repeat.json",
+                acquired_at_ms=1_767_000_000_001,
+            )
+        with sqlite3.connect(root / "index.db") as conn:
+            conn.row_factory = sqlite3.Row
+            session_row = conn.execute(
+                "SELECT content_hash, raw_id FROM sessions WHERE session_id = ?",
+                (first.session_id,),
+            ).fetchone()
+            if session_row is None:
+                raise AssertionError("idempotent scenario did not persist a session row")
+            derived_counts = {
+                "sessions": _row_count(conn, "sessions", "session_id = ?", (first.session_id,)),
+                "messages": _row_count(conn, "messages", "session_id = ?", (first.session_id,)),
+                "blocks": _row_count(conn, "blocks", "session_id = ?", (first.session_id,)),
+                "message_fts": _row_count(conn, "messages_fts"),
+            }
+        with sqlite3.connect(root / "source.db") as source_conn:
+            raw_count = _row_count(source_conn, "raw_sessions")
+    expected_hash = str(session_content_hash(session))
+    stored_hash = session_row["content_hash"]
+    stored_hash_hex = stored_hash.hex() if isinstance(stored_hash, bytes) else str(stored_hash)
+    if first.content_changed is not True:
+        raise AssertionError("first ingest should write the derived session")
+    if second.content_changed is not False or second.counts["skipped_sessions"] != 1:
+        raise AssertionError(f"repeat ingest should skip unchanged content, got {second.counts}")
+    if derived_counts != {"sessions": 1, "messages": 2, "blocks": 2, "message_fts": 2}:
+        raise AssertionError(f"repeat ingest changed derived row counts: {derived_counts}")
+    if raw_count != 2:
+        raise AssertionError(f"raw source rows should retain both ArchiveStore writes, got {raw_count}")
+    if stored_hash_hex != expected_hash:
+        raise AssertionError("stored content_hash does not match session_content_hash")
+    return {
+        "first_counts": first.counts,
+        "repeat_counts": second.counts,
+        "derived_counts": derived_counts,
+        "raw_sessions": raw_count,
+        "content_hash": stored_hash_hex,
+    }
+
+
+def _storage_fts_trigger_drift_check() -> dict[str, object]:
+    session = _parsed_session(
+        "storage-fts",
+        (_parsed_message("m0", Role.USER, "stable fts repair sentinel", 0),),
+        title="Storage FTS",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            first = archive.write_raw_and_parsed_result(
+                session,
+                payload=b'{"session":"storage-fts","version":1}',
+                source_path="/scenario/storage-fts.json",
+                acquired_at_ms=1_767_000_000_000,
+            )
+            with sqlite3.connect(root / "index.db") as conn:
+                before_readiness = message_fts_readiness_sync(conn)
+                before_triggers = _message_fts_trigger_set(conn)
+                conn.execute("DROP TRIGGER messages_fts_ai")
+                conn.commit()
+                drifted_readiness = message_fts_readiness_sync(conn)
+                drifted_triggers = _message_fts_trigger_set(conn)
+            try:
+                FTS5Provider(root / "index.db").search("sentinel")
+            except DatabaseError as exc:
+                search_failure = str(exc)
+            else:
+                raise AssertionError("search should fail while a canonical messages_fts trigger is missing")
+            repaired = repair_messages_fts_surface(root / "index.db")
+            with sqlite3.connect(root / "index.db") as conn:
+                after_readiness = message_fts_readiness_sync(conn)
+                after_triggers = _message_fts_trigger_set(conn)
+                after_rows = _row_count(conn, "messages_fts")
+            search_hits = FTS5Provider(root / "index.db").search("sentinel")
+    expected_triggers = tuple(sorted(_MESSAGE_FTS_TRIGGER_NAMES))
+    exact_ready = {
+        "exists": True,
+        "indexed_rows": 1,
+        "total_rows": 1,
+        "ready": True,
+        "triggers_present": True,
+    }
+    if first.content_changed is not True:
+        raise AssertionError("first FTS scenario ingest should write content")
+    if before_readiness != exact_ready:
+        raise AssertionError(f"initial FTS readiness was not exact: {before_readiness}")
+    if before_triggers != expected_triggers:
+        raise AssertionError(f"initial trigger set is not canonical: {before_triggers}")
+    if bool(drifted_readiness["ready"]) or bool(drifted_readiness["triggers_present"]):
+        raise AssertionError(f"dropped trigger did not fail exact readiness: {drifted_readiness}")
+    if "messages_fts_ai" in drifted_triggers or drifted_triggers != ("messages_fts_ad", "messages_fts_au"):
+        raise AssertionError(f"dropped trigger setup failed: {drifted_triggers}")
+    if repaired is not True:
+        raise AssertionError("production messages_fts surface repair returned false")
+    if after_readiness != exact_ready:
+        raise AssertionError(f"production FTS repair did not restore exact readiness: {after_readiness}")
+    if after_triggers != expected_triggers:
+        raise AssertionError(f"production FTS repair did not restore all canonical triggers: {after_triggers}")
+    if after_rows != 1 or len(search_hits) != 1:
+        raise AssertionError(f"FTS repair did not restore searchable row: after={after_rows}, hits={search_hits}")
+    return {
+        "before_readiness": before_readiness,
+        "before_triggers": before_triggers,
+        "drifted_readiness": drifted_readiness,
+        "drifted_triggers": drifted_triggers,
+        "search_failure": search_failure,
+        "production_repair": repaired,
+        "after_readiness": after_readiness,
+        "after_triggers": after_triggers,
+        "after_fts_rows": after_rows,
+        "search_hits": search_hits,
+    }
+
+
+def _backdate_blob(store: BlobStore, blob_hash: str, *, age_s: float) -> None:
+    blob_path = store.blob_path(blob_hash)
+    timestamp = time.time() - age_s
+    os.utime(blob_path, (timestamp, timestamp))
+
+
+def _storage_blob_gc_invariant_check() -> dict[str, object]:
+    """Exercise the current reservation/reference/generation GC contract."""
+    reserved_payload = b"storage gc publication reservation"
+    referenced_payload = b"storage gc durable raw reference"
+    age_gated_payload = b"storage gc generation age gate"
+    orphan_payload = b"storage gc reclaimable orphan"
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root):
+            pass
+        publisher = ArchiveBlobPublisher(root / "source.db", root / "blob")
+        reserved_hash, reserved_size = publisher.write_from_bytes(reserved_payload)
+        referenced_hash, referenced_size = publisher.write_from_bytes(referenced_payload)
+        publisher.flush()
+        referenced_receipt = publisher.receipt_id(referenced_hash)
+        if referenced_receipt is None:
+            raise AssertionError("published raw blob did not retain a receipt")
+        with ArchiveStore(root) as archive:
+            archive.write_raw_blob_ref(
+                provider=Provider.CODEX,
+                blob_hash_hex=referenced_hash,
+                blob_size=referenced_size,
+                source_path="/scenario/storage-gc-referenced.json",
+                acquired_at_ms=1_767_000_000_000,
+                raw_id="storage-gc-referenced",
+                blob_publication_receipt_id=referenced_receipt,
+            )
+        store = BlobStore(root / "blob")
+        age_gated_hash, age_gated_size = store.write_from_bytes(age_gated_payload)
+        orphan_hash, orphan_size = store.write_from_bytes(orphan_payload)
+        now_s = int(time.time())
+        generation_age_s = 1_000
+        reclaimable_age_s = generation_age_s + 100
+        _backdate_blob(store, reserved_hash, age_s=reclaimable_age_s)
+        _backdate_blob(store, referenced_hash, age_s=reclaimable_age_s)
+        _backdate_blob(store, age_gated_hash, age_s=MIN_AGE_S + 10)
+        _backdate_blob(store, orphan_hash, age_s=reclaimable_age_s)
+        completed_at_ms = (now_s - generation_age_s) * 1000
+        with sqlite3.connect(root / "source.db") as conn:
+            conn.execute(
+                """
+                INSERT INTO gc_generations
+                (generation_id, started_at_ms, completed_at_ms, reclaimed_count, reclaimed_bytes)
+                VALUES (?, ?, ?, 0, 0)
+                """,
+                ("storage-gc-age-boundary", completed_at_ms, completed_at_ms),
+            )
+            reservation_count = _row_count(conn, "blob_publication_reservations")
+            conn.commit()
+        report = run_blob_gc_report(root / "index.db", root / "blob", max_batch=10)
+        history = read_gc_history(root / "index.db", limit=1)
+        survivors = {
+            "reserved": store.exists(reserved_hash),
+            "referenced": store.exists(referenced_hash),
+            "generation_young": store.exists(age_gated_hash),
+        }
+        orphan_survives = store.exists(orphan_hash)
+    if generation_age_s <= MIN_AGE_S + 10:
+        raise AssertionError("GC age-gate scenario no longer distinguishes the generation boundary")
+    if reservation_count != 1:
+        raise AssertionError(f"expected one unconsumed publication reservation, got {reservation_count}")
+    if report.deleted_count != 1 or report.reclaimed_bytes != orphan_size:
+        raise AssertionError(f"GC did not reclaim exactly the orphan: {report.to_dict()}")
+    if report.skipped_reserved != 1 or report.skipped_referenced != 1:
+        raise AssertionError(f"GC did not preserve reservation/reference candidates: {report.to_dict()}")
+    if not all(survivors.values()):
+        raise AssertionError(f"GC removed a protected blob: survivors={survivors}, report={report.to_dict()}")
+    if orphan_survives:
+        raise AssertionError("GC did not reclaim the generation-safe orphan blob")
+    if len(history) != 1 or history[0].reclaimed_count != 1 or history[0].reclaimed_bytes != orphan_size:
+        raise AssertionError(f"GC did not persist typed reclaim evidence: {history}")
+    return {
+        "reserved_size": reserved_size,
+        "referenced_size": referenced_size,
+        "age_gated_size": age_gated_size,
+        "orphan_size": orphan_size,
+        "reservation_count": reservation_count,
+        "gc_report": report.to_dict(),
+        "latest_generation": {
+            "reclaimed_count": history[0].reclaimed_count,
+            "reclaimed_bytes": history[0].reclaimed_bytes,
+        },
+    }
+
+
+def _storage_lineage_composition_check() -> dict[str, object]:
+    parent = _parsed_session(
+        "storage-parent",
+        (
+            _parsed_message("p0", Role.USER, "hello", 0),
+            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("p2", Role.USER, "parent continues alone", 2),
+        ),
+        title="Storage parent",
+    )
+    child = _parsed_session(
+        "storage-child",
+        (
+            _parsed_message("c0", Role.USER, "hello", 0),
+            _parsed_message("c1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("cx", Role.USER, "child diverges here", 2),
+            _parsed_message("cy", Role.ASSISTANT, "child reply", 3),
+        ),
+        title="Storage child",
+        parent_native_id="storage-parent",
+        branch_type=BranchType.FORK,
+    )
+    parent_grown = _parsed_session(
+        "storage-parent",
+        (
+            _parsed_message("p0", Role.USER, "hello", 0),
+            _parsed_message("p1", Role.ASSISTANT, "hi there", 1),
+            _parsed_message("p2", Role.USER, "parent continues alone", 2),
+            _parsed_message("p3", Role.ASSISTANT, "parent grows later", 3),
+        ),
+        title="Storage parent",
+    )
+    with _storage_archive_root() as temp_root:
+        root = Path(temp_root)
+        with ArchiveStore(root) as archive:
+            parent_id = archive.write_parsed(parent, content_hash=str(session_content_hash(parent)))
+            child_id = archive.write_parsed(child, content_hash=str(session_content_hash(child)))
+            archive.write_parsed(parent_grown, content_hash=str(session_content_hash(parent_grown)))
+            archive.commit()
+        with sqlite3.connect(root / "index.db") as conn:
+            conn.row_factory = sqlite3.Row
+            stored_positions = [
+                int(row["position"])
+                for row in conn.execute(
+                    "SELECT position FROM messages WHERE session_id = ? ORDER BY position",
+                    (child_id,),
+                ).fetchall()
+            ]
+            link = conn.execute(
+                """
+                SELECT resolved_dst_session_id, inheritance, branch_point_message_id
+                FROM session_links
+                WHERE src_session_id = ?
+                """,
+                (child_id,),
+            ).fetchone()
+            envelope = read_archive_session_envelope(conn, child_id)
+            composed_texts = ["".join(block.text or "" for block in message.blocks) for message in envelope.messages]
+    if parent_id != "codex-session:storage-parent":
+        raise AssertionError(f"unexpected parent id: {parent_id}")
+    if stored_positions != [2, 3]:
+        raise AssertionError(f"child should physically store only divergent tail, got {stored_positions}")
+    if link is None:
+        raise AssertionError("prefix-sharing child did not persist a session_links row")
+    if link["resolved_dst_session_id"] != parent_id:
+        raise AssertionError(f"lineage link did not resolve to parent: {dict(link)}")
+    if link["inheritance"] != "prefix-sharing" or not link["branch_point_message_id"]:
+        raise AssertionError(f"lineage link did not capture prefix-sharing branch point: {dict(link)}")
+    expected_texts = ["hello", "hi there", "child diverges here", "child reply"]
+    if composed_texts != expected_texts:
+        raise AssertionError(f"child did not compose the logical transcript: {composed_texts}")
+    return {
+        "parent_id": parent_id,
+        "child_id": child_id,
+        "stored_child_positions": stored_positions,
+        "lineage": dict(link),
+        "composed_texts": composed_texts,
+    }
+
+
+_STORAGE_CORRECTNESS_CHECKS: tuple[tuple[str, Callable[[], dict[str, object]]], ...] = (
+    ("idempotent-reingest", _storage_idempotent_reingest_check),
+    ("fts-trigger-drift", _storage_fts_trigger_drift_check),
+    ("blob-gc-invariant", _storage_blob_gc_invariant_check),
+    ("lineage-composition", _storage_lineage_composition_check),
+)
+
+
+def run_storage_correctness(*, report_dir: Path | None) -> StorageCorrectnessResult:
+    """Run archive-backed storage correctness checks."""
+    results: list[StorageCorrectnessCheckResult] = []
+    for name, check in _STORAGE_CORRECTNESS_CHECKS:
+        started = time.monotonic()
+        try:
+            details = check()
+            passed = True
+            error = None
+        except Exception as exc:
+            details = {}
+            passed = False
+            error = f"{type(exc).__name__}: {exc}"
+        results.append(
+            StorageCorrectnessCheckResult(
+                name=name,
+                passed=passed,
+                duration_ms=(time.monotonic() - started) * 1000,
+                details=details,
+                error=error,
+            )
+        )
+    result = StorageCorrectnessResult(check_results=results, report_dir=report_dir)
+    _write_storage_correctness_report(result)
+    return result
+
+
+def _write_storage_correctness_report(result: StorageCorrectnessResult) -> None:
+    if result.report_dir is None:
+        return
+    result.report_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "scenario": result.scenario_name,
+        **result.extra_payload(),
+    }
+    (result.report_dir / "storage-correctness.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+__all__ = [
+    "STORAGE_CORRECTNESS_SCOPE_ADJUDICATION",
+    "STORAGE_CORRECTNESS_SCENARIO_NAME",
+    "StorageCorrectnessCheckResult",
+    "StorageCorrectnessResult",
+    "run_storage_correctness",
+    "storage_correctness_scenario_entry",
+]

--- a/devtools/validation_lane_catalog_contracts.py
+++ b/devtools/validation_lane_catalog_contracts.py
@@ -6,6 +6,7 @@ from devtools.lane_models import LaneEntry
 from polylogue.scenarios import (
     CorpusRequest,
     PipelineProbeRequest,
+    ScenarioMetadata,
     composite_execution,
     devtools_execution,
     pipeline_probe_execution,
@@ -85,6 +86,46 @@ CONTRACT_LANES: dict[str, LaneEntry] = {
             stdout_min_lines=3,
             classification_override=AssertionClass.SMOKE_PROCESS,
         ),
+    ),
+    "storage-correctness": LaneEntry(
+        name="storage-correctness",
+        description="Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition",
+        timeout_s=180,
+        category="contract",
+        execution=devtools_execution(
+            "lab smoke",
+            "run",
+            "storage-correctness",
+            "--json",
+            metadata=ScenarioMetadata(
+                path_targets=(
+                    "raw-reparse-loop",
+                    "raw-archive-ingest-loop",
+                    "message-fts-readiness-loop",
+                    "session-query-loop",
+                ),
+                artifact_targets=(
+                    "source_payload_stream",
+                    "archive_session_rows",
+                    "message_source_rows",
+                    "message_fts",
+                    "session_query_results",
+                ),
+                operation_targets=(
+                    "acquire-raw-sessions",
+                    "ingest-archive-runtime",
+                    "index-message-fts",
+                    "query-sessions",
+                ),
+            ),
+        ),
+        assertion=AssertionSpec(
+            stdout_is_valid_json=True,
+            stdout_contains=('"scenario": "storage-correctness"', '"ok": true'),
+            classification_override=AssertionClass.SMOKE_PROCESS,
+        ),
+        family="storage-correctness",
+        tags=("contract", "storage", "scenario", "fts", "lineage"),
     ),
     "semantic-stack": LaneEntry(
         name="semantic-stack",

--- a/devtools/validation_lane_catalog_contracts.py
+++ b/devtools/validation_lane_catalog_contracts.py
@@ -89,7 +89,7 @@ CONTRACT_LANES: dict[str, LaneEntry] = {
     ),
     "storage-correctness": LaneEntry(
         name="storage-correctness",
-        description="Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition",
+        description="Archive-backed storage correctness for idempotency, FTS drift, blob GC, and lineage composition",
         timeout_s=180,
         category="contract",
         execution=devtools_execution(
@@ -99,20 +99,17 @@ CONTRACT_LANES: dict[str, LaneEntry] = {
             "--json",
             metadata=ScenarioMetadata(
                 path_targets=(
-                    "raw-reparse-loop",
                     "raw-archive-ingest-loop",
                     "message-fts-readiness-loop",
                     "session-query-loop",
                 ),
                 artifact_targets=(
-                    "source_payload_stream",
                     "archive_session_rows",
                     "message_source_rows",
                     "message_fts",
                     "session_query_results",
                 ),
                 operation_targets=(
-                    "acquire-raw-sessions",
                     "ingest-archive-runtime",
                     "index-message-fts",
                     "query-sessions",
@@ -125,7 +122,7 @@ CONTRACT_LANES: dict[str, LaneEntry] = {
             classification_override=AssertionClass.SMOKE_PROCESS,
         ),
         family="storage-correctness",
-        tags=("contract", "storage", "scenario", "fts", "lineage"),
+        tags=("contract", "storage", "scenario", "fts", "gc", "lineage"),
     ),
     "semantic-stack": LaneEntry(
         name="semantic-stack",

--- a/devtools/validation_lane_runtime.py
+++ b/devtools/validation_lane_runtime.py
@@ -59,7 +59,7 @@ def run_lane(lane: LaneEntry) -> int:
             print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
         if result.stderr:
             print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
-        error = lane.assertion.validate_process(result.output, result.exit_code)
+        error = lane.assertion.validate_process(result.stdout, result.exit_code)
         if error is not None:
             print(f"\nLane {lane.name!r} failed assertion: {error}")
             return result.exit_code if result.exit_code != 0 else 1

--- a/docs/plans/scenario-coverage.yaml
+++ b/docs/plans/scenario-coverage.yaml
@@ -90,16 +90,24 @@ families:
       for scenario execution. Supports pytest, CLI, devtools,
       and pipeline-probe execution kinds.
 
-coverage_gaps:
-  - id: scenario.storage-correctness
+  - name: storage_correctness
+    description: Archive-backed storage correctness scenario family
     subject: storage_correctness
-    gap: No dedicated scenario family for storage-layer verification
-    owner: scenario-coverage
-    severity: major
-    declared_at: "2026-05-02"
-    review_after: "2026-08-01"
+    scenario_count: 4
+    location: devtools/storage_correctness_scenario.py
     bead: polylogue-9e5.19
-    next_evidence: devtools lab projections
+    notes: >
+      Realized from the prior scenario.storage-correctness gap.
+      Runs through the devtools lab smoke/lane registry against
+      real ArchiveStore split-tier writes. Covers content-hash
+      idempotency, canonical message FTS trigger drift and production
+      recovery, lineage prefix-sharing composition, and current blob
+      GC invariants. The old blob-lease wording was stale because no
+      production writer populated it. This family instead covers
+      publication/reference survival, gc_generations age/snapshot
+      gating, and typed reclaim evidence.
+
+coverage_gaps:
   - id: scenario.performance
     subject: performance
     gap: No scenario family exercising memory or throughput budgets

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -174,7 +174,7 @@ Use the named lanes through the runner.
 | `semantic-insight-normalization` | 900 | Semantic/session insight normalization, operator/toolchain narrowing, schema contracts, and provider parser cleanup |
 | `semantic-stack` | 360 | Unified harmonization, semantic facts/profile convergence, and contract inventory coverage |
 | `source-provider-fidelity` | 420 | Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity |
-| `storage-correctness` | 180 | Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition |
+| `storage-correctness` | 180 | Archive-backed storage correctness for idempotency, FTS drift, blob GC, and lineage composition |
 | `tui` | 240 | Textual dashboard screens and interaction-state coverage |
 | `verification-substrate-contracts` | 180 | Shared test fixture contracts for JSON metadata, scenario content blocks, and semantic facts |
 
@@ -413,7 +413,7 @@ These projections explain which executable lanes, inferred fixture scenarios, or
 | `validation-lane` | `semantic-stack` | — | — | — | — | — | Unified harmonization, semantic facts/profile convergence, and contract inventory coverage |
 | `validation-lane` | `source-provider-fidelity` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `acquire-raw-sessions` | — | `contract`<br>`sources`<br>`acquisition` | Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity |
 | `validation-lane` | `source-runtime-alignment` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `acquire-raw-sessions` | — | `contract`<br>`sources`<br>`acquisition`<br>`maintenance` | Local source/provider fidelity plus runtime maintenance alignment |
-| `validation-lane` | `storage-correctness` | `raw-reparse-loop`<br>`raw-archive-ingest-loop`<br>`message-fts-readiness-loop`<br>`session-query-loop` | `source_payload_stream`<br>`archive_session_rows`<br>`message_source_rows`<br>`message_fts`<br>`session_query_results` | `acquire-raw-sessions`<br>`ingest-archive-runtime`<br>`index-message-fts`<br>`query-sessions` | — | `contract`<br>`storage`<br>`scenario`<br>`fts`<br>`lineage` | Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition |
+| `validation-lane` | `storage-correctness` | `raw-archive-ingest-loop`<br>`message-fts-readiness-loop`<br>`session-query-loop` | `archive_session_rows`<br>`message_source_rows`<br>`message_fts`<br>`session_query_results` | `ingest-archive-runtime`<br>`index-message-fts`<br>`query-sessions` | — | `contract`<br>`storage`<br>`scenario`<br>`fts`<br>`gc`<br>`lineage` | Archive-backed storage correctness for idempotency, FTS drift, blob GC, and lineage composition |
 | `validation-lane` | `tui` | — | — | — | — | — | Textual dashboard screens and interaction-state coverage |
 | `validation-lane` | `verification-substrate-contracts` | — | `archive_scenario_fixtures`<br>`storage_record_fixtures`<br>`json_contract_helpers` | `seed-archive-scenarios`<br>`build-storage-record-fixtures` | — | `contract`<br>`fixtures`<br>`semantic-precision` | Shared test fixture contracts for JSON metadata, scenario content blocks, and semantic facts |
 

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -8,19 +8,19 @@ This reference is generated from the executable validation-lane, mutation-campai
 
 Current registry snapshot:
 
-- contract lanes: `27`
+- contract lanes: `28`
 - live lanes: `19`
 - composite lanes: `24`
 - mutation campaigns: `19`
 - benchmark campaigns: `7`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `110`
+- scenario projections: `111`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `7`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
-  - validation-lane: `70`
+  - validation-lane: `71`
 
 ## Runtime Coverage
 
@@ -174,6 +174,7 @@ Use the named lanes through the runner.
 | `semantic-insight-normalization` | 900 | Semantic/session insight normalization, operator/toolchain narrowing, schema contracts, and provider parser cleanup |
 | `semantic-stack` | 360 | Unified harmonization, semantic facts/profile convergence, and contract inventory coverage |
 | `source-provider-fidelity` | 420 | Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity |
+| `storage-correctness` | 180 | Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition |
 | `tui` | 240 | Textual dashboard screens and interaction-state coverage |
 | `verification-substrate-contracts` | 180 | Shared test fixture contracts for JSON metadata, scenario content blocks, and semantic facts |
 
@@ -412,6 +413,7 @@ These projections explain which executable lanes, inferred fixture scenarios, or
 | `validation-lane` | `semantic-stack` | — | — | — | — | — | Unified harmonization, semantic facts/profile convergence, and contract inventory coverage |
 | `validation-lane` | `source-provider-fidelity` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `acquire-raw-sessions` | — | `contract`<br>`sources`<br>`acquisition` | Source traversal, Drive/runtime source boundaries, parser decoding, and provider-ingest fidelity |
 | `validation-lane` | `source-runtime-alignment` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `acquire-raw-sessions` | — | `contract`<br>`sources`<br>`acquisition`<br>`maintenance` | Local source/provider fidelity plus runtime maintenance alignment |
+| `validation-lane` | `storage-correctness` | `raw-reparse-loop`<br>`raw-archive-ingest-loop`<br>`message-fts-readiness-loop`<br>`session-query-loop` | `source_payload_stream`<br>`archive_session_rows`<br>`message_source_rows`<br>`message_fts`<br>`session_query_results` | `acquire-raw-sessions`<br>`ingest-archive-runtime`<br>`index-message-fts`<br>`query-sessions` | — | `contract`<br>`storage`<br>`scenario`<br>`fts`<br>`lineage` | Archive-backed storage correctness scenario family for idempotency, FTS drift, and lineage composition |
 | `validation-lane` | `tui` | — | — | — | — | — | Textual dashboard screens and interaction-state coverage |
 | `validation-lane` | `verification-substrate-contracts` | — | `archive_scenario_fixtures`<br>`storage_record_fixtures`<br>`json_contract_helpers` | `seed-archive-scenarios`<br>`build-storage-record-fixtures` | — | `contract`<br>`fixtures`<br>`semantic-precision` | Shared test fixture contracts for JSON metadata, scenario content blocks, and semantic facts |
 

--- a/polylogue/scenarios/runtime.py
+++ b/polylogue/scenarios/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -59,6 +60,13 @@ def resolve_execution_command(
     return (replacement, *tail)
 
 
+def _subprocess_command(command: tuple[str, ...]) -> tuple[str, ...]:
+    """Resolve source-checkout-only control-plane tools for subprocess execution."""
+    if command[:1] == ("devtools",):
+        return (sys.executable, "-m", "devtools", *command[1:])
+    return command
+
+
 def run_execution(
     execution: ExecutionSpec,
     *,
@@ -70,11 +78,12 @@ def run_execution(
 ) -> ExecutionResult:
     """Execute one authored execution spec with consistent subprocess semantics."""
     command = resolve_execution_command(execution, binary_overrides=binary_overrides)
+    subprocess_command = _subprocess_command(command)
     command_env = dict(os.environ)
     if env:
         command_env.update(env)
     completed = subprocess.run(
-        list(command),
+        list(subprocess_command),
         capture_output=capture_output,
         cwd=cwd,
         env=command_env,
@@ -84,7 +93,7 @@ def run_execution(
     )
     return ExecutionResult(
         execution=execution,
-        command=command,
+        command=subprocess_command,
         exit_code=completed.returncode,
         stdout=completed.stdout or "",
         stderr=completed.stderr or "",

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -151,6 +151,7 @@ class ScenarioFamily(BaseModel):
     subject: str
     scenario_count: int | str  # int literal or "dynamic"
     location: str
+    bead: str | None = None
     notes: str | None = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ plog = "polylogue.cli:main"
 polylogue-hook = "polylogue.hooks:hook_main"
 polylogued = "polylogue.daemon.cli:main"
 polylogue-mcp = "polylogue.mcp.cli:main"
+devtools = "devtools.__main__:_entrypoint"
 
 [tool.hatch.build.targets.wheel]
 packages = ["polylogue", "devtools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ plog = "polylogue.cli:main"
 polylogue-hook = "polylogue.hooks:hook_main"
 polylogued = "polylogue.daemon.cli:main"
 polylogue-mcp = "polylogue.mcp.cli:main"
-devtools = "devtools.__main__:_entrypoint"
 
 [tool.hatch.build.targets.wheel]
 packages = ["polylogue", "devtools"]

--- a/tests/unit/devtools/test_lab_scenario.py
+++ b/tests/unit/devtools/test_lab_scenario.py
@@ -38,6 +38,7 @@ def test_list_scenarios_reports_live_paths_without_baseline_counts(capsys: pytes
     payload = json.loads(capsys.readouterr().out)
     archive = next(entry for entry in payload["scenarios"] if entry["name"] == "archive-smoke")
     visual = next(entry for entry in payload["scenarios"] if entry["name"] == "reader-visual-smoke")
+    storage = next(entry for entry in payload["scenarios"] if entry["name"] == "storage-correctness")
     assert archive == {
         "name": "archive-smoke",
         "kind": "cli-smoke",
@@ -46,6 +47,11 @@ def test_list_scenarios_reports_live_paths_without_baseline_counts(capsys: pytes
     assert archive["tier_0_check_count"] > 0
     assert visual["command"]
     assert visual["artifact_count"] > 0
+    assert storage == {
+        "name": "storage-correctness",
+        "kind": "archive-storage",
+        "check_count": 3,
+    }
 
 
 def test_main_prints_direct_stage_summary(capsys: pytest.CaptureFixture[str]) -> None:
@@ -150,6 +156,43 @@ def test_reader_visual_smoke_json_reports_artifact_inventory(
         "polylogue.local_reader.workspace.stack",
     }
     assert run.call_args.kwargs["capture_output"] is True
+
+
+def test_storage_correctness_json_runs_archive_backed_checks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from devtools.lab_scenario import main
+
+    report_dir = tmp_path / "reports"
+
+    assert main(["run", "storage-correctness", "--json", "--report-dir", str(report_dir)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    report_payload = json.loads((report_dir / "storage-correctness.json").read_text(encoding="utf-8"))
+    assert payload["scenario"] == "storage-correctness"
+    assert payload["ok"] is True
+    assert payload["failed_stages"] == []
+    assert set(payload["stages"]) == {"idempotent-reingest", "fts-trigger-drift", "lineage-composition"}
+    assert payload["checks"] == report_payload["checks"]
+    checks = {entry["name"]: entry for entry in payload["checks"]}
+    assert checks["idempotent-reingest"]["details"]["repeat_counts"]["skipped_sessions"] == 1
+    assert checks["idempotent-reingest"]["details"]["derived_counts"] == {
+        "sessions": 1,
+        "messages": 2,
+        "blocks": 2,
+        "message_fts": 2,
+    }
+    assert checks["fts-trigger-drift"]["details"]["drifted_fts_rows"] == 0
+    assert checks["fts-trigger-drift"]["details"]["after_fts_rows"] == 1
+    assert checks["fts-trigger-drift"]["details"]["repeat_counts"]["_fts_repair"] == 1
+    assert checks["lineage-composition"]["details"]["stored_child_positions"] == [2, 3]
+    assert checks["lineage-composition"]["details"]["composed_texts"] == [
+        "hello",
+        "hi there",
+        "child diverges here",
+        "child reply",
+    ]
+    assert checks["lineage-composition"]["details"]["lineage"]["inheritance"] == "prefix-sharing"
 
 
 def test_main_reports_unsupported_archive_smoke_tier(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_lab_scenario.py
+++ b/tests/unit/devtools/test_lab_scenario.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 
 def test_module_imports() -> None:
@@ -50,8 +51,30 @@ def test_list_scenarios_reports_live_paths_without_baseline_counts(capsys: pytes
     assert storage == {
         "name": "storage-correctness",
         "kind": "archive-storage",
-        "check_count": 3,
+        "check_count": 4,
+        "scope_adjudication": storage["scope_adjudication"],
     }
+    assert "blob_gc" in storage["scope_adjudication"]
+
+
+def test_storage_correctness_manifest_records_the_realized_archive_family() -> None:
+    manifest_path = Path(__file__).parents[3] / "docs/plans/scenario-coverage.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(manifest, dict)
+    families = manifest["families"]
+    assert isinstance(families, list)
+    storage = next(family for family in families if family["name"] == "storage_correctness")
+    assert storage == {
+        "name": "storage_correctness",
+        "description": "Archive-backed storage correctness scenario family",
+        "subject": "storage_correctness",
+        "scenario_count": 4,
+        "location": "devtools/storage_correctness_scenario.py",
+        "bead": "polylogue-9e5.19",
+        "notes": storage["notes"],
+    }
+    assert "blob-lease wording was stale" in storage["notes"]
+    assert all(gap["id"] != "scenario.storage-correctness" for gap in manifest["coverage_gaps"])
 
 
 def test_main_prints_direct_stage_summary(capsys: pytest.CaptureFixture[str]) -> None:
@@ -172,8 +195,15 @@ def test_storage_correctness_json_runs_archive_backed_checks(
     assert payload["scenario"] == "storage-correctness"
     assert payload["ok"] is True
     assert payload["failed_stages"] == []
-    assert set(payload["stages"]) == {"idempotent-reingest", "fts-trigger-drift", "lineage-composition"}
+    assert set(payload["stages"]) == {
+        "idempotent-reingest",
+        "fts-trigger-drift",
+        "blob-gc-invariant",
+        "lineage-composition",
+    }
     assert payload["checks"] == report_payload["checks"]
+    assert payload["scope_adjudication"] == report_payload["scope_adjudication"]
+    assert "blob_gc" in payload["scope_adjudication"]
     checks = {entry["name"]: entry for entry in payload["checks"]}
     assert checks["idempotent-reingest"]["details"]["repeat_counts"]["skipped_sessions"] == 1
     assert checks["idempotent-reingest"]["details"]["derived_counts"] == {
@@ -182,9 +212,26 @@ def test_storage_correctness_json_runs_archive_backed_checks(
         "blocks": 2,
         "message_fts": 2,
     }
-    assert checks["fts-trigger-drift"]["details"]["drifted_fts_rows"] == 0
+    assert checks["fts-trigger-drift"]["details"]["drifted_readiness"]["ready"] is False
+    assert checks["fts-trigger-drift"]["details"]["drifted_readiness"]["triggers_present"] is False
+    assert checks["fts-trigger-drift"]["details"]["drifted_triggers"] == [
+        "messages_fts_ad",
+        "messages_fts_au",
+    ]
+    assert "Search index is incomplete" in checks["fts-trigger-drift"]["details"]["search_failure"]
+    assert checks["fts-trigger-drift"]["details"]["production_repair"] is True
+    assert checks["fts-trigger-drift"]["details"]["after_triggers"] == [
+        "messages_fts_ad",
+        "messages_fts_ai",
+        "messages_fts_au",
+    ]
+    assert checks["fts-trigger-drift"]["details"]["after_readiness"]["ready"] is True
     assert checks["fts-trigger-drift"]["details"]["after_fts_rows"] == 1
-    assert checks["fts-trigger-drift"]["details"]["repeat_counts"]["_fts_repair"] == 1
+    assert checks["blob-gc-invariant"]["details"]["reservation_count"] == 1
+    assert checks["blob-gc-invariant"]["details"]["gc_report"]["deleted_count"] == 1
+    assert checks["blob-gc-invariant"]["details"]["gc_report"]["skipped_reserved"] == 1
+    assert checks["blob-gc-invariant"]["details"]["gc_report"]["skipped_referenced"] == 1
+    assert checks["blob-gc-invariant"]["details"]["latest_generation"]["reclaimed_count"] == 1
     assert checks["lineage-composition"]["details"]["stored_child_positions"] == [2, 3]
     assert checks["lineage-composition"]["details"]["composed_texts"] == [
         "hello",
@@ -193,6 +240,24 @@ def test_storage_correctness_json_runs_archive_backed_checks(
         "child reply",
     ]
     assert checks["lineage-composition"]["details"]["lineage"]["inheritance"] == "prefix-sharing"
+
+
+def test_storage_correctness_rejects_production_repair_without_trigger_recreation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from devtools import storage_correctness_scenario
+
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.ensure_fts_triggers_sync",
+        lambda _conn: None,
+    )
+
+    result = storage_correctness_scenario.run_storage_correctness(report_dir=None)
+
+    fts_result = next(check for check in result.check_results if check.name == "fts-trigger-drift")
+    assert fts_result.passed is False
+    assert fts_result.error is not None
+    assert "Search index is incomplete" in fts_result.error
 
 
 def test_main_reports_unsupported_archive_smoke_tier(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -167,6 +167,31 @@ class TestLaneParsing:
             "ingest-archive-runtime",
         )
 
+    def test_storage_correctness_lane_carries_storage_scenario_metadata(self) -> None:
+        lane = LANES["storage-correctness"]
+
+        assert lane.family == "storage-correctness"
+        assert lane.path_targets == (
+            "raw-reparse-loop",
+            "raw-archive-ingest-loop",
+            "message-fts-readiness-loop",
+            "session-query-loop",
+        )
+        assert lane.artifact_targets == (
+            "source_payload_stream",
+            "archive_session_rows",
+            "message_source_rows",
+            "message_fts",
+            "session_query_results",
+        )
+        assert lane.operation_targets == (
+            "acquire-raw-sessions",
+            "ingest-archive-runtime",
+            "index-message-fts",
+            "query-sessions",
+        )
+        assert lane.tags == ("contract", "storage", "scenario", "fts", "lineage")
+
     def test_memory_budget_lane_preserves_wrapped_runtime_metadata(self) -> None:
         lane = LANES["memory-budget"]
 
@@ -205,6 +230,13 @@ class TestCommandConstruction:
         assert "chatgpt" in cmd
         assert "--max-total-ms" in cmd
         assert "--max-peak-rss-mb" in cmd
+
+    def test_storage_correctness_lane_uses_lab_smoke_scenario(self) -> None:
+        cmd = build_lane_command(LANES["storage-correctness"])
+
+        assert cmd[:4] == ["devtools", "lab", "smoke", "run"]
+        assert "storage-correctness" in cmd
+        assert "--json" in cmd
 
     def test_live_archive_subset_parse_probe_lane_uses_medium_archive_subset_probe(self) -> None:
         lane = LANES["live-archive-subset-parse-probe"]

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -172,25 +172,22 @@ class TestLaneParsing:
 
         assert lane.family == "storage-correctness"
         assert lane.path_targets == (
-            "raw-reparse-loop",
             "raw-archive-ingest-loop",
             "message-fts-readiness-loop",
             "session-query-loop",
         )
         assert lane.artifact_targets == (
-            "source_payload_stream",
             "archive_session_rows",
             "message_source_rows",
             "message_fts",
             "session_query_results",
         )
         assert lane.operation_targets == (
-            "acquire-raw-sessions",
             "ingest-archive-runtime",
             "index-message-fts",
             "query-sessions",
         )
-        assert lane.tags == ("contract", "storage", "scenario", "fts", "lineage")
+        assert lane.tags == ("contract", "storage", "scenario", "fts", "gc", "lineage")
 
     def test_memory_budget_lane_preserves_wrapped_runtime_metadata(self) -> None:
         lane = LANES["memory-budget"]
@@ -528,6 +525,29 @@ class TestLaneAssertions:
         captured = capsys.readouterr()
         assert exit_code == 1
         assert "failed assertion" in captured.out
+
+    def test_run_lane_validates_json_from_stdout_when_stderr_has_runtime_logs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        lane = LaneEntry(
+            name="json-with-logs",
+            description="JSON contract with runtime logs",
+            timeout_s=30,
+            category="contract",
+            execution=polylogue_execution("ops", "doctor", "--format", "json"),
+            assertion=AssertionSpec(stdout_is_valid_json=True),
+        )
+
+        class _Result:
+            exit_code = 0
+            stdout = '{"ok": true}'
+            stderr = "daemon maintenance log\n"
+            output = stdout + stderr
+
+        monkeypatch.setattr("devtools.validation_lane_runtime.run_execution", lambda *_args, **_kwargs: _Result())
+
+        assert run_lane(lane) == 0
 
     def test_live_insights_coverage_provider_lane_uses_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-coverage-provider"])

--- a/tests/unit/scenarios/test_runtime.py
+++ b/tests/unit/scenarios/test_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -7,6 +8,7 @@ import pytest
 
 from polylogue.scenarios import (
     RunnerInvocation,
+    devtools_execution,
     dispatch_execution,
     dispatch_runner_execution,
     polylogue_execution,
@@ -69,6 +71,31 @@ def test_run_execution_merges_env_and_captures_output(
     assert captured_kwargs["text"] is True
     env = _string_env(captured_kwargs["env"])
     assert env["POLYLOGUE_FORCE_PLAIN"] == "1"
+
+
+def test_run_execution_dispatches_devtools_through_the_checkout_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_command: list[str] | None = None
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        nonlocal captured_command
+        captured_command = command
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr("polylogue.scenarios.runtime.subprocess.run", fake_run)
+
+    result = run_execution(devtools_execution("lab smoke", "run", "storage-correctness", "--json"), capture_output=True)
+
+    assert captured_command == [
+        sys.executable,
+        "-m",
+        "devtools",
+        "lab",
+        "smoke",
+        "run",
+        "storage-correctness",
+        "--json",
+    ]
+    assert result.command == tuple(captured_command)
 
 
 def test_run_execution_rejects_composite_execution() -> None:


### PR DESCRIPTION
## Summary

Add a `storage-correctness` validation lane backed by real Polylogue archive
and storage APIs. It exercises idempotent re-ingest, FTS trigger drift and
production repair, current blob-GC safety invariants, and lineage composition.

Ref polylogue-9e5.19.

## Problem

The scenario coverage manifest carried storage correctness as an orphaned gap.
An earlier candidate replaced Polylogue with a synthetic archive that proved
only its own invented DDL and algorithms. The real storage contracts therefore
had no compact executable scenario family.

## Solution

- Run all four checks against temporary split-tier `ArchiveStore` archives.
- Drop a canonical FTS trigger, prove readiness/search failure, invoke the
  production daemon repair, and prove trigger/search restoration.
- Exercise publication reservation, durable references, generation age gating,
  reclamation, and typed GC history through production blob APIs.
- Prove prefix-sharing storage and composed lineage after the parent grows.
- Register the family in `devtools lab lanes` and projections with only the
  paths/artifacts/operations actually exercised.
- Route devtools scenario execution through `python -m devtools`, not an
  invented console entry point.
- Extend strict manifest validation so realized families can carry an optional
  Beads ownership reference.

The stale blob-lease wording is explicitly superseded: no production writer
populates that abandoned premise, so the scenario covers the current
reservation/reference/generation contract instead.

## Verification

- `python -m devtools lab lanes --lane storage-correctness` — all four checks passed.
- Storage scenario/lane/runtime suite — 165 passed.
- Focused final selectors and trigger-repair mutation — 26 passed.
- `devtools verify manifests` — manifest consistency passed.
- `devtools verify --quick` — 13/13 steps passed; pre-push repeated after rebase.
