### PR TITLE
fix(storage): fold byte-proven append heads into full snapshots

### DIFF
--- a/polylogue/archive/revision_replay.py
+++ b/polylogue/archive/revision_replay.py
@@ -25,6 +25,7 @@ class RevisionCandidate:
     acquisition_generation: int
     authority: RawRevisionAuthority
     blob_size: int
+    predecessor_source_revision: str | None = None
     predecessor_raw_id: str | None = None
     baseline_raw_id: str | None = None
     append_start_offset: int | None = None

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -6,6 +6,7 @@ Twin-write contract: raw-revision-authority.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import time
@@ -37,6 +38,7 @@ from polylogue.archive.revision_authority import (
     RawRevisionAuthority,
     RawRevisionEnvelope,
     RawRevisionKind,
+    append_source_revision,
     classify_historical_full_revisions,
 )
 from polylogue.archive.revision_replay import (
@@ -150,6 +152,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     stored_message_count,
 )
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
+    FullSnapshotFoldAuthorization,
     RevisionApplicationReceipt,
     assert_session_fts_exact_sync,
     record_revision_application_sync,
@@ -1497,7 +1500,7 @@ class ArchiveStore:
                 """
             SELECT raw_id, revision_kind, source_revision, acquisition_generation,
                    revision_authority, blob_size, predecessor_raw_id, baseline_raw_id,
-                   append_start_offset, append_end_offset
+                   append_start_offset, append_end_offset, predecessor_source_revision
             FROM raw_sessions
             WHERE logical_source_key = ? AND source_revision IS NOT NULL
             """,
@@ -1514,6 +1517,7 @@ class ArchiveStore:
                 acquisition_generation=int(row[3]),
                 authority=RawRevisionAuthority(str(row[4])),
                 blob_size=int(row[5]),
+                predecessor_source_revision=str(row[10]) if row[10] is not None else None,
                 predecessor_raw_id=str(row[6]) if row[6] is not None else None,
                 baseline_raw_id=str(row[7]) if row[7] is not None else None,
                 append_start_offset=int(row[8]) if row[8] is not None else None,
@@ -1521,6 +1525,103 @@ class ArchiveStore:
             )
             for row in rows
         ]
+
+    def _authorize_full_snapshot_fold(
+        self,
+        *,
+        existing_head: tuple[object, ...],
+        full_candidate: RevisionCandidate,
+        candidates: Mapping[str, RevisionCandidate],
+    ) -> FullSnapshotFoldAuthorization | None:
+        """Prove one full raw is exactly the accepted byte-append chain.
+
+        The caller invokes this while holding the index replay transaction;
+        failure intentionally yields no authority and leaves ordinary CAS
+        semantics in force.  Every byte, offset, source revision, and raw
+        predecessor edge is checked instead of trusting parser-normalized
+        content hashes, which are segmentation-sensitive for Codex JSONL.
+        """
+        if (
+            full_candidate.kind is not RawRevisionKind.FULL
+            or full_candidate.authority is not RawRevisionAuthority.BYTE_PROVEN
+            or str(existing_head[4]) != "byte"
+            or str(existing_head[1]) not in candidates
+        ):
+            return None
+        accepted_head = candidates[str(existing_head[1])]
+        frontier = int(cast(int | str | bytes, existing_head[5]))
+        if (
+            accepted_head.kind is not RawRevisionKind.APPEND
+            or accepted_head.authority is not RawRevisionAuthority.BYTE_PROVEN
+            or accepted_head.source_revision != str(existing_head[2])
+            or accepted_head.append_end_offset != frontier
+        ):
+            return None
+        _provider, full_payload, _path, _kind = self.raw_revision_material(full_candidate.raw_id)
+        if len(full_payload) != frontier:
+            return None
+
+        tail_payloads: list[bytes] = []
+        current = accepted_head
+        baseline_raw_id = current.baseline_raw_id
+        expected_end = frontier
+        visited: set[str] = set()
+        while current.kind is RawRevisionKind.APPEND:
+            if (
+                current.raw_id in visited
+                or current.authority is not RawRevisionAuthority.BYTE_PROVEN
+                or current.baseline_raw_id != baseline_raw_id
+                or current.predecessor_raw_id is None
+                or current.predecessor_source_revision is None
+                or current.append_start_offset is None
+                or current.append_end_offset != expected_end
+            ):
+                return None
+            visited.add(current.raw_id)
+            _provider, tail_payload, _path, _kind = self.raw_revision_material(current.raw_id)
+            assert current.append_end_offset is not None
+            assert current.append_start_offset is not None
+            if len(tail_payload) != current.append_end_offset - current.append_start_offset:
+                return None
+            predecessor = candidates.get(current.predecessor_raw_id)
+            if (
+                predecessor is None
+                or predecessor.source_revision != current.predecessor_source_revision
+                or current.source_revision
+                != append_source_revision(predecessor.source_revision, hashlib.sha256(tail_payload).hexdigest())
+            ):
+                return None
+            predecessor_end = (
+                predecessor.blob_size if predecessor.kind is RawRevisionKind.FULL else predecessor.append_end_offset
+            )
+            if predecessor_end != current.append_start_offset:
+                return None
+            tail_payloads.append(tail_payload)
+            expected_end = current.append_start_offset
+            current = predecessor
+        if (
+            current.kind is not RawRevisionKind.FULL
+            or current.authority is not RawRevisionAuthority.BYTE_PROVEN
+            or current.raw_id != baseline_raw_id
+            or current.blob_size != expected_end
+        ):
+            return None
+        _provider, baseline_payload, _path, _kind = self.raw_revision_material(current.raw_id)
+        if (
+            len(baseline_payload) != current.blob_size
+            or baseline_payload + b"".join(reversed(tail_payloads)) != full_payload
+        ):
+            return None
+        return FullSnapshotFoldAuthorization(
+            logical_source_key=full_candidate.logical_source_key,
+            session_id=str(existing_head[0]),
+            accepted_append_raw_id=str(existing_head[1]),
+            accepted_append_source_revision=str(existing_head[2]),
+            accepted_append_content_hash=cast(bytes, existing_head[3]),
+            frontier=frontier,
+            full_raw_id=full_candidate.raw_id,
+            full_source_revision=full_candidate.source_revision,
+        )
 
     def raw_revision_material(self, raw_id: str) -> tuple[Provider, bytes, str, RawRevisionKind]:
         """Read one retained revision with its parsing identity."""
@@ -1997,11 +2098,13 @@ class ArchiveStore:
         session_ids: set[str] = set()
         with self._conn:
             existing_head = self._conn.execute(
-                "SELECT accepted_frontier_kind FROM raw_revision_heads WHERE logical_source_key = ?",
+                """SELECT session_id, accepted_raw_id, accepted_source_revision,
+                          accepted_content_hash, accepted_frontier_kind, accepted_frontier
+                   FROM raw_revision_heads WHERE logical_source_key = ?""",
                 (plan.logical_source_key,),
             ).fetchone()
             accepted_frontier_kind = (
-                "semantic" if existing_head is not None and str(existing_head[0]) == "semantic" else "byte"
+                "semantic" if existing_head is not None and str(existing_head[4]) == "semantic" else "byte"
             )
             if accepted_frontier_kind == "semantic":
                 accepted_projection = session_revision_projection(aggregate_sessions[0])
@@ -2041,6 +2144,13 @@ class ArchiveStore:
                 raise RuntimeError("accepted revision did not produce a hashed session")
             accepted_raw_id = plan.accepted_raw_ids[-1]
             accepted = candidates[accepted_raw_id]
+            fold_authorization = (
+                self._authorize_full_snapshot_fold(
+                    existing_head=tuple(existing_head), full_candidate=accepted, candidates=candidates
+                )
+                if existing_head is not None and accepted_frontier_kind == "byte"
+                else None
+            )
             decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
             for application in plan.applications:
                 candidate = candidates[application.raw_id]
@@ -2071,6 +2181,7 @@ class ArchiveStore:
                         predecessor_raw_id=candidate.predecessor_raw_id,
                         append_end_offset=accepted.append_end_offset,
                         detail=application.detail,
+                        fold_authorization=(fold_authorization if candidate.raw_id == accepted_raw_id else None),
                     ),
                     decided_at_ms=decided_at_ms,
                 )

--- a/polylogue/storage/sqlite/archive_tiers/revision_application.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_application.py
@@ -32,6 +32,7 @@ class RevisionApplicationReceipt:
     predecessor_raw_id: str | None = None
     append_end_offset: int | None = None
     detail: str = ""
+    fold_authorization: FullSnapshotFoldAuthorization | None = None
 
     @property
     def decision_id(self) -> str:
@@ -46,6 +47,48 @@ class RevisionApplicationReceipt:
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
         return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class FullSnapshotFoldAuthorization:
+    """One-shot authority for a cryptographically proven byte-chain fold.
+
+    This is deliberately an in-memory transaction capability, not a new
+    precedence rule.  It binds one incoming full receipt to the exact accepted
+    append head it proved, so it cannot authorize a later or different CAS.
+    """
+
+    logical_source_key: str
+    session_id: str
+    accepted_append_raw_id: str
+    accepted_append_source_revision: str
+    accepted_append_content_hash: bytes
+    frontier: int
+    full_raw_id: str
+    full_source_revision: str
+
+    def permits(self, existing_head: tuple[object, ...], receipt: RevisionApplicationReceipt) -> bool:
+        return (
+            tuple(existing_head[:6])
+            == (
+                self.session_id,
+                self.accepted_append_raw_id,
+                self.accepted_append_source_revision,
+                self.accepted_append_content_hash,
+                "byte",
+                self.frontier,
+            )
+            and receipt.logical_source_key == self.logical_source_key
+            and receipt.decision is ApplicationDecision.SELECTED_BASELINE
+            and receipt.session_id == self.session_id
+            and receipt.raw_id == self.full_raw_id
+            and receipt.accepted_raw_id == self.full_raw_id
+            and receipt.source_revision == self.full_source_revision
+            and receipt.accepted_source_revision == self.full_source_revision
+            and receipt.accepted_frontier_kind == "byte"
+            and receipt.accepted_frontier == self.frontier
+            and receipt.append_end_offset is None
+        )
 
 
 def assert_session_fts_exact_sync(conn: sqlite3.Connection, session_id: str) -> None:
@@ -197,7 +240,10 @@ def record_revision_application_sync(
                 receipt.accepted_frontier_kind,
                 receipt.accepted_frontier,
             )
-            if existing_semantics != accepted_semantics:
+            authorized_fold = receipt.fold_authorization is not None and receipt.fold_authorization.permits(
+                existing_head, receipt
+            )
+            if existing_semantics != accepted_semantics and not authorized_fold:
                 raise RuntimeError("raw revision CAS rejected a conflicting accepted head")
             if tuple(existing_head) == (
                 receipt.session_id,
@@ -246,6 +292,7 @@ def record_revision_application_sync(
 
 __all__ = [
     "RevisionApplicationReceipt",
+    "FullSnapshotFoldAuthorization",
     "assert_session_fts_exact_sync",
     "record_revision_application_sync",
 ]

--- a/tests/unit/storage/test_revision_application.py
+++ b/tests/unit/storage/test_revision_application.py
@@ -9,6 +9,7 @@ import pytest
 from polylogue.archive.revision_replay import ApplicationDecision
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
+    FullSnapshotFoldAuthorization,
     RevisionApplicationReceipt,
     assert_session_fts_exact_sync,
     record_revision_application_sync,
@@ -157,3 +158,46 @@ def test_equal_frontier_full_can_replace_equivalent_append_representation() -> N
         "full-1",
         None,
     )
+
+
+def test_equal_frontier_fold_authorization_is_bound_to_one_exact_head() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    append_head = replace(
+        _receipt(generation=2, revision="append-2", frontier=180),
+        decision=ApplicationDecision.APPLIED_APPEND,
+        append_end_offset=180,
+    )
+    record_revision_application_sync(conn, append_head, decided_at_ms=10)
+    authorization = FullSnapshotFoldAuthorization(
+        logical_source_key="codex:session",
+        session_id="codex-session:session",
+        accepted_append_raw_id="raw-2",
+        accepted_append_source_revision="append-2",
+        accepted_append_content_hash=bytes([2]) * 32,
+        frontier=180,
+        full_raw_id="full",
+        full_source_revision="full-revision",
+    )
+    full = replace(
+        _receipt(generation=3, revision="full-revision", frontier=180),
+        raw_id="full",
+        accepted_raw_id="full",
+        accepted_source_revision="full-revision",
+        accepted_content_hash=b"different-normalized-hash-123456"[:32],
+        append_end_offset=None,
+        fold_authorization=authorization,
+    )
+    record_revision_application_sync(conn, full, decided_at_ms=20)
+    assert conn.execute("SELECT accepted_raw_id FROM raw_revision_heads").fetchone() == ("full",)
+    with pytest.raises(RuntimeError, match="conflicting accepted head"):
+        record_revision_application_sync(
+            conn,
+            replace(
+                full,
+                raw_id="other",
+                accepted_raw_id="other",
+                accepted_content_hash=b"other-normalized-content-hash-123"[:32],
+            ),
+            decided_at_ms=30,
+        )

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -28,7 +28,7 @@ from polylogue.archive.session_revision_membership import (
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.dispatch import merge_parsed_session_chunks, parse_stream_payload
-from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -110,6 +110,25 @@ def _codex_fold_payloads() -> tuple[bytes, bytes]:
         ]
     )
     return baseline, append
+
+
+def _with_fold_attachment(session: ParsedSession) -> ParsedSession:
+    """Exercise attachment persistence without inventing Codex parser behavior."""
+    return session.model_copy(
+        update={
+            "attachments": [
+                ParsedAttachment(
+                    provider_attachment_id="fold-image-1",
+                    message_provider_id="m1",
+                    name="fold-proof.png",
+                    mime_type="image/png",
+                    size_bytes=4,
+                    upload_origin="url",
+                    source_url="https://example.invalid/fold-proof.png",
+                )
+            ]
+        }
+    )
 
 
 def test_replay_selects_newest_full_and_exact_contiguous_suffix_independent_of_order() -> None:
@@ -425,7 +444,7 @@ def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_
 
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         baseline_payload, tail = _codex_fold_payloads()
-        baseline_session = _parse_codex_jsonl(baseline_payload)
+        baseline_session = _with_fold_attachment(_parse_codex_jsonl(baseline_payload))
         append_session = _parse_codex_jsonl(tail)
         folded_payload = baseline_payload + tail
         folded_session = _parse_codex_jsonl(folded_payload)
@@ -511,6 +530,15 @@ def test_real_append_fold_proof_mutations_roll_back(
             ORDER BY b.block_id
             """
         ).fetchall()
+        candidate_matches = archive._conn.execute(
+            """
+            SELECT b.block_id, b.message_id, b.text
+            FROM messages_fts
+            JOIN blocks AS b ON b.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'candidate'
+            ORDER BY b.block_id
+            """
+        ).fetchall()
         return {
             "sessions": archive._conn.execute("SELECT content_hash, message_count FROM sessions").fetchall(),
             "messages": archive._conn.execute(
@@ -527,6 +555,7 @@ def test_real_append_fold_proof_mutations_roll_back(
             ).fetchall(),
             "fts_docsize": archive._conn.execute("SELECT id, sz FROM messages_fts_docsize ORDER BY id").fetchall(),
             "fts_needle": fts_matches,
+            "fts_candidate": candidate_matches,
             "head": archive._conn.execute(
                 "SELECT accepted_raw_id, accepted_content_hash, accepted_frontier FROM raw_revision_heads"
             ).fetchall(),
@@ -537,9 +566,11 @@ def test_real_append_fold_proof_mutations_roll_back(
 
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         baseline_payload, tail = _codex_fold_payloads()
-        baseline_session = _parse_codex_jsonl(baseline_payload)
+        baseline_session = _with_fold_attachment(_parse_codex_jsonl(baseline_payload))
         append_session = _parse_codex_jsonl(tail)
-        folded_session = _parse_codex_jsonl(baseline_payload + tail)
+        candidate_payload = (baseline_payload + tail).replace(b"needle beta", b"candidate X")
+        assert len(candidate_payload) == len(baseline_payload + tail)
+        folded_session = _parse_codex_jsonl(candidate_payload)
         baseline = archive.write_raw_payload(
             provider=Provider.CODEX, payload=baseline_payload, source_path="session.jsonl", acquired_at_ms=1
         )
@@ -570,7 +601,7 @@ def test_real_append_fold_proof_mutations_roll_back(
         )
         chain = archive.raw_revision_replay_plan("codex:session")
         archive.apply_raw_revision_replay(chain, {baseline: baseline_session, append: append_session}, acquired_at_ms=0)
-        folded_payload = baseline_payload + tail
+        folded_payload = candidate_payload
         if mutation in {"baseline", "divergent"}:
             folded_payload = (b"X" if mutation == "baseline" else baseline_payload[:5] + b"X") + folded_payload[
                 1 if mutation == "baseline" else 6 :
@@ -617,7 +648,9 @@ def test_real_append_fold_proof_mutations_roll_back(
         before = state(archive)
         assert before["blocks"]
         assert before["session_events"]
+        assert before["attachments"]
         assert before["fts_needle"]
+        assert not before["fts_candidate"]
         plan = archive.raw_revision_replay_plan("codex:session")
         with pytest.raises(RuntimeError, match="conflicting accepted head"):
             archive.apply_raw_revision_replay(plan, {folded: folded_session}, acquired_at_ms=0)

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import hashlib
 from itertools import permutations
 from pathlib import Path
 
 import pytest
 
 from polylogue.archive.message.roles import Role
-from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.archive.revision_authority import (
+    RawRevisionAuthority,
+    RawRevisionEnvelope,
+    RawRevisionKind,
+    append_source_revision,
+)
 from polylogue.archive.revision_replay import (
     ApplicationDecision,
     RevisionCandidate,
@@ -19,7 +25,7 @@ from polylogue.archive.session_revision_membership import (
     classify_membership_revisions,
 )
 from polylogue.core.enums import Provider
-from polylogue.pipeline.ids import session_revision_projection
+from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -250,7 +256,7 @@ def test_cohort_classification_promotes_late_baseline_and_deferred_append(tmp_pa
     }
 
 
-def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> None:
+def test_real_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
 
     def parsed(*messages: tuple[str, str]) -> ParsedSession:
@@ -269,7 +275,9 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
         )
         archive.bind_raw_revision(
             baseline,
-            RawRevisionEnvelope("codex:session", RawRevisionKind.FULL, "full-0", 0),
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "full-0", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
         )
         append_one = archive.write_raw_payload(
             provider=Provider.CODEX,
@@ -283,12 +291,14 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
             RawRevisionEnvelope(
                 "codex:session",
                 RawRevisionKind.APPEND,
-                "append-1",
-                0,
+                append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                1,
                 predecessor_source_revision="full-0",
+                predecessor_raw_id=baseline,
+                baseline_raw_id=baseline,
                 append_start_offset=10,
                 append_end_offset=15,
-                authority=RawRevisionAuthority.QUARANTINED,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
         append_two = archive.write_raw_payload(
@@ -303,12 +313,17 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
             RawRevisionEnvelope(
                 "codex:session",
                 RawRevisionKind.APPEND,
-                "append-2",
-                0,
-                predecessor_source_revision="append-1",
+                append_source_revision(
+                    append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                    hashlib.sha256(b"c" * 5).hexdigest(),
+                ),
+                2,
+                predecessor_source_revision=append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                predecessor_raw_id=append_one,
+                baseline_raw_id=baseline,
                 append_start_offset=15,
                 append_end_offset=20,
-                authority=RawRevisionAuthority.QUARANTINED,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
         append_plan = archive.classify_raw_revision_cohort("codex:session")
@@ -323,16 +338,27 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
         )
 
         folded = archive.write_raw_payload(
-            provider=Provider.CODEX, payload=b"a" * 20, source_path="session.jsonl", acquired_at_ms=4
+            provider=Provider.CODEX,
+            payload=b"a" * 10 + b"b" * 5 + b"c" * 5,
+            source_path="session.jsonl",
+            acquired_at_ms=4,
         )
         archive.bind_raw_revision(
             folded,
-            RawRevisionEnvelope("codex:session", RawRevisionKind.FULL, "full-folded", 0),
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "full-folded", 3, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
         )
         folded_plan = archive.classify_raw_revision_cohort("codex:session")
+        folded_session = parsed(("full-0", "zero"), ("full-1", "one"), ("full-2", "two"))
+        before_hash = archive._conn.execute(
+            "SELECT accepted_content_hash FROM raw_revision_heads WHERE logical_source_key = ?", ("codex:session",)
+        ).fetchone()
+        assert before_hash is not None
+        assert bytes(before_hash[0]) != bytes.fromhex(session_content_hash(folded_session))
         archive.apply_raw_revision_replay(
             folded_plan,
-            {folded: parsed(("m0", "zero"), ("m1", "one"), ("m2", "two"))},
+            {folded: folded_session},
             acquired_at_ms=0,
         )
 
@@ -342,6 +368,183 @@ def test_real_append_chain_accepts_equivalent_same_end_full(tmp_path: Path) -> N
         ).fetchone()
         assert head is not None
         assert tuple(head) == (folded, 20)
+
+
+def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+
+    def parsed(*messages: tuple[str, str]) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[
+                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
+                for message_id, text in messages
+            ],
+        )
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        baseline_payload, tail = b"0123456789", b"abcdefghij"
+        baseline = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=baseline_payload, source_path="session.jsonl", acquired_at_ms=1
+        )
+        archive.bind_raw_revision(
+            baseline,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "base", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        append = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=tail, source_path="session.jsonl", source_index=-1, acquired_at_ms=2
+        )
+        append_revision = append_source_revision("base", hashlib.sha256(tail).hexdigest())
+        archive.bind_raw_revision(
+            append,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.APPEND,
+                append_revision,
+                1,
+                predecessor_source_revision="base",
+                predecessor_raw_id=baseline,
+                baseline_raw_id=baseline,
+                append_start_offset=10,
+                append_end_offset=20,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        archive.apply_raw_revision_replay(
+            archive.raw_revision_replay_plan("codex:session"),
+            {baseline: parsed(("m0", "zero")), append: parsed(("m1", "one"))},
+            acquired_at_ms=0,
+        )
+        folded = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=baseline_payload + tail, source_path="session.jsonl", acquired_at_ms=3
+        )
+        archive.bind_raw_revision(
+            folded,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "folded", 2, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        folded_session = parsed(("folded-0", "zero"), ("folded-1", "one"))
+        before_hash = archive._conn.execute(
+            "SELECT accepted_content_hash FROM raw_revision_heads WHERE logical_source_key = ?", ("codex:session",)
+        ).fetchone()
+        assert before_hash is not None
+        assert bytes(before_hash[0]) != bytes.fromhex(session_content_hash(folded_session))
+        archive.apply_raw_revision_replay(
+            archive.raw_revision_replay_plan("codex:session"), {folded: folded_session}, acquired_at_ms=0
+        )
+        assert archive.raw_revision_head_raw_id("codex:session") == folded
+
+
+@pytest.mark.parametrize("mutation", ["tail", "gap", "overlap", "predecessor", "baseline", "missing", "divergent"])
+def test_real_append_fold_proof_mutations_roll_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation: str
+) -> None:
+    initialize_active_archive_root(tmp_path)
+
+    def parsed(*messages: tuple[str, str]) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[
+                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
+                for message_id, text in messages
+            ],
+        )
+
+    def state(archive: ArchiveStore) -> tuple[object, ...]:
+        return (
+            archive._conn.execute("SELECT content_hash, message_count FROM sessions").fetchall(),
+            archive._conn.execute("SELECT message_id, content_hash FROM messages ORDER BY message_id").fetchall(),
+            archive._conn.execute("SELECT id, sz FROM messages_fts_docsize ORDER BY id").fetchall(),
+            archive._conn.execute(
+                "SELECT accepted_raw_id, accepted_content_hash, accepted_frontier FROM raw_revision_heads"
+            ).fetchall(),
+            archive._conn.execute("SELECT decision_id FROM raw_revision_applications ORDER BY decision_id").fetchall(),
+        )
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        baseline_payload, tail = b"0123456789", b"abcdefghij"
+        baseline = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=baseline_payload, source_path="session.jsonl", acquired_at_ms=1
+        )
+        archive.bind_raw_revision(
+            baseline,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "base", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        append = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=tail, source_path="session.jsonl", source_index=-1, acquired_at_ms=2
+        )
+        append_revision = append_source_revision("base", hashlib.sha256(tail).hexdigest())
+        archive.bind_raw_revision(
+            append,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.APPEND,
+                append_revision,
+                1,
+                predecessor_source_revision="base",
+                predecessor_raw_id=baseline,
+                baseline_raw_id=baseline,
+                append_start_offset=10,
+                append_end_offset=20,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        chain = archive.raw_revision_replay_plan("codex:session")
+        archive.apply_raw_revision_replay(
+            chain, {baseline: parsed(("m0", "zero")), append: parsed(("m1", "one"))}, acquired_at_ms=0
+        )
+        folded_payload = baseline_payload + tail
+        if mutation in {"baseline", "divergent"}:
+            folded_payload = (b"X" if mutation == "baseline" else baseline_payload[:5] + b"X") + folded_payload[
+                1 if mutation == "baseline" else 6 :
+            ]
+        folded = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=folded_payload, source_path="session.jsonl", acquired_at_ms=3
+        )
+        archive.bind_raw_revision(
+            folded,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "folded", 2, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        source = archive._ensure_source_conn()
+        if mutation == "gap":
+            source.execute("UPDATE raw_sessions SET append_start_offset = 11 WHERE raw_id = ?", (append,))
+        elif mutation == "overlap":
+            source.execute("UPDATE raw_sessions SET append_start_offset = 9 WHERE raw_id = ?", (append,))
+        elif mutation == "predecessor":
+            source.execute("UPDATE raw_sessions SET predecessor_source_revision = 'wrong' WHERE raw_id = ?", (append,))
+        elif mutation == "missing":
+            source.execute("UPDATE raw_sessions SET predecessor_raw_id = 'missing' WHERE raw_id = ?", (append,))
+        elif mutation == "tail":
+            original = archive.raw_revision_material
+
+            def mutated_material(raw_id: str) -> tuple[Provider, bytes, str, RawRevisionKind]:
+                provider, payload, source_path, kind = original(raw_id)
+                return (
+                    (provider, b"Z" * 10, source_path, kind)
+                    if raw_id == append
+                    else (provider, payload, source_path, kind)
+                )
+
+            monkeypatch.setattr(
+                archive,
+                "raw_revision_material",
+                mutated_material,
+            )
+        source.commit()
+        before = state(archive)
+        plan = archive.raw_revision_replay_plan("codex:session")
+        with pytest.raises(RuntimeError, match="conflicting accepted head"):
+            archive.apply_raw_revision_replay(plan, {folded: parsed(("f0", "zero"), ("f1", "one"))}, acquired_at_ms=0)
+        assert state(archive) == before
 
 
 def test_full_replay_preserves_semantic_head_and_rolls_back_regressions(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from itertools import permutations
 from pathlib import Path
 
@@ -26,6 +27,7 @@ from polylogue.archive.session_revision_membership import (
 )
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash, session_revision_projection
+from polylogue.sources.dispatch import merge_parsed_session_chunks, parse_stream_payload
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -60,6 +62,54 @@ def _candidate(
 
 def _decisions(candidates: list[RevisionCandidate]) -> dict[str, ApplicationDecision]:
     return {item.raw_id: item.decision for item in plan_revision_replay(candidates).applications}
+
+
+def _codex_jsonl(records: list[dict[str, object]]) -> bytes:
+    return b"".join(json.dumps(record, separators=(",", ":")).encode() + b"\n" for record in records)
+
+
+def _parse_codex_jsonl(payload: bytes) -> ParsedSession:
+    sessions = parse_stream_payload(
+        Provider.CODEX,
+        (json.loads(line) for line in payload.splitlines() if line),
+        "fold-codex",
+    )
+    assert len(sessions) == 1
+    return sessions[0]
+
+
+def _codex_fold_payloads() -> tuple[bytes, bytes]:
+    baseline = _codex_jsonl(
+        [
+            {"type": "session_meta", "payload": {"id": "fold-codex", "timestamp": "2026-07-12T00:00:00Z"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "m1",
+                    "role": "user",
+                    "timestamp": "2026-07-12T00:00:01Z",
+                    "content": [{"type": "input_text", "text": "needle alpha"}],
+                },
+            },
+        ]
+    )
+    append = _codex_jsonl(
+        [
+            {"type": "turn_context", "payload": {"cwd": "/repo", "model": "gpt-5"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "m2",
+                    "role": "assistant",
+                    "timestamp": "2026-07-12T00:00:02Z",
+                    "content": [{"type": "output_text", "text": "needle beta"}],
+                },
+            },
+        ]
+    )
+    return baseline, append
 
 
 def test_replay_selects_newest_full_and_exact_contiguous_suffix_independent_of_order() -> None:
@@ -373,18 +423,15 @@ def test_real_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: P
 def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
 
-    def parsed(*messages: tuple[str, str]) -> ParsedSession:
-        return ParsedSession(
-            source_name=Provider.CODEX,
-            provider_session_id="session",
-            messages=[
-                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
-                for message_id, text in messages
-            ],
-        )
-
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
-        baseline_payload, tail = b"0123456789", b"abcdefghij"
+        baseline_payload, tail = _codex_fold_payloads()
+        baseline_session = _parse_codex_jsonl(baseline_payload)
+        append_session = _parse_codex_jsonl(tail)
+        folded_payload = baseline_payload + tail
+        folded_session = _parse_codex_jsonl(folded_payload)
+        assert session_content_hash(
+            merge_parsed_session_chunks([baseline_session, append_session])[0]
+        ) != session_content_hash(folded_session)
         baseline = archive.write_raw_payload(
             provider=Provider.CODEX, payload=baseline_payload, source_path="session.jsonl", acquired_at_ms=1
         )
@@ -408,18 +455,18 @@ def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_
                 predecessor_source_revision="base",
                 predecessor_raw_id=baseline,
                 baseline_raw_id=baseline,
-                append_start_offset=10,
-                append_end_offset=20,
+                append_start_offset=len(baseline_payload),
+                append_end_offset=len(folded_payload),
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
         archive.apply_raw_revision_replay(
             archive.raw_revision_replay_plan("codex:session"),
-            {baseline: parsed(("m0", "zero")), append: parsed(("m1", "one"))},
+            {baseline: baseline_session, append: append_session},
             acquired_at_ms=0,
         )
         folded = archive.write_raw_payload(
-            provider=Provider.CODEX, payload=baseline_payload + tail, source_path="session.jsonl", acquired_at_ms=3
+            provider=Provider.CODEX, payload=folded_payload, source_path="session.jsonl", acquired_at_ms=3
         )
         archive.bind_raw_revision(
             folded,
@@ -427,7 +474,6 @@ def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_
                 "codex:session", RawRevisionKind.FULL, "folded", 2, authority=RawRevisionAuthority.BYTE_PROVEN
             ),
         )
-        folded_session = parsed(("folded-0", "zero"), ("folded-1", "one"))
         before_hash = archive._conn.execute(
             "SELECT accepted_content_hash FROM raw_revision_heads WHERE logical_source_key = ?", ("codex:session",)
         ).fetchone()
@@ -455,19 +501,45 @@ def test_real_append_fold_proof_mutations_roll_back(
             ],
         )
 
-    def state(archive: ArchiveStore) -> tuple[object, ...]:
-        return (
-            archive._conn.execute("SELECT content_hash, message_count FROM sessions").fetchall(),
-            archive._conn.execute("SELECT message_id, content_hash FROM messages ORDER BY message_id").fetchall(),
-            archive._conn.execute("SELECT id, sz FROM messages_fts_docsize ORDER BY id").fetchall(),
-            archive._conn.execute(
+    def state(archive: ArchiveStore) -> dict[str, object]:
+        fts_matches = archive._conn.execute(
+            """
+            SELECT b.block_id, b.message_id, b.text
+            FROM messages_fts
+            JOIN blocks AS b ON b.rowid = messages_fts.rowid
+            WHERE messages_fts MATCH 'needle'
+            ORDER BY b.block_id
+            """
+        ).fetchall()
+        return {
+            "sessions": archive._conn.execute("SELECT content_hash, message_count FROM sessions").fetchall(),
+            "messages": archive._conn.execute(
+                "SELECT message_id, content_hash FROM messages ORDER BY message_id"
+            ).fetchall(),
+            "blocks": archive._conn.execute(
+                "SELECT block_id, message_id, block_type, text, search_text, content_hash FROM blocks ORDER BY block_id"
+            ).fetchall(),
+            "session_events": archive._conn.execute(
+                "SELECT event_id, source_message_id, event_type, summary, payload_json FROM session_events ORDER BY event_id"
+            ).fetchall(),
+            "attachments": archive._conn.execute(
+                "SELECT attachment_id, display_name, media_type, byte_count, blob_hash, acquisition_status FROM attachments ORDER BY attachment_id"
+            ).fetchall(),
+            "fts_docsize": archive._conn.execute("SELECT id, sz FROM messages_fts_docsize ORDER BY id").fetchall(),
+            "fts_needle": fts_matches,
+            "head": archive._conn.execute(
                 "SELECT accepted_raw_id, accepted_content_hash, accepted_frontier FROM raw_revision_heads"
             ).fetchall(),
-            archive._conn.execute("SELECT decision_id FROM raw_revision_applications ORDER BY decision_id").fetchall(),
-        )
+            "receipts": archive._conn.execute(
+                "SELECT decision_id FROM raw_revision_applications ORDER BY decision_id"
+            ).fetchall(),
+        }
 
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
-        baseline_payload, tail = b"0123456789", b"abcdefghij"
+        baseline_payload, tail = _codex_fold_payloads()
+        baseline_session = _parse_codex_jsonl(baseline_payload)
+        append_session = _parse_codex_jsonl(tail)
+        folded_session = _parse_codex_jsonl(baseline_payload + tail)
         baseline = archive.write_raw_payload(
             provider=Provider.CODEX, payload=baseline_payload, source_path="session.jsonl", acquired_at_ms=1
         )
@@ -491,15 +563,13 @@ def test_real_append_fold_proof_mutations_roll_back(
                 predecessor_source_revision="base",
                 predecessor_raw_id=baseline,
                 baseline_raw_id=baseline,
-                append_start_offset=10,
-                append_end_offset=20,
+                append_start_offset=len(baseline_payload),
+                append_end_offset=len(baseline_payload + tail),
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
         chain = archive.raw_revision_replay_plan("codex:session")
-        archive.apply_raw_revision_replay(
-            chain, {baseline: parsed(("m0", "zero")), append: parsed(("m1", "one"))}, acquired_at_ms=0
-        )
+        archive.apply_raw_revision_replay(chain, {baseline: baseline_session, append: append_session}, acquired_at_ms=0)
         folded_payload = baseline_payload + tail
         if mutation in {"baseline", "divergent"}:
             folded_payload = (b"X" if mutation == "baseline" else baseline_payload[:5] + b"X") + folded_payload[
@@ -516,9 +586,13 @@ def test_real_append_fold_proof_mutations_roll_back(
         )
         source = archive._ensure_source_conn()
         if mutation == "gap":
-            source.execute("UPDATE raw_sessions SET append_start_offset = 11 WHERE raw_id = ?", (append,))
+            source.execute(
+                "UPDATE raw_sessions SET append_start_offset = ? WHERE raw_id = ?", (len(baseline_payload) + 1, append)
+            )
         elif mutation == "overlap":
-            source.execute("UPDATE raw_sessions SET append_start_offset = 9 WHERE raw_id = ?", (append,))
+            source.execute(
+                "UPDATE raw_sessions SET append_start_offset = ? WHERE raw_id = ?", (len(baseline_payload) - 1, append)
+            )
         elif mutation == "predecessor":
             source.execute("UPDATE raw_sessions SET predecessor_source_revision = 'wrong' WHERE raw_id = ?", (append,))
         elif mutation == "missing":
@@ -529,7 +603,7 @@ def test_real_append_fold_proof_mutations_roll_back(
             def mutated_material(raw_id: str) -> tuple[Provider, bytes, str, RawRevisionKind]:
                 provider, payload, source_path, kind = original(raw_id)
                 return (
-                    (provider, b"Z" * 10, source_path, kind)
+                    (provider, b"Z" * len(tail), source_path, kind)
                     if raw_id == append
                     else (provider, payload, source_path, kind)
                 )
@@ -541,9 +615,12 @@ def test_real_append_fold_proof_mutations_roll_back(
             )
         source.commit()
         before = state(archive)
+        assert before["blocks"]
+        assert before["session_events"]
+        assert before["fts_needle"]
         plan = archive.raw_revision_replay_plan("codex:session")
         with pytest.raises(RuntimeError, match="conflicting accepted head"):
-            archive.apply_raw_revision_replay(plan, {folded: parsed(("f0", "zero"), ("f1", "one"))}, acquired_at_ms=0)
+            archive.apply_raw_revision_replay(plan, {folded: folded_session}, acquired_at_ms=0)
         assert state(archive) == before
 
 


### PR DESCRIPTION
## Summary

Allow a byte-proven full snapshot to replace an equal-frontier baseline-plus-append head only after cryptographically proving that it contains exactly the accepted byte chain.

## Problem

Production catch-up rejected a Codex session whose new full snapshot contained exactly the accepted baseline and append bytes at the same 2,645,672-byte frontier. Split and full Codex parsing produce different normalized hashes because event indices and metadata are segmentation-sensitive, so the ordinary CAS correctly treated the representation change as conflicting.

## Solution

- Walk the currently accepted byte-proven append chain to its full baseline.
- Prove baseline prefix identity, contiguous offsets, raw predecessor links, predecessor source revisions, every recomputed append revision, and exact final frontier bytes.
- Issue an in-memory one-shot authorization bound to the exact accepted append head and incoming full receipt.
- Consume that authorization inside the existing index transaction; every other equal-frontier hash change remains rejected.
- Add real Codex JSONL full-versus-segmented parser coverage plus single/multi-append success and mutation rollback proofs.

No schema change.

Ref polylogue-yla8.9.

## Verification

- Fold/replay focused selection -> 16 passed (`20260712T000436Z-focused-test-1898750-2b2c214c` before final non-vacuity strengthening; final targeted re-review selection also passed).
- Final adversarial targeted selection -> 8 passed, 8 deselected.
- `devtools verify --quick` -> 14/14 passed (`20260712T001347Z-quick-1910200-d66e3655`).
- Baseline `test_no_string_interpolated_sql.py` failure reproduced unchanged on clean `origin/master`: five pre-existing unaudited sites; this diff adds no interpolated SQL.

Adversarial review verified actual Codex parser segmentation, distinct normalized hashes over identical bytes, non-empty attachment rollback, candidate-only FTS absence, blocks/events/messages/session hash/head/receipt restoration, and the exact CAS authorization binding. No remaining release blocker.
