### PR TITLE
fix(sources): restrict append planning to JSONL streams

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1591,7 +1591,10 @@ class LiveBatchProcessor:
         )
 
     def _append_plan(self, path: Path, *, cursor: CursorRecord | None = None) -> _AppendPlan | _DeferredAppend | None:
-        if self._source_name_for(path) == "browser-capture" and path.suffix.lower() == ".json":
+        # Append planning is safe only for newline-delimited record streams.
+        # Watch-source names describe acquisition routes, not file semantics:
+        # mutable browser snapshots can arrive through the generic inbox.
+        if path.suffix.lower() != ".jsonl":
             return None
         cursor = cursor or self._cursor.get_record(path)
         if cursor is None or cursor.parser_fingerprint != self._current_parser_fingerprint():

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -837,32 +837,106 @@ def test_append_plan_defers_when_tail_has_no_complete_line(tmp_path: Path) -> No
     assert processor._append_plan(path) is _DEFER_APPEND
 
 
-def test_browser_capture_json_replacement_bypasses_append_plan(tmp_path: Path) -> None:
-    root = tmp_path / "browser-capture" / "chatgpt"
-    root.mkdir(parents=True)
+@pytest.mark.asyncio
+async def test_inbox_browser_capture_json_replacement_uses_full_ingest(tmp_path: Path) -> None:
+    from polylogue.api import Polylogue
+
+    root = tmp_path / "inbox"
+    root.mkdir()
     path = root / "capture.json"
-    path.write_text('{"polylogue_capture_kind":"browser_llm_session"}', encoding="utf-8")
+
+    def capture(turns: list[dict[str, object]]) -> dict[str, object]:
+        return {
+            "polylogue_capture_kind": "browser_llm_session",
+            "schema_version": 1,
+            "capture_id": "chatgpt:inbox-replacement",
+            "provenance": {
+                "source_url": "https://chatgpt.com/c/inbox-replacement",
+                "page_title": "Inbox replacement",
+                "captured_at": "2026-07-11T00:00:00+00:00",
+                "adapter_name": "chatgpt-native-v1",
+                "capture_mode": "snapshot",
+            },
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": "inbox-replacement",
+                "title": "Inbox replacement",
+                "updated_at": "2026-07-11T00:00:01+00:00",
+                "turns": turns,
+            },
+        }
+
+    first_turn = {
+        "provider_turn_id": "turn-1",
+        "role": "user",
+        "text": "first snapshot",
+        "ordinal": 0,
+    }
+    replacement_turn = {
+        "provider_turn_id": "turn-2",
+        "role": "assistant",
+        "text": "replacement snapshot",
+        "ordinal": 1,
+    }
+    path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
+    archive = Polylogue(archive_root=tmp_path / "archive")
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="inbox", root=root, suffixes=(".json", ".jsonl")),),
+        cursor=CursorStore(archive.backend.db_path),
+        parser_fingerprint="test-parser",
+    )
+
+    try:
+        first = await processor.ingest_files([path], emit_event=False)
+        path.write_text(json.dumps(capture([first_turn, replacement_turn])), encoding="utf-8")
+        second = await processor.ingest_files([path], emit_event=False)
+        assert first.full_file_count == 1
+        assert second.full_file_count == 1
+        assert second.append_file_count == 0
+        with sqlite3.connect(archive.archive_root / "source.db") as conn:
+            source_indexes = conn.execute(
+                "SELECT source_index FROM raw_sessions WHERE source_path = ? ORDER BY acquired_at_ms",
+                (str(path),),
+            ).fetchall()
+        assert source_indexes == [(0,), (0,)]
+    finally:
+        await archive.close()
+
+
+def test_jsonl_stream_retains_append_plan(tmp_path: Path) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "session.jsonl"
+    original = b'{"type":"session_meta","payload":{"id":"append-safe"}}\n'
+    appended = b'{"type":"event_msg","payload":{"message":"new"}}\n'
+    path.write_bytes(original + appended)
     db_path = tmp_path / "archive.sqlite"
     cursor = CursorStore(db_path)
-    old_size = path.stat().st_size
+    stat = path.stat()
     cursor.set(
         path,
-        old_size,
-        byte_offset=old_size,
-        last_complete_newline=old_size,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
         parser_fingerprint="test-parser",
-        content_fingerprint="old-fingerprint",
-        source_name="chatgpt",
+        content_fingerprint="base",
+        source_name="inbox",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
     )
-    path.write_text('{"polylogue_capture_kind":"browser_llm_session","turns":["replacement"]}', encoding="utf-8")
     processor = LiveBatchProcessor(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
-        (WatchSource(name="browser-capture", root=root.parent, suffixes=(".json",)),),
+        (WatchSource(name="inbox", root=root, suffixes=(".jsonl",)),),
         cursor=cursor,
         parser_fingerprint="test-parser",
     )
 
-    assert processor._append_plan(path) is None
+    plan = processor._append_plan(path)
+
+    assert isinstance(plan, _AppendPlan)
+    assert plan.payload.endswith(appended)
 
 
 def test_incomplete_append_is_requeued_not_full_ingested(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_live_cursor_persistence.py
+++ b/tests/unit/sources/test_live_cursor_persistence.py
@@ -67,6 +67,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
         stage_timing_prefix: str,
         manage_transaction: bool,
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
+        revision_authoritative: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         nonlocal attempts
         attempts += 1
@@ -81,6 +82,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
             stage_timing_prefix=stage_timing_prefix,
             manage_transaction=manage_transaction,
             preacquired_attachment_blobs=preacquired_attachment_blobs,
+            revision_authoritative=revision_authoritative,
         )
 
     monkeypatch.setattr(ArchiveStore, "_write_parsed_precedence_result", lock_once)


### PR DESCRIPTION
## Summary

Restrict direct live append planning to proven `.jsonl` record streams. Ordinary JSON documents now always take full-file ingestion regardless of which watcher route discovered them.

## Problem

Six valid browser-capture JSON snapshots arrived through the generic inbox route. Append eligibility was keyed to the `browser-capture` watcher label, so inbox routing treated the replacement document suffix as a JSONL append, retained invalid suffix evidence, and risked suppressing the current full document.

## Solution

- gate `_append_plan` on `.jsonl` format rather than watcher source name
- exercise a real browser-envelope replacement through an `inbox` `WatchSource` and prove both revisions are full (`source_index = 0`) evidence
- retain explicit JSONL append-plan coverage
- update the SQLite-lock cursor fixture for the revision-authority write keyword so it still proves a failed append does not advance the committed cursor

Ref polylogue-yla8.3.

Remaining polylogue-yla8.3 scope: the coordinator owns production re-acquisition and terminal classification of the six obsolete suffix raws.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k 'inbox_browser_capture_json_replacement or jsonl_stream_retains_append_plan'` — `2 passed, 34 deselected`
- `devtools test tests/unit/sources/test_live_cursor_persistence.py -k append_lock_preserves_prior_cursor` — `1 passed, 2 deselected`
- `devtools verify --quick` — 13/13 steps passed, exit 0