### PR TITLE
fix(storage): preserve byte heads during membership replay

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1726,7 +1726,11 @@ class LiveBatchProcessor:
             member_sessions: dict[str, Any] = {}
             projections: dict[str, Any] = {}
             revisions: list[MembershipRevision] = []
-            for member_raw_id in archive.raw_membership_raw_ids(logical_source_key):
+            member_raw_ids = list(archive.raw_membership_raw_ids(logical_source_key))
+            accepted_head_raw_id = archive.raw_revision_head_raw_id(logical_source_key)
+            if accepted_head_raw_id is not None and accepted_head_raw_id not in member_raw_ids:
+                member_raw_ids.append(accepted_head_raw_id)
+            for member_raw_id in member_raw_ids:
                 retained_sessions = (
                     sessions
                     if member_raw_id == source_raw_id

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1866,6 +1866,14 @@ class ArchiveStore:
         )
         return tuple(str(row[0]) for row in rows)
 
+    def raw_revision_head_raw_id(self, logical_source_key: str) -> str | None:
+        """Return the currently indexed accepted raw for one logical session."""
+        row = self._conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?",
+            (logical_source_key,),
+        ).fetchone()
+        return None if row is None else str(row[0])
+
     def raw_membership_authority_complete(self, raw_id: str) -> bool:
         row = (
             self._ensure_source_conn()
@@ -2134,6 +2142,12 @@ class ArchiveStore:
                         or bytes(existing_head[1]) != existing_projection.session_hash
                     ):
                         raise RuntimeError("membership replay cannot retire an unrelated accepted head")
+                    existing_is_byte_governed = conn.execute(
+                        "SELECT 1 FROM raw_sessions WHERE raw_id = ? AND logical_source_key = ?",
+                        (existing_raw_id, logical_source_key),
+                    ).fetchone()
+                    if existing_is_byte_governed is not None and accepted_raw_id != existing_raw_id:
+                        raise RuntimeError("membership replay cannot replace an unconvertible byte head")
                     self._conn.execute(
                         "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
                         (logical_source_key,),

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -2666,6 +2666,142 @@ def test_single_session_full_terminally_supersedes_older_membership_prefix(
     assert "codex:shared" in membership_keys
 
 
+@pytest.mark.parametrize(
+    ("bundle_texts", "succeeds", "census_head"),
+    [
+        (("base",), True, False),
+        (("base", "different"), False, False),
+        (("base", "new", "later"), False, False),
+        (("base", "new", "later"), False, True),
+    ],
+)
+def test_bundle_replay_respects_unconvertible_single_session_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bundle_texts: tuple[str, ...],
+    succeeds: bool,
+    census_head: bool,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    current = root / "current.jsonl"
+    older_bundle = root / "older-bundle.jsonl"
+    current.write_bytes(b'{"current":true}\n')
+    older_bundle.write_bytes(b'{"bundle":true}\n')
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+
+    def session(native_id: str, *texts: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            messages=[
+                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
+                for index, text in enumerate(texts)
+            ],
+        )
+
+    current_session = session("shared", "base", "new")
+    bundle_sessions = [session("shared", *bundle_texts), session("safe", "one")]
+    parsed_batches = iter([[current_session], bundle_sessions])
+    current_raw_id: list[str] = []
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.parse_stream_payload",
+        lambda *_args, **_kwargs: next(parsed_batches),
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda archive, raw_id: (
+            [current_session] if Path(archive.raw_revision_material(raw_id)[2]) == current else bundle_sessions
+        ),
+    )
+
+    assert processor._ingest_full_paths_sync([current], source_name="codex").failed == []
+    with sqlite3.connect(index_db) as conn:
+        row = conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'codex:shared'"
+        ).fetchone()
+        assert row is not None
+        current_raw_id.append(str(row[0]))
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        source_revision = (
+            archive._ensure_source_conn()
+            .execute(
+                "SELECT source_revision FROM raw_sessions WHERE raw_id = ?",
+                (current_raw_id[0],),
+            )
+            .fetchone()
+        )
+        assert source_revision is not None
+        append_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"append":true}\n',
+            source_path=str(current),
+            source_index=-1,
+            acquired_at_ms=2,
+        )
+        archive.bind_raw_revision(
+            append_raw_id,
+            RawRevisionEnvelope(
+                "codex:shared",
+                RawRevisionKind.APPEND,
+                "append-blocker",
+                0,
+                predecessor_source_revision=str(source_revision[0]),
+                append_start_offset=1,
+                append_end_offset=2,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+        assert archive.convertible_full_revision_raw_ids("codex:shared") == ()
+        if census_head:
+            archive.replace_raw_membership_census(
+                current_raw_id[0],
+                [current_session],
+                parser_fingerprint="test-parser",
+                censused_at_ms=2,
+            )
+    with sqlite3.connect(index_db) as conn:
+        head_before = conn.execute(
+            "SELECT accepted_raw_id, accepted_frontier_kind, accepted_frontier "
+            "FROM raw_revision_heads WHERE logical_source_key = 'codex:shared'"
+        ).fetchone()
+        assert head_before is not None
+
+    result = processor._ingest_full_paths_sync([older_bundle], source_name="codex")
+
+    assert result.failed == ([] if succeeds else [older_bundle])
+    assert result.succeeded == ([older_bundle] if succeeds else [])
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute("SELECT message_count FROM sessions WHERE native_id = 'shared'").fetchone() == (2,)
+        head_after = conn.execute(
+            "SELECT accepted_raw_id, accepted_frontier_kind, accepted_frontier "
+            "FROM raw_revision_heads WHERE logical_source_key = 'codex:shared'"
+        ).fetchone()
+        assert head_after == ((current_raw_id[0], "semantic", 2) if succeeds else head_before)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM raw_session_memberships WHERE raw_id = ?",
+            (current_raw_id[0],),
+        ).fetchone() == ((1,) if census_head else (0,))
+        decisions = conn.execute(
+            "SELECT decision FROM raw_session_memberships WHERE logical_source_key = 'codex:shared' AND raw_id != ?",
+            (current_raw_id[0],),
+        ).fetchall()
+        if succeeds:
+            assert decisions == [("superseded_prefix",)]
+
+
 def test_single_session_full_cannot_overwrite_divergent_membership_head(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Preserve an accepted byte-governed session head while older multi-session raw snapshots are classified, without allowing membership replay to create a rebuild-unstable cross-route transition.

## Problem

Production catch-up after PR #2717 reached duplicated Codex recovery snapshots for `019f49d8-0185-7c43-8793-db6e57db13e1`. The current 83.9 MB accepted full raw was absent from the 18-row membership cohort because append evidence kept the logical session under byte governance. Membership replay therefore could not relate the older snapshot to the accepted head and failed with `membership replay cannot retire an unrelated accepted head`.

A naive replacement based on membership census presence is unsafe: backfill can census a byte-governed raw without retiring its append chain, while cold rebuild still treats the byte chain as authoritative.

## Solution

- Expose the currently indexed accepted raw to the live membership classifier.
- Include that raw as comparison evidence when it is absent from the membership cohort.
- Permit replay to preserve the same accepted raw and terminally classify older prefixes.
- Reject replacement while the accepted raw still has source-tier byte governance, including backfill-created dual-census state.
- Keep divergent and newer membership evidence fail-closed until governance can be durably unified.

Ref polylogue-rgh2.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k 'bundle_replay_respects_unconvertible_single_session_head or single_session_full_terminally_supersedes_older_membership_prefix or single_session_full_cannot_overwrite_divergent_membership_head'`
  - `6 passed, 53 deselected`
- `devtools verify --quick`
  - run `20260711T223845Z-quick-1560566-2b7f5fce`, `13/13` steps passed
- Independent adversarial review: no release blocker after two correction rounds.

Anti-vacuity: the regression fixture creates append evidence so the accepted full raw cannot migrate into membership governance and asserts it is absent from membership. Removing the accepted-head injection makes the older-prefix case fail; removing the byte-governance guard lets the newer dual-census case replace the pinned head.
