### PR TITLE
fix(browser): authenticate ChatGPT interpreter asset fetches

### DIFF
--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -426,7 +426,33 @@
         descriptors.push(descriptor);
       }
     };
-    for (const [nodeId, node] of Object.entries(mapping)) {
+    // ChatGPT's mapping insertion order is not conversation order. In a
+    // branched conversation it can put old, expired interpreter assets before
+    // the selected branch's newest deliverable. Because acquisition is
+    // deliberately bounded by a failure breaker and a wall-clock budget, that
+    // incidental order can prevent the current node's live asset from ever
+    // being attempted. Walk the selected lineage newest-first, then cover the
+    // remaining branches newest-first as best-effort backfill.
+    const orderedNodeIds = [];
+    const orderedNodeIdSet = new Set();
+    let lineageNodeId = typeof payload.current_node === "string" ? payload.current_node : null;
+    while (lineageNodeId && !orderedNodeIdSet.has(lineageNodeId)) {
+      const node = mapping[lineageNodeId];
+      if (!node) break;
+      orderedNodeIds.push(lineageNodeId);
+      orderedNodeIdSet.add(lineageNodeId);
+      lineageNodeId = typeof node.parent === "string" ? node.parent : null;
+    }
+    const remainingNodeIds = Object.keys(mapping)
+      .filter((nodeId) => !orderedNodeIdSet.has(nodeId))
+      .sort((left, right) => {
+        const leftTime = Number(mapping[left]?.message?.create_time) || 0;
+        const rightTime = Number(mapping[right]?.message?.create_time) || 0;
+        return rightTime - leftTime;
+      });
+
+    for (const nodeId of [...orderedNodeIds, ...remainingNodeIds]) {
+      const node = mapping[nodeId];
       const message = node && node.message;
       if (!message) continue;
       const messageId = String(message.id || node.id || nodeId);

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -379,7 +379,13 @@
     const pending = assetResponses.get(data.requestId);
     if (!pending) return;
     assetResponses.delete(data.requestId);
-    pending.resolve({ asset: data.asset || null, error: data.error || null });
+    if (data.outcome && typeof data.outcome === "object") {
+      pending.resolve(data.outcome);
+    } else if (data.asset) {
+      pending.resolve({ status: "acquired", phase: "legacy_bridge", asset: data.asset });
+    } else {
+      pending.resolve({ status: "request_failed", phase: "legacy_bridge", detail: "legacy_bridge_error" });
+    }
   });
 
   function requestAssetFromPage(request) {
@@ -387,7 +393,7 @@
     const responsePromise = new Promise((resolve) => {
       const timeout = window.setTimeout(() => {
         assetResponses.delete(requestId);
-        resolve({ asset: null, error: "timeout" });
+        resolve({ status: "request_failed", phase: "content_bridge", detail: "response_timeout" });
       }, assetFetchTimeoutMs);
       assetResponses.set(requestId, {
         resolve(value) {
@@ -479,6 +485,8 @@
       attempted: descriptors.length,
       acquired: 0,
       failed: [],
+      acquired_assets: [],
+      status_counts: {},
       skipped_over_budget: 0,
       skipped_time_budget: 0,
       skipped_circuit_breaker: 0
@@ -511,10 +519,25 @@
         maxBytes: Math.min(assetMaxBytesPerFile, assetMaxBytesTotal - totalBytes)
       };
       const result = await requestAssetFromPage(request);
-      if (result.asset && result.asset.base64) {
+      const status = typeof result.status === "string" ? result.status : "request_failed";
+      const contentSha256 = result.asset && result.asset.sha256;
+      const acquiredIsValid =
+        status === "acquired" &&
+        result.asset &&
+        result.asset.base64 &&
+        typeof contentSha256 === "string" &&
+        /^[0-9a-f]{64}$/.test(contentSha256);
+      const recordedStatus = acquiredIsValid ? "acquired" : status === "acquired" ? "invalid_response" : status;
+      outcome.status_counts[recordedStatus] = (outcome.status_counts[recordedStatus] || 0) + 1;
+      if (acquiredIsValid) {
         totalBytes += result.asset.size_bytes || 0;
         consecutiveFailuresByKind[descriptor.kind] = 0;
         outcome.acquired += 1;
+        outcome.acquired_assets.push({
+          provider_attachment_id: descriptor.provider_attachment_id,
+          sha256: contentSha256,
+          size_bytes: result.asset.size_bytes || 0
+        });
         attachments.push({
           provider_attachment_id: descriptor.provider_attachment_id,
           message_provider_id: descriptor.message_provider_id,
@@ -525,14 +548,19 @@
           provider_meta: {
             capture_source: "chatgpt_page_asset_fetch",
             asset_kind: descriptor.kind,
-            sandbox_path: descriptor.sandboxPath || null
+            sandbox_path: descriptor.sandboxPath || null,
+            content_sha256: contentSha256
           }
         });
       } else {
         consecutiveFailuresByKind[descriptor.kind] += 1;
         outcome.failed.push({
           provider_attachment_id: descriptor.provider_attachment_id,
-          error: result.error || "unknown"
+          status: recordedStatus,
+          error: recordedStatus,
+          phase: result.phase || null,
+          http_status: typeof result.http_status === "number" ? result.http_status : null,
+          detail: status === "acquired" ? "acquired_asset_missing_sha256" : result.detail || null
         });
       }
     }
@@ -574,10 +602,26 @@
           nativePayload,
           String(nativePayload.conversation_id || nativePayload.id || conversationIdFromUrl())
         );
-      } catch (error) {
+      } catch {
         assetAcquisition = {
           attachments: [],
-          outcome: { attempted: 0, acquired: 0, failed: [{ provider_attachment_id: null, error: String(error && error.message ? error.message : error) }], skipped_over_budget: 0 }
+          outcome: {
+            attempted: 0,
+            acquired: 0,
+            acquired_assets: [],
+            status_counts: { request_failed: 1 },
+            failed: [
+              {
+                provider_attachment_id: null,
+                status: "request_failed",
+                error: "request_failed",
+                detail: "asset_acquisition_failed"
+              }
+            ],
+            skipped_over_budget: 0,
+            skipped_time_budget: 0,
+            skipped_circuit_breaker: 0
+          }
         };
       }
     }

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -72,13 +72,15 @@
     }
   }
 
+  async function fetchCurrentAccessToken() {
+    const sessionToken = await fetchSessionAccessToken().catch(() => null);
+    return sessionToken || bootstrapAccessToken();
+  }
+
   function resolveAccessToken() {
-    const bootstrapToken = bootstrapAccessToken();
-    if (bootstrapToken) return Promise.resolve(bootstrapToken);
     if (Date.now() < cachedAccessTokenUntil) return Promise.resolve(cachedAccessToken);
     if (accessTokenPromise) return accessTokenPromise;
-    accessTokenPromise = fetchSessionAccessToken()
-      .catch(() => null)
+    accessTokenPromise = fetchCurrentAccessToken()
       .then((token) => {
         cachedAccessToken = token;
         cachedAccessTokenUntil = Date.now() + accessTokenCacheTtlMs;

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -322,9 +322,14 @@
     if (signedUrl.protocol !== "https:") {
       return assetOutcome("invalid_response", { phase: "metadata", detail: "download_url_not_https" });
     }
+    // Current ChatGPT interpreter downloads may point at the authenticated
+    // same-origin estuary endpoint rather than at a self-authenticating object
+    // store URL. Keep page cookies for that exact origin, but never forward
+    // them (or the bearer) to provider-issued cross-origin signed URLs.
+    const byteCredentials = signedUrl.origin === currentOrigin ? "include" : "omit";
     const fileResponse = await fetchWithAbort(
       signedUrl.href,
-      { credentials: "omit", cache: "no-store" },
+      { credentials: byteCredentials, cache: "no-store" },
       "asset_bytes_fetch"
     );
     if ([401, 403, 404, 410].includes(fileResponse.status)) {

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -29,22 +29,69 @@
   window.__polylogueFetchHookInstalled = true;
 
   const originalFetch = window.fetch;
+  const accessTokenCacheTtlMs = 15000;
+  let cachedAccessToken = null;
+  let cachedAccessTokenUntil = 0;
+  let accessTokenPromise = null;
+
+  function accessTokenFromPayload(payload) {
+    const candidates = [
+      payload?.accessToken,
+      payload?.access_token,
+      payload?.session?.accessToken,
+      payload?.session?.access_token
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate) return candidate;
+    }
+    return null;
+  }
 
   function bootstrapAccessToken() {
     try {
       const raw = document.getElementById("client-bootstrap")?.textContent;
       if (!raw) return null;
-      const bootstrap = JSON.parse(raw);
-      const token = bootstrap?.session?.accessToken;
-      return typeof token === "string" && token ? token : null;
+      return accessTokenFromPayload(JSON.parse(raw));
     } catch {
       return null;
     }
   }
 
-  function authHeaders() {
-    const token = bootstrapAccessToken();
-    return token ? { authorization: `Bearer ${token}` } : {};
+  async function fetchSessionAccessToken() {
+    const sessionUrl = new URL("/api/auth/session", currentOrigin);
+    const response = await fetchWithAbort(
+      sessionUrl.href,
+      { credentials: "include", cache: "no-store" },
+      "access_token_fetch"
+    );
+    if (!response.ok) return null;
+    try {
+      return accessTokenFromPayload(await response.json());
+    } catch {
+      return null;
+    }
+  }
+
+  function resolveAccessToken() {
+    const bootstrapToken = bootstrapAccessToken();
+    if (bootstrapToken) return Promise.resolve(bootstrapToken);
+    if (Date.now() < cachedAccessTokenUntil) return Promise.resolve(cachedAccessToken);
+    if (accessTokenPromise) return accessTokenPromise;
+    accessTokenPromise = fetchSessionAccessToken()
+      .catch(() => null)
+      .then((token) => {
+        cachedAccessToken = token;
+        cachedAccessTokenUntil = Date.now() + accessTokenCacheTtlMs;
+        return token;
+      })
+      .finally(() => {
+        accessTokenPromise = null;
+      });
+    return accessTokenPromise;
+  }
+
+  function bearerHeaders(accessToken) {
+    return { Authorization: `Bearer ${accessToken}` };
   }
 
   function conversationUrl(conversationId) {
@@ -59,6 +106,7 @@
 
   async function fetchConversation(conversationId) {
     const url = conversationUrl(conversationId);
+    const accessToken = await resolveAccessToken();
     const controller = new globalThis.AbortController();
     const timeoutId = window.setTimeout(() => controller.abort(timeoutError("page_bridge_fetch")), nativeFetchTimeoutMs);
     let response;
@@ -66,7 +114,7 @@
       response = await originalFetch.call(window, url.href, {
         credentials: "include",
         cache: "no-store",
-        headers: authHeaders(),
+        headers: accessToken ? bearerHeaders(accessToken) : {},
         signal: controller.signal
       });
     } finally {
@@ -111,6 +159,7 @@
   const assetFetchRequestMessage = "polylogue.chatgpt.assetFetchRequest";
   const assetFetchResponseMessage = "polylogue.chatgpt.assetFetchResponse";
   const assetFetchTimeoutMs = 8000;
+  const assetAbsoluteMaxBytes = 25 * 1024 * 1024;
 
   function assetTimeoutError(label) {
     const error = new Error(`${label}_timeout_after_${assetFetchTimeoutMs}ms`);
@@ -126,6 +175,100 @@
       binary += String.fromCharCode.apply(null, bytes.subarray(offset, offset + chunkSize));
     }
     return window.btoa(binary);
+  }
+
+  function bytesToHex(buffer) {
+    return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  async function sha256Hex(buffer) {
+    if (!globalThis.crypto?.subtle) throw new Error("asset_sha256_unavailable");
+    return bytesToHex(await globalThis.crypto.subtle.digest("SHA-256", buffer));
+  }
+
+  function assetOutcome(status, { phase, httpStatus = null, detail = null, sizeBytes = null, asset = null } = {}) {
+    const outcome = { status, phase };
+    if (httpStatus !== null) outcome.http_status = httpStatus;
+    if (detail !== null) outcome.detail = detail;
+    if (sizeBytes !== null) outcome.size_bytes = sizeBytes;
+    if (asset !== null) outcome.asset = asset;
+    return outcome;
+  }
+
+  function metadataErrorSignal(meta, rawText) {
+    const values = [
+      meta?.error_code,
+      meta?.code,
+      meta?.detail,
+      meta?.message,
+      meta?.error?.code,
+      meta?.error?.message,
+      rawText
+    ];
+    return values
+      .filter((value) => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+  }
+
+  async function readMetadataEnvelope(response) {
+    let rawText = "";
+    try {
+      rawText = (await response.clone().text()).slice(0, 16384);
+    } catch {
+      return { meta: null, rawText: "" };
+    }
+    try {
+      return { meta: JSON.parse(rawText), rawText };
+    } catch {
+      return { meta: null, rawText };
+    }
+  }
+
+  function metadataFailureOutcome(request, response, meta, rawText) {
+    const signal = metadataErrorSignal(meta, rawText);
+    if (signal.includes("ace_pod_expired") || signal.includes("ace pod expired")) {
+      return assetOutcome("pod_expired", {
+        phase: "metadata",
+        httpStatus: response.status,
+        detail: "ace_pod_expired"
+      });
+    }
+    if (signal.includes("interpreter file not found") || (request.kind === "sandbox" && response.status === 404)) {
+      return assetOutcome("missing", {
+        phase: "metadata",
+        httpStatus: response.status,
+        detail: "interpreter_file_not_found"
+      });
+    }
+    if (response.status === 401 || response.status === 403) {
+      return assetOutcome("unauthorized", {
+        phase: "metadata",
+        httpStatus: response.status,
+        detail: `metadata_http_${response.status}`
+      });
+    }
+    if (!response.ok) {
+      return assetOutcome("request_failed", {
+        phase: "metadata",
+        httpStatus: response.status,
+        detail: `metadata_http_${response.status}`
+      });
+    }
+    return null;
+  }
+
+  function boundedMaxBytes(request) {
+    const requested = Number(request.maxBytes);
+    if (!Number.isFinite(requested) || requested <= 0) return assetAbsoluteMaxBytes;
+    return Math.min(requested, assetAbsoluteMaxBytes);
+  }
+
+  function declaredContentLength(response) {
+    const raw = response.headers.get("content-length");
+    if (!raw || !/^\d+$/.test(raw)) return null;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) ? parsed : null;
   }
 
   async function fetchWithAbort(url, options, label) {
@@ -150,28 +293,99 @@
     } else if (request.kind === "file") {
       metaUrl = new URL(`/backend-api/files/${encodeURIComponent(String(request.fileId))}/download`, currentOrigin);
     } else {
-      throw new Error(`unsupported_asset_kind_${request.kind}`);
+      return assetOutcome("invalid_request", { phase: "request", detail: "unsupported_asset_kind" });
+    }
+    const accessToken = await resolveAccessToken();
+    if (!accessToken) {
+      return assetOutcome("unauthorized", { phase: "access_token", detail: "access_token_unavailable" });
     }
     const metaResponse = await fetchWithAbort(
       metaUrl.href,
-      { credentials: "include", cache: "no-store", headers: authHeaders() },
+      { credentials: "include", cache: "no-store", headers: bearerHeaders(accessToken) },
       "asset_meta_fetch"
     );
-    if (!metaResponse.ok) throw new Error(`asset_meta_status_${metaResponse.status}`);
-    const meta = await metaResponse.json();
+    const { meta, rawText } = await readMetadataEnvelope(metaResponse);
+    const failure = metadataFailureOutcome(request, metaResponse, meta, rawText);
+    if (failure) return failure;
     const downloadUrl = meta && (meta.download_url || meta.downloadUrl || meta.url);
-    if (typeof downloadUrl !== "string" || !downloadUrl) throw new Error("asset_meta_missing_download_url");
-    const fileResponse = await fetchWithAbort(downloadUrl, { credentials: "omit", cache: "no-store" }, "asset_bytes_fetch");
-    if (!fileResponse.ok) throw new Error(`asset_bytes_status_${fileResponse.status}`);
+    if (typeof downloadUrl !== "string" || !downloadUrl) {
+      return assetOutcome("invalid_response", { phase: "metadata", detail: "download_url_missing" });
+    }
+    let signedUrl;
+    try {
+      signedUrl = new URL(downloadUrl, currentOrigin);
+    } catch {
+      return assetOutcome("invalid_response", { phase: "metadata", detail: "download_url_invalid" });
+    }
+    if (signedUrl.protocol !== "https:") {
+      return assetOutcome("invalid_response", { phase: "metadata", detail: "download_url_not_https" });
+    }
+    const fileResponse = await fetchWithAbort(
+      signedUrl.href,
+      { credentials: "omit", cache: "no-store" },
+      "asset_bytes_fetch"
+    );
+    if ([401, 403, 404, 410].includes(fileResponse.status)) {
+      return assetOutcome("signed_url_expired", {
+        phase: "signed_bytes",
+        httpStatus: fileResponse.status,
+        detail: `signed_url_http_${fileResponse.status}`
+      });
+    }
+    if (!fileResponse.ok) {
+      return assetOutcome("request_failed", {
+        phase: "signed_bytes",
+        httpStatus: fileResponse.status,
+        detail: `signed_url_http_${fileResponse.status}`
+      });
+    }
+    const maxBytes = boundedMaxBytes(request);
+    const contentLength = declaredContentLength(fileResponse);
+    if (contentLength !== null && contentLength > maxBytes) {
+      return assetOutcome("too_large", {
+        phase: "signed_bytes",
+        httpStatus: fileResponse.status,
+        detail: "content_length_over_limit",
+        sizeBytes: contentLength
+      });
+    }
     const buffer = await fileResponse.arrayBuffer();
-    const maxBytes = Number(request.maxBytes) > 0 ? Number(request.maxBytes) : 25 * 1024 * 1024;
-    if (buffer.byteLength > maxBytes) throw new Error(`asset_too_large_${buffer.byteLength}`);
-    return {
-      base64: arrayBufferToBase64(buffer),
-      size_bytes: buffer.byteLength,
-      mime_type: fileResponse.headers.get("content-type") || null,
-      name: (meta && (meta.file_name || meta.fileName)) || null
-    };
+    if (buffer.byteLength > maxBytes) {
+      return assetOutcome("too_large", {
+        phase: "signed_bytes",
+        httpStatus: fileResponse.status,
+        detail: "downloaded_bytes_over_limit",
+        sizeBytes: buffer.byteLength
+      });
+    }
+    let contentSha256;
+    try {
+      contentSha256 = await sha256Hex(buffer);
+    } catch {
+      return assetOutcome("integrity_error", { phase: "sha256", detail: "sha256_unavailable" });
+    }
+    return assetOutcome("acquired", {
+      phase: "complete",
+      httpStatus: fileResponse.status,
+      asset: {
+        base64: arrayBufferToBase64(buffer),
+        size_bytes: buffer.byteLength,
+        sha256: contentSha256,
+        mime_type: fileResponse.headers.get("content-type") || null,
+        name: (meta && (meta.file_name || meta.fileName)) || null
+      }
+    });
+  }
+
+  function assetExceptionOutcome(error) {
+    const timedOut =
+      error?.name === "AbortError" ||
+      error?.name === "PolylogueTimeoutError" ||
+      String(error?.message || "").includes("timeout_after_");
+    return assetOutcome("request_failed", {
+      phase: "bridge",
+      detail: timedOut ? "request_timeout" : "request_failed"
+    });
   }
 
   window.addEventListener("message", async (event) => {
@@ -179,14 +393,14 @@
     const data = event.data || {};
     if (data.type !== assetFetchRequestMessage || !data.requestId || !data.request) return;
     try {
-      const asset = await fetchAssetBytes(data.request);
-      window.postMessage({ type: assetFetchResponseMessage, requestId: data.requestId, asset }, currentOrigin);
+      const outcome = await fetchAssetBytes(data.request);
+      window.postMessage({ type: assetFetchResponseMessage, requestId: data.requestId, outcome }, currentOrigin);
     } catch (error) {
       window.postMessage(
         {
           type: assetFetchResponseMessage,
           requestId: data.requestId,
-          error: String(error && error.message ? error.message : error)
+          outcome: assetExceptionOutcome(error)
         },
         currentOrigin
       );
@@ -200,8 +414,7 @@
       const absolute = new URL(url, window.location.href);
       const isConversation =
         absolute.origin === currentOrigin &&
-        /\/backend-api\/conversation\/[^/?#]+/.test(absolute.pathname) &&
-        !absolute.pathname.endsWith("/init");
+        /^\/backend-api\/conversation\/[^/?#]+\/?$/.test(absolute.pathname);
       const contentType = response.headers.get("content-type") || "";
       if (isConversation && contentType.includes("application/json")) {
         const body = await response.clone().text();

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -400,4 +400,90 @@ describe("ChatGPT authenticated asset capture envelope", () => {
     expect(durablePayload).not.toContain(bearerToken);
     expect(durablePayload).not.toContain("synthetic-signed-secret");
   });
+
+  it("attempts the selected branch's newest asset before stale off-branch assets trip the breaker", async () => {
+    const targetPath = "/mnt/data/Polylogue-Demo-Packet-v2-Flagships-kit.zip";
+    const stalePaths = ["/mnt/data/stale-1.zip", "/mnt/data/stale-2.zip", "/mnt/data/stale-3.zip"];
+    const mapping = {};
+    for (const [index, sandboxPath] of stalePaths.entries()) {
+      const nodeId = `stale-node-${index + 1}`;
+      mapping[nodeId] = {
+        id: nodeId,
+        parent: null,
+        children: [],
+        message: {
+          id: `stale-message-${index + 1}`,
+          author: { role: "assistant" },
+          create_time: 1781366400 + index,
+          content: { content_type: "text", parts: [`Old: sandbox:${sandboxPath}`] },
+          metadata: { model_slug: "gpt-test" },
+        },
+      };
+    }
+    mapping["current-node"] = {
+      id: "current-node",
+      parent: null,
+      children: [],
+      message: {
+        id: "current-message",
+        author: { role: "assistant" },
+        create_time: 1781366460,
+        content: { content_type: "text", parts: [`Current: sandbox:${targetPath}`] },
+        metadata: { model_slug: "gpt-test" },
+      },
+    };
+    const payload = {
+      ...conversationPayload(),
+      current_node: "current-node",
+      mapping,
+    };
+    const calls = [];
+    const adapter = {
+      calls,
+      fetch: vi.fn(async (input, options = {}) => {
+        const url = new URL(String(input), "https://chatgpt.com");
+        calls.push({ url, options });
+        if (url.pathname === "/api/auth/session") return jsonResponse({ accessToken: bearerToken });
+        if (url.pathname === "/backend-api/conversation/conversation-1") return jsonResponse(payload);
+        if (url.pathname === "/backend-api/conversation/conversation-1/interpreter/download") {
+          const sandboxPath = url.searchParams.get("sandbox_path");
+          const downloadUrl =
+            sandboxPath === targetPath
+              ? signedUrl
+              : `https://files.example.test/expired/${encodeURIComponent(sandboxPath)}`;
+          return jsonResponse({ download_url: downloadUrl, file_name: sandboxPath.split("/").at(-1) });
+        }
+        if (url.href === signedUrl) return byteResponse(assetBytes);
+        if (url.origin === "https://files.example.test" && url.pathname.startsWith("/expired/")) {
+          return byteResponse(new Uint8Array(), 403);
+        }
+        throw new Error(`unexpected synthetic request: ${url.href}`);
+      }),
+    };
+    const harness = installFullCapture(adapter);
+
+    const result = await harness.dom.window.polylogueCapture.capturePage();
+
+    expect(result.envelope.session.provider_meta.asset_acquisition).toMatchObject({
+      attempted: 4,
+      acquired: 1,
+      skipped_circuit_breaker: 0,
+      status_counts: { acquired: 1, signed_url_expired: 3 },
+      acquired_assets: [
+        {
+          provider_attachment_id: `sandbox:current-message:${targetPath}`,
+          sha256: expectedSha256,
+          size_bytes: assetBytes.byteLength,
+        },
+      ],
+    });
+    expect(result.envelope.session.attachments[0]).toMatchObject({
+      provider_attachment_id: `sandbox:current-message:${targetPath}`,
+      provider_meta: { content_sha256: expectedSha256 },
+    });
+    const metadataPaths = calls
+      .filter((call) => call.url.pathname.endsWith("/interpreter/download"))
+      .map((call) => call.url.searchParams.get("sandbox_path"));
+    expect(metadataPaths).toEqual([targetPath, ...stalePaths.slice().reverse()]);
+  });
 });

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -109,7 +109,17 @@ function makeDom(adapter) {
     runScripts: "outside-only",
   });
   openDoms.push(dom);
-  Object.defineProperty(dom.window, "crypto", { configurable: true, value: webcrypto });
+  // Node 20 rejects ArrayBuffers created by a separate jsdom VM realm. Keep
+  // the production dependency on Web Crypto, but adapt test bytes into the
+  // host realm before invoking the real digest implementation.
+  const cryptoAdapter = {
+    subtle: {
+      digest(algorithm, data) {
+        return webcrypto.subtle.digest(algorithm, Buffer.from(new dom.window.Uint8Array(data)));
+      },
+    },
+  };
+  Object.defineProperty(dom.window, "crypto", { configurable: true, value: cryptoAdapter });
   Object.defineProperty(dom.window, "fetch", { configurable: true, value: adapter.fetch });
   return dom;
 }

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -124,8 +124,14 @@ function makeDom(adapter) {
   return dom;
 }
 
-function installBridge(adapter, source = bridgeSource) {
+function installBridge(adapter, source = bridgeSource, { bootstrapToken = null } = {}) {
   const dom = makeDom(adapter);
+  if (bootstrapToken) {
+    const bootstrap = dom.window.document.createElement("script");
+    bootstrap.id = "client-bootstrap";
+    bootstrap.textContent = JSON.stringify({ session: { accessToken: bootstrapToken } });
+    dom.window.document.body.appendChild(bootstrap);
+  }
   const pending = new Map();
   const posted = [];
   Object.defineProperty(dom.window, "postMessage", {
@@ -287,13 +293,37 @@ describe("ChatGPT authenticated interpreter bridge response contract", () => {
     const authCalls = adapter.calls.filter((call) => call.url.pathname === "/api/auth/session");
     expect(metadataCalls).toHaveLength(2);
     expect(authorizationHeader(metadataCalls[0].options)).toBe(`Bearer ${bearerToken}`);
+    expect(metadataCalls[0].options.credentials).toBe("include");
+    expect(metadataCalls[0].url.searchParams.get("message_id")).toBe("assistant-message-1");
+    expect(metadataCalls[0].url.searchParams.get("sandbox_path")).toBe("/mnt/data/kit.zip");
     expect(signedCalls).toHaveLength(2);
     expect(authorizationHeader(signedCalls[0].options)).toBe(null);
     expect(signedCalls[0].options.credentials).toBe("omit");
     expect(authCalls).toHaveLength(1);
+    expect(authCalls[0].options.credentials).toBe("include");
+    expect(authorizationHeader(authCalls[0].options)).toBe(null);
     const disclosed = JSON.stringify(harness.posted);
     expect(disclosed).not.toContain(bearerToken);
     expect(disclosed).not.toContain("synthetic-signed-secret");
+  });
+
+  it("prefers the current session token over a stale legacy bootstrap token", async () => {
+    const adapter = syntheticEndpointAdapter();
+    const harness = installBridge(adapter, bridgeSource, { bootstrapToken: "stale-bootstrap-token" });
+
+    await expect(harness.requestAsset()).resolves.toMatchObject({ status: "acquired" });
+    const metadataCall = adapter.calls.find((call) => call.url.pathname.endsWith("/interpreter/download"));
+    expect(authorizationHeader(metadataCall.options)).toBe(`Bearer ${bearerToken}`);
+    expect(adapter.calls.filter((call) => call.url.pathname === "/api/auth/session")).toHaveLength(1);
+  });
+
+  it("falls back to the trusted bootstrap token when the session endpoint has none", async () => {
+    const adapter = syntheticEndpointAdapter({ authStatus: 401, authBody: { detail: "Unauthorized" } });
+    const harness = installBridge(adapter, bridgeSource, { bootstrapToken: bearerToken });
+
+    await expect(harness.requestAsset()).resolves.toMatchObject({ status: "acquired" });
+    const metadataCall = adapter.calls.find((call) => call.url.pathname.endsWith("/interpreter/download"));
+    expect(authorizationHeader(metadataCall.options)).toBe(`Bearer ${bearerToken}`);
   });
 
   it("rejects a declared body over the per-request cap before publishing bytes", async () => {

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -1,0 +1,363 @@
+import { Buffer } from "node:buffer";
+import { createHash, webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { TextEncoder } from "node:util";
+import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
+
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(resolve(testDirectory, "../../src/content/chatgpt_bridge.js"), "utf8");
+const commonSource = readFileSync(resolve(testDirectory, "../../src/common.js"), "utf8");
+const contentSource = readFileSync(resolve(testDirectory, "../../src/content/chatgpt.js"), "utf8");
+const bearerToken = "synthetic-bearer-must-not-cross-the-page-bridge";
+const signedUrl = "https://files.example.test/download/kit.zip?signature=synthetic-signed-secret";
+const assetBytes = new TextEncoder().encode("polylogue authenticated interpreter asset\n");
+const expectedSha256 = createHash("sha256").update(assetBytes).digest("hex");
+const openDoms = [];
+
+function jsonResponse(body, status = 200) {
+  return new globalThis.Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function byteResponse(bytes, status = 200, declaredSize = null) {
+  const headers = { "content-type": "application/zip" };
+  if (declaredSize !== null) headers["content-length"] = String(declaredSize);
+  return new globalThis.Response(bytes, { status, headers });
+}
+
+function authorizationHeader(options) {
+  return new globalThis.Headers(options?.headers || {}).get("authorization");
+}
+
+function conversationPayload() {
+  return {
+    id: "conversation-1",
+    conversation_id: "conversation-1",
+    title: "Authenticated capture fixture",
+    create_time: 1781366400,
+    update_time: 1781366460,
+    current_node: "assistant-node",
+    mapping: {
+      "assistant-node": {
+        id: "assistant-node",
+        parent: null,
+        children: [],
+        message: {
+          id: "assistant-message-1",
+          author: { role: "assistant" },
+          create_time: 1781366460,
+          content: {
+            content_type: "text",
+            parts: ["Kit ready: [download](sandbox:/mnt/data/kit.zip)"],
+          },
+          metadata: { model_slug: "gpt-test" },
+        },
+      },
+    },
+  };
+}
+
+function syntheticEndpointAdapter({
+  authStatus = 200,
+  authBody = { accessToken: bearerToken },
+  metadataStatus = 200,
+  metadataBody = { download_url: signedUrl, file_name: "kit.zip" },
+  signedStatus = 200,
+  signedBytes = assetBytes,
+  declaredSize = null,
+} = {}) {
+  const calls = [];
+  const fetch = vi.fn(async (input, options = {}) => {
+    const url = new URL(String(input), "https://chatgpt.com");
+    calls.push({ url, options });
+    if (url.origin === "https://chatgpt.com" && url.pathname === "/api/auth/session") {
+      return jsonResponse(authBody, authStatus);
+    }
+    if (url.origin === "https://chatgpt.com" && url.pathname === "/backend-api/conversation/conversation-1") {
+      if (authorizationHeader(options) !== `Bearer ${bearerToken}`) {
+        return jsonResponse({ detail: "Unauthorized" }, 401);
+      }
+      return jsonResponse(conversationPayload());
+    }
+    if (
+      url.origin === "https://chatgpt.com" &&
+      url.pathname === "/backend-api/conversation/conversation-1/interpreter/download"
+    ) {
+      if (authorizationHeader(options) !== `Bearer ${bearerToken}`) {
+        return jsonResponse({ detail: "Unauthorized" }, 401);
+      }
+      return jsonResponse(metadataBody, metadataStatus);
+    }
+    if (url.href === signedUrl) {
+      return byteResponse(signedBytes, signedStatus, declaredSize);
+    }
+    throw new Error(`unexpected synthetic request: ${url.origin}${url.pathname}`);
+  });
+  return { calls, fetch };
+}
+
+function makeDom(adapter) {
+  const dom = new JSDOM("<!doctype html><title>ChatGPT fixture</title>", {
+    url: "https://chatgpt.com/c/conversation-1",
+    runScripts: "outside-only",
+  });
+  openDoms.push(dom);
+  Object.defineProperty(dom.window, "crypto", { configurable: true, value: webcrypto });
+  Object.defineProperty(dom.window, "fetch", { configurable: true, value: adapter.fetch });
+  return dom;
+}
+
+function installBridge(adapter, source = bridgeSource) {
+  const dom = makeDom(adapter);
+  const pending = new Map();
+  const posted = [];
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      posted.push(data);
+      const resolve = pending.get(data?.requestId);
+      if (data?.type === "polylogue.chatgpt.assetFetchResponse" && resolve) {
+        pending.delete(data.requestId);
+        resolve(data.outcome);
+      }
+    },
+  });
+  new Script(source).runInContext(dom.getInternalVMContext());
+
+  function requestAsset(overrides = {}) {
+    const requestId = `asset-request-${pending.size + 1}-${posted.length}`;
+    const response = new Promise((resolve) => pending.set(requestId, resolve));
+    dom.window.dispatchEvent(
+      new dom.window.MessageEvent("message", {
+        source: dom.window,
+        origin: dom.window.location.origin,
+        data: {
+          type: "polylogue.chatgpt.assetFetchRequest",
+          requestId,
+          request: {
+            kind: "sandbox",
+            conversationId: "conversation-1",
+            messageId: "assistant-message-1",
+            sandboxPath: "/mnt/data/kit.zip",
+            maxBytes: 1024,
+            ...overrides,
+          },
+        },
+      }),
+    );
+    return response;
+  }
+
+  return { dom, posted, requestAsset };
+}
+
+function installFullCapture(adapter) {
+  const dom = makeDom(adapter);
+  const posted = [];
+  const runtimeMessages = [];
+  const runtimeListeners = [];
+  const chrome = {
+    runtime: {
+      id: "synthetic-extension-id",
+      getManifest: () => ({ version: "0.1.0" }),
+      onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
+      async sendMessage(message) {
+        runtimeMessages.push(message);
+        if (message.type === "polylogue.capture") {
+          return {
+            ok: true,
+            provider: "chatgpt",
+            provider_session_id: "conversation-1",
+            receiver_request_id: "synthetic-request",
+          };
+        }
+        if (message.type === "polylogue.archiveState") return { captured: true, state: "archived" };
+        return { ok: true };
+      },
+    },
+  };
+  Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      posted.push(data);
+      dom.window.queueMicrotask(() => {
+        dom.window.dispatchEvent(
+          new dom.window.MessageEvent("message", {
+            source: dom.window,
+            origin: dom.window.location.origin,
+            data,
+          }),
+        );
+      });
+    },
+  });
+  const context = dom.getInternalVMContext();
+  new Script(bridgeSource).runInContext(context);
+  new Script(commonSource).runInContext(context);
+  new Script(contentSource).runInContext(context);
+  return { dom, posted, runtimeListeners, runtimeMessages };
+}
+
+afterEach(() => {
+  for (const dom of openDoms.splice(0)) dom.window.close();
+});
+
+describe("ChatGPT authenticated interpreter bridge response contract", () => {
+  it.each([
+    {
+      name: "missing access token",
+      adapter: { authStatus: 401, authBody: { detail: "Unauthorized" } },
+      expected: { status: "unauthorized", phase: "access_token", detail: "access_token_unavailable" },
+    },
+    {
+      name: "provider-reported expired pod",
+      adapter: { metadataBody: { detail: "ace_pod_expired" } },
+      expected: { status: "pod_expired", phase: "metadata", detail: "ace_pod_expired", http_status: 200 },
+    },
+    {
+      name: "provider-reported expired pod on a generic 403",
+      adapter: { metadataStatus: 403, metadataBody: { detail: "ace_pod_expired" } },
+      expected: { status: "pod_expired", phase: "metadata", detail: "ace_pod_expired", http_status: 403 },
+    },
+    {
+      name: "interpreter file missing",
+      adapter: { metadataStatus: 404, metadataBody: { detail: "Interpreter file not found" } },
+      expected: {
+        status: "missing",
+        phase: "metadata",
+        detail: "interpreter_file_not_found",
+        http_status: 404,
+      },
+    },
+    {
+      name: "expired signed URL",
+      adapter: { signedStatus: 403 },
+      expected: {
+        status: "signed_url_expired",
+        phase: "signed_bytes",
+        detail: "signed_url_http_403",
+        http_status: 403,
+      },
+    },
+  ])("classifies $name without collapsing it into a generic HTTP error", async ({ adapter, expected }) => {
+    const harness = installBridge(syntheticEndpointAdapter(adapter));
+
+    await expect(harness.requestAsset()).resolves.toMatchObject(expected);
+  });
+
+  it("acquires signed bytes with a deterministic SHA-256 and no credential disclosure", async () => {
+    const adapter = syntheticEndpointAdapter();
+    const harness = installBridge(adapter);
+
+    const first = await harness.requestAsset();
+    const second = await harness.requestAsset();
+
+    expect(first).toMatchObject({
+      status: "acquired",
+      phase: "complete",
+      asset: {
+        size_bytes: assetBytes.byteLength,
+        sha256: expectedSha256,
+        mime_type: "application/zip",
+        name: "kit.zip",
+      },
+    });
+    expect(second.asset.sha256).toBe(first.asset.sha256);
+    expect(first.asset.base64).toBe(Buffer.from(assetBytes).toString("base64"));
+    const metadataCalls = adapter.calls.filter((call) => call.url.pathname.endsWith("/interpreter/download"));
+    const signedCalls = adapter.calls.filter((call) => call.url.origin === "https://files.example.test");
+    const authCalls = adapter.calls.filter((call) => call.url.pathname === "/api/auth/session");
+    expect(metadataCalls).toHaveLength(2);
+    expect(authorizationHeader(metadataCalls[0].options)).toBe(`Bearer ${bearerToken}`);
+    expect(signedCalls).toHaveLength(2);
+    expect(authorizationHeader(signedCalls[0].options)).toBe(null);
+    expect(signedCalls[0].options.credentials).toBe("omit");
+    expect(authCalls).toHaveLength(1);
+    const disclosed = JSON.stringify(harness.posted);
+    expect(disclosed).not.toContain(bearerToken);
+    expect(disclosed).not.toContain("synthetic-signed-secret");
+  });
+
+  it("rejects a declared body over the per-request cap before publishing bytes", async () => {
+    const harness = installBridge(syntheticEndpointAdapter({ declaredSize: 2048 }));
+
+    await expect(harness.requestAsset({ maxBytes: 1024 })).resolves.toMatchObject({
+      status: "too_large",
+      phase: "signed_bytes",
+      detail: "content_length_over_limit",
+      size_bytes: 2048,
+    });
+  });
+
+  it("reproduces the old unauthorized behavior when the production bearer dependency is removed", async () => {
+    const bearerRequest = '{ credentials: "include", cache: "no-store", headers: bearerHeaders(accessToken) }';
+    const cookieOnlyRequest = '{ credentials: "include", cache: "no-store", headers: {} }';
+    const unauthenticatedSource = bridgeSource.replace(bearerRequest, cookieOnlyRequest);
+    expect(unauthenticatedSource).not.toBe(bridgeSource);
+    const authenticated = installBridge(syntheticEndpointAdapter());
+    const unauthenticated = installBridge(syntheticEndpointAdapter(), unauthenticatedSource);
+
+    await expect(authenticated.requestAsset()).resolves.toMatchObject({ status: "acquired" });
+    await expect(unauthenticated.requestAsset()).resolves.toMatchObject({
+      status: "unauthorized",
+      phase: "metadata",
+      http_status: 401,
+    });
+  });
+});
+
+describe("ChatGPT authenticated asset capture envelope", () => {
+  it("records stable attachment identity, bytes, size, and SHA receipt across repeat capture", async () => {
+    const adapter = syntheticEndpointAdapter();
+    const harness = installFullCapture(adapter);
+
+    const result = await harness.dom.window.polylogueCapture.capturePage();
+    const repeated = await harness.dom.window.polylogueCapture.capturePage();
+
+    expect(result.ok).toBe(true);
+    expect(repeated.ok).toBe(true);
+    expect(repeated.envelope.session).toEqual(result.envelope.session);
+    const [attachment] = result.envelope.session.attachments;
+    expect(attachment).toMatchObject({
+      provider_attachment_id: "sandbox:assistant-message-1:/mnt/data/kit.zip",
+      message_provider_id: "assistant-message-1",
+      name: "kit.zip",
+      size_bytes: assetBytes.byteLength,
+      inline_base64: Buffer.from(assetBytes).toString("base64"),
+      provider_meta: {
+        capture_source: "chatgpt_page_asset_fetch",
+        asset_kind: "sandbox",
+        sandbox_path: "/mnt/data/kit.zip",
+        content_sha256: expectedSha256,
+      },
+    });
+    expect(result.envelope.session.provider_meta.asset_acquisition).toMatchObject({
+      attempted: 1,
+      acquired: 1,
+      status_counts: { acquired: 1 },
+      acquired_assets: [
+        {
+          provider_attachment_id: "sandbox:assistant-message-1:/mnt/data/kit.zip",
+          sha256: expectedSha256,
+          size_bytes: assetBytes.byteLength,
+        },
+      ],
+      failed: [],
+    });
+    const captureMessages = harness.runtimeMessages.filter((message) => message.type === "polylogue.capture");
+    expect(captureMessages).toHaveLength(2);
+    expect(captureMessages[0].envelope).toEqual(result.envelope);
+    expect(captureMessages[1].envelope).toEqual(repeated.envelope);
+    const durablePayload = JSON.stringify({ envelope: result.envelope, posted: harness.posted });
+    expect(durablePayload).not.toContain(bearerToken);
+    expect(durablePayload).not.toContain("synthetic-signed-secret");
+  });
+});

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -68,7 +68,8 @@ function syntheticEndpointAdapter({
   authStatus = 200,
   authBody = { accessToken: bearerToken },
   metadataStatus = 200,
-  metadataBody = { download_url: signedUrl, file_name: "kit.zip" },
+  signedDownloadUrl = signedUrl,
+  metadataBody = { download_url: signedDownloadUrl, file_name: "kit.zip" },
   signedStatus = 200,
   signedBytes = assetBytes,
   declaredSize = null,
@@ -95,7 +96,7 @@ function syntheticEndpointAdapter({
       }
       return jsonResponse(metadataBody, metadataStatus);
     }
-    if (url.href === signedUrl) {
+    if (url.href === signedDownloadUrl) {
       return byteResponse(signedBytes, signedStatus, declaredSize);
     }
     throw new Error(`unexpected synthetic request: ${url.origin}${url.pathname}`);
@@ -305,6 +306,23 @@ describe("ChatGPT authenticated interpreter bridge response contract", () => {
     const disclosed = JSON.stringify(harness.posted);
     expect(disclosed).not.toContain(bearerToken);
     expect(disclosed).not.toContain("synthetic-signed-secret");
+  });
+
+  it("keeps cookies for same-origin estuary bytes without forwarding the bearer", async () => {
+    const estuaryUrl = "https://chatgpt.com/backend-api/estuary/content?download=synthetic-secret";
+    const adapter = syntheticEndpointAdapter({ signedDownloadUrl: estuaryUrl });
+    const harness = installBridge(adapter);
+
+    await expect(harness.requestAsset()).resolves.toMatchObject({
+      status: "acquired",
+      asset: { sha256: expectedSha256 },
+    });
+    const byteCall = adapter.calls.find((call) => call.url.href === estuaryUrl);
+    expect(byteCall.options.credentials).toBe("include");
+    expect(authorizationHeader(byteCall.options)).toBe(null);
+    const disclosed = JSON.stringify(harness.posted);
+    expect(disclosed).not.toContain(bearerToken);
+    expect(disclosed).not.toContain("synthetic-secret");
   });
 
   it("prefers the current session token over a stale legacy bootstrap token", async () => {


### PR DESCRIPTION
## Summary

Authenticate ChatGPT interpreter-asset acquisition through the current page session contract, preserve distinct terminal outcomes, prioritize the selected branch's assets, and attach deterministic SHA-256 receipts without allowing bearer credentials or cross-origin signed URLs to cross the page bridge.

## Problem

Live recovery showed that interpreter files classified as generic 403 failures were still retrievable through ChatGPT's authenticated contract. The bridge read only a legacy bootstrap token, iterated unordered branch mappings until stale assets tripped a kind-wide breaker, and fetched every returned download URL with `credentials: omit`. Current ChatGPT pages instead expose the bearer through `/api/auth/session`; current-node assets can appear late in mapping insertion order; and current interpreter metadata may return a same-origin `/backend-api/estuary/content` URL that requires cookies.

## Solution

- Resolve `/api/auth/session` first, retaining the legacy bootstrap only as a tested fallback.
- Send the bearer only to internally constructed same-origin metadata endpoints.
- For returned HTTPS byte URLs, retain cookies only on the exact ChatGPT page origin; cross-origin signed URLs remain credential-free and never receive the bearer.
- Walk the selected current-node lineage newest-first, then best-effort backfill remaining branches by message recency, so stale off-branch assets cannot suppress a live current deliverable.
- Classify unauthorized, pod-expired, missing, signed-URL-expired, too-large, contract/transport failure, and acquired outcomes independently.
- Enforce the 25 MiB per-file cap, compute SHA-256 with Web Crypto, and retain stable attachment identity plus digest/size receipts.

## Acceptance Matrix

| AC | Status | Evidence |
| --- | --- | --- |
| 1. Live interpreter capture acquires bytes and true SHA without credentials | **Browser/receiver slice satisfied.** Live conversation `6a5350db-c1d8-83ed-9976-035227280d5e` acquired 2/2 assets, each 848,460 bytes at SHA `40fa31aeccd41a8c61e3bbe5d721d1f5395cc4f14c7411f94663b777a23eef77`; no failures, skips, bearer, or cross-origin credentials. Source/index materialization is separately blocked by typed raw-authority debt tracked in `polylogue-57rp`, so this PR does not claim the final content-addressed index row. |
| 2. Unauthorized, pod-expired, missing, signed-expired, acquired remain distinct | **Satisfied.** Production bridge response matrix covers auth-session 401, provider `ace_pod_expired`, interpreter 404, byte 403, same-origin estuary acquisition, and external signed acquisition. |
| 3. Regression fails under previous behavior | **Satisfied.** Removing metadata Authorization changes acquired to unauthorized/401; forcing `credentials: omit` on same-origin estuary reproduces live `403 File stream access denied`; unordered stale-first discovery skips the current-node ZIP. |
| 4. Re-capture a recovered GPT-Pro package with matching SHA | **Satisfied with explicit recovery boundary.** The original pod now returns a fresh metadata URL whose byte request is genuinely expired. The independently recovered 848,460-byte Demo Packet ZIP was re-emitted byte-for-byte through a fresh ChatGPT interpreter and captured through this extension; both the sandbox deliverable and file attachment equal the independent SHA `40fa31ae...f77`. No claim is made that the original pod survived. |
| 5. Focused extension/parser tests and browser smoke pass | **Satisfied.** See verification. |

The browser-auth child remains open until `polylogue-57rp` converges the preserved acquired envelope into the source/index/blob tiers; the parent `polylogue-5k5l` also retains file-service and end-to-end acquisition scope.

## Verification

- `npm test` -> `7 files passed; 121 tests passed`
- `npm run lint` -> `eslint src/ tests/` exited 0
- `npm run validate` -> manifest v0.1.0 OK
- `devtools test tests/unit/sources/test_browser_capture.py tests/unit/storage/test_attachment_acquisition.py -k 'native_payload_delegation_keeps_envelope_acquired_assets or inline_attachment_bytes_are_stored_with_true_hash'` -> `2 passed, 34 deselected`
- pre-push `devtools verify --quick` at `aedb2760b` -> 13/13 steps exited 0, run `20260712T083505Z-quick-1122043-a123e4ab`
- Live extension capture -> native_full, 6 turns, 2 acquired / 0 failed, exact 848,460-byte SHA match, receiver request `polylogue-ext-mrhjgnkn-hzbd33l3`
- Live negative proof -> same-origin estuary `credentials: omit` returned 403 `File stream access denied`; cookie-only and bearer-only requests both returned 200

## Review Notes

Self-review corrected explicit provider-diagnostic precedence, current-session-over-stale-bootstrap precedence, selected-lineage ordering, and same-origin estuary authentication. Cross-origin signed URLs still use `credentials: omit`; serialized capture evidence contains neither bearer nor signed URL. CodeRabbit initially rate-limited and posted no substantive finding. GitHub checks were green before the final live-proof commits; subsequent workflow jobs are account-billing infrastructure failures with zero executed steps, while local gates above exercised the changed surface.

Ref polylogue-5k5l.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ChatGPT conversation and attachment capture reliability.
  * Prioritizes the currently selected conversation branch when locating attachments.
  * Validates downloaded attachments for integrity and size before saving them.
  * Provides clearer acquisition results for successful, skipped, and failed attachments.
  * Improved handling of authentication issues, expired links, missing files, and download failures.
  * Enhanced protection for credentials during conversation and attachment retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->