### PR TITLE
test: make managed pytest runs orphan-proof (#2714)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -52,6 +52,13 @@ run. Full diagnostic and seed runs use the same worker override and also
 default to `-n 4` so database-heavy workers do not multiply memory and I/O
 pressure beyond the explicit broad-run lane.
 
+Every collected test has a 300-second `pytest-timeout` budget. A test that
+genuinely needs longer must declare the exception at the test site with
+`@pytest.mark.timeout(<seconds>)`; a missing marker can never silently turn into
+an unbounded wait. The signal method is the repository default so timeout
+failures retain the responsible node and Python stacks in ordinary pytest
+output.
+
 Pytest temp databases default to `/realm/tmp/polylogue-pytest` so interrupted
 full or xdist runs do not leave multi-GiB `/dev/shm` directories resident in
 RAM. On btrfs scratch volumes, the harness best-effort marks that root with
@@ -91,13 +98,26 @@ and a postmortem diagnosis. The latest run is mirrored to
 - `.cache/verify/current-pytest-events/`
 - `.cache/verify/current-pytest-resources.jsonl`
 - `.cache/verify/current-pytest-postmortem.json`
+- `.cache/verify/current-pytest-containment.json`
 - `.cache/verify/current-pytest-output.log`
 
-The supervisor prints periodic heartbeat lines, drains pytest output
-incrementally so real progress resets the stall clock, samples the pytest
-process tree and host memory/pressure state, and terminates the whole pytest
-process group if the step exceeds `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default
-45 minutes) or produces no output for
+The devtools process drains pytest output, prints periodic heartbeat lines, and
+samples the pytest process tree and host memory/pressure state. A separate
+supervisor owns the pytest controller's process group, watches the devtools
+owner process, and enforces `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S` (default 45
+minutes). Termination sends SIGTERM to that exact group, then SIGKILL after
+`POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S` (default 5 seconds). On Sinnix, the
+supervisor runs in a unique transient scope under the configured build slice;
+`KillMode=control-group` and a slightly later `RuntimeMaxSec` are the final
+boundary if ordinary cleanup cannot run. Other Linux hosts retain the external
+supervisor and process-group boundary and record that fallback honestly in the
+containment receipt. If transient scope creation fails in automatic mode, the
+runner records the failure and retries with that process-group boundary. The
+managed runner requires Linux process identities so it never substitutes an
+unsafe numeric-PGID kill on unsupported hosts. The devtools process
+independently enforces the same absolute deadline, including supervisor
+startup, and also requests group termination when
+pytest produces no output for
 `POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes).
 `POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S` controls resource sampling cadence
 (default 2 seconds). Basetemp size is a recursive filesystem walk, so it is
@@ -120,8 +140,9 @@ focused selections. During or after a run, inspect
 `.cache/verify/current-pytest-progress.json`,
 `.cache/verify/current-pytest-selection.json`,
 `.cache/verify/current-pytest-summary.json`,
-`.cache/verify/current-pytest-events.jsonl`, and
-`.cache/verify/current-pytest-output.log` to see the active/latest test node,
+`.cache/verify/current-pytest-events.jsonl`,
+`.cache/verify/current-pytest-containment.json`,
+and `.cache/verify/current-pytest-output.log` to see the active/latest test node,
 selected/deselected node IDs, collection duration, slowest setup/call/teardown
 phases, captured output, and termination reason if a focused run stalls.
 

--- a/devtools/pytest_supervisor.py
+++ b/devtools/pytest_supervisor.py
@@ -220,9 +220,14 @@ def signal_owned_process_group(
     )
 
 
-def _descendant_identities(root_pid: int) -> list[tuple[int, int]]:
+def _descendant_identities(
+    root_pid: int,
+    *,
+    preserved_roots: Sequence[tuple[int, int]] = (),
+) -> list[tuple[int, int]]:
     if not _linux_proc_available():
         return []
+    preserved = set(preserved_roots)
     rows: dict[int, tuple[int, str, int]] = {}
     for entry in Path("/proc").iterdir():
         if not entry.name.isdigit():
@@ -236,9 +241,19 @@ def _descendant_identities(root_pid: int) -> list[tuple[int, int]]:
     frontier = {root_pid}
     while frontier:
         children = {pid for pid, (ppid, _state, _start) in rows.items() if ppid in frontier and pid not in descendants}
-        descendants.update(children)
-        frontier = children
+        frontier = set()
+        for pid in children:
+            identity = (pid, rows[pid][2])
+            if identity in preserved:
+                continue
+            descendants.add(pid)
+            frontier.add(pid)
     return [(pid, rows[pid][2]) for pid in descendants if rows[pid][1] != "Z"]
+
+
+def descendant_process_identities(root_pid: int) -> list[tuple[int, int]]:
+    """Return exact identities below one process for scoped recovery."""
+    return _descendant_identities(root_pid)
 
 
 def _owned_identities(
@@ -281,9 +296,17 @@ def reap_exited_children() -> None:
             return
 
 
-def signal_descendant_identities(root_pid: int, sig: signal.Signals) -> int:
+def signal_descendant_identities(
+    root_pid: int,
+    sig: signal.Signals,
+    *,
+    preserved_roots: Sequence[tuple[int, int]] = (),
+) -> int:
     """Signal the exact live descendants of a Linux subreaper via pidfds."""
-    return sum(signal_process_identity(pid, start_ticks, sig) for pid, start_ticks in _descendant_identities(root_pid))
+    return sum(
+        signal_process_identity(pid, start_ticks, sig)
+        for pid, start_ticks in _descendant_identities(root_pid, preserved_roots=preserved_roots)
+    )
 
 
 def _systemd_mode(env: Mapping[str, str]) -> str:
@@ -370,11 +393,13 @@ def build_supervisor_launch(
 ) -> SupervisorLaunch:
     """Build the Linux supervisor command and optional owned cgroup scope."""
     values = dict(os.environ if env is None else env)
-    if sys.platform != "linux":
+    if sys.platform != "linux" or not _linux_proc_available():
         raise RuntimeError("managed pytest containment requires Linux process identities")
     receipt_path = receipt_path.absolute()
     request_path = termination_request_path(receipt_path)
     owner_start_ticks = _process_start_ticks(owner_pid)
+    if owner_start_ticks is None:
+        raise RuntimeError("managed pytest containment requires an exact owner process identity")
     systemd_available = user_systemd_available(values)
     requested_mode = _systemd_mode(values)
     if requested_mode == "require" and not systemd_available:
@@ -623,6 +648,44 @@ def supervise(
     started_at = utc_now()
     started = time.monotonic()
     subreaper_enabled = enable_child_subreaper()
+    if owner_start_ticks is None or not subreaper_enabled:
+        reason = (
+            "pytest supervisor lacks an exact owner process identity"
+            if owner_start_ticks is None
+            else "pytest supervisor could not become a Linux child subreaper"
+        )
+        _write_json(
+            receipt_path,
+            {
+                "schema_version": 1,
+                "status": "terminated",
+                "started_at": started_at,
+                "finished_at": utc_now(),
+                "duration_s": round(time.monotonic() - started, 4),
+                "supervisor_pid": os.getpid(),
+                "supervisor_start_ticks": _process_start_ticks(os.getpid()),
+                "owner_pid": owner_pid,
+                "owner_start_ticks": owner_start_ticks,
+                "controller_command": list(controller_cmd),
+                "mode": mode,
+                "unit": unit,
+                "cgroup_path": _cgroup_path(os.getpid()),
+                "cgroup_owned": mode == "systemd-scope",
+                "timeout_s": timeout_s,
+                "term_grace_s": term_grace_s,
+                "runtime_cap_s": runtime_cap_s,
+                "subreaper_enabled": subreaper_enabled,
+                "exit_code": 125,
+                "termination_reason": reason,
+                "signals_sent": [],
+                "escalated_to_sigkill": False,
+                "controller_group_alive": False,
+                "startup_failure": True,
+            },
+        )
+        sys.stderr.write(f"pytest supervisor: {reason}\n")
+        sys.stderr.flush()
+        return 125
     owner_watch = _OwnerWatch(owner_pid, owner_start_ticks)
     received_signal: list[int] = []
 
@@ -638,6 +701,51 @@ def supervise(
     controller_pgid = controller_pid
     controller_sid = controller_pid
     controller_start_ticks = _process_start_ticks(controller_pid)
+    if controller_start_ticks is None:
+        process.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=1)
+        signal_descendant_identities(os.getpid(), signal.SIGKILL)
+        reap_exited_children()
+        reason = "pytest supervisor could not capture the controller process identity"
+        _write_json(
+            receipt_path,
+            {
+                "schema_version": 1,
+                "status": "terminated",
+                "started_at": started_at,
+                "finished_at": utc_now(),
+                "duration_s": round(time.monotonic() - started, 4),
+                "supervisor_pid": os.getpid(),
+                "supervisor_start_ticks": _process_start_ticks(os.getpid()),
+                "owner_pid": owner_pid,
+                "owner_start_ticks": owner_start_ticks,
+                "controller_pid": controller_pid,
+                "controller_start_ticks": None,
+                "controller_command": list(controller_cmd),
+                "mode": mode,
+                "unit": unit,
+                "cgroup_path": _cgroup_path(os.getpid()),
+                "cgroup_owned": mode == "systemd-scope",
+                "timeout_s": timeout_s,
+                "term_grace_s": term_grace_s,
+                "runtime_cap_s": runtime_cap_s,
+                "subreaper_enabled": subreaper_enabled,
+                "exit_code": 125,
+                "controller_returncode": process.poll(),
+                "termination_reason": reason,
+                "signals_sent": ["SIGKILL"],
+                "escalated_to_sigkill": True,
+                "controller_group_alive": False,
+                "startup_failure": True,
+            },
+        )
+        owner_watch.close()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        sys.stderr.write(f"pytest supervisor: {reason}\n")
+        sys.stderr.flush()
+        return 125
     try:
         controller_pgid = os.getpgid(controller_pid)
         controller_sid = os.getsid(controller_pid)
@@ -729,6 +837,16 @@ def supervise(
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
 
+    controller_group_alive = _owned_processes_exist(
+        supervisor_pid=os.getpid(),
+        pgid=controller_pgid,
+        sid=controller_sid,
+        leader_start_ticks=controller_start_ticks,
+    )
+    if controller_group_alive:
+        termination_reason = termination_reason or "owned pytest processes survived cleanup"
+        if requested_exit_code is None and (controller_returncode is None or controller_returncode == 0):
+            requested_exit_code = 125
     if requested_exit_code is not None:
         exit_code = requested_exit_code
     elif controller_returncode is None:
@@ -747,12 +865,7 @@ def supervise(
         "termination_reason": termination_reason,
         "signals_sent": signals_sent,
         "escalated_to_sigkill": escalated,
-        "controller_group_alive": _owned_processes_exist(
-            supervisor_pid=os.getpid(),
-            pgid=controller_pgid,
-            sid=controller_sid,
-            leader_start_ticks=controller_start_ticks,
-        ),
+        "controller_group_alive": controller_group_alive,
     }
     _write_json(receipt_path, final_receipt)
     if termination_reason is not None:

--- a/devtools/pytest_supervisor.py
+++ b/devtools/pytest_supervisor.py
@@ -1,0 +1,804 @@
+"""External lifecycle supervisor for pytest controller process groups.
+
+The verify process is not a sufficient ownership boundary: if it or pytest is
+killed with SIGKILL, Python cleanup handlers cannot run.  This module is
+launched as a separate process for every managed pytest step.  It owns the
+pytest controller's process group, watches the invoking devtools process via a
+pidfd, enforces the whole-run deadline, and persists a containment receipt.
+
+On Sinnix, the supervisor itself runs in a unique transient user-systemd scope
+under the configured build slice.  ``RuntimeMaxSec`` and
+``KillMode=control-group`` provide the final cgroup boundary if both ordinary
+Python cleanup layers are lost.  Other Linux hosts retain the external
+supervisor and process-group guarantees without claiming cgroup isolation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import ctypes
+import json
+import os
+import re
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CGROUP_MODE_ENV = "POLYLOGUE_VERIFY_PYTEST_CGROUP"
+_SYSTEMD_MODES = frozenset({"auto", "off", "require"})
+_POLL_INTERVAL_S = 0.05
+_PR_SET_CHILD_SUBREAPER = 36
+
+
+@dataclass(frozen=True)
+class SupervisorLaunch:
+    """Command and ownership metadata for one external pytest supervisor."""
+
+    argv: list[str]
+    receipt_path: Path
+    request_path: Path
+    mode: str
+    unit: str | None
+    runtime_cap_s: float | None
+    fallback_argv: list[str] | None = None
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_receipt(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def update_receipt(path: Path, updates: Mapping[str, Any]) -> dict[str, Any]:
+    payload = read_receipt(path) or {}
+    payload.update(updates)
+    _write_json(path, payload)
+    return payload
+
+
+def termination_request_path(receipt_path: Path) -> Path:
+    return receipt_path.with_name(f"{receipt_path.name}.terminate")
+
+
+def write_termination_request(path: Path, *, reason: str, exit_code: int = 124) -> None:
+    _write_json(
+        path,
+        {
+            "requested_at": utc_now(),
+            "requested_by_pid": os.getpid(),
+            "reason": reason,
+            "exit_code": int(exit_code),
+        },
+    )
+
+
+def _read_termination_request(path: Path) -> dict[str, Any] | None:
+    return read_receipt(path)
+
+
+def _cgroup_path(pid: int) -> str | None:
+    try:
+        rows = Path(f"/proc/{pid}/cgroup").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for row in rows:
+        parts = row.split(":", 2)
+        if len(parts) == 3 and parts[0] == "0":
+            return parts[2]
+    return None
+
+
+def _process_start_ticks(pid: int) -> int | None:
+    try:
+        fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+        return int(fields[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _linux_proc_available() -> bool:
+    return sys.platform == "linux" and Path("/proc/self/stat").is_file()
+
+
+def signal_process_identity(pid: int, start_ticks: int | None, sig: signal.Signals) -> bool:
+    """Signal one process only when its recorded kernel identity still matches."""
+    if start_ticks is None or _process_start_ticks(pid) != start_ticks:
+        return False
+    pidfd_open = getattr(os, "pidfd_open", None)
+    pidfd_send_signal = getattr(signal, "pidfd_send_signal", None)
+    if pidfd_open is not None and pidfd_send_signal is not None:
+        try:
+            pidfd = int(pidfd_open(pid, 0))
+        except OSError:
+            return False
+        try:
+            # pidfd_open pins an identity, but the PID may have been reused
+            # between the first /proc read and opening it. Validate once more
+            # after the pin; subsequent reuse cannot retarget this pidfd.
+            if _process_start_ticks(pid) != start_ticks:
+                return False
+            pidfd_send_signal(pidfd, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(pidfd)
+    if _process_start_ticks(pid) != start_ticks:
+        return False
+    try:
+        os.kill(pid, sig)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _process_group_identities(
+    *,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+) -> list[tuple[int, int]]:
+    """Snapshot an owned session/group as PID identities, never process names."""
+    if not _linux_proc_available():
+        return []
+    current_leader_ticks = _process_start_ticks(sid)
+    if current_leader_ticks is not None and current_leader_ticks != leader_start_ticks:
+        return []
+    identities: list[tuple[int, int]] = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / "stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+            state = fields[0]
+            process_pgid = int(fields[2])
+            process_sid = int(fields[3])
+            start_ticks = int(fields[19])
+        except (OSError, IndexError, ValueError):
+            continue
+        if state != "Z" and process_pgid == pgid and process_sid == sid:
+            identities.append((int(entry.name), start_ticks))
+    return identities
+
+
+def signal_process_group_identities(
+    *,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+    sig: signal.Signals,
+) -> int:
+    """Signal the exact current members of a recorded process group via pidfds."""
+    return sum(
+        signal_process_identity(pid, start_ticks, sig)
+        for pid, start_ticks in _process_group_identities(
+            pgid=pgid,
+            sid=sid,
+            leader_start_ticks=leader_start_ticks,
+        )
+    )
+
+
+def signal_owned_process_group(
+    *,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+    sig: signal.Signals,
+) -> int:
+    """Signal exact members of an owned Linux process group via pidfds."""
+    if not _linux_proc_available():
+        return 0
+    return signal_process_group_identities(
+        pgid=pgid,
+        sid=sid,
+        leader_start_ticks=leader_start_ticks,
+        sig=sig,
+    )
+
+
+def _descendant_identities(root_pid: int) -> list[tuple[int, int]]:
+    if not _linux_proc_available():
+        return []
+    rows: dict[int, tuple[int, str, int]] = {}
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / "stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+            rows[int(entry.name)] = (int(fields[1]), fields[0], int(fields[19]))
+        except (OSError, IndexError, ValueError):
+            continue
+    descendants: set[int] = set()
+    frontier = {root_pid}
+    while frontier:
+        children = {pid for pid, (ppid, _state, _start) in rows.items() if ppid in frontier and pid not in descendants}
+        descendants.update(children)
+        frontier = children
+    return [(pid, rows[pid][2]) for pid in descendants if rows[pid][1] != "Z"]
+
+
+def _owned_identities(
+    *,
+    supervisor_pid: int,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+) -> list[tuple[int, int]]:
+    return sorted(
+        set(_descendant_identities(supervisor_pid))
+        | set(
+            _process_group_identities(
+                pgid=pgid,
+                sid=sid,
+                leader_start_ticks=leader_start_ticks,
+            )
+        )
+    )
+
+
+def enable_child_subreaper() -> bool:
+    if sys.platform != "linux":
+        return False
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        return int(libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)) == 0
+    except (AttributeError, OSError):
+        return False
+
+
+def reap_exited_children() -> None:
+    """Reap controller descendants adopted through the Linux subreaper."""
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if pid == 0:
+            return
+
+
+def signal_descendant_identities(root_pid: int, sig: signal.Signals) -> int:
+    """Signal the exact live descendants of a Linux subreaper via pidfds."""
+    return sum(signal_process_identity(pid, start_ticks, sig) for pid, start_ticks in _descendant_identities(root_pid))
+
+
+def _systemd_mode(env: Mapping[str, str]) -> str:
+    mode = env.get(CGROUP_MODE_ENV, "auto").strip().lower() or "auto"
+    if mode not in _SYSTEMD_MODES:
+        return "auto"
+    return mode
+
+
+def user_systemd_available(env: Mapping[str, str] | None = None) -> bool:
+    values = os.environ if env is None else env
+    if _systemd_mode(values) == "off" or sys.platform != "linux":
+        return False
+    runtime_dir = values.get("XDG_RUNTIME_DIR")
+    return bool(
+        runtime_dir
+        and Path(runtime_dir, "systemd", "private").is_socket()
+        and shutil.which("systemd-run", path=values.get("PATH"))
+    )
+
+
+def _runtime_inventory_path(env: Mapping[str, str]) -> Path | None:
+    configured = env.get("SINNIX_RUNTIME_INVENTORY_FILE")
+    candidates = (
+        Path(configured) if configured else None,
+        Path("/etc/sinnix/runtime-inventory.json"),
+        Path("/run/current-system/etc/sinnix/runtime-inventory.json"),
+    )
+    return next((path for path in candidates if path is not None and path.is_file()), None)
+
+
+def _sinnix_build_scope(env: Mapping[str, str]) -> tuple[str | None, list[str]]:
+    """Read the existing Sinnix build class instead of duplicating its policy."""
+    path = _runtime_inventory_path(env)
+    if path is None:
+        return None, []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        build = payload["commandClasses"]["build"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None, []
+    if not isinstance(build, dict):
+        return None, []
+    raw_slice = build.get("slice")
+    slice_name = (
+        raw_slice
+        if isinstance(raw_slice, str) and re.fullmatch(r"[A-Za-z0-9_.@:-]+\.slice", raw_slice) and "/" not in raw_slice
+        else None
+    )
+    raw_properties = build.get("systemdProperties")
+    properties: list[str] = []
+    if isinstance(raw_properties, dict):
+        for name, value in sorted(raw_properties.items()):
+            if (
+                name in {"KillMode", "RuntimeMaxSec", "SendSIGKILL", "TimeoutStopSec"}
+                or re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", str(name)) is None
+            ):
+                continue
+            if isinstance(value, bool):
+                rendered = "true" if value else "false"
+            elif isinstance(value, (int, float, str)):
+                rendered = str(value)
+            else:
+                continue
+            properties.append(f"--property={name}={rendered}")
+    return slice_name, properties
+
+
+def _unit_name(run_id: str | None) -> str:
+    safe_run = re.sub(r"[^A-Za-z0-9_.-]+", "-", run_id or "run").strip("-.") or "run"
+    safe_run = safe_run[:80]
+    return f"polylogue-pytest-{safe_run}-{os.getpid()}-{time.monotonic_ns()}.scope"
+
+
+def build_supervisor_launch(
+    controller_cmd: Sequence[str],
+    *,
+    owner_pid: int,
+    timeout_s: float,
+    term_grace_s: float,
+    receipt_path: Path,
+    run_id: str | None,
+    env: Mapping[str, str] | None = None,
+) -> SupervisorLaunch:
+    """Build the Linux supervisor command and optional owned cgroup scope."""
+    values = dict(os.environ if env is None else env)
+    if sys.platform != "linux":
+        raise RuntimeError("managed pytest containment requires Linux process identities")
+    receipt_path = receipt_path.absolute()
+    request_path = termination_request_path(receipt_path)
+    owner_start_ticks = _process_start_ticks(owner_pid)
+    systemd_available = user_systemd_available(values)
+    requested_mode = _systemd_mode(values)
+    if requested_mode == "require" and not systemd_available:
+        raise RuntimeError("user systemd is required for pytest containment but is unavailable")
+
+    mode = "systemd-scope" if systemd_available else "process-group"
+    unit = _unit_name(run_id) if systemd_available else None
+    runtime_cap_s = timeout_s + term_grace_s + 5.0 if systemd_available and timeout_s > 0 else None
+
+    def _supervisor_argv(
+        launch_mode: str,
+        launch_unit: str | None,
+        launch_runtime_cap_s: float | None,
+    ) -> list[str]:
+        argv = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--receipt",
+            str(receipt_path),
+            "--owner-pid",
+            str(owner_pid),
+        ]
+        if owner_start_ticks is not None:
+            argv.extend(("--owner-start-ticks", str(owner_start_ticks)))
+        argv.extend(
+            (
+                "--timeout-s",
+                f"{timeout_s:g}",
+                "--term-grace-s",
+                f"{term_grace_s:g}",
+                "--mode",
+                launch_mode,
+            )
+        )
+        if launch_unit is not None:
+            argv.extend(("--unit", launch_unit))
+        if launch_runtime_cap_s is not None:
+            argv.extend(("--runtime-cap-s", f"{launch_runtime_cap_s:g}"))
+        argv.extend(("--", *controller_cmd))
+        return argv
+
+    supervisor_argv = _supervisor_argv(mode, unit, runtime_cap_s)
+    if not systemd_available:
+        return SupervisorLaunch(supervisor_argv, receipt_path, request_path, mode, None, None)
+
+    systemd_run = shutil.which("systemd-run", path=values.get("PATH"))
+    assert systemd_run is not None
+    slice_name, inherited_properties = _sinnix_build_scope(values)
+    systemd_argv = [
+        systemd_run,
+        "--user",
+        "--scope",
+        "--quiet",
+        "--collect",
+        "--same-dir",
+        f"--unit={unit}",
+        "--property=KillMode=control-group",
+        "--property=SendSIGKILL=yes",
+        f"--property=TimeoutStopSec={term_grace_s:g}s",
+        *inherited_properties,
+    ]
+    if runtime_cap_s is not None:
+        systemd_argv.append(f"--property=RuntimeMaxSec={runtime_cap_s:g}s")
+    if slice_name is not None:
+        systemd_argv.append(f"--slice={slice_name}")
+    systemd_argv.extend(("--", *supervisor_argv))
+    fallback_argv = _supervisor_argv("process-group", None, None) if requested_mode == "auto" else None
+    return SupervisorLaunch(
+        systemd_argv,
+        receipt_path,
+        request_path,
+        mode,
+        unit,
+        runtime_cap_s,
+        fallback_argv,
+    )
+
+
+class _OwnerWatch:
+    def __init__(self, pid: int, start_ticks: int | None) -> None:
+        self.pid = pid
+        self.start_ticks = start_ticks
+        self.pidfd: int | None = None
+        self.poller: select.poll | None = None
+        self.identity_mismatch = start_ticks is not None and _process_start_ticks(pid) != start_ticks
+        if self.identity_mismatch:
+            return
+        pidfd_open = getattr(os, "pidfd_open", None)
+        if pidfd_open is not None:
+            with contextlib.suppress(OSError):
+                self.pidfd = int(pidfd_open(pid, 0))
+                if start_ticks is not None and _process_start_ticks(pid) != start_ticks:
+                    os.close(self.pidfd)
+                    self.pidfd = None
+                    self.identity_mismatch = True
+                    return
+                self.poller = select.poll()
+                self.poller.register(self.pidfd, select.POLLIN | select.POLLHUP | select.POLLERR)
+
+    def gone(self) -> bool:
+        if self.identity_mismatch:
+            return True
+        if self.poller is not None and self.poller.poll(0):
+            return True
+        if self.start_ticks is not None:
+            return _process_start_ticks(self.pid) != self.start_ticks
+        try:
+            os.kill(self.pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+        return False
+
+    def close(self) -> None:
+        if self.pidfd is not None:
+            with contextlib.suppress(OSError):
+                os.close(self.pidfd)
+
+
+def _owned_processes_exist(
+    *,
+    supervisor_pid: int,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+) -> bool:
+    if not _linux_proc_available():
+        return False
+    return bool(
+        _owned_identities(
+            supervisor_pid=supervisor_pid,
+            pgid=pgid,
+            sid=sid,
+            leader_start_ticks=leader_start_ticks,
+        )
+    )
+
+
+def _signal_owned_processes(
+    *,
+    supervisor_pid: int,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+    sig: signal.Signals,
+) -> int:
+    if not _linux_proc_available():
+        return 0
+    return sum(
+        signal_process_identity(pid, start_ticks, sig)
+        for pid, start_ticks in _owned_identities(
+            supervisor_pid=supervisor_pid,
+            pgid=pgid,
+            sid=sid,
+            leader_start_ticks=leader_start_ticks,
+        )
+    )
+
+
+def _terminate_controller_group(
+    process: subprocess.Popen[bytes],
+    *,
+    supervisor_pid: int,
+    pgid: int,
+    sid: int,
+    leader_start_ticks: int | None,
+    grace_s: float,
+) -> tuple[list[str], bool]:
+    sent: list[str] = []
+    if _signal_owned_processes(
+        supervisor_pid=supervisor_pid,
+        pgid=pgid,
+        sid=sid,
+        leader_start_ticks=leader_start_ticks,
+        sig=signal.SIGTERM,
+    ):
+        sent.append("SIGTERM")
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline:
+        process.poll()
+        if not _owned_processes_exist(
+            supervisor_pid=supervisor_pid,
+            pgid=pgid,
+            sid=sid,
+            leader_start_ticks=leader_start_ticks,
+        ):
+            break
+        time.sleep(min(_POLL_INTERVAL_S, max(0.0, deadline - time.monotonic())))
+    process.poll()
+    escalated = _owned_processes_exist(
+        supervisor_pid=supervisor_pid,
+        pgid=pgid,
+        sid=sid,
+        leader_start_ticks=leader_start_ticks,
+    )
+    if escalated and _signal_owned_processes(
+        supervisor_pid=supervisor_pid,
+        pgid=pgid,
+        sid=sid,
+        leader_start_ticks=leader_start_ticks,
+        sig=signal.SIGKILL,
+    ):
+        sent.append("SIGKILL")
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=max(0.2, grace_s))
+    reap_deadline = time.monotonic() + max(0.5, grace_s)
+    while (
+        _owned_processes_exist(
+            supervisor_pid=supervisor_pid,
+            pgid=pgid,
+            sid=sid,
+            leader_start_ticks=leader_start_ticks,
+        )
+        and time.monotonic() < reap_deadline
+    ):
+        time.sleep(_POLL_INTERVAL_S)
+    reap_exited_children()
+    return sent, escalated
+
+
+def _signal_name(returncode: int) -> str:
+    try:
+        return signal.Signals(-returncode).name
+    except ValueError:
+        return str(-returncode)
+
+
+def supervise(
+    controller_cmd: Sequence[str],
+    *,
+    receipt_path: Path,
+    owner_pid: int,
+    owner_start_ticks: int | None,
+    timeout_s: float,
+    term_grace_s: float,
+    mode: str,
+    unit: str | None,
+    runtime_cap_s: float | None,
+) -> int:
+    """Run one pytest controller and clean every process in its owned group."""
+    request_path = termination_request_path(receipt_path)
+    for stale in (receipt_path, request_path):
+        with contextlib.suppress(FileNotFoundError):
+            stale.unlink()
+    started_at = utc_now()
+    started = time.monotonic()
+    subreaper_enabled = enable_child_subreaper()
+    owner_watch = _OwnerWatch(owner_pid, owner_start_ticks)
+    received_signal: list[int] = []
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        if not received_signal:
+            received_signal.append(signum)
+
+    previous_handlers = {
+        signum: signal.signal(signum, _handle_signal) for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+    }
+    process = subprocess.Popen(list(controller_cmd), start_new_session=True)
+    controller_pid = process.pid
+    controller_pgid = controller_pid
+    controller_sid = controller_pid
+    controller_start_ticks = _process_start_ticks(controller_pid)
+    try:
+        controller_pgid = os.getpgid(controller_pid)
+        controller_sid = os.getsid(controller_pid)
+        base_receipt: dict[str, Any] = {
+            "schema_version": 1,
+            "status": "running",
+            "started_at": started_at,
+            "supervisor_pid": os.getpid(),
+            "supervisor_start_ticks": _process_start_ticks(os.getpid()),
+            "owner_pid": owner_pid,
+            "owner_start_ticks": owner_start_ticks,
+            "controller_pid": controller_pid,
+            "controller_start_ticks": controller_start_ticks,
+            "controller_pgid": controller_pgid,
+            "controller_sid": controller_sid,
+            "controller_command": list(controller_cmd),
+            "mode": mode,
+            "unit": unit,
+            "cgroup_path": _cgroup_path(os.getpid()),
+            "cgroup_owned": mode == "systemd-scope",
+            "timeout_s": timeout_s,
+            "term_grace_s": term_grace_s,
+            "runtime_cap_s": runtime_cap_s,
+            "subreaper_enabled": subreaper_enabled,
+        }
+        _write_json(receipt_path, base_receipt)
+    except BaseException:
+        # The controller already owns a new session here. If publishing the
+        # ownership receipt fails, kill that still-pinned group before the
+        # supervisor can exit and strand it without an addressable receipt.
+        _signal_owned_processes(
+            supervisor_pid=os.getpid(),
+            pgid=controller_pgid,
+            sid=controller_sid,
+            leader_start_ticks=controller_start_ticks,
+            sig=signal.SIGKILL,
+        )
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=1)
+        owner_watch.close()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        raise
+
+    termination_reason: str | None = None
+    requested_exit_code: int | None = None
+    controller_returncode: int | None = None
+    signals_sent: list[str] = []
+    escalated = False
+    try:
+        while True:
+            controller_returncode = process.poll()
+            if controller_returncode is not None:
+                if controller_returncode < 0:
+                    termination_reason = f"pytest controller exited by signal {_signal_name(controller_returncode)}"
+                break
+            if owner_watch.gone():
+                termination_reason = f"pytest runner owner pid {owner_pid} exited"
+                requested_exit_code = 125
+                break
+            if received_signal:
+                request = _read_termination_request(request_path)
+                signal_name = signal.Signals(received_signal[0]).name
+                if request is not None and isinstance(request.get("reason"), str):
+                    termination_reason = str(request["reason"])
+                    raw_exit = request.get("exit_code")
+                    requested_exit_code = int(raw_exit) if isinstance(raw_exit, int) else 124
+                else:
+                    termination_reason = f"pytest supervisor received {signal_name}"
+                    requested_exit_code = 128 + received_signal[0]
+                break
+            if timeout_s > 0 and time.monotonic() - started >= timeout_s:
+                termination_reason = f"pytest runtime exceeded {timeout_s:g}s"
+                requested_exit_code = 124
+                break
+            time.sleep(_POLL_INTERVAL_S)
+    finally:
+        signals_sent, escalated = _terminate_controller_group(
+            process,
+            supervisor_pid=os.getpid(),
+            pgid=controller_pgid,
+            sid=controller_sid,
+            leader_start_ticks=controller_start_ticks,
+            grace_s=term_grace_s,
+        )
+        if controller_returncode is None:
+            controller_returncode = process.poll()
+        owner_watch.close()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+    if requested_exit_code is not None:
+        exit_code = requested_exit_code
+    elif controller_returncode is None:
+        exit_code = 125
+    elif controller_returncode < 0:
+        exit_code = 128 + (-controller_returncode)
+    else:
+        exit_code = controller_returncode
+    final_receipt = {
+        **base_receipt,
+        "status": "terminated" if termination_reason is not None else "finished",
+        "finished_at": utc_now(),
+        "duration_s": round(time.monotonic() - started, 4),
+        "exit_code": exit_code,
+        "controller_returncode": controller_returncode,
+        "termination_reason": termination_reason,
+        "signals_sent": signals_sent,
+        "escalated_to_sigkill": escalated,
+        "controller_group_alive": _owned_processes_exist(
+            supervisor_pid=os.getpid(),
+            pgid=controller_pgid,
+            sid=controller_sid,
+            leader_start_ticks=controller_start_ticks,
+        ),
+    }
+    _write_json(receipt_path, final_receipt)
+    if termination_reason is not None:
+        sys.stderr.write(
+            f"pytest supervisor: {termination_reason}; owned pgid={controller_pgid} "
+            f"mode={mode} signals={','.join(signals_sent) or 'none'}\n"
+        )
+        sys.stderr.flush()
+    return exit_code
+
+
+def _parse_args(argv: Sequence[str]) -> tuple[argparse.Namespace, list[str]]:
+    try:
+        separator = list(argv).index("--")
+    except ValueError as exc:
+        raise SystemExit("pytest supervisor: missing '--' before controller command") from exc
+    option_argv = list(argv[:separator])
+    controller_cmd = list(argv[separator + 1 :])
+    if not controller_cmd:
+        raise SystemExit("pytest supervisor: controller command is empty")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--owner-pid", type=int, required=True)
+    parser.add_argument("--owner-start-ticks", type=int)
+    parser.add_argument("--timeout-s", type=float, required=True)
+    parser.add_argument("--term-grace-s", type=float, required=True)
+    parser.add_argument("--mode", choices=("process-group", "systemd-scope"), required=True)
+    parser.add_argument("--unit")
+    parser.add_argument("--runtime-cap-s", type=float)
+    return parser.parse_args(option_argv), controller_cmd
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args, controller_cmd = _parse_args(sys.argv[1:] if argv is None else argv)
+    return supervise(
+        controller_cmd,
+        receipt_path=args.receipt,
+        owner_pid=args.owner_pid,
+        owner_start_ticks=args.owner_start_ticks,
+        timeout_s=max(0.0, args.timeout_s),
+        term_grace_s=max(0.0, args.term_grace_s),
+        mode=args.mode,
+        unit=args.unit,
+        runtime_cap_s=args.runtime_cap_s,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -9,7 +9,8 @@ This command forwards a selection (paths, ``-k``/``-m`` expressions, ``-x``,
 - a single-process worker default (``-n 0``) for fast focused runs, overridable
   with ``-n`` in the selection or ``POLYLOGUE_PYTEST_WORKERS``;
 - live, streamed output (unlike ``devtools verify``, which captures);
-- the same pytest progress ledger, heartbeat, and stall timeout used by
+- the same pytest progress ledger, external deadline supervisor, owned process
+  group/cgroup containment, heartbeat, and stall timeout used by
   ``devtools verify``;
 - a checkout-scoped lock that serializes overlapping runs so two suites from
   the same checkout do not race and burn CPU. Concurrency is already
@@ -31,6 +32,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 from devtools.verify import (
+    PYTEST_CONTAINMENT_PATH,
     PYTEST_EVENTS_PATH,
     PYTEST_OUTPUT_PATH,
     PYTEST_PROGRESS_PATH,
@@ -141,6 +143,7 @@ def main(argv: list[str] | None = None) -> int:
         run.finish(exit_code=rc, duration_s=time.monotonic() - started, diagnosis=metadata.get("diagnosis"))
     sys.stderr.write(
         f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} selection={PYTEST_SELECTION_PATH} "
-        f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} output={PYTEST_OUTPUT_PATH}\n"
+        f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} containment={PYTEST_CONTAINMENT_PATH} "
+        f"output={PYTEST_OUTPUT_PATH}\n"
     )
     return rc

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -42,6 +42,7 @@ from typing import Any
 from devtools.pytest_supervisor import (
     SupervisorLaunch,
     build_supervisor_launch,
+    descendant_process_identities,
     enable_child_subreaper,
     read_receipt,
     reap_exited_children,
@@ -562,7 +563,12 @@ def _request_supervisor_termination(
         process.send_signal(signal.SIGTERM)
 
 
-def _force_kill_owned_run(process: subprocess.Popen[bytes], launch: SupervisorLaunch) -> None:
+def _force_kill_owned_run(
+    process: subprocess.Popen[bytes],
+    launch: SupervisorLaunch,
+    *,
+    preserved_runner_descendants: Sequence[tuple[int, int]] = (),
+) -> None:
     """Escalate only through identities recorded for this pytest run."""
     receipt = read_receipt(launch.receipt_path)
     controller_pgid = receipt.get("controller_pgid") if receipt is not None else None
@@ -590,7 +596,11 @@ def _force_kill_owned_run(process: subprocess.Popen[bytes], launch: SupervisorLa
         )
     if isinstance(supervisor_pid, int) and isinstance(supervisor_start, int):
         signal_process_identity(supervisor_pid, supervisor_start, signal.SIGKILL)
-    signal_descendant_identities(os.getpid(), signal.SIGKILL)
+    signal_descendant_identities(
+        os.getpid(),
+        signal.SIGKILL,
+        preserved_roots=preserved_runner_descendants,
+    )
     if process.poll() is None:
         process.kill()
 
@@ -700,6 +710,7 @@ def _run_pytest_with_heartbeat(
     term_grace_s = _pytest_term_grace_s()
     resource_interval_s = _pytest_resource_interval_s()
     runner_subreaper_enabled = enable_child_subreaper()
+    preserved_runner_descendants = tuple(descendant_process_identities(os.getpid()))
     receipt_path = (
         artifacts.containment_path
         if artifacts is not None
@@ -720,6 +731,50 @@ def _run_pytest_with_heartbeat(
         f"{f', unit={launch.unit}' if launch.unit is not None else ''}, receipt={launch.receipt_path}\n"
     )
     sys.stderr.flush()
+    if not runner_subreaper_enabled:
+        reason = "pytest runner could not become a Linux child subreaper"
+        preflight_receipt = update_receipt(
+            launch.receipt_path,
+            {
+                "schema_version": 1,
+                "status": "terminated",
+                "started_at": utc_now(),
+                "finished_at": utc_now(),
+                "duration_s": round(time.monotonic() - t0, 4),
+                "runner_pid": os.getpid(),
+                "runner_subreaper_enabled": False,
+                "controller_command": list(cmd),
+                "mode": launch.mode,
+                "unit": launch.unit,
+                "cgroup_owned": False,
+                "timeout_s": timeout_s,
+                "term_grace_s": term_grace_s,
+                "runtime_cap_s": launch.runtime_cap_s,
+                "exit_code": 125,
+                "termination_reason": reason,
+                "signals_sent": [],
+                "escalated_to_sigkill": False,
+                "controller_group_alive": False,
+                "startup_failure": True,
+            },
+        )
+        rendered_stderr = f"verify: {reason}; refusing an unowned pytest launch\n"
+        _write_pytest_progress(
+            event="terminated",
+            cmd=cmd,
+            started_at=t0,
+            returncode=125,
+            termination_reason=reason,
+            run_id=run.run_id if run is not None else None,
+            artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+            containment=_containment_summary(launch, preflight_receipt),
+        )
+        _write_pytest_output("", rendered_stderr)
+        if artifacts is not None:
+            artifacts.stdout_path.write_text("", encoding="utf-8")
+            artifacts.stderr_path.write_text(rendered_stderr, encoding="utf-8")
+            artifacts.output_path.write_text(rendered_stderr, encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 125, "", rendered_stderr)
 
     def _spawn_supervisor(argv: Sequence[str]) -> subprocess.Popen[bytes]:
         return subprocess.Popen(
@@ -735,7 +790,11 @@ def _run_pytest_with_heartbeat(
         startup_process: subprocess.Popen[bytes],
         startup_launch: SupervisorLaunch,
     ) -> tuple[bytes, bytes]:
-        _force_kill_owned_run(startup_process, startup_launch)
+        _force_kill_owned_run(
+            startup_process,
+            startup_launch,
+            preserved_runner_descendants=preserved_runner_descendants,
+        )
         try:
             result = startup_process.communicate(timeout=1)
         except subprocess.TimeoutExpired:
@@ -921,7 +980,11 @@ def _run_pytest_with_heartbeat(
                         or (str(receipt_reason) if isinstance(receipt_reason, str) else None)
                         or "pytest supervisor exited while owned output pipes remained open"
                     )
-                    _force_kill_owned_run(process, launch)
+                    _force_kill_owned_run(
+                        process,
+                        launch,
+                        preserved_runner_descendants=preserved_runner_descendants,
+                    )
                     forced_cleanup = True
                     forced_returncode = 125
                     post_exit_forced_at = now
@@ -973,7 +1036,11 @@ def _run_pytest_with_heartbeat(
                 and now - termination_requested_at >= term_grace_s + 1.0
                 and not forced_cleanup
             ):
-                _force_kill_owned_run(process, launch)
+                _force_kill_owned_run(
+                    process,
+                    launch,
+                    preserved_runner_descendants=preserved_runner_descendants,
+                )
                 forced_cleanup = True
                 forced_returncode = 124
                 receipt = update_receipt(

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -39,7 +39,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from devtools.pytest_supervisor import (
+    SupervisorLaunch,
+    build_supervisor_launch,
+    enable_child_subreaper,
+    read_receipt,
+    reap_exited_children,
+    signal_descendant_identities,
+    signal_owned_process_group,
+    signal_process_identity,
+    update_receipt,
+    write_termination_request,
+)
 from devtools.verify_runs import (
+    CURRENT_CONTAINMENT_PATH,
     CURRENT_EVENTS_DIR,
     CURRENT_POSTMORTEM_PATH,
     CURRENT_RESOURCES_PATH,
@@ -184,13 +197,16 @@ PYTEST_EVENTS_DIR = CURRENT_EVENTS_DIR
 PYTEST_SELECTION_PATH = PYTEST_REPORT_DIR / "current-pytest-selection.json"
 PYTEST_SUMMARY_PATH = PYTEST_REPORT_DIR / "current-pytest-summary.json"
 PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
+PYTEST_CONTAINMENT_PATH = CURRENT_CONTAINMENT_PATH
 PYTEST_HEARTBEAT_ENV = "POLYLOGUE_VERIFY_HEARTBEAT_S"
 PYTEST_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S"
 PYTEST_STALL_TIMEOUT_ENV = "POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S"
+PYTEST_TERM_GRACE_ENV = "POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S"
 PYTEST_RESOURCE_INTERVAL_ENV = "POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S"
 DEFAULT_PYTEST_HEARTBEAT_S = 30.0
 DEFAULT_PYTEST_TIMEOUT_S = 45 * 60.0
 DEFAULT_PYTEST_STALL_TIMEOUT_S = 10 * 60.0
+DEFAULT_PYTEST_TERM_GRACE_S = 5.0
 DEFAULT_PYTEST_RESOURCE_INTERVAL_S = 2.0
 DEFAULT_TESTMON_WORKERS = "4"
 
@@ -364,6 +380,7 @@ def _clear_pytest_report(cmd: Sequence[str] = ()) -> None:
         PYTEST_OUTPUT_PATH,
         CURRENT_RESOURCES_PATH,
         CURRENT_POSTMORTEM_PATH,
+        CURRENT_CONTAINMENT_PATH,
     ):
         with contextlib.suppress(FileNotFoundError):
             if path.is_dir():
@@ -394,6 +411,7 @@ def _write_pytest_progress(
     run_id: str | None = None,
     artifact_dir: str | None = None,
     resources: Mapping[str, Any] | None = None,
+    containment: Mapping[str, Any] | None = None,
 ) -> None:
     """Write a live pytest progress artifact for long verify runs."""
     if elapsed_s is None:
@@ -425,6 +443,8 @@ def _write_pytest_progress(
         payload["artifact_dir"] = artifact_dir
     if resources is not None:
         payload["resources"] = dict(resources)
+    if containment is not None:
+        payload["containment"] = dict(containment)
     latest_event = _read_latest_pytest_event()
     if latest_event is not None:
         payload["latest_test_event"] = {
@@ -493,22 +513,176 @@ def _pytest_stall_timeout_s() -> float:
     return _float_env(PYTEST_STALL_TIMEOUT_ENV, DEFAULT_PYTEST_STALL_TIMEOUT_S)
 
 
+def _pytest_term_grace_s() -> float:
+    return _float_env(PYTEST_TERM_GRACE_ENV, DEFAULT_PYTEST_TERM_GRACE_S)
+
+
 def _pytest_resource_interval_s() -> float:
     return _float_env(PYTEST_RESOURCE_INTERVAL_ENV, DEFAULT_PYTEST_RESOURCE_INTERVAL_S)
 
 
-def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
-    with contextlib.suppress(ProcessLookupError):
-        os.killpg(process.pid, signal.SIGTERM)
-    try:
-        process.wait(timeout=5)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    with contextlib.suppress(ProcessLookupError):
-        os.killpg(process.pid, signal.SIGKILL)
-    with contextlib.suppress(subprocess.TimeoutExpired):
-        process.wait(timeout=5)
+def _containment_summary(launch: SupervisorLaunch, receipt: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "mode": launch.mode,
+        "unit": launch.unit,
+        "receipt_path": str(launch.receipt_path),
+        "runtime_cap_s": launch.runtime_cap_s,
+    }
+    if receipt is not None:
+        for key in (
+            "supervisor_pid",
+            "controller_pid",
+            "controller_pgid",
+            "controller_sid",
+            "cgroup_path",
+            "cgroup_owned",
+            "signals_sent",
+            "escalated_to_sigkill",
+            "controller_group_alive",
+        ):
+            if key in receipt:
+                payload[key] = receipt[key]
+    return payload
+
+
+def _request_supervisor_termination(
+    process: subprocess.Popen[bytes],
+    launch: SupervisorLaunch,
+    *,
+    reason: str,
+) -> None:
+    write_termination_request(launch.request_path, reason=reason)
+    receipt = read_receipt(launch.receipt_path)
+    supervisor_pid = receipt.get("supervisor_pid") if receipt is not None else None
+    supervisor_start = receipt.get("supervisor_start_ticks") if receipt is not None else None
+    signalled = False
+    if isinstance(supervisor_pid, int) and isinstance(supervisor_start, int):
+        signalled = signal_process_identity(supervisor_pid, supervisor_start, signal.SIGTERM)
+    if not signalled and process.poll() is None:
+        process.send_signal(signal.SIGTERM)
+
+
+def _force_kill_owned_run(process: subprocess.Popen[bytes], launch: SupervisorLaunch) -> None:
+    """Escalate only through identities recorded for this pytest run."""
+    receipt = read_receipt(launch.receipt_path)
+    controller_pgid = receipt.get("controller_pgid") if receipt is not None else None
+    controller_sid = receipt.get("controller_sid") if receipt is not None else None
+    controller_start = receipt.get("controller_start_ticks") if receipt is not None else None
+    supervisor_pid = receipt.get("supervisor_pid") if receipt is not None else None
+    supervisor_start = receipt.get("supervisor_start_ticks") if receipt is not None else None
+    if launch.unit is not None and shutil.which("systemctl"):
+        with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            result = subprocess.run(
+                ["systemctl", "--user", "kill", "--kill-whom=all", "--signal=SIGKILL", launch.unit],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+            if result.returncode == 0:
+                return
+    if isinstance(controller_pgid, int) and isinstance(controller_sid, int):
+        signal_owned_process_group(
+            pgid=controller_pgid,
+            sid=controller_sid,
+            leader_start_ticks=controller_start if isinstance(controller_start, int) else None,
+            sig=signal.SIGKILL,
+        )
+    if isinstance(supervisor_pid, int) and isinstance(supervisor_start, int):
+        signal_process_identity(supervisor_pid, supervisor_start, signal.SIGKILL)
+    signal_descendant_identities(os.getpid(), signal.SIGKILL)
+    if process.poll() is None:
+        process.kill()
+
+
+def _wait_for_supervisor_start(
+    process: subprocess.Popen[bytes],
+    launch: SupervisorLaunch,
+    *,
+    timeout_s: float = 5.0,
+) -> dict[str, Any] | None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        receipt = read_receipt(launch.receipt_path)
+        if receipt is not None:
+            return receipt
+        if process.poll() is not None:
+            return None
+        time.sleep(0.01)
+    return read_receipt(launch.receipt_path)
+
+
+def _startup_wait_s(*, t0: float, timeout_s: float) -> float:
+    if timeout_s <= 0:
+        return 5.0
+    return max(0.0, min(5.0, t0 + timeout_s - time.monotonic()))
+
+
+def _finish_supervisor_startup_failure(
+    cmd: list[str],
+    *,
+    launch: SupervisorLaunch,
+    process: subprocess.Popen[bytes],
+    t0: float,
+    timeout_s: float,
+    term_grace_s: float,
+    reason: str,
+    exit_code: int,
+    stdout: bytes,
+    stderr: bytes,
+    runner_subreaper_enabled: bool,
+    run: VerifyRun | None,
+    artifacts: PytestStepArtifacts | None,
+) -> subprocess.CompletedProcess[str]:
+    receipt = update_receipt(
+        launch.receipt_path,
+        {
+            "schema_version": 1,
+            "status": "terminated",
+            "finished_at": utc_now(),
+            "duration_s": round(time.monotonic() - t0, 4),
+            "controller_command": list(cmd),
+            "mode": launch.mode,
+            "unit": launch.unit,
+            "cgroup_owned": launch.mode == "systemd-scope",
+            "timeout_s": timeout_s,
+            "term_grace_s": term_grace_s,
+            "runtime_cap_s": launch.runtime_cap_s,
+            "exit_code": exit_code,
+            "supervisor_exit_code": process.poll(),
+            "termination_reason": reason,
+            "signals_sent": ["SIGKILL"],
+            "escalated_to_sigkill": True,
+            "runner_forced_cleanup": True,
+            "runner_forced_at": utc_now(),
+            "runner_pid": os.getpid(),
+            "runner_subreaper_enabled": runner_subreaper_enabled,
+            "startup_failure": True,
+        },
+    )
+    rendered_stdout = stdout.decode(errors="replace")
+    rendered_stderr = stderr.decode(errors="replace")
+    rendered_stderr = f"{rendered_stderr}\nverify: {reason}; pytest supervisor startup was contained\n"
+    output_bytes = {"stdout": len(stdout), "stderr": len(rendered_stderr.encode())}
+    _write_pytest_progress(
+        event="terminated",
+        cmd=cmd,
+        started_at=t0,
+        pid=process.pid,
+        returncode=exit_code,
+        output_bytes=output_bytes,
+        termination_reason=reason,
+        run_id=run.run_id if run is not None else None,
+        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+        containment=_containment_summary(launch, receipt),
+    )
+    _write_pytest_output(rendered_stdout, rendered_stderr)
+    if artifacts is not None:
+        artifacts.stdout_path.write_text(rendered_stdout, encoding="utf-8")
+        artifacts.stderr_path.write_text(rendered_stderr, encoding="utf-8")
+        artifacts.output_path.write_text(rendered_stdout + rendered_stderr, encoding="utf-8")
+    reap_exited_children()
+    return subprocess.CompletedProcess(cmd, exit_code, rendered_stdout, rendered_stderr)
 
 
 def _run_pytest_with_heartbeat(
@@ -523,19 +697,148 @@ def _run_pytest_with_heartbeat(
     heartbeat_s = _pytest_heartbeat_interval()
     timeout_s = _pytest_timeout_s()
     stall_timeout_s = _pytest_stall_timeout_s()
+    term_grace_s = _pytest_term_grace_s()
     resource_interval_s = _pytest_resource_interval_s()
-    sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
-    sys.stderr.flush()
-    process = subprocess.Popen(
-        cmd,
-        cwd=cwd,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
+    runner_subreaper_enabled = enable_child_subreaper()
+    receipt_path = (
+        artifacts.containment_path
+        if artifacts is not None
+        else Path(env.get("POLYLOGUE_PYTEST_CONTAINMENT_PATH", str(Path.cwd() / PYTEST_CONTAINMENT_PATH)))
     )
+    launch = build_supervisor_launch(
+        cmd,
+        owner_pid=os.getpid(),
+        timeout_s=timeout_s,
+        term_grace_s=term_grace_s,
+        receipt_path=receipt_path,
+        run_id=run.run_id if run is not None else env.get("POLYLOGUE_PYTEST_RUN_ID"),
+        env=env,
+    )
+    sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
+    sys.stderr.write(
+        f"    containment: mode={launch.mode}"
+        f"{f', unit={launch.unit}' if launch.unit is not None else ''}, receipt={launch.receipt_path}\n"
+    )
+    sys.stderr.flush()
+
+    def _spawn_supervisor(argv: Sequence[str]) -> subprocess.Popen[bytes]:
+        return subprocess.Popen(
+            list(argv),
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+
+    def _stop_startup_attempt(
+        startup_process: subprocess.Popen[bytes],
+        startup_launch: SupervisorLaunch,
+    ) -> tuple[bytes, bytes]:
+        _force_kill_owned_run(startup_process, startup_launch)
+        try:
+            result = startup_process.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            startup_process.kill()
+            result = startup_process.communicate(timeout=1)
+        reap_exited_children()
+        return result
+
+    process = _spawn_supervisor(launch.argv)
     assert process.stdout is not None
     assert process.stderr is not None
+    startup_receipt = _wait_for_supervisor_start(process, launch, timeout_s=_startup_wait_s(t0=t0, timeout_s=timeout_s))
+    startup_stdout = b""
+    startup_stderr = b""
+    if startup_receipt is None:
+        startup_stdout, startup_stderr = _stop_startup_attempt(process, launch)
+        if timeout_s > 0 and time.monotonic() - t0 >= timeout_s:
+            return _finish_supervisor_startup_failure(
+                cmd,
+                launch=launch,
+                process=process,
+                t0=t0,
+                timeout_s=timeout_s,
+                term_grace_s=term_grace_s,
+                reason=f"pytest runtime exceeded {timeout_s:g}s",
+                exit_code=124,
+                stdout=startup_stdout,
+                stderr=startup_stderr,
+                runner_subreaper_enabled=runner_subreaper_enabled,
+                run=run,
+                artifacts=artifacts,
+            )
+        if launch.fallback_argv is None:
+            detail = startup_stderr.decode(errors="replace").strip()
+            reason = "pytest supervisor failed before publishing ownership"
+            if detail:
+                reason = f"{reason}: {detail}"
+            return _finish_supervisor_startup_failure(
+                cmd,
+                launch=launch,
+                process=process,
+                t0=t0,
+                timeout_s=timeout_s,
+                term_grace_s=term_grace_s,
+                reason=reason,
+                exit_code=125,
+                stdout=startup_stdout,
+                stderr=startup_stderr,
+                runner_subreaper_enabled=runner_subreaper_enabled,
+                run=run,
+                artifacts=artifacts,
+            )
+        fallback_message = (
+            b"pytest supervisor: systemd scope launch failed; retrying with the Linux process-group boundary\n"
+        )
+        startup_stderr += fallback_message
+        sys.stderr.write((startup_stdout + startup_stderr).decode(errors="replace"))
+        sys.stderr.flush()
+        launch = SupervisorLaunch(
+            launch.fallback_argv,
+            launch.receipt_path,
+            launch.request_path,
+            "process-group",
+            None,
+            None,
+        )
+        process = _spawn_supervisor(launch.argv)
+        assert process.stdout is not None
+        assert process.stderr is not None
+        startup_receipt = _wait_for_supervisor_start(
+            process,
+            launch,
+            timeout_s=_startup_wait_s(t0=t0, timeout_s=timeout_s),
+        )
+        if startup_receipt is None:
+            fallback_stdout, fallback_stderr = _stop_startup_attempt(process, launch)
+            startup_stdout += fallback_stdout
+            startup_stderr += fallback_stderr
+            timed_out = timeout_s > 0 and time.monotonic() - t0 >= timeout_s
+            reason = (
+                f"pytest runtime exceeded {timeout_s:g}s"
+                if timed_out
+                else "pytest process-group supervisor failed before publishing ownership"
+            )
+            return _finish_supervisor_startup_failure(
+                cmd,
+                launch=launch,
+                process=process,
+                t0=t0,
+                timeout_s=timeout_s,
+                term_grace_s=term_grace_s,
+                reason=reason,
+                exit_code=124 if timed_out else 125,
+                stdout=startup_stdout,
+                stderr=startup_stderr,
+                runner_subreaper_enabled=runner_subreaper_enabled,
+                run=run,
+                artifacts=artifacts,
+            )
+    stdout_pipe = process.stdout
+    stderr_pipe = process.stderr
+    assert stdout_pipe is not None
+    assert stderr_pipe is not None
     sampler = (
         ResourceSampler(
             root_pid=process.pid,
@@ -557,17 +860,26 @@ def _run_pytest_with_heartbeat(
         output_bytes={"stdout": 0, "stderr": 0},
         run_id=run.run_id if run is not None else None,
         artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+        containment=_containment_summary(launch, startup_receipt),
     )
     selector = selectors.DefaultSelector()
-    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
-    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
-    output: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
-    output_bytes = {"stdout": 0, "stderr": 0}
+    selector.register(stdout_pipe, selectors.EVENT_READ, "stdout")
+    selector.register(stderr_pipe, selectors.EVENT_READ, "stderr")
+    output: dict[str, list[bytes]] = {
+        "stdout": [startup_stdout] if startup_stdout else [],
+        "stderr": [startup_stderr] if startup_stderr else [],
+    }
+    output_bytes = {"stdout": len(startup_stdout), "stderr": len(startup_stderr)}
     last_cpu = _process_cpu_seconds(process.pid)
     last_sample = time.monotonic()
     last_output = last_sample
     last_resource_sample = last_sample
     termination_reason: str | None = None
+    termination_requested_at: float | None = None
+    forced_cleanup = False
+    supervisor_finished_at: float | None = None
+    post_exit_forced_at: float | None = None
+    forced_returncode: int | None = None
     # Test-event progress, not raw output bytes: an xdist master can keep
     # emitting output (its own heartbeat chatter) while every worker is
     # wedged (e.g. a D-state deadlock), so output-silence alone never fires
@@ -592,153 +904,266 @@ def _run_pytest_with_heartbeat(
             last_progress_marker = marker
             last_progress_at = at
 
-    while True:
-        now = time.monotonic()
-        elapsed = now - t0
-        idle = now - last_output
-        progress_idle = now - last_progress_at
-        if timeout_s > 0 and elapsed >= timeout_s:
-            termination_reason = f"pytest runtime exceeded {timeout_s:g}s"
-        elif stall_timeout_s > 0 and idle >= stall_timeout_s:
-            termination_reason = f"pytest produced no output for {stall_timeout_s:g}s"
-        elif stall_timeout_s > 0 and seen_any_progress_event and progress_idle >= stall_timeout_s:
-            termination_reason = (
-                f"pytest reported no test progress for {stall_timeout_s:g}s "
-                f"(output kept flowing; last progress marker: {last_progress_marker})"
-            )
-        if termination_reason is not None:
-            _terminate_process_group(process)
-            break
+    try:
+        while True:
+            now = time.monotonic()
+            elapsed = now - t0
+            idle = now - last_output
+            progress_idle = now - last_progress_at
+            receipt = read_receipt(launch.receipt_path)
+            if receipt is not None and receipt.get("status") in {"finished", "terminated"} and selector.get_map():
+                if supervisor_finished_at is None:
+                    supervisor_finished_at = now
+                elif now - supervisor_finished_at >= max(0.2, term_grace_s) and post_exit_forced_at is None:
+                    receipt_reason = receipt.get("termination_reason")
+                    termination_reason = (
+                        termination_reason
+                        or (str(receipt_reason) if isinstance(receipt_reason, str) else None)
+                        or "pytest supervisor exited while owned output pipes remained open"
+                    )
+                    _force_kill_owned_run(process, launch)
+                    forced_cleanup = True
+                    forced_returncode = 125
+                    post_exit_forced_at = now
+                    receipt = update_receipt(
+                        launch.receipt_path,
+                        {
+                            "status": "terminated",
+                            "supervisor_exit_code": receipt.get("exit_code"),
+                            "exit_code": forced_returncode,
+                            "termination_reason": termination_reason,
+                            "runner_forced_cleanup": True,
+                            "runner_forced_at": datetime.now(timezone.utc).isoformat(),
+                            "runner_pid": os.getpid(),
+                            "runner_subreaper_enabled": runner_subreaper_enabled,
+                        },
+                    )
+                elif post_exit_forced_at is not None and now - post_exit_forced_at >= 1.0:
+                    for selector_key in list(selector.get_map().values()):
+                        with contextlib.suppress(KeyError):
+                            selector.unregister(selector_key.fileobj)
+                        if selector_key.fileobj is stdout_pipe:
+                            stdout_pipe.close()
+                        elif selector_key.fileobj is stderr_pipe:
+                            stderr_pipe.close()
+                        else:
+                            with contextlib.suppress(OSError):
+                                os.close(selector_key.fd)
+                    if process.poll() is None:
+                        process.kill()
+            if termination_reason is None and timeout_s > 0 and elapsed >= timeout_s:
+                termination_reason = f"pytest runtime exceeded {timeout_s:g}s"
+            elif termination_reason is None and stall_timeout_s > 0 and idle >= stall_timeout_s:
+                termination_reason = f"pytest produced no output for {stall_timeout_s:g}s"
+            elif (
+                termination_reason is None
+                and stall_timeout_s > 0
+                and seen_any_progress_event
+                and progress_idle >= stall_timeout_s
+            ):
+                termination_reason = (
+                    f"pytest reported no test progress for {stall_timeout_s:g}s "
+                    f"(output kept flowing; last progress marker: {last_progress_marker})"
+                )
+            if termination_reason is not None and termination_requested_at is None:
+                _request_supervisor_termination(process, launch, reason=termination_reason)
+                termination_requested_at = now
+            if (
+                termination_requested_at is not None
+                and now - termination_requested_at >= term_grace_s + 1.0
+                and not forced_cleanup
+            ):
+                _force_kill_owned_run(process, launch)
+                forced_cleanup = True
+                forced_returncode = 124
+                receipt = update_receipt(
+                    launch.receipt_path,
+                    {
+                        "status": "terminated",
+                        "supervisor_exit_code": process.poll(),
+                        "exit_code": forced_returncode,
+                        "termination_reason": termination_reason,
+                        "runner_forced_cleanup": True,
+                        "runner_forced_at": datetime.now(timezone.utc).isoformat(),
+                        "runner_pid": os.getpid(),
+                        "runner_subreaper_enabled": runner_subreaper_enabled,
+                    },
+                )
 
-        deadlines: list[float] = []
-        if heartbeat_s > 0:
-            deadlines.append(heartbeat_s)
-        if timeout_s > 0:
-            deadlines.append(max(timeout_s - elapsed, 0.0))
-        if stall_timeout_s > 0:
-            deadlines.append(max(stall_timeout_s - idle, 0.0))
-        if stall_timeout_s > 0 and seen_any_progress_event:
-            deadlines.append(max(stall_timeout_s - progress_idle, 0.0))
-        timeout = min(deadlines) if deadlines else None
-        events = selector.select(timeout=timeout)
-        if events:
-            for selector_key, _mask in events:
-                chunk = os.read(selector_key.fd, 65536)
-                if chunk:
-                    stream_name = str(selector_key.data)
-                    output[stream_name].append(chunk)
-                    output_bytes[stream_name] += len(chunk)
-                    sys.stderr.write(chunk.decode(errors="replace"))
-                    sys.stderr.flush()
-                    last_output = time.monotonic()
-                    _refresh_progress_marker(last_output)
-                    _write_pytest_progress(
-                        event="output",
-                        cmd=cmd,
-                        started_at=t0,
-                        pid=process.pid,
-                        idle_s=last_output - last_progress_at,
-                        output_bytes=output_bytes,
-                        status=_process_status(process.pid),
-                        run_id=run.run_id if run is not None else None,
-                        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+            deadlines: list[float] = []
+            if heartbeat_s > 0:
+                deadlines.append(heartbeat_s)
+            if timeout_s > 0 and termination_reason is None:
+                deadlines.append(max(timeout_s - elapsed, 0.0))
+            if stall_timeout_s > 0 and termination_reason is None:
+                deadlines.append(max(stall_timeout_s - idle, 0.0))
+            if stall_timeout_s > 0 and seen_any_progress_event and termination_reason is None:
+                deadlines.append(max(stall_timeout_s - progress_idle, 0.0))
+            if termination_requested_at is not None and not forced_cleanup:
+                deadlines.append(max(term_grace_s + 1.0 - (now - termination_requested_at), 0.0))
+            if supervisor_finished_at is not None and post_exit_forced_at is None:
+                deadlines.append(max(max(0.2, term_grace_s) - (now - supervisor_finished_at), 0.0))
+            if post_exit_forced_at is not None:
+                deadlines.append(max(1.0 - (now - post_exit_forced_at), 0.0))
+            selector_timeout = min(deadlines) if deadlines else None
+            events = selector.select(timeout=selector_timeout)
+            if events:
+                for selector_key, _mask in events:
+                    chunk = os.read(selector_key.fd, 65536)
+                    if chunk:
+                        stream_name = str(selector_key.data)
+                        output[stream_name].append(chunk)
+                        output_bytes[stream_name] += len(chunk)
+                        sys.stderr.write(chunk.decode(errors="replace"))
+                        sys.stderr.flush()
+                        last_output = time.monotonic()
+                        _refresh_progress_marker(last_output)
+                        receipt = read_receipt(launch.receipt_path)
+                        _write_pytest_progress(
+                            event="output",
+                            cmd=cmd,
+                            started_at=t0,
+                            pid=process.pid,
+                            idle_s=last_output - last_progress_at,
+                            output_bytes=output_bytes,
+                            status=_process_status(process.pid),
+                            run_id=run.run_id if run is not None else None,
+                            artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+                            containment=_containment_summary(launch, receipt),
+                        )
+                    else:
+                        selector.unregister(selector_key.fileobj)
+            else:
+                status = _process_status(process.pid)
+                cpu_now = _process_cpu_seconds(process.pid)
+                cpu_pct = None
+                sample_now = time.monotonic()
+                if cpu_now is not None and last_cpu is not None and sample_now > last_sample:
+                    cpu_pct = ((cpu_now - last_cpu) / (sample_now - last_sample)) * 100.0
+                last_cpu = cpu_now
+                last_sample = sample_now
+                rss = status["rss_kb"]
+                rss_text = f", rss={int(rss) // 1024} MiB" if isinstance(rss, int) else ""
+                cpu_text = f", cpu={cpu_pct:.0f}%" if cpu_pct is not None else ""
+                state_text = f", state={status['state']}" if status["state"] is not None else ""
+                latest_event = _read_latest_pytest_event()
+                _refresh_progress_marker(sample_now, latest_event)
+                if latest_event is not None:
+                    event = latest_event.get("event")
+                    nodeid = latest_event.get("nodeid")
+                    node_text = (
+                        f", latest={event}:{nodeid}" if isinstance(event, str) and isinstance(nodeid, str) else ""
                     )
                 else:
-                    selector.unregister(selector_key.fileobj)
-        else:
-            status = _process_status(process.pid)
-            cpu_now = _process_cpu_seconds(process.pid)
-            cpu_pct = None
+                    node_text = ""
+                progress_idle_text = (
+                    f", progress_idle={sample_now - last_progress_at:.0f}s" if seen_any_progress_event else ""
+                )
+                receipt = read_receipt(launch.receipt_path)
+                controller_pid = receipt.get("controller_pid") if receipt is not None else None
+                controller_text = f", controller={controller_pid}" if isinstance(controller_pid, int) else ""
+                sys.stderr.write(
+                    f"    still running: supervisor={process.pid}{controller_text}, elapsed={sample_now - t0:.0f}s, "
+                    f"idle={sample_now - last_output:.0f}s{progress_idle_text}{state_text}{cpu_text}{rss_text}{node_text}\n"
+                )
+                sys.stderr.flush()
+                _write_pytest_progress(
+                    event="heartbeat",
+                    cmd=cmd,
+                    started_at=t0,
+                    pid=process.pid,
+                    elapsed_s=sample_now - t0,
+                    idle_s=sample_now - last_progress_at,
+                    output_bytes=output_bytes,
+                    status=status,
+                    cpu_pct=cpu_pct,
+                    run_id=run.run_id if run is not None else None,
+                    artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+                    containment=_containment_summary(launch, receipt),
+                )
             sample_now = time.monotonic()
-            if cpu_now is not None and last_cpu is not None and sample_now > last_sample:
-                cpu_pct = ((cpu_now - last_cpu) / (sample_now - last_sample)) * 100.0
-            last_cpu = cpu_now
-            last_sample = sample_now
-            rss = status["rss_kb"]
-            rss_text = f", rss={int(rss) // 1024} MiB" if isinstance(rss, int) else ""
-            cpu_text = f", cpu={cpu_pct:.0f}%" if cpu_pct is not None else ""
-            state_text = f", state={status['state']}" if status["state"] is not None else ""
-            latest_event = _read_latest_pytest_event()
-            _refresh_progress_marker(sample_now, latest_event)
-            if latest_event is not None:
-                event = latest_event.get("event")
-                nodeid = latest_event.get("nodeid")
-                node_text = f", latest={event}:{nodeid}" if isinstance(event, str) and isinstance(nodeid, str) else ""
-            else:
-                node_text = ""
-            progress_idle_text = (
-                f", progress_idle={sample_now - last_progress_at:.0f}s" if seen_any_progress_event else ""
-            )
-            sys.stderr.write(
-                f"    still running: pid={process.pid}, elapsed={sample_now - t0:.0f}s, "
-                f"idle={sample_now - last_output:.0f}s{progress_idle_text}{state_text}{cpu_text}{rss_text}{node_text}\n"
-            )
-            sys.stderr.flush()
-            _write_pytest_progress(
-                event="heartbeat",
-                cmd=cmd,
-                started_at=t0,
-                pid=process.pid,
-                elapsed_s=sample_now - t0,
-                idle_s=sample_now - last_progress_at,
-                output_bytes=output_bytes,
-                status=status,
-                cpu_pct=cpu_pct,
-                run_id=run.run_id if run is not None else None,
-                artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
-            )
-        sample_now = time.monotonic()
-        if sampler is not None and resource_interval_s > 0 and sample_now - last_resource_sample >= resource_interval_s:
-            sampler.sample(event="sample")
-            last_resource_sample = sample_now
-        if process.poll() is not None and not selector.get_map():
-            break
+            if (
+                sampler is not None
+                and resource_interval_s > 0
+                and sample_now - last_resource_sample >= resource_interval_s
+            ):
+                sampler.sample(event="sample")
+                last_resource_sample = sample_now
+            if process.poll() is not None and not selector.get_map():
+                break
+    except BaseException:
+        if process.poll() is None:
+            _request_supervisor_termination(process, launch, reason="pytest runner interrupted")
+        raise
+    finally:
+        selector.close()
+    reap_exited_children()
 
-    for stream in (process.stdout, process.stderr):
+    for stream in (stdout_pipe, stderr_pipe):
+        if stream.closed:
+            continue
         with contextlib.suppress(OSError):
             remaining = stream.read()
         if remaining:
-            stream_name = "stdout" if stream is process.stdout else "stderr"
+            stream_name = "stdout" if stream is stdout_pipe else "stderr"
             output[stream_name].append(remaining)
             output_bytes[stream_name] += len(remaining)
     stdout = b"".join(output["stdout"]).decode(errors="replace")
     stderr = b"".join(output["stderr"]).decode(errors="replace")
-    _write_pytest_output(stdout, stderr)
-    if artifacts is not None:
-        artifacts.stdout_path.write_text(stdout, encoding="utf-8")
-        artifacts.stderr_path.write_text(stderr, encoding="utf-8")
-        artifacts.output_path.write_text(stdout + stderr, encoding="utf-8")
+    receipt = read_receipt(launch.receipt_path)
+    if termination_reason is None and receipt is not None and receipt.get("status") == "terminated":
+        receipt_reason = receipt.get("termination_reason")
+        if isinstance(receipt_reason, str):
+            termination_reason = receipt_reason
+    receipt_exit = receipt.get("exit_code") if receipt is not None else None
+    returncode = (
+        forced_returncode
+        if forced_returncode is not None
+        else (int(receipt_exit) if isinstance(receipt_exit, int) else (process.returncode or 0))
+    )
+    containment = _containment_summary(launch, receipt)
     resource_summary: dict[str, Any] = {}
     if sampler is not None:
         sampler.sample(event="finished" if termination_reason is None else "terminated")
         resource_summary = sampler.summary()
     if termination_reason is not None:
+        controller_pgid = containment.get("controller_pgid", process.pid)
+        stderr = (
+            f"{stderr}\nverify: {termination_reason}; terminated owned pytest process group "
+            f"{controller_pgid} ({launch.mode})\n"
+        )
         _write_pytest_progress(
             event="terminated",
             cmd=cmd,
             started_at=t0,
             pid=process.pid,
-            returncode=124,
+            returncode=returncode,
             output_bytes=output_bytes,
             termination_reason=termination_reason,
             run_id=run.run_id if run is not None else None,
             artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
             resources=resource_summary,
+            containment=containment,
         )
-        stderr = f"{stderr}\nverify: {termination_reason}; terminated pytest process group {process.pid}\n"
-        return subprocess.CompletedProcess(cmd, 124, stdout, stderr)
-    _write_pytest_progress(
-        event="finished",
-        cmd=cmd,
-        started_at=t0,
-        pid=process.pid,
-        returncode=process.returncode or 0,
-        output_bytes=output_bytes,
-        run_id=run.run_id if run is not None else None,
-        artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
-        resources=resource_summary,
-    )
-    return subprocess.CompletedProcess(cmd, process.returncode or 0, stdout, stderr)
+    else:
+        _write_pytest_progress(
+            event="finished",
+            cmd=cmd,
+            started_at=t0,
+            pid=process.pid,
+            returncode=returncode,
+            output_bytes=output_bytes,
+            run_id=run.run_id if run is not None else None,
+            artifact_dir=str(artifacts.step_dir) if artifacts is not None else None,
+            resources=resource_summary,
+            containment=containment,
+        )
+    _write_pytest_output(stdout, stderr)
+    if artifacts is not None:
+        artifacts.stdout_path.write_text(stdout, encoding="utf-8")
+        artifacts.stderr_path.write_text(stderr, encoding="utf-8")
+        artifacts.output_path.write_text(stdout + stderr, encoding="utf-8")
+    return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
 
 
 def _run(
@@ -784,6 +1209,7 @@ def _run(
         metadata["heartbeat_s"] = _pytest_heartbeat_interval()
         metadata["timeout_s"] = _pytest_timeout_s()
         metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
+        metadata["term_grace_s"] = _pytest_term_grace_s()
         metadata["resource_interval_s"] = _pytest_resource_interval_s()
         metadata["pytest_tmpfs"] = pytest_tmpfs
         metadata["progress_path"] = str(PYTEST_PROGRESS_PATH)
@@ -794,6 +1220,7 @@ def _run(
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
         metadata["resources_path"] = str(CURRENT_RESOURCES_PATH)
         metadata["postmortem_path"] = str(CURRENT_POSTMORTEM_PATH)
+        metadata["containment_path"] = str(PYTEST_CONTAINMENT_PATH)
         metadata["basetemp_cleanup"] = str(basetemp_cleanup) if basetemp_cleanup is not None else None
         junit_paths = [
             str(path) for path in _pytest_artifact_paths(cmd) if path.suffix == ".xml" or path.name.endswith(".xml")
@@ -845,6 +1272,20 @@ def _run(
             slowest_reports = summary.get("slowest_reports")
             if isinstance(slowest_reports, list):
                 metadata["slowest_report_count"] = len(slowest_reports)
+        containment_path = artifacts.containment_path if artifacts is not None else PYTEST_CONTAINMENT_PATH
+        containment = _read_json_artifact(containment_path)
+        if containment is not None:
+            for source_key, metadata_key in (
+                ("mode", "containment_mode"),
+                ("unit", "containment_unit"),
+                ("cgroup_path", "containment_cgroup_path"),
+                ("controller_pid", "pytest_controller_pid"),
+                ("controller_pgid", "pytest_controller_pgid"),
+                ("signals_sent", "containment_signals_sent"),
+                ("escalated_to_sigkill", "containment_escalated_to_sigkill"),
+            ):
+                if source_key in containment:
+                    metadata[metadata_key] = containment[source_key]
         resource_summary: dict[str, Any] = {}
         if artifacts is not None and artifacts.resources_path.exists():
             sample_count = 0
@@ -892,6 +1333,13 @@ def _run(
                 "report_status": metadata.get("report_status"),
                 "progress_event": metadata.get("progress_event"),
                 "summary_exitstatus": summary.get("exitstatus") if isinstance(summary, dict) else None,
+                "containment_mode": metadata.get("containment_mode"),
+                "containment_unit": metadata.get("containment_unit"),
+                "containment_cgroup_path": metadata.get("containment_cgroup_path"),
+                "pytest_controller_pid": metadata.get("pytest_controller_pid"),
+                "pytest_controller_pgid": metadata.get("pytest_controller_pgid"),
+                "containment_signals_sent": metadata.get("containment_signals_sent"),
+                "containment_escalated_to_sigkill": metadata.get("containment_escalated_to_sigkill"),
                 **resource_summary,
             }
             artifacts.postmortem_path.write_text(json.dumps(postmortem, indent=2, ensure_ascii=False) + "\n")

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -26,6 +26,7 @@ VERIFY_RUNS_DIR = VERIFY_CACHE / "runs"
 CURRENT_RUN_PATH = VERIFY_CACHE / "current-run.json"
 CURRENT_RESOURCES_PATH = VERIFY_CACHE / "current-pytest-resources.jsonl"
 CURRENT_POSTMORTEM_PATH = VERIFY_CACHE / "current-pytest-postmortem.json"
+CURRENT_CONTAINMENT_PATH = VERIFY_CACHE / "current-pytest-containment.json"
 CURRENT_EVENTS_DIR = VERIFY_CACHE / "current-pytest-events"
 DEFAULT_BASETEMP_SIZE_SAMPLE_INTERVAL_S = 15.0
 BASETEMP_SIZE_SAMPLE_INTERVAL_ENV = "POLYLOGUE_VERIFY_BASETEMP_SIZE_INTERVAL_S"
@@ -122,6 +123,7 @@ class PytestStepArtifacts:
     summary_path: Path
     resources_path: Path
     postmortem_path: Path
+    containment_path: Path
 
 
 class VerifyRun:
@@ -173,6 +175,7 @@ class VerifyRun:
             summary_path=step_dir / "summary.json",
             resources_path=step_dir / "resources.jsonl",
             postmortem_path=step_dir / "postmortem.json",
+            containment_path=step_dir / "containment.json",
         )
         step_dir.mkdir(parents=True, exist_ok=True)
         self._payload["steps"].append(
@@ -216,6 +219,7 @@ def env_for_pytest_step(env: dict[str, str], *, run: VerifyRun, artifacts: Pytes
     updated["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(artifacts.events_merged_path)
     updated["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(artifacts.selection_path)
     updated["POLYLOGUE_PYTEST_SUMMARY_PATH"] = str(artifacts.summary_path)
+    updated["POLYLOGUE_PYTEST_CONTAINMENT_PATH"] = str(artifacts.containment_path)
     return updated
 
 
@@ -235,6 +239,8 @@ def copy_current_pytest_artifacts(root: Path, artifacts: PytestStepArtifacts, *,
         shutil.copyfile(artifacts.resources_path, root / CURRENT_RESOURCES_PATH)
     with contextlib.suppress(FileNotFoundError):
         shutil.copyfile(artifacts.postmortem_path, root / CURRENT_POSTMORTEM_PATH)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.copyfile(artifacts.containment_path, root / CURRENT_CONTAINMENT_PATH)
 
 
 def merge_worker_events(events_dir: Path, merged_path: Path) -> int:

--- a/docs/plans/test-clock-allowlist.yaml
+++ b/docs/plans/test-clock-allowlist.yaml
@@ -45,6 +45,8 @@ files:
     reason: "Verification-report timestamps use real now to assert ordering across artifacts."
   - path: tests/unit/devtools/test_verify_manifests.py
     reason: "Manifest-suppression expiry checks intentionally read the host date to validate the live policy decision."
+  - path: tests/unit/devtools/test_pytest_supervisor.py
+    reason: "Process-containment regressions poll real PIDs and cgroups across SIGKILL delivery; a frozen clock cannot advance kernel process state."
 
   # --- Pipeline / storage acquired_at timestamps (no production now() comparison) ---
   - path: tests/unit/pipeline/test_async_index.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ python_files = ["test_*.py", "*_test.py", "fuzz_*.py"]
 asyncio_mode = "auto"
 xfail_strict = true
 cache_dir = ".cache/pytest"
+# Every test is bounded by default. Tests that genuinely need longer must carry
+# an explicit @pytest.mark.timeout(...) override at the test site.
+timeout = 300
+timeout_method = "signal"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks integration tests (pipeline, CLI end-to-end)",

--- a/tests/unit/devtools/test_pytest_supervisor.py
+++ b/tests/unit/devtools/test_pytest_supervisor.py
@@ -255,6 +255,54 @@ def test_non_linux_platform_refuses_unsafe_group_fallback(
         )
 
 
+def test_launch_refuses_missing_exact_owner_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pytest_supervisor, "_process_start_ticks", lambda _pid: None)
+
+    with pytest.raises(RuntimeError, match="requires an exact owner process identity"):
+        build_supervisor_launch(
+            [sys.executable, "-c", "pass"],
+            owner_pid=os.getpid(),
+            timeout_s=1,
+            term_grace_s=0.1,
+            receipt_path=tmp_path / "containment.json",
+            run_id="missing-owner-identity",
+        )
+
+
+def test_supervisor_refuses_controller_without_subreaper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller_started = tmp_path / "controller-started"
+    receipt_path = tmp_path / "containment.json"
+    owner_start_ticks = _process_start_ticks(os.getpid())
+    assert owner_start_ticks is not None
+    monkeypatch.setattr(pytest_supervisor, "enable_child_subreaper", lambda: False)
+
+    rc = pytest_supervisor.supervise(
+        [sys.executable, "-c", f"from pathlib import Path; Path({str(controller_started)!r}).touch()"],
+        receipt_path=receipt_path,
+        owner_pid=os.getpid(),
+        owner_start_ticks=owner_start_ticks,
+        timeout_s=1,
+        term_grace_s=0.1,
+        mode="process-group",
+        unit=None,
+        runtime_cap_s=None,
+    )
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert rc == 125
+    assert not controller_started.exists()
+    assert receipt["status"] == "terminated"
+    assert receipt["startup_failure"] is True
+    assert receipt["subreaper_enabled"] is False
+    assert receipt["termination_reason"] == "pytest supervisor could not become a Linux child subreaper"
+
+
 def test_supervisor_rejects_owner_identity_captured_before_launch(tmp_path: Path) -> None:
     owner_start_ticks = _process_start_ticks(os.getpid())
     if owner_start_ticks is None:
@@ -338,6 +386,37 @@ def test_supervisor_kills_controller_when_receipt_publication_fails(tmp_path: Pa
     assert process.returncode != 0
     assert "injected receipt failure" in process.stderr
     _wait_for(lambda: not _same_process_alive(controller_identity))
+
+
+def test_surviving_owned_process_forces_nonzero_containment_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_path = tmp_path / "containment.json"
+    owner_start_ticks = _process_start_ticks(os.getpid())
+    assert owner_start_ticks is not None
+    monkeypatch.setattr(pytest_supervisor, "_terminate_controller_group", lambda *_args, **_kwargs: ([], False))
+    monkeypatch.setattr(pytest_supervisor, "_owned_processes_exist", lambda **_kwargs: True)
+
+    rc = pytest_supervisor.supervise(
+        [sys.executable, "-c", "pass"],
+        receipt_path=receipt_path,
+        owner_pid=os.getpid(),
+        owner_start_ticks=owner_start_ticks,
+        timeout_s=1,
+        term_grace_s=0,
+        mode="process-group",
+        unit=None,
+        runtime_cap_s=None,
+    )
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert rc == 125
+    assert receipt["status"] == "terminated"
+    assert receipt["exit_code"] == 125
+    assert receipt["controller_returncode"] == 0
+    assert receipt["controller_group_alive"] is True
+    assert receipt["termination_reason"] == "owned pytest processes survived cleanup"
 
 
 def test_managed_runner_retains_responsible_node_for_per_test_timeout(
@@ -470,10 +549,35 @@ def test_whole_run_deadline_bounds_stalled_supervisor_startup(
     assert "pytest runtime exceeded 0.2s" in output
 
 
+def test_runner_refuses_launch_without_subreaper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller_started = tmp_path / "controller-started"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("devtools.verify.enable_child_subreaper", lambda: False)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+
+    rc, _elapsed, metadata = _run(
+        "pytest missing runner subreaper",
+        [sys.executable, "-c", f"from pathlib import Path; Path({str(controller_started)!r}).touch()"],
+    )
+
+    receipt = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
+    assert rc == 125
+    assert not controller_started.exists()
+    assert metadata["diagnosis"] == "pytest_terminated"
+    assert metadata["termination_reason"] == "pytest runner could not become a Linux child subreaper"
+    assert receipt["status"] == "terminated"
+    assert receipt["startup_failure"] is True
+    assert receipt["runner_subreaper_enabled"] is False
+
+
 @pytest.mark.load_sensitive
 def test_runner_deadline_cleans_group_when_fallback_supervisor_is_sigkilled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     ready_path = tmp_path / "fallback-worker.json"
     hanging_test = tmp_path / "test_fallback_supervisor_death.py"
@@ -487,6 +591,15 @@ def test_runner_deadline_cleans_group_when_fallback_supervisor_is_sigkilled(
     monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
     run = VerifyRun(tier="fallback-supervisor-death", argv=[str(hanging_test)], git_head=None, root=tmp_path)
     receipt_path = run.run_dir / "steps" / "01-pytest-fallback-supervisor-death" / "containment.json"
+    unrelated = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    unrelated_identity = (unrelated.pid, _process_start_ticks(unrelated.pid))
+
+    def _cleanup_unrelated() -> None:
+        if unrelated.poll() is None:
+            unrelated.kill()
+        unrelated.wait(timeout=2)
+
+    request.addfinalizer(_cleanup_unrelated)
     observed_group: tuple[int, int] | None = None
     owned_identities: set[tuple[int, int | None]] = set()
     errors: list[BaseException] = []
@@ -547,6 +660,7 @@ def test_runner_deadline_cleans_group_when_fallback_supervisor_is_sigkilled(
     )
     assert "test_streams_forever" in events
     assert "pytest runtime exceeded 4s" in output
+    assert _same_process_alive(unrelated_identity)
 
 
 @pytest.mark.load_sensitive

--- a/tests/unit/devtools/test_pytest_supervisor.py
+++ b/tests/unit/devtools/test_pytest_supervisor.py
@@ -1,0 +1,798 @@
+"""Behavioral proofs for the managed pytest ownership boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+
+import pytest
+import tomllib
+
+import devtools.pytest_supervisor as pytest_supervisor
+from devtools.pytest_supervisor import (
+    CGROUP_MODE_ENV,
+    SupervisorLaunch,
+    build_supervisor_launch,
+    read_receipt,
+    signal_process_identity,
+    termination_request_path,
+    user_systemd_available,
+    write_termination_request,
+)
+from devtools.verify import PYTEST_CONTAINMENT_PATH, PYTEST_REPORT_PATH, ROOT, _run
+from devtools.verify_runs import VerifyRun
+
+
+def _wait_for(predicate: Callable[[], bool], *, timeout_s: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    assert predicate()
+
+
+def _wait_for_receipt(path: Path, *, status: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] | None = None
+
+    def _ready() -> bool:
+        nonlocal payload
+        candidate = read_receipt(path)
+        if candidate is None:
+            return False
+        payload = candidate
+        return status is None or candidate.get("status") == status
+
+    _wait_for(_ready)
+    assert payload is not None
+    return payload
+
+
+def _process_start_ticks(pid: int) -> int | None:
+    try:
+        fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+        return int(fields[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _same_process_alive(identity: tuple[int, int | None]) -> bool:
+    pid, start_ticks = identity
+    try:
+        fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+        state = fields[0]
+        current = int(fields[19])
+    except (OSError, IndexError, ValueError):
+        return False
+    return state != "Z" and current == start_ticks
+
+
+def _cgroup_processes(cgroup_path: str) -> set[int]:
+    path = Path("/sys/fs/cgroup") / cgroup_path.lstrip("/") / "cgroup.procs"
+    try:
+        return {int(row) for row in path.read_text(encoding="utf-8").splitlines() if row.strip()}
+    except OSError:
+        return set()
+
+
+def _session_processes(pgid: int, sid: int) -> set[int]:
+    processes: set[int] = set()
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / "stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()
+            state = fields[0]
+            process_pgid = int(fields[2])
+            process_sid = int(fields[3])
+        except (OSError, IndexError, ValueError):
+            continue
+        if state != "Z" and process_pgid == pgid and process_sid == sid:
+            processes.add(int(entry.name))
+    return processes
+
+
+def _kill_owned_scope(*, unit: str | None, pgid: int | None) -> None:
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if unit is not None:
+        subprocess.run(
+            ["systemctl", "--user", "kill", "--kill-whom=all", "--signal=SIGKILL", unit],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+
+
+def _write_hanging_xdist_test(path: Path) -> None:
+    path.write_text(
+        "import json\n"
+        "import os\n"
+        "import signal\n"
+        "import subprocess\n"
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n\n"
+        "def test_hangs_with_signal_resistant_descendant():\n"
+        "    child_code = (\n"
+        "        'import json, os, signal, time\\n'\n"
+        "        'from pathlib import Path\\n'\n"
+        "        'for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):\\n'\n"
+        "        '    signal.signal(sig, signal.SIG_IGN)\\n'\n"
+        "        \"Path(os.environ['POLYLOGUE_STUBBORN_READY']).write_text(\"\n"
+        "        \"json.dumps({'pid': os.getpid()}))\\n\"\n"
+        "        'time.sleep(60)\\n'\n"
+        "    )\n"
+        "    subprocess.Popen(\n"
+        "        [sys.executable, '-c', child_code],\n"
+        "        env=os.environ.copy(),\n"
+        "        stdout=subprocess.DEVNULL,\n"
+        "        stderr=subprocess.DEVNULL,\n"
+        "    )\n"
+        "    deadline = time.monotonic() + 5\n"
+        "    ready = Path(os.environ['POLYLOGUE_STUBBORN_READY'])\n"
+        "    while not ready.exists() and time.monotonic() < deadline:\n"
+        "        time.sleep(0.02)\n"
+        "    assert ready.exists()\n"
+        "    time.sleep(60)\n",
+        encoding="utf-8",
+    )
+
+
+def _write_streaming_xdist_test(path: Path, ready_path: Path) -> None:
+    path.write_text(
+        "import json\n"
+        "import os\n"
+        "import signal\n"
+        "import subprocess\n"
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n\n"
+        "def test_streams_forever():\n"
+        "    child_code = (\n"
+        "        'import signal, time\\n'\n"
+        "        'for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):\\n'\n"
+        "        '    signal.signal(sig, signal.SIG_IGN)\\n'\n"
+        "        'time.sleep(60)\\n'\n"
+        "    )\n"
+        "    child = subprocess.Popen([sys.executable, '-c', child_code], start_new_session=True)\n"
+        f"    Path({str(ready_path)!r}).write_text(\n"
+        "        json.dumps({'worker_pid': os.getpid(), 'escaped_pid': child.pid})\n"
+        "    )\n"
+        "    while True:\n"
+        "        print('fallback-controller-still-running', flush=True)\n"
+        "        time.sleep(0.02)\n",
+        encoding="utf-8",
+    )
+
+
+def _xdist_controller_cmd(path: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "no:testmon",
+        "-p",
+        "no:randomly",
+        "-p",
+        "devtools.pytest_progress_plugin",
+        f"--rootdir={ROOT}",
+        "-n",
+        "2",
+        "-q",
+        str(path),
+    ]
+
+
+def test_repository_pytest_timeout_policy_is_bounded_and_installed() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    dev_dependencies = config["project"]["optional-dependencies"]["dev"]
+    pytest_config = config["tool"]["pytest"]["ini_options"]
+
+    assert any(dependency.startswith("pytest-timeout") for dependency in dev_dependencies)
+    assert pytest_config["timeout"] == 300
+    assert pytest_config["timeout_method"] == "signal"
+
+
+def test_identity_signal_rejects_reused_pid_identity() -> None:
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        start_ticks = _process_start_ticks(process.pid)
+        assert start_ticks is not None
+        assert signal_process_identity(process.pid, start_ticks + 1, signal.SIGKILL) is False
+        assert process.poll() is None
+    finally:
+        process.kill()
+        process.wait(timeout=2)
+
+
+def test_identity_signal_rechecks_after_opening_pidfd(monkeypatch: pytest.MonkeyPatch) -> None:
+    read_fd, write_fd = os.pipe()
+    observations = iter((41, 42))
+    sent: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(pytest_supervisor, "_process_start_ticks", lambda _pid: next(observations))
+    monkeypatch.setattr(os, "pidfd_open", lambda _pid, _flags: read_fd)
+    monkeypatch.setattr(
+        signal,
+        "pidfd_send_signal",
+        lambda pidfd, sig: sent.append((pidfd, sig)),
+    )
+    try:
+        assert signal_process_identity(1234, 41, signal.SIGKILL) is False
+        assert sent == []
+    finally:
+        os.close(write_fd)
+
+
+def test_non_linux_platform_refuses_unsafe_group_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    with pytest.raises(RuntimeError, match="requires Linux process identities"):
+        build_supervisor_launch(
+            [sys.executable, "-c", "pass"],
+            owner_pid=os.getpid(),
+            timeout_s=1,
+            term_grace_s=0.1,
+            receipt_path=tmp_path / "containment.json",
+            run_id="non-linux",
+        )
+
+
+def test_supervisor_rejects_owner_identity_captured_before_launch(tmp_path: Path) -> None:
+    owner_start_ticks = _process_start_ticks(os.getpid())
+    if owner_start_ticks is None:
+        pytest.skip("kernel process start identity is unavailable")
+    receipt_path = tmp_path / "owner-reuse-containment.json"
+    env = os.environ.copy()
+    env[CGROUP_MODE_ENV] = "off"
+    launch = build_supervisor_launch(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        owner_pid=os.getpid(),
+        timeout_s=10,
+        term_grace_s=0.1,
+        receipt_path=receipt_path,
+        run_id="owner-reuse",
+        env=env,
+    )
+    argv = list(launch.argv)
+    ticks_index = argv.index("--owner-start-ticks") + 1
+    assert int(argv[ticks_index]) == owner_start_ticks
+    argv[ticks_index] = str(owner_start_ticks + 1)
+
+    process = subprocess.Popen(argv, cwd=ROOT, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _stdout, _stderr = process.communicate(timeout=3)
+    final = _wait_for_receipt(receipt_path, status="terminated")
+
+    assert process.returncode == 125
+    assert final["owner_start_ticks"] == owner_start_ticks + 1
+    assert final["termination_reason"] == f"pytest runner owner pid {os.getpid()} exited"
+    assert final["controller_group_alive"] is False
+
+
+def test_supervisor_kills_controller_when_receipt_publication_fails(tmp_path: Path) -> None:
+    ready_path = tmp_path / "setup-controller.json"
+    receipt_path = tmp_path / "unpublished-containment.json"
+    controller_code = (
+        "import json, os, time\n"
+        "from pathlib import Path\n"
+        "fields = Path('/proc/self/stat').read_text().rsplit(') ', 1)[1].split()\n"
+        f"Path({str(ready_path)!r}).write_text(json.dumps({{'pid': os.getpid(), 'start_ticks': int(fields[19])}}))\n"
+        "time.sleep(60)\n"
+    )
+    supervisor_code = (
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "import devtools.pytest_supervisor as supervisor\n"
+        f"ready = Path({str(ready_path)!r})\n"
+        "def fail_write(_path, _payload):\n"
+        "    deadline = time.monotonic() + 2\n"
+        "    while not ready.exists() and time.monotonic() < deadline:\n"
+        "        time.sleep(0.01)\n"
+        "    raise OSError('injected receipt failure')\n"
+        "supervisor._write_json = fail_write\n"
+        f"command = [sys.executable, '-c', {controller_code!r}]\n"
+        "raise SystemExit(supervisor.supervise(\n"
+        "    command,\n"
+        f"    receipt_path=Path({str(receipt_path)!r}),\n"
+        "    owner_pid=os.getppid(),\n"
+        "    owner_start_ticks=supervisor._process_start_ticks(os.getppid()),\n"
+        "    timeout_s=10,\n"
+        "    term_grace_s=0.1,\n"
+        "    mode='process-group',\n"
+        "    unit=None,\n"
+        "    runtime_cap_s=None,\n"
+        "))\n"
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+
+    process = subprocess.run(
+        [sys.executable, "-c", supervisor_code],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    controller = json.loads(ready_path.read_text(encoding="utf-8"))
+    controller_identity = (int(controller["pid"]), int(controller["start_ticks"]))
+    assert process.returncode != 0
+    assert "injected receipt failure" in process.stderr
+    _wait_for(lambda: not _same_process_alive(controller_identity))
+
+
+def test_managed_runner_retains_responsible_node_for_per_test_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hanging_test = tmp_path / "test_deliberate_per_test_timeout.py"
+    hanging_test.write_text(
+        "import time\n\ndef test_deliberate_per_test_timeout():\n    time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "10")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "10")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.2")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+    run = VerifyRun(tier="containment-per-test", argv=[str(hanging_test)], git_head=None, root=tmp_path)
+    report_path = tmp_path / PYTEST_REPORT_PATH
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "devtools.pytest_progress_plugin",
+        "-p",
+        "no:testmon",
+        "-p",
+        "no:randomly",
+        "--timeout=0.2",
+        "--timeout-method=signal",
+        f"--rootdir={ROOT}",
+        "--json-report",
+        f"--json-report-file={report_path}",
+        "-n",
+        "0",
+        "-q",
+        str(hanging_test),
+    ]
+
+    rc, _elapsed, metadata = _run("pytest per-test timeout", cmd, cwd=str(ROOT), run=run)
+
+    artifacts = run.run_dir / "steps" / "01-pytest-per-test-timeout"
+    output = (artifacts / "output.log").read_text(encoding="utf-8")
+    containment = json.loads((artifacts / "containment.json").read_text(encoding="utf-8"))
+    current_containment = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
+    assert rc != 0
+    assert "test_deliberate_per_test_timeout" in output
+    assert "Timeout" in output
+    assert containment["status"] == "finished"
+    assert containment["controller_returncode"] == rc
+    assert current_containment == containment
+    assert metadata["containment_mode"] in {"process-group", "systemd-scope"}
+    assert metadata["report_status"] == "present"
+
+
+def test_auto_mode_retries_when_systemd_scope_launch_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_systemd_run = tmp_path / "systemd-run"
+    fake_systemd_run.write_text("#!/bin/sh\necho 'scope denied' >&2\nexit 42\n", encoding="utf-8")
+    fake_systemd_run.chmod(0o755)
+    real_which = shutil.which
+
+    def _which(name: str, path: str | None = None) -> str | None:
+        if name == "systemd-run":
+            return str(fake_systemd_run)
+        return real_which(name, path=path)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(pytest_supervisor, "user_systemd_available", lambda _env=None: True)
+    monkeypatch.setattr(shutil, "which", _which)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "3")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "3")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.1")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+
+    rc, _elapsed, metadata = _run(
+        "pytest auto fallback",
+        [sys.executable, "-c", "print('fallback-controller-finished')"],
+    )
+
+    output = (tmp_path / ".cache/verify/current-pytest-output.log").read_text(encoding="utf-8")
+    receipt = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
+    assert rc == 0
+    assert metadata["containment_mode"] == "process-group"
+    assert receipt["mode"] == "process-group"
+    assert "scope denied" in output
+    assert "systemd scope launch failed; retrying" in output
+    assert "fallback-controller-finished" in output
+
+
+def test_whole_run_deadline_bounds_stalled_supervisor_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_systemd_run = tmp_path / "systemd-run"
+    fake_systemd_run.write_text("#!/bin/sh\nsleep 60\n", encoding="utf-8")
+    fake_systemd_run.chmod(0o755)
+    real_which = shutil.which
+
+    def _which(name: str, path: str | None = None) -> str | None:
+        if name == "systemd-run":
+            return str(fake_systemd_run)
+        return real_which(name, path=path)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(pytest_supervisor, "user_systemd_available", lambda _env=None: True)
+    monkeypatch.setattr(shutil, "which", _which)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0.2")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "10")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.1")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+
+    rc, elapsed, metadata = _run(
+        "pytest stalled startup",
+        [sys.executable, "-c", "raise AssertionError('controller must not start')"],
+    )
+
+    receipt = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
+    output = (tmp_path / ".cache/verify/current-pytest-output.log").read_text(encoding="utf-8")
+    assert rc == 124
+    assert elapsed < 2
+    assert metadata["termination_reason"] == "pytest runtime exceeded 0.2s"
+    assert receipt["status"] == "terminated"
+    assert receipt["startup_failure"] is True
+    assert receipt["runner_forced_cleanup"] is True
+    assert receipt["controller_command"][-1] == "raise AssertionError('controller must not start')"
+    assert "pytest runtime exceeded 0.2s" in output
+
+
+@pytest.mark.load_sensitive
+def test_runner_deadline_cleans_group_when_fallback_supervisor_is_sigkilled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ready_path = tmp_path / "fallback-worker.json"
+    hanging_test = tmp_path / "test_fallback_supervisor_death.py"
+    _write_streaming_xdist_test(hanging_test, ready_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(CGROUP_MODE_ENV, "off")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0.05")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "4")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "10")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.1")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+    run = VerifyRun(tier="fallback-supervisor-death", argv=[str(hanging_test)], git_head=None, root=tmp_path)
+    receipt_path = run.run_dir / "steps" / "01-pytest-fallback-supervisor-death" / "containment.json"
+    observed_group: tuple[int, int] | None = None
+    owned_identities: set[tuple[int, int | None]] = set()
+    errors: list[BaseException] = []
+
+    def _kill_supervisor() -> None:
+        nonlocal observed_group, owned_identities
+        try:
+            running = _wait_for_receipt(receipt_path, status="running")
+            _wait_for(ready_path.exists)
+            controller_pid = running["controller_pid"]
+            controller_pgid = running["controller_pgid"]
+            controller_sid = running["controller_sid"]
+            supervisor_pid = running["supervisor_pid"]
+            supervisor_start_ticks = running["supervisor_start_ticks"]
+            assert isinstance(controller_pid, int)
+            assert isinstance(controller_pgid, int)
+            assert isinstance(controller_sid, int)
+            assert isinstance(supervisor_pid, int)
+            assert isinstance(supervisor_start_ticks, int)
+            ready = json.loads(ready_path.read_text(encoding="utf-8"))
+            worker_pid = int(ready["worker_pid"])
+            escaped_pid = int(ready["escaped_pid"])
+            owned_pids = _session_processes(controller_pgid, controller_sid)
+            assert {controller_pid, worker_pid} <= owned_pids
+            assert escaped_pid not in owned_pids
+            assert len(owned_pids) >= 3
+            observed_group = (controller_pgid, controller_sid)
+            owned_identities = {(pid, _process_start_ticks(pid)) for pid in owned_pids} | {
+                (escaped_pid, _process_start_ticks(escaped_pid))
+            }
+            assert signal_process_identity(supervisor_pid, supervisor_start_ticks, signal.SIGKILL)
+        except BaseException as exc:
+            errors.append(exc)
+
+    killer = threading.Thread(target=_kill_supervisor, daemon=True)
+    killer.start()
+    cmd = _xdist_controller_cmd(hanging_test)
+    cmd.insert(-1, "-s")
+    rc, elapsed, metadata = _run("pytest fallback supervisor death", cmd, cwd=str(ROOT), run=run)
+    killer.join(timeout=5)
+
+    assert not killer.is_alive()
+    assert errors == []
+    assert rc == 124
+    assert elapsed < 7
+    assert metadata["termination_reason"] == "pytest runtime exceeded 4s"
+    assert metadata["containment_mode"] == "process-group"
+    final = _wait_for_receipt(receipt_path, status="terminated")
+    assert final["runner_forced_cleanup"] is True
+    assert final["exit_code"] == 124
+    _wait_for(lambda: not any(_same_process_alive(identity) for identity in owned_identities))
+    assert observed_group is not None
+    controller_pgid, controller_sid = observed_group
+    _wait_for(lambda: not _session_processes(controller_pgid, controller_sid))
+    output = (run.run_dir / "steps" / "01-pytest-fallback-supervisor-death" / "output.log").read_text(encoding="utf-8")
+    events = (run.run_dir / "steps" / "01-pytest-fallback-supervisor-death" / "events.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert "test_streams_forever" in events
+    assert "pytest runtime exceeded 4s" in output
+
+
+@pytest.mark.load_sensitive
+def test_controller_sigkill_clears_exact_owned_xdist_cgroup(tmp_path: Path) -> None:
+    if not user_systemd_available():
+        pytest.skip("user systemd is unavailable; process-group fallback is covered by timeout tests")
+
+    ready_path = tmp_path / "stubborn-child.json"
+    hanging_test = tmp_path / "test_deliberate_controller_kill.py"
+    _write_hanging_xdist_test(hanging_test)
+    receipt_path = tmp_path / "containment.json"
+    env = os.environ.copy()
+    env[CGROUP_MODE_ENV] = "require"
+    env["POLYLOGUE_STUBBORN_READY"] = str(ready_path)
+    env["PYTHONPATH"] = str(ROOT) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    controller_cmd = _xdist_controller_cmd(hanging_test)
+    launch = build_supervisor_launch(
+        controller_cmd,
+        owner_pid=os.getpid(),
+        timeout_s=30,
+        term_grace_s=0.25,
+        receipt_path=receipt_path,
+        run_id="sigkill-regression",
+        env=env,
+    )
+    process = subprocess.Popen(
+        launch.argv,
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    unrelated = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        start_new_session=True,
+    )
+    unrelated_identity = (unrelated.pid, _process_start_ticks(unrelated.pid))
+    controller_pgid: int | None = None
+    try:
+        running = _wait_for_receipt(receipt_path, status="running")
+        controller_pid_raw = running["controller_pid"]
+        controller_pgid_raw = running["controller_pgid"]
+        assert isinstance(controller_pid_raw, int)
+        assert isinstance(controller_pgid_raw, int)
+        controller_pid = controller_pid_raw
+        controller_pgid = controller_pgid_raw
+        cgroup_path = str(running["cgroup_path"])
+        unit_state = subprocess.run(
+            [
+                "systemctl",
+                "--user",
+                "show",
+                str(launch.unit),
+                "--property=ControlGroup",
+                "--property=KillMode",
+                "--property=RuntimeMaxUSec",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        ).stdout
+        assert "KillMode=control-group" in unit_state
+        assert "RuntimeMaxUSec=" in unit_state and "RuntimeMaxUSec=infinity" not in unit_state
+        assert f"ControlGroup={cgroup_path}" in unit_state
+        _wait_for(ready_path.exists)
+        stubborn_pid = int(json.loads(ready_path.read_text(encoding="utf-8"))["pid"])
+        _wait_for(lambda: stubborn_pid in _cgroup_processes(cgroup_path))
+        owned_pids = _cgroup_processes(cgroup_path)
+        assert {process.pid, controller_pid, stubborn_pid} <= owned_pids
+        assert len(owned_pids) >= 5  # supervisor + controller + two xdist workers + stubborn child
+        owned_identities = {(pid, _process_start_ticks(pid)) for pid in owned_pids}
+
+        cleanup_started_at = time.monotonic()
+        cleanup_deadline = cleanup_started_at + 5.0
+        os.kill(controller_pid, signal.SIGKILL)
+        stdout, stderr = process.communicate(timeout=max(0.001, cleanup_deadline - time.monotonic()))
+        _wait_for(
+            lambda: not any(_same_process_alive(identity) for identity in owned_identities),
+            timeout_s=max(0.0, cleanup_deadline - time.monotonic()),
+        )
+        _wait_for(
+            lambda: not _cgroup_processes(cgroup_path),
+            timeout_s=max(0.0, cleanup_deadline - time.monotonic()),
+        )
+        assert time.monotonic() <= cleanup_deadline
+
+        final = _wait_for_receipt(receipt_path, status="terminated")
+        assert process.returncode == 137
+        assert final["controller_returncode"] == -signal.SIGKILL
+        assert final["signals_sent"] == ["SIGTERM", "SIGKILL"]
+        assert final["escalated_to_sigkill"] is True
+        assert final["controller_group_alive"] is False
+        assert _same_process_alive(unrelated_identity)
+        assert unrelated.poll() is None
+        assert "pytest controller exited by signal SIGKILL" in stderr
+        assert stdout == ""
+    finally:
+        if process.poll() is None:
+            write_termination_request(launch.request_path, reason="regression cleanup", exit_code=125)
+            os.kill(process.pid, signal.SIGTERM)
+            try:
+                process.communicate(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
+        _kill_owned_scope(unit=launch.unit, pgid=controller_pgid)
+        if unrelated.poll() is None:
+            unrelated.kill()
+        unrelated.wait(timeout=2)
+
+
+@pytest.mark.load_sensitive
+def test_owner_sigkill_clears_exact_owned_xdist_cgroup(tmp_path: Path) -> None:
+    if not user_systemd_available():
+        pytest.skip("user systemd is unavailable; owner-watch fallback is Linux process-group only")
+
+    ready_path = tmp_path / "owner-stubborn-child.json"
+    hanging_test = tmp_path / "test_deliberate_owner_kill.py"
+    receipt_path = tmp_path / "owner-containment.json"
+    _write_hanging_xdist_test(hanging_test)
+    env = os.environ.copy()
+    env[CGROUP_MODE_ENV] = "require"
+    env["POLYLOGUE_STUBBORN_READY"] = str(ready_path)
+    env["POLYLOGUE_OWNER_RECEIPT"] = str(receipt_path)
+    env["POLYLOGUE_OWNER_COMMAND"] = json.dumps(_xdist_controller_cmd(hanging_test))
+    env["PYTHONPATH"] = str(ROOT) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    owner_script = (
+        "import json, os, subprocess, time\n"
+        "from pathlib import Path\n"
+        "from devtools.pytest_supervisor import build_supervisor_launch\n"
+        "command = json.loads(os.environ['POLYLOGUE_OWNER_COMMAND'])\n"
+        "receipt = Path(os.environ['POLYLOGUE_OWNER_RECEIPT'])\n"
+        "launch = build_supervisor_launch(command, owner_pid=os.getpid(), timeout_s=30, term_grace_s=0.25, "
+        "receipt_path=receipt, run_id='owner-sigkill-regression', env=os.environ)\n"
+        "subprocess.Popen(launch.argv, cwd=os.environ['POLYLOGUE_REPO_ROOT'], env=os.environ.copy(), "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)\n"
+        "time.sleep(60)\n"
+    )
+    env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
+    owner = subprocess.Popen([sys.executable, "-c", owner_script], cwd=ROOT, env=env, start_new_session=True)
+    unit: str | None = None
+    controller_pgid: int | None = None
+    try:
+        running = _wait_for_receipt(receipt_path, status="running")
+        unit = str(running["unit"])
+        cgroup_path = str(running["cgroup_path"])
+        controller_pgid_raw = running["controller_pgid"]
+        assert isinstance(controller_pgid_raw, int)
+        controller_pgid = controller_pgid_raw
+        _wait_for(ready_path.exists)
+        stubborn_pid = int(json.loads(ready_path.read_text(encoding="utf-8"))["pid"])
+        _wait_for(lambda: stubborn_pid in _cgroup_processes(cgroup_path))
+        owned_identities = {(pid, _process_start_ticks(pid)) for pid in _cgroup_processes(cgroup_path)}
+        assert len(owned_identities) >= 4
+
+        os.kill(owner.pid, signal.SIGKILL)
+        owner.wait(timeout=2)
+        final = _wait_for_receipt(receipt_path, status="terminated")
+        _wait_for(lambda: not any(_same_process_alive(identity) for identity in owned_identities))
+        _wait_for(lambda: not _cgroup_processes(cgroup_path))
+
+        assert final["termination_reason"] == f"pytest runner owner pid {owner.pid} exited"
+        assert final["exit_code"] == 125
+        assert final["signals_sent"] == ["SIGTERM", "SIGKILL"]
+        assert final["controller_group_alive"] is False
+    finally:
+        if owner.poll() is None:
+            os.kill(owner.pid, signal.SIGKILL)
+            owner.wait(timeout=2)
+        _kill_owned_scope(unit=unit, pgid=controller_pgid)
+
+
+def test_runner_bounds_post_supervisor_pipe_drain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ready_path = tmp_path / "escaped-pipe-child.json"
+
+    def _fake_launch(
+        controller_cmd: Sequence[str],
+        *,
+        owner_pid: int,
+        timeout_s: float,
+        term_grace_s: float,
+        receipt_path: Path,
+        run_id: str | None,
+        env: Mapping[str, str] | None = None,
+    ) -> SupervisorLaunch:
+        del controller_cmd, owner_pid, timeout_s, term_grace_s, run_id, env
+        receipt_path = receipt_path.absolute()
+        child_code = (
+            "import json, os, signal, time\n"
+            "from pathlib import Path\n"
+            "for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP): signal.signal(sig, signal.SIG_IGN)\n"
+            "fields = Path('/proc/self/stat').read_text().rsplit(') ', 1)[1].split()\n"
+            f"Path({str(ready_path)!r}).write_text(json.dumps({{'pid': os.getpid(), 'start_ticks': int(fields[19])}}))\n"
+            "time.sleep(60)\n"
+        )
+        fake_supervisor = (
+            "import json, os, subprocess, sys\n"
+            "from pathlib import Path\n"
+            f"child = subprocess.Popen([sys.executable, '-c', {child_code!r}], start_new_session=True)\n"
+            "fields = Path(f'/proc/{child.pid}/stat').read_text().rsplit(') ', 1)[1].split()\n"
+            "self_fields = Path('/proc/self/stat').read_text().rsplit(') ', 1)[1].split()\n"
+            "payload = {'schema_version': 1, 'status': 'finished', 'supervisor_pid': os.getpid(), "
+            "'supervisor_start_ticks': int(self_fields[19]), 'controller_pid': child.pid, "
+            "'controller_start_ticks': int(fields[19]), 'controller_pgid': int(fields[2]), "
+            "'controller_sid': int(fields[3]), 'controller_returncode': 0, 'exit_code': 0, "
+            "'termination_reason': None, 'signals_sent': [], 'escalated_to_sigkill': False, "
+            "'controller_group_alive': True, 'mode': 'process-group', 'unit': None, "
+            "'cgroup_path': None, 'cgroup_owned': False}\n"
+            f"Path({str(receipt_path)!r}).parent.mkdir(parents=True, exist_ok=True)\n"
+            f"Path({str(receipt_path)!r}).write_text(json.dumps(payload))\n"
+        )
+        return SupervisorLaunch(
+            [sys.executable, "-c", fake_supervisor],
+            receipt_path,
+            termination_request_path(receipt_path),
+            "process-group",
+            None,
+            None,
+        )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "10")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "0")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.1")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S", "0")
+    monkeypatch.setattr("devtools.verify.build_supervisor_launch", _fake_launch)
+
+    child_identity: tuple[int, int] | None = None
+    try:
+        rc, elapsed, metadata = _run("pytest escaped pipe", [sys.executable, "-c", "pass"])
+
+        child = json.loads(ready_path.read_text(encoding="utf-8"))
+        child_identity = (int(child["pid"]), int(child["start_ticks"]))
+        assert rc == 125
+        assert elapsed < 3
+        assert metadata["termination_reason"] == "pytest supervisor exited while owned output pipes remained open"
+        assert metadata["containment_mode"] == "process-group"
+        assert not _same_process_alive(child_identity)
+    finally:
+        if child_identity is None and ready_path.exists():
+            child = json.loads(ready_path.read_text(encoding="utf-8"))
+            child_identity = (int(child["pid"]), int(child["start_ticks"]))
+        if child_identity is not None:
+            signal_process_identity(child_identity[0], child_identity[1], signal.SIGKILL)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from devtools.verify import (
+    PYTEST_CONTAINMENT_PATH,
     PYTEST_EVENTS_PATH,
     PYTEST_JUNIT_REPORT_PATH,
     PYTEST_OUTPUT_PATH,
@@ -34,6 +35,7 @@ from devtools.verify import (
 )
 from devtools.verify_runs import (
     ResourceSampler,
+    VerifyRun,
     classify_pytest_result,
     cleanup_managed_pytest_basetemp,
     pytest_basetemp_path,
@@ -558,7 +560,8 @@ def test_pytest_run_emits_heartbeat_for_long_silent_child(
     assert rc == 0
     assert metadata["heartbeat_s"] == 0.1
     assert "command:" in captured.err
-    assert "still running: pid=" in captured.err
+    assert "still running: supervisor=" in captured.err
+    assert ", controller=" in captured.err
     assert "elapsed=" in captured.err
 
 
@@ -672,26 +675,43 @@ def test_pytest_run_preserves_other_lane_reports(
 
 
 def test_pytest_run_terminates_after_runtime_budget(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "0.05")
-    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0.15")
+    monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "1")
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "0")
+    run = VerifyRun(tier="timeout-artifact", argv=[], git_head=None, root=tmp_path)
 
-    rc, _elapsed, metadata = _run("pytest timeout", [sys.executable, "-c", "import time; time.sleep(5)"])
+    rc, _elapsed, metadata = _run(
+        "pytest timeout",
+        [sys.executable, "-c", "import time; time.sleep(5)"],
+        run=run,
+    )
 
     captured = capsys.readouterr()
+    step_containment = json.loads(
+        (run.run_dir / "steps" / "01-pytest-timeout" / "containment.json").read_text(encoding="utf-8")
+    )
+    current_containment = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
     assert rc == 124
-    assert metadata["timeout_s"] == 0.15
+    assert metadata["timeout_s"] == 1.0
     assert metadata["stall_timeout_s"] == 0.0
     assert metadata["events_path"] == str(PYTEST_EVENTS_PATH)
     assert metadata["output_path"] == str(PYTEST_OUTPUT_PATH)
     assert metadata["report_path"] is None
     assert metadata["report_status"] == "missing"
     assert metadata["progress_event"] == "terminated"
-    assert metadata["termination_reason"] == "pytest runtime exceeded 0.15s"
-    assert "pytest runtime exceeded 0.15s" in captured.err
-    assert "terminated pytest process group" in captured.err
+    assert metadata["termination_reason"] == "pytest runtime exceeded 1s"
+    assert metadata["containment_mode"] in {"process-group", "systemd-scope"}
+    assert metadata["containment_signals_sent"] == ["SIGTERM"]
+    assert step_containment == current_containment
+    assert current_containment["status"] == "terminated"
+    assert current_containment["termination_reason"] == "pytest runtime exceeded 1s"
+    assert "pytest runtime exceeded 1s" in captured.err
+    assert "terminated owned pytest process group" in captured.err
 
 
 def test_pytest_run_terminates_with_heartbeat_disabled(
@@ -727,7 +747,7 @@ def test_pytest_run_terminates_after_output_stall(
     assert metadata["stall_timeout_s"] == 0.15
     assert "progress" in captured.err
     assert "pytest produced no output for 0.15s" in captured.err
-    assert "terminated pytest process group" in captured.err
+    assert "terminated owned pytest process group" in captured.err
 
 
 def test_pytest_run_terminates_on_progress_stall_despite_flowing_output(
@@ -771,7 +791,7 @@ def test_pytest_run_terminates_on_progress_stall_despite_flowing_output(
     assert "pytest produced no output" not in captured.err
     assert "pytest reported no test progress for 0.15s" in captured.err
     assert "wedged::test" in captured.err
-    assert "terminated pytest process group" in captured.err
+    assert "terminated owned pytest process group" in captured.err
 
 
 def test_pytest_timeout_env_defaults_and_invalid_values(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Managed pytest runs now have three independent containment layers: a
repository per-test timeout, an external exact-identity supervisor with a
whole-run deadline, and a transient systemd cgroup on supported Linux hosts
with a process-group/subreaper fallback. Incomplete cleanup is itself a hard
test failure, and termination evidence is copied into the normal verify
artifacts.

## Problem

A killed or wedged pytest controller could leave xdist workers and
signal-resistant descendants resident after the managed runner exited.
Controller-local EXIT handlers cannot address SIGKILL, and name-based process
cleanup could affect unrelated runs. The first published implementation also
had two review-proven trust gaps: surviving owned processes did not change a
successful controller result, and fallback escalation treated every runner
descendant as owned.

## Solution

- Configure a 300-second pytest-timeout default using the signal method.
- Route devtools test and pytest-bearing verify steps through
  devtools/pytest_supervisor.py.
- Capture PID start ticks before launch, use pidfds when available, and signal
  only matching process identities.
- Launch pytest in a new session, send SIGTERM to its owned group, escalate to
  SIGKILL after a bounded grace, and reap escaped descendants through Linux
  subreapers.
- Prefer a unique user-systemd scope with KillMode=control-group and
  RuntimeMaxSec; retry with the Linux process-group boundary when automatic
  scope startup fails.
- Make any surviving owned identity a nonzero containment failure even when
  the pytest controller returned zero.
- Preserve exact pre-existing runner descendant roots during fallback
  recovery so unrelated child workloads are never signalled.
- Refuse controller launch when exact /proc identity or child-subreaper
  prerequisites are unavailable.
- Bound startup, execution, supervisor-death, and inherited-pipe drain paths
  with the same outer deadline.
- Publish the containment receipt beside each step and as
  .cache/verify/current-pytest-containment.json.

## Acceptance Criteria

- [x] AC1: pytest-timeout is a normal test dependency with a 300-second
  repository default. Longer overrides remain explicit. Automated override
  linting is honestly deferred to polylogue-c3qh.
- [x] AC2: the managed runner enforces a configurable whole-run deadline,
  exact-group TERM/KILL escalation, and normal-artifact evidence.
- [x] AC3: actual pytest -n 2 regressions kill the controller and owner with
  SIGKILL, prove all exact owned identities and the cgroup empty under one
  five-second deadline, and leave unrelated sentinels untouched. The fallback
  proof additionally preserves an unrelated child of the runner.
- [x] AC4: actual per-test and whole-run hangs exit nonzero with responsible
  node/run diagnostics retained.
- [x] AC5: focused containment tests, the quick gate, graph lint, and a manual
  cgroup receipt pass.

## Verification

- `devtools test tests/unit/devtools/test_pytest_supervisor.py -n 0`
  - `17 passed in 15.67s`
- Focused runner selector over heartbeat/runtime/stall behavior
  - `6 passed, 54 deselected in 4.17s`
- Exact fallback supervisor-death and unrelated-child regression
  - `1 passed in 6.15s`
- `mypy --strict devtools/pytest_supervisor.py devtools/verify.py tests/unit/devtools/test_pytest_supervisor.py`
  - `Success: no issues found in 3 source files`
- `devtools verify --quick` from commit `c4f4fd01e`
  - run `20260711T185456Z-quick-611461-e7b27a51`
  - `13/13 steps passed; exit_code=0; total_duration_s=18.94`
- `.agent/scripts/bd-graph-lint`
  - `violations: dup_labels=0 inversions=0 missing_ac=0`
- Post-run `systemctl --user list-units 'polylogue-pytest-*' --all`
  - no surviving units

The original false-green injection now returns exit 125 with status
`terminated`, `controller_group_alive=true`, and reason `owned pytest
processes survived cleanup`.

Anti-vacuity: the regression route is `devtools test -> run_tests.main ->
verify._run -> _run_pytest_with_heartbeat -> build_supervisor_launch ->
pytest_supervisor.supervise -> actual pytest/xdist`. Removing residue failure
classification makes the successful-controller fault injection green.
Removing the preserved-root filter kills the fallback sentinel. Removing the
identity/subreaper gates creates the controller-start marker and fails the
preflight proofs.

## Adversarial Review Notes

Five independent gpt-5.6-terra high-effort iterations hardened startup,
identity pinning, owner/supervisor death, cgroup cleanup, inherited-pipe drain,
and the shared five-second proof deadline before publication.

A sixth independent review of immutable commit `73cf1168b` found four valid
gaps. Commit `c4f4fd01e` makes surviving owned processes fail the run, replaces
broad fallback descendant signalling with preserved exact roots, fails closed
when identity/subreaper prerequisites are missing, and narrows the unshipped
timeout-lint claim to follow-up bead polylogue-c3qh.

Ref polylogue-lxyt
