### PR TITLE
fix(status): validate actions view readiness

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -178,12 +178,21 @@ def _valid_port(value: str) -> int | None:
     return port if 0 < port < 65536 else None
 
 
-def _table_exists(conn: Any, table_name: str) -> bool:
+def _schema_object_exists(conn: Any, name: str, *, types: Sequence[str]) -> bool:
+    placeholders = ", ".join("?" for _ in types)
     row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
-        (table_name,),
+        f"SELECT 1 FROM sqlite_master WHERE type IN ({placeholders}) AND name = ? LIMIT 1",
+        (*types, name),
     ).fetchone()
     return row is not None
+
+
+def _table_exists(conn: Any, table_name: str) -> bool:
+    return _schema_object_exists(conn, table_name, types=("table",))
+
+
+def _view_exists(conn: Any, view_name: str) -> bool:
+    return _schema_object_exists(conn, view_name, types=("view",))
 
 
 def _archive_index_path(db: Any) -> Any | None:
@@ -825,12 +834,35 @@ def _archive_readiness_counts(
         "root_thread_count": insight_status.root_threads,
         "stale_thread_count": insight_status.stale_thread_count,
         "orphan_thread_count": insight_status.orphan_thread_count,
-        "action_count": _fast_count(conn, "SELECT COUNT(*) FROM actions") if _table_exists(conn, "actions") else 0,
+        **_action_readiness_counts(conn),
         "missing_session_profile_materialization": insight_status.missing_session_profile_materialization_count,
         "missing_work_events_materialization": insight_status.missing_work_event_materialization_count,
         "missing_phases_materialization": insight_status.missing_phase_materialization_count,
         "missing_thread_materialization": insight_status.missing_thread_materialization_count,
         "missing_latency_materialization": insight_status.missing_latency_materialization_count,
+    }
+
+
+def _action_readiness_counts(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Return exact, non-vacuous evidence for the derived ``actions`` view."""
+    tool_use_block_count = (
+        _fast_count(conn, "SELECT COUNT(*) FROM blocks WHERE block_type = 'tool_use'")
+        if _table_exists(conn, "blocks")
+        else 0
+    )
+    actions_view_present = _view_exists(conn, "actions")
+    action_count = 0
+    actions_view_error: str | None = None
+    if actions_view_present:
+        try:
+            action_count = _fast_count(conn, "SELECT COUNT(*) FROM actions")
+        except sqlite3.Error as exc:
+            actions_view_error = str(exc)
+    return {
+        "action_count": action_count,
+        "tool_use_block_count": tool_use_block_count,
+        "actions_view_present": actions_view_present,
+        "actions_view_error": actions_view_error,
     }
 
 
@@ -897,6 +929,13 @@ def _archive_status_surfaces(counts: dict[str, Any], *, source_check_available: 
     )
     thread_blockers.extend(mismatch_blocker("thread_count", "root_thread_count", "thread_root_mismatch"))
     latency_ready, latency_blockers = materialized("latency")
+    tool_usage_blockers: list[str] = []
+    if not bool(counts.get("actions_view_present", False)):
+        tool_usage_blockers.append("actions_view_missing")
+    elif counts.get("actions_view_error"):
+        tool_usage_blockers.append("actions_view_unreadable")
+    elif count("tool_use_block_count") != count("action_count"):
+        tool_usage_blockers.append("actions_tool_use_count_mismatch")
 
     return {
         "archive_sessions": surface(
@@ -968,7 +1007,16 @@ def _archive_status_surfaces(counts: dict[str, Any], *, source_check_available: 
                 "orphan_thread_count": count("orphan_thread_count"),
             },
         ),
-        "tool_usage": surface(ready=True, blockers=[], evidence={"action_count": count("action_count")}),
+        "tool_usage": surface(
+            ready=not tool_usage_blockers,
+            blockers=tool_usage_blockers,
+            evidence={
+                "action_count": count("action_count"),
+                "tool_use_block_count": count("tool_use_block_count"),
+                "actions_view_present": bool(counts.get("actions_view_present", False)),
+                "actions_view_error": counts.get("actions_view_error"),
+            },
+        ),
         "latency_profiles": surface(
             ready=latency_ready,
             blockers=latency_blockers,

--- a/tests/unit/cli/commands/test_status.py
+++ b/tests/unit/cli/commands/test_status.py
@@ -12,6 +12,7 @@ from polylogue.cli.commands.status import (
     _ARCHIVE_FACADE_ROUTES,
     _ARCHIVE_TIER_ENUM,
     _BUILTIN_DAEMON_URL,
+    _action_readiness_counts,
     _archive_cli_route_status,
     _archive_facade_route_status,
     _archive_one_tier_status,
@@ -31,6 +32,7 @@ from polylogue.cli.commands.status import (
     _fmt_bytes,
     _parse_cmdline_api_port,
     _table_exists,
+    _view_exists,
 )
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -443,6 +445,60 @@ class TestTableExists:
         finally:
             conn.close()
 
+    def test_view_is_not_a_table_but_is_a_schema_view(self, tmp_path: Path) -> None:
+        conn = sqlite3.connect(tmp_path / "test.db")
+        try:
+            conn.execute("CREATE TABLE base (id INTEGER)")
+            conn.execute("CREATE VIEW derived AS SELECT id FROM base")
+            assert _table_exists(conn, "derived") is False
+            assert _view_exists(conn, "derived") is True
+        finally:
+            conn.close()
+
+
+class TestActionReadinessCounts:
+    def test_real_index_schema_exposes_queryable_empty_actions_view(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "index.db"
+        initialize_archive_database(db_path, ArchiveTier.INDEX)
+        with sqlite3.connect(db_path) as conn:
+            assert _action_readiness_counts(conn) == {
+                "action_count": 0,
+                "tool_use_block_count": 0,
+                "actions_view_present": True,
+                "actions_view_error": None,
+            }
+
+    def test_removed_actions_view_is_reported_absent(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "index.db"
+        initialize_archive_database(db_path, ArchiveTier.INDEX)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DROP VIEW actions")
+            counts = _action_readiness_counts(conn)
+        assert counts["actions_view_present"] is False
+
+    def test_broken_actions_view_is_reported_unreadable(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "index.db"
+        initialize_archive_database(db_path, ArchiveTier.INDEX)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DROP VIEW actions")
+            conn.execute("CREATE VIEW actions AS SELECT * FROM missing_action_source")
+            counts = _action_readiness_counts(conn)
+        assert counts["actions_view_present"] is True
+        assert counts["actions_view_error"] is not None
+
+    def test_partial_actions_view_exposes_exact_cardinality_mismatch(self, tmp_path: Path) -> None:
+        with sqlite3.connect(tmp_path / "partial.db") as conn:
+            conn.execute("CREATE TABLE blocks (block_type TEXT NOT NULL)")
+            conn.executemany("INSERT INTO blocks VALUES (?)", [("tool_use",), ("tool_use",)])
+            conn.execute("CREATE INDEX blocks_type_idx ON blocks(block_type)")
+            conn.execute("CREATE VIEW actions AS SELECT rowid FROM blocks WHERE block_type = 'tool_use' AND rowid = 1")
+            counts = _action_readiness_counts(conn)
+        result = _archive_status_surfaces({**counts, "missing_latency_materialization": 0}, source_check_available=True)
+        assert counts["tool_use_block_count"] == 2
+        assert counts["action_count"] == 1
+        assert result["tool_usage"]["ready"] is False
+        assert result["tool_usage"]["blockers"] == ["actions_tool_use_count_mismatch"]
+
 
 class TestColumnExists:
     """Tests for _column_exists()."""
@@ -790,9 +846,8 @@ class TestArchiveStatusSurfaces:
         assert result["archive_sessions"]["ready"] is True
         assert result["archive_sessions"]["blockers"] == []
 
-    def test_tool_usage_always_ready(self) -> None:
-        """tool_usage surface is always ready=True."""
-        counts: dict[str, int] = {
+    def test_tool_usage_ready_for_genuine_zero_tool_archive(self) -> None:
+        counts: dict[str, object] = {
             "session_count": 0,
             "raw_link_count": 0,
             "missing_raw_session_count": 0,
@@ -808,11 +863,38 @@ class TestArchiveStatusSurfaces:
             "thread_count": 0,
             "missing_thread_materialization": 0,
             "action_count": 0,
+            "tool_use_block_count": 0,
+            "actions_view_present": True,
+            "actions_view_error": None,
             "missing_session_profile_materialization": 0,
             "missing_latency_materialization": 0,
         }
         result = _archive_status_surfaces(counts, source_check_available=True)
         assert result["tool_usage"]["ready"] is True
+
+    @pytest.mark.parametrize(
+        ("overrides", "blocker"),
+        [
+            ({"actions_view_present": False}, "actions_view_missing"),
+            ({"actions_view_present": True, "actions_view_error": "broken"}, "actions_view_unreadable"),
+            (
+                {"actions_view_present": True, "actions_view_error": None, "tool_use_block_count": 1},
+                "actions_tool_use_count_mismatch",
+            ),
+        ],
+    )
+    def test_tool_usage_blocks_on_non_vacuous_action_failures(self, overrides: dict[str, object], blocker: str) -> None:
+        counts: dict[str, object] = {
+            "action_count": 0,
+            "tool_use_block_count": 0,
+            "actions_view_present": True,
+            "actions_view_error": None,
+            "missing_latency_materialization": 0,
+        }
+        counts.update(overrides)
+        result = _archive_status_surfaces(counts, source_check_available=True)
+        assert result["tool_usage"]["ready"] is False
+        assert result["tool_usage"]["blockers"] == [blocker]
 
     def test_raw_artifacts_unavailable_when_source_check_unavailable(self) -> None:
         """raw_artifacts shows ready=None when source_check_available is False."""


### PR DESCRIPTION
**Summary**

Make exact archive readiness recognize and validate the derived `actions` view instead of silently treating it as an absent table.

**Problem**

`_table_exists` restricted schema probes to `type = table`, but `actions` is a view. Production exact readiness therefore forced `action_count` to zero and reported tool usage ready even with thousands of `tool_use` blocks.

**Solution**

Add typed SQLite schema-object probes for tables and views. Tool-usage readiness now requires the `actions` view to exist, be queryable, and contain exactly one row per `tool_use` block. The indexed `blocks(block_type)` count keeps the source-side exact check bounded to the relevant covering index. Genuine zero-tool archives remain ready. Mutation tests remove, break, and partially filter the view.

**Verification**

- `devtools test tests/unit/cli/commands/test_status.py` -> 92 passed
- `devtools test tests/unit/devtools/test_daemon_workload_probe.py -k readiness` -> 1 passed, 25 deselected
- `devtools verify --quick` -> 13/13 steps passed in 19.24s

Production data and Beads were not modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive readiness checks for tool usage.
  * Readiness now detects missing, unreadable, or inconsistent action data and reports specific blockers.
  * Archive status evidence now includes action counts, tool-use block counts, and action view availability.
* **Tests**
  * Added coverage for action view detection, broken or missing views, and mismatched readiness counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->