### PR TITLE
fix(status): project durable raw authority into readiness

### DIFF
--- a/polylogue/archive/revision_authority.py
+++ b/polylogue/archive/revision_authority.py
@@ -20,6 +20,9 @@ class RawRevisionAuthority(StrEnum):
     QUARANTINED = "quarantined"
 
 
+BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision authority"
+
+
 @dataclass(frozen=True)
 class RawRevisionEnvelope:
     """Evidence captured with raw bytes, before any derived write occurs."""

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -12,6 +12,7 @@ from io import BytesIO
 from pathlib import Path
 from types import TracebackType
 
+from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
@@ -96,7 +97,7 @@ def backfill_historical_revision_evidence(
                             None,
                             parser_fingerprint="revision-membership-v1",
                             censused_at_ms=0,
-                            detail="append fragments are governed by byte revision authority",
+                            detail=BYTE_AUTHORITY_CENSUS_DETAIL,
                         )
                         quarantined += 1
                         continue

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -194,12 +194,15 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
                 WHERE NOT is_materialized
                 """,
             ).fetchall()
-            classified_counts = _classify_raw_gap_rows(
+            classified_counts, parse_failed_origins = _classify_raw_gap_rows(
                 conn,
                 active_archive,
                 gap_rows,
                 raw_columns=raw_columns,
                 session_columns=session_columns,
+                has_revision_applications=bool(_table_columns(conn, "main", "raw_revision_applications")),
+                has_membership_census=bool(_table_columns(conn, "source", "raw_membership_census")),
+                has_session_memberships=bool(_table_columns(conn, "source", "raw_session_memberships")),
             )
             adoption_deferred_count = 0
             if _table_columns(conn, "main", "raw_revision_applications"):
@@ -235,18 +238,6 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
     parsed_without_index_session = int(row["parsed_without_index_session"] or 0)
     parse_failed = classified_counts.get("parse-failed", 0)
     classified = sum(count for category, count in classified_counts.items() if category != "parse-failed")
-    parse_failed_origins = {
-        str(item["origin"] or "unknown")
-        for item in gap_rows
-        if _raw_gap_category(
-            conn,
-            active_archive,
-            item,
-            raw_columns=raw_columns,
-            session_columns=session_columns,
-        )
-        == "parse-failed"
-    }
     actionable = len(parse_failed_origins)
     critical = actionable
     affected_actionable = parse_failed
@@ -451,10 +442,14 @@ def _classify_raw_gap_rows(
     *,
     raw_columns: frozenset[str],
     session_columns: frozenset[str],
-) -> Counter[str]:
+    has_revision_applications: bool,
+    has_membership_census: bool,
+    has_session_memberships: bool,
+) -> tuple[Counter[str], set[str]]:
     if not rows:
-        return Counter()
+        return Counter(), set()
     counts: Counter[str] = Counter()
+    parse_failed_origins: set[str] = set()
     for row in rows:
         category = _raw_gap_category(
             conn,
@@ -462,10 +457,15 @@ def _classify_raw_gap_rows(
             row,
             raw_columns=raw_columns,
             session_columns=session_columns,
+            has_revision_applications=has_revision_applications,
+            has_membership_census=has_membership_census,
+            has_session_memberships=has_session_memberships,
         )
         if category is not None:
             counts[category] += 1
-    return counts
+            if category == "parse-failed":
+                parse_failed_origins.add(str(row["origin"] or "unknown"))
+    return counts, parse_failed_origins
 
 
 def _raw_gap_category(
@@ -475,6 +475,9 @@ def _raw_gap_category(
     *,
     raw_columns: frozenset[str],
     session_columns: frozenset[str],
+    has_revision_applications: bool,
+    has_membership_census: bool,
+    has_session_memberships: bool,
 ) -> str | None:
     can_reconcile_alias = not row["parse_error"] or _retryable_decode_missing_blob_error(row["parse_error"])
     if can_reconcile_alias and _raw_gap_materialized_by_alias(conn, row, session_columns=session_columns):
@@ -485,15 +488,28 @@ def _raw_gap_category(
         return "parsed-non-session-artifact"
     if row["parse_error"]:
         return "parse-failed"
-    authority_category = _raw_gap_authority_category(conn, row)
+    authority_category = _raw_gap_authority_category(
+        conn,
+        row,
+        has_revision_applications=has_revision_applications,
+        has_membership_census=has_membership_census,
+        has_session_memberships=has_session_memberships,
+    )
     if authority_category is not None:
         return authority_category
     return None
 
 
-def _raw_gap_authority_category(conn: sqlite3.Connection, row: sqlite3.Row) -> str | None:
+def _raw_gap_authority_category(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    *,
+    has_revision_applications: bool,
+    has_membership_census: bool,
+    has_session_memberships: bool,
+) -> str | None:
     raw_id = str(row["raw_id"])
-    if _table_columns(conn, "main", "raw_revision_applications"):
+    if has_revision_applications:
         terminal = conn.execute(
             """
             SELECT 1 FROM main.raw_revision_applications
@@ -506,9 +522,7 @@ def _raw_gap_authority_category(conn: sqlite3.Connection, row: sqlite3.Row) -> s
         if terminal is not None:
             return "revision-application-terminal"
 
-    if _table_columns(conn, "source", "raw_membership_census") and _table_columns(
-        conn, "source", "raw_session_memberships"
-    ):
+    if has_membership_census and has_session_memberships:
         membership = conn.execute(
             """
             SELECT 1
@@ -535,7 +549,7 @@ def _raw_gap_authority_category(conn: sqlite3.Connection, row: sqlite3.Row) -> s
     if row["source_index"] == -1:
         if row["revision_authority"] == "byte_proven":
             return "append-authority-proven"
-        if _table_columns(conn, "source", "raw_membership_census"):
+        if has_membership_census:
             quarantined = conn.execute(
                 """
                 SELECT 1 FROM source.raw_membership_census

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -13,8 +13,7 @@ from polylogue.archive.raw_materialization import (
     parsed_non_session_artifact_reason,
     source_path_native_id_candidates,
 )
-
-_BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision authority"
+from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
 
 ACTIVE_REBUILD_STALE_AFTER_S = 180.0
 """Maximum heartbeat/start age for a rebuild-index row to count as active."""
@@ -543,7 +542,7 @@ def _raw_gap_authority_category(conn: sqlite3.Connection, row: sqlite3.Row) -> s
                 WHERE raw_id = ? AND status = 'failed' AND detail = ?
                 LIMIT 1
                 """,
-                (raw_id, _BYTE_AUTHORITY_CENSUS_DETAIL),
+                (raw_id, BYTE_AUTHORITY_CENSUS_DETAIL),
             ).fetchone()
             if quarantined is not None:
                 return "append-authority-quarantined"

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -14,6 +14,8 @@ from polylogue.archive.raw_materialization import (
     source_path_native_id_candidates,
 )
 
+_BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision authority"
+
 ACTIVE_REBUILD_STALE_AFTER_S = 180.0
 """Maximum heartbeat/start age for a rebuild-index row to count as active."""
 
@@ -237,14 +239,14 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
     parse_failed_origins = {
         str(item["origin"] or "unknown")
         for item in gap_rows
-        if item["parse_error"] is not None
-        and (
-            not _retryable_decode_missing_blob_error(item["parse_error"])
-            or (
-                not _raw_gap_materialized_by_alias(conn, item, session_columns=session_columns)
-                and not _raw_gap_matches_missing_index_raw_link(conn, item, session_columns=session_columns)
-            )
+        if _raw_gap_category(
+            conn,
+            active_archive,
+            item,
+            raw_columns=raw_columns,
+            session_columns=session_columns,
         )
+        == "parse-failed"
     }
     actionable = len(parse_failed_origins)
     critical = actionable
@@ -434,6 +436,8 @@ def _raw_gap_select_columns(raw_columns: frozenset[str]) -> str:
         "native_id",
         "source_path",
         "blob_hash",
+        "source_index",
+        "revision_authority",
         "validation_status",
         "parse_error",
         "parsed_at_ms",
@@ -453,19 +457,97 @@ def _classify_raw_gap_rows(
         return Counter()
     counts: Counter[str] = Counter()
     for row in rows:
-        can_reconcile_alias = not row["parse_error"] or _retryable_decode_missing_blob_error(row["parse_error"])
-        if can_reconcile_alias and _raw_gap_materialized_by_alias(conn, row, session_columns=session_columns):
-            counts["materialized-alias"] += 1
-            continue
-        if can_reconcile_alias and _raw_gap_matches_missing_index_raw_link(conn, row, session_columns=session_columns):
-            counts["lost-source-evidence-alias"] += 1
-            continue
-        if _raw_gap_parsed_non_session_artifact(archive_root, row, raw_columns=raw_columns):
-            counts["parsed-non-session-artifact"] += 1
-            continue
-        if row["parse_error"]:
-            counts["parse-failed"] += 1
+        category = _raw_gap_category(
+            conn,
+            archive_root,
+            row,
+            raw_columns=raw_columns,
+            session_columns=session_columns,
+        )
+        if category is not None:
+            counts[category] += 1
     return counts
+
+
+def _raw_gap_category(
+    conn: sqlite3.Connection,
+    archive_root: Path,
+    row: sqlite3.Row,
+    *,
+    raw_columns: frozenset[str],
+    session_columns: frozenset[str],
+) -> str | None:
+    can_reconcile_alias = not row["parse_error"] or _retryable_decode_missing_blob_error(row["parse_error"])
+    if can_reconcile_alias and _raw_gap_materialized_by_alias(conn, row, session_columns=session_columns):
+        return "materialized-alias"
+    if can_reconcile_alias and _raw_gap_matches_missing_index_raw_link(conn, row, session_columns=session_columns):
+        return "lost-source-evidence-alias"
+    if _raw_gap_parsed_non_session_artifact(archive_root, row, raw_columns=raw_columns):
+        return "parsed-non-session-artifact"
+    if row["parse_error"]:
+        return "parse-failed"
+    authority_category = _raw_gap_authority_category(conn, row)
+    if authority_category is not None:
+        return authority_category
+    return None
+
+
+def _raw_gap_authority_category(conn: sqlite3.Connection, row: sqlite3.Row) -> str | None:
+    raw_id = str(row["raw_id"])
+    if _table_columns(conn, "main", "raw_revision_applications"):
+        terminal = conn.execute(
+            """
+            SELECT 1 FROM main.raw_revision_applications
+            WHERE raw_id = ?
+              AND decision IN ('selected_baseline', 'applied_append', 'superseded', 'ambiguous')
+            LIMIT 1
+            """,
+            (raw_id,),
+        ).fetchone()
+        if terminal is not None:
+            return "revision-application-terminal"
+
+    if _table_columns(conn, "source", "raw_membership_census") and _table_columns(
+        conn, "source", "raw_session_memberships"
+    ):
+        membership = conn.execute(
+            """
+            SELECT 1
+            FROM source.raw_membership_census AS c
+            WHERE c.raw_id = ?
+              AND c.status = 'complete'
+              AND c.member_count > 0
+              AND c.member_count = (
+                SELECT COUNT(*) FROM source.raw_session_memberships AS counted
+                WHERE counted.raw_id = c.raw_id
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM source.raw_session_memberships AS m
+                WHERE m.raw_id = c.raw_id
+                  AND (m.decision IS NULL OR m.decision = 'deferred')
+              )
+            LIMIT 1
+            """,
+            (raw_id,),
+        ).fetchone()
+        if membership is not None:
+            return "membership-authority-classified"
+
+    if row["source_index"] == -1:
+        if row["revision_authority"] == "byte_proven":
+            return "append-authority-proven"
+        if _table_columns(conn, "source", "raw_membership_census"):
+            quarantined = conn.execute(
+                """
+                SELECT 1 FROM source.raw_membership_census
+                WHERE raw_id = ? AND status = 'failed' AND detail = ?
+                LIMIT 1
+                """,
+                (raw_id, _BYTE_AUTHORITY_CENSUS_DETAIL),
+            ).fetchone()
+            if quarantined is not None:
+                return "append-authority-quarantined"
+    return None
 
 
 def _retryable_decode_missing_blob_error(parse_error: object) -> bool:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from polylogue.archive.raw_materialization import parsed_non_session_artifact_reason
+from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
 from polylogue.config import Config
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument, json_document
@@ -44,7 +45,6 @@ _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
 RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
-_BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision authority"
 
 
 def _format_bytes(value: int) -> str:
@@ -257,7 +257,7 @@ def _raw_materialization_candidate_ids(
               {source_root_filter}
             ORDER BY r.acquired_at_ms DESC, r.raw_id ASC
             """,
-            [_BYTE_AUTHORITY_CENSUS_DETAIL, _BYTE_AUTHORITY_CENSUS_DETAIL, *params],
+            [BYTE_AUTHORITY_CENSUS_DETAIL, BYTE_AUTHORITY_CENSUS_DETAIL, *params],
         ).fetchall()
         adoption_deferred = 0
         authority_quarantined = 0

--- a/tests/unit/storage/test_archive_readiness.py
+++ b/tests/unit/storage/test_archive_readiness.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
 
+from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 
 
@@ -39,6 +40,11 @@ def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path
                 ("terminal-application", 0, "quarantined"),
                 ("terminal-application-error", 0, "quarantined"),
                 ("authority-pending", -1, "quarantined"),
+                ("append-proven", -1, "byte_proven"),
+                ("membership-settled", 0, "quarantined"),
+                ("membership-incomplete", 0, "quarantined"),
+                ("membership-null", 0, "quarantined"),
+                ("application-deferred", 0, "quarantined"),
             ],
         )
         conn.execute(
@@ -51,12 +57,24 @@ def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path
                     "append-quarantine",
                     "failed",
                     0,
-                    "append fragments are governed by byte revision authority",
+                    BYTE_AUTHORITY_CENSUS_DETAIL,
                 ),
                 ("membership-quarantine", "complete", 1, None),
+                ("membership-settled", "complete", 2, None),
+                ("membership-incomplete", "complete", 2, None),
+                ("membership-null", "complete", 1, None),
             ],
         )
-        conn.execute("INSERT INTO raw_session_memberships VALUES ('membership-quarantine', 'ambiguous')")
+        conn.executemany(
+            "INSERT INTO raw_session_memberships VALUES (?, ?)",
+            [
+                ("membership-quarantine", "ambiguous"),
+                ("membership-settled", "applied"),
+                ("membership-settled", "superseded_equivalent"),
+                ("membership-incomplete", "applied"),
+                ("membership-null", None),
+            ],
+        )
     with sqlite3.connect(index_db) as conn:
         conn.executescript(
             """
@@ -64,28 +82,63 @@ def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path
             CREATE TABLE raw_revision_applications (raw_id TEXT, decision TEXT, detail TEXT);
             INSERT INTO raw_revision_applications VALUES ('terminal-application', 'superseded', 'test');
             INSERT INTO raw_revision_applications VALUES ('terminal-application-error', 'superseded', 'test');
+            INSERT INTO raw_revision_applications VALUES (
+                'application-deferred', 'deferred', 'ordinary_replay:incomparable_existing_index_state'
+            );
             """
         )
 
     snapshot = raw_materialization_readiness_snapshot(tmp_path)
 
     assert snapshot.get("available") is True, snapshot
-    assert snapshot["classified"] == 3
+    assert snapshot["classified"] == 5
     assert snapshot["critical"] == 1
     assert snapshot["actionable"] == 1
     assert snapshot["affected_actionable"] == 1
-    assert snapshot["unchecked"] == 1
-    assert snapshot["affected_unchecked"] == 1
+    assert snapshot["blocked"] == 1
+    assert snapshot["unchecked"] == 3
+    assert snapshot["affected_unchecked"] == 3
     assert _category_counts(snapshot) == {
-        "raw_id_join_gap": 1,
+        "raw_id_join_gap": 3,
         "skipped": 0,
         "parse_failed": 1,
         "raw_parse_failed": 1,
         "parsed_without_index_session": 0,
         "append-authority-quarantined": 1,
-        "membership-authority-classified": 1,
+        "append-authority-proven": 1,
+        "membership-authority-classified": 2,
         "revision-application-terminal": 1,
+        "adoption_deferred": 1,
     }
+
+
+def test_raw_materialization_snapshot_reads_append_census_writer_contract(tmp_path: Path) -> None:
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"append":true}\n',
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=1,
+        )
+        archive.replace_raw_membership_census(
+            raw_id,
+            None,
+            parser_fingerprint="revision-membership-v1",
+            censused_at_ms=0,
+            detail=BYTE_AUTHORITY_CENSUS_DETAIL,
+        )
+
+    snapshot = raw_materialization_readiness_snapshot(tmp_path)
+
+    assert snapshot["classified"] == 1
+    assert snapshot["unchecked"] == 0
+    assert _category_counts(snapshot)["append-authority-quarantined"] == 1
 
 
 def test_raw_materialization_snapshot_ignores_skipped_raw_rows(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_readiness.py
+++ b/tests/unit/storage/test_archive_readiness.py
@@ -12,6 +12,82 @@ def _category_counts(snapshot: Mapping[str, object]) -> Mapping[str, object]:
     return cast(Mapping[str, object], snapshot["category_counts"])
 
 
+def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (
+                raw_id TEXT PRIMARY KEY, origin TEXT, native_id TEXT, source_path TEXT,
+                blob_hash BLOB, source_index INTEGER, revision_authority TEXT,
+                validation_status TEXT, parse_error TEXT, parsed_at_ms INTEGER
+            );
+            CREATE TABLE raw_membership_census (
+                raw_id TEXT PRIMARY KEY, status TEXT, member_count INTEGER, detail TEXT
+            );
+            CREATE TABLE raw_session_memberships (raw_id TEXT, decision TEXT);
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_sessions VALUES (?, 'codex-session', NULL, '', NULL, ?, ?, 'valid', NULL, NULL)
+            """,
+            [
+                ("append-quarantine", -1, "quarantined"),
+                ("membership-quarantine", 0, "quarantined"),
+                ("terminal-application", 0, "quarantined"),
+                ("terminal-application-error", 0, "quarantined"),
+                ("authority-pending", -1, "quarantined"),
+            ],
+        )
+        conn.execute(
+            "UPDATE raw_sessions SET parse_error = 'database locked' WHERE raw_id = 'terminal-application-error'"
+        )
+        conn.executemany(
+            "INSERT INTO raw_membership_census VALUES (?, ?, ?, ?)",
+            [
+                (
+                    "append-quarantine",
+                    "failed",
+                    0,
+                    "append fragments are governed by byte revision authority",
+                ),
+                ("membership-quarantine", "complete", 1, None),
+            ],
+        )
+        conn.execute("INSERT INTO raw_session_memberships VALUES ('membership-quarantine', 'ambiguous')")
+    with sqlite3.connect(index_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (session_id TEXT PRIMARY KEY, raw_id TEXT);
+            CREATE TABLE raw_revision_applications (raw_id TEXT, decision TEXT, detail TEXT);
+            INSERT INTO raw_revision_applications VALUES ('terminal-application', 'superseded', 'test');
+            INSERT INTO raw_revision_applications VALUES ('terminal-application-error', 'superseded', 'test');
+            """
+        )
+
+    snapshot = raw_materialization_readiness_snapshot(tmp_path)
+
+    assert snapshot.get("available") is True, snapshot
+    assert snapshot["classified"] == 3
+    assert snapshot["critical"] == 1
+    assert snapshot["actionable"] == 1
+    assert snapshot["affected_actionable"] == 1
+    assert snapshot["unchecked"] == 1
+    assert snapshot["affected_unchecked"] == 1
+    assert _category_counts(snapshot) == {
+        "raw_id_join_gap": 1,
+        "skipped": 0,
+        "parse_failed": 1,
+        "raw_parse_failed": 1,
+        "parsed_without_index_session": 0,
+        "append-authority-quarantined": 1,
+        "membership-authority-classified": 1,
+        "revision-application-terminal": 1,
+    }
+
+
 def test_raw_materialization_snapshot_ignores_skipped_raw_rows(tmp_path: Path) -> None:
     source_db = tmp_path / "source.db"
     index_db = tmp_path / "index.db"


### PR DESCRIPTION
## Summary

Align the cheap raw-materialization readiness projection with the durable revision-authority model.

## Problem

Final exact verification proved all nine archive surfaces ready and the executable replay backlog empty, yet status still marked raw materialization poisoned because 381 authority-governed raw/index join gaps were left unchecked. The same scan also found 45 transient lock parse markers, which must remain actionable until explicitly cleared.

## Solution

Classify terminal revision applications, exact complete membership censuses, membership ambiguity quarantines, byte-proven append revisions, and censused append quarantines as durable non-executable authority states. Parse failures retain precedence; incomplete, NULL, and deferred authority remains unchecked.

Ref polylogue-b5l.2.

## Verification

- `devtools test tests/unit/storage/test_archive_readiness.py` -> 11 passed
- live pre-repair projection -> classified 838, unchecked 0, parse failures 45 across 2 origins
- after clearing only exact transient-lock markers through existing raw-state API -> critical 0, actionable 0, classified 883, unchecked 0, component ready
- `devtools verify --quick` -> 13/13 steps passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness reporting for raw materialization gaps.
  * Added clearer classification for authority-related states, revision outcomes, membership status, append authority, and quarantined records.
  * Improved parse-failure reporting consistency across readiness summaries.

* **Tests**
  * Added coverage validating readiness snapshots and detailed gap-category counts across varied record and authority states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->