### PR TITLE
fix(claude): project background command outcomes

### DIFF
--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -246,6 +246,25 @@ def _background_task_id(item: dict[str, object]) -> str | None:
     return task_id if isinstance(task_id, str) and task_id else None
 
 
+def _task_notification_from_record(
+    item: dict[str, object], message: object
+) -> ClaudeCodeBackgroundTaskNotification | None:
+    """Read task protocol from message, queue-operation, or queued-command attachment."""
+    candidates: list[object] = []
+    if isinstance(message, dict):
+        candidates.append(message.get("content"))
+    candidates.append(item.get("content"))
+    attachment = item.get("attachment")
+    if isinstance(attachment, dict):
+        candidates.append(attachment.get("prompt"))
+    for candidate in candidates:
+        if isinstance(candidate, str):
+            notification = ClaudeCodeBackgroundTaskNotification.from_protocol_text(candidate)
+            if notification is not None:
+                return notification
+    return None
+
+
 def _mark_background_task_start(
     content_blocks: list[ParsedContentBlock], task_id: str | None
 ) -> list[ParsedContentBlock]:
@@ -286,14 +305,21 @@ def _project_background_task_completions(
             if isinstance(task_id, str) and task_id:
                 starts.setdefault((task_id, block.tool_id), (message_index, block_index))
 
-    terminal_by_start = {
-        (notification.task_id, notification.tool_use_id): notification for notification in notifications
-    }
+    starts_by_task: dict[str, list[tuple[int, int]]] = {}
+    for (task_id, _), location in starts.items():
+        starts_by_task.setdefault(task_id, []).append(location)
+
+    terminal_by_start: dict[tuple[int, int], ClaudeCodeBackgroundTaskNotification] = {}
+    for notification in notifications:
+        matched_location: tuple[int, int] | None = (
+            starts.get((notification.task_id, notification.tool_use_id))
+            if notification.tool_use_id is not None
+            else _unique_background_start(starts_by_task.get(notification.task_id, []))
+        )
+        if matched_location is not None:
+            terminal_by_start[matched_location] = notification
     projected = list(messages)
-    for key, notification in terminal_by_start.items():
-        location = starts.get(key)
-        if location is None:
-            continue
+    for location, notification in terminal_by_start.items():
         message_index, block_index = location
         message = projected[message_index]
         block = message.blocks[block_index]
@@ -311,6 +337,11 @@ def _project_background_task_completions(
         blocks[block_index] = updated_block
         projected[message_index] = message.model_copy(update={"blocks": blocks})
     return projected
+
+
+def _unique_background_start(locations: Sequence[tuple[int, int]]) -> tuple[int, int] | None:
+    """Return a task-only match only when provider evidence identifies one start."""
+    return locations[0] if len(locations) == 1 else None
 
 
 def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSession:
@@ -332,7 +363,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
     cwds: set[str] = set()
     models: set[str] = set()
     message_position = 0
-    background_notifications: list[tuple[ClaudeCodeBackgroundTaskNotification, str, str | None]] = []
+    background_notifications: list[tuple[ClaudeCodeBackgroundTaskNotification, str | None, str | None]] = []
 
     for index, item in enumerate(records, start=1):
         if not isinstance(item, dict):
@@ -383,6 +414,13 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
                 continue
             seen_record_uuids.add(record_uuid)
 
+        if not session_id:
+            session_id = _string_field(item, "sessionId")
+        raw_timestamp = item.get("timestamp")
+        timestamp = normalize_timestamp(raw_timestamp if isinstance(raw_timestamp, str | int | float) else None)
+        message = item.get("message")
+        notification = _task_notification_from_record(item, message)
+
         # ``progress`` records are claude-code hook lifecycle events
         # (`hookEvent`, `hookName`, `command`) carried alongside the
         # tool they fired on — they are NOT message content. Persisting
@@ -393,24 +431,18 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
         # parser; the hook payload, if useful for analytics, belongs in
         # a future ``session_event`` capture, not in the messages table.
         if record_type in _SKIPPED_SIDECAR_RECORD_TYPES:
+            if notification is not None:
+                background_notifications.append((notification, record_uuid, timestamp))
             continue
-
-        if not session_id:
-            session_id = _string_field(item, "sessionId")
-
-        raw_timestamp = item.get("timestamp")
-        timestamp = normalize_timestamp(raw_timestamp if isinstance(raw_timestamp, str | int | float) else None)
         if timestamp:
             created_at = timestamp if created_at is None or timestamp < created_at else created_at
             updated_at = timestamp if updated_at is None or timestamp > updated_at else updated_at
 
-        message = item.get("message")
         raw_content = message.get("content") if isinstance(message, dict) else item.get("content")
         text = extract_message_text(raw_content)
         envelope_role = _record_role(item, message)
         content_blocks = _content_blocks_from_record(message, text)
         content_blocks = _mark_background_task_start(content_blocks, _background_task_id(item))
-        notification = ClaudeCodeBackgroundTaskNotification.from_protocol_text(text)
         message_type = _message_type_from_code_record(item, text)
         if envelope_role is Role.SYSTEM and message_type is MessageType.MESSAGE:
             message_type = MessageType.CONTEXT

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -13,6 +13,7 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import BlockType, MaterialOrigin, PasteBoundary, Provider
 from polylogue.logging import get_logger
 from polylogue.pipeline.semantic_capture import detect_context_compaction
+from polylogue.sources.providers.claude_code_models import ClaudeCodeBackgroundTaskNotification
 
 from ..base import (
     ParsedContentBlock,
@@ -39,6 +40,9 @@ _WHITESPACE_RE = re.compile(r"\s+")
 # a real content hash (boundary_state=hash_only); batch re-ingest can only
 # recover the marker's exact location, so it stamps the span as PROJECTED.
 _PASTE_MARKER_RE = re.compile(r"\[Pasted text #(\d+)[^\]]*\]")
+_BACKGROUND_TASK_ID_METADATA_KEY = "claude_background_task_id"
+_BACKGROUND_COMPLETION_STATUS_METADATA_KEY = "claude_background_completion_status"
+_BACKGROUND_OUTPUT_FILE_METADATA_KEY = "claude_background_output_file"
 
 
 def _detect_paste_spans(text: str | None) -> list[ParsedPasteEvidence]:
@@ -234,6 +238,81 @@ def _string_field(item: dict[str, object], key: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _background_task_id(item: dict[str, object]) -> str | None:
+    tool_result = item.get("toolUseResult")
+    if not isinstance(tool_result, dict):
+        return None
+    task_id = tool_result.get("backgroundTaskId")
+    return task_id if isinstance(task_id, str) and task_id else None
+
+
+def _mark_background_task_start(
+    content_blocks: list[ParsedContentBlock], task_id: str | None
+) -> list[ParsedContentBlock]:
+    """Mark the immediate background acknowledgement as outcome-unknown.
+
+    Claude's initial Bash result acknowledges only that a task started. Its
+    ``is_error=false`` must not be projected as a completed-command success.
+    """
+    if task_id is None:
+        return content_blocks
+    marked: list[ParsedContentBlock] = []
+    for block in content_blocks:
+        if block.type is not BlockType.TOOL_RESULT:
+            marked.append(block)
+            continue
+        metadata = dict(block.metadata or {})
+        metadata[_BACKGROUND_TASK_ID_METADATA_KEY] = task_id
+        marked.append(block.model_copy(update={"metadata": metadata, "is_error": None, "exit_code": None}))
+    return marked
+
+
+def _project_background_task_completions(
+    messages: list[ParsedMessage], notifications: Sequence[ClaudeCodeBackgroundTaskNotification]
+) -> list[ParsedMessage]:
+    """Apply the final structured completion outcome to its start result.
+
+    The exact ``(task-id, tool-use-id)`` pair is the provider protocol join
+    key. Later notifications deliberately replace earlier ones for the same
+    pair, making duplicate delivery and provider updates deterministic.
+    """
+    starts: dict[tuple[str, str], tuple[int, int]] = {}
+    for message_index, message in enumerate(messages):
+        for block_index, block in enumerate(message.blocks):
+            if block.type is not BlockType.TOOL_RESULT or not block.tool_id:
+                continue
+            metadata = block.metadata or {}
+            task_id = metadata.get(_BACKGROUND_TASK_ID_METADATA_KEY)
+            if isinstance(task_id, str) and task_id:
+                starts.setdefault((task_id, block.tool_id), (message_index, block_index))
+
+    terminal_by_start = {
+        (notification.task_id, notification.tool_use_id): notification for notification in notifications
+    }
+    projected = list(messages)
+    for key, notification in terminal_by_start.items():
+        location = starts.get(key)
+        if location is None:
+            continue
+        message_index, block_index = location
+        message = projected[message_index]
+        block = message.blocks[block_index]
+        metadata = dict(block.metadata or {})
+        metadata[_BACKGROUND_COMPLETION_STATUS_METADATA_KEY] = notification.status
+        metadata[_BACKGROUND_OUTPUT_FILE_METADATA_KEY] = notification.output_file
+        updated_block = block.model_copy(
+            update={
+                "metadata": metadata,
+                "is_error": None if notification.exit_code is None else notification.exit_code != 0,
+                "exit_code": notification.exit_code,
+            }
+        )
+        blocks = list(message.blocks)
+        blocks[block_index] = updated_block
+        projected[message_index] = message.model_copy(update={"blocks": blocks})
+    return projected
+
+
 def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSession:
     """Parse Claude Code JSONL payloads into a canonical session model."""
     messages: list[ParsedMessage] = []
@@ -253,6 +332,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
     cwds: set[str] = set()
     models: set[str] = set()
     message_position = 0
+    background_notifications: list[tuple[ClaudeCodeBackgroundTaskNotification, str, str | None]] = []
 
     for index, item in enumerate(records, start=1):
         if not isinstance(item, dict):
@@ -329,6 +409,8 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
         text = extract_message_text(raw_content)
         envelope_role = _record_role(item, message)
         content_blocks = _content_blocks_from_record(message, text)
+        content_blocks = _mark_background_task_start(content_blocks, _background_task_id(item))
+        notification = ClaudeCodeBackgroundTaskNotification.from_protocol_text(text)
         message_type = _message_type_from_code_record(item, text)
         if envelope_role is Role.SYSTEM and message_type is MessageType.MESSAGE:
             message_type = MessageType.CONTEXT
@@ -391,6 +473,8 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
                 paste_spans=paste_spans,
             )
         )
+        if notification is not None:
+            background_notifications.append((notification, provider_message_id, timestamp))
         if isinstance(message, dict) and isinstance(message.get("usage"), dict):
             session_events.append(
                 ParsedSessionEvent(
@@ -420,6 +504,30 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedSe
         model_name = message_payload.get("model")
         if isinstance(model_name, str):
             models.add(model_name)
+
+    messages = _project_background_task_completions(
+        messages, [notification for notification, _, _ in background_notifications]
+    )
+    final_background_notifications = {
+        (notification.task_id, notification.tool_use_id): (notification, source_message_provider_id, timestamp)
+        for notification, source_message_provider_id, timestamp in background_notifications
+    }
+    for notification, source_message_provider_id, timestamp in final_background_notifications.values():
+        session_events.append(
+            ParsedSessionEvent(
+                event_type="background_task_completion",
+                timestamp=timestamp,
+                source_message_provider_id=source_message_provider_id,
+                payload={
+                    "task_id": notification.task_id,
+                    "tool_use_id": notification.tool_use_id,
+                    "output_file": notification.output_file,
+                    "status": notification.status,
+                    "summary": notification.summary,
+                    "exit_code": notification.exit_code,
+                },
+            )
+        )
 
     if duplicate_uuid_count:
         logger.debug(

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -295,7 +295,7 @@ def _project_background_task_completions(
     key. Later notifications deliberately replace earlier ones for the same
     pair, making duplicate delivery and provider updates deterministic.
     """
-    starts: dict[tuple[str, str], tuple[int, int]] = {}
+    starts: dict[tuple[str, str], list[tuple[int, int]]] = {}
     for message_index, message in enumerate(messages):
         for block_index, block in enumerate(message.blocks):
             if block.type is not BlockType.TOOL_RESULT or not block.tool_id:
@@ -303,16 +303,16 @@ def _project_background_task_completions(
             metadata = block.metadata or {}
             task_id = metadata.get(_BACKGROUND_TASK_ID_METADATA_KEY)
             if isinstance(task_id, str) and task_id:
-                starts.setdefault((task_id, block.tool_id), (message_index, block_index))
+                starts.setdefault((task_id, block.tool_id), []).append((message_index, block_index))
 
     starts_by_task: dict[str, list[tuple[int, int]]] = {}
-    for (task_id, _), location in starts.items():
-        starts_by_task.setdefault(task_id, []).append(location)
+    for (task_id, _), locations in starts.items():
+        starts_by_task.setdefault(task_id, []).extend(locations)
 
     terminal_by_start: dict[tuple[int, int], ClaudeCodeBackgroundTaskNotification] = {}
     for notification in notifications:
         matched_location: tuple[int, int] | None = (
-            starts.get((notification.task_id, notification.tool_use_id))
+            _unique_background_start(starts.get((notification.task_id, notification.tool_use_id), []))
             if notification.tool_use_id is not None
             else _unique_background_start(starts_by_task.get(notification.task_id, []))
         )

--- a/polylogue/sources/providers/claude_code.py
+++ b/polylogue/sources/providers/claude_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .claude_code_models import (
+    ClaudeCodeBackgroundTaskNotification,
     ClaudeCodeMessageContent,
     ClaudeCodeTextBlock,
     ClaudeCodeThinkingBlock,
@@ -14,6 +15,7 @@ from .claude_code_models import (
 from .claude_code_record import ClaudeCodeRecord
 
 __all__ = [
+    "ClaudeCodeBackgroundTaskNotification",
     "ClaudeCodeMessageContent",
     "ClaudeCodeRecord",
     "ClaudeCodeTextBlock",

--- a/polylogue/sources/providers/claude_code_models.py
+++ b/polylogue/sources/providers/claude_code_models.py
@@ -15,10 +15,9 @@ from polylogue.core.json import json_document
 ClaudeCodeBlockRecord: TypeAlias = dict[str, object]
 ClaudeCodeContentBlocks: TypeAlias = list[ClaudeCodeBlockRecord]
 
-_BACKGROUND_COMMAND_COMPLETION_RE = re.compile(
-    r'^Background command ".+" completed \(exit code (?P<exit_code>[0-9]+)\)$'
-)
-_TASK_NOTIFICATION_REQUIRED_FIELDS = frozenset({"task-id", "tool-use-id", "output-file", "status", "summary"})
+_BACKGROUND_COMMAND_SUCCESS_RE = re.compile(r'^Background command ".+" completed \(exit code (?P<exit_code>[0-9]+)\)$')
+_BACKGROUND_COMMAND_FAILURE_RE = re.compile(r'^Background command ".+" failed with exit code (?P<exit_code>[0-9]+)$')
+_TASK_NOTIFICATION_REQUIRED_FIELDS = frozenset({"task-id", "output-file", "status", "summary"})
 
 
 class _TaskNotificationEnvelopeParser(HTMLParser):
@@ -52,7 +51,7 @@ class _TaskNotificationEnvelopeParser(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         if not self._stack:
-            if data.strip():
+            if data.strip() and not self._closed_root:
                 self.malformed = True
             return
         if len(self._stack) == 2 and self._stack[0] == "task-notification":
@@ -63,13 +62,13 @@ class ClaudeCodeBackgroundTaskNotification(BaseModel):
     """Typed Claude Code background-command completion protocol evidence.
 
     The numeric exit code is populated only for the observed, version-specific
-    ``Background command ... completed (exit code N)`` summary template.
+    success and failed-command summary templates.
     Other structurally valid notifications deliberately retain ``None`` so
     callers cannot mistake arbitrary provider prose for a process outcome.
     """
 
     task_id: str
-    tool_use_id: str
+    tool_use_id: str | None = None
     output_file: str
     status: str
     summary: str
@@ -92,12 +91,24 @@ class ClaudeCodeBackgroundTaskNotification(BaseModel):
         values = {field: "".join(parser.fields[field]).strip() for field in _TASK_NOTIFICATION_REQUIRED_FIELDS}
         if any(not value for value in values.values()):
             return None
+        tool_use_values = parser.fields.get("tool-use-id")
+        if tool_use_values is not None and len(tool_use_values) != 1:
+            return None
+        tool_use_id = "".join(tool_use_values).strip() if tool_use_values is not None else None
+        if tool_use_values is not None and not tool_use_id:
+            return None
         summary = values["summary"]
-        match = _BACKGROUND_COMMAND_COMPLETION_RE.fullmatch(summary)
-        exit_code = int(match.group("exit_code")) if values["status"] == "completed" and match else None
+        match = (
+            _BACKGROUND_COMMAND_SUCCESS_RE.fullmatch(summary)
+            if values["status"] == "completed"
+            else _BACKGROUND_COMMAND_FAILURE_RE.fullmatch(summary)
+            if values["status"] == "failed"
+            else None
+        )
+        exit_code = int(match.group("exit_code")) if match else None
         return cls(
             task_id=values["task-id"],
-            tool_use_id=values["tool-use-id"],
+            tool_use_id=tool_use_id,
             output_file=values["output-file"],
             status=values["status"],
             summary=summary,

--- a/polylogue/sources/providers/claude_code_models.py
+++ b/polylogue/sources/providers/claude_code_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from html.parser import HTMLParser
 from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -12,6 +14,95 @@ from polylogue.core.json import json_document
 
 ClaudeCodeBlockRecord: TypeAlias = dict[str, object]
 ClaudeCodeContentBlocks: TypeAlias = list[ClaudeCodeBlockRecord]
+
+_BACKGROUND_COMMAND_COMPLETION_RE = re.compile(
+    r'^Background command ".+" completed \(exit code (?P<exit_code>[0-9]+)\)$'
+)
+_TASK_NOTIFICATION_REQUIRED_FIELDS = frozenset({"task-id", "tool-use-id", "output-file", "status", "summary"})
+
+
+class _TaskNotificationEnvelopeParser(HTMLParser):
+    """Strictly collect direct fields from Claude Code's task-notification envelope."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.fields: dict[str, list[str]] = {}
+        self._stack: list[str] = []
+        self._saw_root = False
+        self._closed_root = False
+        self.malformed = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if not self._stack:
+            if tag != "task-notification" or self._saw_root or self._closed_root:
+                self.malformed = True
+                return
+            self._saw_root = True
+        self._stack.append(tag)
+        if len(self._stack) == 2 and self._stack[0] == "task-notification":
+            self.fields.setdefault(tag, [])
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._stack or self._stack[-1] != tag:
+            self.malformed = True
+            return
+        self._stack.pop()
+        if not self._stack:
+            self._closed_root = True
+
+    def handle_data(self, data: str) -> None:
+        if not self._stack:
+            if data.strip():
+                self.malformed = True
+            return
+        if len(self._stack) == 2 and self._stack[0] == "task-notification":
+            self.fields[self._stack[-1]].append(data)
+
+
+class ClaudeCodeBackgroundTaskNotification(BaseModel):
+    """Typed Claude Code background-command completion protocol evidence.
+
+    The numeric exit code is populated only for the observed, version-specific
+    ``Background command ... completed (exit code N)`` summary template.
+    Other structurally valid notifications deliberately retain ``None`` so
+    callers cannot mistake arbitrary provider prose for a process outcome.
+    """
+
+    task_id: str
+    tool_use_id: str
+    output_file: str
+    status: str
+    summary: str
+    exit_code: int | None = None
+
+    @classmethod
+    def from_protocol_text(cls, text: str | None) -> ClaudeCodeBackgroundTaskNotification | None:
+        if not text:
+            return None
+        parser = _TaskNotificationEnvelopeParser()
+        parser.feed(text)
+        parser.close()
+        if parser.malformed or parser._stack or not parser._saw_root or not parser._closed_root:
+            return None
+        if set(parser.fields) & _TASK_NOTIFICATION_REQUIRED_FIELDS != _TASK_NOTIFICATION_REQUIRED_FIELDS:
+            return None
+        if any(len(parser.fields[field]) != 1 for field in _TASK_NOTIFICATION_REQUIRED_FIELDS):
+            return None
+
+        values = {field: "".join(parser.fields[field]).strip() for field in _TASK_NOTIFICATION_REQUIRED_FIELDS}
+        if any(not value for value in values.values()):
+            return None
+        summary = values["summary"]
+        match = _BACKGROUND_COMMAND_COMPLETION_RE.fullmatch(summary)
+        exit_code = int(match.group("exit_code")) if values["status"] == "completed" and match else None
+        return cls(
+            task_id=values["task-id"],
+            tool_use_id=values["tool-use-id"],
+            output_file=values["output-file"],
+            status=values["status"],
+            summary=summary,
+            exit_code=exit_code,
+        )
 
 
 class ClaudeCodeToolUse(BaseModel):

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+from pathlib import Path
+
 from polylogue.archive.message.types import MessageType
 from polylogue.core.enums import MaterialOrigin, Role
 from polylogue.sources.parsers.claude import parse_code
 from polylogue.sources.parsers.claude.common import normalize_timestamp
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 
 def test_normalize_timestamp_returns_canonical_iso_text() -> None:
@@ -165,6 +170,260 @@ def test_parse_code_preserves_tool_result_reclassification_material_origin() -> 
 
     assert result.messages[0].role is Role.TOOL
     assert result.messages[0].material_origin is MaterialOrigin.TOOL_RESULT
+
+
+def _background_task_records() -> list[object]:
+    """Real Claude Code protocol shape, reduced from persisted JSONL evidence."""
+    return [
+        {
+            "type": "assistant",
+            "uuid": "assistant-ok",
+            "sessionId": "background-outcomes",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-ok",
+                        "name": "Bash",
+                        "input": {"command": "true"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "start-ok",
+            "sessionId": "background-outcomes",
+            "toolUseResult": {"backgroundTaskId": "task-ok"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-ok",
+                        "content": "Command running in background with ID: task-ok.",
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-fail",
+            "sessionId": "background-outcomes",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-fail",
+                        "name": "Bash",
+                        "input": {"command": "false"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "start-fail",
+            "sessionId": "background-outcomes",
+            "toolUseResult": {"backgroundTaskId": "task-fail"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-fail",
+                        "content": "Command running in background with ID: task-fail.",
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-foreground",
+            "sessionId": "background-outcomes",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-foreground",
+                        "name": "Bash",
+                        "input": {"command": "printf foreground"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "result-foreground",
+            "sessionId": "background-outcomes",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-foreground",
+                        "content": "foreground",
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "notification-ok",
+            "sessionId": "background-outcomes",
+            "origin": {"kind": "task-notification"},
+            "message": {
+                "role": "user",
+                "content": """<task-notification>
+<task-id>task-ok</task-id>
+<tool-use-id>tool-ok</tool-use-id>
+<output-file>/tmp/task-ok.output</output-file>
+<status>completed</status>
+<summary>Background command \"true\" completed (exit code 0)</summary>
+</task-notification>""",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "notification-fail",
+            "sessionId": "background-outcomes",
+            "origin": {"kind": "task-notification"},
+            "message": {
+                "role": "user",
+                "content": """<task-notification>
+<task-id>task-fail</task-id>
+<tool-use-id>tool-fail</tool-use-id>
+<output-file>/tmp/task-fail.output</output-file>
+<status>completed</status>
+<summary>Background command \"false\" completed (exit code 1)</summary>
+</task-notification>""",
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "notification-fail-update",
+            "sessionId": "background-outcomes",
+            "origin": {"kind": "task-notification"},
+            "message": {
+                "role": "user",
+                "content": """<task-notification>
+<task-id>task-fail</task-id>
+<tool-use-id>tool-fail</tool-use-id>
+<output-file>/tmp/task-fail-final.output</output-file>
+<status>completed</status>
+<summary>Background command \"false\" completed (exit code 1)</summary>
+</task-notification>""",
+            },
+        },
+    ]
+
+
+def test_parse_code_projects_background_completion_outcomes_through_actions(tmp_path: Path) -> None:
+    """Production route: ``parse_code`` -> ``ArchiveStore`` -> ``actions``.
+
+    This fails if ``_project_background_task_completions`` or the
+    ``background_task_completion`` event emission is removed, if the exact
+    task-id/tool-use-id join is replaced with no correlation, or if the
+    known-template exit-code extraction is removed from
+    ``ClaudeCodeBackgroundTaskNotification``.
+    """
+    parsed = parse_code(_background_task_records(), "background-outcomes")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    failed_start = by_id["start-fail"].blocks[0]
+    assert failed_start.exit_code == 1
+    assert failed_start.is_error is True
+    assert failed_start.metadata == {
+        "claude_background_task_id": "task-fail",
+        "claude_background_completion_status": "completed",
+        "claude_background_output_file": "/tmp/task-fail-final.output",
+    }
+    assert by_id["notification-fail"].text is not None
+    assert "<task-notification>" in by_id["notification-fail"].text
+    completion_events = [event for event in parsed.session_events if event.event_type == "background_task_completion"]
+    assert [event.payload for event in completion_events] == [
+        {
+            "task_id": "task-ok",
+            "tool_use_id": "tool-ok",
+            "output_file": "/tmp/task-ok.output",
+            "status": "completed",
+            "summary": 'Background command "true" completed (exit code 0)',
+            "exit_code": 0,
+        },
+        {
+            "task_id": "task-fail",
+            "tool_use_id": "tool-fail",
+            "output_file": "/tmp/task-fail-final.output",
+            "status": "completed",
+            "summary": 'Background command "false" completed (exit code 1)',
+            "exit_code": 1,
+        },
+    ]
+
+    archive_root = tmp_path / "background-outcomes"
+    with ArchiveStore(archive_root) as archive:
+        session_id = archive.write_parsed(parsed)
+        actions = archive.query_session_actions([session_id], limit=10)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        event_rows = conn.execute(
+            """
+            SELECT source_message_provider_id, payload_json
+            FROM session_events
+            WHERE session_id = ? AND event_type = 'background_task_completion'
+            ORDER BY position
+            """,
+            (session_id,),
+        ).fetchall()
+
+    outcomes = {action.tool_command: (action.is_error, action.exit_code) for action in actions}
+    assert outcomes == {
+        "true": (0, 0),
+        "false": (1, 1),
+        "printf foreground": (0, None),
+    }
+    assert len(actions) == 3  # Duplicate notification updates one source action, never creates another.
+    assert [(source_id, json.loads(payload)) for source_id, payload in event_rows] == [
+        ("notification-ok", completion_events[0].payload),
+        ("notification-fail-update", completion_events[1].payload),
+    ]
+
+
+def test_parse_code_degrades_changed_background_completion_template_to_unknown() -> None:
+    """Production dependency: the strict typed notification parser in ``parse_code``.
+
+    This fails if the known-template ``fullmatch`` is loosened to extract an
+    arbitrary ``exit code 7`` phrase, or if background start acknowledgements
+    retain their provider ``is_error=false`` success flag.
+    """
+    records = _background_task_records()
+    notification = records[-2]
+    assert isinstance(notification, dict)
+    message = notification["message"]
+    assert isinstance(message, dict)
+    message["content"] = """<task-notification>
+<task-id>task-fail</task-id>
+<tool-use-id>tool-fail</tool-use-id>
+<output-file>/tmp/task-fail.output</output-file>
+<status>completed</status>
+<summary>Background command \"false\" ended unexpectedly; exit code 7</summary>
+</task-notification>"""
+    # Remove the duplicate so this drifted provider update is terminal.
+    records.pop()
+
+    parsed = parse_code(records, "background-outcomes-drift")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    failed_start = by_id["start-fail"].blocks[0]
+    foreground = by_id["result-foreground"].blocks[0]
+    assert failed_start.exit_code is None
+    assert failed_start.is_error is None
+    assert foreground.exit_code is None
+    assert foreground.is_error is False
 
 
 def test_parse_code_drops_progress_hook_records() -> None:

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -300,8 +300,8 @@ def _background_task_records() -> list[object]:
 <task-id>task-fail</task-id>
 <tool-use-id>tool-fail</tool-use-id>
 <output-file>/tmp/task-fail.output</output-file>
-<status>completed</status>
-<summary>Background command \"false\" completed (exit code 1)</summary>
+<status>failed</status>
+<summary>Background command \"false\" failed with exit code 1</summary>
 </task-notification>""",
             },
         },
@@ -316,12 +316,177 @@ def _background_task_records() -> list[object]:
 <task-id>task-fail</task-id>
 <tool-use-id>tool-fail</tool-use-id>
 <output-file>/tmp/task-fail-final.output</output-file>
-<status>completed</status>
-<summary>Background command \"false\" completed (exit code 1)</summary>
+<status>failed</status>
+<summary>Background command \"false\" failed with exit code 1</summary>
 </task-notification>""",
             },
         },
     ]
+
+
+def _background_start_records(*, task_id: str, tool_id: str, command: str, suffix: str) -> list[object]:
+    return [
+        {
+            "type": "assistant",
+            "uuid": f"assistant-{suffix}",
+            "sessionId": "background-sidecars",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": tool_id, "name": "Bash", "input": {"command": command}}],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": f"start-{suffix}",
+            "sessionId": "background-sidecars",
+            "toolUseResult": {"backgroundTaskId": task_id},
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": f"Command running in background with ID: {task_id}.",
+                        "is_error": False,
+                    }
+                ],
+            },
+        },
+    ]
+
+
+def _task_notification(*, task_id: str, status: str, summary: str, tool_id: str | None = None, suffix: str = "") -> str:
+    tool_use = f"<tool-use-id>{tool_id}</tool-use-id>\n" if tool_id else ""
+    return (
+        "<task-notification>\n"
+        f"<task-id>{task_id}</task-id>\n"
+        f"{tool_use}"
+        f"<output-file>/tmp/{task_id}{suffix}.output</output-file>\n"
+        f"<status>{status}</status>\n"
+        f"<summary>{summary}</summary>\n"
+        "</task-notification>"
+    )
+
+
+def test_parse_code_projects_queue_attachment_and_user_completion_shapes(tmp_path: Path) -> None:
+    """Production route: Claude parser -> ``ArchiveStore`` -> ``actions``.
+
+    This fails if notification extraction is moved below sidecar suppression,
+    the failed-template matcher is removed, or unique task-id fallback is
+    removed from ``_project_background_task_completions``.
+    """
+    records: list[object] = []
+    records.extend(
+        _background_start_records(task_id="task-queue", tool_id="tool-queue", command="true", suffix="queue")
+    )
+    records.extend(
+        _background_start_records(
+            task_id="task-attachment", tool_id="tool-attachment", command="false", suffix="attachment"
+        )
+    )
+    records.extend(
+        _background_start_records(task_id="task-user", tool_id="tool-user", command="printf user", suffix="user")
+    )
+    records.extend(
+        [
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "sessionId": "background-sidecars",
+                "content": _task_notification(
+                    task_id="task-queue",
+                    tool_id="tool-queue",
+                    status="completed",
+                    summary='Background command "true" completed (exit code 0)',
+                ),
+            },
+            {
+                "type": "attachment",
+                "uuid": "attachment-failed",
+                "sessionId": "background-sidecars",
+                "attachment": {
+                    "type": "queued_command",
+                    "commandMode": "task-notification",
+                    "prompt": _task_notification(
+                        task_id="task-attachment",
+                        tool_id="tool-attachment",
+                        status="failed",
+                        summary='Background command "false" failed with exit code 1',
+                    ),
+                },
+            },
+            {
+                "type": "user",
+                "uuid": "user-fallback",
+                "sessionId": "background-sidecars",
+                "origin": {"kind": "task-notification"},
+                "message": {
+                    "role": "user",
+                    "content": _task_notification(
+                        task_id="task-user",
+                        status="completed",
+                        summary='Background command "printf user" completed (exit code 0)',
+                    )
+                    + "\nRead the output file before reporting completion.",
+                },
+            },
+        ]
+    )
+
+    parsed = parse_code(records, "background-sidecars")
+    provider_ids = {message.provider_message_id for message in parsed.messages}
+    assert "attachment-failed" not in provider_ids
+    assert "user-fallback" in provider_ids
+    assert [
+        message.provider_message_id for message in parsed.messages if "<task-notification>" in (message.text or "")
+    ] == ["user-fallback"]
+
+    archive_root = tmp_path / "background-sidecars"
+    with ArchiveStore(archive_root) as archive:
+        session_id = archive.write_parsed(parsed)
+        actions = archive.query_session_actions([session_id], limit=10)
+
+    assert {action.tool_command: (action.is_error, action.exit_code) for action in actions} == {
+        "true": (0, 0),
+        "false": (1, 1),
+        "printf user": (0, 0),
+    }
+    completion_events = [event for event in parsed.session_events if event.event_type == "background_task_completion"]
+    assert [event.source_message_provider_id for event in completion_events] == [
+        None,
+        "attachment-failed",
+        "user-fallback",
+    ]
+
+
+def test_parse_code_keeps_task_only_completion_unknown_when_background_start_is_ambiguous() -> None:
+    """Production dependency: the parser's unique task-id fallback.
+
+    This fails if task-only notifications are correlated to the first matching
+    start instead of requiring exactly one ``backgroundTaskId`` match.
+    """
+    records: list[object] = []
+    records.extend(_background_start_records(task_id="shared-task", tool_id="tool-one", command="true", suffix="one"))
+    records.extend(_background_start_records(task_id="shared-task", tool_id="tool-two", command="false", suffix="two"))
+    records.append(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "sessionId": "background-sidecars",
+            "content": _task_notification(
+                task_id="shared-task",
+                status="completed",
+                summary='Background command "unknown" completed (exit code 0)',
+            ),
+        }
+    )
+
+    parsed = parse_code(records, "background-ambiguous")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    assert by_id["start-one"].blocks[0].exit_code is None
+    assert by_id["start-one"].blocks[0].is_error is None
+    assert by_id["start-two"].blocks[0].exit_code is None
+    assert by_id["start-two"].blocks[0].is_error is None
 
 
 def test_parse_code_projects_background_completion_outcomes_through_actions(tmp_path: Path) -> None:
@@ -340,7 +505,7 @@ def test_parse_code_projects_background_completion_outcomes_through_actions(tmp_
     assert failed_start.is_error is True
     assert failed_start.metadata == {
         "claude_background_task_id": "task-fail",
-        "claude_background_completion_status": "completed",
+        "claude_background_completion_status": "failed",
         "claude_background_output_file": "/tmp/task-fail-final.output",
     }
     assert by_id["notification-fail"].text is not None
@@ -359,8 +524,8 @@ def test_parse_code_projects_background_completion_outcomes_through_actions(tmp_
             "task_id": "task-fail",
             "tool_use_id": "tool-fail",
             "output_file": "/tmp/task-fail-final.output",
-            "status": "completed",
-            "summary": 'Background command "false" completed (exit code 1)',
+            "status": "failed",
+            "summary": 'Background command "false" failed with exit code 1',
             "exit_code": 1,
         },
     ]

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -489,6 +489,40 @@ def test_parse_code_keeps_task_only_completion_unknown_when_background_start_is_
     assert by_id["start-two"].blocks[0].is_error is None
 
 
+def test_parse_code_keeps_exact_pair_completion_unknown_when_start_is_duplicated() -> None:
+    """Production dependency: exact-pair start indexing in ``parse_code``.
+
+    This fails if exact-pair starts are collapsed with ``setdefault`` or if a
+    completion is applied to the first duplicate instead of requiring one
+    candidate just like the task-only fallback.
+    """
+    records: list[object] = []
+    records.extend(_background_start_records(task_id="same-task", tool_id="same-tool", command="true", suffix="first"))
+    records.extend(
+        _background_start_records(task_id="same-task", tool_id="same-tool", command="false", suffix="second")
+    )
+    records.append(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "sessionId": "background-sidecars",
+            "content": _task_notification(
+                task_id="same-task",
+                tool_id="same-tool",
+                status="failed",
+                summary='Background command "false" failed with exit code 1',
+            ),
+        }
+    )
+
+    parsed = parse_code(records, "background-exact-ambiguous")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    assert by_id["start-first"].blocks[0].exit_code is None
+    assert by_id["start-first"].blocks[0].is_error is None
+    assert by_id["start-second"].blocks[0].exit_code is None
+    assert by_id["start-second"].blocks[0].is_error is None
+
+
 def test_parse_code_projects_background_completion_outcomes_through_actions(tmp_path: Path) -> None:
     """Production route: ``parse_code`` -> ``ArchiveStore`` -> ``actions``.
 


### PR DESCRIPTION
## Summary

Project Claude Code background-command completion notifications into durable session events and the existing action outcome fields.

## Problem

Claude persists background Bash starts and terminal notifications in different records. The archive retained the prose but left the originating action outcome unknown, even though the provider protocol supplies an exit code. Early tests false-greened synthetic shapes rather than the live failed, queue-operation, and attachment records.

## Solution

- Parse exact successful and failed task-notification protocol templates.
- Collect notification evidence from queue-operation, attachment, and user envelopes while keeping sidecars out of the message transcript.
- Correlate by task and tool IDs; permit task-only fallback only for one unique start.
- Fail closed for duplicate task IDs and duplicate exact task/tool pairs.
- Project the outcome onto the original tool result so the existing actions view and run insights expose it.
- Persist a deduplicated background completion session event with provider metadata.

Three adversarial remediation passes aligned fixtures to live Claude records, covered older optional-ID/trailing-text shapes, and closed exact-pair ambiguity. A fresh final review found no remaining release blocker.

Ref polylogue-t0p.1.

## Verification

- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py` -> 19 passed.
- Exact-path Ruff and mypy checks -> passed.
- `devtools verify --quick` -> 13/13 steps passed, exit 0 (`20260711T233908Z-quick-1842704-56a25184`).
- Independent review verified real failed/success templates, queue/attachment/user extraction, non-materialization, unique-only correlation, durable events, and the real actions route.
