### PR TITLE
fix(daemon): bound ordinary revision replay

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -67,61 +67,65 @@ def backfill_historical_revision_evidence(
         else ArchiveStore.open_existing(archive_root, read_only=False)
     )
     with archive_context as archive, _ParsedSessionSpill(archive_root) as spill:
-        census_selection: tuple[str, ...] | None = None
-        if selected_raw_ids is not None:
-            census_selection, _keys = archive.expand_raw_membership_selection(selected_raw_ids)
+        census_selections: tuple[tuple[str, ...] | None, ...]
+        if selected_raw_ids is None:
+            census_selections = (None,)
+        else:
+            census_selections = archive.raw_membership_selection_components(selected_raw_ids)
         censused: set[str] = set()
-        while True:
-            rows = archive.raw_membership_census_rows(census_selection)
-            pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in censused]
-            if max_payload_bytes is not None:
-                payload_sizes = archive.raw_payload_sizes([raw_id for raw_id, _index in rows])
-                total_payload_bytes = sum(payload_sizes.values())
-                oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
-                if oversized or total_payload_bytes > max_payload_bytes:
-                    blocked_ids = oversized or list(payload_sizes)
-                    raise RawRevisionReplayResourceBlockedError(
-                        sorted(blocked_ids), max_payload_bytes, total_payload_bytes
-                    )
-            for raw_id, source_index in pending_rows:
-                scanned += 1
-                censused.add(raw_id)
-                if source_index < 0:
+        for initial_selection in census_selections:
+            census_selection = initial_selection
+            while True:
+                rows = archive.raw_membership_census_rows(census_selection)
+                pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in censused]
+                if max_payload_bytes is not None:
+                    payload_sizes = archive.raw_payload_sizes([raw_id for raw_id, _index in rows])
+                    total_payload_bytes = sum(payload_sizes.values())
+                    oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
+                    if oversized or total_payload_bytes > max_payload_bytes:
+                        blocked_ids = oversized or list(payload_sizes)
+                        raise RawRevisionReplayResourceBlockedError(
+                            sorted(blocked_ids), max_payload_bytes, total_payload_bytes
+                        )
+                for raw_id, source_index in pending_rows:
+                    scanned += 1
+                    censused.add(raw_id)
+                    if source_index < 0:
+                        archive.replace_raw_membership_census(
+                            raw_id,
+                            None,
+                            parser_fingerprint="revision-membership-v1",
+                            censused_at_ms=0,
+                            detail="append fragments are governed by byte revision authority",
+                        )
+                        quarantined += 1
+                        continue
+                    try:
+                        sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
+                    except Exception as exc:
+                        archive.replace_raw_membership_census(
+                            raw_id,
+                            None,
+                            parser_fingerprint="revision-membership-v1",
+                            censused_at_ms=0,
+                            detail=str(exc),
+                        )
+                        quarantined += 1
+                        continue
+                    classified += int(len(sessions) == 1)
+                    spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
                     archive.replace_raw_membership_census(
                         raw_id,
-                        None,
+                        sessions,
                         parser_fingerprint="revision-membership-v1",
                         censused_at_ms=0,
-                        detail="append fragments are governed by byte revision authority",
                     )
-                    quarantined += 1
-                    continue
-                try:
-                    sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
-                except Exception as exc:
-                    archive.replace_raw_membership_census(
-                        raw_id,
-                        None,
-                        parser_fingerprint="revision-membership-v1",
-                        censused_at_ms=0,
-                        detail=str(exc),
-                    )
-                    quarantined += 1
-                    continue
-                classified += int(len(sessions) == 1)
-                spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
-                archive.replace_raw_membership_census(
-                    raw_id,
-                    sessions,
-                    parser_fingerprint="revision-membership-v1",
-                    censused_at_ms=0,
-                )
-            if census_selection is None:
-                break
-            expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
-            if set(expanded) == set(census_selection):
-                break
-            census_selection = expanded
+                if census_selection is None:
+                    break
+                expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
+                if set(expanded) == set(census_selection):
+                    break
+                census_selection = expanded
 
         _unclassified, selected_keys = archive.raw_revision_rebuild_selection(selected_raw_ids)
         logical_keys.update(selected_keys)

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -30,12 +30,20 @@ class RevisionBackfillResult:
     adoption_deferred: int = 0
 
 
+class RawRevisionReplayResourceBlockedError(RuntimeError):
+    def __init__(self, raw_ids: list[str], limit_bytes: int) -> None:
+        self.raw_ids = tuple(raw_ids)
+        self.limit_bytes = limit_bytes
+        super().__init__(f"{len(raw_ids)} raw revision(s) exceed replay limit {limit_bytes}")
+
+
 def backfill_historical_revision_evidence(
     archive_root: Path,
     *,
     selected_raw_ids: list[str] | None = None,
     owned_inactive_generation: tuple[str, str] | None = None,
     retention_observer: Callable[[int, int], None] | None = None,
+    max_payload_bytes: int | None = None,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
@@ -58,38 +66,60 @@ def backfill_historical_revision_evidence(
         else ArchiveStore.open_existing(archive_root, read_only=False)
     )
     with archive_context as archive, _ParsedSessionSpill(archive_root) as spill:
-        for raw_id, source_index in archive.raw_membership_census_rows():
-            scanned += 1
-            if source_index < 0:
+        census_selection: tuple[str, ...] | None = None
+        if selected_raw_ids is not None:
+            census_selection, _keys = archive.expand_raw_membership_selection(selected_raw_ids)
+        censused: set[str] = set()
+        while True:
+            rows = archive.raw_membership_census_rows(census_selection)
+            pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in censused]
+            if max_payload_bytes is not None:
+                oversized = [
+                    raw_id
+                    for raw_id, size in archive.raw_payload_sizes([raw_id for raw_id, _index in rows]).items()
+                    if size > max_payload_bytes
+                ]
+                if oversized:
+                    raise RawRevisionReplayResourceBlockedError(sorted(oversized), max_payload_bytes)
+            for raw_id, source_index in pending_rows:
+                scanned += 1
+                censused.add(raw_id)
+                if source_index < 0:
+                    archive.replace_raw_membership_census(
+                        raw_id,
+                        None,
+                        parser_fingerprint="revision-membership-v1",
+                        censused_at_ms=0,
+                        detail="append fragments are governed by byte revision authority",
+                    )
+                    quarantined += 1
+                    continue
+                try:
+                    sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
+                except Exception as exc:
+                    archive.replace_raw_membership_census(
+                        raw_id,
+                        None,
+                        parser_fingerprint="revision-membership-v1",
+                        censused_at_ms=0,
+                        detail=str(exc),
+                    )
+                    quarantined += 1
+                    continue
+                classified += int(len(sessions) == 1)
+                spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
                 archive.replace_raw_membership_census(
                     raw_id,
-                    None,
+                    sessions,
                     parser_fingerprint="revision-membership-v1",
                     censused_at_ms=0,
-                    detail="append fragments are governed by byte revision authority",
                 )
-                quarantined += 1
-                continue
-            try:
-                sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
-            except Exception as exc:
-                archive.replace_raw_membership_census(
-                    raw_id,
-                    None,
-                    parser_fingerprint="revision-membership-v1",
-                    censused_at_ms=0,
-                    detail=str(exc),
-                )
-                quarantined += 1
-                continue
-            classified += int(len(sessions) == 1)
-            spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
-            archive.replace_raw_membership_census(
-                raw_id,
-                sessions,
-                parser_fingerprint="revision-membership-v1",
-                censused_at_ms=0,
-            )
+            if census_selection is None:
+                break
+            expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
+            if set(expanded) == set(census_selection):
+                break
+            census_selection = expanded
 
         _unclassified, selected_keys = archive.raw_revision_rebuild_selection(selected_raw_ids)
         logical_keys.update(selected_keys)
@@ -242,4 +272,4 @@ def _parse_one(provider: Provider, payload: bytes, source_path: str) -> list[Par
     )
 
 
-__all__ = ["RevisionBackfillResult", "backfill_historical_revision_evidence"]
+__all__ = ["RawRevisionReplayResourceBlockedError", "RevisionBackfillResult", "backfill_historical_revision_evidence"]

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -31,10 +31,11 @@ class RevisionBackfillResult:
 
 
 class RawRevisionReplayResourceBlockedError(RuntimeError):
-    def __init__(self, raw_ids: list[str], limit_bytes: int) -> None:
+    def __init__(self, raw_ids: list[str], limit_bytes: int, total_bytes: int) -> None:
         self.raw_ids = tuple(raw_ids)
         self.limit_bytes = limit_bytes
-        super().__init__(f"{len(raw_ids)} raw revision(s) exceed replay limit {limit_bytes}")
+        self.total_bytes = total_bytes
+        super().__init__(f"{len(raw_ids)} raw revision(s) total {total_bytes} bytes exceed replay limit {limit_bytes}")
 
 
 def backfill_historical_revision_evidence(
@@ -74,13 +75,14 @@ def backfill_historical_revision_evidence(
             rows = archive.raw_membership_census_rows(census_selection)
             pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in censused]
             if max_payload_bytes is not None:
-                oversized = [
-                    raw_id
-                    for raw_id, size in archive.raw_payload_sizes([raw_id for raw_id, _index in rows]).items()
-                    if size > max_payload_bytes
-                ]
-                if oversized:
-                    raise RawRevisionReplayResourceBlockedError(sorted(oversized), max_payload_bytes)
+                payload_sizes = archive.raw_payload_sizes([raw_id for raw_id, _index in rows])
+                total_payload_bytes = sum(payload_sizes.values())
+                oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
+                if oversized or total_payload_bytes > max_payload_bytes:
+                    blocked_ids = oversized or list(payload_sizes)
+                    raise RawRevisionReplayResourceBlockedError(
+                        sorted(blocked_ids), max_payload_bytes, total_payload_bytes
+                    )
             for raw_id, source_index in pending_rows:
                 scanned += 1
                 censused.add(raw_id)

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -71,6 +71,7 @@ class RawMaterializationCandidates:
     adoption_deferred: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
+    authority_components: tuple[tuple[str, ...], ...] = ()
 
     @property
     def total_blob_bytes(self) -> int:
@@ -138,6 +139,7 @@ def _raw_materialization_candidate_ids(
     already_parsed = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = {}
+    authority_components: tuple[tuple[str, ...], ...] = ()
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
         conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
@@ -232,7 +234,8 @@ def _raw_materialization_candidate_ids(
                     missing_blob_source_missing += 1
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
-        expanded_raw_ids, _keys = ArchiveStore.expand_raw_membership_selection_sync(conn, raw_ids)
+        authority_components = ArchiveStore.raw_membership_selection_components_sync(conn, raw_ids)
+        expanded_raw_ids = tuple(sorted({raw_id for component in authority_components for raw_id in component}))
         if expanded_raw_ids:
             placeholders = ",".join("?" for _ in expanded_raw_ids)
             expanded_blob_bytes = {
@@ -254,6 +257,7 @@ def _raw_materialization_candidate_ids(
         adoption_deferred=adoption_deferred,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
+        authority_components=authority_components,
     )
 
 
@@ -365,10 +369,15 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
     ]
     # Retained-raw authority replay currently loads blob bytes before handing
     # them to the stream parser, so stream-capable format is diagnostic only.
-    aggregate_resource_blocked = expanded_total_blob_bytes > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
-    resource_blocked_count = len(oversized_raw_ids) or (
-        len(candidates.expanded_raw_ids) if aggregate_resource_blocked else 0
-    )
+    blocked_components = [
+        component
+        for component in candidates.authority_components
+        if sum(expanded_blob_bytes.get(raw_id, 0) for raw_id in component)
+        > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+    ]
+    blocked_component_raw_ids = {raw_id for component in blocked_components for raw_id in component}
+    aggregate_resource_blocked = bool(blocked_components)
+    resource_blocked_count = len(blocked_component_raw_ids)
     blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred
     return {
         "available": True,
@@ -393,6 +402,9 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         "expanded_candidate_count": len(candidates.expanded_raw_ids),
         "expanded_total_blob_bytes": expanded_total_blob_bytes,
         "expanded_aggregate_blocked": aggregate_resource_blocked,
+        "authority_component_count": len(candidates.authority_components),
+        "blocked_authority_component_count": len(blocked_components),
+        "executable_authority_component_count": len(candidates.authority_components) - len(blocked_components),
         "oversized_count": len(oversized_raw_ids),
         "oversized_stream_safe_count": len(oversized_stream_safe),
         "top_raw_rows": top_raw_rows,
@@ -1609,8 +1621,16 @@ def repair_raw_materialization(
     )
 
     archive_root = _raw_materialization_archive_root(config)
-    oversized_raw_id_set = set(oversized_raw_ids)
-    executable_raw_ids = [raw_id for raw_id in raw_ids if raw_id not in oversized_raw_id_set]
+    blocked_component_raw_ids = {
+        raw_id
+        for component in candidates.authority_components
+        if sum(candidates.expanded_blob_bytes.get(member, 0) for member in component)
+        > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+        for raw_id in component
+    }
+    if blocked_component_raw_ids:
+        metrics["raw_materialization_resource_blocked_count"] = float(len(blocked_component_raw_ids))
+    executable_raw_ids = [raw_id for raw_id in raw_ids if raw_id not in blocked_component_raw_ids]
     metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
     if executable_raw_ids:
         try:
@@ -1674,6 +1694,11 @@ def repair_raw_materialization(
         detail += (
             f"; {len(oversized_raw_ids):,} non-stream-safe raw row(s) exceed execution limit "
             f"{_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
+        )
+    elif blocked_component_raw_ids:
+        detail += (
+            f"; {len(blocked_component_raw_ids):,} raw row(s) belong to authority components whose aggregate "
+            f"payload exceeds {_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
         )
     if remaining.missing_blobs:
         detail += f"; {_raw_materialization_missing_blob_detail(remaining, final=True)}"

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -69,6 +69,8 @@ class RawMaterializationCandidates:
     missing_blob_source_available: int = 0
     missing_blob_source_missing: int = 0
     adoption_deferred: int = 0
+    expanded_raw_ids: tuple[str, ...] = ()
+    expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
 
     @property
     def total_blob_bytes(self) -> int:
@@ -134,6 +136,8 @@ def _raw_materialization_candidate_ids(
     missing_blob_source_available = 0
     missing_blob_source_missing = 0
     already_parsed = 0
+    expanded_raw_ids: tuple[str, ...] = ()
+    expanded_blob_bytes: dict[str, int] = {}
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
         conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
@@ -226,6 +230,18 @@ def _raw_materialization_candidate_ids(
                     missing_blob_source_available += 1
                 else:
                     missing_blob_source_missing += 1
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        expanded_raw_ids, _keys = ArchiveStore.expand_raw_membership_selection_sync(conn, raw_ids)
+        if expanded_raw_ids:
+            placeholders = ",".join("?" for _ in expanded_raw_ids)
+            expanded_blob_bytes = {
+                str(row[0]): int(row[1] or 0)
+                for row in conn.execute(
+                    f"SELECT raw_id, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
+                    expanded_raw_ids,
+                )
+            }
     return RawMaterializationCandidates(
         raw_ids=raw_ids,
         missing_blobs=missing_blobs,
@@ -236,6 +252,8 @@ def _raw_materialization_candidate_ids(
         missing_blob_source_available=missing_blob_source_available,
         missing_blob_source_missing=missing_blob_source_missing,
         adoption_deferred=adoption_deferred,
+        expanded_raw_ids=expanded_raw_ids,
+        expanded_blob_bytes=expanded_blob_bytes,
     )
 
 
@@ -337,17 +355,20 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         }
         for raw_id in raw_ids_by_size[:limit]
     ]
+    expanded_blob_bytes = candidates.expanded_blob_bytes
+    expanded_total_blob_bytes = sum(expanded_blob_bytes.values())
     oversized_raw_ids = [
-        raw_id
-        for raw_id in candidates.raw_ids
-        if candidates.raw_blob_bytes.get(raw_id, 0) > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+        raw_id for raw_id, size in expanded_blob_bytes.items() if size > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
     ]
     oversized_stream_safe = [
         raw_id for raw_id in oversized_raw_ids if _raw_materialization_stream_safe(candidates, raw_id)
     ]
     # Retained-raw authority replay currently loads blob bytes before handing
     # them to the stream parser, so stream-capable format is diagnostic only.
-    resource_blocked_count = len(oversized_raw_ids)
+    aggregate_resource_blocked = expanded_total_blob_bytes > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+    resource_blocked_count = len(oversized_raw_ids) or (
+        len(candidates.expanded_raw_ids) if aggregate_resource_blocked else 0
+    )
     blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred
     return {
         "available": True,
@@ -369,6 +390,9 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         "total_blob_bytes": candidates.total_blob_bytes,
         "max_blob_bytes": candidates.max_blob_bytes,
         "execute_blob_limit_bytes": RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+        "expanded_candidate_count": len(candidates.expanded_raw_ids),
+        "expanded_total_blob_bytes": expanded_total_blob_bytes,
+        "expanded_aggregate_blocked": aggregate_resource_blocked,
         "oversized_count": len(oversized_raw_ids),
         "oversized_stream_safe_count": len(oversized_stream_safe),
         "top_raw_rows": top_raw_rows,
@@ -1603,8 +1627,9 @@ def repair_raw_materialization(
                 repaired_count=0,
                 success=False,
                 detail=(
-                    f"Raw materialization blocked: {len(exc.raw_ids):,} expanded-cohort raw row(s) exceed "
-                    f"execution limit {_format_bytes(exc.limit_bytes)}"
+                    f"Raw materialization blocked: {len(exc.raw_ids):,} expanded-cohort raw row(s), "
+                    f"aggregate {_format_bytes(exc.total_bytes)}, exceed execution limit "
+                    f"{_format_bytes(exc.limit_bytes)}"
                 ),
                 metrics=metrics,
             )

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1533,10 +1533,9 @@ def repair_raw_materialization(
     oversized_stream_safe_raw_ids = [
         raw_id for raw_id in oversized_candidate_raw_ids if _raw_materialization_stream_safe(candidates, raw_id)
     ]
-    oversized_stream_safe_raw_id_set = set(oversized_stream_safe_raw_ids)
-    oversized_raw_ids = [
-        raw_id for raw_id in oversized_candidate_raw_ids if raw_id not in oversized_stream_safe_raw_id_set
-    ]
+    # The retained-raw reader materializes bytes before stream parsing, so
+    # stream-capable format is diagnostic only until that reader is replaced.
+    oversized_raw_ids = oversized_candidate_raw_ids
     if oversized_raw_ids:
         metrics["raw_materialization_oversized_count"] = float(len(oversized_raw_ids))
         metrics["raw_materialization_resource_blocked_count"] = float(len(oversized_raw_ids))
@@ -1580,17 +1579,35 @@ def repair_raw_materialization(
             "raw_materialization", repaired_count=0, success=False, detail=detail, metrics=metrics
         )
 
-    from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
+    from polylogue.sources.revision_backfill import (
+        RawRevisionReplayResourceBlockedError,
+        backfill_historical_revision_evidence,
+    )
 
     archive_root = _raw_materialization_archive_root(config)
     oversized_raw_id_set = set(oversized_raw_ids)
     executable_raw_ids = [raw_id for raw_id in raw_ids if raw_id not in oversized_raw_id_set]
     metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
     if executable_raw_ids:
-        replay = backfill_historical_revision_evidence(
-            archive_root,
-            selected_raw_ids=executable_raw_ids,
-        )
+        try:
+            replay = backfill_historical_revision_evidence(
+                archive_root,
+                selected_raw_ids=executable_raw_ids,
+                max_payload_bytes=RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+            )
+        except RawRevisionReplayResourceBlockedError as exc:
+            metrics["raw_materialization_resource_blocked_count"] = float(len(exc.raw_ids))
+            metrics["raw_materialization_executed_count"] = 0.0
+            return _internal_derived_repair_result(
+                "raw_materialization",
+                repaired_count=0,
+                success=False,
+                detail=(
+                    f"Raw materialization blocked: {len(exc.raw_ids):,} expanded-cohort raw row(s) exceed "
+                    f"execution limit {_format_bytes(exc.limit_bytes)}"
+                ),
+                metrics=metrics,
+            )
     else:
         from polylogue.sources.revision_backfill import RevisionBackfillResult
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1636,14 +1636,30 @@ class ArchiveStore:
         )
         return unclassified, logical_keys
 
-    def raw_membership_census_rows(self) -> tuple[tuple[str, int], ...]:
+    def raw_membership_census_rows(self, raw_ids: Sequence[str] | None = None) -> tuple[tuple[str, int], ...]:
         """Return every retained raw whose membership census may affect authority."""
-        rows = (
-            self._ensure_source_conn()
-            .execute("SELECT raw_id, source_index FROM raw_sessions ORDER BY raw_id")
-            .fetchall()
-        )
+        conn = self._ensure_source_conn()
+        if raw_ids is None:
+            rows = conn.execute("SELECT raw_id, source_index FROM raw_sessions ORDER BY raw_id").fetchall()
+        elif raw_ids:
+            placeholders = ",".join("?" for _ in raw_ids)
+            rows = conn.execute(
+                f"SELECT raw_id, source_index FROM raw_sessions WHERE raw_id IN ({placeholders}) ORDER BY raw_id",
+                tuple(raw_ids),
+            ).fetchall()
+        else:
+            rows = []
         return tuple((str(row[0]), int(row[1])) for row in rows)
+
+    def raw_payload_sizes(self, raw_ids: Sequence[str]) -> dict[str, int]:
+        if not raw_ids:
+            return {}
+        placeholders = ",".join("?" for _ in raw_ids)
+        rows = self._ensure_source_conn().execute(
+            f"SELECT raw_id, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
+            tuple(raw_ids),
+        )
+        return {str(row[0]): int(row[1] or 0) for row in rows}
 
     def replace_raw_membership_census(
         self,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1712,7 +1712,14 @@ class ArchiveStore:
 
     def expand_raw_membership_selection(self, raw_ids: list[str] | None) -> tuple[tuple[str, ...], tuple[str, ...]]:
         """Expand scheduling hints to the complete transitive membership cohort."""
-        conn = self._ensure_source_conn()
+        return self.expand_raw_membership_selection_sync(self._ensure_source_conn(), raw_ids)
+
+    @staticmethod
+    def expand_raw_membership_selection_sync(
+        conn: sqlite3.Connection,
+        raw_ids: list[str] | None,
+    ) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """Expand raw scheduling hints using durable path/membership metadata."""
         if raw_ids is None:
             selected = {str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions")}
         else:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1715,6 +1715,26 @@ class ArchiveStore:
         return self.expand_raw_membership_selection_sync(self._ensure_source_conn(), raw_ids)
 
     @staticmethod
+    def raw_membership_selection_components_sync(
+        conn: sqlite3.Connection,
+        raw_ids: list[str],
+    ) -> tuple[tuple[str, ...], ...]:
+        """Partition scheduling hints into transitive authority components."""
+        components: list[set[str]] = []
+        for raw_id in dict.fromkeys(raw_ids):
+            expanded, _keys = ArchiveStore.expand_raw_membership_selection_sync(conn, [raw_id])
+            component = set(expanded)
+            overlapping = [existing for existing in components if existing & component]
+            for existing in overlapping:
+                component.update(existing)
+                components.remove(existing)
+            components.append(component)
+        return tuple(tuple(sorted(component)) for component in sorted(components, key=lambda item: min(item)))
+
+    def raw_membership_selection_components(self, raw_ids: list[str]) -> tuple[tuple[str, ...], ...]:
+        return self.raw_membership_selection_components_sync(self._ensure_source_conn(), raw_ids)
+
+    @staticmethod
     def expand_raw_membership_selection_sync(
         conn: sqlite3.Connection,
         raw_ids: list[str] | None,

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -10,6 +10,7 @@ import pytest
 from polylogue.core.enums import Provider
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import parse_payload
+from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -360,7 +361,9 @@ def test_divergent_bundle_member_preserves_last_accepted_session(tmp_path: Path)
         )
 
 
-def test_targeted_rebuild_expands_same_session_across_source_paths_only(tmp_path: Path) -> None:
+def test_targeted_rebuild_expands_same_session_across_source_paths_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         selected_raw = archive.write_raw_payload(
@@ -382,14 +385,42 @@ def test_targeted_rebuild_expands_same_session_across_source_paths_only(tmp_path
             acquired_at_ms=3,
         )
 
+    # Production ordinary convergence starts from the durable membership
+    # census established by ingestion/offline rebuild, not an empty source-v7
+    # authority catalog.
+    backfill_historical_revision_evidence(tmp_path)
+    (tmp_path / "index.db").unlink()
+    initialize_active_archive_root(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        unrelated_before = conn.execute(
+            "SELECT parser_fingerprint, status, member_count, detail FROM raw_membership_census WHERE raw_id = ?",
+            (unrelated_raw,),
+        ).fetchone()
+
+    from polylogue.sources import revision_backfill
+
+    original_parse = revision_backfill._parse_retained_raw
+    opened: list[str] = []
+
+    def observed_parse(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:
+        opened.append(raw_id)
+        return original_parse(archive, raw_id)
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", observed_parse)
     result = backfill_historical_revision_evidence(tmp_path, selected_raw_ids=[selected_raw])
     assert result.replayed_logical_sources == 1
+    assert result.scanned == 2
+    assert unrelated_raw not in opened
     with sqlite3.connect(tmp_path / "index.db") as conn:
         assert conn.execute("SELECT native_id, message_count FROM sessions").fetchall() == [("shared", 2)]
     with sqlite3.connect(tmp_path / "source.db") as conn:
-        assert conn.execute(
-            "SELECT decision FROM raw_session_memberships WHERE raw_id = ?", (unrelated_raw,)
-        ).fetchone() == (None,)
+        assert (
+            conn.execute(
+                "SELECT parser_fingerprint, status, member_count, detail FROM raw_membership_census WHERE raw_id = ?",
+                (unrelated_raw,),
+            ).fetchone()
+            == unrelated_before
+        )
 
 
 def test_membership_census_retains_only_one_logical_cohort_at_scale(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1447,6 +1447,94 @@ def test_raw_materialization_blocks_oversized_expanded_cohort_before_blob_open(
     assert "expanded-cohort" in result.detail
 
 
+def test_raw_materialization_backlog_expands_to_oversized_materialized_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    small_payload = b'{"type":"session_meta","payload":{"id":"small-gap"}}\n'
+    large_payload = b'{"type":"session_meta","payload":{"id":"large-done"}}\n'
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        small_raw = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=small_payload, source_path="shared.jsonl", acquired_at_ms=1
+        )
+        large_raw = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=large_payload, source_path="shared.jsonl", acquired_at_ms=2
+        )
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            (repair_mod.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES + 1, large_raw),
+        )
+        source_conn.commit()
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        index_conn.execute(
+            "INSERT INTO sessions(native_id, origin, raw_id, title, content_hash) VALUES (?, ?, ?, ?, ?)",
+            ("large-done", "codex-session", large_raw, "done", bytes(32)),
+        )
+        index_conn.commit()
+
+    backlog = repair_mod.raw_materialization_replay_backlog(_config(tmp_path))
+    assert backlog["candidate_count"] == 1
+    assert backlog["expanded_candidate_count"] == 2
+    assert backlog["execution_blocked"] is True
+    assert backlog["blocked_candidate_count"] == 1
+
+    monkeypatch.setattr(
+        "polylogue.sources.revision_backfill._parse_retained_raw",
+        lambda *_args, **_kwargs: pytest.fail("oversized materialized sibling must block before blob open"),
+    )
+    result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_id=small_raw)
+    assert result.success is False
+    assert "expanded-cohort" in result.detail
+
+
+def test_raw_materialization_blocks_aggregate_sub_limit_cohort_before_blob_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=f'{{"type":"session_meta","payload":{{"id":"aggregate-{index}"}}}}\n'.encode(),
+                source_path="aggregate.jsonl",
+                acquired_at_ms=index,
+            )
+            for index in range(2)
+        ]
+    per_raw_size = 600 * 1024 * 1024
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.executemany(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            ((per_raw_size, raw_id) for raw_id in raw_ids),
+        )
+        source_conn.commit()
+
+    backlog = repair_mod.raw_materialization_replay_backlog(_config(tmp_path))
+    assert backlog["oversized_count"] == 0
+    assert backlog["expanded_aggregate_blocked"] is True
+    assert backlog["execution_blocked"] is True
+
+    monkeypatch.setattr(
+        "polylogue.sources.revision_backfill._parse_retained_raw",
+        lambda *_args, **_kwargs: pytest.fail("aggregate cohort limit must be checked before blob open"),
+    )
+    result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
+    assert result.success is False
+    assert result.metrics["raw_materialization_resource_blocked_count"] == 2.0
+    assert "aggregate 1.2 GiB" in result.detail
+
+
 def test_raw_materialization_quarantines_parse_failures_without_legacy_parser(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1384,6 +1384,10 @@ def test_raw_materialization_classifies_oversized_stream_record_replay(
     monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", FakeParsingService)
     monkeypatch.setattr("polylogue.storage.repository.SessionRepository", FakeRepository)
     monkeypatch.setattr("polylogue.storage.sqlite.async_sqlite.SQLiteBackend", FakeBackend)
+    monkeypatch.setattr(
+        "polylogue.sources.revision_backfill.backfill_historical_revision_evidence",
+        lambda *_args, **_kwargs: pytest.fail("oversized stream raw must be blocked before backfill"),
+    )
 
     result = repair_mod.repair_raw_materialization(config, dry_run=False)
 
@@ -1393,6 +1397,54 @@ def test_raw_materialization_classifies_oversized_stream_record_replay(
     assert "1 replay candidate(s) remain" in result.detail
     assert "parse_kwargs" not in calls
     assert "closed" not in calls
+
+
+def test_raw_materialization_blocks_oversized_expanded_cohort_before_blob_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"expanded-size","timestamp":"2026-07-11T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"one","role":"user","content":'
+        b'[{"type":"input_text","text":"one"}]}}\n'
+    )
+    newest = baseline + (
+        b'{"type":"response_item","payload":{"type":"message","id":"two","role":"assistant","content":'
+        b'[{"type":"output_text","text":"two"}]}}\n'
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        small_raw = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=baseline, source_path="expanded.jsonl", acquired_at_ms=1
+        )
+        oversized_raw = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=newest, source_path="expanded.jsonl", acquired_at_ms=2
+        )
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            (repair_mod.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES + 1, oversized_raw),
+        )
+        source_conn.commit()
+
+    monkeypatch.setattr(
+        "polylogue.sources.revision_backfill._parse_retained_raw",
+        lambda *_args, **_kwargs: pytest.fail("expanded cohort size must be checked before opening any blob"),
+    )
+    result = repair_mod.repair_raw_materialization(
+        _config(tmp_path),
+        raw_artifact_id=small_raw,
+        dry_run=False,
+    )
+
+    assert result.success is False
+    assert result.repaired_count == 0
+    assert result.metrics["raw_materialization_resource_blocked_count"] == 1.0
+    assert "expanded-cohort" in result.detail
 
 
 def test_raw_materialization_quarantines_parse_failures_without_legacy_parser(

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1324,6 +1324,9 @@ def test_raw_materialization_blocks_oversized_actual_replay(
             0,
             0,
             {"raw-1": 2 * 1024 * 1024 * 1024},
+            expanded_raw_ids=("raw-1",),
+            expanded_blob_bytes={"raw-1": 2 * 1024 * 1024 * 1024},
+            authority_components=(("raw-1",),),
         ),
     )
     monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", UnexpectedParsingService)
@@ -1379,6 +1382,9 @@ def test_raw_materialization_classifies_oversized_stream_record_replay(
             {"raw-1": 2 * 1024 * 1024 * 1024},
             {"raw-1": "claude-code-session"},
             {"raw-1": "/captures/claude/session.jsonl"},
+            expanded_raw_ids=("raw-1",),
+            expanded_blob_bytes={"raw-1": 2 * 1024 * 1024 * 1024},
+            authority_components=(("raw-1",),),
         ),
     )
     monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", FakeParsingService)
@@ -1443,8 +1449,8 @@ def test_raw_materialization_blocks_oversized_expanded_cohort_before_blob_open(
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert result.metrics["raw_materialization_resource_blocked_count"] == 1.0
-    assert "expanded-cohort" in result.detail
+    assert result.metrics["raw_materialization_resource_blocked_count"] == 2.0
+    assert "authority components" in result.detail
 
 
 def test_raw_materialization_backlog_expands_to_oversized_materialized_sibling(
@@ -1482,7 +1488,7 @@ def test_raw_materialization_backlog_expands_to_oversized_materialized_sibling(
     assert backlog["candidate_count"] == 1
     assert backlog["expanded_candidate_count"] == 2
     assert backlog["execution_blocked"] is True
-    assert backlog["blocked_candidate_count"] == 1
+    assert backlog["blocked_candidate_count"] == 2
 
     monkeypatch.setattr(
         "polylogue.sources.revision_backfill._parse_retained_raw",
@@ -1490,7 +1496,7 @@ def test_raw_materialization_backlog_expands_to_oversized_materialized_sibling(
     )
     result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_id=small_raw)
     assert result.success is False
-    assert "expanded-cohort" in result.detail
+    assert "authority components" in result.detail
 
 
 def test_raw_materialization_blocks_aggregate_sub_limit_cohort_before_blob_open(
@@ -1532,7 +1538,50 @@ def test_raw_materialization_blocks_aggregate_sub_limit_cohort_before_blob_open(
     result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
     assert result.success is False
     assert result.metrics["raw_materialization_resource_blocked_count"] == 2.0
-    assert "aggregate 1.2 GiB" in result.detail
+    assert "aggregate payload exceeds 1.0 GiB" in result.detail
+
+
+def test_raw_materialization_processes_independent_components_across_bounded_passes(tmp_path: Path) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    raw_count = 25
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=f'{{"type":"session_meta","payload":{{"id":"independent-{index}"}}}}\n'.encode(),
+                source_path=f"independent-{index}.jsonl",
+                acquired_at_ms=index,
+            )
+            for index in range(raw_count)
+        ]
+    per_raw_size = 50 * 1024 * 1024
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.executemany(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            ((per_raw_size, raw_id) for raw_id in raw_ids),
+        )
+        source_conn.commit()
+
+    config = _config(tmp_path)
+    backlog = repair_mod.raw_materialization_replay_backlog(config)
+    assert backlog["candidate_count"] == raw_count
+    assert backlog["authority_component_count"] == raw_count
+    assert (
+        int(cast(int, backlog["expanded_total_blob_bytes"])) > repair_mod.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+    )
+    assert backlog["execution_blocked"] is False
+    assert backlog["executable_authority_component_count"] == raw_count
+
+    repaired_per_pass: list[int] = []
+    for _pass in range(5):
+        result = repair_mod.repair_raw_materialization(config, raw_artifact_limit=5)
+        repaired_per_pass.append(result.repaired_count)
+    assert repaired_per_pass == [5, 5, 5, 5, 5]
+    assert repair_mod.repair_raw_materialization(config, raw_artifact_limit=5).success is True
 
 
 def test_raw_materialization_quarantines_parse_failures_without_legacy_parser(


### PR DESCRIPTION
## Summary

Correct the unsafe ordinary-daemon replay amplification merged in #2688. Ordinary replay now censuses only the selected authority cohort; explicit offline rebuild remains the only archive-wide census route. Payload size is enforced after full durable cohort expansion and before opening any retained blob.

## Problem

Independent adversarial review of #2688 found two critical defects:

1. `backfill_historical_revision_evidence(selected_raw_ids=...)` still parsed and rewrote membership census for every retained raw before applying the selection. A 120-row daemon batch would therefore rescan roughly 18k raws / 45 GiB and mutate unrelated source evidence.
2. The pre-expansion size guard could select a small raw whose authority sibling exceeded 1 GiB. Stream-capable formats were also incorrectly treated as executable even though `raw_revision_material` materializes the full retained payload before stream parsing.

#2688 remains explicit evidence of the superseded unsafe implementation; this PR corrects it forward without rewriting history.

## Solution

- Add selected-row support to the source-tier census reader.
- Expand selected IDs through durable source-path and membership authority, census only that fixed-point cohort, and leave unrelated raw census rows untouched.
- Keep `selected_raw_ids=None` as the explicit archive-wide/offline behavior.
- Enforce `max_payload_bytes` over the fully expanded cohort before `_parse_retained_raw` opens any blob.
- Treat all oversized retained raws as blocked; stream capability remains diagnostic until the retained reader actually streams.
- Return a typed resource-blocked result to ordinary repair with stable metrics and detail.
- Add anti-amplification, oversized-stream, and small-selected/oversized-sibling regressions that fail if unrelated or oversized blobs are opened.

## Verification

- `devtools test tests/unit/storage/test_archive_readiness.py tests/unit/storage/test_repair.py tests/unit/sources/test_revision_backfill.py` — 56 passed in 81.81s.
- `devtools verify --quick` — all 13 steps passed in 22.37s.

Ref polylogue-yla8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for replaying historical revision data.
  * Added clear resource-blocking errors when individual or combined payloads exceed configured limits.
  * Expanded repair diagnostics to include related payload cohorts and authority components.
  * Added support for targeted census selection and payload-size reporting.

* **Bug Fixes**
  * Prevented oversized or blocked payloads from being opened or replayed during repair.
  * Improved handling of parsing failures, append fragments, and related session data.

* **Tests**
  * Added coverage for oversized cohorts, independent processing, and targeted rebuild isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->