### PR TITLE
fix(packaging): sync the uv lock project version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1491,7 +1491,7 @@ wheels = [
 
 [[package]]
 name = "polylogue"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Synchronize the editable Polylogue project entry in `uv.lock` with the canonical package version `0.2.0`.

## Problem

`pyproject.toml` declares `0.2.0`, but the committed lock still identified the local editable project as `0.1.0`. The open 0.3 release PR updates package metadata but does not regenerate `uv.lock`, so the current master remains internally inconsistent.

## Solution

Refresh only the generated local-project version. Dependency identities and resolution are unchanged.

## Verification

- `uv lock --check`
  - `Resolved 154 packages`
- Pre-push `devtools verify --quick`
