### PR TITLE
fix(storage): reconcile equivalent revision receipts

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/revision_application.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_application.py
@@ -124,16 +124,47 @@ def record_revision_application_sync(
             """,
             (receipt.decision_id,),
         ).fetchone()
-        expected = (
-            receipt.raw_id,
-            receipt.session_id,
-            receipt.decision.value,
-            receipt.accepted_raw_id,
-            receipt.accepted_source_revision,
-            receipt.accepted_content_hash,
-        )
-        if existing is None or tuple(existing) != expected:
-            raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+        if existing is not None:
+            expected = (
+                receipt.raw_id,
+                receipt.session_id,
+                receipt.decision.value,
+                receipt.accepted_raw_id,
+                receipt.accepted_source_revision,
+                receipt.accepted_content_hash,
+            )
+            if tuple(existing) != expected:
+                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+        else:
+            if receipt.decision is not ApplicationDecision.SUPERSEDED:
+                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+            semantic_identity = conn.execute(
+                """
+                SELECT raw_id, session_id, logical_source_key, decision,
+                       accepted_source_revision, accepted_content_hash
+                FROM raw_revision_applications
+                WHERE raw_id = ? AND session_id = ? AND decision = ?
+                  AND source_revision = ?
+                  AND COALESCE(accepted_source_revision, '') = COALESCE(?, '')
+                """,
+                (
+                    receipt.raw_id,
+                    receipt.session_id,
+                    receipt.decision.value,
+                    receipt.source_revision,
+                    receipt.accepted_source_revision,
+                ),
+            ).fetchone()
+            expected_identity = (
+                receipt.raw_id,
+                receipt.session_id,
+                receipt.logical_source_key,
+                receipt.decision.value,
+                receipt.accepted_source_revision,
+                receipt.accepted_content_hash,
+            )
+            if semantic_identity is None or tuple(semantic_identity) != expected_identity:
+                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
     if receipt.accepted_raw_id is None or receipt.decision not in {
         ApplicationDecision.SELECTED_BASELINE,
         ApplicationDecision.APPLIED_APPEND,

--- a/tests/unit/storage/test_revision_application.py
+++ b/tests/unit/storage/test_revision_application.py
@@ -49,6 +49,26 @@ def test_application_receipt_is_idempotent_and_rejects_older_head() -> None:
         record_revision_application_sync(conn, _receipt(generation=1, revision="revision-old"), decided_at_ms=40)
 
 
+def test_equivalent_accepted_raw_reuses_semantic_receipt_identity() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    receipt = replace(
+        _receipt(),
+        decision=ApplicationDecision.SUPERSEDED,
+        accepted_raw_id="representative-b",
+        accepted_source_revision="semantic-revision",
+    )
+    record_revision_application_sync(conn, receipt, decided_at_ms=10)
+
+    equivalent_representative = replace(receipt, accepted_raw_id="representative-a")
+    assert equivalent_representative.decision_id != receipt.decision_id
+    record_revision_application_sync(conn, equivalent_representative, decided_at_ms=20)
+
+    assert conn.execute(
+        "SELECT accepted_raw_id, accepted_source_revision, accepted_content_hash FROM raw_revision_applications"
+    ).fetchall() == [("representative-b", "semantic-revision", receipt.accepted_content_hash)]
+
+
 def test_session_fts_proof_detects_missing_row_and_trigger_mutation() -> None:
     conn = sqlite3.connect(":memory:")
     conn.executescript(INDEX_DDL)

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -13,7 +13,11 @@ from polylogue.archive.revision_replay import (
     RevisionReplayPlan,
     plan_revision_replay,
 )
-from polylogue.archive.session_revision_membership import MembershipClassification
+from polylogue.archive.session_revision_membership import (
+    MembershipClassification,
+    MembershipRevision,
+    classify_membership_revisions,
+)
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
@@ -75,6 +79,87 @@ def test_replay_selects_newest_full_and_exact_contiguous_suffix_independent_of_o
     }
     for ordering in permutations(candidates):
         assert _decisions(list(ordering)) == expected
+
+
+def test_membership_reselection_reuses_equivalent_superseded_receipt(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="session",
+        messages=[ParsedMessage(provider_message_id="m0", role=Role.USER, text="same")],
+    )
+    projection = session_revision_projection(session)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+
+        def add_member(raw_id: str) -> MembershipRevision:
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=raw_id.encode(),
+                source_path=f"{raw_id}.jsonl",
+                acquired_at_ms=1,
+                raw_id=raw_id,
+            )
+            archive.replace_raw_membership_census(
+                raw_id,
+                [session],
+                parser_fingerprint="test-parser",
+                censused_at_ms=1,
+            )
+            return MembershipRevision(raw_id, projection)
+
+        members = [add_member("representative-b"), add_member("equivalent-z")]
+        first = classify_membership_revisions(members)
+        assert first.accepted_raw_ids == ("equivalent-z",)
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            first,
+            {member.raw_id: session for member in members},
+            {member.raw_id: projection for member in members},
+            acquired_at_ms=1,
+        )
+
+        members.append(add_member("accepted-a"))
+        second = classify_membership_revisions(members)
+        assert second.accepted_raw_ids == ("accepted-a",)
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            second,
+            {member.raw_id: session for member in members},
+            {member.raw_id: projection for member in members},
+            acquired_at_ms=2,
+        )
+
+        head = archive._conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'codex:session'"
+        ).fetchone()
+        assert head is not None and tuple(head) == ("accepted-a",)
+        application_rows = archive._conn.execute(
+            """
+            SELECT raw_id, decision, accepted_raw_id
+            FROM raw_revision_applications
+            WHERE logical_source_key = 'codex:session'
+            ORDER BY raw_id, decision
+            """
+        ).fetchall()
+        assert [tuple(row) for row in application_rows] == [
+            ("accepted-a", "selected_baseline", "accepted-a"),
+            ("equivalent-z", "selected_baseline", "equivalent-z"),
+            ("equivalent-z", "superseded", "accepted-a"),
+            ("representative-b", "superseded", "equivalent-z"),
+        ]
+        matching_receipts = archive._conn.execute(
+            """
+            SELECT COUNT(*) FROM raw_revision_heads AS h
+            JOIN raw_revision_applications AS a
+              ON a.logical_source_key = h.logical_source_key
+             AND a.accepted_raw_id = h.accepted_raw_id
+             AND a.accepted_content_hash = h.accepted_content_hash
+            WHERE h.logical_source_key = 'codex:session'
+              AND a.decision IN ('selected_baseline', 'applied_append')
+            """
+        ).fetchone()
+        assert matching_receipts is not None and tuple(matching_receipts) == (1,)
 
 
 def test_replay_defers_gap_and_quarantines_unproven_evidence() -> None:


### PR DESCRIPTION
## Summary

Treat equivalent accepted-raw representative changes as the same immutable semantic decision for `SUPERSEDED` receipts, while retaining strict receipt requirements for all head-bearing decisions.

## Problem

Production catch-up of `claude-code:journal` reselected the canonical equivalent raw from `975f…` to lexicographically smaller `45d…`. Replaying an older raw's `SUPERSEDED` receipt then hit `idx_raw_revision_applications_identity`: the semantic identity was unchanged, but `decision_id` differed because it includes `accepted_raw_id`. `INSERT OR IGNORE` correctly preserved the first receipt, while the code incorrectly looked up only the new decision ID and raised `conflicting raw revision application receipt: 269dd3bb…`.

## Solution

- Keep exact decision-ID replay validation unchanged.
- On a semantic unique-index collision, allow reuse only for `SUPERSEDED` decisions.
- Require exact raw, session, logical key, decision, source revision, accepted semantic revision, and accepted content hash.
- Preserve the original immutable receipt and continue no head CAS for the alias.
- Continue rejecting all baseline/append alias collisions so every head has its own CAS-bearing receipt.

Ref polylogue-fmob.

## Verification

- `devtools test tests/unit/storage/test_revision_application.py tests/unit/storage/test_revision_replay.py -k 'equivalent_accepted_raw or membership_reselection or equal_frontier_cas'`
  - `6 passed, 11 deselected`
- `devtools verify --quick`
  - run `20260711T225618Z-quick-1627605-df8fe713`, `13/13` steps passed
- Independent adversarial review: passed after narrowing alias reuse to `SUPERSEDED`.

Anti-vacuity: the route test classifies equivalent membership raws twice, introducing a smaller representative on the second application. Reverting the compatibility lookup reproduces the production unique-index conflict. The test also proves the old receipt remains immutable and the new head has exactly one matching baseline/append receipt.
