### PR TITLE
feat(devtools): enforce production writer ownership

### DIFF
--- a/devtools/verify_layering.py
+++ b/devtools/verify_layering.py
@@ -351,6 +351,36 @@ def _imported_writer_modules(tree: ast.Module) -> dict[str, str]:
     return imports
 
 
+def _imported_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.update(alias.asname or alias.name for alias in node.names)
+    return names
+
+
+def _imported_sql_execution_lines(tree: ast.Module) -> list[int]:
+    """Find execute calls whose SQL text is hidden behind an import.
+
+    The layering gate cannot classify an imported constant against this
+    module's owned tiers. Keep executable SQL beside its owning writer so a
+    change to the statement cannot bypass the writer inventory.
+    """
+    imported = _imported_names(tree)
+    return sorted(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _SQL_EXECUTION_METHODS
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id in imported
+    )
+
+
 def _called_function_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     names: set[str] = set()
     for node in ast.walk(function):
@@ -367,9 +397,15 @@ def _entrypoint_tiers(
     tree: ast.Module,
     entrypoint: str,
     specs: dict[str, WriterModuleSpec],
+    *,
+    follow_imports: bool = True,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] | None = None,
+    imported_modules: dict[str, str] | None = None,
+    direct_tiers: dict[str, frozenset[str]] | None = None,
 ) -> frozenset[str]:
-    functions = _function_definitions(tree)
-    imported_modules = _imported_writer_modules(tree)
+    functions = functions or _function_definitions(tree)
+    imported_modules = imported_modules or _imported_writer_modules(tree)
+    direct_tiers = direct_tiers or {name: _mutation_tiers(function) for name, function in functions.items()}
     pending = [entrypoint]
     visited: set[str] = set()
     tiers: set[str] = set()
@@ -380,11 +416,11 @@ def _entrypoint_tiers(
         visited.add(name)
         function = functions.get(name)
         if function is None:
-            spec = specs.get(imported_modules.get(name, ""))
+            spec = specs.get(imported_modules.get(name, "")) if follow_imports else None
             if spec is not None:
                 tiers.update(surface.tier for surface in spec.surfaces)
             continue
-        tiers.update(_mutation_tiers(function))
+        tiers.update(direct_tiers[name])
         for called_name in _called_function_names(function):
             if called_name in functions or called_name in imported_modules:
                 pending.append(called_name)
@@ -477,6 +513,14 @@ def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolic
             continue
 
         expected_tiers = tuple(surface.tier for surface in spec.surfaces)
+        for line in _imported_sql_execution_lines(tree):
+            violations.append(
+                {
+                    "file": spec.path,
+                    "line": line,
+                    "rule": "writer_module_imported_sql_opaque",
+                }
+            )
         observed_tiers = _mutation_tiers(tree)
         unexpected_tiers = sorted(observed_tiers.difference(expected_tiers))
         if unexpected_tiers:
@@ -498,6 +542,11 @@ def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolic
                     "expected": list(expected_tiers),
                 }
             )
+
+        functions = _function_definitions(tree)
+        imported_modules = _imported_writer_modules(tree)
+        direct_tiers = {name: _mutation_tiers(function) for name, function in functions.items()}
+
         if len(declaration.tiers) > 1:
             if not _contract_is_audited(declaration, spec, policy):
                 violations.append(
@@ -514,14 +563,21 @@ def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolic
                 assert contract_name is not None
                 contract = policy.twin_write_contracts[contract_name]
                 for entrypoint in contract.entrypoints:
-                    reached_tiers = _entrypoint_tiers(tree, entrypoint, specs)
-                    if set(contract.surfaces) != reached_tiers:
+                    contract_tiers = _entrypoint_tiers(
+                        tree,
+                        entrypoint,
+                        specs,
+                        functions=functions,
+                        imported_modules=imported_modules,
+                        direct_tiers=direct_tiers,
+                    )
+                    if set(contract.surfaces) != contract_tiers:
                         violations.append(
                             {
                                 "file": spec.path,
                                 "rule": "writer_module_contract_unproven",
                                 "entrypoint": entrypoint,
-                                "observed": sorted(reached_tiers),
+                                "observed": sorted(contract_tiers),
                                 "expected": list(contract.surfaces),
                             }
                         )
@@ -535,9 +591,19 @@ def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolic
                 }
             )
 
-        functions = _function_definitions(tree)
         observed_entrypoints = {
-            name for name, function in functions.items() if not name.startswith("_") and _mutation_tiers(function)
+            name
+            for name in functions
+            if not name.startswith("_")
+            and _entrypoint_tiers(
+                tree,
+                name,
+                specs,
+                follow_imports=False,
+                functions=functions,
+                imported_modules=imported_modules,
+                direct_tiers=direct_tiers,
+            )
         }
         if observed_entrypoints != set(spec.entrypoints):
             violations.append(
@@ -558,7 +624,15 @@ def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolic
                         "entrypoint": entrypoint,
                     }
                 )
-            elif not _mutation_tiers(function):
+            elif not _entrypoint_tiers(
+                tree,
+                entrypoint,
+                specs,
+                follow_imports=False,
+                functions=functions,
+                imported_modules=imported_modules,
+                direct_tiers=direct_tiers,
+            ):
                 violations.append(
                     {
                         "file": spec.path,

--- a/devtools/verify_layering.py
+++ b/devtools/verify_layering.py
@@ -1,11 +1,12 @@
-"""Verify inter-package layering rules from docs/plans/layering.yaml.
+"""Verify import layering and production SQLite writer ownership.
 
 Gate classification: **blocking architectural boundary check**.
 
-Enforces the substrate-vs-surface import boundary: substrate packages
-(storage, pipeline, sources, insights) must not import surface adapters
-(cli, mcp, daemon, ui, rendering). This is a durable architecture contract,
-not placement hygiene.
+The writer doctrine is intentionally rooted in real mutation surfaces rather
+than voluntary class labels.  Each archive-tier module that performs a direct
+SQL mutation must be inventoried in ``docs/plans/layering.yaml`` and declare
+its owned tier(s) in its module docstring.  A module spanning two tiers is
+allowed only when the same manifest names a reviewed twin-write contract.
 
 Usage:
   devtools verify layering
@@ -16,11 +17,76 @@ from __future__ import annotations
 
 import argparse
 import ast
+import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from devtools import repo_root as _get_root
 from polylogue.core.json import dumps
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
+
+_DEFAULT_WRITER_MODULE_MARKER = "Writer module:"
+_TWIN_WRITE_CONTRACT_MARKER = "Twin-write contract:"
+_WRITER_TIER_RE = re.compile(r"[a-z][a-z0-9_-]*")
+_SQL_MUTATION_RE = re.compile(r"(?:^|\n)\s*(?:INSERT|UPDATE|DELETE|REPLACE)\b", re.IGNORECASE)
+_SQL_MUTATION_TABLE_RE = re.compile(
+    r"^\s*(?:INSERT(?:\s+OR\s+\w+)?\s+INTO|REPLACE\s+INTO|UPDATE|DELETE\s+FROM)\s+[`\"\[]?([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`\"\[]?([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+_SQL_EXECUTION_METHODS = frozenset({"execute", "executemany", "executescript"})
+_WRITER_SURFACE_CONTRACTS = {
+    "source": ("durable", "atomic"),
+    "index": ("rebuildable", "replayable"),
+    "embeddings": ("rebuildable", "replayable"),
+    "user": ("durable", "atomic"),
+    "ops": ("disposable", "restartable"),
+}
+
+
+@dataclass(frozen=True)
+class WriterModuleSurface:
+    tier: str
+    durability: str
+    interruption: str
+
+
+@dataclass(frozen=True)
+class WriterModuleSpec:
+    path: str
+    surfaces: tuple[WriterModuleSurface, ...]
+    entrypoints: tuple[str, ...]
+    twin_write_contract: str | None
+
+
+@dataclass(frozen=True)
+class TwinWriteContract:
+    name: str
+    module: str
+    surfaces: tuple[str, ...]
+    entrypoints: tuple[str, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class WriterModulePolicy:
+    marker: str
+    mutation_roots: tuple[str, ...]
+    modules: tuple[WriterModuleSpec, ...]
+    twin_write_contracts: dict[str, TwinWriteContract]
+
+
+@dataclass(frozen=True)
+class WriterModuleDeclaration:
+    file: str
+    tiers: tuple[str, ...]
+    contract: str | None
+    line: int
+    well_formed: bool
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -29,15 +95,19 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _load_rules(rules_path: Path) -> list[dict[str, object]]:
+def _load_manifest(rules_path: Path) -> dict[str, object]:
     import yaml
 
     with open(rules_path, encoding="utf-8") as f:
         data: object = yaml.safe_load(f)
-    if isinstance(data, dict):
-        rules: object = data.get("rules", [])
-        if isinstance(rules, list):
-            return rules
+    return data if isinstance(data, dict) else {}
+
+
+def _load_rules(rules_path: Path) -> list[dict[str, object]]:
+    data = _load_manifest(rules_path)
+    rules: object = data.get("rules", [])
+    if isinstance(rules, list):
+        return [rule for rule in rules if isinstance(rule, dict)]
     return []
 
 
@@ -70,6 +140,451 @@ def _package_matches(target: str, import_module: str) -> bool:
     return normalized_import == normalized_target or normalized_import.startswith(normalized_target + ".")
 
 
+def _strings(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item) for item in value if isinstance(item, str))
+
+
+def _writer_module_policy(manifest: dict[str, object]) -> WriterModulePolicy | None:
+    raw_policy = manifest.get("writer_modules")
+    if not isinstance(raw_policy, dict):
+        return None
+
+    raw_modules = raw_policy.get("modules")
+    modules: list[WriterModuleSpec] = []
+    if isinstance(raw_modules, list):
+        for raw_module in raw_modules:
+            if not isinstance(raw_module, dict):
+                continue
+            raw_surfaces = raw_module.get("surfaces")
+            surfaces: list[WriterModuleSurface] = []
+            if isinstance(raw_surfaces, list):
+                for raw_surface in raw_surfaces:
+                    if not isinstance(raw_surface, dict):
+                        continue
+                    tier = raw_surface.get("tier")
+                    durability = raw_surface.get("durability")
+                    interruption = raw_surface.get("interruption")
+                    if isinstance(tier, str) and isinstance(durability, str) and isinstance(interruption, str):
+                        surfaces.append(
+                            WriterModuleSurface(
+                                tier=tier,
+                                durability=durability,
+                                interruption=interruption,
+                            )
+                        )
+            path = raw_module.get("path")
+            if isinstance(path, str):
+                contract = raw_module.get("twin_write_contract")
+                modules.append(
+                    WriterModuleSpec(
+                        path=path,
+                        surfaces=tuple(surfaces),
+                        entrypoints=_strings(raw_module.get("entrypoints")),
+                        twin_write_contract=contract if isinstance(contract, str) else None,
+                    )
+                )
+
+    contracts: dict[str, TwinWriteContract] = {}
+    raw_contracts = raw_policy.get("twin_write_contracts")
+    if isinstance(raw_contracts, list):
+        for raw_contract in raw_contracts:
+            if not isinstance(raw_contract, dict):
+                continue
+            name = raw_contract.get("name")
+            module = raw_contract.get("module")
+            reason = raw_contract.get("reason")
+            if isinstance(name, str) and isinstance(module, str) and isinstance(reason, str):
+                contracts[name] = TwinWriteContract(
+                    name=name,
+                    module=module,
+                    surfaces=_strings(raw_contract.get("surfaces")),
+                    entrypoints=_strings(raw_contract.get("entrypoints")),
+                    reason=reason,
+                )
+
+    return WriterModulePolicy(
+        marker=str(raw_policy.get("marker") or _DEFAULT_WRITER_MODULE_MARKER),
+        mutation_roots=_strings(raw_policy.get("mutation_roots")),
+        modules=tuple(modules),
+        twin_write_contracts=contracts,
+    )
+
+
+def _string_fragments(expression: ast.expr, values: dict[str, tuple[str, ...]] | None = None) -> tuple[str, ...]:
+    if isinstance(expression, ast.Constant) and isinstance(expression.value, str):
+        return (expression.value,)
+    if isinstance(expression, ast.Name) and values is not None:
+        return values.get(expression.id, ())
+    if isinstance(expression, ast.JoinedStr):
+        return tuple(
+            value.value
+            for value in expression.values
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        )
+    if isinstance(expression, ast.BinOp) and isinstance(expression.op, ast.Add):
+        return _string_fragments(expression.left, values) + _string_fragments(expression.right, values)
+    return ()
+
+
+def _string_assignments(tree: ast.AST) -> dict[str, tuple[str, ...]]:
+    values: dict[str, tuple[str, ...]] = {}
+    for _ in range(3):
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            fragments = _string_fragments(node.value, values)
+            if fragments:
+                values[node.targets[0].id] = fragments
+    return values
+
+
+def _mutation_sql(node: ast.Call, *, values: dict[str, tuple[str, ...]]) -> str | None:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in _SQL_EXECUTION_METHODS:
+        return None
+    if not node.args:
+        return None
+    sql = "".join(_string_fragments(node.args[0], values))
+    return sql if sql and _SQL_MUTATION_RE.search(sql) else None
+
+
+def _mutation_table(sql: str) -> str | None:
+    match = _SQL_MUTATION_TABLE_RE.match(sql)
+    return match.group(1) if match is not None else None
+
+
+def _archive_table_tiers() -> dict[str, str]:
+    table_tiers: dict[str, str] = {}
+    for tier, ddl in ARCHIVE_DDL_BY_TIER.items():
+        tier_name = str(getattr(tier, "value", tier))
+        for table in _CREATE_TABLE_RE.findall(ddl):
+            table_tiers[table] = tier_name
+    return table_tiers
+
+
+def _mutation_calls(tree: ast.AST) -> tuple[ast.Call, ...]:
+    values = _string_assignments(tree)
+    return tuple(
+        node for node in ast.walk(tree) if isinstance(node, ast.Call) and _mutation_sql(node, values=values) is not None
+    )
+
+
+def _mutation_tiers(tree: ast.AST) -> frozenset[str]:
+    values = _string_assignments(tree)
+    table_tiers = _archive_table_tiers()
+    tiers: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        sql = _mutation_sql(node, values=values)
+        if sql is None:
+            continue
+        table = _mutation_table(sql)
+        if table is not None and (tier := table_tiers.get(table)) is not None:
+            tiers.add(tier)
+    return frozenset(tiers)
+
+
+def _parse_writer_module_declaration(tree: ast.Module, *, file: str, marker: str) -> WriterModuleDeclaration | None:
+    docstring = ast.get_docstring(tree, clean=False)
+    if docstring is None or marker not in docstring or not tree.body:
+        return None
+
+    marker_lines = [line.strip() for line in docstring.splitlines() if line.strip().startswith(marker)]
+    if len(marker_lines) != 1:
+        return WriterModuleDeclaration(file=file, tiers=(), contract=None, line=tree.body[0].lineno, well_formed=False)
+
+    raw_tiers = marker_lines[0][len(marker) :].strip().removesuffix(".")
+    tiers = tuple(part.strip() for part in raw_tiers.split(",") if part.strip())
+    well_formed = bool(tiers) and all(_WRITER_TIER_RE.fullmatch(tier) is not None for tier in tiers)
+
+    contract_lines = [
+        line.strip() for line in docstring.splitlines() if line.strip().startswith(_TWIN_WRITE_CONTRACT_MARKER)
+    ]
+    contract: str | None = None
+    if len(contract_lines) == 1:
+        candidate = contract_lines[0][len(_TWIN_WRITE_CONTRACT_MARKER) :].strip().removesuffix(".")
+        contract = candidate or None
+    elif len(contract_lines) > 1:
+        well_formed = False
+
+    return WriterModuleDeclaration(
+        file=file,
+        tiers=tiers,
+        contract=contract,
+        line=tree.body[0].lineno,
+        well_formed=well_formed,
+    )
+
+
+def _writer_module_files(repo_root: Path, policy: WriterModulePolicy) -> dict[str, tuple[Path, ast.Module]]:
+    files: dict[str, tuple[Path, ast.Module]] = {}
+    for root in policy.mutation_roots:
+        root_path = repo_root / root
+        if not root_path.exists():
+            continue
+        for py_file in root_path.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            rel = py_file.relative_to(repo_root).as_posix()
+            files[rel] = (py_file, tree)
+    return files
+
+
+def _function_definitions(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    return {node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)}
+
+
+def _imported_writer_modules(tree: ast.Module) -> dict[str, str]:
+    imports: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        if not node.module.startswith("polylogue.storage.sqlite.archive_tiers."):
+            continue
+        path = node.module.replace(".", "/") + ".py"
+        for alias in node.names:
+            imports[alias.asname or alias.name] = path
+    return imports
+
+
+def _called_function_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            names.add(node.func.attr)
+    return names
+
+
+def _entrypoint_tiers(
+    tree: ast.Module,
+    entrypoint: str,
+    specs: dict[str, WriterModuleSpec],
+) -> frozenset[str]:
+    functions = _function_definitions(tree)
+    imported_modules = _imported_writer_modules(tree)
+    pending = [entrypoint]
+    visited: set[str] = set()
+    tiers: set[str] = set()
+    while pending:
+        name = pending.pop()
+        if name in visited:
+            continue
+        visited.add(name)
+        function = functions.get(name)
+        if function is None:
+            spec = specs.get(imported_modules.get(name, ""))
+            if spec is not None:
+                tiers.update(surface.tier for surface in spec.surfaces)
+            continue
+        tiers.update(_mutation_tiers(function))
+        for called_name in _called_function_names(function):
+            if called_name in functions or called_name in imported_modules:
+                pending.append(called_name)
+    return frozenset(tiers)
+
+
+def _contract_is_audited(
+    declaration: WriterModuleDeclaration,
+    spec: WriterModuleSpec,
+    policy: WriterModulePolicy,
+) -> bool:
+    if declaration.contract is None or declaration.contract != spec.twin_write_contract:
+        return False
+    contract = policy.twin_write_contracts.get(declaration.contract)
+    if contract is None or contract.module != spec.path:
+        return False
+    expected_tiers = tuple(surface.tier for surface in spec.surfaces)
+    return (
+        tuple(contract.surfaces) == expected_tiers
+        and set(contract.entrypoints).issubset(spec.entrypoints)
+        and bool(contract.reason)
+    )
+
+
+def _collect_writer_module_violations(repo_root: Path, policy: WriterModulePolicy | None) -> list[dict[str, object]]:
+    if policy is None:
+        return []
+
+    violations: list[dict[str, object]] = []
+    files = _writer_module_files(repo_root, policy)
+    specs = {spec.path: spec for spec in policy.modules}
+    declarations = {
+        rel: _parse_writer_module_declaration(tree, file=rel, marker=policy.marker) for rel, (_, tree) in files.items()
+    }
+    mutation_files = {rel for rel, (_, tree) in files.items() if _mutation_calls(tree)}
+
+    for rel in sorted(mutation_files):
+        spec = specs.get(rel)
+        declaration = declarations[rel]
+        if spec is None or declaration is None:
+            violations.append(
+                {
+                    "file": rel,
+                    "rule": "writer_module_unmarked_mutation",
+                    "marker": policy.marker,
+                }
+            )
+
+    for rel, declaration in declarations.items():
+        if declaration is not None and rel not in specs:
+            violations.append(
+                {
+                    "file": rel,
+                    "line": declaration.line,
+                    "rule": "writer_module_uninventoried_declaration",
+                }
+            )
+
+    for spec in policy.modules:
+        file_entry = files.get(spec.path)
+        if file_entry is None:
+            violations.append({"file": spec.path, "rule": "writer_module_missing_file"})
+            continue
+        _, tree = file_entry
+        declaration = declarations[spec.path]
+        if spec.path not in mutation_files:
+            violations.append({"file": spec.path, "rule": "writer_module_inventory_without_mutation"})
+            continue
+        if declaration is None:
+            continue
+        for surface in spec.surfaces:
+            if _WRITER_SURFACE_CONTRACTS.get(surface.tier) != (surface.durability, surface.interruption):
+                violations.append(
+                    {
+                        "file": spec.path,
+                        "rule": "writer_module_invalid_surface",
+                        "tier": surface.tier,
+                        "durability": surface.durability,
+                        "interruption": surface.interruption,
+                    }
+                )
+        if not declaration.well_formed:
+            violations.append(
+                {
+                    "file": spec.path,
+                    "line": declaration.line,
+                    "rule": "writer_module_invalid_declaration",
+                }
+            )
+            continue
+
+        expected_tiers = tuple(surface.tier for surface in spec.surfaces)
+        observed_tiers = _mutation_tiers(tree)
+        unexpected_tiers = sorted(observed_tiers.difference(expected_tiers))
+        if unexpected_tiers:
+            violations.append(
+                {
+                    "file": spec.path,
+                    "rule": "writer_module_observed_tier_mismatch",
+                    "observed": sorted(observed_tiers),
+                    "expected": list(expected_tiers),
+                }
+            )
+        if declaration.tiers != expected_tiers:
+            violations.append(
+                {
+                    "file": spec.path,
+                    "line": declaration.line,
+                    "rule": "writer_module_declaration_mismatch",
+                    "declared": list(declaration.tiers),
+                    "expected": list(expected_tiers),
+                }
+            )
+        if len(declaration.tiers) > 1:
+            if not _contract_is_audited(declaration, spec, policy):
+                violations.append(
+                    {
+                        "file": spec.path,
+                        "line": declaration.line,
+                        "rule": "writer_module_mixed_file",
+                        "declared": list(declaration.tiers),
+                        "contract": declaration.contract,
+                    }
+                )
+            else:
+                contract_name = declaration.contract
+                assert contract_name is not None
+                contract = policy.twin_write_contracts[contract_name]
+                for entrypoint in contract.entrypoints:
+                    reached_tiers = _entrypoint_tiers(tree, entrypoint, specs)
+                    if set(contract.surfaces) != reached_tiers:
+                        violations.append(
+                            {
+                                "file": spec.path,
+                                "rule": "writer_module_contract_unproven",
+                                "entrypoint": entrypoint,
+                                "observed": sorted(reached_tiers),
+                                "expected": list(contract.surfaces),
+                            }
+                        )
+        elif len(declaration.tiers) == 1 and declaration.contract is not None:
+            violations.append(
+                {
+                    "file": spec.path,
+                    "line": declaration.line,
+                    "rule": "writer_module_unneeded_contract",
+                    "contract": declaration.contract,
+                }
+            )
+
+        functions = _function_definitions(tree)
+        observed_entrypoints = {
+            name for name, function in functions.items() if not name.startswith("_") and _mutation_tiers(function)
+        }
+        if observed_entrypoints != set(spec.entrypoints):
+            violations.append(
+                {
+                    "file": spec.path,
+                    "rule": "writer_module_entrypoint_inventory_mismatch",
+                    "observed": sorted(observed_entrypoints),
+                    "expected": list(spec.entrypoints),
+                }
+            )
+        for entrypoint in spec.entrypoints:
+            function = functions.get(entrypoint)
+            if function is None:
+                violations.append(
+                    {
+                        "file": spec.path,
+                        "rule": "writer_module_missing_entrypoint",
+                        "entrypoint": entrypoint,
+                    }
+                )
+            elif not _mutation_tiers(function):
+                violations.append(
+                    {
+                        "file": spec.path,
+                        "line": function.lineno,
+                        "rule": "writer_module_entrypoint_not_mutating",
+                        "entrypoint": entrypoint,
+                    }
+                )
+    return violations
+
+
+def _format_violation(violation: dict[str, object]) -> str:
+    rule = str(violation.get("rule"))
+    if rule.startswith("writer_module_"):
+        detail = ""
+        if "entrypoint" in violation:
+            detail = f" entrypoint={violation['entrypoint']}"
+        elif "declared" in violation:
+            detail = f" declared={violation['declared']}"
+        elif "contract" in violation:
+            detail = f" contract={violation['contract']}"
+        line = f":{violation['line']}" if "line" in violation else ""
+        return f"  {violation['file']}{line}: {rule}{detail}"
+    return f"  {violation['file']}: imports {violation['import']} ({violation['rule']})"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -81,6 +596,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {rules_path} not found", file=sys.stderr)
         return 1
 
+    manifest = _load_manifest(rules_path)
     rules = _load_rules(rules_path)
     violations: list[dict[str, object]] = []
 
@@ -106,42 +622,39 @@ def main(argv: list[str] | None = None) -> int:
         imports = _collect_imports(target_dir, repo_root=repo_root)
         for file_rel, file_imports in imports.items():
             for imp in file_imports:
-                # Only check polylogue-internal imports
-                module = imp
-                if not module.startswith("polylogue"):
+                if not imp.startswith("polylogue"):
                     continue
-
-                # Check disallow first
                 for disallowed in disallow_from:
-                    if _package_matches(str(disallowed), module):
+                    if _package_matches(str(disallowed), imp):
                         violations.append(
                             {
                                 "target": target,
                                 "file": file_rel,
-                                "import": module,
+                                "import": imp,
                                 "rule": "disallow",
                                 "disallowed_package": disallowed,
                             }
                         )
                         break
                 else:
-                    # If allow list is non-empty, check the import is allowed
-                    if allow_from and not any(_package_matches(str(allowed), module) for allowed in allow_from):
+                    if allow_from and not any(_package_matches(str(allowed), imp) for allowed in allow_from):
                         violations.append(
                             {
                                 "target": target,
                                 "file": file_rel,
-                                "import": module,
+                                "import": imp,
                                 "rule": "not_allowed",
                                 "allowed": allow_from,
                             }
                         )
 
+    violations.extend(_collect_writer_module_violations(repo_root, _writer_module_policy(manifest)))
+
     if args.json:
         print(dumps({"violations": violations, "count": len(violations)}))
     else:
-        for v in violations:
-            print(f"  {v['file']}: imports {v['import']} ({v['rule']})")
+        for violation in violations:
+            print(_format_violation(violation))
         if not violations:
             print("  No layering violations found.")
 

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -26,13 +26,17 @@ writer_modules:
         - tier: index
           durability: rebuildable
           interruption: replayable
-      entrypoints: [delete_sessions]
+      entrypoints:
+        [delete_sessions, write_parsed_for_retained_raw, write_raw_and_parsed,
+        write_raw_and_parsed_result, write_raw_blob_and_parsed, write_raw_blob_and_parsed_result]
     - path: polylogue/storage/sqlite/archive_tiers/source_write.py
       surfaces:
         - tier: source
           durability: durable
           interruption: atomic
-      entrypoints: [apply_source_raw_state_update, write_history_sidecar, write_source_raw_session, write_source_raw_session_blob_ref]
+      entrypoints:
+        [apply_source_raw_state_update, bind_source_raw_revision, write_history_sidecar, write_source_blob_refs,
+        write_source_raw_session, write_source_raw_session_blob_ref]
     - path: polylogue/storage/sqlite/archive_tiers/write.py
       surfaces:
         - tier: index
@@ -42,21 +46,27 @@ writer_modules:
           durability: durable
           interruption: atomic
       entrypoints:
-        [apply_insight_materialization, rebuild_archive_messages_fts, upsert_session_phase, upsert_session_profile_costs,
-        upsert_session_tag, upsert_session_work_event, write_parsed_session_to_archive]
+        [apply_insight_materialization, rebuild_archive_messages_fts, repair_stale_prefix_branch_points,
+        replace_parser_ingest_flag_tags, upsert_insight_materialization, upsert_parser_ingest_flag_tags,
+        upsert_session_phase, upsert_session_profile_costs, upsert_session_tag, upsert_session_work_event,
+        write_parsed_session_to_archive]
       twin_write_contract: session-tag-assertion-mirror
     - path: polylogue/storage/sqlite/archive_tiers/embedding_write.py
       surfaces:
         - tier: embeddings
           durability: rebuildable
           interruption: replayable
-      entrypoints: [mark_session_embedding_error, upsert_message_embeddings]
+      entrypoints: [mark_session_embedding_error, upsert_message_embedding, upsert_message_embeddings]
     - path: polylogue/storage/sqlite/archive_tiers/user_write.py
       surfaces:
         - tier: user
           durability: durable
           interruption: atomic
-      entrypoints: [mark_assertion_status, upsert_assertion]
+      entrypoints:
+        [judge_assertion_candidate, mark_assertion_status, upsert_annotation, upsert_assertion,
+        upsert_blackboard_note, upsert_correction, upsert_mark, upsert_pathology_findings_as_assertions,
+        upsert_recall_pack, upsert_saved_view, upsert_session_metadata_assertion, upsert_session_tag_assertion,
+        upsert_suppression, upsert_transform_candidate_assertions, upsert_workspace]
     - path: polylogue/storage/sqlite/archive_tiers/ops_write.py
       surfaces:
         - tier: ops
@@ -70,7 +80,7 @@ writer_modules:
         - tier: index
           durability: rebuildable
           interruption: replayable
-      entrypoints: [record_capture_gap_event]
+      entrypoints: [record_capture_gap_event, record_source_outage_events]
     - path: polylogue/storage/sqlite/archive_tiers/pricing_seed.py
       surfaces:
         - tier: index

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -9,6 +9,80 @@
 #   - "disallow" means the import is always forbidden
 #   - "allow" with an empty or absent from list means all sources are allowed
 #   - "allow" with a from list restricts imports to those packages only
+#   - writer modules declare their owned surfaces in the module docstring as
+#     "Writer module: <tier>[, <tier>]". The policy is the audited inventory.
+#   - durability/interruption pairs are deliberately distinct: durable writes
+#     are atomic, rebuildable writes are replayable, and ops writes restart.
+#   - a module may own multiple tiers only through a named twin-write contract.
+
+writer_modules:
+  marker: "Writer module:"
+  # This boundary inventories tier-owning archive facade modules. Lower-level
+  # query helpers execute on caller-supplied connections and do not own tiers.
+  mutation_roots: [polylogue/storage/sqlite/archive_tiers]
+  modules:
+    - path: polylogue/storage/sqlite/archive_tiers/archive.py
+      surfaces:
+        - tier: index
+          durability: rebuildable
+          interruption: replayable
+      entrypoints: [delete_sessions]
+    - path: polylogue/storage/sqlite/archive_tiers/source_write.py
+      surfaces:
+        - tier: source
+          durability: durable
+          interruption: atomic
+      entrypoints: [apply_source_raw_state_update, write_history_sidecar, write_source_raw_session, write_source_raw_session_blob_ref]
+    - path: polylogue/storage/sqlite/archive_tiers/write.py
+      surfaces:
+        - tier: index
+          durability: rebuildable
+          interruption: replayable
+        - tier: user
+          durability: durable
+          interruption: atomic
+      entrypoints:
+        [apply_insight_materialization, rebuild_archive_messages_fts, upsert_session_phase, upsert_session_profile_costs,
+        upsert_session_tag, upsert_session_work_event, write_parsed_session_to_archive]
+      twin_write_contract: session-tag-assertion-mirror
+    - path: polylogue/storage/sqlite/archive_tiers/embedding_write.py
+      surfaces:
+        - tier: embeddings
+          durability: rebuildable
+          interruption: replayable
+      entrypoints: [mark_session_embedding_error, upsert_message_embeddings]
+    - path: polylogue/storage/sqlite/archive_tiers/user_write.py
+      surfaces:
+        - tier: user
+          durability: durable
+          interruption: atomic
+      entrypoints: [mark_assertion_status, upsert_assertion]
+    - path: polylogue/storage/sqlite/archive_tiers/ops_write.py
+      surfaces:
+        - tier: ops
+          durability: disposable
+          interruption: restartable
+      entrypoints:
+        [add_convergence_debt, record_cursor_lag_sample, record_daemon_stage_event, record_ingest_attempt,
+        upsert_embedding_catchup_run, upsert_ingest_cursor, upsert_otlp_span]
+    - path: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
+      surfaces:
+        - tier: index
+          durability: rebuildable
+          interruption: replayable
+      entrypoints: [record_capture_gap_event]
+    - path: polylogue/storage/sqlite/archive_tiers/pricing_seed.py
+      surfaces:
+        - tier: index
+          durability: rebuildable
+          interruption: replayable
+      entrypoints: [seed_price_catalog]
+  twin_write_contracts:
+    - name: session-tag-assertion-mirror
+      module: polylogue/storage/sqlite/archive_tiers/write.py
+      surfaces: [index, user]
+      entrypoints: [upsert_session_tag]
+      reason: "Legacy single-file archives co-locate assertions; a user tag mirrors to its durable assertion only when that table is present."
 
 rules:
   - target: polylogue/cli

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1,4 +1,7 @@
-"""Small archive-root façade over archive source/index/user tiers."""
+"""Small archive-root façade over archive source/index/user tiers.
+
+Writer module: index.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/storage/sqlite/archive_tiers/embedding_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/embedding_write.py
@@ -1,4 +1,7 @@
-"""Archive embedding metadata write helpers."""
+"""Archive embedding metadata write helpers.
+
+Writer module: embeddings.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
+++ b/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
@@ -1,4 +1,7 @@
-"""Shared archive write precedence helpers."""
+"""Shared archive write precedence helpers.
+
+Writer module: index.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -1,4 +1,7 @@
-"""Minimal ops-tier archive read/write helpers."""
+"""Minimal ops-tier archive read/write helpers.
+
+Writer module: ops.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
+++ b/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
@@ -11,6 +11,8 @@ Design constraints:
 - The catalog_id is a deterministic slug so re-seeding is idempotent.
 - INSERT … ON CONFLICT DO NOTHING on both tables: re-running after a
   schema-version bump (wipe-and-reinit) or daemon restart is safe.
+
+Writer module: index.
 """
 
 from __future__ import annotations

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -1,4 +1,7 @@
-"""Raw-capture writer/read helpers for source.db."""
+"""Raw-capture writer/read helpers for source.db.
+
+Writer module: source.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -2,6 +2,8 @@
 
 These functions are intentionally narrow: they provide deterministic upsert
 helpers and compact envelope readers for user-only tables in ``user.py``.
+
+Writer module: user.
 """
 
 from __future__ import annotations

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1,4 +1,8 @@
-"""Minimal archive index parsed-session writer/read helpers."""
+"""Minimal archive index parsed-session writer/read helpers.
+
+Writer module: index, user.
+Twin-write contract: session-tag-assertion-mirror.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -8,9 +8,9 @@ are caught during validation rather than silently ignored.
 from __future__ import annotations
 
 from datetime import date
-from typing import ClassVar
+from typing import ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # ──────────────────────────────────────────────────────────────────────
 # Topology manifest        (topology-target.yaml)
@@ -273,10 +273,66 @@ class LayeringRule(BaseModel):
     allow: LayeringConstraint | None = None
 
 
+class WriterModuleSurface(BaseModel):
+    """Durability and interruption contract for one writer-owned tier."""
+
+    model_config = ConfigDict(extra="forbid")
+    tier: Literal["source", "index", "embeddings", "user", "ops"]
+    durability: Literal["durable", "rebuildable", "disposable"]
+    interruption: Literal["atomic", "replayable", "restartable"]
+
+    _TIER_CONTRACTS: ClassVar[dict[str, tuple[str, str]]] = {
+        "source": ("durable", "atomic"),
+        "index": ("rebuildable", "replayable"),
+        "embeddings": ("rebuildable", "replayable"),
+        "user": ("durable", "atomic"),
+        "ops": ("disposable", "restartable"),
+    }
+
+    @model_validator(mode="after")
+    def _check_tier_contract(self) -> WriterModuleSurface:
+        expected = self._TIER_CONTRACTS[self.tier]
+        if (self.durability, self.interruption) != expected:
+            raise ValueError(f"{self.tier} requires durability/interruption {expected}")
+        return self
+
+
+class WriterModuleEntry(BaseModel):
+    """One production module that owns one or more SQLite write surfaces."""
+
+    model_config = ConfigDict(extra="forbid")
+    path: str
+    surfaces: list[WriterModuleSurface] = Field(min_length=1)
+    entrypoints: list[str] = Field(min_length=1)
+    twin_write_contract: str | None = None
+
+
+class TwinWriteContract(BaseModel):
+    """Explicit exception for one module that atomically spans two tiers."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    module: str
+    surfaces: list[Literal["source", "index", "embeddings", "user", "ops"]] = Field(min_length=2)
+    entrypoints: list[str] = Field(min_length=1)
+    reason: str
+
+
+class WriterModulePolicy(BaseModel):
+    """Production writer-module inventory and its interruption doctrine."""
+
+    model_config = ConfigDict(extra="forbid")
+    marker: str = "Writer module:"
+    mutation_roots: list[str] = Field(min_length=1)
+    modules: list[WriterModuleEntry] = Field(min_length=1)
+    twin_write_contracts: list[TwinWriteContract] = Field(default_factory=list)
+
+
 class LayeringManifest(BaseModel):
     """Root of layering.yaml."""
 
     model_config = ConfigDict(extra="forbid")
+    writer_modules: WriterModulePolicy | None = None
     rules: list[LayeringRule]
 
 
@@ -670,6 +726,10 @@ __all__ = [
     "FuzzTool",
     "LayeringManifest",
     "LayeringRule",
+    "TwinWriteContract",
+    "WriterModuleEntry",
+    "WriterModulePolicy",
+    "WriterModuleSurface",
     "LintEscalationManifest",
     "LintRule",
     "MANIFEST_MODELS",

--- a/tests/unit/devtools/test_topology_gates.py
+++ b/tests/unit/devtools/test_topology_gates.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -282,3 +283,63 @@ def test_package_matches_exact_and_prefix() -> None:
     assert verify_layering._package_matches("polylogue/cli", "polylogue.cli") is True
     assert verify_layering._package_matches("polylogue/cli", "polylogue.storage") is False
     assert verify_layering._package_matches("polylogue/cli", "polylogue.cliclone") is False
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ARCHIVE_TIERS_RELATIVE = Path("polylogue/storage/sqlite/archive_tiers")
+
+
+def _production_writer_policy() -> verify_layering.WriterModulePolicy:
+    manifest = verify_layering._load_manifest(_REPO_ROOT / "docs/plans/layering.yaml")
+    policy = verify_layering._writer_module_policy(manifest)
+    assert policy is not None
+    return policy
+
+
+def _copy_production_writer_surface(tmp_path: Path) -> Path:
+    destination = tmp_path / _ARCHIVE_TIERS_RELATIVE
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_REPO_ROOT / _ARCHIVE_TIERS_RELATIVE, destination)
+    return destination
+
+
+def test_layering_production_writer_inventory_passes() -> None:
+    policy = _production_writer_policy()
+
+    assert verify_layering._collect_writer_module_violations(_REPO_ROOT, policy) == []
+
+
+def test_layering_unmarked_production_writer_mutation_fails(tmp_path: Path) -> None:
+    writer_root = _copy_production_writer_surface(tmp_path)
+    source_writer = writer_root / "source_write.py"
+    source_writer.write_text(
+        source_writer.read_text(encoding="utf-8").replace("Writer module: source.\n", ""),
+        encoding="utf-8",
+    )
+
+    violations = verify_layering._collect_writer_module_violations(tmp_path, _production_writer_policy())
+
+    assert any(
+        violation["file"] == "polylogue/storage/sqlite/archive_tiers/source_write.py"
+        and violation["rule"] == "writer_module_unmarked_mutation"
+        for violation in violations
+    )
+
+
+def test_layering_user_ops_mutation_fails_without_a_twin_write_contract(tmp_path: Path) -> None:
+    writer_root = _copy_production_writer_surface(tmp_path)
+    user_writer = writer_root / "user_write.py"
+    user_writer.write_text(
+        user_writer.read_text(encoding="utf-8")
+        + "\n\ndef upsert_ops_control_plane(conn: sqlite3.Connection) -> None:\n"
+        + '    conn.execute("INSERT INTO ingest_cursor (source_path, updated_at_ms) VALUES (?, ?)", ("test", 0))\n',
+        encoding="utf-8",
+    )
+
+    violations = verify_layering._collect_writer_module_violations(tmp_path, _production_writer_policy())
+
+    assert any(
+        violation["file"] == "polylogue/storage/sqlite/archive_tiers/user_write.py"
+        and violation["rule"] == "writer_module_observed_tier_mismatch"
+        for violation in violations
+    )

--- a/tests/unit/devtools/test_topology_gates.py
+++ b/tests/unit/devtools/test_topology_gates.py
@@ -343,3 +343,48 @@ def test_layering_user_ops_mutation_fails_without_a_twin_write_contract(tmp_path
         and violation["rule"] == "writer_module_observed_tier_mismatch"
         for violation in violations
     )
+
+
+def test_layering_delegated_public_writer_is_inventoried(tmp_path: Path) -> None:
+    writer_root = _copy_production_writer_surface(tmp_path)
+    source_writer = writer_root / "source_write.py"
+    source_writer.write_text(
+        source_writer.read_text(encoding="utf-8")
+        + "\n\ndef publish_raw_revision(conn: sqlite3.Connection) -> None:\n"
+        + "    _publish_raw_revision(conn)\n\n"
+        + "def _publish_raw_revision(conn: sqlite3.Connection) -> None:\n"
+        + '    conn.execute("UPDATE raw_sessions SET parsed_at_ms = 0")\n',
+        encoding="utf-8",
+    )
+
+    violations = verify_layering._collect_writer_module_violations(tmp_path, _production_writer_policy())
+
+    mismatch = next(
+        violation
+        for violation in violations
+        if violation["file"] == "polylogue/storage/sqlite/archive_tiers/source_write.py"
+        and violation["rule"] == "writer_module_entrypoint_inventory_mismatch"
+    )
+    observed = mismatch.get("observed")
+    assert isinstance(observed, list)
+    assert "publish_raw_revision" in observed
+
+
+def test_layering_imported_sql_cannot_hide_a_mutation(tmp_path: Path) -> None:
+    writer_root = _copy_production_writer_surface(tmp_path)
+    source_writer = writer_root / "source_write.py"
+    source_writer.write_text(
+        source_writer.read_text(encoding="utf-8")
+        + "\nfrom tests.fixtures.sql import HIDDEN_MUTATION_SQL\n\n"
+        + "def run_hidden_mutation(conn: sqlite3.Connection) -> None:\n"
+        + "    conn.execute(HIDDEN_MUTATION_SQL)\n",
+        encoding="utf-8",
+    )
+
+    violations = verify_layering._collect_writer_module_violations(tmp_path, _production_writer_policy())
+
+    assert any(
+        violation["file"] == "polylogue/storage/sqlite/archive_tiers/source_write.py"
+        and violation["rule"] == "writer_module_imported_sql_opaque"
+        for violation in violations
+    )


### PR DESCRIPTION
## Summary

Replace the vacuous class-docstring writer check with an audited inventory of real archive-tier writer modules and their durability/interruption contracts.

## Problem

The previous gate only inspected classes that voluntarily carried a marker. Polylogue's production writers are module-level functions, so the gate could pass while checking no real write path. It also grouped durable `user.db` and disposable `ops.db` writes into one class, obscuring the interruption behavior the doctrine is meant to protect.

## Solution

- Inventory each tier-owning module under `archive_tiers`, its public mutation entry points, and its durability/interruption contract.
- Infer direct SQL mutation surfaces from the canonical tier DDL and reject unmarked writer modules, stale entry-point inventories, and declared/observed tier mismatches.
- Require an explicit audited contract for the legacy index/user tag mirror.
- Copy and mutate the production writer surface in tests, so removing a marker or adding an `ops` mutation to the `user` writer makes the gate fail.
- Keep lower-level query helpers outside this ownership boundary: they execute on caller-supplied connections and do not select or own archive tiers.

Ref polylogue-cpf.2

## Verification

- `uv run devtools verify layering --json` -> `{"violations":[],"count":0}`
- `uv run devtools test tests/unit/devtools/test_topology_gates.py -k layering` -> `6 passed, 11 deselected`
- `uv run devtools verify --quick` -> 13/13 steps passed in 41.83s
- Pre-push quick gate -> 13/13 steps passed in 18.58s
