### PR TITLE
fix(storage): stop scheduling governed replay debt

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -72,6 +72,7 @@ class RawMaterializationCandidates:
     adoption_deferred: int = 0
     authority_quarantined: int = 0
     byte_authority_fragments: int = 0
+    byte_authority_quarantined: int = 0
     byte_authority_pending: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
@@ -208,13 +209,17 @@ def _raw_materialization_candidate_ids(
                          AND c.status = 'complete'
                          AND m.decision = 'ambiguous'
                    ) AS membership_authority_quarantined
-                   , EXISTS (
-                       SELECT 1
-                       FROM raw_membership_census AS c
-                       WHERE c.raw_id = r.raw_id
-                         AND c.status = 'failed'
-                         AND c.detail = ?
-                   ) AS byte_authority_fragment
+                   , (r.source_index = -1 AND r.revision_authority = 'byte_proven')
+                     AS byte_authority_fragment
+                   , (r.source_index = -1
+                      AND r.revision_authority != 'byte_proven'
+                      AND EXISTS (
+                        SELECT 1
+                        FROM raw_membership_census AS c
+                        WHERE c.raw_id = r.raw_id
+                          AND c.status = 'failed'
+                          AND c.detail = ?
+                      )) AS byte_authority_quarantined
                    , (r.source_index = -1 AND NOT EXISTS (
                        SELECT 1
                        FROM raw_membership_census AS c
@@ -257,6 +262,7 @@ def _raw_materialization_candidate_ids(
         adoption_deferred = 0
         authority_quarantined = 0
         byte_authority_fragments = 0
+        byte_authority_quarantined = 0
         byte_authority_pending = 0
         for row in rows:
             if bool(row["adoption_deferred"]):
@@ -271,6 +277,9 @@ def _raw_materialization_candidate_ids(
                 continue
             if bool(row["byte_authority_fragment"]):
                 byte_authority_fragments += 1
+                continue
+            if bool(row["byte_authority_quarantined"]):
+                byte_authority_quarantined += 1
                 continue
             if bool(row["byte_authority_pending"]):
                 byte_authority_pending += 1
@@ -323,6 +332,7 @@ def _raw_materialization_candidate_ids(
         adoption_deferred=adoption_deferred,
         authority_quarantined=authority_quarantined,
         byte_authority_fragments=byte_authority_fragments,
+        byte_authority_quarantined=byte_authority_quarantined,
         byte_authority_pending=byte_authority_pending,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
@@ -410,6 +420,7 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
             "durable_authority_debt_count": 0,
             "authority_quarantined_count": 0,
             "byte_authority_fragment_count": 0,
+            "byte_authority_quarantined_count": 0,
             "byte_authority_pending_count": 0,
             "candidate_count": 0,
             "top_raw_rows": [],
@@ -453,7 +464,10 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
     resource_blocked_count = len(blocked_component_raw_ids)
     blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred + candidates.byte_authority_pending
     durable_authority_debt_count = (
-        candidates.authority_quarantined + candidates.byte_authority_fragments + candidates.byte_authority_pending
+        candidates.authority_quarantined
+        + candidates.byte_authority_fragments
+        + candidates.byte_authority_quarantined
+        + candidates.byte_authority_pending
     )
     return {
         "available": True,
@@ -471,6 +485,7 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         "durable_authority_debt_count": durable_authority_debt_count,
         "authority_quarantined_count": candidates.authority_quarantined,
         "byte_authority_fragment_count": candidates.byte_authority_fragments,
+        "byte_authority_quarantined_count": candidates.byte_authority_quarantined,
         "byte_authority_pending_count": candidates.byte_authority_pending,
         "adoption_deferred_count": candidates.adoption_deferred,
         "candidate_count": len(candidates.raw_ids),
@@ -1642,6 +1657,7 @@ def repair_raw_materialization(
         "raw_materialization_adoption_deferred_count": float(candidates.adoption_deferred),
         "raw_materialization_authority_quarantined_count": float(candidates.authority_quarantined),
         "raw_materialization_byte_authority_fragment_count": float(candidates.byte_authority_fragments),
+        "raw_materialization_byte_authority_quarantined_count": float(candidates.byte_authority_quarantined),
         "raw_materialization_byte_authority_pending_count": float(candidates.byte_authority_pending),
     }
     if raw_artifact_limit is not None:
@@ -1665,10 +1681,16 @@ def repair_raw_materialization(
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
     if not raw_ids:
         detail = "Executable raw replay converged"
-        if candidates.authority_quarantined or candidates.byte_authority_fragments or candidates.byte_authority_pending:
+        if (
+            candidates.authority_quarantined
+            or candidates.byte_authority_fragments
+            or candidates.byte_authority_quarantined
+            or candidates.byte_authority_pending
+        ):
             detail += (
                 f"; {candidates.authority_quarantined:,} explicit authority quarantine(s), "
                 f"{candidates.byte_authority_fragments:,} byte-authority fragment(s) excluded from replay, "
+                f"{candidates.byte_authority_quarantined:,} append authority quarantine(s), "
                 f"{candidates.byte_authority_pending:,} append fragment(s) pending byte-authority adjudication"
             )
         if candidates.adoption_deferred:
@@ -1687,7 +1709,11 @@ def repair_raw_materialization(
                 and candidates.byte_authority_pending == 0
                 and (
                     raw_artifact_id is None
-                    or (candidates.authority_quarantined == 0 and candidates.byte_authority_fragments == 0)
+                    or (
+                        candidates.authority_quarantined == 0
+                        and candidates.byte_authority_fragments == 0
+                        and candidates.byte_authority_quarantined == 0
+                    )
                 )
             ),
             detail=detail,
@@ -1773,6 +1799,9 @@ def repair_raw_materialization(
             "raw_materialization_remaining_candidate_count": float(len(remaining.raw_ids)),
             "raw_materialization_remaining_authority_quarantined_count": float(remaining.authority_quarantined),
             "raw_materialization_remaining_byte_authority_fragment_count": float(remaining.byte_authority_fragments),
+            "raw_materialization_remaining_byte_authority_quarantined_count": float(
+                remaining.byte_authority_quarantined
+            ),
             "raw_materialization_remaining_byte_authority_pending_count": float(remaining.byte_authority_pending),
         }
     )
@@ -1784,7 +1813,11 @@ def repair_raw_materialization(
         and remaining.byte_authority_pending == 0
         and (
             raw_artifact_id is None
-            or (remaining.authority_quarantined == 0 and remaining.byte_authority_fragments == 0)
+            or (
+                remaining.authority_quarantined == 0
+                and remaining.byte_authority_fragments == 0
+                and remaining.byte_authority_quarantined == 0
+            )
         )
     )
     detail = (
@@ -1797,10 +1830,16 @@ def repair_raw_materialization(
         detail += f"; {replay.adoption_deferred:,} revision(s) deferred behind incomparable existing index state"
     if remaining.adoption_deferred:
         detail += f"; {remaining.adoption_deferred:,} deferred adoption decision(s) remain blocked"
-    if remaining.authority_quarantined or remaining.byte_authority_fragments or remaining.byte_authority_pending:
+    if (
+        remaining.authority_quarantined
+        or remaining.byte_authority_fragments
+        or remaining.byte_authority_quarantined
+        or remaining.byte_authority_pending
+    ):
         detail += (
             f"; durable authority debt: {remaining.authority_quarantined:,} quarantine(s), "
             f"{remaining.byte_authority_fragments:,} governed append fragment(s), "
+            f"{remaining.byte_authority_quarantined:,} append authority quarantine(s), "
             f"{remaining.byte_authority_pending:,} append fragment(s) pending adjudication"
         )
     if oversized_raw_ids:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -44,6 +44,7 @@ _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
 RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
+_BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision authority"
 
 
 def _format_bytes(value: int) -> str:
@@ -69,6 +70,8 @@ class RawMaterializationCandidates:
     missing_blob_source_available: int = 0
     missing_blob_source_missing: int = 0
     adoption_deferred: int = 0
+    authority_quarantined: int = 0
+    byte_authority_fragments: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
     authority_components: tuple[tuple[str, ...], ...] = ()
@@ -185,12 +188,32 @@ def _raw_materialization_candidate_ids(
                        FROM raw_membership_census AS c
                        WHERE c.raw_id = r.raw_id
                          AND c.status = 'complete'
+                         AND c.member_count > 0
+                         AND c.member_count = (
+                           SELECT COUNT(*) FROM raw_session_memberships AS counted
+                           WHERE counted.raw_id = c.raw_id
+                         )
                          AND NOT EXISTS (
                            SELECT 1 FROM raw_session_memberships AS m
                            WHERE m.raw_id = c.raw_id
                              AND (m.decision IS NULL OR m.decision IN ('ambiguous', 'deferred'))
                          )
                    ) AS membership_authority_complete
+                   , EXISTS (
+                       SELECT 1
+                       FROM raw_membership_census AS c
+                       JOIN raw_session_memberships AS m ON m.raw_id = c.raw_id
+                       WHERE c.raw_id = r.raw_id
+                         AND c.status = 'complete'
+                         AND m.decision = 'ambiguous'
+                   ) AS membership_authority_quarantined
+                   , (r.source_index = -1 OR EXISTS (
+                       SELECT 1
+                       FROM raw_membership_census AS c
+                       WHERE c.raw_id = r.raw_id
+                         AND c.status = 'failed'
+                         AND c.detail = ?
+                   )) AS byte_authority_fragment
             FROM raw_sessions AS r
             LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
             LEFT JOIN index_tier.sessions AS s_by_native
@@ -221,9 +244,11 @@ def _raw_materialization_candidate_ids(
               {source_root_filter}
             ORDER BY r.acquired_at_ms DESC, r.raw_id ASC
             """,
-            params,
+            [_BYTE_AUTHORITY_CENSUS_DETAIL, *params],
         ).fetchall()
         adoption_deferred = 0
+        authority_quarantined = 0
+        byte_authority_fragments = 0
         for row in rows:
             if bool(row["adoption_deferred"]):
                 adoption_deferred += 1
@@ -231,6 +256,12 @@ def _raw_materialization_candidate_ids(
             if bool(row["application_terminal"]):
                 continue
             if bool(row["membership_authority_complete"]):
+                continue
+            if bool(row["membership_authority_quarantined"]):
+                authority_quarantined += 1
+                continue
+            if bool(row["byte_authority_fragment"]):
+                byte_authority_fragments += 1
                 continue
             if row["parse_error"] and not _raw_materialization_retryable_missing_blob_error(row["parse_error"]):
                 continue
@@ -278,6 +309,8 @@ def _raw_materialization_candidate_ids(
         missing_blob_source_available=missing_blob_source_available,
         missing_blob_source_missing=missing_blob_source_missing,
         adoption_deferred=adoption_deferred,
+        authority_quarantined=authority_quarantined,
+        byte_authority_fragments=byte_authority_fragments,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
         authority_components=authority_components,
@@ -1581,6 +1614,8 @@ def repair_raw_materialization(
         "raw_materialization_selected_total_blob_bytes": float(selected_total_bytes),
         "raw_materialization_selected_max_blob_bytes": float(selected_max_bytes),
         "raw_materialization_adoption_deferred_count": float(candidates.adoption_deferred),
+        "raw_materialization_authority_quarantined_count": float(candidates.authority_quarantined),
+        "raw_materialization_byte_authority_fragment_count": float(candidates.byte_authority_fragments),
     }
     if raw_artifact_limit is not None:
         metrics["raw_materialization_limit"] = float(raw_artifact_limit)
@@ -1603,6 +1638,11 @@ def repair_raw_materialization(
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
     if not raw_ids:
         detail = "Raw materialization ready"
+        if candidates.authority_quarantined or candidates.byte_authority_fragments:
+            detail += (
+                f"; {candidates.authority_quarantined:,} explicit authority quarantine(s), "
+                f"{candidates.byte_authority_fragments:,} byte-authority fragment(s) excluded from replay"
+            )
         if candidates.adoption_deferred:
             detail = (
                 f"Raw materialization blocked: {candidates.adoption_deferred:,} revision adoption decision(s) "

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -72,6 +72,7 @@ class RawMaterializationCandidates:
     adoption_deferred: int = 0
     authority_quarantined: int = 0
     byte_authority_fragments: int = 0
+    byte_authority_pending: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
     authority_components: tuple[tuple[str, ...], ...] = ()
@@ -207,13 +208,20 @@ def _raw_materialization_candidate_ids(
                          AND c.status = 'complete'
                          AND m.decision = 'ambiguous'
                    ) AS membership_authority_quarantined
-                   , (r.source_index = -1 OR EXISTS (
+                   , EXISTS (
                        SELECT 1
                        FROM raw_membership_census AS c
                        WHERE c.raw_id = r.raw_id
                          AND c.status = 'failed'
                          AND c.detail = ?
-                   )) AS byte_authority_fragment
+                   ) AS byte_authority_fragment
+                   , (r.source_index = -1 AND NOT EXISTS (
+                       SELECT 1
+                       FROM raw_membership_census AS c
+                       WHERE c.raw_id = r.raw_id
+                         AND c.status = 'failed'
+                         AND c.detail = ?
+                   )) AS byte_authority_pending
             FROM raw_sessions AS r
             LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
             LEFT JOIN index_tier.sessions AS s_by_native
@@ -244,11 +252,12 @@ def _raw_materialization_candidate_ids(
               {source_root_filter}
             ORDER BY r.acquired_at_ms DESC, r.raw_id ASC
             """,
-            [_BYTE_AUTHORITY_CENSUS_DETAIL, *params],
+            [_BYTE_AUTHORITY_CENSUS_DETAIL, _BYTE_AUTHORITY_CENSUS_DETAIL, *params],
         ).fetchall()
         adoption_deferred = 0
         authority_quarantined = 0
         byte_authority_fragments = 0
+        byte_authority_pending = 0
         for row in rows:
             if bool(row["adoption_deferred"]):
                 adoption_deferred += 1
@@ -262,6 +271,9 @@ def _raw_materialization_candidate_ids(
                 continue
             if bool(row["byte_authority_fragment"]):
                 byte_authority_fragments += 1
+                continue
+            if bool(row["byte_authority_pending"]):
+                byte_authority_pending += 1
                 continue
             if row["parse_error"] and not _raw_materialization_retryable_missing_blob_error(row["parse_error"]):
                 continue
@@ -311,6 +323,7 @@ def _raw_materialization_candidate_ids(
         adoption_deferred=adoption_deferred,
         authority_quarantined=authority_quarantined,
         byte_authority_fragments=byte_authority_fragments,
+        byte_authority_pending=byte_authority_pending,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
         authority_components=authority_components,
@@ -394,6 +407,10 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
             "execution_blocked": False,
             "execution_block_reason": None,
             "blocked_candidate_count": 0,
+            "durable_authority_debt_count": 0,
+            "authority_quarantined_count": 0,
+            "byte_authority_fragment_count": 0,
+            "byte_authority_pending_count": 0,
             "candidate_count": 0,
             "top_raw_rows": [],
             "origin_summary": [],
@@ -434,7 +451,10 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
     blocked_component_raw_ids = {raw_id for component in blocked_components for raw_id in component}
     aggregate_resource_blocked = bool(blocked_components)
     resource_blocked_count = len(blocked_component_raw_ids)
-    blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred
+    blocked_candidate_count = resource_blocked_count + candidates.adoption_deferred + candidates.byte_authority_pending
+    durable_authority_debt_count = (
+        candidates.authority_quarantined + candidates.byte_authority_fragments + candidates.byte_authority_pending
+    )
     return {
         "available": True,
         "execution_blocked": blocked_candidate_count > 0,
@@ -443,9 +463,15 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
             if resource_blocked_count
             else "revision adoption deferred behind incomparable existing index state"
             if candidates.adoption_deferred
+            else "append fragments remain pending byte-authority adjudication"
+            if candidates.byte_authority_pending
             else None
         ),
         "blocked_candidate_count": blocked_candidate_count,
+        "durable_authority_debt_count": durable_authority_debt_count,
+        "authority_quarantined_count": candidates.authority_quarantined,
+        "byte_authority_fragment_count": candidates.byte_authority_fragments,
+        "byte_authority_pending_count": candidates.byte_authority_pending,
         "adoption_deferred_count": candidates.adoption_deferred,
         "candidate_count": len(candidates.raw_ids),
         "missing_blob_count": candidates.missing_blobs,
@@ -1616,6 +1642,7 @@ def repair_raw_materialization(
         "raw_materialization_adoption_deferred_count": float(candidates.adoption_deferred),
         "raw_materialization_authority_quarantined_count": float(candidates.authority_quarantined),
         "raw_materialization_byte_authority_fragment_count": float(candidates.byte_authority_fragments),
+        "raw_materialization_byte_authority_pending_count": float(candidates.byte_authority_pending),
     }
     if raw_artifact_limit is not None:
         metrics["raw_materialization_limit"] = float(raw_artifact_limit)
@@ -1637,11 +1664,12 @@ def repair_raw_materialization(
     if oversized_stream_safe_raw_ids:
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
     if not raw_ids:
-        detail = "Raw materialization ready"
-        if candidates.authority_quarantined or candidates.byte_authority_fragments:
+        detail = "Executable raw replay converged"
+        if candidates.authority_quarantined or candidates.byte_authority_fragments or candidates.byte_authority_pending:
             detail += (
                 f"; {candidates.authority_quarantined:,} explicit authority quarantine(s), "
-                f"{candidates.byte_authority_fragments:,} byte-authority fragment(s) excluded from replay"
+                f"{candidates.byte_authority_fragments:,} byte-authority fragment(s) excluded from replay, "
+                f"{candidates.byte_authority_pending:,} append fragment(s) pending byte-authority adjudication"
             )
         if candidates.adoption_deferred:
             detail = (
@@ -1653,7 +1681,15 @@ def repair_raw_materialization(
         return _internal_derived_repair_result(
             "raw_materialization",
             repaired_count=0,
-            success=missing_blobs == 0 and candidates.adoption_deferred == 0,
+            success=(
+                missing_blobs == 0
+                and candidates.adoption_deferred == 0
+                and candidates.byte_authority_pending == 0
+                and (
+                    raw_artifact_id is None
+                    or (candidates.authority_quarantined == 0 and candidates.byte_authority_fragments == 0)
+                )
+            ),
             detail=detail,
             metrics=metrics,
         )
@@ -1735,6 +1771,9 @@ def repair_raw_materialization(
             "raw_materialization_quarantined_count": float(replay.quarantined),
             "raw_materialization_adoption_deferred_count": float(replay.adoption_deferred),
             "raw_materialization_remaining_candidate_count": float(len(remaining.raw_ids)),
+            "raw_materialization_remaining_authority_quarantined_count": float(remaining.authority_quarantined),
+            "raw_materialization_remaining_byte_authority_fragment_count": float(remaining.byte_authority_fragments),
+            "raw_materialization_remaining_byte_authority_pending_count": float(remaining.byte_authority_pending),
         }
     )
     success = (
@@ -1742,6 +1781,11 @@ def repair_raw_materialization(
         and remaining.missing_blobs == 0
         and replay.adoption_deferred == 0
         and remaining.adoption_deferred == 0
+        and remaining.byte_authority_pending == 0
+        and (
+            raw_artifact_id is None
+            or (remaining.authority_quarantined == 0 and remaining.byte_authority_fragments == 0)
+        )
     )
     detail = (
         f"Replayed {replay.replayed_logical_sources:,} logical source(s) through typed revision authority; "
@@ -1753,6 +1797,12 @@ def repair_raw_materialization(
         detail += f"; {replay.adoption_deferred:,} revision(s) deferred behind incomparable existing index state"
     if remaining.adoption_deferred:
         detail += f"; {remaining.adoption_deferred:,} deferred adoption decision(s) remain blocked"
+    if remaining.authority_quarantined or remaining.byte_authority_fragments or remaining.byte_authority_pending:
+        detail += (
+            f"; durable authority debt: {remaining.authority_quarantined:,} quarantine(s), "
+            f"{remaining.byte_authority_fragments:,} governed append fragment(s), "
+            f"{remaining.byte_authority_pending:,} append fragment(s) pending adjudication"
+        )
     if oversized_raw_ids:
         detail += (
             f"; {len(oversized_raw_ids):,} non-stream-safe raw row(s) exceed execution limit "

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -739,7 +739,7 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
                     raw_id, parser_fingerprint, status, member_count, censused_at_ms
                 ) VALUES (?, 'test', 'complete', ?, 1)
                 """,
-                (raw_id, 2 if position == 1 else 1),
+                (raw_id, 2 if position in (1, 4) else 1),
             )
             source_conn.execute(
                 """
@@ -758,6 +758,17 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
                     1 if decision is not None else None,
                 ),
             )
+            if position == 4:
+                source_conn.execute(
+                    """
+                    INSERT INTO raw_session_memberships (
+                        raw_id, logical_source_key, provider_session_id, source_revision,
+                        normalized_content_hash, message_count, decision, decided_at_ms
+                    ) VALUES (?, 'bundle:4:second', 'session-4-second', 'revision-4-second', ?, 1,
+                              'superseded_equivalent', 1)
+                    """,
+                    (raw_id, bytes.fromhex(raw_id)),
+                )
         source_conn.commit()
 
     candidates = repair_mod._raw_materialization_candidate_ids(config)
@@ -812,8 +823,19 @@ def test_raw_materialization_reports_uncensused_append_fragments_as_pending_debt
     governed_target = repair_mod.repair_raw_materialization(config, raw_artifact_id=raw_id)
 
     assert governed.byte_authority_pending == 0
-    assert governed.byte_authority_fragments == 1
+    assert governed.byte_authority_quarantined == 1
     assert governed_target.success is False
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            "UPDATE raw_sessions SET revision_authority = 'byte_proven' WHERE raw_id = ?",
+            (raw_id,),
+        )
+        source_conn.commit()
+
+    proven = repair_mod._raw_materialization_candidate_ids(config)
+    assert proven.byte_authority_quarantined == 0
+    assert proven.byte_authority_fragments == 1
 
 
 def test_raw_materialization_ordinary_replay_reaches_two_call_fixed_point(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -737,9 +737,9 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
                 """
                 INSERT INTO raw_membership_census (
                     raw_id, parser_fingerprint, status, member_count, censused_at_ms
-                ) VALUES (?, 'test', 'complete', 1, 1)
+                ) VALUES (?, 'test', 'complete', ?, 1)
                 """,
-                (raw_id,),
+                (raw_id, 2 if position == 1 else 1),
             )
             source_conn.execute(
                 """
@@ -762,7 +762,31 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
 
     candidates = repair_mod._raw_materialization_candidate_ids(config)
 
-    assert set(candidates.raw_ids) == {raw_ids[1], raw_ids[2]}
+    assert set(candidates.raw_ids) == {raw_ids[0], raw_ids[2]}
+    assert candidates.authority_quarantined == 1
+
+
+def test_raw_materialization_does_not_replay_uncensused_append_fragments(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_store = BlobStore(tmp_path / "blob")
+    raw_id, blob_size = blob_store.write_from_bytes(b'{"fragment":true}')
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, 'codex-session', 'session.jsonl', -1, ?, ?, 1)
+            """,
+            (raw_id, bytes.fromhex(raw_id), blob_size),
+        )
+        source_conn.commit()
+
+    candidates = repair_mod._raw_materialization_candidate_ids(config)
+
+    assert candidates.raw_ids == []
+    assert candidates.byte_authority_fragments == 1
 
 
 def test_raw_materialization_ordinary_replay_reaches_two_call_fixed_point(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -722,7 +722,7 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
     blob_store = BlobStore(tmp_path / "blob")
     raw_ids: list[str] = []
     with sqlite3.connect(tmp_path / "source.db") as source_conn:
-        for position, decision in enumerate(("applied", "ambiguous", None), start=1):
+        for position, decision in enumerate(("applied", "ambiguous", None, "applied"), start=1):
             raw_id, blob_size = blob_store.write_from_bytes(f'{{"bundle":{position}}}'.encode())
             raw_ids.append(raw_id)
             source_conn.execute(
@@ -766,7 +766,7 @@ def test_raw_materialization_retires_only_complete_governed_bundle_membership(tm
     assert candidates.authority_quarantined == 1
 
 
-def test_raw_materialization_does_not_replay_uncensused_append_fragments(tmp_path: Path) -> None:
+def test_raw_materialization_reports_uncensused_append_fragments_as_pending_debt(tmp_path: Path) -> None:
     config = _config(tmp_path)
     initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
     initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
@@ -784,9 +784,36 @@ def test_raw_materialization_does_not_replay_uncensused_append_fragments(tmp_pat
         source_conn.commit()
 
     candidates = repair_mod._raw_materialization_candidate_ids(config)
+    backlog = repair_mod.raw_materialization_replay_backlog(config)
+    targeted = repair_mod.repair_raw_materialization(config, raw_artifact_id=raw_id)
 
     assert candidates.raw_ids == []
-    assert candidates.byte_authority_fragments == 1
+    assert candidates.byte_authority_pending == 1
+    assert backlog["candidate_count"] == 0
+    assert backlog["execution_blocked"] is True
+    assert backlog["durable_authority_debt_count"] == 1
+    assert backlog["byte_authority_pending_count"] == 1
+    assert targeted.success is False
+    assert "pending byte-authority adjudication" in targeted.detail
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+            ) VALUES (?, 'test', 'failed', 0, 2,
+                      'append fragments are governed by byte revision authority')
+            """,
+            (raw_id,),
+        )
+        source_conn.commit()
+
+    governed = repair_mod._raw_materialization_candidate_ids(config)
+    governed_target = repair_mod.repair_raw_materialization(config, raw_artifact_id=raw_id)
+
+    assert governed.byte_authority_pending == 0
+    assert governed.byte_authority_fragments == 1
+    assert governed_target.success is False
 
 
 def test_raw_materialization_ordinary_replay_reaches_two_call_fixed_point(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Separate executable raw replay from durable byte-authority fragments and explicit membership quarantines.

## Problem

The final production convergence pass expanded 259 apparent candidates into 1,373 raw rows and replayed 1,044 logical sources. Read-only census showed that 205 rows were append fragments already governed by byte revision authority, 69 were explicit ambiguity quarantines, and only two were uncensused append fragments. Ordinary replay could not resolve those classes and repeated roughly 20 minutes of work.

## Solution

- classify source-index `-1` append fragments and their durable census marker as visible non-executable authority debt
- classify explicit membership ambiguity separately from executable replay
- require positive, exact census cardinality before retiring a governed bundle
- expose both non-executable classes in repair metrics and detail

Ref polylogue-yla8.

## Verification

- `devtools test tests/unit/storage/test_repair.py -k "retires_only_complete_governed_bundle_membership or does_not_replay_uncensused_append_fragments or ordinary_replay_reaches_two_call_fixed_point"` -> 3 passed
- production read-only selector probe -> `raw_ids=0`, `authority_quarantined=69`, `byte_authority_fragments=207`, `expanded_raw_ids=0`
- `devtools verify --quick` -> 13/13 steps passed