### PR TITLE
fix(pipeline): stop the one-shot importer duplicating raw rows

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -35,7 +35,7 @@ writer_modules:
       entrypoints:
         [apply_raw_membership_classification, apply_raw_revision_replay, classify_raw_revision_cohort,
         delete_sessions, replace_raw_membership_census,
-        write_parsed_for_retained_raw, write_raw_and_parsed,
+        write_parsed_for_retained_raw, write_parsed_for_retained_raw_result, write_raw_and_parsed,
         write_raw_and_parsed_result, write_raw_blob_and_parsed, write_raw_blob_and_parsed_result]
       twin_write_contract: raw-revision-authority
     - path: polylogue/storage/sqlite/archive_tiers/revision_application.py

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from polylogue.config import Source
 from polylogue.core.enums import Provider
+from polylogue.core.sources import origin_from_provider
 from polylogue.logging import get_logger
 from polylogue.pipeline.services.parsing_models import ParseResult
 from polylogue.sources.parsers.base import ParsedSession, RawSessionData
@@ -22,6 +23,7 @@ from polylogue.sources.source_parsing import (
 from polylogue.sources.source_walk import _setup_source_walk
 from polylogue.sources.sqlite_snapshot import hermes_profile_raw_id
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
 from polylogue.storage.sqlite.maintenance import maybe_optimize_archive_tiers
 from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_archive_wals
 
@@ -123,6 +125,22 @@ async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> Pa
 
     parse_blob_publisher = ArchiveBlobPublisher(archive_root / "source.db", blob_root)
     counters = {"raw_rows": 0, "index_rows": 0, "pending_messages": 0}
+    # A grouped JSONL file (Claude Code/Codex resume-fork chains, Gemini/Drive
+    # bundles) can parse into MULTIPLE sessions that all share the identical
+    # captured raw bytes (`_SessionEmitter._emit_grouped` yields the SAME
+    # `raw_data` for every session in the group). Without this cache, each
+    # session's write independently derives its raw_id from
+    # `deterministic_raw_session_id(..., native_id=session.provider_session_id)`
+    # (see write_source_raw_session), so byte-identical content produces a
+    # DIFFERENT raw_sessions row per split session -- and a second, unrelated
+    # raw row for the same bytes reappears on every re-ingest. The live daemon
+    # watcher instead writes ONE raw per file (`write_raw_payload`, no
+    # native_id) and defers session identity to membership-census
+    # classification; this cache makes the one-shot importer converge on that
+    # SAME single-raw-per-bytes model, keyed by the raw's own (origin,
+    # source_path, source_index, blob_hash) so a later re-ingest of identical
+    # bytes resolves to the SAME raw_id every time. Ref polylogue-sjf6.
+    shared_raw_ids: dict[tuple[str, str, int, str], str] = {}
 
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
 
@@ -136,22 +154,61 @@ async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> Pa
             source_index = _archive_raw_source_index(raw_data)
             raw_id = None
             blob_hash = getattr(raw_data, "blob_hash", None)
-            if session.source_name is Provider.HERMES and isinstance(blob_hash, str) and blob_hash:
-                raw_id = hermes_profile_raw_id(source_path, source_index, blob_hash)
-            try:
-                write_result = archive.write_raw_and_parsed_result(
-                    session,
-                    payload=payload,
-                    source_path=source_path,
-                    acquired_at_ms=acquired_at_ms,
-                    source_index=source_index,
-                    raw_id=raw_id,
-                    stage_timings_s=result.stage_timings_s,
-                    manage_transaction=not batched,
-                    blob_publication_receipt_id=(
-                        raw_data.blob_publication_receipt_id if raw_data is not None else None
-                    ),
+            blob_hash_str = blob_hash if isinstance(blob_hash, str) and blob_hash else None
+            if session.source_name is Provider.HERMES and blob_hash_str is not None:
+                raw_id = hermes_profile_raw_id(source_path, source_index, blob_hash_str)
+            shared_key: tuple[str, str, int, str] | None = None
+            if raw_id is None and blob_hash_str is not None:
+                # Keyed by origin (not provider) to match deterministic_raw_session_id
+                # below -- origin_from_provider is non-injective (GEMINI and DRIVE
+                # both collapse to AISTUDIO_DRIVE), so two sessions with different
+                # `source_name` but the same origin must still share one raw_id.
+                shared_key = (
+                    origin_from_provider(session.source_name).value,
+                    source_path,
+                    source_index,
+                    blob_hash_str,
                 )
+            existing_raw_id = shared_raw_ids.get(shared_key) if shared_key is not None else None
+            try:
+                if existing_raw_id is not None:
+                    # A prior session parsed from this exact raw already
+                    # committed the raw row this batch; index this session
+                    # against that SAME raw_id instead of writing a duplicate.
+                    retained_result = archive.write_parsed_for_retained_raw_result(
+                        session,
+                        raw_id=existing_raw_id,
+                        source_path=source_path,
+                        acquired_at_ms=acquired_at_ms,
+                        source_index=source_index,
+                        stage_timings_s=result.stage_timings_s,
+                        manage_transaction=not batched,
+                    )
+                    write_result = retained_result
+                else:
+                    if shared_key is not None and blob_hash_str is not None:
+                        raw_id = deterministic_raw_session_id(
+                            origin_from_provider(session.source_name),
+                            source_path,
+                            source_index,
+                            bytes.fromhex(blob_hash_str),
+                            None,
+                        )
+                    write_result = archive.write_raw_and_parsed_result(
+                        session,
+                        payload=payload,
+                        source_path=source_path,
+                        acquired_at_ms=acquired_at_ms,
+                        source_index=source_index,
+                        raw_id=raw_id,
+                        stage_timings_s=result.stage_timings_s,
+                        manage_transaction=not batched,
+                        blob_publication_receipt_id=(
+                            raw_data.blob_publication_receipt_id if raw_data is not None else None
+                        ),
+                    )
+                    if shared_key is not None:
+                        shared_raw_ids[shared_key] = write_result.raw_id
             except Exception:
                 # Discard the in-flight uncommitted batch so a failed write
                 # never leaves prior sessions in this batch half-applied.

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1304,6 +1304,42 @@ class ArchiveStore:
         revision_authoritative: bool = False,
     ) -> tuple[str, str]:
         """Index one session for raw evidence that is already durable."""
+        result = self.write_parsed_for_retained_raw_result(
+            session,
+            raw_id=raw_id,
+            source_path=source_path,
+            acquired_at_ms=acquired_at_ms,
+            source_index=source_index,
+            stage_timings_s=stage_timings_s,
+            stage_timing_prefix=stage_timing_prefix,
+            manage_transaction=manage_transaction,
+            finalize_raw_parse=finalize_raw_parse,
+            revision_authoritative=revision_authoritative,
+        )
+        return result.raw_id, result.session_id
+
+    def write_parsed_for_retained_raw_result(
+        self,
+        session: ParsedSession,
+        *,
+        raw_id: str,
+        source_path: str,
+        acquired_at_ms: int,
+        source_index: int = 0,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "append",
+        manage_transaction: bool = True,
+        finalize_raw_parse: bool = True,
+        revision_authoritative: bool = False,
+    ) -> ArchiveRawParsedWriteResult:
+        """Index one session for raw evidence that is already durable, with counts.
+
+        Used both by append-chain replay and by any caller that must index
+        several sessions parsed from ONE physical raw acquisition (e.g. a
+        Claude Code/Codex grouped JSONL file whose content splits into
+        multiple sessions) against the SAME raw_id, instead of writing a
+        duplicate raw row per session.
+        """
         preacquired_attachments, attachment_blob_refs = self._preacquire_attachment_blobs(
             session,
             source_path=source_path,
@@ -1327,7 +1363,7 @@ class ArchiveStore:
         if stage_timings_s is not None:
             key = f"{stage_timing_prefix}.index_parsed_write"
             stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - index_started)
-        return result.raw_id, result.session_id
+        return result
 
     def bind_raw_revision(self, raw_id: str, revision: RawRevisionEnvelope) -> None:
         bind_source_raw_revision(self._ensure_source_conn(), raw_id, revision)

--- a/tests/unit/pipeline/test_archive_ingest_shared_raw.py
+++ b/tests/unit/pipeline/test_archive_ingest_shared_raw.py
@@ -1,0 +1,175 @@
+"""Regression coverage for polylogue-sjf6.
+
+A Claude Code resume/fork JSONL file physically carries over ONE boundary
+record from its parent session (same content, but tagged with the PARENT's
+``sessionId``) before switching to its own session id for the rest of the
+file. `_claude_code_grouped_record_specs` (dispatch.py) correctly splits such
+a file into two `ParsedSession`s that share the identical captured raw bytes.
+
+Before this fix, `pipeline/services/archive_ingest.py`'s one-shot importer
+(`parse_sources_archive` / `write_pair`) wrote a SEPARATE `raw_sessions` row
+per split session via `write_raw_and_parsed_result`, whose raw_id is derived
+from `deterministic_raw_session_id(..., native_id=session.provider_session_id)`
+(see `write_source_raw_session`). Two sessions parsed from the SAME bytes
+therefore produced TWO DIFFERENT raw_id rows differentiated only by
+native_id -- and the live daemon watcher (`sources/live/batch.py`,
+`write_raw_payload`) independently commits a THIRD raw for the same bytes
+with native_id always NULL. These extra, duplicate raw rows for
+byte-identical content are what the daemon's membership-replay guard
+(archive.py:2255, "membership replay cannot retire an unrelated accepted
+head", added by rgh2/#2718) later discovers as spurious competing claims on
+a `logical_source_key` it already has an accepted head for.
+
+Verified directly against the live production archive (2026-07-12): the
+exact production file (a 41 MB, 8984-line JSONL whose first record carries
+its logical parent session's id) had TWO raw_sessions rows for the identical
+`source_path`, one with native_id set (from a `polylogue import` run) and one
+with native_id NULL (from the daemon), joined only by identical blob bytes.
+
+This test proves the fix: `write_pair` now caches raw_ids by
+(origin, source_path, source_index, blob_hash) so every session parsed from
+the SAME physical raw acquisition is indexed against ONE shared raw_id
+(computed WITHOUT native_id, matching the daemon's own raw-identity scheme),
+using `write_parsed_for_retained_raw_result` for the second and further
+sessions instead of writing a duplicate raw row.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+
+
+def _write_carryover_chain(root: Path) -> tuple[Path, Path]:
+    """Write parent.jsonl (real "parent" session) + child.jsonl (a 1-record
+    carryover of parent's tail under `sessionId=parent`, then real "child"
+    session content) -- the exact structural shape found in production.
+    """
+    parent_file = root / "parent.jsonl"
+    child_file = root / "child.jsonl"
+
+    def rec(session_id: str, uuid: str, role: str, text: str, parent_uuid: str | None = None) -> str:
+        import json as _json
+
+        return _json.dumps(
+            {
+                "type": role,
+                "sessionId": session_id,
+                "uuid": uuid,
+                "parentUuid": parent_uuid,
+                "message": {"role": role, "content": [{"type": "text", "text": text}]},
+                "timestamp": "2026-02-13T00:00:00.000Z",
+            }
+        )
+
+    parent_file.write_text(
+        "\n".join(
+            [
+                rec("parent-session", "p-u1", "user", "p1"),
+                rec("parent-session", "p-a1", "assistant", "p2", parent_uuid="p-u1"),
+            ]
+        )
+        + "\n"
+    )
+    child_file.write_text(
+        "\n".join(
+            [
+                # Boundary carryover: same conversation thread, still tagged
+                # with the PARENT's sessionId, referencing parent's last uuid.
+                rec(
+                    "parent-session",
+                    "carryover",
+                    "user",
+                    "[Request interrupted by user for tool use]",
+                    parent_uuid="p-a1",
+                ),
+                rec("child-session", "c-u1", "user", "c1"),
+                rec("child-session", "c-a1", "assistant", "c2", parent_uuid="c-u1"),
+            ]
+        )
+        + "\n"
+    )
+    return parent_file, child_file
+
+
+def _raw_rows_for_path(source_db: Path, source_path: str) -> list[tuple[str, str | None]]:
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(
+            "SELECT raw_id, native_id FROM raw_sessions WHERE source_path = ? ORDER BY raw_id",
+            (source_path,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [(str(r[0]), r[1]) for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_grouped_carryover_sessions_share_one_raw_row(tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+    """Two sessions split from ONE Claude Code file's bytes must NOT produce
+    two raw_sessions rows for that file -- the specific bug behind
+    polylogue-sjf6's live guard crash."""
+    archive_root = workspace_env["archive_root"]
+    root = tmp_path / "sessions"
+    root.mkdir()
+    _parent_file, child_file = _write_carryover_chain(root)
+    sources = [Source(name="claude-code", path=child_file)]
+
+    result = await parse_sources_archive(archive_root, sources)
+    assert result.parse_failures == 0
+
+    rows = _raw_rows_for_path(archive_root / "source.db", str(child_file))
+    # Anti-vacuity: this is the production dependency under test --
+    # write_pair's shared-raw cache (pipeline/services/archive_ingest.py).
+    # Deleting that cache (reverting to one write_raw_and_parsed_result call
+    # per split session, each deriving its own native_id-based raw_id) makes
+    # this assertion fail with TWO rows instead of one.
+    assert len(rows) == 1, f"expected exactly one raw row for child.jsonl's bytes, got {rows}"
+
+    # Both split sessions (the 1-record carryover under "parent-session" and
+    # the real "child-session" content) must still have been indexed.
+    conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        native_ids = {
+            str(r[0])
+            for r in conn.execute(
+                "SELECT native_id FROM sessions WHERE native_id IN ('parent-session', 'child-session')"
+            )
+        }
+    finally:
+        conn.close()
+    assert native_ids == {"parent-session", "child-session"}
+
+
+@pytest.mark.asyncio
+async def test_reingesting_identical_bytes_resolves_to_the_same_raw_id(
+    tmp_path: Path, workspace_env: dict[str, Path]
+) -> None:
+    """AC #1: a deterministic fixture re-acquired twice with byte-identical
+    bytes must yield the SAME raw_id (and therefore the same downstream
+    logical_source_key) both times -- not a second, native_id-differentiated
+    raw row that later collides with the first in membership classification.
+    """
+    archive_root = workspace_env["archive_root"]
+    root = tmp_path / "sessions"
+    root.mkdir()
+    _parent_file, child_file = _write_carryover_chain(root)
+    sources = [Source(name="claude-code", path=child_file)]
+
+    await parse_sources_archive(archive_root, sources)
+    first_rows = _raw_rows_for_path(archive_root / "source.db", str(child_file))
+    assert len(first_rows) == 1
+    first_raw_id = first_rows[0][0]
+
+    # Re-ingest the exact same byte-identical file again (simulating the
+    # daemon's later catch-up revisit of unchanged content).
+    await parse_sources_archive(archive_root, sources)
+    second_rows = _raw_rows_for_path(archive_root / "source.db", str(child_file))
+
+    assert len(second_rows) == 1, f"re-ingest must not create a second raw row, got {second_rows}"
+    assert second_rows[0][0] == first_raw_id, "raw_id must be deterministic across re-acquisitions of identical bytes"


### PR DESCRIPTION
## Summary

The one-shot `polylogue import` pipeline (`pipeline/services/archive_ingest.py`) wrote a separate `raw_sessions` row per split session for grouped Claude Code/Codex/Gemini/Drive JSONL files, differentiated only by `native_id` even though the underlying acquired bytes were identical. This produced duplicate raw rows for byte-identical content that the live daemon's membership-replay guard later rejected as an "unrelated accepted head".

## Problem

Live production evidence (2026-07-12, daemon PID 1932060): the daemon repeatedly failed full ingest of `/home/sinity/.claude/projects/-realm-project-sinex/1e5805bd-72d6-4010-b052-b2b4a0e78425.jsonl` (and a sibling file) with `RuntimeError: "membership replay cannot retire an unrelated accepted head"` (`archive.py:2255`, guard added by rgh2/#2718).

Direct inspection of the live `source.db` `raw_sessions` table showed **two rows for the identical `source_path`**, byte-identical content, differing only by `native_id` (one set to `a5724e23-...`, one `NULL`) — and therefore by `raw_id`, since `deterministic_raw_session_id` hashes `native_id` into the id.

Root cause traced to `pipeline/services/archive_ingest.py`'s `write_pair`: for a Claude Code JSONL file whose content splits into multiple sessions (`_SessionEmitter._emit_grouped` yields the *same* captured raw bytes for every split session — verified via source read), the one-shot importer calls `write_raw_and_parsed_result(session, payload=<whole file>, ..., native_id=session.provider_session_id)` **once per split session**, writing the whole file's bytes multiple times under different `native_id`-derived `raw_id`s. The live daemon watcher instead writes **one** raw per file (`write_raw_payload`, `native_id` always `NULL`) and defers session identity to membership-census classification (`raw_session_memberships` / `raw_revision_heads`). The two pipelines therefore disagree on raw identity for the same bytes, and the daemon's membership-replay guard discovers the importer's extra raw as a spurious competing claim on a `logical_source_key` it already has an accepted head for.

Reproduced structurally against the real production file: its first record is a 1-message carryover of the *last* message of a **separate, real session** (`a5724e23-...`) — a Claude Code resume/fork artifact where the CLI copies one boundary record into the new file before switching session ids. The same pattern recurs three levels deep in this project's history (`25cc6e75 -> 1eed506e -> a5724e23 -> 1e5805bd`).

## Solution

`write_pair` (`pipeline/services/archive_ingest.py`) now caches raw_ids by `(origin, source_path, source_index, blob_hash)` — the raw's own acquired-bytes identity, not any single session's derived identity:

- The first session sharing a raw commits it via a `raw_id` computed **without** `native_id` (matching the daemon's own scheme).
- Every further session sharing that same raw indexes against the **same** `raw_id` via a new `ArchiveStore.write_parsed_for_retained_raw_result` — a counts-returning sibling of the existing `write_parsed_for_retained_raw` (needed because that method only returns a bare `(raw_id, session_id)` tuple, and `write_pair` needs `.counts`/`.content_changed` for its own bookkeeping).
- The cache key uses `origin_from_provider(session.source_name)`, not the raw `Provider`, since `origin_from_provider` is non-injective (`GEMINI` and `DRIVE` both collapse to `AISTUDIO_DRIVE`) and `deterministic_raw_session_id` hashes the origin, not the provider.

`docs/plans/layering.yaml` gained the new public entrypoint in the writer-module inventory (`verify layering` enforces this).

The `archive.py:2255` guard itself is **untouched**: it must still reject genuinely divergent content. An initial attempt to also soften the guard directly was reverted after discovering it would skip essential `raw_session_memberships` bookkeeping on early return. The write-path fix alone removes the structural precondition (duplicate raw rows for identical bytes) that let the guard ever see an "unrelated" head for these files.

## Verification

```
devtools test tests/unit/pipeline/test_archive_ingest_shared_raw.py \
  tests/unit/pipeline/test_archive_ingest_commit_batching.py \
  tests/unit/storage/test_revision_replay.py \
  tests/unit/sources/test_live_batch_support.py
```
-> 91 passed, 6 pre-existing failures in `test_live_batch_support.py` (verified identical on unmodified master via `git stash`; unrelated browser-capture route-observability and append crash-injection assertions).

**Anti-vacuity**: reverted this diff and reran the two new tests in `tests/unit/pipeline/test_archive_ingest_shared_raw.py` — both failed exactly as predicted (2 raw rows differentiated by `native_id` instead of 1). The production dependency exercised is `write_pair`'s raw-identity computation in `pipeline/services/archive_ingest.py`; the mutation that makes the test fail is deleting the shared-raw cache (reverting to one `write_raw_and_parsed_result` call per split session).

```
devtools verify --quick
```
-> all 14 steps ok, exit 0.

## Acceptance criteria (polylogue-sjf6)

1. **Deterministic fixture, byte-identical re-acquisition -> same raw_id/logical_source_key**: satisfied — `test_reingesting_identical_bytes_resolves_to_the_same_raw_id`.
2. **The two specific live raw_ids reparse to the same key / second acquisition no longer raises**: the write-path fix prevents this class of duplicate-raw creation going forward from either pipeline. The two specific live raw_ids already in the archive predate this fix and are historical data, not re-created by it — I could not, despite extensive reproduction attempts (single/batched acquisition orderings, up to a 3-hop carryover chain), reproduce the exact `RuntimeError` in a controlled unit test from a *single* pipeline's behavior; the live crash required the specific cross-pipeline (one-shot import + daemon) duplicate-raw state that this PR prevents recreating. Flagging as a residual open question for the coordinator: whether the two already-affected raw rows on the live host need separate remediation (e.g. `raw_revision_rebuild_selection`/`raw_membership_census` compaction) is not addressed here.
3. **Genuinely divergent content still trips the guard**: preserved — the guard itself is unmodified, and `test_single_session_full_cannot_overwrite_divergent_membership_head` (the guard's own regression test) still passes.
4. **Focused tests + `devtools verify --quick` pass, anti-vacuity stated**: satisfied, see above.
5. **Live catch-up completes without the RuntimeError**: not independently re-verified against the live host from this PR; the write-path fix removes the mechanism that created the duplicate raws in the first place.

Ref polylogue-sjf6