### PR TITLE
docs: position Polylogue as a local evidence system

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/sinity/polylogue/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/sinity/polylogue/ci.yml?branch=master&label=ci" alt="CI status"></a>
 </p>
 
-**Polylogue is the local flight recorder and system of record for AI work.** It turns ChatGPT, Claude, Codex, Gemini, Antigravity, Hermes, and coding-agent histories into one evidence-addressable archive: search what happened, read tool activity as work rather than chat, audit claims against structural outcomes, understand cost and lineage, and give the next agent reviewed context.
+**Polylogue is a local evidence system for AI work.** It turns ChatGPT, Claude, Codex, Gemini, Antigravity, Hermes, and coding-agent histories into one evidence-addressable archive: search what happened, read tool activity as work rather than chat, audit claims against structural outcomes, understand cost and lineage, and give the next agent reviewed context.
 
 <p align="center">
   <img src="docs/examples/visual-tapes/query-tour.gif" alt="Polylogue query and evidence drilldown" width="900">

--- a/devtools/pages_templates.py
+++ b/devtools/pages_templates.py
@@ -42,7 +42,7 @@ BASE_TEMPLATE = """<!DOCTYPE html>
         </main>
     </div>
     <footer class="site-footer">
-        <span>Polylogue — the flight recorder for AI work</span>
+        <span>Polylogue — local evidence for AI work</span>
         <a href="https://github.com/Sinity/polylogue">GitHub</a>
     </footer>
     <script>
@@ -66,7 +66,7 @@ HOME_TEMPLATE = """{% extends "base.html" %}
 {% block content %}
 <div class="home-hero">
     <p class="eyebrow">Local-first · cross-provider · evidence-addressable</p>
-    <h1>The flight recorder for AI work</h1>
+    <h1>Keep the receipts for AI work</h1>
     <p class="tagline">Search every provider. Read tool activity as work, not chat. Audit claims against outcomes. Resume from reviewed evidence.</p>
     <div class="hero-command"><code>nix run github:Sinity/polylogue -- demo tour</code></div>
     <div class="hero-stats" aria-label="Local archive snapshot">

--- a/docs/public-claims.yaml
+++ b/docs/public-claims.yaml
@@ -15,14 +15,24 @@ public_surfaces:
 retired_phrases:
   - your AI memory
 claims:
-  - id: category.flight-recorder
+  - id: category.local-evidence-system
     status: capability
     evidence_class: implementation_contract
-    publication: Polylogue is the local flight recorder and system of record for AI work.
+    publication: Polylogue is a local evidence system for AI work.
     scope: Product category for the current local archive, query, evidence, and context surfaces.
     evidence: [README.md, docs/architecture.md, docs/proof-artifacts.md]
     caveat: Pre-1.0; not every planned memory or coordination feature is complete.
     owner_beads: [polylogue-3tl.12, polylogue-3tl.8]
+    proof_commands: []
+
+  - id: analogy.flight-recorder
+    status: capability
+    evidence_class: implementation_contract
+    publication: Polylogue can be described as a flight recorder for AI work when the analogy is qualified by its supported origins and evidence limits.
+    scope: Explanatory analogy, not the primary product category or a forensic chain-of-custody claim.
+    evidence: [docs/architecture.md, docs/proof-artifacts.md]
+    caveat: The archive is not tamper-proof, universally complete, or a replacement for production agent observability.
+    owner_beads: [polylogue-3tl.12, polylogue-3tl.16]
     proof_commands: []
 
   - id: demo.private-data-free

--- a/docs/site/pages.toml
+++ b/docs/site/pages.toml
@@ -105,7 +105,7 @@ path = "/design/whole-product/"
 
 [[pages]]
 path = "/index.html"
-title = "Polylogue — The Flight Recorder for AI Work"
+title = "Polylogue — Keep the Receipts for AI Work"
 template = "home.html"
 
 [[pages]]

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Polylogue - local flight recorder and system of record for AI work";
+  description = "Polylogue - local evidence system for AI work";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -1574,7 +1574,7 @@ function renderLandingView() {
   var readiness = status.component_readiness || {};
   var recent = (state.sessions || []).slice(0, 6);
   var html = '<div class="landing">';
-  html += '<div class="landing-hero"><h1>The local flight recorder for AI work.</h1>'
+  html += '<div class="landing-hero"><h1>Keep the receipts for AI work.</h1>'
     + '<p>Search every archived session, analyze usage and cost, audit claims against structural '
     + 'evidence, and remember reviewed judgment across Claude, Codex, ChatGPT, Gemini, and more.</p></div>';
   html += '<div class="stat-row">'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "polylogue"
 version = "0.2.0"
-description = "Local flight recorder and system of record for AI work"
+description = "Local evidence system for AI work"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = ["ai", "chatgpt", "claude", "session", "archive", "llm"]


### PR DESCRIPTION
## Summary

Adopt the recovered category-research finding that Polylogue should lead as a local evidence system, while retaining “flight recorder” only as a qualified analogy.

## Problem

The public surfaces currently use “flight recorder” and “system of record” as primary category labels. The recovered GPT-Pro category research found substantial category collision and expectation debt in both phrases. The existing wording also reaches beyond the claims ledger's bounded evidence contract.

## Solution

Update the README, package metadata, docs-site title, and web landing headline to use “local evidence system” and “keep the receipts.” Extend the public claims ledger with the category claim and narrow the flight-recorder entry to an analogy with explicit caveats.

The recovered Cockpit kit was also audited. Its runtime and contract proposals are stale or superseded by current work and are intentionally not imported.

Ref `polylogue-3tl`, `polylogue-3tl.12`, `polylogue-3tl.16`.

## Verification

- `devtools verify public-claims --json` — 9 claims, 17 evidence paths, valid
- `devtools test tests/unit/devtools/test_public_claims.py tests/unit/daemon/test_web_cockpit.py` — 12 passed
- `devtools render all --check` — clean
- `devtools verify --quick` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product descriptions to present Polylogue as a local evidence system for AI work.
  * Refreshed public claims and homepage metadata to use clearer, consistent terminology.

* **Style**
  * Updated landing page messaging and taglines, including “Keep the receipts for AI work.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->