### PR TITLE
perf(storage): bound revision census memory

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -2761,7 +2761,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 147
+    loc: 229
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import os
+import pickle
+import sqlite3
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
+from types import TracebackType
 
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Provider
@@ -28,13 +34,18 @@ def backfill_historical_revision_evidence(
     *,
     selected_raw_ids: list[str] | None = None,
     owned_inactive_generation: tuple[str, str] | None = None,
+    retention_observer: Callable[[int, int], None] | None = None,
 ) -> RevisionBackfillResult:
-    """Census every retained raw, then replay byte and bundle authority cohorts."""
+    """Census every retained raw, then replay byte and bundle authority cohorts.
+
+    Parser output is spilled beside the target archive during the census and
+    loaded one logical authority cohort at a time. Peak retained session trees
+    therefore follow the largest raw/cohort, not the archive-wide raw count.
+    """
     scanned = 0
     classified = 0
     quarantined = 0
     logical_keys: set[str] = set()
-    parsed_by_raw: dict[str, list[ParsedSession]] = {}
     archive_context = (
         ArchiveStore.open_owned_inactive_generation(
             archive_root,
@@ -44,7 +55,7 @@ def backfill_historical_revision_evidence(
         if owned_inactive_generation is not None
         else ArchiveStore.open_existing(archive_root, read_only=False)
     )
-    with archive_context as archive:
+    with archive_context as archive, _ParsedSessionSpill(archive_root) as spill:
         for raw_id, source_index in archive.raw_membership_census_rows():
             scanned += 1
             if source_index < 0:
@@ -58,8 +69,7 @@ def backfill_historical_revision_evidence(
                 quarantined += 1
                 continue
             try:
-                provider, payload, source_path, _kind = archive.raw_revision_material(raw_id)
-                sessions = _parse_one(provider, payload, source_path)
+                sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
             except Exception as exc:
                 archive.replace_raw_membership_census(
                     raw_id,
@@ -70,7 +80,8 @@ def backfill_historical_revision_evidence(
                 )
                 quarantined += 1
                 continue
-            parsed_by_raw[raw_id] = sessions
+            classified += int(len(sessions) == 1)
+            spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
             archive.replace_raw_membership_census(
                 raw_id,
                 sessions,
@@ -80,8 +91,6 @@ def backfill_historical_revision_evidence(
 
         _unclassified, selected_keys = archive.raw_revision_rebuild_selection(selected_raw_ids)
         logical_keys.update(selected_keys)
-        classified = sum(1 for sessions in parsed_by_raw.values() if len(sessions) == 1)
-
         _selected_membership_raws, membership_keys = archive.expand_raw_membership_selection(selected_raw_ids)
 
         replayed = 0
@@ -90,11 +99,15 @@ def backfill_historical_revision_evidence(
             if not plan.accepted_raw_ids:
                 continue
             parsed_by_raw_id: dict[str, ParsedSession] = {}
+            retained_bytes = 0
             for raw_id in plan.accepted_raw_ids:
-                sessions = parsed_by_raw.get(raw_id, [])
+                sessions, payload_bytes = spill.for_raw(raw_id)
                 if len(sessions) != 1:
                     raise RuntimeError(f"classified raw revision {raw_id} no longer parses to one session")
                 parsed_by_raw_id[raw_id] = sessions[0]
+                retained_bytes += payload_bytes
+            if retention_observer is not None:
+                retention_observer(len(parsed_by_raw_id), retained_bytes)
             archive.apply_raw_revision_replay(plan, parsed_by_raw_id, acquired_at_ms=0)
             replayed += 1
 
@@ -104,14 +117,15 @@ def backfill_historical_revision_evidence(
             member_sessions: dict[str, ParsedSession] = {}
             revisions: list[MembershipRevision] = []
             projections = {}
-            for raw_id, sessions in parsed_by_raw.items():
-                for session in sessions:
-                    if f"{session.source_name.value}:{session.provider_session_id}" != logical_key:
-                        continue
-                    projection = session_revision_projection(session)
-                    member_sessions[raw_id] = session
-                    projections[raw_id] = projection
-                    revisions.append(MembershipRevision(raw_id, projection))
+            retained_bytes = 0
+            for raw_id, session, payload_bytes in spill.for_logical_key(logical_key):
+                projection = session_revision_projection(session)
+                member_sessions[raw_id] = session
+                projections[raw_id] = projection
+                revisions.append(MembershipRevision(raw_id, projection))
+                retained_bytes += payload_bytes
+            if retention_observer is not None:
+                retention_observer(len(member_sessions), retained_bytes)
             classification = classify_membership_revisions(revisions)
             if classification.ambiguous_raw_ids:
                 quarantined += len(classification.ambiguous_raw_ids)
@@ -125,6 +139,74 @@ def backfill_historical_revision_evidence(
             if classification.accepted_raw_ids:
                 replayed += 1
     return RevisionBackfillResult(scanned, classified, replayed, quarantined)
+
+
+def _parse_retained_raw(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:
+    provider, payload, source_path, _kind = archive.raw_revision_material(raw_id)
+    return _parse_one(provider, payload, source_path), len(payload)
+
+
+class _ParsedSessionSpill:
+    """Disk-backed parser output cache bounded by one logical replay cohort."""
+
+    def __init__(self, archive_root: Path) -> None:
+        fd, name = tempfile.mkstemp(prefix=".revision-census-", suffix=".sqlite", dir=archive_root)
+        os.close(fd)
+        self.path = Path(name)
+        self.conn = sqlite3.connect(self.path)
+        self.conn.execute(
+            """
+            CREATE TABLE parsed_sessions (
+                raw_id TEXT NOT NULL,
+                logical_key TEXT NOT NULL,
+                payload_bytes INTEGER NOT NULL,
+                parsed BLOB NOT NULL,
+                PRIMARY KEY(raw_id, logical_key)
+            ) STRICT
+            """
+        )
+        self.conn.execute("CREATE INDEX parsed_sessions_logical ON parsed_sessions(logical_key, raw_id)")
+
+    def __enter__(self) -> _ParsedSessionSpill:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.conn.close()
+        self.path.unlink(missing_ok=True)
+
+    def add(self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int) -> None:
+        with self.conn:
+            self.conn.executemany(
+                "INSERT INTO parsed_sessions(raw_id, logical_key, payload_bytes, parsed) VALUES (?, ?, ?, ?)",
+                (
+                    (
+                        raw_id,
+                        f"{session.source_name.value}:{session.provider_session_id}",
+                        payload_bytes,
+                        pickle.dumps(session, protocol=pickle.HIGHEST_PROTOCOL),
+                    )
+                    for session in sessions
+                ),
+            )
+
+    def for_raw(self, raw_id: str) -> tuple[list[ParsedSession], int]:
+        rows = self.conn.execute(
+            "SELECT parsed, payload_bytes FROM parsed_sessions WHERE raw_id = ? ORDER BY logical_key", (raw_id,)
+        ).fetchall()
+        return [pickle.loads(bytes(row[0])) for row in rows], int(rows[0][1]) if rows else 0
+
+    def for_logical_key(self, logical_key: str) -> list[tuple[str, ParsedSession, int]]:
+        rows = self.conn.execute(
+            "SELECT raw_id, parsed, payload_bytes FROM parsed_sessions WHERE logical_key = ? ORDER BY raw_id",
+            (logical_key,),
+        ).fetchall()
+        return [(str(row[0]), pickle.loads(bytes(row[1])), int(row[2])) for row in rows]
 
 
 def _parse_one(provider: Provider, payload: bytes, source_path: str) -> list[ParsedSession]:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -390,3 +390,42 @@ def test_targeted_rebuild_expands_same_session_across_source_paths_only(tmp_path
         assert conn.execute(
             "SELECT decision FROM raw_session_memberships WHERE raw_id = ?", (unrelated_raw,)
         ).fetchone() == (None,)
+
+
+def test_membership_census_retains_only_one_logical_cohort_at_scale(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    independent_raw_count = 64
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(independent_raw_count):
+            payload = _bundle(_chatgpt_session(f"session-{index}", f"message-{index}"))
+            archive.write_raw_payload(
+                provider=Provider.CHATGPT,
+                payload=payload,
+                source_path=f"bundle-{index}.json",
+                acquired_at_ms=index + 1,
+            )
+        shared_payloads = [
+            _bundle(_chatgpt_session("shared", "base")),
+            _bundle(_chatgpt_session("shared", "base", "new")),
+        ]
+        for index, payload in enumerate(shared_payloads, start=1):
+            archive.write_raw_payload(
+                provider=Provider.CHATGPT,
+                payload=payload,
+                source_path=f"shared-{index}.json",
+                acquired_at_ms=independent_raw_count + index,
+            )
+    raw_count = independent_raw_count + len(shared_payloads)
+
+    retained: list[tuple[int, int]] = []
+    result = backfill_historical_revision_evidence(
+        tmp_path,
+        retention_observer=lambda count, payload_bytes: retained.append((count, payload_bytes)),
+    )
+
+    assert result.scanned == raw_count
+    assert result.replayed_logical_sources == independent_raw_count + 1
+    assert len(retained) == independent_raw_count + 1
+    assert max(count for count, _payload_bytes in retained) == 2
+    assert max(payload_bytes for _count, payload_bytes in retained) == sum(map(len, shared_payloads))
+    assert sum(count for count, _payload_bytes in retained) == raw_count


### PR DESCRIPTION
## Summary

Replaces archive-wide retention of parsed raw payloads during revision backfill with a disk-backed census spill. Replay loads only one selected logical authority cohort at a time while preserving the existing database-driven fixed-point, byte-revision, and bundle-membership classification semantics.

## Problem

Production dogfood of the schema-v32 inactive-generation rebuild was safely aborted before promotion after RSS grew from 2.4 GiB to 6.9 GiB while membership census had processed only 1,452 of 18,013 retained raws. `revision_backfill.py` kept `parsed_by_raw` for every censused raw, so memory grew with the entire archive and would exhaust the host long before replay.

The active v30 index was not promoted or mutated by the aborted candidate.

## Solution

- Persist each parsed session tree in a temporary SQLite spill beside the target archive as soon as its durable membership census row is written.
- Keep fixed-point cohort expansion in `source.db`; no authority or ordering decision depends on spill enumeration.
- Load only accepted byte-revision raws or one bundle member's logical cohort for classification/application, then release it before the next cohort.
- Remove the spill on success and ordinary exception paths.
- Add an observer-backed scale regression with 66 retained raws, 64 distinct bundle-member cohorts, and one two-revision shared cohort. Peak retained parsed count is exactly the maximum cohort size (2), independent of total raw count.

Tradeoff: the spill adds local NVMe writes proportional to parsed session output. That is deliberate: production evidence showed RAM, not sequential local storage, is the binding resource. Each retained raw is parsed once; bundle members are loaded from the spill rather than reparsing a large bundle per member.

Ref polylogue-nkmy.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/storage/test_revision_replay.py tests/unit/storage/test_revision_application.py tests/unit/storage/test_raw_revision_authority.py` -> 35 passed
- `devtools verify --quick` -> 13/13 steps passed in 42.21s
