### PR TITLE
feat(refs): add analysis-provenance ObjectRefKind kinds

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -274,6 +274,29 @@ def _unresolved_ref_payload(
     )
 
 
+#: ObjectRefKind values registered ahead of their backing storage tier
+#: (polylogue-rxdo analysis-provenance epic). ``resolve_ref`` returns a typed
+#: ``PendingObjectRefPayload`` (reason=substrate-pending) for these instead of
+#: attempting a lookup against tables that do not exist yet.
+_PENDING_OBJECT_REF_KINDS: frozenset[str] = frozenset(
+    {"query", "query-run", "result-set", "finding", "cohort", "analysis", "annotation-batch"}
+)
+
+
+def _pending_ref_payload(ref: str, normalized_ref: str, kind: str) -> Any:
+    from polylogue.surfaces.payloads import PendingObjectRefPayload, PublicRefResolutionPayload, model_json_document
+
+    return PublicRefResolutionPayload(
+        ref=ref,
+        normalized_ref=normalized_ref,
+        kind=kind,
+        resolved=False,
+        payload_kind="pending",
+        payload=model_json_document(PendingObjectRefPayload(kind=kind)),
+        caveats=(f"{kind} substrate is not implemented yet (reason=substrate-pending)",),
+    )
+
+
 def _archive_action_sequence(values: Sequence[str]) -> tuple[str, ...]:
     return normalize_action_sequence("action_sequence", ",".join(values))
 
@@ -2734,6 +2757,11 @@ class PolylogueArchiveMixin:
                 return self._resolve_assertion_object_ref(archive_root, ref, normalized_ref, object_ref)
             if object_ref.kind in {"run", "observed-event", "context-snapshot"}:
                 return self._resolve_runtime_object_ref(archive, ref, normalized_ref, object_ref)
+            if object_ref.kind in _PENDING_OBJECT_REF_KINDS:
+                return cast(
+                    PublicRefResolutionPayload,
+                    _pending_ref_payload(ref, normalized_ref, object_ref.kind),
+                )
         return cast(
             PublicRefResolutionPayload,
             _unresolved_ref_payload(

--- a/polylogue/core/refs.py
+++ b/polylogue/core/refs.py
@@ -35,6 +35,18 @@ ObjectRefKind: TypeAlias = Literal[
     "github-issue",
     "github-pr",
     "github-review",
+    # Analysis-provenance object kinds (polylogue-rxdo epic). Refs land here
+    # first; resolution is stubbed pending=true until the backing storage
+    # tiers exist (polylogue-rxdo.2/.3/.4/.7/.8). Do not append a
+    # ``@content-hash`` anchor suffix onto these — that belongs to the
+    # separate citation-anchor work (polylogue-bby.11).
+    "query",
+    "query-run",
+    "result-set",
+    "finding",
+    "cohort",
+    "analysis",
+    "annotation-batch",
 ]
 
 EvidenceRefKind: TypeAlias = Literal["session", "message", "block"]
@@ -70,6 +82,13 @@ _OBJECT_REF_KINDS: Final[dict[str, ObjectRefKind]] = {
     "github-issue": "github-issue",
     "github-pr": "github-pr",
     "github-review": "github-review",
+    "query": "query",
+    "query-run": "query-run",
+    "result-set": "result-set",
+    "finding": "finding",
+    "cohort": "cohort",
+    "analysis": "analysis",
+    "annotation-batch": "annotation-batch",
 }
 
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -1774,6 +1774,22 @@ class PublicRefResolutionPayload(SurfacePayloadModel):
         return tuple(normalize_public_ref_text(ref) for ref in value)
 
 
+class PendingObjectRefPayload(SurfacePayloadModel):
+    """Typed placeholder embedded in ``PublicRefResolutionPayload.payload``.
+
+    Some ``ObjectRefKind`` values (the polylogue-rxdo analysis-provenance
+    kinds: ``query``, ``query-run``, ``result-set``, ``finding``, ``cohort``,
+    ``analysis``, ``annotation-batch``) are registered before their backing
+    storage tiers exist. ``resolve_ref`` returns this typed payload for them
+    instead of an opaque not-found so clients can distinguish "not yet
+    implemented" from "does not exist".
+    """
+
+    unit: Literal["pending"] = "pending"
+    kind: str
+    reason: Literal["substrate-pending"] = "substrate-pending"
+
+
 class SessionReadViewEnvelope(SurfacePayloadModel):
     """Stable daemon envelope for one executed session read-view."""
 
@@ -2882,6 +2898,7 @@ __all__ = [
     "ProviderPackageCompletenessPayload",
     "ProviderPackageCompletenessRowPayload",
     "ProviderPackageCompletenessTotalsPayload",
+    "PendingObjectRefPayload",
     "PublicRefResolutionPayload",
     "MachineErrorPayload",
     "MachineErrorEnvelope",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -2250,6 +2250,48 @@ async def test_resolve_ref_returns_bounded_session_message_block_and_runtime_pay
         await archive.close()
 
 
+@pytest.mark.parametrize(
+    ("kind", "object_id"),
+    [
+        ("query", "sha256:deadbeef"),
+        ("query-run", "sha256:deadbeef:run-1"),
+        ("result-set", "sha256:deadbeef:run-1:result-1"),
+        ("finding", "finding-hash-1"),
+        ("cohort", "cohort-1"),
+        ("analysis", "analysis-1"),
+        ("annotation-batch", "batch-1"),
+    ],
+)
+async def test_resolve_ref_returns_typed_pending_payload_for_analysis_provenance_kinds(
+    tmp_path: Path, kind: str, object_id: str
+) -> None:
+    """polylogue-rxdo.1: refs land ahead of storage; resolution stubs cleanly.
+
+    ``query``/``query-run``/``result-set``/``finding``/``cohort``/``analysis``/
+    ``annotation-batch`` are registered ObjectRefKind values with no backing
+    table yet (polylogue-rxdo.2/.3/.4/.7/.8). resolve_ref must not raise and
+    must not silently pretend to resolve them — it returns a typed pending
+    payload carrying reason=substrate-pending so a client can distinguish
+    "not implemented yet" from "does not exist".
+    """
+    archive = _archive(tmp_path)
+    try:
+        ref = f"{kind}:{object_id}"
+        payload = await archive.resolve_ref(ref)
+
+        assert payload.resolved is False
+        assert payload.kind == kind
+        assert payload.normalized_ref == ref
+        assert payload.payload_kind == "pending"
+        assert payload.payload is not None
+        assert payload.payload["reason"] == "substrate-pending"
+        assert payload.payload["kind"] == kind
+        assert payload.payload["unit"] == "pending"
+        assert any("substrate-pending" in caveat for caveat in payload.caveats)
+    finally:
+        await archive.close()
+
+
 async def test_resolve_ref_returns_assertion_payload(tmp_path: Path) -> None:
     """Assertion refs resolve through the shared assertion claim DTO."""
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database

--- a/tests/unit/core/test_refs.py
+++ b/tests/unit/core/test_refs.py
@@ -42,6 +42,15 @@ from polylogue.core.refs import (
         ("agent:codex/main", "agent", "codex/main", ()),
         ("tool-call:codex-session:demo:tool-1", "tool-call", "codex-session:demo:tool-1", ()),
         ("subagent-report:codex-session:demo:tool-2", "subagent-report", "codex-session:demo:tool-2", ()),
+        # Analysis-provenance object kinds (polylogue-rxdo.1). Resolvers are
+        # stubbed pending the storage tiers; the ref shape round-trips today.
+        ("query:sha256:deadbeef", "query", "sha256:deadbeef", ()),
+        ("query-run:sha256:deadbeef:run-1", "query-run", "sha256:deadbeef:run-1", ()),
+        ("result-set:sha256:deadbeef:run-1:result-1", "result-set", "sha256:deadbeef:run-1:result-1", ()),
+        ("finding:finding-hash-1", "finding", "finding-hash-1", ()),
+        ("cohort:cohort-1", "cohort", "cohort-1", ()),
+        ("analysis:analysis-1", "analysis", "analysis-1", ()),
+        ("annotation-batch:batch-1", "annotation-batch", "batch-1", ()),
     ],
 )
 def test_object_ref_parses_and_formats_existing_assertion_ref_shapes(
@@ -111,3 +120,43 @@ def test_public_ref_parser_prefers_object_refs_and_accepts_recovery_evidence_ref
 def test_object_ref_normalizer_rejects_unscoped_raw_strings() -> None:
     with pytest.raises(ValueError):
         normalize_object_ref_text("demo-fixture-world")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "query:sha256:deadbeef",
+        "query-run:sha256:deadbeef:run-1",
+        "result-set:sha256:deadbeef:run-1:result-1",
+        "finding:finding-hash-1",
+        "cohort:cohort-1",
+        "analysis:analysis-1",
+        "annotation-batch:batch-1",
+    ],
+)
+def test_normalize_object_ref_text_accepts_analysis_provenance_kinds(raw: str) -> None:
+    """polylogue-rxdo.1: the analysis-provenance kinds normalize/round-trip today.
+
+    Resolution is stubbed pending storage (see resolve_ref tests); the ref
+    grammar itself must accept these kinds without any special-casing.
+    """
+    assert normalize_object_ref_text(raw) == raw
+    assert normalize_public_ref_text(raw) == raw
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "query:",
+        "query-run:",
+        "result-set:",
+        "finding:",
+        "cohort:",
+        "analysis:",
+        "annotation-batch:",
+    ],
+)
+def test_object_ref_rejects_empty_ids_for_analysis_provenance_kinds(raw: str) -> None:
+    """New kinds reuse the shared empty-id guard; they don't weaken validation."""
+    with pytest.raises(ValueError):
+        normalize_object_ref_text(raw)


### PR DESCRIPTION
## Summary

Extends `ObjectRefKind` (`polylogue/core/refs.py`) with seven analysis-provenance
kinds — `query`, `query-run`, `result-set`, `finding`, `cohort`, `analysis`,
`annotation-batch` — and wires `resolve_ref` to return a typed pending payload
for them instead of an opaque not-found.

## Problem

`ObjectRefKind` was a closed `Literal` of 29 kinds with none of the
analysis-object kinds, so nothing could target a query, query-run, result-set,
finding, cohort, analysis, or annotation-batch — the narrow prerequisite for
the whole analysis-provenance epic (`polylogue-rxdo`): refs first, resolvers
stubbed until tables land, tables second.

## Solution

- `polylogue/core/refs.py`: add the seven kinds to `ObjectRefKind` and the
  `_OBJECT_REF_KINDS` lookup dict. `ObjectRef.parse`/`.format()` and
  `normalize_object_ref_text` handle them with zero special-casing — they use
  the existing `kind:id` grammar (the `finding`/`query`-style `@content-hash`
  anchor suffix explicitly does **not** land here; that belongs to the
  separate citation-anchor work, `polylogue-bby.11`).
- `polylogue/surfaces/payloads.py`: new `PendingObjectRefPayload` model
  (`unit=pending`, `kind`, `reason=substrate-pending`) embedded in the shared
  `PublicRefResolutionPayload.payload` field.
- `polylogue/api/archive.py` (`Polylogue.resolve_ref`, the single seam shared
  by CLI/MCP/daemon): a new dispatch branch for the seven pending kinds
  returns `resolved=False`, `payload_kind="pending"`, and the typed payload
  above, with a caveat spelling out the reason — instead of raising or
  returning the generic "unsupported public ref kind" message.
- Deliberately **not** added: `AssertionKind.FINDING` (belongs to
  `polylogue-rxdo.4`, which reuses the existing candidate→judge assertion
  lifecycle for findings) and the delegation ObjectRef kind (belongs to
  `polylogue-lph4`).

### Registration-trap check (per the bead's callout)

Verified `render openapi` / `render cli-output-schemas` do **not** need
regeneration for this change: `PublicRefResolutionPayload` is not in either
generator's published-model allowlist
(`devtools/render_openapi.py:_PUBLISHED_MODELS`,
`devtools/render_cli_output_schemas.py:SCHEMAS`), and `rg -n "ObjectRefKind"`
across the tree shows no consumer outside `core/refs.py` itself — every other
`ObjectRef(...)` construction site just passes a `kind` string literal.
`devtools render all --check` confirms no drift.

## Verification

- `devtools test tests/unit/core/test_refs.py tests/unit/api/test_facade_contracts.py -k "refs or resolve_ref"` → 75 passed
- `devtools test tests/unit/api/test_facade_contracts.py` → 250 passed, 1 failure
  (`test_archive_tiers_api_raw_artifacts_read_source_tier`) reproduced
  identically on `master` via `git stash` (pre-existing `parsed_at`
  wall-clock hygiene bug, unrelated to this diff)
- `devtools test` across every other `ObjectRef`/`resolve_ref` consumer
  (`cli/test_query_verbs_runtime.py`, `context/test_compiler.py`,
  `core/test_models.py`, `core/test_synthetic_relations.py`,
  `insights/test_transforms.py`, `mcp/test_envelope_contracts.py`,
  `mcp/test_server_surfaces.py`, `mcp/test_tool_discovery.py`,
  `cli/test_correlate_view.py`, `insights/test_pathology.py`,
  `insights/test_session_commit.py`, `mcp/test_correlate_session.py`,
  `storage/test_archive_tiers_user_audit.py`,
  `daemon/test_route_contracts.py`) → all passed
- `devtools verify --quick` → exit 0 (ruff format/check, mypy --strict,
  render all --check, topology, layering, closure-matrix, manifests,
  ci-workflows, doc-commands, test-infra-currency, test-clock-hygiene,
  pytest-timeout-overrides, degrade-loudly all green)
- Pre-push gate ran the same quick baseline on push — green.

Not run: full `devtools verify --all` / testmon-seeded run (fresh worktree,
not seeded; targeted `devtools test` above covers every identified
touchpoint).

Ref polylogue-rxdo.1

Note: GitHub Actions CI is currently blocked by an account billing lock
unrelated to this diff — red/pending CI checks are expected and not a signal
about this PR.