### PR TITLE
fix(storage): apply authorized semantic head transitions

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2121,7 +2121,7 @@ class ArchiveStore:
                     """,
                     (logical_source_key,),
                 ).fetchone()
-                if existing_head is not None and str(existing_head[2]) == "byte":
+                if existing_head is not None:
                     existing_raw_id = str(existing_head[0])
                     existing_projection = projections_by_raw_id.get(existing_raw_id)
                     classified_raw_ids = {
@@ -2133,7 +2133,7 @@ class ArchiveStore:
                         or existing_raw_id not in classified_raw_ids
                         or bytes(existing_head[1]) != existing_projection.session_hash
                     ):
-                        raise RuntimeError("membership replay cannot retire an unrelated byte head")
+                        raise RuntimeError("membership replay cannot retire an unrelated accepted head")
                     self._conn.execute(
                         "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
                         (logical_source_key,),

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -2737,6 +2737,68 @@ def test_single_session_full_cannot_overwrite_divergent_membership_head(
         ).fetchone() == ("ambiguous", None, None)
 
 
+def test_single_session_full_advances_authorized_metadata_only_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    bundle = root / "bundle.jsonl"
+    metadata_update = root / "metadata-update.jsonl"
+    bundle.write_bytes(b'{"bundle":true}\n')
+    metadata_update.write_bytes(b'{"metadata_update":true}\n')
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+
+    def session(native_id: str, title: str, updated_at: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            title=title,
+            updated_at=updated_at,
+            messages=[ParsedMessage(provider_message_id=f"{native_id}-0", role=Role.USER, text="same content")],
+        )
+
+    older = session("shared", "old title", "2026-01-01T00:00:00Z")
+    newer = session("shared", "new title", "2026-01-02T00:00:00Z")
+    bundle_sessions = [older, session("safe", "safe", "2026-01-01T00:00:00Z")]
+    parsed_batches = iter([bundle_sessions, [newer]])
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.parse_stream_payload",
+        lambda *_args, **_kwargs: next(parsed_batches),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda _archive, _raw_id: bundle_sessions,
+    )
+
+    assert processor._ingest_full_paths_sync([bundle], source_name="codex").failed == []
+    update_result = processor._ingest_full_paths_sync([metadata_update], source_name="codex")
+
+    assert update_result.succeeded == [metadata_update]
+    assert update_result.failed == []
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute(
+            """
+            SELECT s.title, s.updated_at_ms, h.accepted_frontier_kind,
+                   h.accepted_content_hash = s.content_hash
+            FROM sessions AS s
+            JOIN raw_revision_heads AS h USING (session_id)
+            WHERE s.native_id = 'shared'
+            """
+        ).fetchone() == ("new title", 1767312000000, "semantic", 1)
+
+
 def test_bundle_promotes_prior_single_full_into_membership_authority(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Allow the membership classifier's proven metadata-only successor to replace an equal-frontier semantic head atomically.

## Problem

The first packaged retry after PR #2716 still rejected the production ChatGPT capture. Membership classification selected the later metadata revision using direct provider timestamps, but generic equal-frontier CAS rejected the changed session hash before updating the head.

Ref polylogue-yla8.

## Solution

Retire an existing accepted head, byte or semantic, only when its accepted raw belongs to the classifier's accepted/equivalent cohort and its reparsed projection hash exactly matches the stored accepted hash. Head retirement, authoritative replacement, FTS proof, immutable receipts, and the new semantic head remain one index transaction. Ambiguous/divergent classifications never reach this path.

## Verification

- Metadata-only live-route advancement plus larger-divergence containment: 2 passed.
- `devtools verify --quick`: final-head run `20260711T221806Z-quick-1498581-d007ebfe`, 13/13 passed.
- Independent adversarial review found no authority widening, rollback, or anti-vacuity blocker.
- Packaged production evidence before this patch: classifier reached equal-frontier CAS and failed with `raw revision CAS rejected a conflicting accepted head`; the new test reproduces that exact pre-patch failure.
