### PR TITLE
fix(storage): preserve semantic replay frontiers

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1930,6 +1930,22 @@ class ArchiveStore:
             write_source_blob_refs(self._ensure_source_conn(), raw_id, refs)
         session_ids: set[str] = set()
         with self._conn:
+            existing_head = self._conn.execute(
+                "SELECT accepted_frontier_kind FROM raw_revision_heads WHERE logical_source_key = ?",
+                (plan.logical_source_key,),
+            ).fetchone()
+            accepted_frontier_kind = (
+                "semantic" if existing_head is not None and str(existing_head[0]) == "semantic" else "byte"
+            )
+            if accepted_frontier_kind == "semantic":
+                accepted_projection = session_revision_projection(aggregate_sessions[0])
+                accepted_frontier = (
+                    len(accepted_projection.message_hashes)
+                    + len(accepted_projection.event_hashes)
+                    + len(accepted_projection.attachment_hashes)
+                )
+            else:
+                accepted_frontier = None
             for position, raw_id in enumerate(plan.accepted_raw_ids):
                 result = self._index_parsed_for_retained_raw(
                     parsed_by_raw_id[raw_id],
@@ -1977,8 +1993,14 @@ class ArchiveStore:
                         accepted_raw_id=accepted_raw_id if has_head else None,
                         accepted_source_revision=accepted.source_revision if has_head else None,
                         accepted_content_hash=stored[0] if has_head else None,
-                        accepted_frontier_kind="byte" if has_head else None,
-                        accepted_frontier=(accepted.append_end_offset or accepted.blob_size) if has_head else None,
+                        accepted_frontier_kind=accepted_frontier_kind if has_head else None,
+                        accepted_frontier=(
+                            accepted_frontier
+                            if accepted_frontier_kind == "semantic"
+                            else accepted.append_end_offset or accepted.blob_size
+                        )
+                        if has_head
+                        else None,
                         baseline_raw_id=candidate.baseline_raw_id,
                         predecessor_raw_id=candidate.predecessor_raw_id,
                         append_end_offset=accepted.append_end_offset,

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 from itertools import permutations
 from pathlib import Path
 
+import pytest
+
 from polylogue.archive.message.roles import Role
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
-from polylogue.archive.revision_replay import ApplicationDecision, RevisionCandidate, plan_revision_replay
+from polylogue.archive.revision_replay import (
+    ApplicationDecision,
+    RevisionCandidate,
+    RevisionReplayPlan,
+    plan_revision_replay,
+)
+from polylogue.archive.session_revision_membership import MembershipClassification
 from polylogue.core.enums import Provider
+from polylogue.pipeline.ids import session_revision_projection
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -248,3 +257,101 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
         ).fetchone()
         assert head is not None
         assert tuple(head) == (folded, 20)
+
+
+def test_full_replay_preserves_semantic_head_and_rolls_back_regressions(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+
+    def parsed(*messages: tuple[str, str]) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[
+                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
+                for message_id, text in messages
+            ],
+        )
+
+    def write_full(archive: ArchiveStore, label: str, generation: int) -> str:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=label.encode(),
+            source_path="session.json",
+            acquired_at_ms=generation,
+        )
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.FULL,
+                f"revision-{label}",
+                generation,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        return raw_id
+
+    def selected_full_plan(raw_id: str, generation: int, size: int) -> RevisionReplayPlan:
+        return plan_revision_replay([_candidate(raw_id, RawRevisionKind.FULL, generation, size=size)])
+
+    def durable_index_state(archive: ArchiveStore) -> tuple[object, ...]:
+        return (
+            archive._conn.execute(
+                "SELECT message_count, content_hash FROM sessions WHERE session_id = 'codex-session:session'"
+            ).fetchone(),
+            archive._conn.execute("SELECT message_id, content_hash FROM messages ORDER BY position").fetchall(),
+            archive._conn.execute("SELECT block_id, search_text FROM blocks ORDER BY message_id, position").fetchall(),
+            archive._conn.execute("SELECT id, sz FROM messages_fts_docsize ORDER BY id").fetchall(),
+            archive._conn.execute(
+                """SELECT accepted_raw_id, accepted_source_revision, accepted_content_hash,
+                          accepted_frontier_kind, accepted_frontier
+                   FROM raw_revision_heads WHERE logical_source_key = 'codex:session'"""
+            ).fetchone(),
+            archive._conn.execute("SELECT COUNT(*) FROM raw_revision_applications").fetchone(),
+        )
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        base_session = parsed(("m0", "zero"))
+        base = write_full(archive, "base", 1)
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            MembershipClassification((base,), (), ()),
+            {base: base_session},
+            {base: session_revision_projection(base_session)},
+            acquired_at_ms=0,
+        )
+
+        later_session = parsed(("m0", "zero"), ("m1", "one"), ("m2", "two"))
+        later = write_full(archive, "later", 2)
+        later_plan = selected_full_plan(later, 2, len("later"))
+        archive.apply_raw_revision_replay(later_plan, {later: later_session}, acquired_at_ms=0)
+
+        semantic_head = archive._conn.execute(
+            """SELECT accepted_raw_id, accepted_frontier_kind, accepted_frontier
+               FROM raw_revision_heads WHERE logical_source_key = 'codex:session'"""
+        ).fetchone()
+        assert semantic_head is not None
+        assert tuple(semantic_head) == (later, "semantic", 3)
+
+        for label, rejected_session, error in (
+            ("older", parsed(("m0", "zero"), ("m1", "one")), "older accepted frontier"),
+            (
+                "conflict",
+                parsed(("m0", "zero"), ("m1", "one"), ("m2", "different")),
+                "conflicting accepted head",
+            ),
+        ):
+            before = durable_index_state(archive)
+            generation = 3 if label == "older" else 4
+            rejected_raw = write_full(archive, label, generation)
+            rejected_plan = selected_full_plan(rejected_raw, generation, len(label))
+            with pytest.raises(RuntimeError, match=error):
+                archive.apply_raw_revision_replay(
+                    rejected_plan,
+                    {rejected_raw: rejected_session},
+                    acquired_at_ms=0,
+                )
+            assert durable_index_state(archive) == before
+            assert archive._ensure_source_conn().execute(
+                "SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (rejected_raw,)
+            ).fetchone() == (None,)


### PR DESCRIPTION
## Summary

Preserve semantic authority when a later full snapshot updates a session bootstrapped through membership replay.

## Problem

Production recovery acquired six complete browser snapshots, but full replay always emitted byte frontiers. Their existing heads were semantic, so CAS rejected every update as incomparable even when the new semantic projection was strictly later.

## Solution

- inspect the existing logical head inside the replay transaction
- derive the accepted session projection frontier when that head is semantic
- retain byte frontiers for byte-governed full/append chains
- prove later semantic replacement advances while older and same-frontier conflicting replacements roll back session, messages, blocks, FTS, head, and receipts

Ref polylogue-yla8.4.

## Verification

- `devtools test tests/unit/storage/test_revision_replay.py` -> 7 passed
- `devtools verify --quick` -> 13/13 steps passed