### PR TITLE
fix(storage): retire governed bundle raws

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -179,7 +179,18 @@ def _raw_materialization_candidate_ids(
                          AND a.decision IN (
                            'selected_baseline', 'applied_append', 'superseded', 'ambiguous'
                          )
-                   ) AS application_terminal
+                   ) AS application_terminal,
+                   EXISTS (
+                       SELECT 1
+                       FROM raw_membership_census AS c
+                       WHERE c.raw_id = r.raw_id
+                         AND c.status = 'complete'
+                         AND NOT EXISTS (
+                           SELECT 1 FROM raw_session_memberships AS m
+                           WHERE m.raw_id = c.raw_id
+                             AND (m.decision IS NULL OR m.decision IN ('ambiguous', 'deferred'))
+                         )
+                   ) AS membership_authority_complete
             FROM raw_sessions AS r
             LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
             LEFT JOIN index_tier.sessions AS s_by_native
@@ -218,6 +229,8 @@ def _raw_materialization_candidate_ids(
                 adoption_deferred += 1
                 continue
             if bool(row["application_terminal"]):
+                continue
+            if bool(row["membership_authority_complete"]):
                 continue
             if row["parse_error"] and not _raw_materialization_retryable_missing_blob_error(row["parse_error"]):
                 continue

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -715,6 +715,56 @@ def test_raw_materialization_receipts_partition_terminal_deferred_and_executable
     assert candidates.adoption_deferred == 1
 
 
+def test_raw_materialization_retires_only_complete_governed_bundle_membership(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    raw_ids: list[str] = []
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        for position, decision in enumerate(("applied", "ambiguous", None), start=1):
+            raw_id, blob_size = blob_store.write_from_bytes(f'{{"bundle":{position}}}'.encode())
+            raw_ids.append(raw_id)
+            source_conn.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+                ) VALUES (?, 'chatgpt-export', ?, 0, ?, ?, ?)
+                """,
+                (raw_id, f"bundle-{position}.json", bytes.fromhex(raw_id), blob_size, position),
+            )
+            source_conn.execute(
+                """
+                INSERT INTO raw_membership_census (
+                    raw_id, parser_fingerprint, status, member_count, censused_at_ms
+                ) VALUES (?, 'test', 'complete', 1, 1)
+                """,
+                (raw_id,),
+            )
+            source_conn.execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count, decision, decided_at_ms
+                ) VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+                """,
+                (
+                    raw_id,
+                    f"bundle:{position}",
+                    f"session-{position}",
+                    f"revision-{position}",
+                    bytes.fromhex(raw_id),
+                    decision,
+                    1 if decision is not None else None,
+                ),
+            )
+        source_conn.commit()
+
+    candidates = repair_mod._raw_materialization_candidate_ids(config)
+
+    assert set(candidates.raw_ids) == {raw_ids[1], raw_ids[2]}
+
+
 def test_raw_materialization_ordinary_replay_reaches_two_call_fixed_point(tmp_path: Path) -> None:
     config = _config(tmp_path)
     initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)


### PR DESCRIPTION
## Summary

Retire fully governed multi-session bundle raws from ordinary replay selection.

## Problem

A contained production pass replayed 1,044 logical membership sources yet left the same 262 raw candidates because bundle raws cannot be represented by one `sessions.raw_id`.

## Solution

Use the existing complete-census/no-unresolved-membership authority predicate in candidate selection. Incomplete, NULL, ambiguous, and deferred memberships remain visible.

Ref polylogue-yla8.5.

## Verification

- focused repair selector/fixed-point tests -> 3 passed
- `devtools verify --quick` -> 13/13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair and replay handling for raw records with governed session membership.
  * Records are now treated as resolved only when membership data is complete and unambiguous, preventing incomplete cases from being skipped.

* **Tests**
  * Added coverage to verify that only fully complete membership bundles are retired from repair consideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->