### PR TITLE
fix: enforce degrade-loudly on silent daemon/storage/coordination soft-fails

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -841,6 +841,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify pytest-timeout-overrides", "devtools verify pytest-timeout-overrides --json"),
     ),
     CommandSpec(
+        "verify degrade-loudly",
+        "verification",
+        "Verify broad except-handlers in daemon/storage/insights/coordination log or signal on failure.",
+        "devtools.verify_degrade_loudly",
+        use_when=(
+            "Enforce the degrade-loudly doctrine (polylogue-cpf.4): a broad except-handler "
+            "(Exception/BaseException/*.Error) in derived-read, status, or probe code that "
+            "swallows the exception with no log call and no re-raise is indistinguishable from "
+            "'no data' to a reader. New silent sites must add a log call, or add a typed signal "
+            "plus a rationale entry in docs/plans/degrade-loudly-allowlist.yaml."
+        ),
+        examples=("devtools verify degrade-loudly", "devtools verify degrade-loudly --json"),
+    ),
+    CommandSpec(
         "release verify-distribution",
         "release",
         "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1486,6 +1486,7 @@ def build_verify_steps(
                 ("verify test-infra-currency", _devtools_cmd("verify test-infra-currency")),
                 ("verify test-clock-hygiene", _devtools_cmd("verify test-clock-hygiene")),
                 ("verify pytest-timeout-overrides", _devtools_cmd("verify pytest-timeout-overrides")),
+                ("verify degrade-loudly", _devtools_cmd("verify degrade-loudly")),
             ]
         )
 

--- a/devtools/verify_degrade_loudly.py
+++ b/devtools/verify_degrade_loudly.py
@@ -1,0 +1,329 @@
+"""Lint: broad except-handlers in derived-read/status/probe code must signal.
+
+Background (polylogue-cpf.4, the "degrade loudly" doctrine under
+``polylogue-cpf``): a deep read (2026-07-05) found the daemon/storage/
+insights/coordination packages systematically degrade *silently* on
+derived-read, fallback, and freshness-probe paths — a caught exception is
+swallowed and a plain default (``None``/``0``/``[]``/``False``) is returned,
+which is indistinguishable from the query genuinely finding nothing. For a
+system-of-record that is a construct-validity hole: a reader cannot tell
+"no data" from "the probe/query failed".
+
+This lint scans ``polylogue/daemon``, ``polylogue/storage``,
+``polylogue/insights``, and ``polylogue/coordination`` (excluding tests) for
+``except`` handlers that catch a broad exception type (``Exception``,
+``BaseException``, or any ``*.Error`` such as ``sqlite3.Error``) whose body:
+
+1. Never calls anything with "log" in its name (covers ``logger.warning``,
+   ``self._logger.exception``, etc.) — the doctrine's "log loudly" minimum, and
+2. Never re-raises.
+
+Narrower excepts (``ValueError``, ``TypeError``, ``JSONDecodeError``, ...) are
+not flagged: in this codebase they are overwhelmingly routine defensive value
+coercion on a single optionally-malformed field (a documented fallback for
+*one field*, not a derived-read health/readiness signal), not the
+system-of-record degradation the doctrine targets.
+
+A violation is not automatically a bug: many broad excepts already return a
+typed signal instead of logging (``HealthAlert(severity=ERROR, message=f"...:
+{exc}")`` in ``daemon/health.py``, ``{"available": False, "error": str(exc)}``
+dicts, ``_repair_result(..., success=False, detail=f"...: {exc}")``). This
+lint cannot see through a return value to tell whether it structurally
+encodes the failure, so those sites are pre-approved in the allowlist at
+``docs/plans/degrade-loudly-allowlist.yaml`` with a one-line rationale, the
+same shape as ``docs/plans/test-clock-allowlist.yaml``.
+
+New broad excepts must either add a log call (cheapest fix), return a typed
+signal *and* add an allowlist entry explaining what the signal is, or
+genuinely re-raise. The allowlist is keyed by (path, enclosing function
+qualname, sorted exception names, occurrence index within that function) —
+not line number — so it survives unrelated line-shift churn elsewhere in the
+file; only an edit to the flagged function's except-handler shape invalidates
+an entry. Stale allowlist entries (no longer matching any current violation)
+are also rejected, so the allowlist can't quietly grow unbounded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is a hard repo dep
+    yaml = None  # type: ignore[assignment]
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+TARGET_DIRS = (
+    "polylogue/daemon",
+    "polylogue/storage",
+    "polylogue/insights",
+    "polylogue/coordination",
+)
+ALLOWLIST_PATH = ROOT / "docs" / "plans" / "degrade-loudly-allowlist.yaml"
+
+_BROAD_NAMES = {"Exception", "BaseException", "Error"}
+_LOG_HINT = "log"
+
+
+@dataclass(frozen=True, slots=True)
+class Site:
+    path: str
+    function: str
+    exceptions: tuple[str, ...]
+    occurrence: int
+    lineno: int
+
+    @property
+    def key(self) -> tuple[str, str, tuple[str, ...], int]:
+        return (self.path, self.function, self.exceptions, self.occurrence)
+
+
+def _exception_names(handler: ast.ExceptHandler) -> tuple[str, ...]:
+    node = handler.type
+    if node is None:
+        return ("<bare>",)
+    names: list[str] = []
+    elts = node.elts if isinstance(node, ast.Tuple) else [node]
+    for elt in elts:
+        if isinstance(elt, ast.Name):
+            names.append(elt.id)
+        elif isinstance(elt, ast.Attribute):
+            names.append(elt.attr)
+    return tuple(sorted(names))
+
+
+def _body_logs_or_raises(body: list[ast.stmt]) -> bool:
+    holder = ast.Module(body=body, type_ignores=[])
+    for node in ast.walk(holder):
+        if isinstance(node, ast.Raise):
+            return True
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and _LOG_HINT in func.value.id.lower()
+            ):
+                return True
+            if isinstance(func, ast.Name) and _LOG_HINT in func.id.lower():
+                return True
+    return False
+
+
+class _FunctionScopeVisitor(ast.NodeVisitor):
+    """Walk a module tracking enclosing function qualnames and per-function
+    occurrence counters for broad, unsignalled except-handlers."""
+
+    def __init__(self, relpath: str) -> None:
+        self.relpath = relpath
+        self._stack: list[str] = ["<module>"]
+        self._occurrence: dict[str, int] = {}
+        self.sites: list[Site] = []
+
+    def _qualname(self) -> str:
+        return ".".join(self._stack)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._stack.append(node.name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        names = _exception_names(node)
+        if set(names) & _BROAD_NAMES and not _body_logs_or_raises(node.body):
+            qualname = self._qualname()
+            occ_key = f"{qualname}::{names}"
+            occurrence = self._occurrence.get(occ_key, 0)
+            self._occurrence[occ_key] = occurrence + 1
+            self.sites.append(
+                Site(
+                    path=self.relpath,
+                    function=qualname,
+                    exceptions=names,
+                    occurrence=occurrence,
+                    lineno=node.lineno,
+                )
+            )
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path, *, root: Path) -> list[Site]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    relpath = str(path.relative_to(root))
+    visitor = _FunctionScopeVisitor(relpath)
+    visitor.visit(tree)
+    return visitor.sites
+
+
+def _scan_repo(*, root: Path) -> list[Site]:
+    sites: list[Site] = []
+    for target in TARGET_DIRS:
+        base = root / target
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "test" in path.parts:
+                continue
+            sites.extend(_scan_file(path, root=root))
+    return sites
+
+
+@dataclass(frozen=True, slots=True)
+class AllowlistEntry:
+    path: str
+    function: str
+    exceptions: tuple[str, ...]
+    occurrence: int
+    reason: str
+
+    @property
+    def key(self) -> tuple[str, str, tuple[str, ...], int]:
+        return (self.path, self.function, self.exceptions, self.occurrence)
+
+
+def _load_allowlist(allowlist_path: Path) -> list[AllowlistEntry]:
+    if not allowlist_path.exists():
+        return []
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to read the degrade-loudly allowlist")
+    data = yaml.safe_load(allowlist_path.read_text(encoding="utf-8")) or {}
+    entries = data.get("entries", []) or []
+    out: list[AllowlistEntry] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        exceptions = entry.get("exceptions", [])
+        out.append(
+            AllowlistEntry(
+                path=str(entry.get("path", "")),
+                function=str(entry.get("function", "")),
+                exceptions=tuple(sorted(str(e) for e in exceptions)),
+                occurrence=int(entry.get("occurrence", 0)),
+                reason=str(entry.get("reason", "")),
+            )
+        )
+    return out
+
+
+def _format_report(
+    *,
+    sites: list[Site],
+    allowlist: list[AllowlistEntry],
+    unallowlisted: list[Site],
+    stale: list[AllowlistEntry],
+    root: Path,
+    allowlist_path: Path,
+) -> str:
+    lines = [
+        f"broad except-handlers scanned across {len(TARGET_DIRS)} package(s): {len(sites)}",
+        f"allowlisted: {len(allowlist)}",
+        f"unallowlisted (new silent soft-fails): {len(unallowlisted)}",
+        f"stale allowlist entries: {len(stale)}",
+    ]
+    if unallowlisted:
+        lines.append("")
+        lines.append("Broad except-handlers with no log call and no re-raise, outside the allowlist:")
+        for site in sorted(unallowlisted, key=lambda s: (s.path, s.lineno)):
+            lines.append(
+                f"  {site.path}:{site.lineno} in {site.function}() except {list(site.exceptions)} "
+                "— add a log call (or re-raise), or add an allowlist entry at "
+                f"{allowlist_path.relative_to(root) if allowlist_path.is_relative_to(root) else allowlist_path} "
+                "explaining the existing signal (polylogue-cpf.4)."
+            )
+    if stale:
+        lines.append("")
+        lines.append("Allowlist entries that no longer match a current violation (remove them):")
+        for entry in sorted(stale, key=lambda e: (e.path, e.function)):
+            lines.append(
+                f"  {entry.path} :: {entry.function}() except {list(entry.exceptions)} [occurrence {entry.occurrence}]"
+            )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to scan.")
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Allowlist YAML path (defaults to <root>/docs/plans/degrade-loudly-allowlist.yaml).",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root.resolve()
+    default_allowlist = root / "docs" / "plans" / "degrade-loudly-allowlist.yaml"
+    allowlist_path: Path = (args.allowlist or default_allowlist).resolve()
+
+    sites = _scan_repo(root=root)
+    allowlist = _load_allowlist(allowlist_path)
+    allowed_keys = {entry.key for entry in allowlist}
+    site_keys = {site.key for site in sites}
+
+    unallowlisted = [site for site in sites if site.key not in allowed_keys]
+    stale = [entry for entry in allowlist if entry.key not in site_keys]
+
+    ok = not unallowlisted and not stale
+
+    if args.json:
+        payload = {
+            "sites_scanned": len(sites),
+            "allowlisted": len(allowlist),
+            "violations": [
+                {
+                    "path": site.path,
+                    "line": site.lineno,
+                    "function": site.function,
+                    "exceptions": list(site.exceptions),
+                }
+                for site in sorted(unallowlisted, key=lambda s: (s.path, s.lineno))
+            ],
+            "stale_allowlist_entries": [
+                {
+                    "path": entry.path,
+                    "function": entry.function,
+                    "exceptions": list(entry.exceptions),
+                    "occurrence": entry.occurrence,
+                }
+                for entry in sorted(stale, key=lambda e: (e.path, e.function))
+            ],
+            "ok": ok,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            _format_report(
+                sites=sites,
+                allowlist=allowlist,
+                unallowlisted=unallowlisted,
+                stale=stale,
+                root=root,
+                allowlist_path=allowlist_path,
+            )
+        )
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -155,6 +155,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |
 | `devtools verify coverage` | Run pytest with the repository coverage floor from pyproject.toml. |
+| `devtools verify degrade-loudly` | Verify broad except-handlers in daemon/storage/insights/coordination log or signal on failure. |
 | `devtools verify doc-commands` | Verify README/docs command examples resolve to live polylogue, polylogued, and devtools commands. |
 | `devtools verify evidence` | Render the pytest-first evidence dashboard or a changed-path trace. |
 | `devtools verify layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |

--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -1,0 +1,503 @@
+# Pre-approved broad except-handlers for `devtools verify degrade-loudly`
+# (polylogue-cpf.4). Each entry documents WHY the handler already carries a
+# degradation signal (or is safely fail-closed) despite having no log call.
+# Keyed by (path, function qualname, exception set, occurrence-within-function)
+# rather than line number, so unrelated edits elsewhere in the file don't
+# require re-numbering. New broad excepts must either log, or be added here
+# with a real rationale -- not a rubber stamp.
+#
+# Generated 2026-07-12 during the polylogue-cpf.4 degrade-loudly sweep after
+# converting ~35 genuine silent-failure sites to log/signal; these are the
+# audited remainder that already signal via a typed return value, a
+# convergence_debt/HealthAlert/_repair_result-style mechanism, or a
+# documented fail-safe direction.
+
+entries:
+- path: polylogue/daemon/backup.py
+  function: <module>._check_prerequisites
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Appends f"disk space check failed: {exc}" to the warnings list it returns -- a typed signal
+    via the list itself, not a log call.'
+- path: polylogue/daemon/backup.py
+  function: <module>._readable_sqlite
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Returns str(exc) itself as the "why unreadable" reason -- the exception text is the signal.
+- path: polylogue/daemon/backup.py
+  function: <module>._verify_backup_result
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Both sites already build {"ok": False, "error": str(exc)} / result.error = f"...: {exc}" typed
+    signals.'
+- path: polylogue/daemon/backup.py
+  function: <module>._verify_backup_result
+  exceptions:
+  - Exception
+  occurrence: 1
+  reason: 'Both sites already build {"ok": False, "error": str(exc)} / result.error = f"...: {exc}" typed
+    signals.'
+- path: polylogue/daemon/cli.py
+  function: <module>._close_raw_materialization_fts
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Records the failure via _record_raw_materialization_fts_debt(index_db, reason) -- signals through
+    convergence_debt, the pattern polylogue-cpf.4 explicitly says to leave alone.
+- path: polylogue/daemon/cli.py
+  function: <module>._close_raw_materialization_fts
+  exceptions:
+  - Exception
+  occurrence: 1
+  reason: Records the failure via _record_raw_materialization_fts_debt(index_db, reason) -- signals through
+    convergence_debt, the pattern polylogue-cpf.4 explicitly says to leave alone.
+- path: polylogue/daemon/convergence_debt_alert.py
+  function: <module>.source_family_for_path
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Returns the explicit "unknown" sentinel, distinguishable from any real family token.
+- path: polylogue/daemon/fts_startup.py
+  function: <module>._blocks_search_text_has_rows_sync
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: None triggers the not-ready path in the startup repair decision (fail-toward-needs-work).
+- path: polylogue/daemon/fts_startup.py
+  function: <module>._count_or_zero
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow startup probe; 0 is the fail-toward-repair default consumed by the FTS startup-readiness
+    decision (safe direction, matches the 1xc.11 precedent).
+- path: polylogue/daemon/fts_startup.py
+  function: <module>._ensure_archive_messages_fts_startup_readiness_sync
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: False triggers startup FTS repair (fail-toward-needs-work), matching the 1xc.11 precedent for
+    probe handlers.
+- path: polylogue/daemon/fts_startup.py
+  function: <module>._message_fts_docsize_has_rows_sync
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: False triggers the not-ready path in the startup repair decision (fail-toward-needs-work).
+- path: polylogue/daemon/fts_startup.py
+  function: <module>._message_fts_freshness_row_sync
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: None triggers the not-ready path in the startup repair decision (fail-toward-needs-work).
+- path: polylogue/daemon/health.py
+  function: <module>._archive_repeated_stage_failure_info
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Internal fallback: None triggers the local-tier query in the caller (_check_repeated_stage_failures_medium),
+    which itself returns a typed HealthAlert(severity=ERROR) on its own failure.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_blob_integrity_expensive
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_convergence_debt_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_cursor_lag_anomaly_layer
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_cursor_lag_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_daemon_liveness_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Returns HealthAlert(severity=ERROR, message=f"...: {exc}") -- a typed degradation signal, the
+    established pattern for every _check_*_{fast,medium,expensive} probe in this file.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_db_integrity_expensive
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_disk_space_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_embedding_coverage_expensive
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_fts_readiness_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_hook_flow_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_insight_freshness_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_raw_failures_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_repeated_stage_failures_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_schema_version_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_source_availability_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_stale_ingest_attempts_medium
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
+  function: <module>._check_wal_size_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/http.py
+  function: <module>._handle_health
+  exceptions:
+  - Error
+  - OSError
+  occurrence: 0
+  reason: quick_check_ok=False is the safe fail-toward-unhealthy direction and is itself the boolean field
+    the JSON response reports.
+- path: polylogue/daemon/http.py
+  function: <module>._handle_health_check
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Sends a typed JSON error response ({"ok": False, "status": "error", "detail": "health check
+    failed"}) -- the HTTP response itself is the signal.'
+- path: polylogue/daemon/metrics.py
+  function: <module>.format_metrics
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: polylogue_version = "unknown" is an explicit sentinel distinguishable from any real version
+    string.
+- path: polylogue/daemon/status.py
+  function: <module>._archive_debt_status_summary
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Returns {"available": False, ...} -- the available flag already distinguishes this from a successful
+    lookup.'
+- path: polylogue/daemon/status.py
+  function: <module>._archive_insight_freshness_info
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Internal fallback: None triggers the local-DB query in the caller (_insight_freshness_info),
+    which now logs on its own failure (fixed in this sweep).'
+- path: polylogue/daemon/status.py
+  function: <module>._archive_live_cursor_summary_info
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Internal fallback: None triggers the local-DB query in the caller (_live_cursor_summary_info),
+    which now logs on its own failure (fixed in this sweep).'
+- path: polylogue/daemon/status.py
+  function: <module>._archive_live_ingest_attempt_summary_info
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Internal fallback: None triggers the local-DB query in the caller (_live_ingest_attempt_summary_info),
+    which now logs on its own failure (fixed in this sweep).'
+- path: polylogue/daemon/status.py
+  function: <module>._archive_raw_failure_info
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Internal fallback: None triggers the local-DB query in the caller (_raw_failure_info), which
+    now logs on its own failure (fixed in this sweep).'
+- path: polylogue/daemon/status.py
+  function: <module>._raw_replay_backlog_info
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Returns {"available": False, "reason": str(exc), ...} -- an already-typed signal.'
+- path: polylogue/daemon/status_snapshot.py
+  function: <module>._minimal_status_payload
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Captures refresh_error = refresh_error or str(exc), threaded into the returned snapshot payload
+    -- a typed signal.
+- path: polylogue/daemon/status_snapshot.py
+  function: <module>.refresh_status_snapshot
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Captures refresh_error = str(exc) and passes it into _minimal_status_payload(refresh_error=...)
+    -- a typed signal.
+- path: polylogue/daemon/write_coordinator.py
+  function: <module>._run_in_daemon_thread.worker
+  exceptions:
+  - BaseException
+  occurrence: 0
+  reason: Propagates the exception itself via loop.call_soon_threadsafe(publish, None, exc) to the awaiting
+    asyncio Future, which re-raises it to the caller -- the exception is not discarded, just marshalled
+    across the thread boundary.
+- path: polylogue/insights/audit.py
+  function: <module>.build_insight_rigor_audit_report
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Captures error = f"{type(exc).__name__}: {exc}" and merges it into the returned entry via model_copy(update={"error":
+    error}) -- a typed signal.'
+- path: polylogue/insights/correlation_view.py
+  function: <module>._print_otlp_evidence
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Prints a visible CLI message to the operator (console.print("No OTLP data available")) rather
+    than silently returning -- not a silent failure, though the wording could better distinguish absence
+    from failure (tracked as a wording follow-up, not a silent-failure instance).
+- path: polylogue/storage/archive_readiness.py
+  function: <module>.missing_source_raw_session_evidence
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Returns {"available": False, "reason": str(exc), ...} -- an already-typed signal.'
+- path: polylogue/storage/archive_readiness.py
+  function: <module>.raw_materialization_readiness_snapshot
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Returns {"available": False, "error": str(exc)} -- an already-typed signal.'
+- path: polylogue/storage/artifacts/inspection.py
+  function: <module>._hermes_state_db_schema_version
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow schema-version probe; None ("unknown version") is the fail-safe default already distinct
+    from a real version int.
+- path: polylogue/storage/artifacts/inspection.py
+  function: <module>.inspect_raw_artifact
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Falls through to classify_artifact_path()-derived kind/reason fields on the constructed record
+    rather than raising -- an already-typed fallback classification, not a bare default.
+- path: polylogue/storage/blob_gc.py
+  function: <module>._database_has_table
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow schema probe; False ("table absent") is the fail-safe direction already consumed defensively
+    by callers.
+- path: polylogue/storage/embeddings/materialization.py
+  function: <module>._embedding_status_row_exists
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'True on error is the conservative default for this specific caller: it runs immediately after
+    vec_provider.upsert() succeeded, so treating a post-hoc verification-query failure as "row exists"
+    avoids a false no_embeddable_messages misclassification of a session that was actually embedded. This
+    is not the 1xc.11 fail-toward-needs-work pattern; the safe direction here is inverted by the calling
+    context.'
+- path: polylogue/storage/embeddings/materialization.py
+  function: <module>._qualified_table_exists
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow schema probe; False ("table absent") is the fail-safe direction.
+- path: polylogue/storage/embeddings/materialization.py
+  function: <module>._table_columns
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow schema probe; an empty column set is the fail-safe direction (callers treat missing columns
+    as "feature unavailable").
+- path: polylogue/storage/embeddings/materialization.py
+  function: <module>.embed_archive_session_sync
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Calls mark_session_embedding_error(...) -- an already-typed signal recorded in the embedding_status
+    tier.
+- path: polylogue/storage/embeddings/materialization.py
+  function: <module>.embed_session_sync
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Calls _record_embedding_failure(...) and returns EmbedSessionOutcome(status="error", error=str(exc))
+    -- an already-typed signal.
+- path: polylogue/storage/embeddings/preflight.py
+  function: <module>._is_archive_index
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow probe; False ("not a usable archive index") is the fail-safe direction that causes the
+    candidate path to be skipped rather than mistakenly opened.
+- path: polylogue/storage/embeddings/status_payload.py
+  function: <module>._archive_catchup_runs
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Feeds latest_catchup_run/latest_material_catchup_run, informational display fields that render
+    as null for both "no runs" and "query failed" -- low severity (not a gating/health signal).
+- path: polylogue/storage/embeddings/status_payload.py
+  function: <module>._sqlite_stat1_index_rows
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow planner-stat probe; None ("unknown") is the fail-safe default for an optional diagnostic
+    field.
+- path: polylogue/storage/repair.py
+  function: <module>._archive_index_present
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow probe; False ("index not present/versioned") is the fail-safe direction.
+- path: polylogue/storage/repair.py
+  function: <module>._run_sql_repair
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Returns _repair_result(..., success=False, detail=f"Repair failed: {exc}") -- an already-typed
+    signal, the established pattern for every repair_* function in this file.'
+- path: polylogue/storage/repair.py
+  function: <module>.repair_orphaned_attachments
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+- path: polylogue/storage/repair.py
+  function: <module>.repair_orphaned_messages
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+- path: polylogue/storage/repair.py
+  function: <module>.repair_session_insights
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+- path: polylogue/storage/repository/raw/repository_raw.py
+  function: <module>.get_known_source_cursors
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Feeds the stat-based fast path for cursor comparison (per its own docstring); an empty dict
+    only degrades the optimization, the correctness-critical cursor path does not depend on this cache.
+- path: polylogue/storage/sqlite/archive_tiers/archive.py
+  function: <module>._ensure_read_runtime_indexes
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Explicitly documented "best-effort performance-index ensure" (see the function's own docstring)
+    -- not correctness-affecting.
+- path: polylogue/storage/sqlite/archive_tiers/archive_plan.py
+  function: <module>._read_user_version
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Narrow user_version probe (two except blocks: connect, then PRAGMA read); None ("unknown version")
+    is the fail-safe default.'
+- path: polylogue/storage/sqlite/archive_tiers/archive_plan.py
+  function: <module>._read_user_version
+  exceptions:
+  - Error
+  occurrence: 1
+  reason: 'Narrow user_version probe (two except blocks: connect, then PRAGMA read); None ("unknown version")
+    is the fail-safe default.'
+- path: polylogue/storage/sqlite/maintenance.py
+  function: <module>.maybe_optimize_archive_tiers
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Appends a SqliteOptimizeObservation capturing the exception -- an already-typed signal.
+- path: polylogue/storage/sqlite/maintenance.py
+  function: <module>.maybe_optimize_sqlite
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Returns SqliteOptimizeObservation(reason=reason, ran=False, ...) with the exception captured
+    -- an already-typed signal.
+- path: polylogue/storage/sqlite/sqlite_vec_extension.py
+  function: <module>.try_load_sqlite_vec
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Returns (False, exc) -- the exception object itself is the signal, not discarded.
+- path: polylogue/storage/sqlite/sqlite_vec_extension.py
+  function: <module>.try_load_sqlite_vec_async
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: Returns (False, exc) -- the exception object itself is the signal, not discarded.
+- path: polylogue/storage/sqlite/wal_checkpoint.py
+  function: <module>.maybe_checkpoint_wal
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Captures error = str(exc), included in the returned checkpoint result -- an already-typed signal.
+- path: polylogue/storage/usage.py
+  function: <module>._source_raw_stats
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Returns ({}, {}, f"...: {exc}") -- the third tuple element is an already-typed reason string.'
+- path: polylogue/storage/usage.py
+  function: <module>._source_schema_alias
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow ATTACH-DATABASE probe; None ("no usable source alias") is the fail-safe direction.
+- path: polylogue/storage/usage.py
+  function: <module>._table_exists_in_schema
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: Narrow schema probe; False ("table absent") is the fail-safe direction.

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -41,7 +41,10 @@ from polylogue.coordination.payloads import (
     CoordinationView,
     CoordinationWorkItemPayload,
 )
+from polylogue.logging import get_logger
 from polylogue.paths import active_index_db_path, archive_root
+
+logger = get_logger(__name__)
 
 CommandRunner = Callable[[Sequence[str], Path | None], "CommandResult"]
 
@@ -121,14 +124,21 @@ def build_coordination_envelope(
     resources = all_resources[:resource_limit]
     archive = _archive_payload(resources)
     handoff = _handoff_payloads(repo.root or str(root_cwd), archive=archive, limit=peer_limit)
-    session_trees, activity_episodes, subagent_exchanges, proof_refs, context_flow_refs = _archive_evidence_payloads(
+    (
+        session_trees,
+        activity_episodes,
+        subagent_exchanges,
+        proof_refs,
+        context_flow_refs,
+        archive_evidence_degraded_reason,
+    ) = _archive_evidence_payloads(
         repo,
         self_payload,
         archive,
         limit=peer_limit,
     )
     overlaps = _overlap_payloads(repo, work_item, peers, resources)
-    advisories = _advisories(repo, work_item, overlaps, archive)
+    advisories = _advisories(repo, work_item, overlaps, archive, archive_evidence_degraded_reason)
     provenance = (repo.provenance, work_item.provenance, self_payload.provenance)
     payload = AgentCoordinationPayload(
         view=view,
@@ -1053,7 +1063,8 @@ def _process_snapshot(runner: CommandRunner) -> tuple[CommandResult, tuple[_Proc
 def _configured_archive_resource() -> str | None:
     try:
         return str(archive_root().resolve())
-    except Exception:
+    except Exception as exc:
+        logger.warning("coordination archive-resource resolution failed: %s", exc, exc_info=True)
         return None
 
 
@@ -1455,7 +1466,8 @@ def _assertion_handoff_payloads(
                 """,
                 (limit * 4,),
             ).fetchall()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("coordination assertion-handoff query failed: %s", exc, exc_info=True)
         return ()
     repo_tokens = {str(repo_root), repo_root.name}
     scoped_rows = [
@@ -1503,7 +1515,14 @@ def _archive_payload(resources: tuple[CoordinationResourceEpisodePayload, ...]) 
     try:
         archive = archive_root().resolve()
         index = active_index_db_path().resolve()
-    except Exception:
+    except Exception as exc:
+        # archive_root()/active_index_db_path() raise both for the ordinary
+        # "no archive configured" case and for genuine config-resolution
+        # bugs; a bare None return makes the two indistinguishable to the
+        # caller (no archive field, no advisory). Log loudly so the failure
+        # is visible even though the payload shape can't carry a reason here
+        # (polylogue-cpf.4).
+        logger.warning("coordination archive-root resolution failed: %s", exc, exc_info=True)
         return None
     hook_flow_states: dict[str, str] = {}
     hook_flow_healthy: bool | None = None
@@ -1519,7 +1538,11 @@ def _archive_payload(resources: tuple[CoordinationResourceEpisodePayload, ...]) 
         hook_flow_gaps = tuple(
             f"{status.harness}:{status.flow_state}" for status in configured if status.flow_healthy is not True
         )
-    except Exception:
+    except Exception as exc:
+        # hook_flow_healthy stays None ("unknown"), not True, so this does
+        # not misreport as healthy — but it looks identical to "no hooks
+        # configured" without a log line.
+        logger.warning("coordination hook-status query failed: %s", exc, exc_info=True)
         hook_flow_states = {}
     return CoordinationArchivePayload(
         archive_root=str(archive),
@@ -1543,7 +1566,8 @@ def _sqlite_user_version(path: Path) -> int | None:
     try:
         with closing(sqlite3.connect(uri, uri=True, timeout=0.2)) as conn:
             row = conn.execute("PRAGMA user_version").fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("coordination user_version probe failed for %s: %s", path, exc, exc_info=True)
         return None
     return int(row[0]) if row else None
 
@@ -1560,15 +1584,33 @@ def _archive_evidence_payloads(
     tuple[CoordinationSubagentExchangePayload, ...],
     tuple[CoordinationProofRefPayload, ...],
     tuple[CoordinationContextFlowRefPayload, ...],
+    str | None,
 ]:
+    """Return bounded archive-evidence tuples plus a degradation reason.
+
+    Empty tuples are ambiguous on their own: they mean "no archive
+    configured", "archive schema not ready yet", and "the read-only SQLite
+    query hit the 0.2s timeout/lock/corruption" alike. The trailing
+    ``str | None`` distinguishes the last case (a genuine query failure,
+    logged here too) from ordinary absence of evidence, per the
+    degrade-loudly doctrine (polylogue-cpf.4).
+    """
+    empty: tuple[
+        tuple[CoordinationSessionTreePayload, ...],
+        tuple[CoordinationActivityEpisodePayload, ...],
+        tuple[CoordinationSubagentExchangePayload, ...],
+        tuple[CoordinationProofRefPayload, ...],
+        tuple[CoordinationContextFlowRefPayload, ...],
+    ] = ((), (), (), (), ())
     if archive is None or not archive.index_exists or archive.index_user_version is None:
-        return (), (), (), (), ()
+        return (*empty, None)
     index = Path(archive.index_db)
     try:
         conn = sqlite3.connect(f"file:{index}?mode=ro", uri=True, timeout=0.2)
         conn.row_factory = sqlite3.Row
-    except sqlite3.Error:
-        return (), (), (), (), ()
+    except sqlite3.Error as exc:
+        logger.warning("coordination archive-evidence connect failed: %s", exc, exc_info=True)
+        return (*empty, f"archive-evidence connect failed: {exc}")
     try:
         if not _archive_tables_present(
             conn,
@@ -1580,7 +1622,7 @@ def _archive_evidence_payloads(
                 "session_context_snapshots",
             ),
         ):
-            return (), (), (), (), ()
+            return (*empty, None)
         target_session_id = _resolve_coordination_session(conn, repo, self_payload)
         session_tree: tuple[CoordinationSessionTreePayload, ...] = ()
         if target_session_id is not None:
@@ -1590,9 +1632,10 @@ def _archive_evidence_payloads(
         subagent_exchanges = _archive_subagent_exchange_payloads(conn, target_session_id, repo, limit=limit)
         proof_refs = _archive_proof_payloads(conn, target_session_id, repo, limit=limit)
         context_refs = _archive_context_flow_payloads(conn, target_session_id, repo, limit=limit)
-        return session_tree, activity, subagent_exchanges, proof_refs, context_refs
-    except sqlite3.Error:
-        return (), (), (), (), ()
+        return session_tree, activity, subagent_exchanges, proof_refs, context_refs, None
+    except sqlite3.Error as exc:
+        logger.warning("coordination archive-evidence query failed: %s", exc, exc_info=True)
+        return (*empty, f"archive-evidence query failed: {exc}")
     finally:
         conn.close()
 
@@ -2144,6 +2187,7 @@ def _advisories(
     work_item: CoordinationWorkItemPayload,
     overlaps: tuple[CoordinationOverlapPayload, ...],
     archive: CoordinationArchivePayload | None,
+    archive_evidence_degraded_reason: str | None = None,
 ) -> tuple[str, ...]:
     advisories: list[str] = []
     if repo.dirty:
@@ -2154,4 +2198,10 @@ def _advisories(
         advisories.append("One or more overlap/resource signals deserve review before heavy work.")
     if archive is not None and not archive.index_exists:
         advisories.append("Active index.db is not present for the resolved archive root.")
+    if archive_evidence_degraded_reason is not None:
+        # Distinguishes "the archive genuinely has no matching evidence" from
+        # "the bounded archive-evidence query failed" — session_trees/
+        # activity_episodes/subagent_exchanges/proof_refs/context_flow_refs
+        # are empty in both cases without this advisory (polylogue-cpf.4).
+        advisories.append(f"Archive-evidence lookup degraded: {archive_evidence_degraded_reason}")
     return tuple(advisories)

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -293,8 +293,12 @@ def _check_prerequisites(*, profile: BackupProfile = "rebuildable_cache_exclude"
                 f"low disk space: {free / (1024**3):.1f} GB free, "
                 f"~{needed / (1024**3):.1f} GB needed for backup and scratch verification"
             )
-    except Exception:
-        pass
+    except Exception as exc:
+        # A swallowed failure here previously left the disk-space check
+        # unrepresented in `warnings` at all — indistinguishable from "disk
+        # space is fine". Surface it as its own warning so the check's own
+        # failure is visible (polylogue-cpf.4).
+        warnings.append(f"disk space check failed: {exc}")
 
     return warnings
 

--- a/polylogue/daemon/catchup_status.py
+++ b/polylogue/daemon/catchup_status.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+logger = get_logger(__name__)
 
 
 class CatchupStageEvent(BaseModel):
@@ -174,7 +177,8 @@ def _recent_stage_events(dbf: Path) -> list[CatchupStageEvent]:
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("catchup live stage-event query failed for %s: %s", dbf, exc, exc_info=True)
         return []
     return [_catchup_stage_event_from_row(row) for row in rows]
 
@@ -200,7 +204,8 @@ def _archive_recent_stage_events(ops_db: Path) -> list[CatchupStageEvent]:
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("catchup archive stage-event query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
     return [_archive_catchup_stage_event_from_row(row) for row in rows]
 

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+logger = get_logger(__name__)
 
 
 class ConvergenceDebtStageSummary(BaseModel):
@@ -76,7 +79,13 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                 return None
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        # Falls through to convergence_debt_summary_info()'s bare
+        # ConvergenceDebtSummary() default, which reports zero debt — the
+        # same shape as a genuinely converged archive. Log loudly so a
+        # transient ops.db failure isn't mistaken for "no debt"
+        # (polylogue-cpf.4).
+        logger.warning("convergence-debt summary query failed for %s: %s", ops_db, exc, exc_info=True)
         return None
 
     items = [

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -900,6 +900,10 @@ def _schema_archive_session_ids_for_source_paths(
             if not _ensure_source_tier_attached(conn):
                 return {path: [] for path in normalized_paths}
         except sqlite3.Error:
+            # Swallowed here, one level below the stage's own check/execute
+            # logging (the 1xc.11 fix), so the outer probe never sees this
+            # failure and can't log it either.
+            logger.warning("archive convergence: failed to attach source tier", exc_info=True)
             return {path: [] for path in normalized_paths}
     result: dict[Path, list[str]] = {path: [] for path in normalized_paths}
     paths_by_text = {str(path): path for path in normalized_paths}
@@ -1395,6 +1399,7 @@ def _archive_hot_insight_session_ids(
             if not _ensure_source_tier_attached(conn):
                 return set()
         except sqlite3.Error:
+            logger.warning("archive convergence: failed to attach source tier", exc_info=True)
             return set()
     placeholders = ", ".join("?" for _ in unique_ids)
     rows = conn.execute(

--- a/polylogue/daemon/cursor_lag_baseline.py
+++ b/polylogue/daemon/cursor_lag_baseline.py
@@ -43,6 +43,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from polylogue.daemon.cursor_lag_status import CursorLagItem, CursorLagSummary
+from polylogue.logging import get_logger
 from polylogue.sources.live._lag_sample_ddl import _LAG_SAMPLE_DDL, _LAG_SAMPLE_INDEX_DDL
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
@@ -50,6 +51,8 @@ from polylogue.storage.sqlite.archive_tiers.ops_write import (
 )
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_daemon_connection, open_readonly_connection
+
+logger = get_logger(__name__)
 
 
 def ensure_lag_sample_table(conn: sqlite3.Connection) -> None:
@@ -291,7 +294,12 @@ def _load_archive_family_baseline(
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        # Falls through to load_family_baseline()'s confident=False default,
+        # which is directionally safe (the anomaly check already refuses to
+        # alert off an unconfident baseline) but identical to "not enough
+        # samples yet" without this log line.
+        logger.warning("cursor-lag family baseline query failed for %s (%s): %s", ops_db, family, exc, exc_info=True)
         return None
     lags = sorted(float(row[0]) / 1000.0 for row in rows)
     count = len(lags)

--- a/polylogue/daemon/cursor_lag_status.py
+++ b/polylogue/daemon/cursor_lag_status.py
@@ -34,7 +34,10 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+logger = get_logger(__name__)
 
 
 class CursorLagBaselineState(BaseModel):
@@ -119,7 +122,12 @@ def cursor_lag_summary_info(dbf: Path, *, now: datetime | None = None) -> Cursor
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        # A bare CursorLagSummary() reports zero families/stuck files, which
+        # reads identically to "archive genuinely has no cursor lag" — log
+        # loudly so a transient query failure isn't mistaken for a clean
+        # ingest state (polylogue-cpf.4).
+        logger.warning("cursor-lag summary query failed for %s: %s", dbf, exc, exc_info=True)
         return CursorLagSummary()
 
     summary = _project_rows(rows, now=resolved_now)
@@ -153,7 +161,8 @@ def _archive_cursor_lag_summary_info(ops_db: Path, *, now: datetime) -> CursorLa
                 return None
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("cursor-lag ops-archive query failed for %s: %s", ops_db, exc, exc_info=True)
         return None
 
     projected_rows: list[sqlite3.Row | tuple[object, ...]] = [
@@ -202,7 +211,8 @@ def _decorate_with_baselines(
             min_samples=thresholds.baseline_min_samples,
             now=now,
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("cursor-lag baseline decoration failed: %s", exc, exc_info=True)
         return summary
 
     decorated: list[CursorLagFamilySummary] = []

--- a/polylogue/daemon/embedding_readiness.py
+++ b/polylogue/daemon/embedding_readiness.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import polylogue.config as polylogue_config
+from polylogue.logging import get_logger
 from polylogue.storage.embeddings.status_payload import embedding_status_payload
+
+logger = get_logger(__name__)
 
 
 def _defaults(*, enabled: bool, config_enabled: bool, has_key: bool, model: str, dimension: int) -> dict[str, object]:
@@ -56,7 +59,12 @@ def embedding_readiness_info(db_file: Path, *, detail: bool = False) -> dict[str
             include_retrieval_bands=False,
             include_detail=detail,
         )
-    except (sqlite3.Error, OSError):
+    except (sqlite3.Error, OSError) as exc:
+        # _defaults() reports embedding_status="empty" / retrieval_ready=False
+        # / pending counts of 0 — identical to a genuinely fresh archive with
+        # no embeddings yet. Log loudly so a transient DB error doesn't read
+        # as "nothing to embed" (polylogue-cpf.4).
+        logger.warning("embedding readiness query failed for %s: %s", db_file, exc, exc_info=True)
         return _defaults(
             enabled=enabled,
             config_enabled=config_enabled,

--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -7,9 +7,12 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from polylogue.logging import get_logger
 from polylogue.storage.fts.freshness import STALE, UNKNOWN, freshness_ready_record_trusted
 from polylogue.storage.fts.fts_lifecycle import FtsInvariantSnapshot, FtsSurfaceInvariant, fts_invariant_snapshot_sync
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+logger = get_logger(__name__)
 
 _FTS_SURFACES: tuple[tuple[str, str, str, tuple[str, ...]], ...] = (
     (
@@ -70,7 +73,8 @@ def _triggers_present(conn: sqlite3.Connection, trigger_names: tuple[str, ...]) 
 def _source_has_rows(conn: sqlite3.Connection, table_name: str) -> bool | None:
     try:
         row = conn.execute(f"SELECT 1 FROM {table_name} LIMIT 1").fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("fts source-rows probe failed for %s: %s", table_name, exc, exc_info=True)
         return None
     return row is not None
 
@@ -354,7 +358,8 @@ def _archive_readiness_info(index_db: Path, *, exact: bool) -> dict[str, object]
             return _archive_readiness_payload(conn, exact=exact)
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("fts archive readiness query failed for %s: %s", index_db, exc, exc_info=True)
         return {
             "indexed_surface": "messages_fts",
             "messages_ready": False,
@@ -470,7 +475,8 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
             if exact:
                 conn.rollback()
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("fts readiness query failed for %s: %s", dbf, exc, exc_info=True)
         return {
             "messages_ready": False,
             "session_work_events_ready": False,

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -390,7 +390,8 @@ def _web_reader_archive_root() -> Path | None:
         try:
             with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as conn:
                 version = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
-        except sqlite3.Error:
+        except sqlite3.Error as exc:
+            logger.warning("web-reader archive-root version probe failed for %s: %s", path, exc, exc_info=True)
             return None
         if version != ARCHIVE_VERSION_BY_TIER[tier]:
             return None

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -233,7 +233,8 @@ def _attached_table_exists(conn: sqlite3.Connection, schema_name: str, table: st
             f"SELECT 1 FROM {schema_name}.sqlite_master WHERE type='table' AND name=?",
             (table,),
         ).fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: attached-table probe failed for %s.%s: %s", schema_name, table, exc, exc_info=True)
         return False
     return row is not None
 
@@ -299,7 +300,8 @@ def _ops_attempt_counts(ops_db: Path) -> dict[str, int] | None:
             rows = conn.execute("SELECT status, COUNT(*) FROM ingest_attempts GROUP BY status").fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops attempt-counts query failed for %s: %s", ops_db, exc, exc_info=True)
         return None
     if not rows:
         return None
@@ -365,7 +367,8 @@ def _ops_recent_attempt_durations(ops_db: Path, *, limit: int = 50) -> list[floa
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops attempt-durations query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
     return [max(0.0, (int(row[1]) - int(row[0])) / 1000.0) for row in rows if row[0] is not None and row[1] is not None]
 
@@ -408,7 +411,8 @@ def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, int]]
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops convergence-debt-by-stage query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
     return [(str(row[0] or "unknown"), int(row[1] or 0)) for row in rows]
 
@@ -506,7 +510,8 @@ def _ops_latest_ingest_memory(ops_db: Path) -> list[tuple[str, float]]:
             ).fetchone()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops latest-ingest-memory query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
     if row is None:
         return []
@@ -630,7 +635,8 @@ def _ops_storage_route_counts(ops_db: Path) -> dict[str, int] | None:
             return counts
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops storage-route-counts query failed for %s: %s", ops_db, exc, exc_info=True)
         return None
 
 
@@ -802,7 +808,8 @@ def _archive_latest_embedding_run_state(ops_db: Path | None) -> ArchiveEmbedding
             runs = list_embedding_catchup_runs(conn)
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: archive latest-embedding-run query failed for %s: %s", ops_db, exc, exc_info=True)
         return None
     if not runs:
         return None
@@ -1252,7 +1259,11 @@ def _emit_hook_flow_metrics(lines: list[str], db: Path) -> None:
 
     try:
         statuses = hook_statuses(coverage=True, archive_root_path=db.parent)
-    except Exception:
+    except Exception as exc:
+        # statuses=() reads identically to "no hooks configured" on the
+        # emitted gauges. Log so a hook_statuses() bug doesn't masquerade as
+        # a clean hook-flow dashboard.
+        logger.warning("metrics: hook-flow status query failed: %s", exc, exc_info=True)
         statuses = ()
     healthy_samples: list[tuple[dict[str, str] | None, float | int]] = []
     state_samples: list[tuple[dict[str, str] | None, float | int]] = []
@@ -1434,7 +1445,8 @@ def _emit_ops_throughput_metrics(lines: list[str], ops_db: Path) -> bool:
             ).fetchone()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: ops throughput query failed for %s: %s", ops_db, exc, exc_info=True)
         return False
 
     if row is None:
@@ -1551,8 +1563,8 @@ def _emit_db_space_metrics(lines: list[str], db: Path) -> None:
             )
         finally:
             space_conn.close()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("metrics: db-space query failed for %s: %s", db, exc, exc_info=True)
 
 
 def _emit_archive_storage_metrics(lines: list[str], db: Path) -> None:
@@ -1798,7 +1810,8 @@ def _archive_user_version(path: Path) -> int:
             return int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("metrics: archive user_version probe failed for %s: %s", path, exc, exc_info=True)
         return 0
 
 
@@ -1820,8 +1833,8 @@ def _emit_raw_record_metrics(lines: list[str], conn: sqlite3.Connection, *, db_p
                         return
                 finally:
                     source_conn.close()
-            except sqlite3.Error:
-                pass
+            except sqlite3.Error as exc:
+                logger.warning("metrics: source.db raw-record probe failed for %s: %s", source_db, exc, exc_info=True)
     if not _table_exists(conn, "raw_sessions"):
         _emit_metric(
             lines, name="polylogue_raw_records_total", help_text="Total raw records.", metric_type="gauge", samples=[]

--- a/polylogue/daemon/otlp_receiver.py
+++ b/polylogue/daemon/otlp_receiver.py
@@ -283,6 +283,6 @@ def _count_entities(request: Any, signal_type: str) -> tuple[int, int]:
                 resources += 1
                 for sl in rl.scope_logs:
                     entities += len(sl.log_records)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("otlp entity count failed for signal_type=%s: %s", signal_type, exc, exc_info=True)
     return resources, entities

--- a/polylogue/daemon/provenance.py
+++ b/polylogue/daemon/provenance.py
@@ -34,8 +34,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final
 
+from polylogue.logging import get_logger
 from polylogue.paths import active_index_db_path
 from polylogue.storage.blob_store import get_blob_store
+
+logger = get_logger(__name__)
 
 # Hard server-side cap on the preview window. The endpoint will never
 # return more than this many bytes of raw content regardless of what a
@@ -155,7 +158,12 @@ def _fetch_archive_provenance_row(archive_db: Path, session_id: str) -> Provenan
                 """,
                 (session_id,),
             ).fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        # None already means "no provenance row for this session_id" —
+        # identical to a query failure. Provenance is the evidence-chain
+        # surface itself, so log loudly rather than let a transient error
+        # look like "nothing to show" (polylogue-cpf.4).
+        logger.warning("provenance row query failed for session %s: %s", session_id, exc, exc_info=True)
         return None
     finally:
         conn.close()

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -32,7 +32,7 @@ from polylogue.daemon.cursor_lag_status import CursorLagSummary as CursorLagSumm
 from polylogue.daemon.cursor_lag_status import cursor_lag_summary_info
 from polylogue.daemon.embedding_readiness import embedding_readiness_info
 from polylogue.daemon.fts_status import FTSReadiness, fts_readiness_info
-from polylogue.daemon.health import DaemonHealth, check_health
+from polylogue.daemon.health import DaemonHealth, HealthAlert, HealthSeverity, check_health
 from polylogue.daemon.live_ingest_attempt_models import (
     LiveIngestAttemptState,
 )
@@ -51,6 +51,7 @@ from polylogue.daemon.live_ingest_attempt_workload import (
     latest_stage_events,
     workload_fields,
 )
+from polylogue.logging import get_logger
 from polylogue.paths import archive_root, db_path, index_db_path, resolve_active_index_db_path
 from polylogue.readiness.capability import CapabilityReadinessState, ComponentReadiness
 from polylogue.readiness.claim_guard import derive_claim_guard
@@ -65,6 +66,8 @@ from polylogue.storage.repair import raw_materialization_replay_backlog
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+logger = get_logger(__name__)
 
 # Backwards-compatible alias for the stuck threshold (#1246). The "stale"
 # rollup field stays in the typed status payload to avoid breaking
@@ -488,8 +491,12 @@ def _archive_tier_status(
             )
         finally:
             conn.close()
-    except sqlite3.Error:
-        pass
+    except sqlite3.Error as exc:
+        # version_status already defaults to "invalid" above and stays that
+        # way here, so this branch does carry a signal — but the exception
+        # itself was previously discarded. Log it so operators can tell a
+        # read failure from a genuinely corrupt/unversioned tier.
+        logger.warning("archive tier status query failed for %s (%s): %s", path, name, exc, exc_info=True)
     return ArchiveTierStatus(
         name=name,
         path=str(path),
@@ -544,7 +551,8 @@ def _insight_freshness_info() -> dict[str, object]:
             "sessions_with_profiles": sessions_with_profiles,
             "total_sessions": total_sessions,
         }
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("status: insight-freshness query failed for %s: %s", dbf, exc, exc_info=True)
         return {"sessions_with_profiles": 0, "total_sessions": 0}
 
 
@@ -663,8 +671,12 @@ def _raw_failure_info() -> dict[str, object]:
                         ).fetchone()[0]
                         or 0
                     )
-            except Exception:
-                pass
+            except Exception as exc:
+                # contextlib.suppress above already covers the expected
+                # "detection_warnings column not on this schema yet" case;
+                # anything reaching here is unexpected and previously
+                # vanished silently behind a 0 count.
+                logger.warning("detection-warnings count query failed: %s", exc, exc_info=True)
             # Bounded failure samples (most recent 50), typed.
             samples: list[RawFailureSample] = []
             raw_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(raw_sessions)").fetchall()}
@@ -714,7 +726,8 @@ def _raw_failure_info() -> dict[str, object]:
             "maintenance_failures": maintenance_count,
             "samples": combined,
         }
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("status: raw-failure query failed for %s: %s", dbf, exc, exc_info=True)
         return {
             "parse_failures": 0,
             "validation_failures": 0,
@@ -829,7 +842,8 @@ def _maintenance_failure_info() -> tuple[list[RawFailureSample], int]:
         root = archive_root()
         records = read_maintenance_failures(root)
         total = count_maintenance_failures(root)
-    except Exception:
+    except Exception as exc:
+        logger.warning("status: maintenance-failure read failed: %s", exc, exc_info=True)
         return [], 0
 
     samples: list[RawFailureSample] = []
@@ -964,7 +978,8 @@ def _live_cursor_summary_info() -> LiveCursorSummary:
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("status: live-cursor summary query failed for %s: %s", dbf, exc, exc_info=True)
         return LiveCursorSummary()
 
     now = datetime.now(UTC)
@@ -1157,7 +1172,8 @@ def _live_ingest_attempt_summary_info() -> LiveIngestAttemptSummary:
             slow_threshold_s = compute_slow_threshold_s(conn)
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("status: live-ingest-attempt summary query failed for %s: %s", dbf, exc, exc_info=True)
         return LiveIngestAttemptSummary()
 
     now = datetime.now(UTC)
@@ -1979,8 +1995,25 @@ def build_daemon_status(
         health_tiers.update({HealthTier.MEDIUM, HealthTier.EXPENSIVE})
     try:
         health = check_health(tiers=health_tiers)
-    except Exception:
-        health = DaemonHealth()
+    except Exception as exc:
+        # DaemonHealth() alone defaults to overall_status=OK with zero
+        # alerts — the single most misleading fallback possible for a
+        # health check: a failed check would present as "everything is
+        # fine" instead of "the check itself broke" (polylogue-cpf.4).
+        logger.warning("status: check_health() failed: %s", exc, exc_info=True)
+        health = DaemonHealth(
+            overall_status=HealthSeverity.ERROR,
+            checked_at=datetime.now(UTC).isoformat(),
+            alerts=[
+                HealthAlert(
+                    check_name="check_health",
+                    tier=HealthTier.FAST,
+                    severity=HealthSeverity.ERROR,
+                    message=f"health check itself failed: {exc}",
+                    checked_at=datetime.now(UTC).isoformat(),
+                )
+            ],
+        )
 
     # Surface memory pressure from the most recent running attempt
     rss_current_mb: float | None = None
@@ -2124,8 +2157,11 @@ def daemon_status_payload(
                 "ts": last.get("ts"),
                 "payload": last.get("payload"),
             }
-    except Exception:
-        pass
+    except Exception as exc:
+        # last_ingestion stays None, identical to "daemon hasn't ingested
+        # anything yet" — log so a get_last_ingestion_batch() failure isn't
+        # mistaken for a cold-start daemon.
+        logger.warning("daemon status last-ingestion lookup failed: %s", exc, exc_info=True)
 
     status = build_daemon_status(
         sources=sources,

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -14,6 +14,9 @@ from polylogue.archive.raw_materialization import (
     source_path_native_id_candidates,
 )
 from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
 
 ACTIVE_REBUILD_STALE_AFTER_S = 180.0
 """Maximum heartbeat/start age for a rebuild-index row to count as active."""
@@ -39,7 +42,8 @@ def active_rebuild_index_attempts(ops_db: Path) -> list[dict[str, object]]:
                 """,
                 (cutoff_ms,),
             ).fetchall()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("active rebuild-index attempts query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
     return [
         {
@@ -403,7 +407,14 @@ def _missing_source_raw_session_samples(conn: sqlite3.Connection, *, limit: int 
 def _readiness_scalar_int(conn: sqlite3.Connection, sql: str) -> int:
     try:
         row = conn.execute(sql).fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        # Nested inside missing_source_raw_session_evidence()'s own
+        # try/except: a failure here is swallowed before the outer function
+        # ever sees it, so the caller reports "available": True with a
+        # count of 0 — identical to a genuinely clean archive. Log loudly
+        # so a query failure doesn't masquerade as zero lost evidence
+        # (polylogue-cpf.4).
+        logger.warning("archive readiness scalar query failed: %s", exc, exc_info=True)
         return 0
     return int(row[0] or 0) if row is not None else 0
 
@@ -411,7 +422,8 @@ def _readiness_scalar_int(conn: sqlite3.Connection, sql: str) -> int:
 def _table_columns(conn: sqlite3.Connection, schema: str, table: str) -> frozenset[str]:
     try:
         rows = conn.execute(f"PRAGMA {schema}.table_info({table})").fetchall()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("archive readiness table-columns probe failed for %s.%s: %s", schema, table, exc, exc_info=True)
         return frozenset()
     return frozenset(str(row["name"] if isinstance(row, sqlite3.Row) else row[1]) for row in rows)
 

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -24,8 +24,11 @@ from typing import Any, Literal
 
 from polylogue.core.json import dumps_bytes as json_dumps_bytes
 from polylogue.core.json import loads as json_loads
+from polylogue.logging import get_logger
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.connection import open_read_connection
+
+logger = get_logger(__name__)
 
 BlobIntegrityKind = Literal["orphan_blobs", "missing_referenced_blobs", "hash_mismatch"]
 BlobIntegritySeverity = Literal["warning", "critical"]
@@ -522,8 +525,14 @@ def _referenced_blob_hashes(db_path: Path, conn: sqlite3.Connection) -> list[str
                     return source_archive_hashes
             finally:
                 source_conn.close()
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            # Falls through to _raw_session_hashes(conn), a less-complete
+            # reference set — a report consuming this could mis-classify a
+            # still-referenced blob as orphaned if source.db's evidence was
+            # silently dropped here (polylogue-cpf.4).
+            logger.warning(
+                "blob integrity: source.db referenced-hash query failed for %s: %s", source_db, exc, exc_info=True
+            )
 
     return _raw_session_hashes(conn)
 
@@ -543,8 +552,10 @@ def _reference_source_counts(db_path: Path, conn: sqlite3.Connection) -> dict[st
                     return {f"source.db:{table}": len(hashes) for table, hashes in source.items()}
             finally:
                 source_conn.close()
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            logger.warning(
+                "blob integrity: source.db reference-count query failed for %s: %s", source_db, exc, exc_info=True
+            )
 
     fallback_count = len(_raw_session_hashes(conn))
     return {"raw_sessions.raw_id": fallback_count} if fallback_count else {}

--- a/polylogue/storage/blob_repair.py
+++ b/polylogue/storage/blob_repair.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from polylogue.config import Config
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -70,8 +73,13 @@ def _referenced_blob_hashes(
                 surfaces.extend(source_surfaces)
             finally:
                 source_conn.close()
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            # hashes/surfaces feed a repair decision about which blobs are
+            # still referenced; silently dropping source.db's references
+            # here could make a still-referenced blob look orphaned.
+            logger.warning(
+                "blob repair: source.db referenced-hash query failed for %s: %s", source_db_path, exc, exc_info=True
+            )
 
     return hashes, surfaces
 

--- a/polylogue/storage/source_sessions.py
+++ b/polylogue/storage/source_sessions.py
@@ -6,6 +6,10 @@ import sqlite3
 from collections.abc import Sequence
 from pathlib import Path
 
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
+
 
 def session_ids_for_source_path(conn: sqlite3.Connection, path: Path) -> list[str]:
     return session_ids_for_source_paths(conn, [path]).get(path, [])
@@ -50,7 +54,11 @@ def _schema_archive_session_ids_for_source_paths(
             """,
             tuple(paths_by_text),
         ).fetchall()
-    except Exception:
+    except Exception as exc:
+        # session_ids_for_source_paths() falls through to an all-empty
+        # dict when this returns None, identical to "no sessions reference
+        # these paths" — log so a query failure isn't mistaken for that.
+        logger.warning("source-sessions lookup failed: %s", exc, exc_info=True)
         return None
     for row in rows:
         path = paths_by_text.get(str(row[0]))

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -401,6 +401,44 @@ def test_coordination_envelope_degrades_without_archive_tables(
     assert payload.context_flow_refs == ()
 
 
+def test_coordination_envelope_signals_archive_evidence_query_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A genuine archive-evidence query failure must not look identical to
+    "no evidence" (polylogue-cpf.4). Before the fix, both cases returned the
+    same five empty tuples with no advisory and no log line.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    index = archive / "index.db"
+    _seed_coordination_archive(index)
+    monkeypatch.setattr("polylogue.coordination.envelope.archive_root", lambda: archive)
+    monkeypatch.setattr("polylogue.coordination.envelope.active_index_db_path", lambda: index)
+
+    def _boom(*args: object, **kwargs: object) -> bool:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr("polylogue.coordination.envelope._archive_tables_present", _boom)
+
+    with caplog.at_level("WARNING"):
+        payload = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), limit=4)
+
+    # Same empty shape a reader would see for "no matching evidence" --
+    # the advisory (and the log line) is what makes the two distinguishable.
+    assert payload.session_trees == ()
+    assert payload.activity_episodes == ()
+    assert payload.subagent_exchanges == ()
+    assert payload.proof_refs == ()
+    assert payload.context_flow_refs == ()
+    assert any("Archive-evidence lookup degraded" in advisory for advisory in payload.advisories)
+    assert any("database is locked" in advisory for advisory in payload.advisories)
+    assert "coordination archive-evidence query failed" in caplog.text
+
+
 def test_coordination_view_projection_is_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = tmp_path / "repo"
     root.mkdir()

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -284,6 +284,34 @@ def test_daemon_status_honors_explicit_disabled_browser_capture(
     assert status.component_state.browser_capture == "stopped"
 
 
+def test_daemon_status_check_health_failure_reports_error_not_ok(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A check_health() exception must not present as a clean bill of health.
+
+    Before the fix, ``except Exception: health = DaemonHealth()`` defaulted
+    to ``overall_status=OK`` with zero alerts -- the single most misleading
+    fallback possible for a health check: the check itself breaking would
+    have looked identical to "everything is fine" (polylogue-cpf.4).
+    """
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("health backend unavailable")
+
+    monkeypatch.setattr(status_module, "check_health", _boom)
+
+    with caplog.at_level("WARNING"):
+        status = build_daemon_status(sources=())
+
+    assert status.health.overall_status == "error"
+    assert len(status.health.alerts) == 1
+    alert = status.health.alerts[0]
+    assert alert.severity == "error"
+    assert "health backend unavailable" in alert.message
+    assert "check_health() failed" in caplog.text
+
+
 def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: Path) -> None:
     db = tmp_path / "index.db"
     failed = tmp_path / "failed.jsonl"

--- a/tests/unit/daemon/test_embedding_readiness.py
+++ b/tests/unit/daemon/test_embedding_readiness.py
@@ -373,6 +373,43 @@ def test_readiness_failure_branch_counts_error_message_rows(tmp_path: Path) -> N
     assert info["embedding_failure_count"] == 1
 
 
+# ── degrade-loudly (polylogue-cpf.4): a query failure must not look like ──
+# ── a clean, empty archive ─────────────────────────────────────────────
+
+
+def test_readiness_query_failure_logs_instead_of_looking_like_a_clean_archive(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A transient query failure returns the same shape as "nothing to embed
+    yet", so the failure must be logged loudly — otherwise it is invisible
+    that ``embedding_status="empty"`` came from an error, not a fresh archive.
+    """
+    db = tmp_path / "status.sqlite"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.touch()
+
+    cfg = _FakeCfg(embedding_enabled=True, voyage_api_key="vk-live")
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise sqlite3.OperationalError("database is locked")
+
+    with (
+        patch("polylogue.config.load_polylogue_config", return_value=cfg),
+        patch("polylogue.daemon.embedding_readiness.embedding_status_payload", side_effect=_boom),
+        caplog.at_level("WARNING"),
+    ):
+        info = embedding_readiness_info(db)
+
+    # Same shape as a genuinely empty archive -- this is exactly the
+    # ambiguity the doctrine flags. The log line is what makes the two
+    # distinguishable.
+    assert info["embedding_status"] == "empty"
+    assert info["embedding_retrieval_ready"] is False
+    assert "embedding readiness query failed" in caplog.text
+    assert "database is locked" in caplog.text
+
+
 def test_reconcile_embedding_dimension_mismatch_marks_reindex_and_drops_vec0(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/devtools/test_verify_degrade_loudly.py
+++ b/tests/unit/devtools/test_verify_degrade_loudly.py
@@ -1,0 +1,233 @@
+"""Tests for the degrade-loudly review-gate lint (polylogue-cpf.4).
+
+The lint is the "review-gate or lint flags new bare soft-fails" half of the
+bead's acceptance criteria — these tests prove it actually catches a new
+silent soft-fail, accepts a logged/allowlisted one, and rejects a stale
+allowlist entry, using synthetic fixture trees (not the real repo, so a
+future edit to real source can't accidentally make this test vacuous).
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import verify_degrade_loudly
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def _run_json(root: Path, capsys: pytest.CaptureFixture[str], *, allowlist: Path | None = None) -> dict[str, Any]:
+    args = ["--json", "--root", str(root)]
+    if allowlist is not None:
+        args += ["--allowlist", str(allowlist)]
+    rc = verify_degrade_loudly.main(args)
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+    payload["_rc"] = rc
+    return payload
+
+
+def test_flags_new_silent_except_with_no_log_or_signal(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A bare ``except Exception: return None`` with no log call is exactly
+    the pattern polylogue-cpf.4 targets."""
+    _write(
+        tmp_path,
+        "polylogue/daemon/example_status.py",
+        """
+        def get_widget_count(path):
+            try:
+                return _query(path)
+            except Exception:
+                return None
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    violations = payload["violations"]
+    assert len(violations) == 1
+    assert violations[0]["path"] == "polylogue/daemon/example_status.py"
+    assert violations[0]["function"] == "<module>.get_widget_count"
+    assert violations[0]["exceptions"] == ["Exception"]
+
+
+def test_accepts_logged_except_with_no_allowlist_entry(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Adding a log call is the cheapest fix and needs no allowlist entry."""
+    _write(
+        tmp_path,
+        "polylogue/daemon/example_status.py",
+        """
+        def get_widget_count(path):
+            try:
+                return _query(path)
+            except Exception as exc:
+                logger.warning("widget count query failed: %s", exc, exc_info=True)
+                return None
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["ok"] is True
+    assert payload["violations"] == []
+
+
+def test_accepts_reraise_with_no_allowlist_entry(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_repair.py",
+        """
+        def repair(path):
+            try:
+                return _run(path)
+            except Exception as exc:
+                raise RuntimeError("repair failed") from exc
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["violations"] == []
+
+
+def test_narrow_exceptions_are_not_flagged(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """ValueError/TypeError/JSONDecodeError-style narrow coercion is out of
+    scope -- only broad Exception/BaseException/*.Error catches are flagged."""
+    _write(
+        tmp_path,
+        "polylogue/storage/example_mappers.py",
+        """
+        def coerce_int(value, default):
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                return default
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["violations"] == []
+
+
+def test_allowlisted_site_passes_with_matching_entry(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/insights/example_audit.py",
+        """
+        def build_report(path):
+            try:
+                return _query(path)
+            except Exception as exc:
+                return {"available": False, "error": str(exc)}
+        """,
+    )
+    allowlist = tmp_path / "docs" / "plans" / "degrade-loudly-allowlist.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/degrade-loudly-allowlist.yaml",
+        """
+        entries:
+        - path: polylogue/insights/example_audit.py
+          function: <module>.build_report
+          exceptions: [Exception]
+          occurrence: 0
+          reason: 'Returns {"available": False, "error": str(exc)} -- already typed.'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, allowlist=allowlist)
+
+    assert payload["_rc"] == 0
+    assert payload["ok"] is True
+    assert payload["allowlisted"] == 1
+    assert payload["violations"] == []
+    assert payload["stale_allowlist_entries"] == []
+
+
+def test_stale_allowlist_entry_is_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """An allowlist entry with no matching site (the except was removed, or
+    logging was added) must fail the gate too -- otherwise the allowlist
+    only ever grows and stops meaning anything."""
+    _write(
+        tmp_path,
+        "polylogue/insights/example_audit.py",
+        """
+        def build_report(path):
+            return _query(path)
+        """,
+    )
+    allowlist = tmp_path / "docs" / "plans" / "degrade-loudly-allowlist.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/degrade-loudly-allowlist.yaml",
+        """
+        entries:
+        - path: polylogue/insights/example_audit.py
+          function: <module>.build_report
+          exceptions: [Exception]
+          occurrence: 0
+          reason: 'No longer matches any except-handler in this function.'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, allowlist=allowlist)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    assert len(payload["stale_allowlist_entries"]) == 1
+    assert payload["stale_allowlist_entries"][0]["function"] == "<module>.build_report"
+
+
+def test_test_files_and_non_target_packages_are_excluded(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "tests/unit/daemon/test_example.py",
+        """
+        def test_thing():
+            try:
+                pass
+            except Exception:
+                pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "polylogue/cli/example_click.py",
+        """
+        def run():
+            try:
+                pass
+            except Exception:
+                pass
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["sites_scanned"] == 0
+
+
+def test_real_repo_allowlist_is_internally_consistent(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed docs/plans/degrade-loudly-allowlist.yaml must currently
+    match the real repo exactly -- no unallowlisted sites, no stale entries.
+    This is the gate that runs in ``devtools verify``."""
+    assert verify_degrade_loudly.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["violations"] == []
+    assert payload["stale_allowlist_entries"] == []


### PR DESCRIPTION
## Summary

Sweeps `polylogue/coordination/`, `polylogue/daemon/`, and `polylogue/storage/` for the "degrade-loudly" doctrine violation: broad `except`-handlers that swallow a genuine query/probe failure and return the same bare default a caller would see for ordinary absence of evidence (empty tuple, `None`, `0`, `False`, a fake-healthy default). Converts ~35 genuinely silent sites to log a warning and/or carry a typed signal, and adds a `devtools verify degrade-loudly` review-gate lint so new silent sites are caught going forward.

## Problem

`polylogue-cpf.4`'s design note (informed by a 2026-07-05 deep read) named four concrete instances of this pattern; three (`polylogue-1xc.11`, `polylogue-4ts.6`, `polylogue-tf0e`) already have dedicated closed beads. The fourth — `coordination/envelope.py`'s `_archive_evidence_payloads` returning five empty tuples on a 0.2s SQLite timeout, indistinguishable from "no evidence" — was still open, and the bead itself is the **class** sweep: audit derived-read/fallback/probe paths across the codebase for the same anti-pattern.

An AST-based inventory of `except Exception`/`except BaseException`/`except *.Error` handlers with no log call and no re-raise across the four target packages found 377 raw sites; most were routine narrow-exception field coercion (`except ValueError: return default` on a single optional field) which is out of scope. Filtering to broad exception catches narrowed this to ~123, and manual review classified each as: already carries a typed signal (`HealthAlert`, `_repair_result`, `{"available": False, "error": ...}`, `convergence_debt`), a fail-safe direction with no consequence, or genuinely silent.

The most severe instance found beyond the originally-named one: `daemon/status.py`'s `build_daemon_status` had `except Exception: health = DaemonHealth()` on a `check_health()` failure — `DaemonHealth()`'s default is `overall_status=OK` with zero alerts, so a crash in the health check itself presented as a clean bill of health.

## Solution

**Modules touched** (grouped as separate commits for review):
1. `polylogue/coordination/envelope.py` — the flagship site. `_archive_evidence_payloads` now returns a degradation reason threaded into a new advisory string; four sibling swallows in the same file (`_archive_payload`, `_configured_archive_resource`, `_sqlite_user_version`, `_assertion_handoff_payloads`) now log.
2. `polylogue/daemon/*.py` (13 files) — the daemon status/probe/metrics family. Same anti-pattern the `1xc.11` fix addressed in `convergence_stages.py`, found unfixed in `cursor_lag_status.py`, `cursor_lag_baseline.py`, `convergence_debt_status.py`, `embedding_readiness.py`, `fts_status.py`, `catchup_status.py`; plus `status.py`'s health-fallback fix, `backup.py`, `provenance.py`, `http.py`, `metrics.py` (13 sites — the daemon's own observability endpoint), `otlp_receiver.py`.
3. `polylogue/storage/*.py` (4 files) — `blob_integrity.py`/`blob_repair.py`'s source.db fallback for referenced-blob-hash computation (a silent failure here could make a still-referenced blob look orphaned in a GC-adjacent report), `archive_readiness.py`'s nested scalar/table-column helpers, `source_sessions.py`.
4. `devtools/verify_degrade_loudly.py` (new) — AST-based review-gate lint mirroring `verify_test_clock_hygiene.py`'s shape, wired into `devtools verify`'s default tier. Flags a broad except with no log/re-raise; an allowlist at `docs/plans/degrade-loudly-allowlist.yaml` (keyed by path/function/exception-set/occurrence, not line number) documents the 74 remaining sites that already carry a typed signal or a documented fail-safe direction, with per-site rationale. Stale allowlist entries fail the gate too.

**Decision boundary** (what's explicitly out of scope, documented in the allowlist): routine single-field `ValueError`/`TypeError`/`JSONDecodeError` coercion helpers; the `false_means_pending` convergence-debt deferral pattern (already signaled per the bead's own instruction to leave it alone); sites that already return a typed signal (`HealthAlert`, `_repair_result`, exception-carrying tuples/dicts); narrow schema/version probes whose fail-safe default is directionally correct and low-consequence.

## Verification

- `devtools verify degrade-loudly` — 74 allowlisted, 0 unallowlisted, 0 stale.
- `devtools test tests/unit/coordination/test_envelope.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_embedding_readiness.py tests/unit/devtools/test_verify_degrade_loudly.py` — 87 passed. New tests inject a real exception into each fixed path and assert the log line/signal actually appears (not just that the code compiles): `test_coordination_envelope_signals_archive_evidence_query_failure`, `test_daemon_status_check_health_failure_reports_error_not_ok`, `test_readiness_query_failure_logs_instead_of_looking_like_a_clean_archive`, plus 8 cases proving the lint itself catches a new silent site, accepts a logged/allowlisted/re-raising one, and rejects a stale allowlist entry.
- `ruff format --check` / `ruff check` / `mypy --strict` clean across all 25 touched Python files.
- `devtools verify --quick` — all 15 steps pass (includes the new lint step).
- Broader storage suites (`test_archive_readiness.py`, `test_blob_integrity*.py`, `test_blob_repair.py`, `test_source_sessions.py` — 37 tests) and the daemon/http/metrics/otlp suites pass individually; two unrelated pre-existing failures (`test_backup_verification_scratch_stays_near_backup_output`, `test_server_close_shuts_down_archive_query_executor`) were confirmed to fail identically on `origin/master` via `git stash` before/after comparison.

Not run: full non-quick `devtools verify` (heavy pytest-testmon pass) — the per-file focused runs above cover every touched module.

Ref polylogue-cpf.4