### PR TITLE
feat(devtools): enforce pytest timeout override policy

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -830,6 +830,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify test-clock-hygiene", "devtools verify test-clock-hygiene --json"),
     ),
     CommandSpec(
+        "verify pytest-timeout-overrides",
+        "verification",
+        "Verify explicit pytest timeout overrides are positive, bounded, and justified.",
+        "devtools.verify_pytest_timeout_overrides",
+        use_when=(
+            "Check AST-parsed @pytest.mark.timeout decorators and managed pytest command literals. "
+            "Values above the pyproject default require an exact manifest rationale."
+        ),
+        examples=("devtools verify pytest-timeout-overrides", "devtools verify pytest-timeout-overrides --json"),
+    ),
+    CommandSpec(
         "release verify-distribution",
         "release",
         "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",

--- a/devtools/pytest_timeout_overrides.toml
+++ b/devtools/pytest_timeout_overrides.toml
@@ -1,0 +1,8 @@
+# Exceptions to pytest's repository-wide 300-second timeout default.
+# Every path/value pair must correspond to a live literal command override;
+# `devtools verify pytest-timeout-overrides` rejects stale entries.
+
+[[exception]]
+path = "devtools/coverage_gate.py"
+value = 600
+rationale = "The single-process coverage gate needs a bounded diagnostic budget for the full non-benchmark suite."

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1485,6 +1485,7 @@ def build_verify_steps(
                 ("verify doc-commands", _devtools_cmd("verify doc-commands")),
                 ("verify test-infra-currency", _devtools_cmd("verify test-infra-currency")),
                 ("verify test-clock-hygiene", _devtools_cmd("verify test-clock-hygiene")),
+                ("verify pytest-timeout-overrides", _devtools_cmd("verify pytest-timeout-overrides")),
             ]
         )
 

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -1,0 +1,300 @@
+"""Verify explicit pytest timeout overrides remain bounded and reviewable.
+
+The repository-wide pytest-timeout default lives in ``pyproject.toml``. This
+gate only inspects explicit exceptions: test decorators and literal pytest
+commands owned by ``devtools``. It deliberately parses Python ASTs rather than
+searching source text, so prose and generated documentation are out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+MANIFEST_RELATIVE_PATH = Path("devtools/pytest_timeout_overrides.toml")
+
+
+@dataclass(frozen=True, slots=True)
+class TimeoutOverride:
+    path: str
+    line: int
+    value: float
+    source: str
+
+    @property
+    def manifest_key(self) -> tuple[str, float]:
+        return (self.path, self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestEntry:
+    path: str
+    value: float
+    rationale: str
+
+    @property
+    def key(self) -> tuple[str, float]:
+        return (self.path, self.value)
+
+
+def _number_from_literal(node: ast.expr) -> float | None:
+    if isinstance(node, ast.Constant) and not isinstance(node.value, bool) and isinstance(node.value, (int, float)):
+        value = float(node.value)
+        return value if math.isfinite(value) else None
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+        operand = _number_from_literal(node.operand)
+        if operand is not None:
+            return -operand if isinstance(node.op, ast.USub) else operand
+    return None
+
+
+def _is_pytest_timeout_decorator(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "timeout"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "mark"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "pytest"
+    )
+
+
+def _parse_decorator_override(path: str, node: ast.Call) -> tuple[TimeoutOverride | None, str | None]:
+    location = f"{path}:{node.lineno}"
+    if node.keywords or len(node.args) != 1:
+        return None, f"{location}: malformed pytest timeout decorator; use exactly one numeric literal argument"
+    argument = node.args[0]
+    if isinstance(argument, ast.Constant) and argument.value is None:
+        return None, f"{location}: unbounded pytest timeout decorator is forbidden"
+    value = _number_from_literal(argument)
+    if value is None:
+        return None, f"{location}: dynamic or malformed pytest timeout decorator is forbidden"
+    if value <= 0:
+        return None, f"{location}: pytest timeout must be positive, got {value:g}"
+    return TimeoutOverride(path, node.lineno, value, "decorator"), None
+
+
+def _is_pytest_execution_call(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Name) and node.func.id == "pytest_execution"
+
+
+def _literal_tokens(nodes: list[ast.expr]) -> list[ast.expr]:
+    return list(nodes)
+
+
+def _is_literal_pytest_command(nodes: list[ast.expr]) -> bool:
+    return any(isinstance(node, ast.Constant) and node.value == "pytest" for node in nodes)
+
+
+def _parse_command_overrides(path: str, line: int, nodes: list[ast.expr]) -> tuple[list[TimeoutOverride], list[str]]:
+    overrides: list[TimeoutOverride] = []
+    errors: list[str] = []
+    for index, node in enumerate(nodes):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        token = node.value
+        if token == "--timeout":
+            location = f"{path}:{getattr(node, 'lineno', line)}"
+            if index + 1 >= len(nodes):
+                errors.append(f"{location}: unbounded pytest --timeout override is forbidden")
+                continue
+            value_node = nodes[index + 1]
+            if not isinstance(value_node, ast.Constant) or not isinstance(value_node.value, str):
+                errors.append(f"{location}: dynamic or malformed pytest --timeout override is forbidden")
+                continue
+            raw_value = value_node.value
+        elif token.startswith("--timeout="):
+            location = f"{path}:{getattr(node, 'lineno', line)}"
+            raw_value = token.removeprefix("--timeout=")
+            if not raw_value:
+                errors.append(f"{location}: unbounded pytest --timeout override is forbidden")
+                continue
+        else:
+            continue
+        try:
+            value = float(raw_value)
+        except ValueError:
+            errors.append(f"{location}: malformed pytest --timeout override {raw_value!r}")
+            continue
+        if not math.isfinite(value):
+            errors.append(f"{location}: malformed pytest --timeout override {raw_value!r}")
+        elif value <= 0:
+            errors.append(f"{location}: pytest timeout must be positive, got {value:g}")
+        else:
+            overrides.append(TimeoutOverride(path, getattr(node, "lineno", line), value, "command"))
+    return overrides, errors
+
+
+def _scan_python(
+    path: Path, root: Path, *, scan_decorators: bool, scan_commands: bool
+) -> tuple[list[TimeoutOverride], list[str]]:
+    relative = path.relative_to(root).as_posix()
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+    except SyntaxError as exc:
+        return [], [f"{relative}:{exc.lineno or 0}: cannot parse Python source: {exc.msg}"]
+
+    overrides: list[TimeoutOverride] = []
+    errors: list[str] = []
+    for node in ast.walk(tree):
+        if scan_decorators and isinstance(node, ast.Call) and _is_pytest_timeout_decorator(node):
+            override, error = _parse_decorator_override(relative, node)
+            if override is not None:
+                overrides.append(override)
+            if error is not None:
+                errors.append(error)
+        if not scan_commands:
+            continue
+        command_nodes: list[ast.expr] | None = None
+        is_pytest_command = False
+        line = getattr(node, "lineno", 0)
+        if isinstance(node, (ast.List, ast.Tuple)):
+            command_nodes = _literal_tokens(node.elts)
+            is_pytest_command = _is_literal_pytest_command(command_nodes)
+        elif isinstance(node, ast.Call) and _is_pytest_execution_call(node):
+            command_nodes = _literal_tokens(node.args)
+            is_pytest_command = True
+        if command_nodes is not None and is_pytest_command:
+            found, found_errors = _parse_command_overrides(relative, line, command_nodes)
+            overrides.extend(found)
+            errors.extend(found_errors)
+    return overrides, errors
+
+
+def _read_default_timeout(pyproject_path: Path) -> float:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    timeout: object = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("timeout")
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not math.isfinite(float(timeout))
+        or timeout <= 0
+    ):
+        raise ValueError("tool.pytest.ini_options.timeout must be a positive finite number")
+    return float(timeout)
+
+
+def _read_manifest(manifest_path: Path, root: Path) -> tuple[list[ManifestEntry], list[str]]:
+    if not manifest_path.exists():
+        return [], [f"missing timeout override manifest: {manifest_path}"]
+    try:
+        data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        return [], [f"{manifest_path}: invalid TOML: {exc}"]
+    raw_entries = data.get("exception", [])
+    if not isinstance(raw_entries, list):
+        return [], [f"{manifest_path}: exception must be an array of tables"]
+
+    entries: list[ManifestEntry] = []
+    errors: list[str] = []
+    seen: set[tuple[str, float]] = set()
+    for index, raw_entry in enumerate(raw_entries):
+        label = f"{manifest_path}: exception[{index}]"
+        if not isinstance(raw_entry, dict):
+            errors.append(f"{label} must be a table")
+            continue
+        path = raw_entry.get("path")
+        value = raw_entry.get("value")
+        rationale = raw_entry.get("rationale")
+        if not isinstance(path, str) or not path or Path(path).is_absolute() or ".." in Path(path).parts:
+            errors.append(f"{label} path must be a repository-relative path")
+            continue
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or value <= 0
+        ):
+            errors.append(f"{label} value must be a positive finite number")
+            continue
+        if not isinstance(rationale, str) or not rationale.strip():
+            errors.append(f"{label} rationale must be non-empty")
+            continue
+        entry = ManifestEntry(path, float(value), rationale.strip())
+        if entry.key in seen:
+            errors.append(f"{label} duplicates manifest entry for {path} value {entry.value:g}")
+            continue
+        seen.add(entry.key)
+        entries.append(entry)
+    return entries, errors
+
+
+def check_timeout_overrides(
+    root: Path, *, pyproject_path: Path | None = None, manifest_path: Path | None = None
+) -> tuple[list[TimeoutOverride], list[str]]:
+    """Return all valid overrides and every policy violation under ``root``."""
+    root = root.resolve()
+    pyproject_path = (pyproject_path or root / "pyproject.toml").resolve()
+    manifest_path = (manifest_path or root / MANIFEST_RELATIVE_PATH).resolve()
+    try:
+        default_timeout = _read_default_timeout(pyproject_path)
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+        return [], [f"{pyproject_path}: cannot read pytest timeout default: {exc}"]
+
+    overrides: list[TimeoutOverride] = []
+    errors: list[str] = []
+    tests_dir = root / "tests"
+    if tests_dir.exists():
+        for path in sorted(tests_dir.rglob("*.py")):
+            found, found_errors = _scan_python(path, root, scan_decorators=True, scan_commands=False)
+            overrides.extend(found)
+            errors.extend(found_errors)
+    devtools_dir = root / "devtools"
+    if devtools_dir.exists():
+        for path in sorted(devtools_dir.glob("*.py")):
+            found, found_errors = _scan_python(path, root, scan_decorators=False, scan_commands=True)
+            overrides.extend(found)
+            errors.extend(found_errors)
+
+    entries, manifest_errors = _read_manifest(manifest_path, root)
+    errors.extend(manifest_errors)
+    exceptional = {override.manifest_key for override in overrides if override.value > default_timeout}
+    declared = {entry.key for entry in entries}
+    for entry_path, value in sorted(exceptional - declared):
+        errors.append(f"{entry_path}: timeout {value:g}s exceeds {default_timeout:g}s without a manifest rationale")
+    for entry_path, value in sorted(declared - exceptional):
+        errors.append(f"stale timeout override manifest entry: {entry_path} value {value:g}")
+    return overrides, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to inspect.")
+    parser.add_argument("--pyproject", type=Path, help="pytest configuration path (defaults to ROOT/pyproject.toml).")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Exception manifest path (defaults to ROOT/devtools/pytest_timeout_overrides.toml).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the policy result as JSON.")
+    args = parser.parse_args(argv)
+    overrides, errors = check_timeout_overrides(args.root, pyproject_path=args.pyproject, manifest_path=args.manifest)
+    payload: dict[str, Any] = {
+        "overrides": [
+            {"path": item.path, "line": item.line, "value": item.value, "source": item.source} for item in overrides
+        ],
+        "errors": errors,
+        "ok": not errors,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"pytest timeout overrides: {len(overrides)} explicit override(s), {len(errors)} violation(s)")
+        for error in errors:
+            print(f"  {error}")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -287,7 +287,7 @@ def _scan_python(
     assignments = _module_assignments(tree)
     if scan_decorators:
         for top_level in tree.body:
-            if not isinstance(top_level, (ast.Assign, ast.AnnAssign)):
+            if not isinstance(top_level, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
                 continue
             targets = top_level.targets if isinstance(top_level, ast.Assign) else [top_level.target]
             value = top_level.value

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -97,11 +97,31 @@ def _is_literal_pytest_command(nodes: list[ast.expr]) -> bool:
     return any(isinstance(node, ast.Constant) and node.value == "pytest" for node in nodes)
 
 
+def _dynamic_string_fragments(node: ast.expr) -> tuple[str, ...]:
+    """Return literal pieces embedded in a dynamic string expression."""
+    if isinstance(node, ast.JoinedStr):
+        return tuple(
+            value.value for value in node.values if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        )
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return (*_dynamic_string_fragments(node.left), *_dynamic_string_fragments(node.right))
+    return ()
+
+
+def _is_dynamic_timeout_option(node: ast.expr) -> bool:
+    return not isinstance(node, ast.Constant) and any(
+        "--timeout" in fragment for fragment in _dynamic_string_fragments(node)
+    )
+
+
 def _parse_command_overrides(path: str, line: int, nodes: list[ast.expr]) -> tuple[list[TimeoutOverride], list[str]]:
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
     for index, node in enumerate(nodes):
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            if _is_dynamic_timeout_option(node):
+                location = f"{path}:{getattr(node, 'lineno', line)}"
+                errors.append(f"{location}: dynamic or malformed pytest --timeout override is forbidden")
             continue
         token = node.value
         if token == "--timeout":
@@ -252,7 +272,7 @@ def check_timeout_overrides(
             errors.extend(found_errors)
     devtools_dir = root / "devtools"
     if devtools_dir.exists():
-        for path in sorted(devtools_dir.glob("*.py")):
+        for path in sorted(devtools_dir.rglob("*.py")):
             found, found_errors = _scan_python(path, root, scan_decorators=False, scan_commands=True)
             overrides.extend(found)
             errors.extend(found_errors)

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -237,11 +237,18 @@ def _is_dynamic_timeout_option(node: ast.expr, assignments: dict[str, ast.expr])
 
 
 def _parse_command_overrides(
-    path: str, line: int, nodes: list[ast.expr], assignments: dict[str, ast.expr]
+    path: str,
+    line: int,
+    nodes: list[ast.expr],
+    assignments: dict[str, ast.expr],
+    rebound: set[str],
 ) -> tuple[list[TimeoutOverride], list[str]]:
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
     for index, node in enumerate(nodes):
+        if isinstance(node, ast.Name) and node.id in rebound:
+            errors.append(f"{path}:{node.lineno}: rebound managed pytest command alias is forbidden")
+            continue
         resolved_node = _resolve_alias(node, assignments)
         if not isinstance(resolved_node, ast.Constant) or not isinstance(resolved_node.value, str):
             if _is_dynamic_timeout_option(node, assignments):
@@ -301,12 +308,14 @@ def _flatten_marker_values(
     rebound: set[str],
     seen: set[str] | None = None,
 ) -> tuple[list[ast.expr], str | None]:
-    """Resolve safe list/tuple marker aliases without evaluating Python."""
+    """Resolve only immutable tuple marker aliases without evaluating Python."""
     if isinstance(node, ast.Name):
         if node.id in rebound:
             return [], "rebound pytest marker alias is forbidden"
         if node.id not in assignments:
             return [], "dynamic pytest marker alias is forbidden"
+        if isinstance(assignments[node.id], ast.List):
+            return [], "mutable pytest marker alias is forbidden; use an inline mark or tuple"
         seen = set() if seen is None else seen
         if node.id in seen:
             return [], "cyclic pytest marker alias is forbidden"
@@ -321,6 +330,10 @@ def _flatten_marker_values(
             markers.extend(nested)
         return markers, None
     return [node], None
+
+
+def _mentions_rebound_alias(node: ast.AST, rebound: set[str]) -> bool:
+    return any(isinstance(descendant, ast.Name) and descendant.id in rebound for descendant in ast.walk(node))
 
 
 def _scan_timeout_markers(
@@ -427,6 +440,8 @@ def _scan_python(
                 is_pytest_command = _is_literal_pytest_command(command_nodes)
                 if is_pytest_command and dynamic_expression and _is_dynamic_timeout_option(candidate, assignments):
                     errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
+                if is_pytest_command and _mentions_rebound_alias(candidate, rebound):
+                    errors.append(f"{relative}:{line}: rebound managed pytest command alias is forbidden")
         elif isinstance(candidate, ast.Call) and _is_pytest_execution_call(candidate):
             flattened = _flatten_command_expression(ast.Tuple(elts=candidate.args, ctx=ast.Load()), assignments)
             if flattened is None:
@@ -449,8 +464,10 @@ def _scan_python(
                     for argument in candidate.args
                 ):
                     errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
+                if _mentions_rebound_alias(candidate, rebound):
+                    errors.append(f"{relative}:{line}: rebound managed pytest command alias is forbidden")
         if command_nodes is not None and is_pytest_command:
-            found, found_errors = _parse_command_overrides(relative, line, command_nodes, assignments)
+            found, found_errors = _parse_command_overrides(relative, line, command_nodes, assignments, rebound)
             overrides.extend(found)
             errors.extend(found_errors)
     return overrides, errors

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -58,10 +58,11 @@ def _number_from_literal(node: ast.expr) -> float | None:
     return None
 
 
-def _pytest_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
-    """Return local names bound to ``pytest`` and ``pytest.mark`` imports."""
+def _pytest_aliases(tree: ast.Module) -> tuple[set[str], set[str], set[str]]:
+    """Return local names bound to ``pytest``, ``pytest.mark``, and ``pytest.param``."""
     pytest_names: set[str] = set()
     mark_names: set[str] = set()
+    param_names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -71,7 +72,9 @@ def _pytest_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
             for alias in node.names:
                 if alias.name == "mark":
                     mark_names.add(alias.asname or "mark")
-    return pytest_names, mark_names
+                elif alias.name == "param":
+                    param_names.add(alias.asname or "param")
+    return pytest_names, mark_names, param_names
 
 
 def _is_pytest_timeout_decorator(node: ast.expr, pytest_names: set[str], mark_names: set[str]) -> bool:
@@ -88,6 +91,15 @@ def _is_pytest_timeout_decorator(node: ast.expr, pytest_names: set[str], mark_na
                 and func.value.value.id in pytest_names
             )
         )
+    )
+
+
+def _is_pytest_param_call(node: ast.Call, pytest_names: set[str], param_names: set[str]) -> bool:
+    return (isinstance(node.func, ast.Name) and node.func.id in param_names) or (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "param"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in pytest_names
     )
 
 
@@ -283,7 +295,7 @@ def _scan_python(
 
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
-    pytest_names, mark_names = _pytest_aliases(tree)
+    pytest_names, mark_names, param_names = _pytest_aliases(tree)
     assignments = _module_assignments(tree)
     if scan_decorators:
         for top_level in tree.body:
@@ -319,6 +331,25 @@ def _scan_python(
                     overrides.append(override)
                 if error is not None:
                     errors.append(error)
+        if (
+            scan_decorators
+            and isinstance(candidate, ast.Call)
+            and _is_pytest_param_call(candidate, pytest_names, param_names)
+        ):
+            for keyword in candidate.keywords:
+                if keyword.arg != "marks":
+                    continue
+                for marker in _pytestmark_values(keyword.value):
+                    override, error = _scan_timeout_marker(
+                        marker,
+                        path=relative,
+                        pytest_names=pytest_names,
+                        mark_names=mark_names,
+                    )
+                    if override is not None:
+                        overrides.append(override)
+                    if error is not None:
+                        errors.append(error)
         if not scan_commands:
             continue
         command_nodes: list[ast.expr] | None = None

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -252,6 +252,26 @@ def _parse_command_overrides(
     return overrides, errors
 
 
+def _scan_timeout_marker(
+    marker: ast.expr,
+    *,
+    path: str,
+    pytest_names: set[str],
+    mark_names: set[str],
+) -> tuple[TimeoutOverride | None, str | None]:
+    if not _is_pytest_timeout_decorator(marker, pytest_names, mark_names):
+        return None, None
+    if not isinstance(marker, ast.Call):
+        return None, f"{path}:{marker.lineno}: malformed pytest timeout decorator is missing a timeout value"
+    return _parse_decorator_override(path, marker)
+
+
+def _pytestmark_values(node: ast.expr) -> list[ast.expr]:
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return list(node.elts)
+    return [node]
+
+
 def _scan_python(
     path: Path, root: Path, *, scan_decorators: bool, scan_commands: bool
 ) -> tuple[list[TimeoutOverride], list[str]]:
@@ -265,17 +285,36 @@ def _scan_python(
     errors: list[str] = []
     pytest_names, mark_names = _pytest_aliases(tree)
     assignments = _module_assignments(tree)
-    for node in ast.walk(tree):
-        if scan_decorators and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            for decorator in node.decorator_list:
-                if not _is_pytest_timeout_decorator(decorator, pytest_names, mark_names):
-                    continue
-                if not isinstance(decorator, ast.Call):
-                    errors.append(
-                        f"{relative}:{decorator.lineno}: malformed pytest timeout decorator is missing a timeout value"
-                    )
-                    continue
-                override, error = _parse_decorator_override(relative, decorator)
+    if scan_decorators:
+        for top_level in tree.body:
+            if not isinstance(top_level, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = top_level.targets if isinstance(top_level, ast.Assign) else [top_level.target]
+            value = top_level.value
+            if value is None or not any(
+                isinstance(target, ast.Name) and target.id == "pytestmark" for target in targets
+            ):
+                continue
+            for marker in _pytestmark_values(value):
+                override, error = _scan_timeout_marker(
+                    marker,
+                    path=relative,
+                    pytest_names=pytest_names,
+                    mark_names=mark_names,
+                )
+                if override is not None:
+                    overrides.append(override)
+                if error is not None:
+                    errors.append(error)
+    for candidate in ast.walk(tree):
+        if scan_decorators and isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for decorator in candidate.decorator_list:
+                override, error = _scan_timeout_marker(
+                    decorator,
+                    path=relative,
+                    pytest_names=pytest_names,
+                    mark_names=mark_names,
+                )
                 if override is not None:
                     overrides.append(override)
                 if error is not None:
@@ -284,23 +323,23 @@ def _scan_python(
             continue
         command_nodes: list[ast.expr] | None = None
         is_pytest_command = False
-        line = getattr(node, "lineno", 0)
-        if isinstance(node, (ast.List, ast.Tuple, ast.BinOp)):
-            flattened = _flatten_command_expression(node, assignments)
+        line = getattr(candidate, "lineno", 0)
+        if isinstance(candidate, (ast.List, ast.Tuple, ast.BinOp)):
+            flattened = _flatten_command_expression(candidate, assignments)
             if flattened is not None:
                 command_nodes, dynamic_expression = flattened
                 is_pytest_command = _is_literal_pytest_command(command_nodes)
-                if is_pytest_command and dynamic_expression and _is_dynamic_timeout_option(node, assignments):
+                if is_pytest_command and dynamic_expression and _is_dynamic_timeout_option(candidate, assignments):
                     errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
-        elif isinstance(node, ast.Call) and _is_pytest_execution_call(node):
-            flattened = _flatten_command_expression(ast.Tuple(elts=node.args, ctx=ast.Load()), assignments)
+        elif isinstance(candidate, ast.Call) and _is_pytest_execution_call(candidate):
+            flattened = _flatten_command_expression(ast.Tuple(elts=candidate.args, ctx=ast.Load()), assignments)
             if flattened is None:
                 if any(
                     _is_dynamic_timeout_option(
                         argument.value if isinstance(argument, ast.Starred) else argument,
                         assignments,
                     )
-                    for argument in node.args
+                    for argument in candidate.args
                 ):
                     errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
             else:
@@ -311,7 +350,7 @@ def _scan_python(
                         argument.value if isinstance(argument, ast.Starred) else argument,
                         assignments,
                     )
-                    for argument in node.args
+                    for argument in candidate.args
                 ):
                     errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
         if command_nodes is not None and is_pytest_command:

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -58,23 +58,69 @@ def _number_from_literal(node: ast.expr) -> float | None:
     return None
 
 
-def _is_pytest_timeout_decorator(node: ast.Call) -> bool:
-    func = node.func
+def _pytest_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Return local names bound to ``pytest`` and ``pytest.mark`` imports."""
+    pytest_names: set[str] = set()
+    mark_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "pytest":
+                    pytest_names.add(alias.asname or "pytest")
+        elif isinstance(node, ast.ImportFrom) and node.module == "pytest":
+            for alias in node.names:
+                if alias.name == "mark":
+                    mark_names.add(alias.asname or "mark")
+    return pytest_names, mark_names
+
+
+def _is_pytest_timeout_decorator(node: ast.expr, pytest_names: set[str], mark_names: set[str]) -> bool:
+    func = node.func if isinstance(node, ast.Call) else node
     return (
         isinstance(func, ast.Attribute)
         and func.attr == "timeout"
-        and isinstance(func.value, ast.Attribute)
-        and func.value.attr == "mark"
-        and isinstance(func.value.value, ast.Name)
-        and func.value.value.id == "pytest"
+        and (
+            (isinstance(func.value, ast.Name) and func.value.id in mark_names)
+            or (
+                isinstance(func.value, ast.Attribute)
+                and func.value.attr == "mark"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id in pytest_names
+            )
+        )
     )
 
 
 def _parse_decorator_override(path: str, node: ast.Call) -> tuple[TimeoutOverride | None, str | None]:
     location = f"{path}:{node.lineno}"
-    if node.keywords or len(node.args) != 1:
-        return None, f"{location}: malformed pytest timeout decorator; use exactly one numeric literal argument"
-    argument = node.args[0]
+    if len(node.args) > 2:
+        return None, f"{location}: malformed pytest timeout decorator; too many positional arguments"
+    timeout_argument: ast.expr | None = node.args[0] if node.args else None
+    method_argument: ast.expr | None = node.args[1] if len(node.args) == 2 else None
+    seen_keywords: set[str] = set()
+    for keyword in node.keywords:
+        if keyword.arg not in {"timeout", "method", "func_only"} or keyword.arg in seen_keywords:
+            return None, f"{location}: malformed pytest timeout decorator keyword"
+        seen_keywords.add(keyword.arg)
+        if keyword.arg == "timeout":
+            if timeout_argument is not None:
+                return None, f"{location}: malformed pytest timeout decorator has multiple timeout values"
+            timeout_argument = keyword.value
+        elif keyword.arg == "method":
+            if method_argument is not None:
+                return None, f"{location}: malformed pytest timeout decorator has multiple method values"
+            method_argument = keyword.value
+        elif not (isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, bool)):
+            return None, f"{location}: dynamic or malformed pytest timeout func_only option is forbidden"
+    if timeout_argument is None:
+        return None, f"{location}: malformed pytest timeout decorator is missing a timeout value"
+    if method_argument is not None and (
+        not isinstance(method_argument, ast.Constant)
+        or not isinstance(method_argument.value, str)
+        or method_argument.value not in {"signal", "thread"}
+    ):
+        return None, f"{location}: dynamic or malformed pytest timeout method option is forbidden"
+    argument = timeout_argument
     if isinstance(argument, ast.Constant) and argument.value is None:
         return None, f"{location}: unbounded pytest timeout decorator is forbidden"
     value = _number_from_literal(argument)
@@ -89,8 +135,54 @@ def _is_pytest_execution_call(node: ast.Call) -> bool:
     return isinstance(node.func, ast.Name) and node.func.id == "pytest_execution"
 
 
-def _literal_tokens(nodes: list[ast.expr]) -> list[ast.expr]:
-    return list(nodes)
+def _module_assignments(tree: ast.Module) -> dict[str, ast.expr]:
+    assignments: dict[str, ast.expr] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
+            assignments[node.target.id] = node.value
+    return assignments
+
+
+def _resolve_alias(node: ast.expr, assignments: dict[str, ast.expr], seen: set[str] | None = None) -> ast.expr:
+    if not isinstance(node, ast.Name) or node.id not in assignments:
+        return node
+    seen = set() if seen is None else seen
+    if node.id in seen:
+        return node
+    seen.add(node.id)
+    return _resolve_alias(assignments[node.id], assignments, seen)
+
+
+def _flatten_command_expression(node: ast.expr, assignments: dict[str, ast.expr]) -> tuple[list[ast.expr], bool] | None:
+    node = _resolve_alias(node, assignments)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        items: list[ast.expr] = []
+        dynamic = False
+        for item in node.elts:
+            if isinstance(item, ast.Starred):
+                flattened = _flatten_command_expression(item.value, assignments)
+                if flattened is None:
+                    dynamic = True
+                else:
+                    nested_items, nested_dynamic = flattened
+                    items.extend(nested_items)
+                    dynamic = dynamic or nested_dynamic
+            else:
+                items.append(item)
+        return items, dynamic
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _flatten_command_expression(node.left, assignments)
+        right = _flatten_command_expression(node.right, assignments)
+        if left is None or right is None:
+            if left is None and right is None:
+                return None
+            return [*(left[0] if left is not None else []), *(right[0] if right is not None else [])], True
+        return [*left[0], *right[0]], left[1] or right[1]
+    return None
 
 
 def _is_literal_pytest_command(nodes: list[ast.expr]) -> bool:
@@ -108,22 +200,26 @@ def _dynamic_string_fragments(node: ast.expr) -> tuple[str, ...]:
     return ()
 
 
-def _is_dynamic_timeout_option(node: ast.expr) -> bool:
+def _is_dynamic_timeout_option(node: ast.expr, assignments: dict[str, ast.expr]) -> bool:
+    node = _resolve_alias(node, assignments)
     return not isinstance(node, ast.Constant) and any(
         "--timeout" in fragment for fragment in _dynamic_string_fragments(node)
     )
 
 
-def _parse_command_overrides(path: str, line: int, nodes: list[ast.expr]) -> tuple[list[TimeoutOverride], list[str]]:
+def _parse_command_overrides(
+    path: str, line: int, nodes: list[ast.expr], assignments: dict[str, ast.expr]
+) -> tuple[list[TimeoutOverride], list[str]]:
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
     for index, node in enumerate(nodes):
-        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
-            if _is_dynamic_timeout_option(node):
+        resolved_node = _resolve_alias(node, assignments)
+        if not isinstance(resolved_node, ast.Constant) or not isinstance(resolved_node.value, str):
+            if _is_dynamic_timeout_option(node, assignments):
                 location = f"{path}:{getattr(node, 'lineno', line)}"
                 errors.append(f"{location}: dynamic or malformed pytest --timeout override is forbidden")
             continue
-        token = node.value
+        token = resolved_node.value
         if token == "--timeout":
             location = f"{path}:{getattr(node, 'lineno', line)}"
             if index + 1 >= len(nodes):
@@ -167,26 +263,59 @@ def _scan_python(
 
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
+    pytest_names, mark_names = _pytest_aliases(tree)
+    assignments = _module_assignments(tree)
     for node in ast.walk(tree):
-        if scan_decorators and isinstance(node, ast.Call) and _is_pytest_timeout_decorator(node):
-            override, error = _parse_decorator_override(relative, node)
-            if override is not None:
-                overrides.append(override)
-            if error is not None:
-                errors.append(error)
+        if scan_decorators and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in node.decorator_list:
+                if not _is_pytest_timeout_decorator(decorator, pytest_names, mark_names):
+                    continue
+                if not isinstance(decorator, ast.Call):
+                    errors.append(
+                        f"{relative}:{decorator.lineno}: malformed pytest timeout decorator is missing a timeout value"
+                    )
+                    continue
+                override, error = _parse_decorator_override(relative, decorator)
+                if override is not None:
+                    overrides.append(override)
+                if error is not None:
+                    errors.append(error)
         if not scan_commands:
             continue
         command_nodes: list[ast.expr] | None = None
         is_pytest_command = False
         line = getattr(node, "lineno", 0)
-        if isinstance(node, (ast.List, ast.Tuple)):
-            command_nodes = _literal_tokens(node.elts)
-            is_pytest_command = _is_literal_pytest_command(command_nodes)
+        if isinstance(node, (ast.List, ast.Tuple, ast.BinOp)):
+            flattened = _flatten_command_expression(node, assignments)
+            if flattened is not None:
+                command_nodes, dynamic_expression = flattened
+                is_pytest_command = _is_literal_pytest_command(command_nodes)
+                if is_pytest_command and dynamic_expression and _is_dynamic_timeout_option(node, assignments):
+                    errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
         elif isinstance(node, ast.Call) and _is_pytest_execution_call(node):
-            command_nodes = _literal_tokens(node.args)
-            is_pytest_command = True
+            flattened = _flatten_command_expression(ast.Tuple(elts=node.args, ctx=ast.Load()), assignments)
+            if flattened is None:
+                if any(
+                    _is_dynamic_timeout_option(
+                        argument.value if isinstance(argument, ast.Starred) else argument,
+                        assignments,
+                    )
+                    for argument in node.args
+                ):
+                    errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
+            else:
+                command_nodes, dynamic_expression = flattened
+                is_pytest_command = True
+                if dynamic_expression and any(
+                    _is_dynamic_timeout_option(
+                        argument.value if isinstance(argument, ast.Starred) else argument,
+                        assignments,
+                    )
+                    for argument in node.args
+                ):
+                    errors.append(f"{relative}:{line}: dynamic managed pytest command expression is forbidden")
         if command_nodes is not None and is_pytest_command:
-            found, found_errors = _parse_command_overrides(relative, line, command_nodes)
+            found, found_errors = _parse_command_overrides(relative, line, command_nodes, assignments)
             overrides.extend(found)
             errors.extend(found_errors)
     return overrides, errors

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -4,6 +4,9 @@ The repository-wide pytest-timeout default lives in ``pyproject.toml``. This
 gate only inspects explicit exceptions: test decorators and literal pytest
 commands owned by ``devtools``. It deliberately parses Python ASTs rather than
 searching source text, so prose and generated documentation are out of scope.
+
+Marker aliases are deliberately fail-closed: imported, unresolved, cyclic, or
+rebound names cannot prove the absence of a timeout override and are rejected.
 """
 
 from __future__ import annotations
@@ -147,16 +150,30 @@ def _is_pytest_execution_call(node: ast.Call) -> bool:
     return isinstance(node.func, ast.Name) and node.func.id == "pytest_execution"
 
 
-def _module_assignments(tree: ast.Module) -> dict[str, ast.expr]:
+def _module_assignments(tree: ast.Module) -> tuple[dict[str, ast.expr], set[str]]:
+    """Return only module bindings that have one unambiguous source assignment."""
     assignments: dict[str, ast.expr] = {}
+    rebound: set[str] = set()
     for node in tree.body:
+        targets: list[ast.expr]
+        value: ast.expr | None
         if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    assignments[target.id] = node.value
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
-            assignments[node.target.id] = node.value
-    return assignments
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if value is None:
+            continue
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if target.id in assignments or target.id in rebound:
+                assignments.pop(target.id, None)
+                rebound.add(target.id)
+            else:
+                assignments[target.id] = value
+    return assignments, rebound
 
 
 def _resolve_alias(node: ast.expr, assignments: dict[str, ast.expr], seen: set[str] | None = None) -> ast.expr:
@@ -281,21 +298,24 @@ def _scan_timeout_marker(
 def _flatten_marker_values(
     node: ast.expr,
     assignments: dict[str, ast.expr],
+    rebound: set[str],
     seen: set[str] | None = None,
 ) -> tuple[list[ast.expr], str | None]:
     """Resolve safe list/tuple marker aliases without evaluating Python."""
     if isinstance(node, ast.Name):
+        if node.id in rebound:
+            return [], "rebound pytest marker alias is forbidden"
         if node.id not in assignments:
             return [], "dynamic pytest marker alias is forbidden"
         seen = set() if seen is None else seen
         if node.id in seen:
             return [], "cyclic pytest marker alias is forbidden"
         seen.add(node.id)
-        return _flatten_marker_values(assignments[node.id], assignments, seen)
+        return _flatten_marker_values(assignments[node.id], assignments, rebound, seen)
     if isinstance(node, (ast.List, ast.Tuple)):
         markers: list[ast.expr] = []
         for item in node.elts:
-            nested, error = _flatten_marker_values(item, assignments, set(seen or ()))
+            nested, error = _flatten_marker_values(item, assignments, rebound, set(seen or ()))
             if error is not None:
                 return [], error
             markers.extend(nested)
@@ -308,10 +328,11 @@ def _scan_timeout_markers(
     *,
     path: str,
     assignments: dict[str, ast.expr],
+    rebound: set[str],
     pytest_names: set[str],
     mark_names: set[str],
 ) -> tuple[list[TimeoutOverride], list[str]]:
-    markers, flatten_error = _flatten_marker_values(marker_expression, assignments)
+    markers, flatten_error = _flatten_marker_values(marker_expression, assignments, rebound)
     if flatten_error is not None:
         return [], [f"{path}:{marker_expression.lineno}: {flatten_error}"]
     overrides: list[TimeoutOverride] = []
@@ -342,7 +363,7 @@ def _scan_python(
     overrides: list[TimeoutOverride] = []
     errors: list[str] = []
     pytest_names, mark_names, param_names = _pytest_aliases(tree)
-    assignments = _module_assignments(tree)
+    assignments, rebound = _module_assignments(tree)
     if scan_decorators:
         for top_level in tree.body:
             if not isinstance(top_level, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
@@ -357,6 +378,7 @@ def _scan_python(
                 value,
                 path=relative,
                 assignments=assignments,
+                rebound=rebound,
                 pytest_names=pytest_names,
                 mark_names=mark_names,
             )
@@ -387,6 +409,7 @@ def _scan_python(
                     keyword.value,
                     path=relative,
                     assignments=assignments,
+                    rebound=rebound,
                     pytest_names=pytest_names,
                     mark_names=mark_names,
                 )

--- a/devtools/verify_pytest_timeout_overrides.py
+++ b/devtools/verify_pytest_timeout_overrides.py
@@ -278,10 +278,56 @@ def _scan_timeout_marker(
     return _parse_decorator_override(path, marker)
 
 
-def _pytestmark_values(node: ast.expr) -> list[ast.expr]:
+def _flatten_marker_values(
+    node: ast.expr,
+    assignments: dict[str, ast.expr],
+    seen: set[str] | None = None,
+) -> tuple[list[ast.expr], str | None]:
+    """Resolve safe list/tuple marker aliases without evaluating Python."""
+    if isinstance(node, ast.Name):
+        if node.id not in assignments:
+            return [], "dynamic pytest marker alias is forbidden"
+        seen = set() if seen is None else seen
+        if node.id in seen:
+            return [], "cyclic pytest marker alias is forbidden"
+        seen.add(node.id)
+        return _flatten_marker_values(assignments[node.id], assignments, seen)
     if isinstance(node, (ast.List, ast.Tuple)):
-        return list(node.elts)
-    return [node]
+        markers: list[ast.expr] = []
+        for item in node.elts:
+            nested, error = _flatten_marker_values(item, assignments, set(seen or ()))
+            if error is not None:
+                return [], error
+            markers.extend(nested)
+        return markers, None
+    return [node], None
+
+
+def _scan_timeout_markers(
+    marker_expression: ast.expr,
+    *,
+    path: str,
+    assignments: dict[str, ast.expr],
+    pytest_names: set[str],
+    mark_names: set[str],
+) -> tuple[list[TimeoutOverride], list[str]]:
+    markers, flatten_error = _flatten_marker_values(marker_expression, assignments)
+    if flatten_error is not None:
+        return [], [f"{path}:{marker_expression.lineno}: {flatten_error}"]
+    overrides: list[TimeoutOverride] = []
+    errors: list[str] = []
+    for marker in markers:
+        override, error = _scan_timeout_marker(
+            marker,
+            path=path,
+            pytest_names=pytest_names,
+            mark_names=mark_names,
+        )
+        if override is not None:
+            overrides.append(override)
+        if error is not None:
+            errors.append(error)
+    return overrides, errors
 
 
 def _scan_python(
@@ -307,17 +353,15 @@ def _scan_python(
                 isinstance(target, ast.Name) and target.id == "pytestmark" for target in targets
             ):
                 continue
-            for marker in _pytestmark_values(value):
-                override, error = _scan_timeout_marker(
-                    marker,
-                    path=relative,
-                    pytest_names=pytest_names,
-                    mark_names=mark_names,
-                )
-                if override is not None:
-                    overrides.append(override)
-                if error is not None:
-                    errors.append(error)
+            found, found_errors = _scan_timeout_markers(
+                value,
+                path=relative,
+                assignments=assignments,
+                pytest_names=pytest_names,
+                mark_names=mark_names,
+            )
+            overrides.extend(found)
+            errors.extend(found_errors)
     for candidate in ast.walk(tree):
         if scan_decorators and isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             for decorator in candidate.decorator_list:
@@ -339,17 +383,15 @@ def _scan_python(
             for keyword in candidate.keywords:
                 if keyword.arg != "marks":
                     continue
-                for marker in _pytestmark_values(keyword.value):
-                    override, error = _scan_timeout_marker(
-                        marker,
-                        path=relative,
-                        pytest_names=pytest_names,
-                        mark_names=mark_names,
-                    )
-                    if override is not None:
-                        overrides.append(override)
-                    if error is not None:
-                        errors.append(error)
+                found, found_errors = _scan_timeout_markers(
+                    keyword.value,
+                    path=relative,
+                    assignments=assignments,
+                    pytest_names=pytest_names,
+                    mark_names=mark_names,
+                )
+                overrides.extend(found)
+                errors.extend(found_errors)
         if not scan_commands:
             continue
         command_nodes: list[ast.expr] | None = None

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -160,6 +160,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify public-claims` | Validate public claims, evidence paths, Beads owners, and retired copy. |
+| `devtools verify pytest-timeout-overrides` | Verify explicit pytest timeout overrides are positive, bounded, and justified. |
 | `devtools verify test-clock-hygiene` | Verify test files use the frozen_clock fixture instead of reading the host wall clock (#1300). |
 | `devtools verify test-infra-currency` | Verify tests/infra/ helpers reference only tables that exist in the current SCHEMA_VERSION. |
 | `devtools verify topology` | Verify the realized polylogue tree against the topology projection. |

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -28,6 +28,7 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
     assert "### Lab Checks" in rendered
     assert "| `devtools render all` |" in rendered
     assert "| `devtools render demo-corpus-datasheet` |" in rendered
+    assert "| `devtools verify pytest-timeout-overrides` |" in rendered
     assert "Common forms: `devtools status`" in rendered
 
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -67,6 +67,7 @@ def test_quick_verify_omits_pytest() -> None:
         "verify doc-commands",
         "verify test-infra-currency",
         "verify test-clock-hygiene",
+        "verify pytest-timeout-overrides",
     ]
 
 

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -74,6 +74,7 @@ def test_registered_verifier_rejects_invalid_decorator_overrides(
         ("COMMAND = ['pytest', '--timeout=0']\n", "must be positive"),
         ("COMMAND = ['pytest', '--timeout=-1']\n", "must be positive"),
         ("LIMIT = '30'\nCOMMAND = ['pytest', '--timeout', LIMIT]\n", "dynamic or malformed"),
+        ("LIMIT = 0\nCOMMAND = ['pytest', f'--timeout={LIMIT}']\n", "dynamic or malformed"),
         ("COMMAND = ['pytest', '--timeout=forever']\n", "malformed"),
         ("COMMAND = ['pytest', '--timeout']\n", "unbounded"),
         ("execution = pytest_execution('--timeout=')\n", "unbounded"),
@@ -92,6 +93,20 @@ def test_registered_verifier_rejects_invalid_managed_command_overrides(
 
     assert rc == 1
     assert expected in output
+
+
+def test_registered_verifier_scans_nested_devtools_commands(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: replacing the recursive devtools scan with glob() makes this test fail."""
+    root = _make_tree(tmp_path)
+    _write(root, "devtools/nested/managed_command.py", "COMMAND = ['pytest', '--timeout=0']\n")
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "must be positive" in output
 
 
 def test_registered_verifier_requires_exact_rationale_manifest_for_longer_values(

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -105,6 +105,106 @@ def test_registered_verifier_accepts_bounded_pytest_param_marks(
     assert rc == 0, output
 
 
+def test_registered_verifier_rejects_module_timeout_mark_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: removing safe marker-alias flattening makes this production-command test fail."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nTIMEOUT_MARKS = [pytest.mark.timeout(None)]\npytestmark = TIMEOUT_MARKS\n"
+            "def test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "unbounded" in output
+
+
+def test_registered_verifier_rejects_incremental_timeout_mark_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: bypassing alias flattening for pytestmark += makes this production-command test fail."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nEXTRA_MARKS = [pytest.mark.timeout(None)]\npytestmark = []\n"
+            "pytestmark += EXTRA_MARKS\ndef test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "unbounded" in output
+
+
+def test_registered_verifier_rejects_parameter_timeout_mark_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: removing alias flattening for pytest.param marks makes this production-command test fail."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nCASE_MARK = pytest.mark.timeout(0)\n"
+            "CASE = pytest.param(1, marks=CASE_MARK)\ndef test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "must be positive" in output
+
+
+def test_registered_verifier_rejects_cyclic_marker_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: removing cycle detection makes this production-command test fail instead of terminating safely."""
+    root = _make_tree(
+        tmp_path,
+        test_source="FIRST = SECOND\nSECOND = FIRST\npytestmark = FIRST\ndef test_target():\n    pass\n",
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "cyclic pytest marker alias" in output
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import pytest\n\nMARKS = [pytest.mark.timeout(30)]\npytestmark = MARKS\ndef test_target():\n    pass\n",
+        (
+            "import pytest\n\nEXTRA_MARKS = [pytest.mark.timeout(30)]\npytestmark = []\n"
+            "pytestmark += EXTRA_MARKS\ndef test_target():\n    pass\n"
+        ),
+        (
+            "import pytest\n\nCASE_MARK = pytest.mark.timeout(30)\n"
+            "CASE = pytest.param(1, marks=CASE_MARK)\ndef test_target():\n    pass\n"
+        ),
+    ],
+)
+def test_registered_verifier_accepts_bounded_marker_aliases(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+) -> None:
+    """Anti-vacuity: rejecting safe list/tuple marker aliases makes this production-command test fail."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 0, output
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -51,6 +51,9 @@ def _run_registered(root: Path, capsys: pytest.CaptureFixture[str]) -> tuple[int
         ),
         ("import pytest\n\n@pytest.mark.timeout()\ndef test_target():\n    pass\n", "malformed"),
         ("import pytest\n\n@pytest.mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
+        ("import pytest\n\n@pytest.mark.timeout\ndef test_target():\n    pass\n", "missing a timeout value"),
+        ("from pytest import mark\n\n@mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
+        ("import pytest as pt\n\n@pt.mark.timeout(0)\ndef test_target():\n    pass\n", "must be positive"),
     ],
 )
 def test_registered_verifier_rejects_invalid_decorator_overrides(
@@ -75,6 +78,17 @@ def test_registered_verifier_rejects_invalid_decorator_overrides(
         ("COMMAND = ['pytest', '--timeout=-1']\n", "must be positive"),
         ("LIMIT = '30'\nCOMMAND = ['pytest', '--timeout', LIMIT]\n", "dynamic or malformed"),
         ("LIMIT = 0\nCOMMAND = ['pytest', f'--timeout={LIMIT}']\n", "dynamic or malformed"),
+        (
+            "LIMIT = 0\nTIMEOUT_ARG = f'--timeout={LIMIT}'\nCOMMAND = ['pytest', TIMEOUT_ARG]\n",
+            "dynamic or malformed",
+        ),
+        (
+            "LIMIT = 0\nTIMEOUT_ARGS = [f'--timeout={LIMIT}']\nexecution = pytest_execution(*TIMEOUT_ARGS)\n",
+            "dynamic or malformed",
+        ),
+        ("TIMEOUT_ARGS = ['--timeout=0']\nexecution = pytest_execution(*TIMEOUT_ARGS)\n", "must be positive"),
+        ("COMMAND = ['pytest'] + ['--timeout=0']\n", "must be positive"),
+        ("COMMAND = ['pytest', *['--timeout=0']]\n", "must be positive"),
         ("COMMAND = ['pytest', '--timeout=forever']\n", "malformed"),
         ("COMMAND = ['pytest', '--timeout']\n", "unbounded"),
         ("execution = pytest_execution('--timeout=')\n", "unbounded"),
@@ -93,6 +107,26 @@ def test_registered_verifier_rejects_invalid_managed_command_overrides(
 
     assert rc == 1
     assert expected in output
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import pytest\n\n@pytest.mark.timeout(30, method='thread')\ndef test_target():\n    pass\n",
+        "import pytest\n\n@pytest.mark.timeout(timeout=30, func_only=True)\ndef test_target():\n    pass\n",
+    ],
+)
+def test_registered_verifier_accepts_supported_static_decorator_options(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+) -> None:
+    """Anti-vacuity: rejecting every keyword option makes this production-command test fail."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 0, output
 
 
 def test_registered_verifier_scans_nested_devtools_commands(

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -1,0 +1,143 @@
+"""Focused mutation tests for the registered pytest timeout policy command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devtools.command_catalog import COMMANDS
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_tree(
+    tmp_path: Path,
+    *,
+    test_source: str = "def test_ok():\n    pass\n",
+    devtools_source: str = "COMMAND = ['pytest']\n",
+    manifest: str = "",
+) -> Path:
+    _write(
+        tmp_path,
+        "pyproject.toml",
+        "[tool.pytest.ini_options]\ntimeout = 300\n",
+    )
+    _write(tmp_path, "tests/unit/test_target.py", test_source)
+    _write(tmp_path, "devtools/managed_command.py", devtools_source)
+    _write(tmp_path, "devtools/pytest_timeout_overrides.toml", manifest)
+    return tmp_path
+
+
+def _run_registered(root: Path, capsys: pytest.CaptureFixture[str]) -> tuple[int, str]:
+    """Exercise the catalog-resolved production command, not a test-only helper."""
+    command = COMMANDS["verify pytest-timeout-overrides"].resolve_main()
+    rc = command(["--root", str(root)])
+    return rc, capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("import pytest\n\n@pytest.mark.timeout(0)\ndef test_target():\n    pass\n", "must be positive"),
+        ("import pytest\n\n@pytest.mark.timeout(-1)\ndef test_target():\n    pass\n", "must be positive"),
+        (
+            "import pytest\n\nLIMIT = 30\n@pytest.mark.timeout(LIMIT)\ndef test_target():\n    pass\n",
+            "dynamic or malformed",
+        ),
+        ("import pytest\n\n@pytest.mark.timeout()\ndef test_target():\n    pass\n", "malformed"),
+        ("import pytest\n\n@pytest.mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
+    ],
+)
+def test_registered_verifier_rejects_invalid_decorator_overrides(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    expected: str,
+) -> None:
+    """Anti-vacuity: deleting decorator AST parsing makes this production-command test fail."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert expected in output
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("COMMAND = ['pytest', '--timeout=0']\n", "must be positive"),
+        ("COMMAND = ['pytest', '--timeout=-1']\n", "must be positive"),
+        ("LIMIT = '30'\nCOMMAND = ['pytest', '--timeout', LIMIT]\n", "dynamic or malformed"),
+        ("COMMAND = ['pytest', '--timeout=forever']\n", "malformed"),
+        ("COMMAND = ['pytest', '--timeout']\n", "unbounded"),
+        ("execution = pytest_execution('--timeout=')\n", "unbounded"),
+    ],
+)
+def test_registered_verifier_rejects_invalid_managed_command_overrides(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    expected: str,
+) -> None:
+    """Anti-vacuity: deleting command-literal AST parsing makes this production-command test fail."""
+    root = _make_tree(tmp_path, devtools_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert expected in output
+
+
+def test_registered_verifier_requires_exact_rationale_manifest_for_longer_values(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: removing above-default reconciliation makes this production-command test fail."""
+    root = _make_tree(tmp_path, devtools_source="COMMAND = ['pytest', '--timeout=600']\n")
+
+    missing_rc, missing_output = _run_registered(root, capsys)
+    _write(
+        root,
+        "devtools/pytest_timeout_overrides.toml",
+        "[[exception]]\npath = 'devtools/managed_command.py'\nvalue = 600\nrationale = 'Bounded full diagnostic.'\n",
+    )
+    present_rc, present_output = _run_registered(root, capsys)
+
+    assert missing_rc == 1
+    assert "without a manifest rationale" in missing_output
+    assert present_rc == 0, present_output
+
+
+def test_registered_verifier_rejects_stale_or_rationaleless_manifest_entry(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: removing stale-entry or rationale validation makes this production-command test fail."""
+    root = _make_tree(
+        tmp_path,
+        manifest=(
+            "[[exception]]\npath = 'devtools/retired.py'\nvalue = 600\nrationale = 'No longer live.'\n"
+            "\n[[exception]]\npath = 'devtools/managed_command.py'\nvalue = 700\nrationale = ''\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "rationale must be non-empty" in output
+    assert "stale timeout override manifest entry" in output
+
+
+def test_committed_registered_verifier_is_clean(capsys: pytest.CaptureFixture[str]) -> None:
+    """Anti-vacuity: deleting real-surface scanning or the live 600s manifest entry makes this test fail."""
+    command = COMMANDS["verify pytest-timeout-overrides"].resolve_main()
+
+    rc = command([])
+
+    assert rc == 0, capsys.readouterr().out

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -178,6 +178,87 @@ def test_registered_verifier_rejects_cyclic_marker_alias(
     assert "cyclic pytest marker alias" in output
 
 
+def test_registered_verifier_rejects_rebound_module_marker_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: retaining a final rebinding makes this source-order marker test falsely pass."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nBAD = [pytest.mark.timeout(None)]\npytestmark = BAD\nBAD = []\n"
+            "def test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "rebound pytest marker alias" in output
+
+
+def test_registered_verifier_rejects_rebound_incremental_marker_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: resolving the final BAD binding hides the prior pytestmark += timeout mark."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nBAD = [pytest.mark.timeout(None)]\npytestmark = []\npytestmark += BAD\n"
+            "BAD = []\ndef test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "rebound pytest marker alias" in output
+
+
+def test_registered_verifier_rejects_rebound_parameter_marker_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: resolving the final CASE binding hides the parameter timeout mark at its source site."""
+    root = _make_tree(
+        tmp_path,
+        test_source=(
+            "import pytest\n\nCASE = pytest.mark.timeout(0)\npytest.param(1, marks=CASE)\n"
+            "CASE = pytest.mark.slow\ndef test_target():\n    pass\n"
+        ),
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "rebound pytest marker alias" in output
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import pytest\n\nMARKS = [pytest.mark.timeout(30)]\npytestmark = MARKS\ndef test_target():\n    pass\n",
+        (
+            "import pytest\n\nEXTRA = [pytest.mark.timeout(30)]\npytestmark = []\n"
+            "pytestmark += EXTRA\ndef test_target():\n    pass\n"
+        ),
+        "import pytest\n\nCASE = pytest.mark.timeout(30)\npytest.param(1, marks=CASE)\ndef test_target():\n    pass\n",
+    ],
+)
+def test_registered_verifier_accepts_single_assignment_marker_aliases(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+) -> None:
+    """Anti-vacuity: rejecting every alias instead of only rebindings makes this test fail."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 0, output
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -60,6 +60,14 @@ def _run_registered(root: Path, capsys: pytest.CaptureFixture[str]) -> tuple[int
             "import pytest\n\npytestmark = []\npytestmark += [pytest.mark.timeout(None)]\ndef test_target():\n    pass\n",
             "unbounded",
         ),
+        (
+            "import pytest\n\nCASE = pytest.param(1, marks=pytest.mark.timeout(None))\ndef test_target():\n    pass\n",
+            "unbounded",
+        ),
+        (
+            "import pytest as pt\n\nLIMIT = 30\nCASE = pt.param(1, marks=[pt.mark.timeout(LIMIT)])\ndef test_target():\n    pass\n",
+            "dynamic or malformed",
+        ),
     ],
 )
 def test_registered_verifier_rejects_invalid_decorator_overrides(
@@ -75,6 +83,26 @@ def test_registered_verifier_rejects_invalid_decorator_overrides(
 
     assert rc == 1
     assert expected in output
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import pytest\n\nCASE = pytest.param(1, marks=pytest.mark.timeout(30))\ndef test_target():\n    pass\n",
+        "from pytest import mark, param\n\nCASE = param(1, marks=[mark.timeout(30), mark.slow])\ndef test_target():\n    pass\n",
+    ],
+)
+def test_registered_verifier_accepts_bounded_pytest_param_marks(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+) -> None:
+    """Anti-vacuity: removing pytest.param marks scanning makes this production-command test fail."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 0, output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -56,6 +56,10 @@ def _run_registered(root: Path, capsys: pytest.CaptureFixture[str]) -> tuple[int
         ("import pytest as pt\n\n@pt.mark.timeout(0)\ndef test_target():\n    pass\n", "must be positive"),
         ("import pytest\n\n@pytest.mark.timeout(None)\nclass TestTarget:\n    pass\n", "unbounded"),
         ("import pytest\n\npytestmark = pytest.mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
+        (
+            "import pytest\n\npytestmark = []\npytestmark += [pytest.mark.timeout(None)]\ndef test_target():\n    pass\n",
+            "unbounded",
+        ),
     ],
 )
 def test_registered_verifier_rejects_invalid_decorator_overrides(

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -113,7 +113,7 @@ def test_registered_verifier_rejects_module_timeout_mark_alias(
     root = _make_tree(
         tmp_path,
         test_source=(
-            "import pytest\n\nTIMEOUT_MARKS = [pytest.mark.timeout(None)]\npytestmark = TIMEOUT_MARKS\n"
+            "import pytest\n\nTIMEOUT_MARKS = (pytest.mark.timeout(None),)\npytestmark = TIMEOUT_MARKS\n"
             "def test_target():\n    pass\n"
         ),
     )
@@ -132,7 +132,7 @@ def test_registered_verifier_rejects_incremental_timeout_mark_alias(
     root = _make_tree(
         tmp_path,
         test_source=(
-            "import pytest\n\nEXTRA_MARKS = [pytest.mark.timeout(None)]\npytestmark = []\n"
+            "import pytest\n\nEXTRA_MARKS = (pytest.mark.timeout(None),)\npytestmark = []\n"
             "pytestmark += EXTRA_MARKS\ndef test_target():\n    pass\n"
         ),
     )
@@ -235,12 +235,63 @@ def test_registered_verifier_rejects_rebound_parameter_marker_alias(
     assert "rebound pytest marker alias" in output
 
 
+def test_registered_verifier_rejects_rebound_managed_command_alias(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Anti-vacuity: resolving a final command binding makes this source-order timeout argument pass."""
+    root = _make_tree(
+        tmp_path,
+        devtools_source="TIMEOUT_ARG = '--timeout=0'\nCOMMAND = ['pytest', TIMEOUT_ARG]\nTIMEOUT_ARG = '--timeout=30'\n",
+    )
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert "rebound managed pytest command alias" in output
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "import pytest\n\nMARKS = []\nMARKS.append(pytest.mark.timeout(None))\npytestmark = MARKS\n"
+            "def test_target():\n    pass\n",
+            "mutable pytest marker alias",
+        ),
+        (
+            "import pytest\n\nMARKS = []\nMARKS.append(pytest.mark.timeout(None))\n"
+            "pytest.param(1, marks=MARKS)\ndef test_target():\n    pass\n",
+            "mutable pytest marker alias",
+        ),
+        (
+            "import pytest\n\nMARKS = [pytest.mark.timeout(30)]\nMARKS[0] = pytest.mark.timeout(None)\n"
+            "pytestmark = MARKS\ndef test_target():\n    pass\n",
+            "mutable pytest marker alias",
+        ),
+    ],
+)
+def test_registered_verifier_rejects_mutable_marker_aliases(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    expected: str,
+) -> None:
+    """Anti-vacuity: interpreting mutable list aliases makes these runtime-effective marks false-green."""
+    root = _make_tree(tmp_path, test_source=source)
+
+    rc, output = _run_registered(root, capsys)
+
+    assert rc == 1
+    assert expected in output
+
+
 @pytest.mark.parametrize(
     "source",
     [
-        "import pytest\n\nMARKS = [pytest.mark.timeout(30)]\npytestmark = MARKS\ndef test_target():\n    pass\n",
+        "import pytest\n\nMARKS = (pytest.mark.timeout(30),)\npytestmark = MARKS\ndef test_target():\n    pass\n",
         (
-            "import pytest\n\nEXTRA = [pytest.mark.timeout(30)]\npytestmark = []\n"
+            "import pytest\n\nEXTRA = (pytest.mark.timeout(30),)\npytestmark = []\n"
             "pytestmark += EXTRA\ndef test_target():\n    pass\n"
         ),
         "import pytest\n\nCASE = pytest.mark.timeout(30)\npytest.param(1, marks=CASE)\ndef test_target():\n    pass\n",
@@ -262,9 +313,9 @@ def test_registered_verifier_accepts_single_assignment_marker_aliases(
 @pytest.mark.parametrize(
     "source",
     [
-        "import pytest\n\nMARKS = [pytest.mark.timeout(30)]\npytestmark = MARKS\ndef test_target():\n    pass\n",
+        "import pytest\n\nMARKS = (pytest.mark.timeout(30),)\npytestmark = MARKS\ndef test_target():\n    pass\n",
         (
-            "import pytest\n\nEXTRA_MARKS = [pytest.mark.timeout(30)]\npytestmark = []\n"
+            "import pytest\n\nEXTRA_MARKS = (pytest.mark.timeout(30),)\npytestmark = []\n"
             "pytestmark += EXTRA_MARKS\ndef test_target():\n    pass\n"
         ),
         (

--- a/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
+++ b/tests/unit/devtools/test_verify_pytest_timeout_overrides.py
@@ -54,6 +54,8 @@ def _run_registered(root: Path, capsys: pytest.CaptureFixture[str]) -> tuple[int
         ("import pytest\n\n@pytest.mark.timeout\ndef test_target():\n    pass\n", "missing a timeout value"),
         ("from pytest import mark\n\n@mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
         ("import pytest as pt\n\n@pt.mark.timeout(0)\ndef test_target():\n    pass\n", "must be positive"),
+        ("import pytest\n\n@pytest.mark.timeout(None)\nclass TestTarget:\n    pass\n", "unbounded"),
+        ("import pytest\n\npytestmark = pytest.mark.timeout(None)\ndef test_target():\n    pass\n", "unbounded"),
     ],
 )
 def test_registered_verifier_rejects_invalid_decorator_overrides(


### PR DESCRIPTION
## Summary

Add an AST-backed policy gate for explicit pytest timeout overrides and wire it into the quick verification tier.

## Problem

Tests and devtools-managed pytest commands could disable or exceed the repository's 300-second timeout floor without a reviewable exception boundary. Literal-only scanning false-greened aliases, dynamic expressions, class/module/parameter marks, source-order rebinding, and mutable marker lists.

## Solution

- Scan timeout decorators, class marks, module `pytestmark`, and `pytest.param(..., marks=...)` declarations with pytest import aliases.
- Scan managed pytest command constructors and reject dynamic or rebound timeout-shaped expressions.
- Resolve only conservative immutable marker aliases; mutable, cyclic, unresolved, or rebound aliases fail closed.
- Reconcile every longer exception against an exact path/value/rationale TOML manifest.
- Register the policy command in devtools and `devtools verify --quick`.
- Execute mutation-style cases through the registered production command.

Adversarial review iterated over dynamic/composed expressions, marker aliases/options, class/module/parameter marks, source-order rebinding, and mutable alias mutation. The final contract deliberately supports bounded static syntax rather than pretending to solve arbitrary Python dataflow.

Ref polylogue-c3qh.

## Verification

- `devtools test tests/unit/devtools/test_verify_pytest_timeout_overrides.py -n 0` -> 50 passed.
- `devtools verify --quick` -> 14/14 steps passed, exit 0 (`20260711T235725Z-quick-1886475-c0df049a`).
- Independent registered-command probes reject aliased, dynamic, rebound, class/module/parameter, and mutable-list unbounded timeout declarations.
