### PR TITLE
feat(query): constrain action sequence edges

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -133,6 +133,7 @@ from polylogue.archive.query.predicate import (
     QueryNotPredicate,
     QueryPredicate,
     QuerySemanticPredicate,
+    QuerySequenceConstraint,
     QuerySequencePredicate,
     QueryTextPredicate,
 )
@@ -644,7 +645,7 @@ _QUERY_GRAMMAR = rf"""
     ?not_expr: NOT not_expr                -> not_expr
         | atom
     ?atom: EXISTS STRUCT_UNIT "(" expr ")" -> exists_leaf
-        | SEQ "(" sequence_step (ARROW sequence_step)+ ")" -> sequence_leaf
+        | SEQ "(" sequence_step (sequence_link sequence_step)+ ")" -> sequence_leaf
         | SEMANTIC_QUOTED_TEXT             -> semantic_quoted_leaf
         | SEMANTIC_BARE_TEXT               -> semantic_bare_leaf
         | FTS_QUOTED_TEXT                  -> fts_quoted_leaf
@@ -659,6 +660,7 @@ _QUERY_GRAMMAR = rf"""
         | FIELD_CLAUSE                     -> field_leaf
         | "(" expr ")"
     sequence_step: sequence_atom (AND sequence_atom)*
+    sequence_link: ARROW SEQUENCE_CONSTRAINT?
     ?sequence_atom: FIELD_CLAUSE                     -> field_leaf
 
     SESSIONS: /sessions/i
@@ -666,6 +668,7 @@ _QUERY_GRAMMAR = rf"""
     EXISTS: /exists/i
     SEQ: /seq/i
     ARROW: "->"
+    SEQUENCE_CONSTRAINT.8: /\[(?:next|within:\d+(?:ms|s|m|h|d))\]/i
     STRUCT_UNIT: /(observed-event|context-snapshot|message|action|block|assertion|file|run)/i
     OR: /or/i
     AND: /and/i
@@ -1240,7 +1243,8 @@ def _bind_predicate_context(
         )
     if isinstance(predicate, QuerySequencePredicate):
         return QuerySequencePredicate(
-            steps=tuple(_bind_predicate_context(step, unit="action") for step in predicate.steps)
+            steps=tuple(_bind_predicate_context(step, unit="action") for step in predicate.steps),
+            constraints=predicate.constraints,
         )
     return predicate
 
@@ -1351,11 +1355,27 @@ class _BooleanQueryTransformer(Transformer[Token, QueryPredicate]):
             return predicates[0]
         return QueryBoolPredicate(op="and", children=predicates)
 
+    def sequence_link(self, _arrow: Token, constraint: Token | None = None) -> QuerySequenceConstraint:
+        if constraint is None:
+            return QuerySequenceConstraint()
+        value = str(constraint)[1:-1].lower()
+        if value == "next":
+            return QuerySequenceConstraint(kind="next")
+        amount_text, unit = value.removeprefix("within:")[:-1], value[-1]
+        if value.endswith("ms"):
+            amount_text, unit = value.removeprefix("within:")[:-2], "ms"
+        multiplier = {"ms": 1, "s": 1_000, "m": 60_000, "h": 3_600_000, "d": 86_400_000}[unit]
+        within_ms = int(amount_text) * multiplier
+        if within_ms <= 0:
+            raise ExpressionCompileError("seq within duration must be greater than zero", field=None)
+        return QuerySequenceConstraint(kind="within", within_ms=within_ms)
+
     def sequence_leaf(self, _seq: Token, *items: object) -> QueryPredicate:
         steps = _predicate_children(items)
+        constraints = tuple(item for item in items if isinstance(item, QuerySequenceConstraint))
         if len(steps) < 2:
             raise ExpressionCompileError("seq() requires at least two action steps", field=None)
-        return QuerySequencePredicate(steps=steps)
+        return QuerySequencePredicate(steps=steps, constraints=constraints)
 
 
 _BOOLEAN_QUERY_TRANSFORMER = _BooleanQueryTransformer()

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -19,6 +19,21 @@ QueryExistsUnit: TypeAlias = Literal[
     "observed-event",
     "context-snapshot",
 ]
+QuerySequenceConstraintKind: TypeAlias = Literal["ordered", "next", "within"]
+
+
+@dataclass(frozen=True)
+class QuerySequenceConstraint:
+    """Constraint on the edge between two action-sequence steps."""
+
+    kind: QuerySequenceConstraintKind = "ordered"
+    within_ms: int | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": self.kind}
+        if self.within_ms is not None:
+            payload["within_ms"] = self.within_ms
+        return payload
 
 
 @dataclass(frozen=True)
@@ -119,6 +134,7 @@ class QuerySequencePredicate:
 
     steps: tuple[QueryPredicate, ...] = ()
     action_terms: tuple[str, ...] = ()
+    constraints: tuple[QuerySequenceConstraint, ...] = ()
 
     def __post_init__(self) -> None:
         if self.steps:
@@ -129,6 +145,14 @@ class QuerySequencePredicate:
                 "steps",
                 tuple(QueryFieldPredicate(field="action", values=(term,), op="=") for term in self.action_terms),
             )
+        if self.steps and not self.constraints:
+            object.__setattr__(
+                self,
+                "constraints",
+                tuple(QuerySequenceConstraint() for _ in range(len(self.steps) - 1)),
+            )
+        if len(self.constraints) != max(0, len(self.steps) - 1):
+            raise ValueError("sequence constraints must describe every edge between steps")
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -136,6 +160,8 @@ class QuerySequencePredicate:
             "unit": "action",
             "steps": [step.to_payload() for step in self.steps],
         }
+        if any(constraint.kind != "ordered" for constraint in self.constraints):
+            payload["constraints"] = [constraint.to_payload() for constraint in self.constraints]
         if self.action_terms:
             payload["actions"] = list(self.action_terms)
         return payload
@@ -212,5 +238,7 @@ __all__ = [
     "QueryPredicate",
     "QuerySemanticPredicate",
     "QuerySequencePredicate",
+    "QuerySequenceConstraint",
+    "QuerySequenceConstraintKind",
     "QueryTextPredicate",
 ]

--- a/polylogue/archive/query/runtime_matching.py
+++ b/polylogue/archive/query/runtime_matching.py
@@ -9,6 +9,7 @@ from polylogue.archive.query.predicate import (
     QueryFieldPredicate,
     QueryNotPredicate,
     QueryPredicate,
+    QuerySequenceConstraint,
 )
 
 if TYPE_CHECKING:
@@ -81,22 +82,44 @@ def matches_action_sequence(plan: SessionQueryPlan, session: Session) -> bool:
     return False
 
 
-def matches_action_predicate_sequence(steps: tuple[QueryPredicate, ...], session: Session) -> bool:
+def matches_action_predicate_sequence(
+    steps: tuple[QueryPredicate, ...],
+    session: Session,
+    constraints: tuple[QuerySequenceConstraint, ...] = (),
+) -> bool:
     if not steps:
         return True
     actions = _actions_for(session)
     if not actions:
         return False
 
-    index = 0
-    target_count = len(steps)
-    for action in actions:
-        if not _matches_action_predicate(steps[index], action):
-            continue
-        index += 1
-        if index >= target_count:
-            return True
-    return False
+    edge_constraints = constraints or tuple(QuerySequenceConstraint() for _ in range(len(steps) - 1))
+    if len(edge_constraints) != len(steps) - 1:
+        raise ValueError("sequence constraints must describe every edge between steps")
+
+    candidates = [index for index, action in enumerate(actions) if _matches_action_predicate(steps[0], action)]
+    for step_index, step in enumerate(steps[1:]):
+        constraint = edge_constraints[step_index]
+        next_candidates: list[int] = []
+        for previous_index in candidates:
+            for current_index in range(previous_index + 1, len(actions)):
+                if constraint.kind == "next" and current_index != previous_index + 1:
+                    break
+                if not _matches_action_predicate(step, actions[current_index]):
+                    continue
+                if constraint.kind == "within":
+                    previous_time = actions[previous_index].timestamp
+                    current_time = actions[current_index].timestamp
+                    if previous_time is None or current_time is None:
+                        continue
+                    elapsed_ms = int((current_time - previous_time).total_seconds() * 1000)
+                    if elapsed_ms < 0 or constraint.within_ms is None or elapsed_ms > constraint.within_ms:
+                        continue
+                next_candidates.append(current_index)
+        candidates = next_candidates
+        if not candidates:
+            return False
+    return bool(candidates)
 
 
 def _matches_action_predicate(predicate: QueryPredicate, action: Action) -> bool:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -28,6 +28,7 @@ from polylogue.archive.query.predicate import (
     QueryLineagePredicate,
     QueryNotPredicate,
     QueryPredicate,
+    QuerySequenceConstraint,
     QuerySequencePredicate,
     QueryTextPredicate,
 )
@@ -9131,7 +9132,7 @@ def _boolean_predicate_clause(
     if isinstance(predicate, QuerySequencePredicate):
         if len(predicate.steps) < 2:
             raise ValueError("action sequence predicates require at least two steps")
-        return _action_sequence_steps_clause(table_alias, predicate.steps)
+        return _action_sequence_steps_clause(table_alias, predicate.steps, predicate.constraints)
     if isinstance(predicate, QueryTextPredicate):
         return _fts_predicate_clause(table_alias, predicate)
     if isinstance(predicate, QueryLineagePredicate):
@@ -9466,13 +9467,18 @@ def _action_sequence_clause(table_alias: str, action_sequence: tuple[str, ...]) 
     return _action_sequence_steps_clause(table_alias, steps)
 
 
-def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate, ...]) -> tuple[str, list[object]]:
+def _action_sequence_steps_clause(
+    table_alias: str,
+    steps: tuple[QueryPredicate, ...],
+    constraints: tuple[QuerySequenceConstraint, ...] = (),
+) -> tuple[str, list[object]]:
     needs_followup = any(_predicate_uses_unit_field(step, "followup_class", unit="action") for step in steps)
     relation_sql = _ACTION_FOLLOWUP_RELATION_SQL if needs_followup else ""
     action_relation = "action_rows" if needs_followup else "actions"
     joins: list[str] = []
     predicates: list[str] = []
     params: list[object] = []
+    edge_constraints = constraints or tuple(QuerySequenceConstraint() for _ in range(len(steps) - 1))
     for index, step in enumerate(steps):
         action_alias = f"seq_a{index}"
         message_alias = f"seq_m{index}"
@@ -9493,6 +9499,16 @@ def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate,
             params.extend(step_params)
         if index > 0:
             predicates.append(_action_after_predicate(index - 1, index))
+            constraint = edge_constraints[index - 1]
+            if constraint.kind == "next":
+                predicates.append(_no_action_between_predicate(index - 1, index, action_relation))
+            elif constraint.kind == "within":
+                predicates.append(
+                    f"{message_alias}.occurred_at_ms IS NOT NULL AND seq_m{index - 1}.occurred_at_ms IS NOT NULL "
+                    f"AND {message_alias}.occurred_at_ms >= seq_m{index - 1}.occurred_at_ms "
+                    f"AND {message_alias}.occurred_at_ms - seq_m{index - 1}.occurred_at_ms <= ?"
+                )
+                params.append(constraint.within_ms)
     sql = (
         "EXISTS ("
         f"{relation_sql} "
@@ -9505,7 +9521,7 @@ def _action_sequence_steps_clause(table_alias: str, steps: tuple[QueryPredicate,
     return sql, params
 
 
-def _action_after_predicate(previous: int, current: int) -> str:
+def _action_after_predicate(previous: int | str, current: int | str) -> str:
     prev_message = f"seq_m{previous}"
     curr_message = f"seq_m{current}"
     prev_block = f"seq_b{previous}"
@@ -9518,6 +9534,20 @@ def _action_after_predicate(previous: int, current: int) -> str:
         f"OR ({curr_message}.position = {prev_message}.position "
         f"AND {curr_message}.variant_index = {prev_message}.variant_index "
         f"AND {curr_block}.position > {prev_block}.position)"
+        ")"
+    )
+
+
+def _no_action_between_predicate(previous: int, current: int, action_relation: str) -> str:
+    after_previous = _action_after_predicate(previous, "between")
+    before_current = _action_after_predicate("between", current)
+    return (
+        "NOT EXISTS ("
+        f"SELECT 1 FROM {action_relation} seq_abetween "
+        "JOIN messages seq_mbetween ON seq_mbetween.message_id = seq_abetween.message_id "
+        "JOIN blocks seq_bbetween ON seq_bbetween.block_id = seq_abetween.tool_use_block_id "
+        f"WHERE seq_abetween.session_id = seq_a{previous}.session_id "
+        f"AND {after_previous} AND {before_current}"
         ")"
     )
 

--- a/tests/unit/archive/test_query_runtime_matching.py
+++ b/tests/unit/archive/test_query_runtime_matching.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from polylogue.archive.actions.actions import Action
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.query.plan import SessionQueryPlan
-from polylogue.archive.query.predicate import QueryBoolPredicate, QueryFieldPredicate, QueryFieldRef
+from polylogue.archive.query.predicate import (
+    QueryBoolPredicate,
+    QueryFieldPredicate,
+    QueryFieldRef,
+    QuerySequenceConstraint,
+)
 from polylogue.archive.query.runtime_matching import (
     matches_action_predicate_sequence,
     matches_action_sequence,
@@ -39,11 +44,12 @@ def _event(
     output_text: str | None = None,
     search_text: str = "",
     index: int = 0,
+    timestamp: datetime | None = datetime(2026, 1, 1, tzinfo=timezone.utc),
 ) -> Action:
     return Action(
         action_id=f"action-{index}",
         message_id="message-1",
-        timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        timestamp=timestamp,
         sequence_index=index,
         kind=kind,
         tool_name=tool_name,
@@ -209,3 +215,46 @@ def test_matches_action_predicate_sequence_treats_field_values_as_alternatives(
     )
 
     assert matches_action_predicate_sequence(steps, session) is True
+
+
+def test_matches_action_predicate_sequence_enforces_next(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _session()
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.FILE_EDIT, index=0),
+            _event(ToolCategory.SEARCH, index=1),
+            _event(ToolCategory.SHELL, index=2),
+        ),
+    )
+    steps = (_action_predicate("action", "file_edit"), _action_predicate("action", "shell"))
+
+    assert matches_action_predicate_sequence(steps, session) is True
+    assert matches_action_predicate_sequence(steps, session, (QuerySequenceConstraint(kind="next"),)) is False
+
+
+def test_matches_action_predicate_sequence_enforces_known_within_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session()
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    steps = (_action_predicate("action", "file_edit"), _action_predicate("action", "shell"))
+    constraint = (QuerySequenceConstraint(kind="within", within_ms=300_000),)
+
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.FILE_EDIT, index=0, timestamp=start),
+            _event(ToolCategory.SHELL, index=1, timestamp=start + timedelta(minutes=5)),
+        ),
+    )
+    assert matches_action_predicate_sequence(steps, session, constraint) is True
+
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.FILE_EDIT, index=0, timestamp=start),
+            _event(ToolCategory.SHELL, index=1, timestamp=None),
+        ),
+    )
+    assert matches_action_predicate_sequence(steps, session, constraint) is False

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -55,6 +55,7 @@ from polylogue.archive.query.predicate import (
     QueryLineagePredicate,
     QueryNotPredicate,
     QuerySemanticPredicate,
+    QuerySequenceConstraint,
     QuerySequencePredicate,
     QueryTextPredicate,
 )
@@ -1185,6 +1186,24 @@ class TestBooleanQueryExpression:
         ast = parse_expression_ast("seq(action:file_edit -> action:shell -> action:file_edit)")
 
         assert ast.boolean_predicate == QuerySequencePredicate(action_terms=("file_edit", "shell", "file_edit"))
+
+    def test_sequence_ast_exposes_next_and_within_constraints(self) -> None:
+        ast = parse_expression_ast("seq(action:file_edit ->[next] action:shell ->[within:5m] action:file_edit)")
+
+        assert isinstance(ast.boolean_predicate, QuerySequencePredicate)
+        assert ast.boolean_predicate.constraints == (
+            QuerySequenceConstraint(kind="next"),
+            QuerySequenceConstraint(kind="within", within_ms=300_000),
+        )
+        assert ast.boolean_predicate.to_payload()["constraints"] == [
+            {"kind": "next"},
+            {"kind": "within", "within_ms": 300_000},
+        ]
+
+    @pytest.mark.parametrize("modifier", ["within:0s", "within:5weeks", "adjacent"])
+    def test_sequence_rejects_invalid_constraints(self, modifier: str) -> None:
+        with pytest.raises(ExpressionCompileError):
+            compile_expression(f"seq(action:file_edit ->[{modifier}] action:shell)")
 
     def test_sequence_predicate_derives_action_terms_from_steps_when_both_are_supplied(self) -> None:
         predicate = QuerySequencePredicate(
@@ -4585,6 +4604,67 @@ class TestBooleanQueryExpression:
             rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
 
         assert [row.session_id for row in rows] == ["claude-code-session:ext-hit"]
+
+    def test_constrained_sequence_predicates_execute_against_archive(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+
+        def add_action(builder: SessionBuilder, message_id: str, action: str, timestamp: str | None) -> None:
+            tool_name = {"file_edit": "Edit", "search": "Grep", "shell": "Bash"}[action]
+            builder.add_message(
+                message_id,
+                role="assistant",
+                text=action,
+                timestamp=timestamp,
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": tool_name,
+                        "tool_id": f"tool-{message_id}",
+                        "input": {"command": action},
+                        "semantic_type": action,
+                    }
+                ],
+            )
+
+        adjacent = SessionBuilder(index_db, "constrained-adjacent").provider("claude-code")
+        add_action(adjacent, "a1", "file_edit", "2026-01-01T00:00:00+00:00")
+        add_action(adjacent, "a2", "shell", "2026-01-01T00:05:00+00:00")
+        adjacent.save()
+
+        intervening = SessionBuilder(index_db, "constrained-intervening").provider("claude-code")
+        add_action(intervening, "i1", "file_edit", "2026-01-01T00:00:00+00:00")
+        add_action(intervening, "i2", "search", "2026-01-01T00:01:00+00:00")
+        add_action(intervening, "i3", "shell", "2026-01-01T00:02:00+00:00")
+        intervening.save()
+
+        timeless = SessionBuilder(index_db, "constrained-timeless").provider("claude-code")
+        add_action(timeless, "t1", "file_edit", None)
+        add_action(timeless, "t2", "shell", None)
+        timeless.save()
+
+        def selected(expression: str) -> list[str]:
+            spec = compile_expression(expression)
+            assert spec.boolean_predicate is not None
+            with ArchiveStore.open_existing(index_db.parent) as archive:
+                rows = archive.list_summaries(limit=100, boolean_predicate=spec.boolean_predicate)
+            return sorted(row.session_id for row in rows)
+
+        assert selected("seq(action:file_edit -> action:shell)") == [
+            "claude-code-session:ext-constrained-adjacent",
+            "claude-code-session:ext-constrained-intervening",
+            "claude-code-session:ext-constrained-timeless",
+        ]
+        assert selected("seq(action:file_edit ->[next] action:shell)") == [
+            "claude-code-session:ext-constrained-adjacent",
+            "claude-code-session:ext-constrained-timeless",
+        ]
+        assert selected("seq(action:file_edit ->[within:5m] action:shell)") == [
+            "claude-code-session:ext-constrained-adjacent",
+            "claude-code-session:ext-constrained-intervening",
+        ]
 
     def test_single_action_sequence_filter_still_executes_against_archive(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary

Regenerate the highest-value recoverable Query DSL slice from branch 16 against the current shared Lark grammar.

## Problem

The expired GPT-Pro package proposed useful constrained sequence semantics, but no implementation bytes survive. The current DSL supports ordered sequences but cannot express immediate adjacency or a bounded time gap.

## Solution

Add `->[next]` and `->[within:<N>{ms|s|m|h|d}]` to the existing grammar and typed AST. Enforce both in SQLite lowering and runtime matching. Preserve bare-arrow behavior and payload shape. `within` requires timestamps on both actions and accepts the exact boundary; missing time never becomes zero.

Repetition and span-capture composition remain on `polylogue-fnm.3`; aggregate percentiles remain on `polylogue-fnm.1`.

Ref `polylogue-fnm.3`.

## Verification

- `devtools test tests/unit/archive/test_query_runtime_matching.py tests/unit/cli/test_query_expression.py -k sequence` — 20 passed, 376 deselected
- `devtools verify --quick` — all 13 steps passed
