### PR TITLE
refactor(archive): consume structural tool_result outcome in terminal_state

### DIFF
--- a/docs/insights-rigor-matrix.md
+++ b/docs/insights-rigor-matrix.md
@@ -56,6 +56,36 @@ API.
 - Consumer-facing fields: `session_id`, `provider_name`, `title`,
   `semantic_tier`, `evidence`, `inference`, `enrichment`,
   `provenance`, `inference_provenance`, `enrichment_provenance`.
+- Notes (heuristic-tier inventory, polylogue-b0b): `inference.terminal_state`
+  (`archive/session/runtime.py::_terminal_state`) now prefers a structural,
+  session-wide `tool_id -> outcome` map (`_session_tool_results`)
+  sourced from the keystone `blocks.tool_result_is_error`/
+  `tool_result_exit_code` columns (index schema v16) over the prior prose
+  `_ERROR_MARKERS` keyword scan for the mid-session error-action signal. The
+  lookup is session-wide (mirroring `_pending_tool_blocks` and
+  `insights/transforms.py::_extract_events`) rather than routed through the
+  per-message `Action`/`ToolCall` pairing, because Claude/Codex-style
+  transcripts near-always place a `tool_use` in one message and its
+  `tool_result` in a later message — per-message pairing alone would miss
+  the common case. That structural signal is origin-gated, not universal
+  (polylogue-9e5.3 audit): `tool_result_is_error`
+  is well-populated only for claude-code-session (44.8%) and claude-ai-export
+  (100% of a small volume), 0% for chatgpt-export/hermes-session/
+  aistudio-drive; `tool_result_exit_code` is populated only for
+  codex-session, and just 14.2% of even that. For origins/results with no
+  structural coverage the code falls back to the tagged text scan rather
+  than reporting a false negative. Every branch of `_terminal_state` now
+  returns an `evidence_class` key in `inference.terminal_state_evidence` —
+  `raw_evidence` (tool-pairing counts, the structural action signal, the
+  provider-emitted session-event status field, or message role) or
+  `text_derived` (the last-message `_ERROR_MARKERS` scan and its
+  `clean_finish` complement, and the structural-fallback text scan above).
+  Consumers needing only grounded rows should filter on
+  `inference.terminal_state_evidence.evidence_class == 'raw_evidence'`.
+  `session_work_events`' sibling classifier's 50.5% (coin-flip) accuracy
+  finding (9e5.9, below) is the reason this scan was not simply deleted: not
+  measured as reliable, but not proven unreliable enough to remove entirely
+  while the last-resort fallback path still has explicit provenance.
 
 ### `session_work_events` — Work Events
 

--- a/polylogue/archive/actions/actions.py
+++ b/polylogue/archive/actions/actions.py
@@ -86,6 +86,15 @@ class Action:
     output_text: str | None
     search_text: str
     raw: Mapping[str, object]
+    #: Structural pass/fail from the paired tool_result's keystone columns
+    #: (``tool_result_is_error``/``tool_result_exit_code``, see
+    #: :func:`polylogue.archive.actions.parsing.tool_result_outcome`).
+    #: ``True``/``False`` is a genuinely structural verdict; ``None`` means
+    #: the origin never populated either column for this result -- not a
+    #: negative claim, since most origins are structurally uncovered here
+    #: (polylogue-9e5.3 audit). Consumers must not text-scan ``output_text``
+    #: to recover a verdict this field reports as ``None``.
+    tool_success: bool | None = None
 
     @property
     def normalized_tool_name(self) -> str:
@@ -157,6 +166,7 @@ def _build_action_from_message_fields(
             output_text=output_text,
         ),
         raw=call.raw,
+        tool_success=call.success,
     )
 
 

--- a/polylogue/archive/actions/followup.py
+++ b/polylogue/archive/actions/followup.py
@@ -1,4 +1,29 @@
-"""Failure follow-up classification for action query surfaces."""
+"""Failure follow-up classification for action query surfaces.
+
+polylogue-b0b heuristic-tier inventory: ``ACKNOWLEDGMENT_MARKERS`` (and the
+classifiers below that consume it) determine whether the *next* assistant
+turn after a structurally confirmed action failure (``is_error:true`` --
+already 100% structural, see ``tool_result_is_error``/``tool_result_exit_code``)
+explicitly acknowledges that failure, versus silently proceeding. There is
+no structural equivalent to convert to: "did the assistant say something
+acknowledging this" is inherently a judgment about prose content, not a
+fact recoverable from provider-emitted columns. This stays LABEL/
+heuristic-tier (evidence class ``text_derived``), not CONVERT -- the caveat
+is that ``silent_proceed`` is only as good as this keyword list's recall,
+and it undercounts acknowledgments phrased without any of the listed
+markers.
+
+Two independent consumers apply this same marker list: the live
+``followup_class`` SQL CASE expression in
+``polylogue/storage/sqlite/archive_tiers/archive.py``
+(``_ACTION_FOLLOWUP_RELATION_SQL``, the public query-surface path) and
+``devtools/claim_vs_evidence.py``'s ``devtools claim-vs-evidence`` analysis
+command (which calls :func:`classify_failed_followup_evidence` directly).
+The SQL path reimplements the same short-follow-up/marker-match precedence
+in SQL rather than calling this module, so a change to one does not
+automatically apply to the other -- keep them in sync by hand if the
+classification rule changes.
+"""
 
 from __future__ import annotations
 

--- a/polylogue/archive/actions/parsing.py
+++ b/polylogue/archive/actions/parsing.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
+from typing import Literal
 
 from polylogue.archive.viewport.viewports import ToolCall, ToolCategory, classify_tool
 from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDocument, json_document
+
+#: Structural pass/fail verdict for a tool_result, or "unknown" when the
+#: origin never populated the keystone columns for this result at all.
+ToolResultOutcome = Literal["ok", "failed", "unknown"]
 
 
 def _clean_str(value: object) -> str | None:
@@ -47,6 +52,71 @@ def _tool_category_from_semantic(value: object) -> ToolCategory | None:
         return None
 
 
+def _block_outcome_int(block: Mapping[str, object], key: str, *, legacy_key: str) -> int | None:
+    """Read a structural outcome int, preferring the hydrated storage-column
+    name (e.g. ``tool_result_is_error``) and falling back to the bare
+    parse-time field name (``is_error``) that :class:`ParsedContentBlock`
+    and some pre-hydration block dicts use -- the same dual-key convention
+    ``rendering/block_models.py`` already applies when reading blocks that
+    may not have passed through storage hydration.
+    """
+    value = block.get(key, block.get(legacy_key))
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def tool_result_outcome(is_error: int | None, exit_code: int | None) -> ToolResultOutcome:
+    """Structural pass/fail from the provider-reported tool_result columns.
+
+    ``exit_code`` is authoritative when present (0 = ok, anything else =
+    failed); otherwise the boolean ``is_error`` flag decides. Both ``None``
+    means the origin never populated these keystone columns (index schema
+    v16: ``blocks.tool_result_is_error`` / ``tool_result_exit_code``) for
+    this result -- returns ``"unknown"``, never guessed from prose.
+
+    Coverage is origin-gated, not universal (polylogue-9e5.3 column-honesty
+    audit, ``.agent/scratch/research/2026-07-09-substrate-honesty-audit.md``):
+    ``tool_result_is_error`` is well-populated only for claude-code-session
+    (44.8%) and claude-ai-export (100% of a small volume); it is 0% for
+    chatgpt-export, hermes-session, and aistudio-drive. ``tool_result_exit_code``
+    is *only ever* populated for codex-session, and just 14.2% of even that.
+    Callers must not treat an "unknown" result as a negative claim -- for
+    most origins it is the expected, honest outcome, not a gap.
+
+    This is the single canonical implementation of the exit_code/is_error
+    precedence rule; :func:`polylogue.insights.transforms._tool_status`
+    delegates to it to avoid two independently-maintained copies drifting.
+    """
+
+    if exit_code is not None:
+        return "ok" if exit_code == 0 else "failed"
+    if is_error is not None:
+        return "failed" if is_error else "ok"
+    return "unknown"
+
+
+def tool_result_block_outcome(block: Mapping[str, object]) -> ToolResultOutcome:
+    """Structural pass/fail for one ``tool_result``-typed block dict.
+
+    Reads both the hydrated storage-column keys (``tool_result_is_error``/
+    ``tool_result_exit_code``) and the bare parse-time keys (``is_error``/
+    ``exit_code``) a block dict may carry, then applies
+    :func:`tool_result_outcome`'s exit_code/is_error precedence. Used both
+    by :func:`build_tool_calls_from_content_blocks` (per-message pairing)
+    and by session-wide tool_id/result scans (e.g.
+    ``archive/session/runtime.py::_terminal_state``) that pair a tool_use in
+    one message with its tool_result in a later message -- the common shape
+    for Claude/Codex-style transcripts, which per-message pairing alone
+    misses.
+    """
+    is_error = _block_outcome_int(block, "tool_result_is_error", legacy_key="is_error")
+    exit_code = _block_outcome_int(block, "tool_result_exit_code", legacy_key="exit_code")
+    return tool_result_outcome(is_error, exit_code)
+
+
 def build_tool_calls_from_content_blocks(
     *,
     provider: Provider | str | None,
@@ -54,6 +124,7 @@ def build_tool_calls_from_content_blocks(
 ) -> tuple[ToolCall, ...]:
     """Normalize canonical ToolCall viewports from content blocks."""
     tool_result_outputs: dict[str, str] = {}
+    tool_result_outcomes: dict[str, ToolResultOutcome] = {}
     tool_use_blocks: list[Mapping[str, object]] = []
     for block in content_blocks:
         block_type = str(block.get("type"))
@@ -62,6 +133,8 @@ def build_tool_calls_from_content_blocks(
             text = block.get("text")
             if isinstance(tool_id, str) and tool_id and isinstance(text, str) and text:
                 tool_result_outputs.setdefault(tool_id, text)
+            if isinstance(tool_id, str) and tool_id:
+                tool_result_outcomes.setdefault(tool_id, tool_result_block_outcome(block))
             continue
         if block_type != "tool_use":
             continue
@@ -100,12 +173,16 @@ def build_tool_calls_from_content_blocks(
             "semantic_type": block.get("semantic_type"),
             "text": block.get("text"),
         }
+        outcome_tool_id = tool_id if isinstance(tool_id, str) and tool_id else None
+        outcome = tool_result_outcomes.get(outcome_tool_id, "unknown") if outcome_tool_id else "unknown"
+        success = {"ok": True, "failed": False, "unknown": None}[outcome]
         calls.append(
             ToolCall(
                 name=name,
-                id=tool_id if isinstance(tool_id, str) and tool_id else None,
+                id=outcome_tool_id,
                 input=normalized_input,
                 output=tool_result_outputs.get(tool_id) if isinstance(tool_id, str) else None,
+                success=success,
                 category=category,
                 provider=normalized_provider,
                 raw=raw,
@@ -115,7 +192,10 @@ def build_tool_calls_from_content_blocks(
 
 
 __all__ = [
+    "ToolResultOutcome",
     "_clean_str",
     "_extract_first_string",
     "build_tool_calls_from_content_blocks",
+    "tool_result_block_outcome",
+    "tool_result_outcome",
 ]

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -477,7 +477,7 @@ _COMMON_STRUCTURAL_FIELD_INFO: dict[str, StructuralQueryFieldInfo] = {
     "exit_code": _field_info("exit_code", "Tool/action exit-code predicate.", "exit_code > 0"),
     "followup_class": _field_info(
         "followup_class",
-        "Failed-action next-assistant follow-up class.",
+        "Failed-action next-assistant follow-up class (keyword-heuristic, text-derived).",
         "followup_class:silent_proceed",
     ),
     "is_error": _field_info("is_error", "Tool/action structured error flag.", "is_error:true"),

--- a/polylogue/archive/session/runtime.py
+++ b/polylogue/archive/session/runtime.py
@@ -8,8 +8,9 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
+from polylogue.archive.actions.parsing import tool_result_block_outcome
 from polylogue.archive.phase.extraction import extract_phases
 from polylogue.archive.semantic.facts import build_session_semantic_facts
 from polylogue.archive.semantic.timing import compute_session_timing, compute_tool_active_duration_ms
@@ -236,17 +237,94 @@ def _pending_tool_blocks(session: Session) -> int:
     return pending_identified + pending_unidentified
 
 
+class _ToolResultSummary(NamedTuple):
+    outcome: str
+    text: str | None
+
+
+def _session_tool_results(session: Session) -> dict[str, _ToolResultSummary]:
+    """Session-wide ``tool_id -> (structural outcome, result text)`` map.
+
+    Mirrors ``_pending_tool_blocks``'s session-wide (not per-message)
+    ``tool_use``/``tool_result`` pairing and
+    ``insights/transforms.py::_extract_events``'s identical pairing strategy:
+    Claude/Codex-style transcripts near-always place a ``tool_use`` in one
+    message and its paired ``tool_result`` in a *later* message, which
+    :func:`polylogue.archive.actions.parsing.build_tool_calls_from_content_blocks`
+    (and therefore ``Action.output_text``, per-message only) cannot see.
+    Reading blocks directly session-wide here is what makes both the
+    structural error signal and its tagged text fallback in
+    :func:`_terminal_state` actually fire for the common shape, not just the
+    rare same-message case.
+    """
+    results: dict[str, _ToolResultSummary] = {}
+    for message in session.messages:
+        for block in message.blocks:
+            if not isinstance(block, dict):
+                continue
+            if str(block.get("type") or "").strip().lower() != "tool_result":
+                continue
+            tool_id = _tool_block_id(block)
+            if tool_id is None:
+                continue
+            text = block.get("text")
+            results[tool_id] = _ToolResultSummary(
+                outcome=tool_result_block_outcome(block),
+                text=text if isinstance(text, str) and text else None,
+            )
+    return results
+
+
 def _terminal_state(
     session: Session, analysis: SessionAnalysis
 ) -> tuple[str, float, dict[str, int | float | str | None]]:
+    """Classify how a session's tool/turn activity ended.
+
+    polylogue-b0b: the action-level error signal below prefers the
+    structural, session-wide ``tool_id -> outcome`` map from
+    :func:`_session_tool_results` (sourced from the keystone
+    ``blocks.tool_result_is_error``/``tool_result_exit_code`` columns, index
+    schema v16) over prose. That structural signal is origin-gated -- absent
+    for most origins (polylogue-9e5.3 audit) -- so a ``_ERROR_MARKERS`` text
+    scan over ``action.output_text`` remains as an explicit, tagged fallback
+    only when the structural signal is absent for that action's tool_id,
+    never silently substituted for it. Every returned ``evidence_class``
+    entry in the features dict is ``"raw_evidence"`` (grounded in
+    structure/role, never guessed from prose) or ``"text_derived"`` (a
+    keyword/prose judgment) so callers can filter or caveat accordingly --
+    see ``polylogue.insights.transforms.FieldEvidenceClass`` for the sibling
+    convention this mirrors.
+    """
     pending_block_count = _pending_tool_blocks(session)
     if pending_block_count:
-        return "tool_left", 0.9, {"pending_tool_count": pending_block_count}
+        return (
+            "tool_left",
+            0.9,
+            {"pending_tool_count": pending_block_count, "evidence_class": "raw_evidence"},
+        )
+    tool_results = _session_tool_results(session)
     latest_error_action_id: str | None = None
+    latest_error_action_evidence_class: str | None = None
     for action in analysis.facts.actions:
-        output_text = (action.output_text or "").lower()
-        if any(marker in output_text for marker in _ERROR_MARKERS):
+        result = tool_results.get(action.tool_id) if action.tool_id else None
+        outcome = result.outcome if result is not None else None
+        if outcome == "failed":
             latest_error_action_id = action.action_id
+            latest_error_action_evidence_class = "raw_evidence"
+        elif outcome in (None, "unknown"):
+            # No structural tool_result_is_error/exit_code for this origin's
+            # result (polylogue-9e5.3) -- fall back to a tagged prose scan
+            # over the session-wide tool_result text (falling back further to
+            # the per-message Action.output_text if no session-wide result
+            # text was found at all) instead of reporting a false "no error"
+            # negative.
+            fallback_text = (result.text if result is not None else None) or action.output_text or ""
+            if any(marker in fallback_text.lower() for marker in _ERROR_MARKERS):
+                latest_error_action_id = action.action_id
+                latest_error_action_evidence_class = "text_derived"
+        # outcome == "ok" is a structural negative -- do not fall through to
+        # a prose scan that could misclassify a benign mention of the word
+        # "error" (e.g. "0 errors found") as a failure.
 
     pending: set[str] = set()
     pending_without_id = 0
@@ -265,11 +343,18 @@ def _terminal_state(
                 pending_without_id -= 1
             elif call_id is not None:
                 pending.discard(call_id)
+            # Structural: a typed status key on the provider's own tool-call
+            # protocol event payload (e.g. Codex function_call_output), not
+            # a prose scan -- see sources/parsers/codex.py:_compact_response_payload.
             status = str(event.payload.get("status") or "").lower()
             if status in {"error", "failed", "failure"}:
                 latest_error_event_id = str(event.id)
     if pending or pending_without_id:
-        return "tool_left", 0.9, {"pending_tool_count": len(pending) + pending_without_id}
+        return (
+            "tool_left",
+            0.9,
+            {"pending_tool_count": len(pending) + pending_without_id, "evidence_class": "raw_evidence"},
+        )
 
     meaningful = [
         message for message in analysis.facts.message_facts if message.text.strip() and not message.is_protocol_artifact
@@ -277,21 +362,32 @@ def _terminal_state(
     last = meaningful[-1] if meaningful else None
     if last is None:
         if latest_error_action_id is not None:
-            return "error_left", 0.78, {"action_id": latest_error_action_id}
+            return (
+                "error_left",
+                0.78,
+                {"action_id": latest_error_action_id, "evidence_class": latest_error_action_evidence_class},
+            )
         if latest_error_event_id is not None:
-            return "error_left", 0.78, {"event_id": latest_error_event_id}
+            return "error_left", 0.78, {"event_id": latest_error_event_id, "evidence_class": "raw_evidence"}
         return "unknown", 0.1, {}
     text_lower = last.text.lower()
     if last.is_candidate_human_authored:
-        return "question_left", 0.72, {"message_id": last.message_id}
+        return "question_left", 0.72, {"message_id": last.message_id, "evidence_class": "raw_evidence"}
     if last.is_assistant and any(marker in text_lower for marker in _ERROR_MARKERS):
         if latest_error_action_id is not None:
-            return "error_left", 0.78, {"action_id": latest_error_action_id}
+            return (
+                "error_left",
+                0.78,
+                {"action_id": latest_error_action_id, "evidence_class": latest_error_action_evidence_class},
+            )
         if latest_error_event_id is not None:
-            return "error_left", 0.78, {"event_id": latest_error_event_id}
-        return "error_left", 0.7, {"message_id": last.message_id}
+            return "error_left", 0.78, {"event_id": latest_error_event_id, "evidence_class": "raw_evidence"}
+        return "error_left", 0.7, {"message_id": last.message_id, "evidence_class": "text_derived"}
     if last.is_assistant:
-        return "clean_finish", 0.68, {"message_id": last.message_id}
+        # No structural "did the last turn conclude cleanly" signal exists;
+        # this is the complement of the text-marker scan above, so it is
+        # text_derived too, not a grounded positive.
+        return "clean_finish", 0.68, {"message_id": last.message_id, "evidence_class": "text_derived"}
     return "unknown", 0.2, {"message_id": last.message_id}
 
 

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -158,6 +158,42 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             RigorVersionField(name="inference_version", current_version=SESSION_INFERENCE_VERSION),
             RigorVersionField(name="enrichment_version", current_version=SESSION_ENRICHMENT_VERSION),
         ),
+        notes=(
+            "Heuristic-tier inventory (polylogue-b0b): `inference.terminal_state` "
+            "(`archive/session/runtime.py::_terminal_state`) now prefers a "
+            "structural, session-wide `tool_id -> outcome` map "
+            "(`_session_tool_results`) sourced from the keystone "
+            "`blocks.tool_result_is_error`/`tool_result_exit_code` columns "
+            "(index schema v16) over the prior prose `_ERROR_MARKERS` keyword "
+            "scan for the mid-session error-action signal. The lookup is "
+            "session-wide (mirroring `_pending_tool_blocks` and "
+            "`insights/transforms.py::_extract_events`) rather than routed "
+            "through the per-message `Action`/`ToolCall` pairing, because "
+            "Claude/Codex-style transcripts near-always place a `tool_use` in "
+            "one message and its `tool_result` in a later message -- "
+            "per-message pairing alone would miss the common case. That "
+            "structural signal is origin-gated, not universal "
+            "(polylogue-9e5.3 audit): `tool_result_is_error` is well-populated "
+            "only for claude-code-session (44.8%) and claude-ai-export (100% "
+            "of a small volume), 0% for chatgpt-export/hermes-session/"
+            "aistudio-drive; `tool_result_exit_code` is populated only for "
+            "codex-session, and just 14.2% of even that. For origins/results "
+            "with no structural coverage the code falls back to the tagged "
+            "text scan rather than reporting a false negative. Every branch "
+            "of `_terminal_state` now returns an `evidence_class` key in "
+            "`inference.terminal_state_evidence` -- `raw_evidence` (tool-pairing "
+            "counts, the structural action signal, the provider-emitted "
+            "session-event status field, or message role) or `text_derived` "
+            "(the last-message `_ERROR_MARKERS` scan and its `clean_finish` "
+            "complement, and the structural-fallback text scan above). "
+            "Consumers needing only grounded rows should filter on "
+            "`inference.terminal_state_evidence.evidence_class == 'raw_evidence'`. "
+            "`session_work_events`' sibling classifier's 50.5% (coin-flip) "
+            "accuracy finding (9e5.9, noted below) is the reason this scan was "
+            "not simply deleted: not measured as reliable, but not proven "
+            "unreliable enough to remove entirely while the last-resort "
+            "fallback path still has explicit provenance."
+        ),
     ),
     RigorContract(
         insight_name="session_work_events",

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -20,6 +20,7 @@ from typing import Literal, TypeVar
 
 from pydantic import Field, field_validator, model_validator
 
+from polylogue.archive.actions.parsing import tool_result_outcome
 from polylogue.archive.message.models import Message
 from polylogue.archive.session.domain_models import Session
 from polylogue.core.refs import EvidenceRef, ObjectRef
@@ -2303,13 +2304,12 @@ def _tool_status(is_error: int | None, exit_code: int | None) -> Literal["ok", "
 
     Exit code is authoritative when present; otherwise the boolean is_error
     flag decides. NULL on both means unknown — never a fabricated positive
-    inferred from output text (#2482).
+    inferred from output text (#2482). Delegates to
+    :func:`polylogue.archive.actions.parsing.tool_result_outcome`, the
+    canonical implementation (polylogue-b0b), so this precedence rule has a
+    single source of truth instead of two copies that can drift.
     """
-    if exit_code is not None:
-        return "ok" if exit_code == 0 else "failed"
-    if is_error is not None:
-        return "failed" if is_error else "ok"
-    return "unknown"
+    return tool_result_outcome(is_error, exit_code)
 
 
 def _tool_handler_kind(

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -532,7 +532,7 @@ def test_build_session_profile_terminal_state_detects_unanswered_user_turn() -> 
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "question_left"
-    assert profile.terminal_state_evidence == {"message_id": "u1"}
+    assert profile.terminal_state_evidence == {"message_id": "u1", "evidence_class": "raw_evidence"}
 
 
 def test_build_session_profile_terminal_state_detects_pending_tool() -> None:
@@ -558,7 +558,7 @@ def test_build_session_profile_terminal_state_detects_pending_tool() -> None:
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "tool_left"
-    assert profile.terminal_state_evidence == {"pending_tool_count": 1}
+    assert profile.terminal_state_evidence == {"pending_tool_count": 1, "evidence_class": "raw_evidence"}
 
 
 def test_build_session_profile_terminal_state_ignores_paired_tool_blocks() -> None:
@@ -596,7 +596,7 @@ def test_build_session_profile_terminal_state_ignores_paired_tool_blocks() -> No
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "clean_finish"
-    assert profile.terminal_state_evidence == {"message_id": "a2"}
+    assert profile.terminal_state_evidence == {"message_id": "a2", "evidence_class": "text_derived"}
 
 
 def test_build_session_profile_terminal_state_detects_unpaired_tool_block() -> None:
@@ -626,7 +626,7 @@ def test_build_session_profile_terminal_state_detects_unpaired_tool_block() -> N
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "tool_left"
-    assert profile.terminal_state_evidence == {"pending_tool_count": 1}
+    assert profile.terminal_state_evidence == {"pending_tool_count": 1, "evidence_class": "raw_evidence"}
 
 
 def test_build_session_profile_terminal_state_detects_provider_error() -> None:
@@ -665,7 +665,10 @@ def test_build_session_profile_terminal_state_detects_provider_error() -> None:
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "error_left"
-    assert profile.terminal_state_evidence == {"event_id": "conv-error-left:event-1"}
+    assert profile.terminal_state_evidence == {
+        "event_id": "conv-error-left:event-1",
+        "evidence_class": "raw_evidence",
+    }
 
 
 def test_build_session_profile_terminal_state_ignores_recovered_tool_error() -> None:
@@ -707,7 +710,146 @@ def test_build_session_profile_terminal_state_ignores_recovered_tool_error() -> 
     profile = build_session_profile(session)
 
     assert profile.terminal_state == "clean_finish"
-    assert profile.terminal_state_evidence == {"message_id": "a2"}
+    assert profile.terminal_state_evidence == {"message_id": "a2", "evidence_class": "text_derived"}
+
+
+def test_build_session_profile_terminal_state_detects_structural_error_with_silent_prose() -> None:
+    """polylogue-b0b: a structurally-confirmed failure is caught even when no
+    message text anywhere in the session mentions an error keyword -- proving
+    the signal comes from ``tool_result_is_error``, not a prose scan."""
+    session = make_conv(
+        id="conv-structural-error-silent-prose",
+        origin=Provider.CLAUDE_CODE,
+        title="Structural error, silent prose",
+        messages=[
+            make_msg(id="u1", role="user", origin=Provider.CLAUDE_CODE, text=""),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CLAUDE_CODE,
+                text="",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_id": "tool-1",
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "./deploy.sh"},
+                    }
+                ],
+            ),
+            make_msg(
+                id="t1",
+                role="tool",
+                origin=Provider.CLAUDE_CODE,
+                text="",
+                blocks=[
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-1",
+                        "text": "deployment halted, no diagnostic output captured",
+                        "tool_result_is_error": 1,
+                    }
+                ],
+            ),
+        ],
+    )
+
+    profile = build_session_profile(session)
+
+    assert profile.terminal_state == "error_left"
+    assert profile.terminal_state_evidence["evidence_class"] == "raw_evidence"
+    assert "action_id" in profile.terminal_state_evidence
+
+
+def test_build_session_profile_terminal_state_structural_success_suppresses_misleading_prose() -> None:
+    """polylogue-b0b: ``tool_result_is_error=0`` must suppress a false
+    positive even when the tool's own output text contains a word from
+    ``_ERROR_MARKERS`` (here "error" inside "0 errors found") -- the old
+    unconditional prose scan over ``action.output_text`` would have
+    misclassified this as ``error_left``."""
+    session = make_conv(
+        id="conv-structural-success-misleading-prose",
+        origin=Provider.CLAUDE_CODE,
+        title="Structural success, misleading prose",
+        messages=[
+            make_msg(id="u1", role="user", origin=Provider.CLAUDE_CODE, text=""),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CLAUDE_CODE,
+                text="",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_id": "tool-1",
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "./lint.sh"},
+                    }
+                ],
+            ),
+            make_msg(
+                id="t1",
+                role="tool",
+                origin=Provider.CLAUDE_CODE,
+                text="",
+                blocks=[
+                    {
+                        "type": "tool_result",
+                        "tool_id": "tool-1",
+                        "text": "0 errors found; lint succeeded cleanly",
+                        "tool_result_is_error": 0,
+                        "tool_result_exit_code": 0,
+                    }
+                ],
+            ),
+        ],
+    )
+
+    profile = build_session_profile(session)
+
+    assert profile.terminal_state == "unknown"
+    assert profile.terminal_state_evidence == {}
+
+
+def test_build_session_profile_terminal_state_falls_back_to_text_derived_when_structure_absent() -> None:
+    """polylogue-b0b: an origin/result with no keystone columns at all (e.g.
+    chatgpt-export, which never populates ``tool_result_is_error``) still
+    gets the tagged prose fallback rather than a silent, unlabeled gap."""
+    session = make_conv(
+        id="conv-no-structural-coverage",
+        origin=Provider.CHATGPT,
+        title="No structural coverage",
+        messages=[
+            make_msg(id="u1", role="user", origin=Provider.CHATGPT, text=""),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CHATGPT,
+                text="",
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_id": "tool-1",
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "./build.sh"},
+                    }
+                ],
+            ),
+            make_msg(
+                id="t1",
+                role="tool",
+                origin=Provider.CHATGPT,
+                text="",
+                blocks=[{"type": "tool_result", "tool_id": "tool-1", "text": "Command failed with a stack trace"}],
+            ),
+        ],
+    )
+
+    profile = build_session_profile(session)
+
+    assert profile.terminal_state == "error_left"
+    assert profile.terminal_state_evidence["evidence_class"] == "text_derived"
+    assert "action_id" in profile.terminal_state_evidence
 
 
 def test_build_session_profile_ignores_unpaired_tool_windows() -> None:


### PR DESCRIPTION
## Summary

Converts `_terminal_state`'s (session_profiles' terminal-state classifier) mid-session error detection from an unconditional prose-keyword scan to the structural `blocks.tool_result_is_error`/`tool_result_exit_code` columns (index schema v16 keystone), with an honest per-origin coverage caveat and an `evidence_class` tag (`raw_evidence`/`text_derived`) on every branch. Also completes the module:line -> verdict inventory the bead's acceptance criteria requires, documenting sites that were already structural, sites with no structural equivalent (LABEL, not CONVERT), and sites out of scope.

## Problem

`polylogue-b0b`'s design note: wherever detectors/insights modules regex-match prose to infer outcomes, consume `tool_result_is_error`/`tool_result_exit_code` instead, with per-origin coverage caveats where structure is absent. `polylogue-9e5.9`'s closing evidence found the sibling keyword classifier in the same file (`runtime.py::_terminal_state`'s `_ERROR_MARKERS` fallback) scores only 50.5% (coin-flip) agreement against structural ground truth on 14,377 real runs — the exact "construct-validity moat" this bead exists to protect.

Grepping `insights/`, `archive/`, `schemas/code_detection/`, and the pathology surfaces for prose-pattern outcome matching found:

- `archive/session/runtime.py::_terminal_state`'s action-loop `_ERROR_MARKERS` scan over `action.output_text` — the live CONVERT target.
- `archive/session/runtime.py::_terminal_state`'s last-message scan and its `clean_finish` complement — no structural equivalent (LABEL).
- `archive/actions/followup.py`'s `ACKNOWLEDGMENT_MARKERS`/`classify_failed_followup(_evidence)` — classifies whether the assistant *acknowledged* an already-structural failure; no structural equivalent (LABEL). Two live consumers: the public `followup_class` query-DSL field (SQL reimplementation in `archive_tiers/archive.py`) and `devtools claim-vs-evidence`.
- Several sites already fully structural, needing only documentation: `insights/pathology.py` (the former prose-mined `missed_review` detector was already removed in #2482 — the bead's own cautionary fixture), `insights/transforms.py::_extract_events`/`_tool_status`, `insights/run_projection.py::_main_run_status`, `_terminal_state`'s session-event status check (a typed key on Codex's own protocol event payload, not prose), `schemas/code_detection/tree_sitter.py`'s tree-sitter AST error node, and `sources/providers/claude_code_models.py`'s anchored parse-time notification-envelope regexes.
- `insights/transforms.py::_tool_handler_kind`/`_looks_like_test_output` — a *category* classifier (test vs. shell), not a pass/fail determination (already 100% structural); adjacent to but outside the outcome/pathology scope.

## Solution

- **`archive/actions/parsing.py`**: new `tool_result_outcome()`/`tool_result_block_outcome()` helpers implementing the canonical exit_code/is_error precedence (exit_code authoritative when present, else is_error, else `"unknown"` — never guessed from prose). Reads both the hydrated storage-column keys and the bare parse-time keys (`ParsedContentBlock.is_error`/`exit_code`), matching the dual-key convention `rendering/block_models.py` already uses. `build_tool_calls_from_content_blocks` now populates the previously-declared-but-dead `ToolCall.success` field from this structural signal.
- **`archive/actions/actions.py`**: `Action` gains `tool_success: bool | None`, propagated from `ToolCall.success`.
- **`archive/session/runtime.py`**: `_terminal_state` resolves a session-wide `tool_id -> (outcome, text)` map (`_session_tool_results`), mirroring `_pending_tool_blocks`'s and `insights/transforms.py`'s existing session-wide `tool_use`/`tool_result` pairing — per-message `Action` pairing alone misses the common Claude/Codex shape where a `tool_use` and its `tool_result` land in separate messages (discovered while writing the regression tests: a naive per-message `Action.tool_success` never fired for realistic fixtures). A structural `"failed"` verdict is used directly; a structural `"ok"` verdict suppresses the prose fallback (fixes a real false positive: "0 errors found" previously matched the `"error"` keyword substring); only a genuinely absent structural signal falls back to the tagged `_ERROR_MARKERS` scan. Every branch now returns an `evidence_class` key (`"raw_evidence"`/`"text_derived"`) in `terminal_state_evidence`.
- **`insights/transforms.py::_tool_status`** delegates to the new canonical `tool_result_outcome()` instead of duplicating the same precedence rule (dedup, per the sibling-drift risk the bead's construct-validity framing calls out).
- **`insights/rigor.py` + `docs/insights-rigor-matrix.md`**: `session_profiles` contract gains a notes entry (following the `#b0b.1` established pattern) describing the CONVERT, its origin-gated coverage caveat (`tool_result_is_error` well-populated only for claude-code-session/claude-ai-export, `tool_result_exit_code` only for codex-session at 14%), and the `evidence_class` contract.
- **`archive/actions/followup.py`**: documents the LABEL verdict for `ACKNOWLEDGMENT_MARKERS`/its consumers in the module docstring.
- **`archive/query/metadata.py`**: `followup_class` DSL field description now reads "(keyword-heuristic, text-derived)" so query discovery/CLI help surfaces the tier honestly.

## Alternatives rejected

Fixing `build_tool_calls_from_content_blocks` to pair `tool_use`/`tool_result` session-wide (instead of adding a dedicated session-wide helper in `runtime.py`) was rejected — it would change `Action.output_text`/`search_text` for every `Action` consumer (CLI action rendering, tool-usage stats, search text), a much larger blast radius than this bead's outcome-heuristic scope.

## Verification

- `devtools test tests/unit/core/test_semantic_facts.py -k terminal_state` — 9 passed (6 existing tests updated for the new `evidence_class` key, 3 new tests: structural failure caught with zero error-marker prose anywhere in the session; structural `"ok"` suppressing a misleading "0 errors found" false positive; an origin with no structural coverage still getting the tagged text fallback).
- `devtools test tests/unit/core/test_semantic_facts.py tests/unit/archive/ tests/unit/insights/ tests/unit/devtools/test_claim_vs_evidence.py` — clean individually and in this combined run (678+ passed); large multi-directory/whole-suite batches on this shared host show unrelated pre-existing flakiness (confirmed identical failure sets reproduce with these changes fully `git stash`ed out — shared `seeded_db`/host contention, not this diff).
- `devtools lab policy insight-honesty` — every registered insight contracted or exempt.
- `devtools verify --quick` — exit 0 (ran twice: pre-rebase and via the pre-push hook).

Not run: full `devtools verify --all` / testmon-seeded suite (fresh worktree requiring a full-suite seed pass; the targeted runs above cover every file this change touches).

Ref polylogue-b0b