### PR TITLE
perf(storage): bound provider usage full diagnostics (#2713)

### DIFF
--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -733,9 +733,11 @@ def _acquired_not_materialized_raw_rows(
                r.raw_id AS raw_id,
                r.source_path AS source_path,
                r.blob_hash AS blob_hash,
-               r.parsed_at_ms AS parsed_at_ms
+               r.parsed_at_ms AS parsed_at_ms,
+               c.status AS membership_census_status
         FROM {alias_sql}.raw_sessions AS r
         LEFT JOIN sessions AS s ON s.raw_id = r.raw_id
+        LEFT JOIN {alias_sql}.raw_membership_census AS c ON c.raw_id = r.raw_id
         {_where_origin(origin, table_alias="r")}
           {"AND" if origin is not None else "WHERE"} (r.parse_error IS NULL OR TRIM(r.parse_error) = '')
           AND s.session_id IS NULL
@@ -763,6 +765,11 @@ def _raw_row_is_known_non_session_artifact(archive_root: Path, row: sqlite3.Row)
     if str(row["origin"]) != Origin.CODEX_SESSION.value:
         return False
     if row["parsed_at_ms"] is None:
+        return False
+    census_status = str(row["membership_census_status"] or "")
+    if census_status == "non_session":
+        return True
+    if census_status in {"complete", "failed"}:
         return False
     return _raw_jsonl_type_set(_raw_blob_path(archive_root, row), limit=8) == {"session_meta"}
 
@@ -799,157 +806,166 @@ def _stale_provider_rollup_stats(
     origin: str | None,
     limit: int | None,
 ) -> tuple[dict[str, int], dict[str, tuple[str, ...]]]:
-    """Return stale counts and bounded samples without materializing event rows.
+    """Return stale counts and bounded samples from indexed session seeks.
 
-    The materializer treats cumulative Codex totals as session-global: the
-    latest row with billable lanes wins, while sessions without a cumulative
-    row sum request-scoped ``last_*`` values by model.  Keep that exact model
-    in SQLite so a full diagnostic does not fetch the event table, model table,
-    and session table into Python before comparing them.
-
-    ``json_group_array`` sees only the requested sample rows.  JSON keeps
-    provider-native identifiers lossless even when they contain control
-    characters.  The query therefore returns one row per stale origin
-    regardless of the number of stale sessions; ``limit=None`` intentionally
-    preserves the existing all-sample behavior for callers that explicitly
-    request it.
+    Cumulative Codex totals are session-global, so one reverse index seek per
+    session finds the only candidate the materializer can have applied.  The
+    uncommon sessions without a cumulative row stream their request-scoped
+    events through Python's arbitrary-precision integers.  This keeps memory
+    bounded by session/model cardinality, preserves accepted large counters,
+    and avoids sorting or materializing the provider-event table.
     """
 
-    rows = conn.execute(
+    from polylogue.storage.sqlite.archive_tiers.write import _provider_usage_disjoint_lanes
+
+    latest_rows = conn.execute(
         """
-        /* provider_usage_stale_rollups */
-        WITH filtered_sessions AS (
-            SELECT session_id, origin
-            FROM sessions
-            WHERE (? IS NULL OR origin = ?)
-        ),
-        model_counts AS (
-            SELECT fs.session_id,
+        /* provider_usage_stale_latest */
+        WITH session_models AS MATERIALIZED (
+            SELECT s.origin,
+                   s.session_id,
                    COUNT(NULLIF(TRIM(u.model_name), '')) AS model_count,
                    MIN(NULLIF(TRIM(u.model_name), '')) AS sole_model
-            FROM filtered_sessions AS fs
-            LEFT JOIN session_model_usage AS u ON u.session_id = fs.session_id
-            GROUP BY fs.session_id
+            FROM sessions AS s
+            LEFT JOIN session_model_usage AS u ON u.session_id = s.session_id
+            WHERE (? IS NULL OR s.origin = ?)
+            GROUP BY s.origin, s.session_id
         ),
-        token_events AS (
-            SELECT fs.origin,
-                   e.session_id,
-                   e.position,
-                   COALESCE(
-                       NULLIF(TRIM(e.model_name), ''),
-                       CASE WHEN mc.model_count = 1 THEN mc.sole_model END
-                   ) AS model_name,
-                   e.last_input_tokens,
-                   e.last_output_tokens,
-                   e.last_cached_input_tokens,
-                   e.last_cache_write_tokens,
-                   e.last_reasoning_output_tokens,
-                   e.last_total_tokens,
-                   e.total_input_tokens,
-                   e.total_output_tokens,
-                   e.total_cached_input_tokens,
-                   e.total_cache_write_tokens
-            FROM filtered_sessions AS fs
-            JOIN session_provider_usage_events AS e ON e.session_id = fs.session_id
-            LEFT JOIN model_counts AS mc ON mc.session_id = e.session_id
-            WHERE e.provider_event_type = 'token_count'
-        ),
-        cumulative_candidates AS (
-            SELECT *,
-                   ROW_NUMBER() OVER (
-                       PARTITION BY session_id
-                       ORDER BY position DESC
-                   ) AS recency_rank
-            FROM token_events
-            WHERE model_name IS NOT NULL
-              AND (
-                  total_input_tokens != 0
-                  OR total_output_tokens != 0
-                  OR total_cached_input_tokens != 0
-                  OR total_cache_write_tokens != 0
-              )
-        ),
-        latest_cumulative AS (
-            SELECT origin,
-                   session_id,
-                   model_name,
-                   MAX(total_input_tokens - total_cached_input_tokens, 0) AS input_tokens,
-                   total_output_tokens AS output_tokens,
-                   total_cached_input_tokens AS cache_read_tokens,
-                   total_cache_write_tokens AS cache_write_tokens
-            FROM cumulative_candidates
-            WHERE recency_rank = 1
-        ),
-        summed_last AS (
-            SELECT origin,
-                   session_id,
-                   model_name,
-                   CASE
-                       WHEN SUM(last_input_tokens) > SUM(last_cached_input_tokens)
-                       THEN SUM(last_input_tokens) - SUM(last_cached_input_tokens)
-                       ELSE 0
-                   END AS input_tokens,
-                   SUM(last_output_tokens) AS output_tokens,
-                   SUM(last_cached_input_tokens) AS cache_read_tokens,
-                   SUM(last_cache_write_tokens) AS cache_write_tokens
-            FROM token_events
-            WHERE model_name IS NOT NULL
-              AND (
-                  last_input_tokens != 0
-                  OR last_output_tokens != 0
-                  OR last_cached_input_tokens != 0
-                  OR last_cache_write_tokens != 0
-                  OR last_reasoning_output_tokens != 0
-                  OR last_total_tokens != 0
-              )
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM latest_cumulative AS lc
-                  WHERE lc.session_id = token_events.session_id
-              )
-            GROUP BY origin, session_id, model_name
-        ),
-        expected_rollups AS (
-            SELECT * FROM latest_cumulative
-            UNION ALL
-            SELECT * FROM summed_last
-        ),
-        stale_sessions AS (
-            SELECT expected.origin, expected.session_id
-            FROM expected_rollups AS expected
-            LEFT JOIN session_model_usage AS actual
-                ON actual.session_id = expected.session_id
-               AND actual.model_name = expected.model_name
-            WHERE COALESCE(actual.input_tokens, -1) != expected.input_tokens
-               OR COALESCE(actual.output_tokens, -1) != expected.output_tokens
-               OR COALESCE(actual.cache_read_tokens, -1) != expected.cache_read_tokens
-               OR COALESCE(actual.cache_write_tokens, -1) != expected.cache_write_tokens
-            GROUP BY expected.origin, expected.session_id
-        ),
-        ranked_stale_sessions AS (
-            SELECT origin,
-                   session_id,
-                   COUNT(*) OVER (PARTITION BY origin) AS stale_count,
-                   ROW_NUMBER() OVER (PARTITION BY origin ORDER BY session_id) AS sample_rank
-            FROM stale_sessions
+        latest_positions AS MATERIALIZED (
+            SELECT sm.*,
+                   (
+                       SELECT e.position
+                       FROM session_provider_usage_events AS e
+                       WHERE e.session_id = sm.session_id
+                         AND e.provider_event_type = 'token_count'
+                         AND (
+                             e.total_input_tokens != 0
+                             OR e.total_output_tokens != 0
+                             OR e.total_cached_input_tokens != 0
+                             OR e.total_cache_write_tokens != 0
+                         )
+                         AND COALESCE(
+                             NULLIF(TRIM(e.model_name), ''),
+                             CASE WHEN sm.model_count = 1 THEN sm.sole_model END
+                         ) IS NOT NULL
+                       ORDER BY e.position DESC
+                       LIMIT 1
+                   ) AS latest_position
+            FROM session_models AS sm
         )
-        SELECT origin,
-               MAX(stale_count) AS stale_count,
-               COALESCE(
-                   json_group_array(session_id) FILTER (
-                       WHERE ? IS NULL OR sample_rank <= ?
-                   ),
-                   '[]'
-               ) AS sample_session_ids
-        FROM ranked_stale_sessions
-        GROUP BY origin
-        ORDER BY origin
+        SELECT lp.origin,
+               lp.session_id,
+               lp.model_count,
+               lp.sole_model,
+               lp.latest_position,
+               e.model_name,
+               e.total_input_tokens,
+               e.total_output_tokens,
+               e.total_cached_input_tokens,
+               e.total_cache_write_tokens
+        FROM latest_positions AS lp
+        LEFT JOIN session_provider_usage_events AS e
+          ON e.session_id = lp.session_id
+         AND e.position = lp.latest_position
         """,
-        (origin, origin, limit, limit),
+        (origin, origin),
     ).fetchall()
-    counts = {str(row["origin"]): _int(row["stale_count"]) for row in rows}
+
+    origin_by_session: dict[str, str] = {}
+    sole_model_by_session: dict[str, str | None] = {}
+    expected: dict[str, dict[str, tuple[int, int, int, int]]] = defaultdict(dict)
+    fallback_session_ids: list[str] = []
+    for row in latest_rows:
+        session_id = str(row["session_id"])
+        origin_by_session[session_id] = str(row["origin"])
+        sole_model = str(row["sole_model"]) if _int(row["model_count"]) == 1 else None
+        sole_model_by_session[session_id] = sole_model
+        if row["latest_position"] is None:
+            fallback_session_ids.append(session_id)
+            continue
+        model_name = str(row["model_name"] or "").strip() or sole_model or ""
+        if not model_name:
+            continue
+        expected[session_id][model_name] = _provider_usage_disjoint_lanes(
+            _int(row["total_input_tokens"]),
+            _int(row["total_output_tokens"]),
+            _int(row["total_cached_input_tokens"]),
+            _int(row["total_cache_write_tokens"]),
+        )
+
+    for session_id in fallback_session_ids:
+        summed_by_model: dict[str, list[int]] = {}
+        for row in conn.execute(
+            """
+            /* provider_usage_stale_fallback */
+            SELECT model_name,
+                   last_input_tokens,
+                   last_output_tokens,
+                   last_cached_input_tokens,
+                   last_cache_write_tokens,
+                   last_reasoning_output_tokens,
+                   last_total_tokens
+            FROM session_provider_usage_events
+            WHERE session_id = ?
+              AND provider_event_type = 'token_count'
+            ORDER BY position
+            """,
+            (session_id,),
+        ):
+            model_name = str(row["model_name"] or "").strip() or sole_model_by_session[session_id] or ""
+            if not model_name:
+                continue
+            last_values = (
+                _int(row["last_input_tokens"]),
+                _int(row["last_output_tokens"]),
+                _int(row["last_cached_input_tokens"]),
+                _int(row["last_cache_write_tokens"]),
+                _int(row["last_reasoning_output_tokens"]),
+                _int(row["last_total_tokens"]),
+            )
+            if not any(last_values):
+                continue
+            bucket = summed_by_model.setdefault(model_name, [0, 0, 0, 0, 0])
+            for index, value in enumerate(last_values[:5]):
+                bucket[index] += value
+        for model_name, totals in summed_by_model.items():
+            expected[session_id][model_name] = _provider_usage_disjoint_lanes(
+                totals[0], totals[1], totals[2], totals[3]
+            )
+
+    actual_rows = conn.execute(
+        """
+        SELECT u.session_id,
+               u.model_name,
+               u.input_tokens,
+               u.output_tokens,
+               u.cache_read_tokens,
+               u.cache_write_tokens
+        FROM session_model_usage AS u
+        JOIN sessions AS s ON s.session_id = u.session_id
+        WHERE (? IS NULL OR s.origin = ?)
+        """,
+        (origin, origin),
+    ).fetchall()
+    actual = {
+        (str(row["session_id"]), str(row["model_name"])): (
+            _int(row["input_tokens"]),
+            _int(row["output_tokens"]),
+            _int(row["cache_read_tokens"]),
+            _int(row["cache_write_tokens"]),
+        )
+        for row in actual_rows
+    }
+    stale_by_origin: dict[str, set[str]] = defaultdict(set)
+    for session_id, expected_by_model in expected.items():
+        for model_name, expected_tokens in expected_by_model.items():
+            if actual.get((session_id, model_name)) != expected_tokens:
+                stale_by_origin[origin_by_session[session_id]].add(session_id)
+
+    counts = {origin_name: len(session_ids) for origin_name, session_ids in stale_by_origin.items()}
     samples = {
-        str(row["origin"]): tuple(str(sample) for sample in json.loads(str(row["sample_session_ids"]))) for row in rows
+        origin_name: tuple(sorted(session_ids)[:limit]) if limit is not None else tuple(sorted(session_ids))
+        for origin_name, session_ids in stale_by_origin.items()
     }
     return counts, samples
 
@@ -1330,8 +1346,9 @@ def _provider_event_stats(conn: sqlite3.Connection, origin: str | None) -> dict[
     select_parts.append(f"COALESCE(SUM(CASE WHEN {zero_predicate} THEN 1 ELSE 0 END), 0) AS zero_token_event_count")
     for public_name, expr in last_cols.items():
         select_parts.append(f"COALESCE(SUM({expr}), 0) AS {public_name}")
-    rows = conn.execute(
-        f"""
+    try:
+        rows = conn.execute(
+            f"""
         SELECT {", ".join(select_parts)}
         FROM session_provider_usage_events e
         {join_sessions}
@@ -1339,8 +1356,12 @@ def _provider_event_stats(conn: sqlite3.Connection, origin: str | None) -> dict[
         GROUP BY origin
         ORDER BY origin
         """,
-        args,
-    ).fetchall()
+            args,
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "integer overflow" not in str(exc).lower():
+            raise
+        return _provider_event_stats_streaming(conn, origin)
     result: dict[str, dict[str, object]] = {}
     for row in rows:
         result[str(row["origin"])] = {
@@ -1363,42 +1384,128 @@ def _provider_event_stats(conn: sqlite3.Connection, origin: str | None) -> dict[
     return result
 
 
-def _provider_cumulative_usage(conn: sqlite3.Connection, origin: str | None) -> dict[str, UsageCounters]:
-    columns = _table_columns(conn, "session_provider_usage_events")
-    total_cols = _counter_columns(columns, prefix="total")
-    total_predicate = " OR ".join([f"COALESCE({expr}, 0) > 0" for expr in total_cols.values()])
-    origin_select = "? AS origin" if origin is not None else "s.origin AS origin"
-    join_sessions = "" if origin is not None else "JOIN sessions s ON s.session_id = e.session_id"
-    origin_filter = _event_origin_predicate(origin)
-    where_parts = [part for part in (origin_filter, f"({total_predicate})") if part]
-    where_clause = "WHERE " + " AND ".join(where_parts)
+def _provider_event_stats_streaming(conn: sqlite3.Connection, origin: str | None) -> dict[str, dict[str, object]]:
+    """Exact fallback for legal counters whose aggregate exceeds SQLite INTEGER."""
+
     rows = conn.execute(
-        f"""
-        SELECT {origin_select},
-               e.session_id AS session_id,
-               COALESCE(NULLIF(TRIM(e.model_name), ''), '__unknown_model__') AS model_key,
-               e.position AS position,
-               {total_cols["input_tokens"]} AS input_tokens,
-               {total_cols["output_tokens"]} AS output_tokens,
-               {total_cols["cached_input_tokens"]} AS cached_input_tokens,
-               {total_cols["cache_write_tokens"]} AS cache_write_tokens,
-               {total_cols["reasoning_output_tokens"]} AS reasoning_output_tokens,
-               {total_cols["total_tokens"]} AS total_tokens
-        FROM session_provider_usage_events e
-        {join_sessions}
-        {where_clause}
-        ORDER BY origin, e.session_id, e.position
+        """
+        SELECT s.origin,
+               e.session_id,
+               e.provider_event_type,
+               e.model_name,
+               e.last_input_tokens,
+               e.last_output_tokens,
+               e.last_cached_input_tokens,
+               e.last_cache_write_tokens,
+               e.last_reasoning_output_tokens,
+               e.last_total_tokens,
+               e.total_input_tokens,
+               e.total_output_tokens,
+               e.total_cached_input_tokens,
+               e.total_cache_write_tokens,
+               e.total_reasoning_output_tokens,
+               e.total_tokens
+        FROM sessions AS s
+        JOIN session_provider_usage_events AS e ON e.session_id = s.session_id
+        WHERE (? IS NULL OR s.origin = ?)
         """,
-        (*_event_origin_args(origin),),
-    ).fetchall()
-    # The cumulative total_* is session-global, so dedupe to one latest
-    # cumulative per (origin, session) — the highest-position event — rather
-    # than per model. Partitioning by model and summing double-counts because
-    # each model's latest cumulative already includes prior models' tokens
-    # (#2472). ORDER BY ... e.position makes the last write per session win.
-    latest: dict[tuple[str, str], UsageCounters] = {}
+        (origin, origin),
+    )
+    counts_by_origin: dict[str, Counter[str]] = defaultdict(Counter)
+    sessions_by_origin: dict[str, set[str]] = defaultdict(set)
+    last_totals_by_origin: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0, 0, 0, 0])
     for row in rows:
-        latest[(str(row["origin"]), str(row["session_id"]))] = UsageCounters.from_row(
+        origin_name = str(row["origin"])
+        counts = counts_by_origin[origin_name]
+        counts["provider_event_count"] += 1
+        sessions_by_origin[origin_name].add(str(row["session_id"]))
+        counts[f"{row['provider_event_type']}_event_count"] += 1
+        if row["model_name"] is None or not str(row["model_name"]).strip():
+            counts["missing_model_event_count"] += 1
+        last_values = (
+            _int(row["last_input_tokens"]),
+            _int(row["last_output_tokens"]),
+            _int(row["last_cached_input_tokens"]),
+            _int(row["last_cache_write_tokens"]),
+            _int(row["last_reasoning_output_tokens"]),
+            _int(row["last_total_tokens"]),
+        )
+        total_values = (
+            _int(row["total_input_tokens"]),
+            _int(row["total_output_tokens"]),
+            _int(row["total_cached_input_tokens"]),
+            _int(row["total_cache_write_tokens"]),
+            _int(row["total_reasoning_output_tokens"]),
+            _int(row["total_tokens"]),
+        )
+        if not any((*last_values, *total_values)):
+            counts["zero_token_event_count"] += 1
+        last_totals = last_totals_by_origin[origin_name]
+        for index, value in enumerate(last_values):
+            last_totals[index] += value
+
+    result: dict[str, dict[str, object]] = {}
+    for origin_name, counts in counts_by_origin.items():
+        result[origin_name] = {
+            "provider_event_count": counts["provider_event_count"],
+            "provider_event_session_count": len(sessions_by_origin[origin_name]),
+            "token_count_event_count": counts["token_count_event_count"],
+            "message_usage_event_count": counts["message_usage_event_count"],
+            "missing_model_event_count": counts["missing_model_event_count"],
+            "zero_token_event_count": counts["zero_token_event_count"],
+            "provider_request_usage": UsageCounters(*last_totals_by_origin[origin_name]),
+        }
+    return result
+
+
+def _provider_cumulative_usage(conn: sqlite3.Connection, origin: str | None) -> dict[str, UsageCounters]:
+    """Return cumulative usage from at most one indexed event per session."""
+
+    rows = conn.execute(
+        """
+        /* provider_usage_latest_cumulative */
+        WITH latest_positions AS MATERIALIZED (
+            SELECT s.origin,
+                   s.session_id,
+                   (
+                       SELECT e.position
+                       FROM session_provider_usage_events AS e
+                       WHERE e.session_id = s.session_id
+                         AND (
+                             e.total_input_tokens > 0
+                             OR e.total_output_tokens > 0
+                             OR e.total_cached_input_tokens > 0
+                             OR e.total_cache_write_tokens > 0
+                             OR e.total_reasoning_output_tokens > 0
+                             OR e.total_tokens > 0
+                         )
+                       ORDER BY e.position DESC
+                       LIMIT 1
+                   ) AS latest_position
+            FROM sessions AS s
+            WHERE (? IS NULL OR s.origin = ?)
+        )
+        SELECT lp.origin,
+               lp.session_id,
+               e.total_input_tokens AS input_tokens,
+               e.total_output_tokens AS output_tokens,
+               e.total_cached_input_tokens AS cached_input_tokens,
+               e.total_cache_write_tokens AS cache_write_tokens,
+               e.total_reasoning_output_tokens AS reasoning_output_tokens,
+               e.total_tokens AS total_tokens
+        FROM latest_positions AS lp
+        JOIN session_provider_usage_events AS e
+          ON e.session_id = lp.session_id
+         AND e.position = lp.latest_position
+        """,
+        (origin, origin),
+    ).fetchall()
+    # The query emits at most one row per session; Python retains exact integer
+    # addition even when an all-origin total exceeds SQLite's signed 64-bit SUM.
+    by_origin: dict[str, UsageCounters] = defaultdict(UsageCounters)
+    for row in rows:
+        origin_name = str(row["origin"])
+        counters = UsageCounters.from_row(
             row,
             input_key="input_tokens",
             output_key="output_tokens",
@@ -1407,8 +1514,6 @@ def _provider_cumulative_usage(conn: sqlite3.Connection, origin: str | None) -> 
             reasoning_output_key="reasoning_output_tokens",
             total_key="total_tokens",
         )
-    by_origin: dict[str, UsageCounters] = defaultdict(UsageCounters)
-    for (origin_name, _session_id), counters in latest.items():
         by_origin[origin_name] = by_origin[origin_name].plus(counters)
     return dict(by_origin)
 

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -799,169 +799,159 @@ def _stale_provider_rollup_stats(
     origin: str | None,
     limit: int | None,
 ) -> tuple[dict[str, int], dict[str, tuple[str, ...]]]:
-    expected = _expected_provider_model_rollups(conn, origin)
-    if not expected:
-        return {}, {}
-    actual = _actual_model_rollups(conn, origin)
-    origin_by_session = _origin_by_session(conn, origin)
-    stale_by_origin: dict[str, set[str]] = defaultdict(set)
-    for session_id, expected_by_model in expected.items():
-        for model_name, expected_tokens in expected_by_model.items():
-            if actual.get((session_id, model_name)) != expected_tokens:
-                origin_name = origin_by_session.get(session_id)
-                if origin_name:
-                    stale_by_origin[origin_name].add(session_id)
-    counts = {origin_name: len(session_ids) for origin_name, session_ids in stale_by_origin.items()}
+    """Return stale counts and bounded samples without materializing event rows.
+
+    The materializer treats cumulative Codex totals as session-global: the
+    latest row with billable lanes wins, while sessions without a cumulative
+    row sum request-scoped ``last_*`` values by model.  Keep that exact model
+    in SQLite so a full diagnostic does not fetch the event table, model table,
+    and session table into Python before comparing them.
+
+    ``GROUP_CONCAT`` sees only the requested sample rows.  The query therefore
+    returns one row per stale origin regardless of the number of stale
+    sessions; ``limit=None`` intentionally preserves the existing all-sample
+    behavior for callers that explicitly request it.
+    """
+
+    rows = conn.execute(
+        """
+        /* provider_usage_stale_rollups */
+        WITH filtered_sessions AS (
+            SELECT session_id, origin
+            FROM sessions
+            WHERE (? IS NULL OR origin = ?)
+        ),
+        model_counts AS (
+            SELECT fs.session_id,
+                   COUNT(NULLIF(TRIM(u.model_name), '')) AS model_count,
+                   MIN(NULLIF(TRIM(u.model_name), '')) AS sole_model
+            FROM filtered_sessions AS fs
+            LEFT JOIN session_model_usage AS u ON u.session_id = fs.session_id
+            GROUP BY fs.session_id
+        ),
+        token_events AS (
+            SELECT fs.origin,
+                   e.session_id,
+                   e.position,
+                   COALESCE(
+                       NULLIF(TRIM(e.model_name), ''),
+                       CASE WHEN mc.model_count = 1 THEN mc.sole_model END
+                   ) AS model_name,
+                   e.last_input_tokens,
+                   e.last_output_tokens,
+                   e.last_cached_input_tokens,
+                   e.last_cache_write_tokens,
+                   e.last_reasoning_output_tokens,
+                   e.last_total_tokens,
+                   e.total_input_tokens,
+                   e.total_output_tokens,
+                   e.total_cached_input_tokens,
+                   e.total_cache_write_tokens
+            FROM filtered_sessions AS fs
+            JOIN session_provider_usage_events AS e ON e.session_id = fs.session_id
+            LEFT JOIN model_counts AS mc ON mc.session_id = e.session_id
+            WHERE e.provider_event_type = 'token_count'
+        ),
+        cumulative_candidates AS (
+            SELECT *,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY session_id
+                       ORDER BY position DESC
+                   ) AS recency_rank
+            FROM token_events
+            WHERE model_name IS NOT NULL
+              AND (
+                  total_input_tokens != 0
+                  OR total_output_tokens != 0
+                  OR total_cached_input_tokens != 0
+                  OR total_cache_write_tokens != 0
+              )
+        ),
+        latest_cumulative AS (
+            SELECT origin,
+                   session_id,
+                   model_name,
+                   MAX(total_input_tokens - total_cached_input_tokens, 0) AS input_tokens,
+                   total_output_tokens AS output_tokens,
+                   total_cached_input_tokens AS cache_read_tokens,
+                   total_cache_write_tokens AS cache_write_tokens
+            FROM cumulative_candidates
+            WHERE recency_rank = 1
+        ),
+        summed_last AS (
+            SELECT origin,
+                   session_id,
+                   model_name,
+                   CASE
+                       WHEN SUM(last_input_tokens) > SUM(last_cached_input_tokens)
+                       THEN SUM(last_input_tokens) - SUM(last_cached_input_tokens)
+                       ELSE 0
+                   END AS input_tokens,
+                   SUM(last_output_tokens) AS output_tokens,
+                   SUM(last_cached_input_tokens) AS cache_read_tokens,
+                   SUM(last_cache_write_tokens) AS cache_write_tokens
+            FROM token_events
+            WHERE model_name IS NOT NULL
+              AND (
+                  last_input_tokens != 0
+                  OR last_output_tokens != 0
+                  OR last_cached_input_tokens != 0
+                  OR last_cache_write_tokens != 0
+                  OR last_reasoning_output_tokens != 0
+                  OR last_total_tokens != 0
+              )
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM latest_cumulative AS lc
+                  WHERE lc.session_id = token_events.session_id
+              )
+            GROUP BY origin, session_id, model_name
+        ),
+        expected_rollups AS (
+            SELECT * FROM latest_cumulative
+            UNION ALL
+            SELECT * FROM summed_last
+        ),
+        stale_sessions AS (
+            SELECT expected.origin, expected.session_id
+            FROM expected_rollups AS expected
+            LEFT JOIN session_model_usage AS actual
+                ON actual.session_id = expected.session_id
+               AND actual.model_name = expected.model_name
+            WHERE COALESCE(actual.input_tokens, -1) != expected.input_tokens
+               OR COALESCE(actual.output_tokens, -1) != expected.output_tokens
+               OR COALESCE(actual.cache_read_tokens, -1) != expected.cache_read_tokens
+               OR COALESCE(actual.cache_write_tokens, -1) != expected.cache_write_tokens
+            GROUP BY expected.origin, expected.session_id
+        ),
+        ranked_stale_sessions AS (
+            SELECT origin,
+                   session_id,
+                   COUNT(*) OVER (PARTITION BY origin) AS stale_count,
+                   ROW_NUMBER() OVER (PARTITION BY origin ORDER BY session_id) AS sample_rank
+            FROM stale_sessions
+        )
+        SELECT origin,
+               MAX(stale_count) AS stale_count,
+               COALESCE(
+                   GROUP_CONCAT(
+                       CASE WHEN ? IS NULL OR sample_rank <= ? THEN session_id END,
+                       char(31)
+                   ),
+                   ''
+               ) AS sample_session_ids
+        FROM ranked_stale_sessions
+        GROUP BY origin
+        ORDER BY origin
+        """,
+        (origin, origin, limit, limit),
+    ).fetchall()
+    counts = {str(row["origin"]): _int(row["stale_count"]) for row in rows}
     samples = {
-        origin_name: tuple(sorted(session_ids)[:limit]) if limit is not None else tuple(sorted(session_ids))
-        for origin_name, session_ids in stale_by_origin.items()
-    }
-    return counts, samples
-
-
-def _expected_provider_model_rollups(
-    conn: sqlite3.Connection,
-    origin: str | None,
-) -> dict[str, dict[str, tuple[int, int, int, int]]]:
-    models_by_session = _models_by_session(conn, origin)
-    if not models_by_session:
-        return {}
-    rows = conn.execute(
-        f"""
-        SELECT s.origin AS origin, e.session_id AS session_id, e.model_name AS model_name, e.position AS position,
-               e.last_input_tokens AS last_input_tokens,
-               e.last_output_tokens AS last_output_tokens,
-               e.last_cached_input_tokens AS last_cached_input_tokens,
-               e.last_cache_write_tokens AS last_cache_write_tokens,
-               e.last_reasoning_output_tokens AS last_reasoning_output_tokens,
-               e.last_total_tokens AS last_total_tokens,
-               e.total_input_tokens AS total_input_tokens,
-               e.total_output_tokens AS total_output_tokens,
-               e.total_cached_input_tokens AS total_cached_input_tokens,
-               e.total_cache_write_tokens AS total_cache_write_tokens,
-               e.total_reasoning_output_tokens AS total_reasoning_output_tokens,
-               e.total_tokens AS total_tokens
-        FROM session_provider_usage_events AS e
-        JOIN sessions AS s ON s.session_id = e.session_id
-        {_where_origin(origin, table_alias="s")}
-          {"AND" if origin is not None else "WHERE"} e.provider_event_type = 'token_count'
-        ORDER BY e.session_id, e.position
-        """,
-        _origin_args(origin),
-    ).fetchall()
-    latest_total_by_session: dict[str, tuple[str, tuple[int, int, int, int, int]]] = {}
-    summed_last_by_model: dict[tuple[str, str], list[int]] = {}
-    for row in rows:
-        session_id = str(row["session_id"])
-        model_name = str(row["model_name"]).strip() if row["model_name"] else ""
-        existing_models = models_by_session.get(session_id, ())
-        if not model_name and len(existing_models) == 1:
-            model_name = existing_models[0]
-        if not model_name:
-            continue
-        last_values = (
-            _int(row["last_input_tokens"]),
-            _int(row["last_output_tokens"]),
-            _int(row["last_cached_input_tokens"]),
-            _int(row["last_cache_write_tokens"]),
-            _int(row["last_reasoning_output_tokens"]),
-            _int(row["last_total_tokens"]),
-        )
-        total_values = (
-            _int(row["total_input_tokens"]),
-            _int(row["total_output_tokens"]),
-            _int(row["total_cached_input_tokens"]),
-            _int(row["total_cache_write_tokens"]),
-            _int(row["total_reasoning_output_tokens"]),
-            _int(row["total_tokens"]),
-        )
-        if any(total_values[:4]):
-            latest_total_by_session[session_id] = (model_name, total_values[:5])
-            continue
-        key = (session_id, model_name)
-        if any(last_values):
-            bucket = summed_last_by_model.setdefault(key, [0, 0, 0, 0, 0])
-            bucket[0] += last_values[0]
-            bucket[1] += last_values[1]
-            bucket[2] += last_values[2]
-            bucket[3] += last_values[3]
-            bucket[4] += last_values[4]
-    expected: dict[str, dict[str, tuple[int, int, int, int]]] = defaultdict(dict)
-    # Same disjoint-lane mapping the materializer applies, so this audit's
-    # "expected" rollup matches the corrected session_model_usage rows instead
-    # of flagging false drift (cached is subtracted out of input; reasoning is
-    # already inside output). See _provider_usage_disjoint_lanes for the
-    # corpus-verified Codex token semantics.
-    from polylogue.storage.sqlite.archive_tiers.write import _provider_usage_disjoint_lanes
-
-    for session_id, (model_name, total_tuple) in latest_total_by_session.items():
-        expected[session_id][model_name] = _provider_usage_disjoint_lanes(
-            total_tuple[0], total_tuple[1], total_tuple[2], total_tuple[3]
-        )
-    for (session_id, model_name), last_totals in summed_last_by_model.items():
-        if session_id in latest_total_by_session:
-            continue
-        expected[session_id][model_name] = _provider_usage_disjoint_lanes(
-            last_totals[0], last_totals[1], last_totals[2], last_totals[3]
-        )
-    return {session_id: dict(rows) for session_id, rows in expected.items()}
-
-
-def _actual_model_rollups(
-    conn: sqlite3.Connection,
-    origin: str | None,
-) -> dict[tuple[str, str], tuple[int, int, int, int]]:
-    rows = conn.execute(
-        f"""
-        SELECT u.session_id AS session_id, u.model_name AS model_name,
-               u.input_tokens AS input_tokens, u.output_tokens AS output_tokens,
-               u.cache_read_tokens AS cache_read_tokens, u.cache_write_tokens AS cache_write_tokens
-        FROM session_model_usage AS u
-        JOIN sessions AS s ON s.session_id = u.session_id
-        {_where_origin(origin, table_alias="s")}
-        """,
-        _origin_args(origin),
-    ).fetchall()
-    return {
-        (str(row["session_id"]), str(row["model_name"])): (
-            _int(row["input_tokens"]),
-            _int(row["output_tokens"]),
-            _int(row["cache_read_tokens"]),
-            _int(row["cache_write_tokens"]),
-        )
+        str(row["origin"]): tuple(sample for sample in str(row["sample_session_ids"]).split("\x1f") if sample)
         for row in rows
     }
-
-
-def _models_by_session(conn: sqlite3.Connection, origin: str | None) -> dict[str, tuple[str, ...]]:
-    rows = conn.execute(
-        f"""
-        SELECT u.session_id AS session_id, u.model_name AS model_name
-        FROM session_model_usage AS u
-        JOIN sessions AS s ON s.session_id = u.session_id
-        {_where_origin(origin, table_alias="s")}
-        ORDER BY u.session_id, u.model_name
-        """,
-        _origin_args(origin),
-    ).fetchall()
-    result: dict[str, list[str]] = defaultdict(list)
-    for row in rows:
-        model_name = str(row["model_name"]).strip() if row["model_name"] else ""
-        if model_name:
-            result[str(row["session_id"])].append(model_name)
-    return {session_id: tuple(models) for session_id, models in result.items()}
-
-
-def _origin_by_session(conn: sqlite3.Connection, origin: str | None) -> dict[str, str]:
-    rows = conn.execute(
-        f"""
-        SELECT session_id, origin
-        FROM sessions
-        {_where_origin(origin)}
-        """,
-        _origin_args(origin),
-    ).fetchall()
-    return {str(row["session_id"]): str(row["origin"]) for row in rows}
+    return counts, samples
 
 
 def _source_schema_alias(conn: sqlite3.Connection) -> str | None:

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -807,10 +807,12 @@ def _stale_provider_rollup_stats(
     in SQLite so a full diagnostic does not fetch the event table, model table,
     and session table into Python before comparing them.
 
-    ``GROUP_CONCAT`` sees only the requested sample rows.  The query therefore
-    returns one row per stale origin regardless of the number of stale
-    sessions; ``limit=None`` intentionally preserves the existing all-sample
-    behavior for callers that explicitly request it.
+    ``json_group_array`` sees only the requested sample rows.  JSON keeps
+    provider-native identifiers lossless even when they contain control
+    characters.  The query therefore returns one row per stale origin
+    regardless of the number of stale sessions; ``limit=None`` intentionally
+    preserves the existing all-sample behavior for callers that explicitly
+    request it.
     """
 
     rows = conn.execute(
@@ -934,11 +936,10 @@ def _stale_provider_rollup_stats(
         SELECT origin,
                MAX(stale_count) AS stale_count,
                COALESCE(
-                   GROUP_CONCAT(
-                       CASE WHEN ? IS NULL OR sample_rank <= ? THEN session_id END,
-                       char(31)
+                   json_group_array(session_id) FILTER (
+                       WHERE ? IS NULL OR sample_rank <= ?
                    ),
-                   ''
+                   '[]'
                ) AS sample_session_ids
         FROM ranked_stale_sessions
         GROUP BY origin
@@ -948,8 +949,7 @@ def _stale_provider_rollup_stats(
     ).fetchall()
     counts = {str(row["origin"]): _int(row["stale_count"]) for row in rows}
     samples = {
-        str(row["origin"]): tuple(sample for sample in str(row["sample_session_ids"]).split("\x1f") if sample)
-        for row in rows
+        str(row["origin"]): tuple(str(sample) for sample in json.loads(str(row["sample_session_ids"]))) for row in rows
     }
     return counts, samples
 

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -26,6 +26,21 @@ from polylogue.core.enums import Origin, Provider
 
 UsageReportDetail = Literal["headline", "full"]
 
+# Match the whitespace contract of Python ``str.strip()``, which the provider
+# usage writer uses when resolving model names. SQLite ``TRIM`` removes only
+# U+0020 by default, so SQL predicates must receive this explicit character set.
+_MODEL_NAME_STRIP_CHARS = (
+    "\t\n\v\f\r"
+    "\x1c\x1d\x1e\x1f"
+    " \x85\xa0\u1680"
+    "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a"
+    "\u2028\u2029\u202f\u205f\u3000"
+)
+
+
+def _normalize_model_name(value: object) -> str:
+    return str(value).strip(_MODEL_NAME_STRIP_CHARS) if value else ""
+
 
 @dataclass(frozen=True, slots=True)
 class ProviderUsageCoverage:
@@ -824,11 +839,11 @@ def _stale_provider_rollup_stats(
         WITH session_models AS MATERIALIZED (
             SELECT s.origin,
                    s.session_id,
-                   COUNT(NULLIF(TRIM(u.model_name), '')) AS model_count,
-                   MIN(NULLIF(TRIM(u.model_name), '')) AS sole_model
+                   COUNT(NULLIF(TRIM(u.model_name, :model_strip_chars), '')) AS model_count,
+                   MIN(NULLIF(TRIM(u.model_name, :model_strip_chars), '')) AS sole_model
             FROM sessions AS s
             LEFT JOIN session_model_usage AS u ON u.session_id = s.session_id
-            WHERE (? IS NULL OR s.origin = ?)
+            WHERE (:origin IS NULL OR s.origin = :origin)
             GROUP BY s.origin, s.session_id
         ),
         latest_positions AS MATERIALIZED (
@@ -845,7 +860,7 @@ def _stale_provider_rollup_stats(
                              OR e.total_cache_write_tokens != 0
                          )
                          AND COALESCE(
-                             NULLIF(TRIM(e.model_name), ''),
+                             NULLIF(TRIM(e.model_name, :model_strip_chars), ''),
                              CASE WHEN sm.model_count = 1 THEN sm.sole_model END
                          ) IS NOT NULL
                        ORDER BY e.position DESC
@@ -865,11 +880,16 @@ def _stale_provider_rollup_stats(
                e.total_cache_write_tokens
         FROM latest_positions AS lp
         LEFT JOIN session_provider_usage_events AS e
-          ON e.session_id = lp.session_id
+         ON e.session_id = lp.session_id
          AND e.position = lp.latest_position
         """,
-        (origin, origin),
+        {"model_strip_chars": _MODEL_NAME_STRIP_CHARS, "origin": origin},
     ).fetchall()
+
+    # Preserve the established payload contract: without any model rollup rows,
+    # the report has no comparison basis and does not classify the origin stale.
+    if not any(_int(row["model_count"]) for row in latest_rows):
+        return {}, {}
 
     origin_by_session: dict[str, str] = {}
     sole_model_by_session: dict[str, str | None] = {}
@@ -878,12 +898,12 @@ def _stale_provider_rollup_stats(
     for row in latest_rows:
         session_id = str(row["session_id"])
         origin_by_session[session_id] = str(row["origin"])
-        sole_model = str(row["sole_model"]) if _int(row["model_count"]) == 1 else None
+        sole_model = _normalize_model_name(row["sole_model"]) if _int(row["model_count"]) == 1 else None
         sole_model_by_session[session_id] = sole_model
         if row["latest_position"] is None:
             fallback_session_ids.append(session_id)
             continue
-        model_name = str(row["model_name"] or "").strip() or sole_model or ""
+        model_name = _normalize_model_name(row["model_name"]) or sole_model or ""
         if not model_name:
             continue
         expected[session_id][model_name] = _provider_usage_disjoint_lanes(
@@ -912,7 +932,7 @@ def _stale_provider_rollup_stats(
             """,
             (session_id,),
         ):
-            model_name = str(row["model_name"] or "").strip() or sole_model_by_session[session_id] or ""
+            model_name = _normalize_model_name(row["model_name"]) or sole_model_by_session[session_id] or ""
             if not model_name:
                 continue
             last_values = (
@@ -1331,14 +1351,15 @@ def _provider_event_stats(conn: sqlite3.Connection, origin: str | None) -> dict[
     origin_select = "? AS origin" if origin is not None else "s.origin AS origin"
     join_sessions = "" if origin is not None else "JOIN sessions s ON s.session_id = e.session_id"
     where_clause = _event_origin_where(origin)
-    args = _event_origin_args(origin)
+    event_args = _event_origin_args(origin)
+    args = (*event_args[:1], _MODEL_NAME_STRIP_CHARS, *event_args[1:])
     select_parts = [
         origin_select,
         "COUNT(*) AS provider_event_count",
         "COUNT(DISTINCT e.session_id) AS provider_event_session_count",
         "COALESCE(SUM(CASE WHEN e.provider_event_type = 'token_count' THEN 1 ELSE 0 END), 0) AS token_count_event_count",
         "COALESCE(SUM(CASE WHEN e.provider_event_type = 'message_usage' THEN 1 ELSE 0 END), 0) AS message_usage_event_count",
-        "COALESCE(SUM(CASE WHEN e.model_name IS NULL OR TRIM(e.model_name) = '' THEN 1 ELSE 0 END), 0) AS missing_model_event_count",
+        "COALESCE(SUM(CASE WHEN e.model_name IS NULL OR TRIM(e.model_name, ?) = '' THEN 1 ELSE 0 END), 0) AS missing_model_event_count",
     ]
     last_cols = _counter_columns(columns, prefix="last")
     total_cols = _counter_columns(columns, prefix="total")
@@ -1420,7 +1441,7 @@ def _provider_event_stats_streaming(conn: sqlite3.Connection, origin: str | None
         counts["provider_event_count"] += 1
         sessions_by_origin[origin_name].add(str(row["session_id"]))
         counts[f"{row['provider_event_type']}_event_count"] += 1
-        if row["model_name"] is None or not str(row["model_name"]).strip():
+        if not _normalize_model_name(row["model_name"]):
             counts["missing_model_event_count"] += 1
         last_values = (
             _int(row["last_input_tokens"]),

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -117,12 +117,6 @@ _AUDITED_SITES: Final[dict[_AuditedSiteKey, str]] = {
     ): "provider usage summary interpolates closed counter-column expressions and WHERE fragments; filter values are bound.",
     (
         "polylogue/storage/usage.py",
-        "_provider_cumulative_usage",
-        "ad7bb9d262cfceb3",
-        0,
-    ): "provider cumulative usage interpolates closed counter-column expressions and origin SELECT/JOIN fragments; origin is bound.",
-    (
-        "polylogue/storage/usage.py",
         "_sample_event_sessions",
         "f437ad380e1b12d6",
         0,

--- a/tests/unit/storage/test_provider_usage_report.py
+++ b/tests/unit/storage/test_provider_usage_report.py
@@ -574,13 +574,19 @@ def test_provider_usage_report_stale_rollups_use_one_bounded_sql_diagnostic(tmp_
     assert row.stale_rollup_session_count == stale_count
     assert row.sample_stale_rollup_sessions == tuple(f"codex-session:{native_id}" for native_id in stale_native_ids[:3])
 
-    stale_diagnostics = [statement for statement in traced_sql if "provider_usage_stale_rollups" in statement]
-    assert len(stale_diagnostics) == 1
-    stale_sql = stale_diagnostics[0]
-    assert "json_group_array" in stale_sql
-    assert "ROW_NUMBER() OVER" in stale_sql
-    assert "GROUP BY origin" in stale_sql
-    assert stale_sql.count("session_provider_usage_events AS e") == 1
+    stale_latest = [statement for statement in traced_sql if "provider_usage_stale_latest" in statement]
+    assert len(stale_latest) == 1
+    assert "ORDER BY e.position DESC" in stale_latest[0]
+    assert "LIMIT 1" in stale_latest[0]
+    stale_plan = [str(plan[3]) for plan in conn.execute("EXPLAIN QUERY PLAN " + stale_latest[0])]
+    assert any("CORRELATED SCALAR SUBQUERY" in detail for detail in stale_plan)
+    assert any("SEARCH e USING INDEX idx_session_provider_usage_events_session" in detail for detail in stale_plan)
+    assert not any(detail.startswith("SCAN e") for detail in stale_plan)
+
+    cumulative_latest = [statement for statement in traced_sql if "provider_usage_latest_cumulative" in statement]
+    assert len(cumulative_latest) == 1
+    assert "ORDER BY e.position DESC" in cumulative_latest[0]
+    assert "LIMIT 1" in cumulative_latest[0]
 
 
 def test_provider_usage_report_preserves_control_characters_in_stale_sample_ids(tmp_path: Path) -> None:
@@ -628,6 +634,53 @@ def test_provider_usage_report_preserves_control_characters_in_stale_sample_ids(
     assert report.origins[0].sample_stale_rollup_sessions == (session_id,)
 
 
+def test_provider_usage_report_handles_large_accepted_last_usage_totals(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    input_tokens = 2**62
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="large-accepted-usage",
+        title="large accepted usage",
+        models_used=["gpt-large"],
+        messages=[],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-large",
+                    "last_token_usage": {"input_tokens": input_tokens, "cached_input_tokens": 1},
+                },
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-large",
+                    "last_token_usage": {"input_tokens": input_tokens, "cached_input_tokens": 1},
+                },
+            ),
+        ],
+    )
+    write_parsed_session_to_archive(conn, session)
+
+    report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+
+    row = report.origins[0]
+    # Anti-vacuity: SQLite SUM over the accepted input rows raises integer
+    # overflow; exact streaming must preserve the provider and stale audits.
+    assert row.provider_request_usage.input_tokens == 2**63
+    assert row.provider_request_usage.cached_input_tokens == 2
+    assert row.stale_rollup_session_count == 0
+    assert row.sample_stale_rollup_sessions == ()
+
+
 def test_provider_usage_report_ignores_codex_metadata_only_raw_rows(tmp_path: Path) -> None:
     index_conn = _connect(tmp_path / "index.db")
     source_conn = _connect(tmp_path / "source.db", ArchiveTier.SOURCE)
@@ -665,6 +718,55 @@ def test_provider_usage_report_ignores_codex_metadata_only_raw_rows(tmp_path: Pa
     assert row.acquired_not_materialized_count == 0
     assert row.sample_acquired_not_materialized_raw_ids == ()
     assert row.coverage_state == "no_sessions"
+
+
+def test_provider_usage_report_uses_membership_census_before_raw_blob_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index_conn = _connect(tmp_path / "index.db")
+    source_conn = _connect(tmp_path / "source.db", ArchiveTier.SOURCE)
+    census_rows = (
+        ("raw-codex-censused-complete", "complete", 1),
+        ("raw-codex-censused-failed", "failed", 0),
+        ("raw-codex-censused-non-session", "non_session", 0),
+    )
+    source_conn.executemany(
+        """
+        INSERT INTO raw_sessions (
+            raw_id, origin, native_id, source_path, source_index, blob_hash,
+            blob_size, acquired_at_ms, parsed_at_ms, validation_status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (raw_id, "codex-session", status, f"missing-{status}.jsonl", 0, bytes(32), 1, 1, 2, "passed")
+            for raw_id, status, _member_count in census_rows
+        ],
+    )
+    source_conn.executemany(
+        """
+        INSERT INTO raw_membership_census (
+            raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+        ) VALUES (?, 'test-parser', ?, ?, 2, 'classified')
+        """,
+        census_rows,
+    )
+    source_conn.commit()
+    source_conn.close()
+
+    def fail_blob_probe(_path: Path, *, limit: int) -> set[str]:
+        raise AssertionError(f"censused raw payload was reopened with limit={limit}")
+
+    monkeypatch.setattr("polylogue.storage.usage._raw_jsonl_type_set", fail_blob_probe)
+    report = provider_usage_report_from_connection(index_conn, archive_root=tmp_path, origin="codex-session")
+
+    row = report.origins[0]
+    # Anti-vacuity: removing any census short-circuit calls fail_blob_probe.
+    assert row.raw_session_count == 3
+    assert row.acquired_not_materialized_count == 2
+    assert row.sample_acquired_not_materialized_raw_ids == (
+        "raw-codex-censused-complete",
+        "raw-codex-censused-failed",
+    )
 
 
 def test_provider_usage_coverage_matrix_marks_estimate_only_exports(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_provider_usage_report.py
+++ b/tests/unit/storage/test_provider_usage_report.py
@@ -634,6 +634,155 @@ def test_provider_usage_report_preserves_control_characters_in_stale_sample_ids(
     assert report.origins[0].sample_stale_rollup_sessions == (session_id,)
 
 
+def test_provider_usage_report_ignores_whitespace_only_cumulative_tail_for_stale_audit(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="whitespace-model-tail",
+        title="whitespace model tail",
+        models_used=["model-a", "model-b"],
+        messages=[],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "model-a",
+                    "total_token_usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cached_input_tokens": 80,
+                    },
+                },
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "\t\x1f",
+                    "total_token_usage": {
+                        "input_tokens": 200,
+                        "output_tokens": 40,
+                        "cached_input_tokens": 150,
+                    },
+                },
+            ),
+        ],
+    )
+    write_parsed_session_to_archive(conn, session)
+    conn.execute(
+        """
+        UPDATE session_model_usage
+        SET input_tokens = 0, output_tokens = 0, cache_read_tokens = 0
+        WHERE session_id = 'codex-session:whitespace-model-tail'
+          AND model_name = 'model-a'
+        """
+    )
+
+    report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+
+    row = report.origins[0]
+    # Anti-vacuity: SQLite's default space-only TRIM selects the unresolved
+    # tail, which Python then rejects, and this stale session disappears.
+    assert row.stale_rollup_session_count == 1
+    assert row.sample_stale_rollup_sessions == ("codex-session:whitespace-model-tail",)
+
+
+def test_provider_usage_report_overflow_fallback_uses_model_whitespace_contract(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    event = ParsedSessionEvent(
+        event_type="token_count",
+        payload={
+            "type": "token_count",
+            "model": "\t\x1f",
+            "last_token_usage": {"input_tokens": 2**62, "cached_input_tokens": 1},
+        },
+    )
+
+    def write_session(event_count: int) -> None:
+        write_parsed_session_to_archive(
+            conn,
+            ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id="overflow-whitespace-model",
+                title="overflow whitespace model",
+                models_used=["gpt-large"],
+                messages=[],
+                session_events=[event] * event_count,
+            ),
+        )
+
+    write_session(1)
+    fast_report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+    assert fast_report.origins[0].missing_model_event_count == 1
+
+    write_session(2)
+    overflow_report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+
+    row = overflow_report.origins[0]
+    # Anti-vacuity: two accepted counters overflow SQLite SUM, so the streaming
+    # fallback must retain both the exact total and the same missing-model rule.
+    assert row.provider_request_usage.input_tokens == 2**63
+    assert row.missing_model_event_count == 2
+    assert row.stale_rollup_session_count == 0
+
+
+def test_provider_usage_report_does_not_mark_event_only_origin_stale_without_rollup_basis(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="event-only-origin",
+        title="event only origin",
+        models_used=["gpt-large"],
+        messages=[],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="token_count",
+                payload={
+                    "type": "token_count",
+                    "model": "gpt-large",
+                    "total_token_usage": {"input_tokens": 100, "output_tokens": 20},
+                },
+            )
+        ],
+    )
+    write_parsed_session_to_archive(conn, session)
+    conn.execute("DELETE FROM session_model_usage WHERE session_id = 'codex-session:event-only-origin'")
+
+    report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+
+    row = report.origins[0]
+    # Anti-vacuity: without the compatibility early return, the event-derived
+    # expected row has no actual row and changes the public coverage state.
+    assert row.stale_rollup_session_count == 0
+    assert row.sample_stale_rollup_sessions == ()
+    assert row.coverage_state == "exact_provider_telemetry"
+
+
 def test_provider_usage_report_handles_large_accepted_last_usage_totals(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     input_tokens = 2**62

--- a/tests/unit/storage/test_provider_usage_report.py
+++ b/tests/unit/storage/test_provider_usage_report.py
@@ -577,10 +577,55 @@ def test_provider_usage_report_stale_rollups_use_one_bounded_sql_diagnostic(tmp_
     stale_diagnostics = [statement for statement in traced_sql if "provider_usage_stale_rollups" in statement]
     assert len(stale_diagnostics) == 1
     stale_sql = stale_diagnostics[0]
-    assert "GROUP_CONCAT" in stale_sql
+    assert "json_group_array" in stale_sql
     assert "ROW_NUMBER() OVER" in stale_sql
     assert "GROUP BY origin" in stale_sql
     assert stale_sql.count("session_provider_usage_events AS e") == 1
+
+
+def test_provider_usage_report_preserves_control_characters_in_stale_sample_ids(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    native_id = "stale\x1fsession"
+    session_id = f"codex-session:{native_id}"
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            origin, native_id, title, session_kind,
+            created_at_ms, updated_at_ms, message_count, word_count, content_hash
+        ) VALUES ('codex-session', ?, 'usage', 'standard', 1, 1, 0, 0, zeroblob(32))
+        """,
+        (native_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO session_model_usage (
+            session_id, model_name, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens
+        ) VALUES (?, 'gpt-5-codex', 0, 0, 0, 0)
+        """,
+        (session_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO session_provider_usage_events (
+            session_id, position, provider_event_type, model_name,
+            total_input_tokens, total_output_tokens, total_cached_input_tokens
+        ) VALUES (?, 0, 'token_count', 'gpt-5-codex', 100, 20, 80)
+        """,
+        (session_id,),
+    )
+
+    report = provider_usage_report_from_connection(
+        conn,
+        archive_root=tmp_path,
+        origin="codex-session",
+        detail="full",
+        limit=3,
+    )
+
+    # Anti-vacuity: delimiter packing or lossy decoding splits this one
+    # production session identity into multiple sample entries.
+    assert report.origins[0].sample_stale_rollup_sessions == (session_id,)
 
 
 def test_provider_usage_report_ignores_codex_metadata_only_raw_rows(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_provider_usage_report.py
+++ b/tests/unit/storage/test_provider_usage_report.py
@@ -493,6 +493,96 @@ def test_provider_usage_report_ignores_reasoning_only_cumulative_rows(tmp_path: 
     }
 
 
+def test_provider_usage_report_stale_rollups_use_one_bounded_sql_diagnostic(tmp_path: Path) -> None:
+    """Full reports keep stale diagnostics in SQLite and preserve lane semantics."""
+
+    conn = _connect(tmp_path / "index.db")
+    stale_count = 32
+    stale_native_ids = [f"stale-{index:02d}" for index in range(stale_count)]
+    conn.executemany(
+        """
+        INSERT INTO sessions (
+            origin, native_id, title, session_kind,
+            created_at_ms, updated_at_ms, message_count, word_count, content_hash
+        ) VALUES (?, ?, 'usage', 'standard', 1, 1, 0, 0, zeroblob(32))
+        """,
+        [
+            *(("codex-session", native_id) for native_id in stale_native_ids),
+            ("codex-session", "reasoning-only-tail"),
+            ("codex-session", "multi-model"),
+            ("claude-code-session", "outside-origin-filter"),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO session_model_usage (
+            session_id, model_name, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        [
+            *((f"codex-session:{native_id}", "gpt-5-codex", 0, 0, 0, 0) for native_id in stale_native_ids),
+            ("codex-session:reasoning-only-tail", "gpt-5-codex", 20, 20, 80, 0),
+            # A session-global Codex cumulative belongs only to its latest
+            # model. The old model is deliberately nonzero to prove this row
+            # does not create a false stale result.
+            ("codex-session:multi-model", "old-model", 999, 999, 999, 999),
+            ("codex-session:multi-model", "new-model", 50, 40, 150, 0),
+            ("claude-code-session:outside-origin-filter", "claude-model", 0, 0, 0, 0),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO session_provider_usage_events (
+            session_id, position, provider_event_type, model_name,
+            total_input_tokens, total_output_tokens, total_cached_input_tokens
+        ) VALUES (?, ?, 'token_count', ?, ?, ?, ?)
+        """,
+        [
+            *((f"codex-session:{native_id}", 0, "gpt-5-codex", 100, 20, 80) for native_id in stale_native_ids),
+            ("codex-session:reasoning-only-tail", 0, "gpt-5-codex", 100, 20, 80),
+            ("codex-session:multi-model", 0, "old-model", 100, 20, 80),
+            ("codex-session:multi-model", 1, "new-model", 200, 40, 150),
+            ("claude-code-session:outside-origin-filter", 0, "claude-model", 100, 20, 80),
+        ],
+    )
+    conn.execute(
+        """
+        INSERT INTO session_provider_usage_events (
+            session_id, position, provider_event_type, model_name,
+            total_reasoning_output_tokens
+        ) VALUES ('codex-session:reasoning-only-tail', 1, 'token_count', 'gpt-5-codex', 30)
+        """
+    )
+
+    traced_sql: list[str] = []
+    conn.set_trace_callback(traced_sql.append)
+    try:
+        report = provider_usage_report_from_connection(
+            conn,
+            archive_root=tmp_path,
+            origin="codex-session",
+            detail="full",
+            limit=3,
+        )
+    finally:
+        conn.set_trace_callback(None)
+
+    assert len(report.origins) == 1
+    row = report.origins[0]
+    assert row.origin == "codex-session"
+    assert row.stale_rollup_session_count == stale_count
+    assert row.sample_stale_rollup_sessions == tuple(f"codex-session:{native_id}" for native_id in stale_native_ids[:3])
+
+    stale_diagnostics = [statement for statement in traced_sql if "provider_usage_stale_rollups" in statement]
+    assert len(stale_diagnostics) == 1
+    stale_sql = stale_diagnostics[0]
+    assert "GROUP_CONCAT" in stale_sql
+    assert "ROW_NUMBER() OVER" in stale_sql
+    assert "GROUP BY origin" in stale_sql
+    assert stale_sql.count("session_provider_usage_events AS e") == 1
+
+
 def test_provider_usage_report_ignores_codex_metadata_only_raw_rows(tmp_path: Path) -> None:
     index_conn = _connect(tmp_path / "index.db")
     source_conn = _connect(tmp_path / "source.db", ArchiveTier.SOURCE)


### PR DESCRIPTION
## Summary

Bound provider-usage Python retention plus stale/cumulative reconstruction by session/model cardinality. The required provider-event totals remain one set-based event scan. Indexed frontier seeks, exact overflow fallbacks, durable raw-membership classifications, and one explicit model-whitespace contract make the active Codex report interactive while preserving the established zero-rollup comparison behavior.

## Problem

The first rewrite bounded returned stale samples but still scanned and sorted the 2.21M-row event table twice. It took 112.19 seconds and 1,098,080 KiB RSS on the active archive, while cumulative reconstruction fetched every matching event and raw-debt classification reopened already-classified blobs.

Final review also found two edge-contract gaps: SQLite's default space-only `TRIM` disagreed with the writer's Python `str.strip()` model normalization, and the optimized stale query treated event-only origins with no model rollup rows as newly stale.

## Solution

- Resolve the latest cumulative event through the existing `(session_id, position)` index and return at most one row per session.
- Stream only sessions without cumulative telemetry through Python arbitrary-precision counters, preserving accepted values that overflow SQLite `SUM`.
- Keep provider-event aggregation on its set-based event-scan path, with an exact streaming fallback for legal provider-counter aggregate overflow.
- Bind one explicit Python-compatible model-whitespace set into SQLite and reuse the same normalizer in streaming code.
- Preserve the established empty-rollup contract: without model rows, the stale audit has no comparison basis.
- Use durable `raw_membership_census` states before probing legacy raw blobs.
- Preserve session IDs losslessly in stale samples and remove the obsolete interpolated-SQL audit exception.

## Verification

- `devtools test tests/unit/storage/test_provider_usage_report.py tests/unit/storage/test_no_string_interpolated_sql.py::test_audited_sites_are_real_violations` - 17 passed at `f437ca4bb`.
- `devtools verify --quick` - all 13 checks passed; pre-push receipt `20260711T184110Z-quick-581184-e2469c26` at `f437ca4bb`.
- `.agent/scripts/bd-graph-lint` - no dependency cycles or violations.
- Earlier active-archive performance receipt for the unchanged frontier algorithm: 2,213,101 Codex events and 2,774 sessions improved from warmed 58.78 s / 1,632,480 KiB RSS to 4.70 s / 71,452 KiB RSS.
- That active report retained the same 13,709-byte SHA-256 `a75bea72927b866446faba09ed621cfd097757099beacdaf5ef18b1fac5aafe9` before and after the performance rewrite.
- Active `EXPLAIN QUERY PLAN` uses correlated scalar subqueries plus `idx_session_provider_usage_events_session`; it does not scan the provider-event table for cumulative/stale frontiers.

Anti-vacuity: default SQLite `TRIM` hides the multi-model whitespace-tail stale fixture; changing the overflow fallback's normalizer changes its missing-model count; removing the empty-rollup early return changes coverage state; restoring SQLite `SUM` breaks the accepted `2**62` counter case; removing `LIMIT 1` or the session-position predicate breaks plan assertions; removing census short-circuits triggers a forced blob-probe failure; delimiter packing breaks the control-character identity case.

Scope note: provider-event and cumulative counter overflow are covered here. Pre-existing SQL `SUM` limits in derived model/pricing rollups are separate from this PR.

Ref polylogue-xy95.
