### PR TITLE
fix(daemon): enable authority-safe raw convergence

### DIFF
--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -164,6 +164,7 @@ async def rebuild_index_from_source(
         "classified_full_count": result.classified_full,
         "replayed_logical_source_count": result.replayed_logical_sources,
         "quarantined_raw_count": result.quarantined,
+        "adoption_deferred_raw_count": result.adoption_deferred,
         "authority_selection_expanded": True,
     }
 

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -27,6 +27,7 @@ class RevisionBackfillResult:
     classified_full: int
     replayed_logical_sources: int
     quarantined: int
+    adoption_deferred: int = 0
 
 
 def backfill_historical_revision_evidence(
@@ -45,6 +46,7 @@ def backfill_historical_revision_evidence(
     scanned = 0
     classified = 0
     quarantined = 0
+    adoption_deferred = 0
     logical_keys: set[str] = set()
     archive_context = (
         ArchiveStore.open_owned_inactive_generation(
@@ -108,6 +110,11 @@ def backfill_historical_revision_evidence(
                 retained_bytes += payload_bytes
             if retention_observer is not None:
                 retention_observer(len(parsed_by_raw_id), retained_bytes)
+            accepted_sessions = [parsed_by_raw_id[raw_id] for raw_id in plan.accepted_raw_ids]
+            if not archive.raw_revision_replay_adoptable(accepted_sessions):
+                archive.defer_raw_revision_adoption(plan.logical_source_key, plan.accepted_raw_ids, accepted_sessions)
+                adoption_deferred += len(plan.accepted_raw_ids)
+                continue
             archive.apply_raw_revision_replay(plan, parsed_by_raw_id, acquired_at_ms=0)
             replayed += 1
 
@@ -129,6 +136,15 @@ def backfill_historical_revision_evidence(
             classification = classify_membership_revisions(revisions)
             if classification.ambiguous_raw_ids:
                 quarantined += len(classification.ambiguous_raw_ids)
+            accepted_sessions = [member_sessions[raw_id] for raw_id in classification.accepted_raw_ids]
+            if accepted_sessions and not archive.raw_revision_replay_adoptable(accepted_sessions):
+                archive.defer_raw_revision_adoption(
+                    logical_key,
+                    classification.accepted_raw_ids,
+                    accepted_sessions,
+                )
+                adoption_deferred += len(classification.accepted_raw_ids)
+                continue
             archive.apply_raw_membership_classification(
                 logical_key,
                 classification,
@@ -138,7 +154,7 @@ def backfill_historical_revision_evidence(
             )
             if classification.accepted_raw_ids:
                 replayed += 1
-    return RevisionBackfillResult(scanned, classified, replayed, quarantined)
+    return RevisionBackfillResult(scanned, classified, replayed, quarantined, adoption_deferred)
 
 
 def _parse_retained_raw(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -200,6 +200,23 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
                 raw_columns=raw_columns,
                 session_columns=session_columns,
             )
+            adoption_deferred_count = 0
+            if _table_columns(conn, "main", "raw_revision_applications"):
+                adoption_deferred_count = int(
+                    conn.execute(
+                        """
+                        SELECT COUNT(DISTINCT r.raw_id)
+                        FROM source.raw_sessions AS r
+                        JOIN main.raw_revision_applications AS a ON a.raw_id = r.raw_id
+                        WHERE a.decision = 'deferred'
+                          AND a.detail = 'ordinary_replay:incomparable_existing_index_state'
+                          AND NOT EXISTS (
+                              SELECT 1 FROM main.sessions AS s WHERE s.raw_id = r.raw_id
+                          )
+                        """
+                    ).fetchone()[0]
+                    or 0
+                )
             lost_source_evidence_count = _missing_source_raw_session_count(conn)
             lost_source_evidence_samples = _missing_source_raw_session_samples(conn)
     except Exception as exc:
@@ -232,8 +249,8 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
     actionable = len(parse_failed_origins)
     critical = actionable
     affected_actionable = parse_failed
-    unchecked = max(total - classified - affected_actionable, 0)
-    classification = "cheap_projection" if classified else "not_run"
+    unchecked = max(total - classified - affected_actionable - adoption_deferred_count, 0)
+    classification = "cheap_projection" if classified or adoption_deferred_count else "not_run"
     raw_id_join_gap_count = unchecked
     category_counts: dict[str, int] = {
         "raw_id_join_gap": raw_id_join_gap_count,
@@ -242,6 +259,8 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
         "raw_parse_failed": raw_parse_failed,
         "parsed_without_index_session": parsed_without_index_session,
     }
+    if adoption_deferred_count:
+        category_counts["adoption_deferred"] = adoption_deferred_count
     category_counts.update(
         {category: count for category, count in classified_counts.items() if category != "parse-failed"}
     )
@@ -257,12 +276,12 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
         "critical": critical,
         "warning": 0,
         "actionable": actionable,
-        "blocked": 0,
+        "blocked": adoption_deferred_count,
         "classified": classified,
         "unchecked": unchecked,
         "affected_total": total,
         "affected_actionable": affected_actionable,
-        "affected_blocked": 0,
+        "affected_blocked": adoption_deferred_count,
         "affected_open": 0,
         "affected_classified": classified,
         "affected_unchecked": unchecked,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -42,9 +42,8 @@ logger = get_logger(__name__)
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
-RAW_MATERIALIZATION_REPLAY_BLOCK_REASON = (
-    "raw source-to-index replay is disabled until per-session revision authority is implemented (Ref polylogue-yla8)"
-)
+RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
+_TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
 
 
 def _format_bytes(value: int) -> str:
@@ -69,6 +68,7 @@ class RawMaterializationCandidates:
     raw_source_paths: dict[str, str] = field(default_factory=dict)
     missing_blob_source_available: int = 0
     missing_blob_source_missing: int = 0
+    adoption_deferred: int = 0
 
     @property
     def total_blob_bytes(self) -> int:
@@ -158,7 +158,14 @@ def _raw_materialization_candidate_ids(
         rows = conn.execute(
             f"""
             SELECT r.raw_id, r.origin, r.native_id, r.source_path, r.blob_hash, r.blob_size, r.parsed_at_ms,
-                   r.parse_error
+                   r.parse_error,
+                   EXISTS (
+                       SELECT 1
+                       FROM index_tier.raw_revision_applications AS a
+                       WHERE a.raw_id = r.raw_id
+                         AND a.decision = 'deferred'
+                         AND a.detail = 'ordinary_replay:incomparable_existing_index_state'
+                   ) AS adoption_deferred
             FROM raw_sessions AS r
             LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
             LEFT JOIN index_tier.sessions AS s_by_native
@@ -174,6 +181,7 @@ def _raw_materialization_candidate_ids(
               )
               AND (
                 r.parse_error IS NULL
+                OR r.parse_error = 'OperationalError: database is locked'
                 OR (
                   r.parse_error LIKE 'decode:%No such file or directory:%'
                 )
@@ -190,7 +198,11 @@ def _raw_materialization_candidate_ids(
             """,
             params,
         ).fetchall()
+        adoption_deferred = 0
         for row in rows:
+            if bool(row["adoption_deferred"]):
+                adoption_deferred += 1
+                continue
             if row["parse_error"] and not _raw_materialization_retryable_missing_blob_error(row["parse_error"]):
                 continue
             if _raw_materialized_by_source_path_native(conn, row):
@@ -223,6 +235,7 @@ def _raw_materialization_candidate_ids(
         raw_source_paths=raw_source_paths,
         missing_blob_source_available=missing_blob_source_available,
         missing_blob_source_missing=missing_blob_source_missing,
+        adoption_deferred=adoption_deferred,
     )
 
 
@@ -235,7 +248,9 @@ def _raw_materialization_stream_safe(candidates: RawMaterializationCandidates, r
 def _raw_materialization_retryable_missing_blob_error(parse_error: object) -> bool:
     if not isinstance(parse_error, str):
         return False
-    return parse_error.startswith("decode:") and "No such file or directory" in parse_error
+    return parse_error == _TRANSIENT_LOCK_PARSE_ERROR or (
+        parse_error.startswith("decode:") and "No such file or directory" in parse_error
+    )
 
 
 def _raw_materialization_total_bytes(candidates: RawMaterializationCandidates, raw_ids: list[str]) -> int:
@@ -298,8 +313,8 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         return {
             "available": False,
             "reason": "source_or_index_tier_missing",
-            "execution_blocked": True,
-            "execution_block_reason": RAW_MATERIALIZATION_REPLAY_BLOCK_REASON,
+            "execution_blocked": False,
+            "execution_block_reason": None,
             "blocked_candidate_count": 0,
             "candidate_count": 0,
             "top_raw_rows": [],
@@ -330,11 +345,22 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
     oversized_stream_safe = [
         raw_id for raw_id in oversized_raw_ids if _raw_materialization_stream_safe(candidates, raw_id)
     ]
+    # Retained-raw authority replay currently loads blob bytes before handing
+    # them to the stream parser, so stream-capable format is diagnostic only.
+    resource_blocked_count = len(oversized_raw_ids)
+    blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred
     return {
         "available": True,
-        "execution_blocked": True,
-        "execution_block_reason": RAW_MATERIALIZATION_REPLAY_BLOCK_REASON,
-        "blocked_candidate_count": len(candidates.raw_ids),
+        "execution_blocked": blocked_candidate_count > 0,
+        "execution_block_reason": (
+            RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON
+            if resource_blocked_count
+            else "revision adoption deferred behind incomparable existing index state"
+            if candidates.adoption_deferred
+            else None
+        ),
+        "blocked_candidate_count": blocked_candidate_count,
+        "adoption_deferred_count": candidates.adoption_deferred,
         "candidate_count": len(candidates.raw_ids),
         "missing_blob_count": candidates.missing_blobs,
         "missing_blob_source_available_count": candidates.missing_blob_source_available,
@@ -1468,8 +1494,7 @@ def repair_raw_materialization(
     raw_artifact_limit: int | None = None,
     progress_callback: ProgressCallback | None = None,
 ) -> RepairResult:
-    """Report raw replay debt without applying authority-ambiguous revisions."""
-    del progress_callback
+    """Converge retained raws through typed per-session revision authority."""
     candidates = _raw_materialization_candidate_ids(
         config,
         raw_artifact_id=raw_artifact_id,
@@ -1496,6 +1521,7 @@ def repair_raw_materialization(
         "raw_materialization_max_blob_bytes": float(candidates.max_blob_bytes),
         "raw_materialization_selected_total_blob_bytes": float(selected_total_bytes),
         "raw_materialization_selected_max_blob_bytes": float(selected_max_bytes),
+        "raw_materialization_adoption_deferred_count": float(candidates.adoption_deferred),
     }
     if raw_artifact_limit is not None:
         metrics["raw_materialization_limit"] = float(raw_artifact_limit)
@@ -1513,44 +1539,108 @@ def repair_raw_materialization(
     ]
     if oversized_raw_ids:
         metrics["raw_materialization_oversized_count"] = float(len(oversized_raw_ids))
+        metrics["raw_materialization_resource_blocked_count"] = float(len(oversized_raw_ids))
         metrics["raw_materialization_execute_blob_limit_bytes"] = float(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)
     if oversized_stream_safe_raw_ids:
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
     if not raw_ids:
         detail = "Raw materialization ready"
+        if candidates.adoption_deferred:
+            detail = (
+                f"Raw materialization blocked: {candidates.adoption_deferred:,} revision adoption decision(s) "
+                "remain deferred behind incomparable existing index state"
+            )
         if missing_blobs:
             detail += f"; {_raw_materialization_missing_blob_detail(candidates, final=True)}"
         return _internal_derived_repair_result(
             "raw_materialization",
             repaired_count=0,
-            success=missing_blobs == 0,
+            success=missing_blobs == 0 and candidates.adoption_deferred == 0,
             detail=detail,
             metrics=metrics,
         )
-    metrics["raw_materialization_replay_blocked_count"] = float(len(raw_ids))
-    detail = (
-        f"Raw materialization blocked: {RAW_MATERIALIZATION_REPLAY_BLOCK_REASON}; "
-        f"left {len(raw_ids):,} of {len(candidate_raw_ids):,} selected replay candidate(s) pending; "
-        f"selected raw payload bytes total={_format_bytes(selected_total_bytes)}, "
-        f"largest={_format_bytes(selected_max_bytes)}"
-    )
     if dry_run:
-        detail = f"Preview only. {detail}"
-    if candidates.already_parsed:
-        detail += f"; {candidates.already_parsed:,} already parsed but not materialized"
-    if missing_blobs:
-        detail += f"; {_raw_materialization_missing_blob_detail(candidates, final=True)}"
+        detail = (
+            f"Would: classify and replay {len(raw_ids):,} selected raw row(s) through per-session revision authority; "
+            f"selected raw payload bytes total={_format_bytes(selected_total_bytes)}, "
+            f"largest={_format_bytes(selected_max_bytes)}"
+        )
+        if candidates.already_parsed:
+            detail += f"; {candidates.already_parsed:,} already parsed but not materialized"
+        if missing_blobs:
+            detail += f"; {_raw_materialization_missing_blob_detail(candidates, final=True)}"
+        if oversized_raw_ids:
+            detail += (
+                f"; {len(oversized_raw_ids):,} raw rows exceed replay size advisory "
+                f"{_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
+            )
+        if oversized_stream_safe_raw_ids:
+            detail += f"; {len(oversized_stream_safe_raw_ids):,} oversized stream-record raw rows are stream-capable"
+        return _internal_derived_repair_result(
+            "raw_materialization", repaired_count=0, success=False, detail=detail, metrics=metrics
+        )
+
+    from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
+
+    archive_root = _raw_materialization_archive_root(config)
+    oversized_raw_id_set = set(oversized_raw_ids)
+    executable_raw_ids = [raw_id for raw_id in raw_ids if raw_id not in oversized_raw_id_set]
+    metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
+    if executable_raw_ids:
+        replay = backfill_historical_revision_evidence(
+            archive_root,
+            selected_raw_ids=executable_raw_ids,
+        )
+    else:
+        from polylogue.sources.revision_backfill import RevisionBackfillResult
+
+        replay = RevisionBackfillResult(scanned=0, classified_full=0, replayed_logical_sources=0, quarantined=0)
+    remaining = _raw_materialization_candidate_ids(
+        config,
+        raw_artifact_id=raw_artifact_id,
+        provider=provider,
+        source_family=source_family,
+        source_root=source_root,
+    )
+    metrics.update(
+        {
+            "raw_materialization_scanned_raw_count": float(replay.scanned),
+            "raw_materialization_classified_full_count": float(replay.classified_full),
+            "raw_materialization_replayed_logical_source_count": float(replay.replayed_logical_sources),
+            "raw_materialization_quarantined_count": float(replay.quarantined),
+            "raw_materialization_adoption_deferred_count": float(replay.adoption_deferred),
+            "raw_materialization_remaining_candidate_count": float(len(remaining.raw_ids)),
+        }
+    )
+    success = (
+        not remaining.raw_ids
+        and remaining.missing_blobs == 0
+        and replay.adoption_deferred == 0
+        and remaining.adoption_deferred == 0
+    )
+    detail = (
+        f"Replayed {replay.replayed_logical_sources:,} logical source(s) through typed revision authority; "
+        f"{len(remaining.raw_ids):,} replay candidate(s) remain"
+    )
+    if replay.quarantined:
+        detail += f"; {replay.quarantined:,} ambiguous/legacy revision(s) quarantined"
+    if replay.adoption_deferred:
+        detail += f"; {replay.adoption_deferred:,} revision(s) deferred behind incomparable existing index state"
+    if remaining.adoption_deferred:
+        detail += f"; {remaining.adoption_deferred:,} deferred adoption decision(s) remain blocked"
     if oversized_raw_ids:
         detail += (
-            f"; {len(oversized_raw_ids):,} raw rows also exceed replay size limit "
+            f"; {len(oversized_raw_ids):,} non-stream-safe raw row(s) exceed execution limit "
             f"{_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
         )
-    if oversized_stream_safe_raw_ids:
-        detail += f"; {len(oversized_stream_safe_raw_ids):,} oversized stream-record raw rows are stream-capable"
+    if remaining.missing_blobs:
+        detail += f"; {_raw_materialization_missing_blob_detail(remaining, final=True)}"
+    if progress_callback is not None:
+        progress_callback(replay.replayed_logical_sources, detail)
     return _internal_derived_repair_result(
         "raw_materialization",
-        repaired_count=0,
-        success=False,
+        repaired_count=replay.replayed_logical_sources,
+        success=success,
         detail=detail,
         metrics=metrics,
     )

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1784,6 +1784,77 @@ class ArchiveStore:
         )
         return row is not None and bool(row[0])
 
+    def raw_revision_replay_adoptable(self, sessions: Sequence[ParsedSession]) -> bool:
+        """Return whether replay may adopt an existing ungoverned session."""
+        aggregate = merge_parsed_session_chunks(sessions)
+        if len(aggregate) != 1:
+            return False
+        session = aggregate[0]
+        session_id = str(make_session_id(session.source_name, session.provider_session_id))
+        row = self._conn.execute(
+            "SELECT content_hash FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            return True
+        governed = self._conn.execute(
+            "SELECT 1 FROM raw_revision_heads WHERE session_id = ? LIMIT 1",
+            (session_id,),
+        ).fetchone()
+        if governed is not None:
+            return True
+        existing_hash = row[0]
+        existing_hex = existing_hash.hex() if isinstance(existing_hash, bytes) else str(existing_hash or "")
+        return existing_hex == session_content_hash(session)
+
+    def defer_raw_revision_adoption(
+        self,
+        logical_source_key: str,
+        raw_ids: Sequence[str],
+        sessions: Sequence[ParsedSession],
+    ) -> None:
+        """Receipt a derived replay decision without rewriting source evidence."""
+        if not raw_ids:
+            return
+        source_conn = self._ensure_source_conn()
+        decided_at_ms = int(time.time() * 1000)
+        aggregate = merge_parsed_session_chunks(sessions)
+        if len(aggregate) != 1:
+            raise RuntimeError("deferred revision cohort did not compose to one session")
+        session = aggregate[0]
+        session_id = str(make_session_id(session.source_name, session.provider_session_id))
+        with self._conn:
+            for raw_id in raw_ids:
+                row = source_conn.execute(
+                    """
+                    SELECT COALESCE(r.source_revision, m.source_revision),
+                           COALESCE(r.acquisition_generation, m.acquisition_generation, 0)
+                    FROM raw_sessions AS r
+                    LEFT JOIN raw_session_memberships AS m
+                      ON m.raw_id = r.raw_id AND m.logical_source_key = ?
+                    WHERE r.raw_id = ?
+                    """,
+                    (logical_source_key, raw_id),
+                ).fetchone()
+                if row is None or row[0] is None:
+                    raise RuntimeError(f"deferred raw revision lacks source evidence: {raw_id}")
+                record_revision_application_sync(
+                    self._conn,
+                    RevisionApplicationReceipt(
+                        raw_id=raw_id,
+                        session_id=session_id,
+                        logical_source_key=logical_source_key,
+                        source_revision=str(row[0]),
+                        acquisition_generation=int(row[1]),
+                        decision=ApplicationDecision.DEFERRED,
+                        accepted_raw_id=None,
+                        accepted_source_revision=None,
+                        accepted_content_hash=None,
+                        detail="ordinary_replay:incomparable_existing_index_state",
+                    ),
+                    decided_at_ms=decided_at_ms,
+                )
+
     def apply_raw_revision_replay(
         self,
         plan: RevisionReplayPlan,

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -248,9 +248,9 @@ def test_raw_materialization_preview_counts_replayable_rows_without_erasing_miss
         "raw_materialization_max_blob_bytes": float(replayable_size),
         "raw_materialization_selected_total_blob_bytes": float(replayable_size),
         "raw_materialization_selected_max_blob_bytes": float(replayable_size),
-        "raw_materialization_replay_blocked_count": 1.0,
+        "raw_materialization_adoption_deferred_count": 0.0,
     }
-    assert "raw source-to-index replay is disabled" in result.detail
+    assert "per-session revision authority" in result.detail
     assert "selected raw payload bytes total=" in result.detail
     assert "largest=" in result.detail
     assert "1 raw rows remain blocked by missing blobs (1 with source paths missing)" in result.detail
@@ -300,7 +300,7 @@ def test_raw_materialization_replays_same_native_when_index_raw_link_is_dangling
     assert result.metrics["raw_materialization_candidate_count"] == 1.0
 
 
-def test_raw_materialization_split_root_reports_containment_from_routed_archive(tmp_path: Path) -> None:
+def test_raw_materialization_split_root_routes_authority_replay(tmp_path: Path) -> None:
     configured_root = tmp_path / "configured"
     routed_root = tmp_path / "routed"
     configured_root.mkdir()
@@ -337,14 +337,50 @@ def test_raw_materialization_split_root_reports_containment_from_routed_archive(
     backlog = repair_mod.raw_materialization_replay_backlog(config)
     result = repair_mod.repair_raw_materialization(config)
 
-    assert backlog["execution_blocked"] is True
-    assert backlog["execution_block_reason"] == repair_mod.RAW_MATERIALIZATION_REPLAY_BLOCK_REASON
-    assert backlog["blocked_candidate_count"] == 1
+    assert backlog["execution_blocked"] is False
+    assert backlog["execution_block_reason"] is None
+    assert backlog["blocked_candidate_count"] == 0
     assert backlog["candidate_count"] == 1
-    assert result.success is False
-    assert result.repaired_count == 0
+    assert result.success is True
+    assert result.repaired_count == 1
     assert result.metrics["raw_materialization_candidate_count"] == 1.0
-    assert result.metrics["raw_materialization_replay_blocked_count"] == 1.0
+    assert result.metrics["raw_materialization_selected_count"] == 1.0
+
+
+def test_raw_materialization_retries_typed_transient_lock_failure(tmp_path: Path) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    payload = (
+        b'{"type":"session_meta","payload":{"id":"lock-retry","timestamp":"2026-07-11T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"one","role":"user","content":'
+        b'[{"type":"input_text","text":"survives retry"}]}}\n'
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=payload,
+            source_path="lock-retry.jsonl",
+            acquired_at_ms=1,
+        )
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            "UPDATE raw_sessions SET parse_error = 'OperationalError: database is locked' WHERE raw_id = ?",
+            (raw_id,),
+        )
+        source_conn.commit()
+
+    result = repair_mod.repair_raw_materialization(_config(tmp_path), dry_run=False)
+
+    assert result.success is True
+    assert result.repaired_count == 1
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        assert source_conn.execute(
+            "SELECT parsed_at_ms IS NOT NULL, parse_error FROM raw_sessions WHERE raw_id = ?",
+            (raw_id,),
+        ).fetchone() == (1, None)
 
 
 def test_raw_materialization_split_root_classifies_parsed_sidecar_from_routed_blob(tmp_path: Path) -> None:
@@ -598,7 +634,7 @@ def test_raw_materialization_replays_parsed_rows_after_interrupted_index_rebuild
     assert "already parsed but not materialized" in result.detail
 
 
-def test_raw_materialization_blocks_before_batch_parse_call(
+def test_raw_materialization_uses_authority_replay_not_legacy_batch_parser(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -657,9 +693,9 @@ def test_raw_materialization_blocks_before_batch_parse_call(
 
     result = repair_mod.repair_raw_materialization(config)
 
-    assert result.success is False
-    assert result.repaired_count == 0
-    assert result.metrics["raw_materialization_replay_blocked_count"] == 2.0
+    assert result.success is True
+    assert result.repaired_count == 2
+    assert result.metrics["raw_materialization_selected_count"] == 2.0
     assert calls == []
 
 
@@ -746,13 +782,19 @@ def test_raw_materialization_ordinary_repair_preserves_newer_index_state(
 
     monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", UnexpectedParsingService)
 
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_authority_before = source_conn.execute(
+            "SELECT revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (raw_id,),
+        ).fetchone()
+
     result = repair_mod.repair_raw_materialization(config, dry_run=False)
 
     assert result.success is False
     assert result.repaired_count == 0
     assert result.metrics["raw_materialization_candidate_count"] == 1.0
-    assert result.metrics["raw_materialization_replay_blocked_count"] == 1.0
-    assert "raw source-to-index replay is disabled" in result.detail
+    assert result.metrics["raw_materialization_selected_count"] == 1.0
+    assert "typed revision authority" in result.detail
     with sqlite3.connect(tmp_path / "index.db") as index_conn:
         row = index_conn.execute(
             "SELECT raw_id, title, content_hash, message_count FROM sessions WHERE native_id = 'logical-session'"
@@ -772,10 +814,30 @@ def test_raw_materialization_ordinary_repair_preserves_newer_index_state(
     assert fts_hits_after == fts_hits_before
     with sqlite3.connect(tmp_path / "source.db") as source_conn:
         raw_state = source_conn.execute(
-            "SELECT parsed_at_ms, parse_error FROM raw_sessions WHERE raw_id = ?",
+            "SELECT parsed_at_ms, parse_error, revision_authority FROM raw_sessions WHERE raw_id = ?",
             (raw_id,),
         ).fetchone()
-    assert raw_state == (None, None)
+    assert raw_state == (None, None, source_authority_before[0])
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        deferred = index_conn.execute(
+            "SELECT decision, detail FROM raw_revision_applications WHERE raw_id = ?",
+            (raw_id,),
+        ).fetchone()
+    assert deferred == ("deferred", "ordinary_replay:incomparable_existing_index_state")
+    assert result.metrics["raw_materialization_adoption_deferred_count"] == 1.0
+    from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot
+
+    readiness = raw_materialization_readiness_snapshot(tmp_path)
+    assert readiness["blocked"] == 1
+    assert readiness["affected_blocked"] == 1
+    readiness_categories = cast(dict[str, int], readiness["category_counts"])
+    assert readiness_categories["adoption_deferred"] == 1
+
+    retry = repair_mod.repair_raw_materialization(config, dry_run=False)
+    assert retry.success is False
+    assert retry.metrics["raw_materialization_candidate_count"] == 0.0
+    assert retry.metrics["raw_materialization_adoption_deferred_count"] == 1.0
+    assert "remain deferred" in retry.detail
 
 
 def test_raw_materialization_dry_run_reports_limited_selection(
@@ -807,7 +869,7 @@ def test_raw_materialization_dry_run_reports_limited_selection(
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert "Preview only. Raw materialization blocked" in result.detail
+    assert "Would: classify and replay" in result.detail
     assert result.metrics["raw_materialization_candidate_count"] == 4.0
     assert result.metrics["raw_materialization_selected_count"] == 2.0
     assert result.metrics["raw_materialization_limit"] == 2.0
@@ -816,7 +878,7 @@ def test_raw_materialization_dry_run_reports_limited_selection(
     assert result.metrics["raw_materialization_selected_max_blob_bytes"] == 1024.0
 
 
-def test_raw_materialization_execute_blocks_limited_selection(
+def test_raw_materialization_execute_limits_authority_selection(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -875,7 +937,7 @@ def test_raw_materialization_execute_blocks_limited_selection(
     assert "parse_kwargs" not in calls
     assert result.metrics["raw_materialization_candidate_count"] == 4.0
     assert result.metrics["raw_materialization_selected_count"] == 2.0
-    assert result.metrics["raw_materialization_replay_blocked_count"] == 2.0
+    assert result.metrics["raw_materialization_executed_count"] == 2.0
 
 
 def test_raw_materialization_raw_artifact_filter_counts_only_target(tmp_path: Path) -> None:
@@ -1127,7 +1189,7 @@ def test_raw_materialization_scope_filters_count_only_matching_raw_rows(tmp_path
     assert by_provider.metrics["raw_materialization_max_blob_bytes"] == float(max(claude_size, other_root_size))
 
 
-def test_raw_materialization_blocks_before_fts_or_ingest_stage(
+def test_raw_materialization_uses_authority_substrate_not_legacy_ingest_stage(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1180,13 +1242,13 @@ def test_raw_materialization_blocks_before_fts_or_ingest_stage(
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert "raw source-to-index replay is disabled" in result.detail
+    assert "typed revision authority" in result.detail
     assert "parse_kwargs" not in calls
     assert calls["raw_artifact_id"] is None
     assert "closed" not in calls
 
 
-def test_raw_materialization_block_reports_raw_payload_size_without_progress(
+def test_raw_materialization_reports_authority_progress_and_payload_size(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1237,10 +1299,11 @@ def test_raw_materialization_block_reports_raw_payload_size_without_progress(
     )
 
     assert result.success is False
-    assert progress == []
+    assert len(progress) == 1
+    assert "typed revision authority" in progress[0]
     assert result.metrics["raw_materialization_total_blob_bytes"] == float(256 * 1024 * 1024)
     assert result.metrics["raw_materialization_max_blob_bytes"] == float(256 * 1024 * 1024)
-    assert result.metrics["raw_materialization_replay_blocked_count"] == 1.0
+    assert result.metrics["raw_materialization_selected_count"] == 1.0
 
 
 def test_raw_materialization_blocks_oversized_actual_replay(
@@ -1269,13 +1332,14 @@ def test_raw_materialization_blocks_oversized_actual_replay(
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert "also exceed replay size limit 1.0 GiB" in result.detail
-    assert "largest=2.0 GiB" in result.detail
+    assert "1 replay candidate(s) remain" in result.detail
     assert result.metrics["raw_materialization_oversized_count"] == 1.0
+    assert result.metrics["raw_materialization_resource_blocked_count"] == 1.0
+    assert result.metrics["raw_materialization_executed_count"] == 0.0
     assert result.metrics["raw_materialization_execute_blob_limit_bytes"] == float(1024 * 1024 * 1024)
 
 
-def test_raw_materialization_blocks_oversized_stream_record_replay(
+def test_raw_materialization_classifies_oversized_stream_record_replay(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1326,12 +1390,12 @@ def test_raw_materialization_blocks_oversized_stream_record_replay(
     assert result.success is False
     assert result.repaired_count == 0
     assert result.metrics["raw_materialization_stream_oversized_count"] == 1.0
-    assert "oversized stream-record raw rows are stream-capable" in result.detail
+    assert "1 replay candidate(s) remain" in result.detail
     assert "parse_kwargs" not in calls
     assert "closed" not in calls
 
 
-def test_raw_materialization_blocks_before_parse_write_failures(
+def test_raw_materialization_quarantines_parse_failures_without_legacy_parser(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1373,7 +1437,7 @@ def test_raw_materialization_blocks_before_parse_write_failures(
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert "raw source-to-index replay is disabled" in result.detail
+    assert "typed revision authority" in result.detail
     assert result.metrics["raw_materialization_already_parsed_count"] == 1.0
 
 


### PR DESCRIPTION
## Summary

Enable ordinary daemon raw materialization through the existing typed revision-authority replay path, replacing the temporary all-replay containment gate.

## Problem

Source v7/index v32 shipped monotonic cohort classification, immutable application receipts, and safe offline replay, but `repair_raw_materialization` still refused every daemon candidate. Production therefore accumulated ordinary raw debt even after the authority substrate existed. A naive wire-up could also overwrite pre-authority index state, hot-retry incomparable cohorts, or parse retained blobs above the bounded-memory limit.

## Solution

- Route bounded ordinary repair selections through `backfill_historical_revision_evidence`; selection remains a scheduling hint and authority expands complete cohorts.
- Preserve a different ungoverned existing session and record immutable `deferred` index-tier receipts instead of changing durable source evidence.
- Exclude deferred receipts from hot retry while exposing them as blocked raw-materialization readiness.
- Keep every retained raw over 1 GiB resource-blocked because the current backfill loads blob bytes before stream parsing.
- Retry the exact production transient `OperationalError: database is locked` parse failure, while leaving arbitrary parse errors non-retryable.
- Keep dry-run read-only and non-successful while executable debt remains.

The offline inactive-generation rebuild continues to use the same authority substrate with explicit generation ownership; this PR does not merge ordinary and offline execution policy.

## Verification

- `devtools test tests/unit/storage/test_archive_readiness.py tests/unit/storage/test_repair.py tests/unit/sources/test_revision_backfill.py` — 53 passed; one expectation updated afterward for the intended deferred metric, then focused regressions passed.
- `devtools test tests/unit/storage/test_repair.py -k 'transient_lock_failure or ordinary_repair_preserves or preview_counts_replayable'` — 3 passed.
- `devtools test tests/unit/daemon/test_daemon_cli.py -k 'drain_raw_materialization_once or raw_materialization_closes_fts'` — 2 passed.
- `devtools verify --quick` — all 13 steps passed.

Ref polylogue-yla8.
