### PR TITLE
fix(storage): unify cross-route revision authority

### DIFF
--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from polylogue.core.timestamps import parse_timestamp
 from polylogue.pipeline.ids import SessionRevisionProjection
 
 
@@ -11,6 +12,7 @@ from polylogue.pipeline.ids import SessionRevisionProjection
 class MembershipRevision:
     raw_id: str
     projection: SessionRevisionProjection
+    provider_updated_at: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,15 +26,37 @@ def classify_membership_revisions(revisions: list[MembershipRevision]) -> Member
     """Accept one total strict-growth chain; never choose between branches."""
     if not revisions:
         return MembershipClassification((), (), ())
-    by_session_hash: dict[bytes, list[MembershipRevision]] = {}
+    by_content: dict[tuple[tuple[bytes, ...], tuple[bytes, ...], frozenset[bytes]], list[MembershipRevision]] = {}
     for revision in revisions:
-        by_session_hash.setdefault(revision.projection.session_hash, []).append(revision)
+        projection = revision.projection
+        key = (projection.message_hashes, projection.event_hashes, projection.attachment_hashes)
+        by_content.setdefault(key, []).append(revision)
     representatives: list[MembershipRevision] = []
     equivalents: list[str] = []
-    for group in by_session_hash.values():
-        ordered_group = sorted(group, key=lambda item: item.raw_id)
-        representatives.append(ordered_group[0])
-        equivalents.extend(item.raw_id for item in ordered_group[1:])
+    for group in by_content.values():
+        by_session_hash: dict[bytes, list[MembershipRevision]] = {}
+        for item in group:
+            by_session_hash.setdefault(item.projection.session_hash, []).append(item)
+        metadata_variants: list[MembershipRevision] = []
+        for hash_group in by_session_hash.values():
+            representative = min(hash_group, key=lambda item: item.raw_id)
+            metadata_variants.append(representative)
+            equivalents.extend(item.raw_id for item in hash_group if item.raw_id != representative.raw_id)
+        if len(metadata_variants) == 1:
+            representatives.extend(metadata_variants)
+            continue
+        timestamped = [
+            (parsed.timestamp(), item)
+            for item in metadata_variants
+            if (parsed := parse_timestamp(item.provider_updated_at)) is not None
+        ]
+        timestamps = [timestamp for timestamp, _item in timestamped]
+        if len(timestamped) == len(metadata_variants) and len(set(timestamps)) == len(timestamps):
+            representative = max(timestamped, key=lambda pair: pair[0])[1]
+            representatives.append(representative)
+            equivalents.extend(item.raw_id for item in metadata_variants if item.raw_id != representative.raw_id)
+        else:
+            representatives.extend(metadata_variants)
     representatives.sort(key=lambda item: (_frontier(item.projection), item.raw_id))
     if any(
         not _strictly_dominates(older.projection, newer.projection)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1591,28 +1591,49 @@ class LiveBatchProcessor:
                     if len(sessions) == 1:
                         session = sessions[0]
                         logical_source_key = f"{provider.value}:{session.provider_session_id}"
-                        archive.bind_raw_revision(
-                            source_raw_id,
-                            RawRevisionEnvelope(
-                                logical_source_key=logical_source_key,
-                                kind=RawRevisionKind.FULL,
-                                source_revision=record.captured_source_revision or source_raw_id,
-                                acquisition_generation=0,
-                                authority=RawRevisionAuthority.QUARANTINED,
-                            ),
-                        )
-                        plan = archive.classify_raw_revision_cohort(logical_source_key)
-                        if not plan.accepted_raw_ids:
-                            continue
-                        parsed_by_raw_id = self._parse_raw_revision_chain(archive, plan)
-                        session_id, applied_raw_ids = archive.apply_raw_revision_replay(
-                            plan,
-                            parsed_by_raw_id,
-                            acquired_at_ms=acquired_at_ms,
-                        )
-                        record_session_ids.append(session_id)
-                        record_session_count = 1
-                        record_message_count = sum(len(parsed_by_raw_id[raw_id].messages) for raw_id in applied_raw_ids)
+                        if archive.raw_membership_raw_ids(logical_source_key):
+                            archive.replace_raw_membership_census(
+                                source_raw_id,
+                                sessions,
+                                parser_fingerprint=self._current_parser_fingerprint(),
+                                censused_at_ms=acquired_at_ms,
+                            )
+                            (
+                                record_session_ids,
+                                record_session_count,
+                                record_message_count,
+                                raw_authority_complete,
+                            ) = self._apply_membership_sessions(
+                                archive,
+                                source_raw_id,
+                                sessions,
+                                acquired_at_ms=acquired_at_ms,
+                            )
+                        else:
+                            archive.bind_raw_revision(
+                                source_raw_id,
+                                RawRevisionEnvelope(
+                                    logical_source_key=logical_source_key,
+                                    kind=RawRevisionKind.FULL,
+                                    source_revision=record.captured_source_revision or source_raw_id,
+                                    acquisition_generation=0,
+                                    authority=RawRevisionAuthority.QUARANTINED,
+                                ),
+                            )
+                            plan = archive.classify_raw_revision_cohort(logical_source_key)
+                            if not plan.accepted_raw_ids:
+                                continue
+                            parsed_by_raw_id = self._parse_raw_revision_chain(archive, plan)
+                            session_id, applied_raw_ids = archive.apply_raw_revision_replay(
+                                plan,
+                                parsed_by_raw_id,
+                                acquired_at_ms=acquired_at_ms,
+                            )
+                            record_session_ids.append(session_id)
+                            record_session_count = 1
+                            record_message_count = sum(
+                                len(parsed_by_raw_id[raw_id].messages) for raw_id in applied_raw_ids
+                            )
                     else:
                         archive.replace_raw_membership_census(
                             source_raw_id,
@@ -1620,43 +1641,17 @@ class LiveBatchProcessor:
                             parser_fingerprint=self._current_parser_fingerprint(),
                             censused_at_ms=acquired_at_ms,
                         )
-                        for session in sessions:
-                            logical_source_key = f"{session.source_name.value}:{session.provider_session_id}"
-                            member_sessions: dict[str, Any] = {}
-                            projections: dict[str, Any] = {}
-                            revisions: list[MembershipRevision] = []
-                            for member_raw_id in archive.raw_membership_raw_ids(logical_source_key):
-                                retained_sessions = (
-                                    sessions
-                                    if member_raw_id == source_raw_id
-                                    else self._parse_retained_raw_sessions(archive, member_raw_id)
-                                )
-                                matches = [
-                                    item
-                                    for item in retained_sessions
-                                    if f"{item.source_name.value}:{item.provider_session_id}" == logical_source_key
-                                ]
-                                if len(matches) != 1:
-                                    raise RuntimeError(
-                                        f"membership {member_raw_id}:{logical_source_key} no longer parses uniquely"
-                                    )
-                                projection = session_revision_projection(matches[0])
-                                member_sessions[member_raw_id] = matches[0]
-                                projections[member_raw_id] = projection
-                                revisions.append(MembershipRevision(member_raw_id, projection))
-                            classification = classify_membership_revisions(revisions)
-                            membership_session_id = archive.apply_raw_membership_classification(
-                                logical_source_key,
-                                classification,
-                                member_sessions,
-                                projections,
-                                acquired_at_ms=acquired_at_ms,
-                            )
-                            if membership_session_id is not None:
-                                record_session_ids.append(membership_session_id)
-                                record_session_count += 1
-                                record_message_count += len(session.messages)
-                        raw_authority_complete = archive.raw_membership_authority_complete(source_raw_id)
+                        (
+                            record_session_ids,
+                            record_session_count,
+                            record_message_count,
+                            raw_authority_complete,
+                        ) = self._apply_membership_sessions(
+                            archive,
+                            source_raw_id,
+                            sessions,
+                            acquired_at_ms=acquired_at_ms,
+                        )
                     if raw_authority_complete:
                         result.raw_ids[record.raw_id] = record_raw_id
                     result.session_ids.extend(record_session_ids)
@@ -1691,6 +1686,81 @@ class LiveBatchProcessor:
                 raise RuntimeError(f"raw revision {raw_id} did not replay to exactly one session")
             parsed_by_raw_id[raw_id] = sessions[0]
         return parsed_by_raw_id
+
+    def _apply_membership_sessions(
+        self,
+        archive: Any,
+        source_raw_id: str,
+        sessions: list[Any],
+        *,
+        acquired_at_ms: int,
+    ) -> tuple[list[str], int, int, bool]:
+        session_ids: list[str] = []
+        session_count = 0
+        message_count = 0
+        for session in sessions:
+            logical_source_key = f"{session.source_name.value}:{session.provider_session_id}"
+            for revision_raw_id in archive.convertible_full_revision_raw_ids(logical_source_key):
+                retained_sessions = (
+                    sessions
+                    if revision_raw_id == source_raw_id
+                    else self._parse_retained_raw_sessions(archive, revision_raw_id)
+                )
+                matches = [
+                    item
+                    for item in retained_sessions
+                    if f"{item.source_name.value}:{item.provider_session_id}" == logical_source_key
+                ]
+                if len(retained_sessions) != 1 or len(matches) != 1:
+                    raise RuntimeError(
+                        f"full revision {revision_raw_id}:{logical_source_key} no longer parses uniquely"
+                    )
+                archive.replace_raw_membership_census(
+                    revision_raw_id,
+                    retained_sessions,
+                    parser_fingerprint=self._current_parser_fingerprint(),
+                    censused_at_ms=acquired_at_ms,
+                    detail="cross-route full revision governance",
+                    retire_full_revision_governance=True,
+                )
+            member_sessions: dict[str, Any] = {}
+            projections: dict[str, Any] = {}
+            revisions: list[MembershipRevision] = []
+            for member_raw_id in archive.raw_membership_raw_ids(logical_source_key):
+                retained_sessions = (
+                    sessions
+                    if member_raw_id == source_raw_id
+                    else self._parse_retained_raw_sessions(archive, member_raw_id)
+                )
+                matches = [
+                    item
+                    for item in retained_sessions
+                    if f"{item.source_name.value}:{item.provider_session_id}" == logical_source_key
+                ]
+                if len(matches) != 1:
+                    raise RuntimeError(f"membership {member_raw_id}:{logical_source_key} no longer parses uniquely")
+                projection = session_revision_projection(matches[0])
+                member_sessions[member_raw_id] = matches[0]
+                projections[member_raw_id] = projection
+                revisions.append(MembershipRevision(member_raw_id, projection, matches[0].updated_at))
+            classification = classify_membership_revisions(revisions)
+            membership_session_id = archive.apply_raw_membership_classification(
+                logical_source_key,
+                classification,
+                member_sessions,
+                projections,
+                acquired_at_ms=acquired_at_ms,
+            )
+            if membership_session_id is not None:
+                session_ids.append(membership_session_id)
+                session_count += 1
+                message_count += len(member_sessions[classification.accepted_raw_ids[-1]].messages)
+        return (
+            session_ids,
+            session_count,
+            message_count,
+            archive.raw_membership_authority_complete(source_raw_id),
+        )
 
     @staticmethod
     def _parse_retained_raw_sessions(archive: Any, raw_id: str) -> list[Any]:

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -310,7 +310,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         title=envelope.session.title or envelope.provenance.page_title or provider_session_id,
         session_kind=_session_kind_for_browser_capture(envelope, provider_session_id),
         created_at=envelope.session.created_at,
-        updated_at=envelope.session.updated_at or envelope.provenance.captured_at,
+        updated_at=envelope.session.updated_at,
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
         attachments=attachments,

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -166,7 +166,7 @@ def backfill_historical_revision_evidence(
                 projection = session_revision_projection(session)
                 member_sessions[raw_id] = session
                 projections[raw_id] = projection
-                revisions.append(MembershipRevision(raw_id, projection))
+                revisions.append(MembershipRevision(raw_id, projection, session.updated_at))
                 retained_bytes += payload_bytes
             if retention_observer is not None:
                 retention_observer(len(member_sessions), retained_bytes)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1670,10 +1670,48 @@ class ArchiveStore:
         parser_fingerprint: str,
         censused_at_ms: int,
         detail: str = "",
+        retire_full_revision_governance: bool = False,
     ) -> None:
         """Atomically replace one raw's complete parser census and memberships."""
         conn = self._ensure_source_conn()
         with conn:
+            if retire_full_revision_governance:
+                revision = conn.execute(
+                    "SELECT logical_source_key, revision_kind FROM raw_sessions WHERE raw_id = ?",
+                    (raw_id,),
+                ).fetchone()
+                if revision is None:
+                    raise RuntimeError(f"membership census raw is missing: {raw_id}")
+                if revision[0] is not None and str(revision[1]) != RawRevisionKind.FULL.value:
+                    raise RuntimeError("only self-contained full raws can move to membership governance")
+                dependent = conn.execute(
+                    """
+                    SELECT 1 FROM raw_sessions
+                    WHERE raw_id != ?
+                      AND (predecessor_raw_id = ? OR baseline_raw_id = ?)
+                    LIMIT 1
+                    """,
+                    (raw_id, raw_id, raw_id),
+                ).fetchone()
+                if dependent is not None:
+                    raise RuntimeError("an active byte-revision chain cannot move to membership governance")
+                conn.execute(
+                    """
+                    UPDATE raw_sessions
+                    SET logical_source_key = NULL,
+                        revision_kind = 'unknown',
+                        source_revision = NULL,
+                        predecessor_raw_id = NULL,
+                        baseline_raw_id = NULL,
+                        append_start_offset = NULL,
+                        append_end_offset = NULL,
+                        acquisition_generation = NULL,
+                        revision_authority = 'quarantined',
+                        predecessor_source_revision = NULL
+                    WHERE raw_id = ?
+                    """,
+                    (raw_id,),
+                )
             conn.execute("DELETE FROM raw_session_memberships WHERE raw_id = ?", (raw_id,))
             if sessions is not None:
                 for session in sessions:
@@ -1710,6 +1748,25 @@ class ArchiveStore:
                 """,
                 (raw_id, parser_fingerprint, status, len(sessions or []), censused_at_ms, detail),
             )
+
+    def convertible_full_revision_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
+        """Return a full-only byte cohort that can join semantic membership."""
+        rows = (
+            self._ensure_source_conn()
+            .execute(
+                """
+            SELECT raw_id, revision_kind
+            FROM raw_sessions
+            WHERE logical_source_key = ?
+            ORDER BY raw_id
+            """,
+                (logical_source_key,),
+            )
+            .fetchall()
+        )
+        if not rows or any(str(row[1]) != RawRevisionKind.FULL.value for row in rows):
+            return ()
+        return tuple(str(row[0]) for row in rows)
 
     def expand_raw_membership_selection(self, raw_ids: list[str] | None) -> tuple[tuple[str, ...], tuple[str, ...]]:
         """Expand scheduling hints to the complete transitive membership cohort."""
@@ -2057,6 +2114,30 @@ class ArchiveStore:
                 self._blob_publisher.flush()
             write_source_blob_refs(conn, accepted_raw_id, refs)
             with self._conn:
+                existing_head = self._conn.execute(
+                    """
+                    SELECT accepted_raw_id, accepted_content_hash, accepted_frontier_kind
+                    FROM raw_revision_heads WHERE logical_source_key = ?
+                    """,
+                    (logical_source_key,),
+                ).fetchone()
+                if existing_head is not None and str(existing_head[2]) == "byte":
+                    existing_raw_id = str(existing_head[0])
+                    existing_projection = projections_by_raw_id.get(existing_raw_id)
+                    classified_raw_ids = {
+                        *classification.accepted_raw_ids,
+                        *classification.equivalent_raw_ids,
+                    }
+                    if (
+                        existing_projection is None
+                        or existing_raw_id not in classified_raw_ids
+                        or bytes(existing_head[1]) != existing_projection.session_hash
+                    ):
+                        raise RuntimeError("membership replay cannot retire an unrelated byte head")
+                    self._conn.execute(
+                        "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
+                        (logical_source_key,),
+                    )
                 result = self._index_parsed_for_retained_raw(
                     accepted_session,
                     raw_id=accepted_raw_id,

--- a/tests/unit/archive/test_session_revision_membership.py
+++ b/tests/unit/archive/test_session_revision_membership.py
@@ -31,3 +31,72 @@ def test_refuses_divergent_maxima() -> None:
     )
     assert result.accepted_raw_ids == ()
     assert result.ambiguous_raw_ids == ("raw-a", "raw-b", "raw-c")
+
+
+def test_metadata_only_revision_uses_latest_provider_timestamp() -> None:
+    def revision(raw_id: str, updated_at: str | None, *, title: str = "title") -> MembershipRevision:
+        session = ParsedSession(
+            source_name=Provider.CHATGPT,
+            provider_session_id="session",
+            title=title,
+            updated_at=updated_at,
+            messages=[ParsedMessage(provider_message_id="0", role=Role.USER, text="one")],
+        )
+        return MembershipRevision(raw_id, session_revision_projection(session), updated_at)
+
+    older = revision("raw-old", "2026-01-01T00:00:00Z")
+    newer = revision("raw-new", "2026-01-02T00:00:00Z")
+    assert older.projection.session_hash != newer.projection.session_hash
+
+    result = classify_membership_revisions([older, newer])
+
+    assert result.accepted_raw_ids == ("raw-new",)
+    assert result.equivalent_raw_ids == ("raw-old",)
+    assert result.ambiguous_raw_ids == ()
+
+
+def test_metadata_revision_without_complete_provider_time_is_ambiguous() -> None:
+    with_timestamp = ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id="session",
+        title="new title",
+        updated_at="2026-01-02T00:00:00Z",
+        messages=[ParsedMessage(provider_message_id="0", role=Role.USER, text="one")],
+    )
+    missing_timestamp = with_timestamp.model_copy(update={"title": "old title", "updated_at": None})
+
+    result = classify_membership_revisions(
+        [
+            MembershipRevision("raw-new", session_revision_projection(with_timestamp), with_timestamp.updated_at),
+            MembershipRevision(
+                "raw-old",
+                session_revision_projection(missing_timestamp),
+                missing_timestamp.updated_at,
+            ),
+        ]
+    )
+
+    assert result.accepted_raw_ids == ()
+    assert result.ambiguous_raw_ids == ("raw-new", "raw-old")
+
+
+def test_metadata_revisions_with_equal_provider_time_are_ambiguous() -> None:
+    timestamp = "2026-01-02T00:00:00Z"
+    first = ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id="session",
+        title="first",
+        updated_at=timestamp,
+        messages=[ParsedMessage(provider_message_id="0", role=Role.USER, text="one")],
+    )
+    second = first.model_copy(update={"title": "second"})
+
+    result = classify_membership_revisions(
+        [
+            MembershipRevision("raw-a", session_revision_projection(first), timestamp),
+            MembershipRevision("raw-b", session_revision_projection(second), timestamp),
+        ]
+    )
+
+    assert result.accepted_raw_ids == ()
+    assert result.ambiguous_raw_ids == ("raw-a", "raw-b")

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -77,12 +77,24 @@ def test_browser_capture_parses_session_metadata_and_deduplicates_turns() -> Non
     assert session.source_name is Provider.CHATGPT
     assert session.provider_session_id == "conv-123"
     assert session.title == "Work plan"
+    assert session.updated_at == "2026-04-24T00:00:01+00:00"
     assert [message.provider_message_id for message in session.messages] == ["u1", "a1"]
     assert len(session.attachments) == 1
     assert session.attachments[0].message_provider_id == "a1"
     assert session.attachments[0].source_url == "https://chatgpt.com/attachment/1"
     assert DOM_FALLBACK_INGEST_FLAG in session.ingest_flags
     assert NATIVE_BROWSER_CAPTURE_INGEST_FLAG not in session.ingest_flags
+
+
+def test_browser_capture_does_not_launder_capture_time_as_provider_update() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    del session_payload["updated_at"]
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")
+
+    assert parsed[0].updated_at is None
 
 
 def test_browser_capture_embedded_attachment_payloads_become_inline_bytes() -> None:

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -13,6 +13,11 @@ import pytest
 
 import polylogue.sources.live.watcher as live_watcher
 from polylogue.archive.message.roles import Role
+from polylogue.archive.revision_authority import (
+    RawRevisionAuthority,
+    RawRevisionEnvelope,
+    RawRevisionKind,
+)
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.sources.dispatch import parse_payload
@@ -2573,6 +2578,234 @@ def test_live_multi_session_divergence_reopens_raw_authority(
             ("safe-2",),
             ("shared",),
         }
+
+
+def test_single_session_full_terminally_supersedes_older_membership_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    bundle = root / "bundle.jsonl"
+    older = root / "older.jsonl"
+    bundle.write_bytes(b'{"bundle":true}\n')
+    older.write_bytes(b'{"older":true}\n')
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+
+    def session(native_id: str, *texts: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            messages=[
+                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
+                for index, text in enumerate(texts)
+            ],
+        )
+
+    bundle_sessions = [session("shared", "base", "new"), session("safe", "one")]
+    parsed_batches = iter([bundle_sessions, [session("shared", "base")]])
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.parse_stream_payload",
+        lambda *_args, **_kwargs: next(parsed_batches),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda _archive, _raw_id: bundle_sessions,
+    )
+
+    assert processor._ingest_full_paths_sync([bundle], source_name="codex").failed == []
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        rejected_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=older.read_bytes(),
+            source_path=str(older),
+            acquired_at_ms=1,
+        )
+        archive.bind_raw_revision(
+            rejected_raw_id,
+            RawRevisionEnvelope(
+                logical_source_key="codex:shared",
+                kind=RawRevisionKind.FULL,
+                source_revision=sha256(older.read_bytes()).hexdigest(),
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+    older_result = processor._ingest_full_paths_sync([older], source_name="codex")
+
+    assert older_result.succeeded == [older]
+    assert older_result.failed == []
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute("SELECT message_count FROM sessions WHERE native_id = 'shared'").fetchone() == (2,)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            """
+            SELECT m.decision, r.parsed_at_ms IS NOT NULL, r.parse_error,
+                   r.logical_source_key, r.revision_kind
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE r.source_path = ? AND m.logical_source_key = 'codex:shared'
+            """,
+            (str(older),),
+        ).fetchone() == ("superseded_prefix", 1, None, None, "unknown")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _unclassified, revision_keys = archive.raw_revision_rebuild_selection([rejected_raw_id])
+        _membership_raws, membership_keys = archive.expand_raw_membership_selection([rejected_raw_id])
+    assert revision_keys == ()
+    assert "codex:shared" in membership_keys
+
+
+def test_single_session_full_cannot_overwrite_divergent_membership_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    bundle = root / "bundle.jsonl"
+    divergent = root / "divergent.jsonl"
+    bundle.write_bytes(b'{"bundle":true}\n')
+    divergent.write_bytes(b'{"divergent":true}\n')
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+
+    def session(native_id: str, *texts: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            messages=[
+                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
+                for index, text in enumerate(texts)
+            ],
+        )
+
+    bundle_sessions = [session("shared", "base", "left"), session("safe", "one")]
+    parsed_batches = iter([bundle_sessions, [session("shared", "base", "right", "extra")]])
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.parse_stream_payload",
+        lambda *_args, **_kwargs: next(parsed_batches),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda _archive, _raw_id: bundle_sessions,
+    )
+
+    assert processor._ingest_full_paths_sync([bundle], source_name="codex").failed == []
+    divergent_result = processor._ingest_full_paths_sync([divergent], source_name="codex")
+
+    assert divergent_result.succeeded == []
+    assert divergent_result.failed == [divergent]
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute(
+            """
+            SELECT m.position, b.search_text
+            FROM messages AS m
+            JOIN blocks AS b USING (message_id)
+            WHERE m.session_id = 'codex-session:shared'
+            ORDER BY m.position, b.position
+            """
+        ).fetchall() == [(0, "base"), (1, "left")]
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            """
+            SELECT m.decision, r.parsed_at_ms, r.parse_error
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE r.source_path = ? AND m.logical_source_key = 'codex:shared'
+            """,
+            (str(divergent),),
+        ).fetchone() == ("ambiguous", None, None)
+
+
+def test_bundle_promotes_prior_single_full_into_membership_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    single = root / "single.jsonl"
+    bundle = root / "bundle.jsonl"
+    single.write_bytes(b'{"single":true}\n')
+    bundle.write_bytes(b'{"bundle":true}\n')
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+
+    def session(native_id: str, *texts: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            messages=[
+                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
+                for index, text in enumerate(texts)
+            ],
+        )
+
+    single_session = session("shared", "base")
+    bundle_sessions = [session("shared", "base", "new"), session("safe", "one")]
+    parsed_batches = iter([[single_session], bundle_sessions])
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.parse_stream_payload",
+        lambda *_args, **_kwargs: next(parsed_batches),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda _archive, _raw_id: [single_session],
+    )
+
+    assert processor._ingest_full_paths_sync([single], source_name="codex").failed == []
+    bundle_result = processor._ingest_full_paths_sync([bundle], source_name="codex")
+
+    assert bundle_result.succeeded == [bundle]
+    assert bundle_result.failed == []
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute(
+            """
+            SELECT s.message_count, h.accepted_frontier_kind
+            FROM sessions AS s
+            JOIN raw_revision_heads AS h USING (session_id)
+            WHERE s.native_id = 'shared'
+            """
+        ).fetchone() == (2, "semantic")
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            """
+            SELECT m.decision, r.logical_source_key, r.revision_kind
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE r.source_path = ? AND m.logical_source_key = 'codex:shared'
+            """,
+            (str(single),),
+        ).fetchone() == ("superseded_prefix", None, "unknown")
 
 
 def test_append_crash_after_index_commit_repairs_idempotently(


### PR DESCRIPTION
## Summary

Unify single-session full captures and multi-session export members under one typed semantic revision authority when they describe the same logical session.

## Problem

Production post-repair catch-up proved the existing split was arrival-order dependent. An older Gemini full snapshot retried forever against a semantic head, while a ChatGPT browser capture for an account-export session collided at the same frontier. More seriously, a numerically larger but divergent single capture could pass cardinality-only CAS and overwrite the membership-governed session.

Ref polylogue-yla8.

## Solution

- Move only self-contained, append-independent full cohorts from byte revision fields into durable membership census rows.
- Handle both bundle-first and single-first arrival, including raws already bound by a previous failed deployed attempt.
- Transition a related byte head to semantic authority inside the same index transaction as the replacement and receipts.
- Keep divergent or insufficiently ordered metadata variants ambiguous and retry-visible.
- Accept metadata-only revisions only with pairwise-unique direct provider update timestamps.
- Stop browser capture from substituting provenance capture time for missing provider `updated_at`.
- Reuse one membership application helper and report the accepted cohort member's message count.

## Verification

- `devtools test -k 'single_session_full or bundle_promotes_prior_single_full or live_multi_session_divergence or metadata_revision or browser_capture_does_not_launder' tests/unit/sources/test_live_batch_support.py tests/unit/archive/test_session_revision_membership.py tests/unit/sources/test_browser_capture.py` — 7 passed.
- `devtools test tests/unit/archive/test_session_revision_membership.py` — 5 passed.
- `devtools test tests/unit/storage/test_revision_replay.py::test_full_replay_preserves_semantic_head_and_rolls_back_regressions` — 1 passed.
- `devtools verify --quick` — run `20260711T220233Z-quick-1445786-3516ef36`, 13/13 steps passed.
- Full `test_live_batch_support.py` result was 47 passed / 6 failed; all six exact failures reproduced unchanged on a clean detached `origin/master` checkout and are unrelated baseline failures.
- Three independent adversarial review rounds found and then verified closure of dual-governance, reverse-arrival, rebuild-stability, byte-head rollback, and timestamp-laundering blockers; final review found no release blocker.

Anti-vacuity: on `origin/master`, the older cross-route full rejects instead of becoming terminal, a larger divergent single full overwrites by cardinality, already-bound failed raws remain byte-selected during rebuild, and reverse arrival hits incomparable frontier authority. The new real ArchiveStore/source/index tests require all four outcomes to change while preserving ambiguous branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revision selection when provider update timestamps distinguish otherwise equivalent membership data.
  * Prevented missing capture metadata from being treated as a provider update time.
  * Improved full-ingest membership precedence and handling of conflicting revisions.
  * Preserved previously accepted messages when divergent revisions are rejected.
* **Tests**
  * Added coverage for timestamp-based selection, ambiguous metadata, browser capture timestamps, and live-ingest authority transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->