### PR TITLE
fix(core): dedupe drifted provider-for-origin mappings, add census tool

### DIFF
--- a/devtools/census_provider_vocabulary.py
+++ b/devtools/census_provider_vocabulary.py
@@ -1,0 +1,354 @@
+"""Census: provider/origin vocabulary leak surface (polylogue-9e5.8 Step 0).
+
+Background: the provider->origin retirement program (``polylogue-9e5.8``) was
+rejected twice by paired adversarial falsification (2026-07-10) because its
+manual ``rg "Provider\\."`` census only counted ``Provider.<MEMBER>`` enum
+literal usage (Axis 1) and missed that ``provider``/``providers`` as a bare
+*identifier* -- a parameter name, a dataclass/Pydantic/TypedDict field, a
+dict/set string-literal key, a CLI flag, an HTTP route -- is an independent,
+much larger leak axis (Axis 2/3) concentrated in one connected call graph
+running from ``protocols.py`` down through ``api/*.py``,
+``storage/repository/**``, and ``storage/sqlite/**``. A lexical grep for the
+enum token stays green while missing all of that.
+
+This is a scripted, AST-level replacement for that manual census (the bead's
+own Step 0): it enumerates, per run:
+
+- ``param``   -- function/method parameters literally named ``provider``/``providers``.
+- ``field``   -- dataclass/Pydantic/TypedDict class-body fields, same names.
+- ``key``     -- dict or set/frozenset string-literal elements ``"provider"``/``"providers"``
+                 (covers filter-key sets like ``daemon/http.py``'s ``_SCOPE_FILTER_KEYS``).
+- ``literal`` -- CLI-option-shaped (``--...provider...``) or HTTP-route-shaped
+                 (``/...provider...``) string literals.
+
+Enum-literal usage (Axis 1, ``Provider.<MEMBER>``) is intentionally out of
+scope here -- the 2026-07-09 census already tiered it correctly (see the
+Appendix in polylogue-9e5.8's design field) and it is not the axis the
+falsification rounds found missing.
+
+Scanning excludes ``polylogue/sources``, ``polylogue/schemas``,
+``polylogue/pipeline`` (Tier-A, wire-boundary-legitimate by design -- see
+CLAUDE.md's Provider/Origin/Source vocabulary section) and
+``polylogue/browser_capture`` (wire-boundary-adjacent for the same reason:
+it identifies which website a payload came from or an outbound reply posts
+to, per polylogue-9e5.8's Axis-2 exclusion #4), plus all test files.
+
+A handful of remaining *mixed-purpose* files carry one genuinely
+false-positive site alongside real leak sites (billing-vendor terminology,
+not archive-origin identity) -- those are pre-approved in the allowlist at
+``docs/plans/provider-vocabulary-exclusions.yaml`` with a one-line rationale,
+the same shape ``devtools/verify_degrade_loudly.py`` uses for its allowlist.
+
+This tool is deliberately a *census*, not a hard gate on the (currently
+large, expected) backlog of real findings -- Step 3 of polylogue-9e5.8's plan
+is the actual coordinated flip that retires them. The only thing ``--check``
+enforces is allowlist hygiene: no stale entries (an allowlist entry that no
+longer matches any current site), and a non-zero total site count (a census
+that ever reports zero everywhere is far more likely a broken scanner than a
+fully retired vocabulary -- see the bead's own "not vacuous" acceptance
+criterion). Re-running this after each later step in the plan should show
+the unallowlisted count trending toward zero, which is the durable,
+independently-verifiable substrate the falsification rounds asked for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is a hard repo dep
+    yaml = None  # type: ignore[assignment]
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+
+# Tier-A / wire-boundary-legitimate top-level packages (polylogue-9e5.8
+# Appendix A + Axis-2 exclusion #4): sources/schemas/pipeline speak
+# provider-wire vocabulary by design at the parse boundary; browser_capture
+# identifies which website a payload came from / an outbound reply posts to,
+# "Tier-A-like for the same reason sources/parsers are". Never flip, so never
+# flagged.
+EXCLUDED_TOP_PACKAGES: tuple[str, ...] = ("sources", "schemas", "pipeline", "browser_capture")
+
+ALLOWLIST_PATH = ROOT / "docs" / "plans" / "provider-vocabulary-exclusions.yaml"
+
+_TOKENS = frozenset({"provider", "providers"})
+_CLI_FLAG_RE = re.compile(r"^--[\w-]*provider[\w-]*$", re.IGNORECASE)
+_ROUTE_RE = re.compile(r"^/[\w/{}\-]*provider[\w/{}\-]*$", re.IGNORECASE)
+
+_CATEGORY_LABELS: dict[str, str] = {
+    "param": 'function/method parameter literally named "provider"/"providers"',
+    "field": 'dataclass/Pydantic/TypedDict field literally named "provider"/"providers"',
+    "key": 'dict or set/frozenset string-literal element "provider"/"providers"',
+    "literal": 'CLI-option or HTTP-route string literal containing "provider"',
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Site:
+    path: str
+    lineno: int
+    category: str
+    qualname: str
+    identifier: str
+    occurrence: int
+
+    @property
+    def key(self) -> tuple[str, str, str, int]:
+        return (self.path, self.category, self.identifier, self.occurrence)
+
+
+class _Visitor(ast.NodeVisitor):
+    """Walk a module tracking enclosing scope and per-(category, identifier)
+    occurrence counters for provider/providers identifier and literal sites."""
+
+    def __init__(self, relpath: str) -> None:
+        self.relpath = relpath
+        self._stack: list[str] = ["<module>"]
+        self._occurrence: dict[tuple[str, str], int] = {}
+        self.sites: list[Site] = []
+
+    def _qualname(self) -> str:
+        return ".".join(self._stack)
+
+    def _record(self, lineno: int, category: str, identifier: str) -> None:
+        occ_key = (category, identifier)
+        occurrence = self._occurrence.get(occ_key, 0)
+        self._occurrence[occ_key] = occurrence + 1
+        self.sites.append(
+            Site(
+                path=self.relpath,
+                lineno=lineno,
+                category=category,
+                qualname=self._qualname(),
+                identifier=identifier,
+                occurrence=occurrence,
+            )
+        )
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        args = node.args
+        all_args = [*args.posonlyargs, *args.args, *args.kwonlyargs]
+        for arg in all_args:
+            if arg.arg in _TOKENS:
+                self._record(node.lineno, "param", arg.arg)
+        self._stack.append(node.name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._stack.append(node.name)
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.target.id in _TOKENS:
+                self._record(stmt.lineno, "field", stmt.target.id)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        for k in node.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str) and k.value in _TOKENS:
+                self._record(node.lineno, "key", k.value)
+        self.generic_visit(node)
+
+    def visit_Set(self, node: ast.Set) -> None:
+        for elt in node.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str) and elt.value in _TOKENS:
+                self._record(node.lineno, "key", elt.value)
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            value = node.value
+            if _CLI_FLAG_RE.match(value) or _ROUTE_RE.match(value):
+                self._record(node.lineno, "literal", value)
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path, *, root: Path) -> list[Site]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    relpath = str(path.relative_to(root))
+    visitor = _Visitor(relpath)
+    visitor.visit(tree)
+    return visitor.sites
+
+
+def _scan_repo(*, root: Path) -> list[Site]:
+    base = root / "polylogue"
+    if not base.exists():
+        return []
+    sites: list[Site] = []
+    for path in sorted(base.rglob("*.py")):
+        relative_parts = path.relative_to(base).parts
+        if relative_parts and relative_parts[0] in EXCLUDED_TOP_PACKAGES:
+            continue
+        if "test" in path.parts:
+            continue
+        sites.extend(_scan_file(path, root=root))
+    return sites
+
+
+@dataclass(frozen=True, slots=True)
+class AllowlistEntry:
+    path: str
+    category: str
+    identifier: str
+    occurrence: int
+    reason: str
+
+    @property
+    def key(self) -> tuple[str, str, str, int]:
+        return (self.path, self.category, self.identifier, self.occurrence)
+
+
+def _load_allowlist(allowlist_path: Path) -> list[AllowlistEntry]:
+    if not allowlist_path.exists():
+        return []
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to read the provider-vocabulary census allowlist")
+    data = yaml.safe_load(allowlist_path.read_text(encoding="utf-8")) or {}
+    entries = data.get("entries", []) or []
+    out: list[AllowlistEntry] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        out.append(
+            AllowlistEntry(
+                path=str(entry.get("path", "")),
+                category=str(entry.get("category", "")),
+                identifier=str(entry.get("identifier", "")),
+                occurrence=int(entry.get("occurrence", 0)),
+                reason=str(entry.get("reason", "")),
+            )
+        )
+    return out
+
+
+def _format_report(
+    *,
+    sites: list[Site],
+    allowlist: list[AllowlistEntry],
+    unallowlisted: list[Site],
+    stale: list[AllowlistEntry],
+) -> str:
+    lines = [f"provider/origin vocabulary sites scanned: {len(sites)}"]
+    for category, label in _CATEGORY_LABELS.items():
+        count = sum(1 for s in sites if s.category == category)
+        lines.append(f"  {category:<8} ({label}): {count}")
+    lines.append(f"allowlisted: {len(allowlist)}")
+    lines.append(f"unallowlisted (retirement candidates + not-yet-triaged findings): {len(unallowlisted)}")
+    lines.append(f"stale allowlist entries: {len(stale)}")
+    if unallowlisted:
+        lines.append("")
+        lines.append("Sites (path:line category identifier [in qualname]):")
+        for site in sorted(unallowlisted, key=lambda s: (s.category, s.path, s.lineno)):
+            lines.append(f"  {site.path}:{site.lineno} {site.category} {site.identifier!r} in {site.qualname}()")
+    if stale:
+        lines.append("")
+        lines.append("Allowlist entries that no longer match a current site (remove them):")
+        for entry in sorted(stale, key=lambda e: (e.path, e.category, e.identifier)):
+            lines.append(f"  {entry.path} :: {entry.category} {entry.identifier!r} [occurrence {entry.occurrence}]")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to scan.")
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Allowlist YAML path (defaults to <root>/docs/plans/provider-vocabulary-exclusions.yaml).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Exit non-zero on allowlist hygiene failures only (stale entries, or a "
+            "vacuous zero-site scan) -- does NOT fail on the large, expected backlog "
+            "of unallowlisted retirement candidates. Use for CI; omit for a plain census."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root.resolve()
+    default_allowlist = root / "docs" / "plans" / "provider-vocabulary-exclusions.yaml"
+    allowlist_path: Path = (args.allowlist or default_allowlist).resolve()
+
+    sites = _scan_repo(root=root)
+    allowlist = _load_allowlist(allowlist_path)
+    allowed_keys = {entry.key for entry in allowlist}
+    site_keys = {site.key for site in sites}
+
+    unallowlisted = [site for site in sites if site.key not in allowed_keys]
+    stale = [entry for entry in allowlist if entry.key not in site_keys]
+
+    ok = True
+    if args.check:
+        ok = not stale and len(sites) > 0
+
+    if args.json:
+        payload = {
+            "sites_scanned": len(sites),
+            "counts_by_category": {
+                category: sum(1 for s in sites if s.category == category) for category in _CATEGORY_LABELS
+            },
+            "allowlisted": len(allowlist),
+            "unallowlisted": [
+                {
+                    "path": site.path,
+                    "line": site.lineno,
+                    "category": site.category,
+                    "identifier": site.identifier,
+                    "qualname": site.qualname,
+                    "occurrence": site.occurrence,
+                }
+                for site in sorted(unallowlisted, key=lambda s: (s.category, s.path, s.lineno))
+            ],
+            "stale_allowlist_entries": [
+                {
+                    "path": entry.path,
+                    "category": entry.category,
+                    "identifier": entry.identifier,
+                    "occurrence": entry.occurrence,
+                }
+                for entry in sorted(stale, key=lambda e: (e.path, e.category, e.identifier))
+            ],
+            "ok": ok,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            _format_report(
+                sites=sites,
+                allowlist=allowlist,
+                unallowlisted=unallowlisted,
+                stale=stale,
+            )
+        )
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 CommandMain = Callable[[list[str] | None], int]
 CONTROL_PLANE = "devtools"
 VERIFICATION_LAB_COMMAND_NAMES: tuple[str, ...] = (
+    "lab census provider-vocabulary",
     "lab graph",
     "lab lanes",
     "lab policy demo-packet-registry",
@@ -258,6 +259,27 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools lab provider completeness --json",
             "devtools lab provider completeness --origin codex-session --json",
             "devtools lab provider completeness --check",
+        ),
+    ),
+    CommandSpec(
+        "lab census provider-vocabulary",
+        "verification lab",
+        "AST-level census of provider/origin vocabulary leak sites (polylogue-9e5.8 Step 0).",
+        "devtools.census_provider_vocabulary",
+        use_when=(
+            "Enumerate function/method parameters, dataclass/Pydantic/TypedDict fields, "
+            "dict/set string-literal keys, and CLI-flag/HTTP-route literals literally named "
+            "provider/providers outside sources/schemas/pipeline/browser_capture, replacing "
+            "the manual rg census that two adversarial falsification rounds proved misses the "
+            "identifier-vocabulary leak axis. --check only fails on allowlist rot (stale "
+            "entries or a vacuous zero-site scan), not on the large expected backlog of "
+            "unallowlisted retirement candidates -- rerun after each later step in the plan to "
+            "watch that backlog trend toward zero."
+        ),
+        examples=(
+            "devtools lab census provider-vocabulary",
+            "devtools lab census provider-vocabulary --json",
+            "devtools lab census provider-vocabulary --check",
         ),
     ),
     CommandSpec(

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -45,6 +45,7 @@ They are not a proof ledger or end-user archive workflow.
 
 | Command | Role |
 | --- | --- |
+| `devtools lab census provider-vocabulary` | Enumerate function/method parameters, dataclass/Pydantic/TypedDict fields, dict/set string-literal keys, and CLI-flag/HTTP-route literals literally named provider/providers outside sources/schemas/pipeline/browser_capture, replacing the manual rg census that two adversarial falsification rounds proved misses the identifier-vocabulary leak axis. --check only fails on allowlist rot (stale entries or a vacuous zero-site scan), not on the large expected backlog of unallowlisted retirement candidates -- rerun after each later step in the plan to watch that backlog trend toward zero. |
 | `devtools lab graph` | Inspect the authored runtime graph and see which scenarios currently cover declared artifacts and operations. |
 | `devtools lab lanes` | List, dry-run, or execute authored validation lanes from the executable lane registry. |
 | `devtools lab policy demo-packet-registry` | Enforce the 212 portfolio contract (polylogue-212.7): every demo prompt in .agent/demos/registry.json must have a packet directory carrying PROMPT.md, finding.yaml (five-part provenance stanza), report.md (fixed section order), evidence.ndjson, queries.ndjson, checks.json, and run.log. Catches a missing or malformed packet before it silently drops out of the demo shelf. |
@@ -122,6 +123,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools lab census provider-vocabulary` | AST-level census of provider/origin vocabulary leak sites (polylogue-9e5.8 Step 0). |
 | `devtools lab graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools lab lanes` | Run named validation lanes. |
 | `devtools lab policy demo-packet-registry` | Verify every registered 212 demo has a conforming Demo Finding Packet. |

--- a/docs/plans/provider-vocabulary-exclusions.yaml
+++ b/docs/plans/provider-vocabulary-exclusions.yaml
@@ -1,0 +1,99 @@
+# Pre-approved false-positive sites for `devtools lab census provider-vocabulary`
+# (polylogue-9e5.8). Each entry documents WHY a literal "provider"/"providers"
+# identifier or CLI-flag/route token at this exact site is ordinary-English or
+# vendor-billing terminology, not an archive-origin identity leak. Keyed by
+# (path, category, identifier, occurrence-within-file) rather than line number,
+# so unrelated edits elsewhere in the file don't require re-numbering. New
+# provider/providers sites outside these classes are real retirement
+# candidates for polylogue-9e5.8's Step 2/3 -- they show up as "unallowlisted"
+# in the census report, which is expected and not itself a failure.
+#
+# These entries transcribe polylogue-9e5.8's own design-field "explicit
+# exclusions" list (Axis-2 exclusion classes #2, #3, #4) into a machine-checked
+# form. Class #1 (VectorProvider/SearchProvider/etc.) and class #5
+# (daemon/web_shell.py cosmetic CSS/JS) need no entries here: #1 never matches
+# because the scanner requires the identifier to be *exactly* "provider"/
+# "providers", not a compound name; #5's tokens live inside larger CSS/JS
+# string blobs the CLI-flag/route regexes don't match standalone.
+
+entries:
+- path: polylogue/cost/plans.py
+  category: field
+  identifier: provider
+  occurrence: 0
+  reason: >
+    SubscriptionPlan.provider is a free-text LiteLLM billing-catalog vendor
+    label ("anthropic"), not one of the 10 Origin tokens -- ordinary-English
+    "provider" (subscription vendor), out of scope (polylogue-9e5.8 Axis-2
+    exclusion #2).
+
+- path: polylogue/storage/usage.py
+  category: field
+  identifier: provider
+  occurrence: 0
+  reason: >
+    ProviderUsageCoverage.provider is part of the declared provider-usage
+    telemetry coverage matrix -- vendor-billing-scoped accounting
+    terminology ("as the LLM provider's API reported it"), permanently
+    exempt, not a retirement candidate (polylogue-9e5.8 Axis-2 exclusion #3).
+
+- path: polylogue/storage/usage.py
+  category: field
+  identifier: provider
+  occurrence: 1
+  reason: >
+    OriginUsageReport.provider is the same billing-vendor-scoped accounting
+    field on the usage-report side of the same module (polylogue-9e5.8
+    Axis-2 exclusion #3).
+
+- path: polylogue/storage/usage.py
+  category: key
+  identifier: provider
+  occurrence: 0
+  reason: >
+    ProviderUsageCoverage.to_dict()'s "provider" key mirrors the exempt
+    billing-vendor field above (polylogue-9e5.8 Axis-2 exclusion #3).
+
+- path: polylogue/storage/usage.py
+  category: key
+  identifier: provider
+  occurrence: 1
+  reason: >
+    OriginUsageReport.to_dict()'s "provider" key mirrors the exempt
+    billing-vendor field above (polylogue-9e5.8 Axis-2 exclusion #3).
+
+- path: polylogue/daemon/http.py
+  category: literal
+  identifier: /api/provider-usage
+  occurrence: 0
+  reason: >
+    The /api/provider-usage HTTP route is genuinely vendor-billing-scoped
+    ("provider-reported usage"); permanently exempt -- do not rename to
+    /api/origin-usage (polylogue-9e5.8 Axis-2 exclusion #3).
+
+- path: polylogue/daemon/route_contracts.py
+  category: literal
+  identifier: /api/provider-usage
+  occurrence: 0
+  reason: >
+    Route contract for the exempt /api/provider-usage billing endpoint above
+    (polylogue-9e5.8 Axis-2 exclusion #3).
+
+- path: polylogue/daemon/browser_capture.py
+  category: literal
+  identifier: --provider
+  occurrence: 0
+  reason: >
+    The `browser-capture post --provider` CLI option identifies which
+    website an outbound reply posts to (BrowserPostProvider) -- wire-boundary
+    -adjacent, Tier-A-like, not a retirement candidate now (polylogue-9e5.8
+    Axis-2 exclusion #4).
+
+- path: polylogue/daemon/browser_capture.py
+  category: param
+  identifier: provider
+  occurrence: 0
+  reason: >
+    post_command(provider: str, ...) is the click callback parameter bound
+    to the --provider option excluded immediately above; same command, same
+    rationale (polylogue-9e5.8 Axis-2 exclusion #4).

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -19,8 +19,8 @@ from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.domain_models import Session, SessionSummary
-from polylogue.core.enums import MaterialOrigin, Provider
-from polylogue.core.sources import origin_from_provider
+from polylogue.core.enums import MaterialOrigin, Origin, Provider
+from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.core.timestamps import parse_archive_datetime
 from polylogue.types import SessionId
 
@@ -42,21 +42,25 @@ if TYPE_CHECKING:
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveMessageRow, ArchiveSessionEnvelope
 
 
-_ORIGIN_TO_PROVIDER = {
-    "claude-code-session": Provider.CLAUDE_CODE,
-    "codex-session": Provider.CODEX,
-    "gemini-cli-session": Provider.GEMINI_CLI,
-    "hermes-session": Provider.HERMES,
-    "antigravity-session": Provider.ANTIGRAVITY,
-    "chatgpt-export": Provider.CHATGPT,
-    "claude-ai-export": Provider.CLAUDE_AI,
-    "aistudio-drive": Provider.GEMINI,
-    "unknown-export": Provider.UNKNOWN,
-}
-
-
 def _provider_for_origin(origin: str) -> Provider:
-    return _ORIGIN_TO_PROVIDER.get(origin, Provider.UNKNOWN)
+    """Return the canonical provider-wire ``Provider`` for an origin token.
+
+    Delegates to :func:`polylogue.core.sources.provider_from_origin`, the
+    single source of truth for this reverse mapping, instead of a hand-copied
+    dict. Three independent hand-copies of this exact table used to live in
+    this module, ``storage/sqlite/archive_tiers/archive.py``, and
+    ``storage/sqlite/queries/tool_usage.py`` -- none delegating to the
+    canonical one in ``core/sources.py`` -- and had already silently drifted
+    (all three were missing a ``grok-export`` entry, falling back to
+    ``Provider.UNKNOWN`` instead of ``Provider.GROK``). Delegating fixes that
+    drift and makes future drift structurally impossible (polylogue-9e5.8).
+    ``Origin.AISTUDIO_DRIVE`` still canonically resolves to ``Provider.GEMINI``
+    here -- that collapse is a deliberate, documented, non-injective design
+    choice (see ``core/sources.py``'s ``_ORIGIN_TO_PROVIDER`` comment), not a
+    bug this delegation fixes; un-collapsing it needs a Source-family
+    disambiguator (polylogue-9e5.8 Step 5), not a narrow fix here.
+    """
+    return provider_from_origin(Origin.from_string(origin))
 
 
 def _session_seed_scored(

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -11,8 +11,6 @@ import inspect
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
-from polylogue.core.enums import Origin
-from polylogue.core.sources import provider_from_origin
 from polylogue.insights.archive import (
     SessionLatencyProfileInsightQuery,
 )
@@ -23,7 +21,7 @@ from polylogue.insights.registry import (
     insight_items_payload,
     project_origin_payload,
 )
-from polylogue.mcp.insight_tool_contracts import InsightListToolSpec
+from polylogue.mcp.insight_tool_contracts import InsightListToolSpec, _origin_to_provider_token
 from polylogue.mcp.payloads import MCPRootPayload
 from polylogue.mcp.query_contracts import MCPSessionQueryRequest
 
@@ -46,12 +44,6 @@ def _object_int(value: object) -> int:
     if value is None:
         return 0
     return int(str(value))
-
-
-def _origin_to_provider_token(value: str | None) -> str | None:
-    if value is None or value == "":
-        return None
-    return provider_from_origin(Origin(value)).value
 
 
 def _project_origin_payload(value: object) -> object:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -10511,17 +10511,18 @@ def _month_bucket_end_ms(bucket: str) -> int:
 
 
 def _provider_for_origin(origin: str) -> Provider:
-    return {
-        "claude-code-session": Provider.CLAUDE_CODE,
-        "codex-session": Provider.CODEX,
-        "gemini-cli-session": Provider.GEMINI_CLI,
-        "hermes-session": Provider.HERMES,
-        "antigravity-session": Provider.ANTIGRAVITY,
-        "chatgpt-export": Provider.CHATGPT,
-        "claude-ai-export": Provider.CLAUDE_AI,
-        "aistudio-drive": Provider.GEMINI,
-        "unknown-export": Provider.UNKNOWN,
-    }.get(origin, Provider.UNKNOWN)
+    """Return the canonical provider-wire ``Provider`` for an origin token.
+
+    Delegates to the already-imported :func:`provider_from_origin` (the
+    single source of truth in ``core/sources.py``) instead of a hand-copied
+    dict -- this module, ``archive/query/archive_execution.py``, and
+    ``storage/sqlite/queries/tool_usage.py`` used to each hand-roll the same
+    table independently and had already silently drifted (all three were
+    missing a ``grok-export`` entry). See ``archive_execution.py``'s
+    ``_provider_for_origin`` docstring for the full rationale
+    (polylogue-9e5.8).
+    """
+    return provider_from_origin(Origin.from_string(origin))
 
 
 __all__ = ["ArchiveFileQueryRow", "ArchiveStore", "ArchiveSessionSearchHit", "ArchiveSessionSummary"]

--- a/polylogue/storage/sqlite/queries/tool_usage.py
+++ b/polylogue/storage/sqlite/queries/tool_usage.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import aiosqlite
 from typing_extensions import TypedDict
 
-from polylogue.core.enums import Provider
-from polylogue.core.sources import origin_from_provider
+from polylogue.core.enums import Origin, Provider
+from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.insights.tool_usage import ToolUsageInsightQuery
 
 __all__ = [
@@ -198,14 +198,12 @@ def _origin_for_tool_usage_filter(provider_or_origin: str | None) -> str | None:
 
 
 def _provider_for_origin(origin: str) -> Provider:
-    return {
-        "claude-code-session": Provider.CLAUDE_CODE,
-        "codex-session": Provider.CODEX,
-        "gemini-cli-session": Provider.GEMINI_CLI,
-        "hermes-session": Provider.HERMES,
-        "antigravity-session": Provider.ANTIGRAVITY,
-        "chatgpt-export": Provider.CHATGPT,
-        "claude-ai-export": Provider.CLAUDE_AI,
-        "aistudio-drive": Provider.GEMINI,
-        "unknown-export": Provider.UNKNOWN,
-    }.get(origin, Provider.UNKNOWN)
+    """Return the canonical provider-wire ``Provider`` for an origin token.
+
+    Delegates to the single source of truth in ``core/sources.py`` instead
+    of a hand-copied dict -- see ``archive/query/archive_execution.py``'s
+    ``_provider_for_origin`` docstring for the full rationale
+    (polylogue-9e5.8): three independent hand-copies of this table had
+    already silently drifted (all missing a ``grok-export`` entry).
+    """
+    return provider_from_origin(Origin.from_string(origin))

--- a/tests/unit/core/test_provider_origin_dedup.py
+++ b/tests/unit/core/test_provider_origin_dedup.py
@@ -1,0 +1,106 @@
+"""Regression tests for the provider<->origin reverse-lookup dedup (polylogue-9e5.8 Step 1).
+
+Ground truth found while executing polylogue-9e5.8's plan: the bead's design
+field described ``archive/query/archive_execution.py``'s ``_ORIGIN_TO_PROVIDER``
+dict as uniquely, silently collapsing ``aistudio-drive`` onto
+``Provider.GEMINI``. Reading the live source showed this collapse is actually
+a *deliberate, documented* choice already centralized in
+``core/sources.py::provider_from_origin`` (``Origin.AISTUDIO_DRIVE`` is
+non-injective -- both ``Provider.GEMINI`` and ``Provider.DRIVE`` produce it --
+and ``GEMINI`` is the documented canonical choice so a Gemini session
+round-trips). The real, verified bug was that three independent modules
+(``archive/query/archive_execution.py``, ``storage/sqlite/archive_tiers/
+archive.py``, ``storage/sqlite/queries/tool_usage.py``) each hand-rolled an
+*independent copy* of that exact table instead of delegating to the
+canonical function -- and had already silently drifted: all three copies were
+missing a ``grok-export`` entry, so a Grok-origin session would resolve to
+``Provider.UNKNOWN`` instead of ``Provider.GROK`` through these three call
+sites specifically, while the canonical ``core/sources.py`` table already
+handled it correctly.
+
+The fix replaces all three hand-rolled dicts with delegation to
+``provider_from_origin``. These tests prove: (1) all three now agree with the
+canonical function for every ``Origin`` value, including the previously-drifted
+``grok-export`` case, and (2) the well-known, deliberate GEMINI/DRIVE collapse
+is preserved (not "fixed" -- that needs a Source-family disambiguator, Step 5
+of the plan, out of scope here).
+
+Un-collapsing DRIVE from GEMINI is explicitly *not* what this fix does or
+claims to do -- see polylogue-9e5.8's design field, "The non-injective
+GEMINI/DRIVE blocker" section.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+import polylogue.mcp.server_insight_tools as server_insight_tools_module
+from polylogue.archive.query.archive_execution import _provider_for_origin as _archive_execution_provider_for_origin
+from polylogue.core.enums import Origin, Provider
+from polylogue.core.sources import provider_from_origin
+from polylogue.mcp.insight_tool_contracts import _origin_to_provider_token as _contracts_origin_to_provider_token
+from polylogue.storage.sqlite.archive_tiers.archive import _provider_for_origin as _archive_tiers_provider_for_origin
+from polylogue.storage.sqlite.queries.tool_usage import _provider_for_origin as _tool_usage_provider_for_origin
+
+_DUPLICATED_PROVIDER_FOR_ORIGIN: tuple[Callable[[str], Provider], ...] = (
+    _archive_execution_provider_for_origin,
+    _archive_tiers_provider_for_origin,
+    _tool_usage_provider_for_origin,
+)
+
+
+@pytest.mark.parametrize("fn", _DUPLICATED_PROVIDER_FOR_ORIGIN)
+def test_provider_for_origin_agrees_with_canonical_for_every_origin(fn: Callable[[str], Provider]) -> None:
+    """Every de-duplicated call site must agree with the single source of
+    truth for every known Origin token -- no more silent drift between
+    hand-copies."""
+    for origin in Origin:
+        assert fn(origin.value) == provider_from_origin(origin), (
+            f"{fn.__module__}.{fn.__qualname__}({origin.value!r}) diverges from "
+            "the canonical polylogue.core.sources.provider_from_origin"
+        )
+
+
+@pytest.mark.parametrize("fn", _DUPLICATED_PROVIDER_FOR_ORIGIN)
+def test_grok_export_no_longer_silently_falls_back_to_unknown(fn: Callable[[str], Provider]) -> None:
+    """The regression this dedup fixes: all three hand-rolled dicts were
+    missing a grok-export entry and fell back to Provider.UNKNOWN. Delegating
+    to the canonical function fixes this at all three call sites at once."""
+    assert fn("grok-export") == Provider.GROK
+
+
+@pytest.mark.parametrize("fn", _DUPLICATED_PROVIDER_FOR_ORIGIN)
+def test_aistudio_drive_still_canonically_resolves_to_gemini(fn: Callable[[str], Provider]) -> None:
+    """Documents, rather than "fixes", the deliberate non-injective collapse:
+    Origin.AISTUDIO_DRIVE is produced by both Provider.GEMINI and
+    Provider.DRIVE, and GEMINI is the documented canonical reverse choice
+    (core/sources.py). Un-collapsing this needs a Source-family
+    disambiguator (polylogue-9e5.8 Step 5) -- out of scope for this fix."""
+    assert fn("aistudio-drive") == Provider.GEMINI
+
+
+@pytest.mark.parametrize("fn", _DUPLICATED_PROVIDER_FOR_ORIGIN)
+def test_unknown_origin_token_falls_back_to_unknown_provider(fn: Callable[[str], Provider]) -> None:
+    assert fn("not-a-real-origin") == Provider.UNKNOWN
+
+
+def test_origin_to_provider_token_is_a_single_shared_definition() -> None:
+    """polylogue-9e5.8's design field flagged _origin_to_provider_token as
+    defined twice, independently, in mcp/insight_tool_contracts.py and
+    mcp/server_insight_tools.py -- itself evidence of an ad hoc, uncentralized
+    shim. server_insight_tools now imports the contracts module's definition
+    instead of re-declaring it; this asserts there is exactly one function
+    object, not two behaviorally-identical copies."""
+    assert getattr(server_insight_tools_module, "_origin_to_provider_token") is _contracts_origin_to_provider_token  # noqa: B009
+
+
+def test_origin_to_provider_token_round_trips_known_origins() -> None:
+    for origin in Origin:
+        assert _contracts_origin_to_provider_token(origin.value) == provider_from_origin(origin).value
+
+
+def test_origin_to_provider_token_none_and_empty_are_none() -> None:
+    assert _contracts_origin_to_provider_token(None) is None
+    assert _contracts_origin_to_provider_token("") is None

--- a/tests/unit/devtools/test_census_provider_vocabulary.py
+++ b/tests/unit/devtools/test_census_provider_vocabulary.py
@@ -1,0 +1,270 @@
+"""Tests for the provider/origin vocabulary census (polylogue-9e5.8 Step 0).
+
+The census is the "scripted, AST-level census (not another manual rg pass)"
+the bead's design field calls for -- these tests prove it actually catches
+each of the four leak categories on synthetic fixture trees (not the real
+repo, so a future edit to real source can't accidentally make the fixture
+tests vacuous), correctly excludes Tier-A packages and test files, honors
+the allowlist, and rejects a stale allowlist entry.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import census_provider_vocabulary
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def _run_json(
+    root: Path, capsys: pytest.CaptureFixture[str], *, allowlist: Path | None = None, check: bool = False
+) -> dict[str, Any]:
+    args = ["--json", "--root", str(root)]
+    if allowlist is not None:
+        args += ["--allowlist", str(allowlist)]
+    if check:
+        args += ["--check"]
+    rc = census_provider_vocabulary.main(args)
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+    payload["_rc"] = rc
+    return payload
+
+
+def test_flags_function_parameter_named_provider(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/api/example.py",
+        """
+        def list_sessions(provider: str | None = None, providers: list[str] | None = None) -> list[str]:
+            return []
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    params = [s for s in payload["unallowlisted"] if s["category"] == "param"]
+    assert {s["identifier"] for s in params} == {"provider", "providers"}
+    assert payload["counts_by_category"]["param"] == 2
+
+
+def test_flags_dataclass_field_named_provider(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_models.py",
+        """
+        from dataclasses import dataclass
+
+
+        @dataclass(frozen=True)
+        class SessionRecordQuery:
+            provider: str | None = None
+            unrelated: int = 0
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    fields = [s for s in payload["unallowlisted"] if s["category"] == "field"]
+    assert len(fields) == 1
+    assert fields[0]["identifier"] == "provider"
+    assert fields[0]["qualname"] == "<module>.SessionRecordQuery"
+
+
+def test_flags_dict_and_set_literal_keys(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/daemon/example_http.py",
+        """
+        _SCOPE_FILTER_KEYS = frozenset({"session_ids", "provider", "source_family"})
+
+
+        def to_dict(self):
+            return {"provider": self.provider, "unrelated": 1}
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    keys = [s for s in payload["unallowlisted"] if s["category"] == "key"]
+    assert len(keys) == 2
+    assert {s["identifier"] for s in keys} == {"provider"}
+
+
+def test_flags_cli_flag_and_http_route_literals(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/cli/example_check_options.py",
+        """
+        SCHEMA_PROVIDER_FLAG = "--schema-provider"
+        ROUTE = "/api/some-provider-scoped-thing"
+        UNRELATED_FLAG = "--format"
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    literals = [s for s in payload["unallowlisted"] if s["category"] == "literal"]
+    assert {s["identifier"] for s in literals} == {"--schema-provider", "/api/some-provider-scoped-thing"}
+
+
+def test_compound_provider_identifiers_are_not_flagged(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """VectorProvider/vector_provider/create_vector_provider-style compound
+    names are exact-match excluded by construction (polylogue-9e5.8 Axis-2
+    exclusion #1) -- no allowlist entry needed for them."""
+    _write(
+        tmp_path,
+        "polylogue/storage/example_search_providers.py",
+        """
+        class VectorProvider:
+            def __init__(self, vector_provider=None):
+                self.vector_provider = vector_provider
+
+
+        def create_vector_provider(backend):
+            return VectorProvider(vector_provider=backend)
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["sites_scanned"] == 0
+    assert payload["unallowlisted"] == []
+
+
+def test_sources_schemas_pipeline_browser_capture_and_tests_are_excluded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for relative in (
+        "polylogue/sources/example_parser.py",
+        "polylogue/schemas/example_schema.py",
+        "polylogue/pipeline/example_ids.py",
+        "polylogue/browser_capture/example_models.py",
+        "tests/unit/api/test_example.py",
+    ):
+        _write(
+            tmp_path,
+            relative,
+            """
+            def handler(provider: str) -> str:
+                return provider
+            """,
+        )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["sites_scanned"] == 0
+
+
+def test_allowlisted_site_passes_and_check_flag_is_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/cost/example_plans.py",
+        """
+        from dataclasses import dataclass
+
+
+        @dataclass(frozen=True)
+        class SubscriptionPlan:
+            provider: str
+        """,
+    )
+    allowlist = tmp_path / "docs" / "plans" / "provider-vocabulary-exclusions.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/provider-vocabulary-exclusions.yaml",
+        """
+        entries:
+        - path: polylogue/cost/example_plans.py
+          category: field
+          identifier: provider
+          occurrence: 0
+          reason: 'Free-text LiteLLM billing-catalog vendor label, ordinary-English "provider".'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, allowlist=allowlist, check=True)
+
+    assert payload["_rc"] == 0
+    assert payload["ok"] is True
+    assert payload["allowlisted"] == 1
+    assert payload["unallowlisted"] == []
+    assert payload["stale_allowlist_entries"] == []
+
+
+def test_stale_allowlist_entry_fails_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """An allowlist entry with no matching site (the field was renamed or
+    removed) must fail --check -- otherwise the allowlist only ever grows."""
+    _write(
+        tmp_path,
+        "polylogue/cost/example_plans.py",
+        """
+        def unrelated() -> None:
+            return None
+        """,
+    )
+    allowlist = tmp_path / "docs" / "plans" / "provider-vocabulary-exclusions.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/provider-vocabulary-exclusions.yaml",
+        """
+        entries:
+        - path: polylogue/cost/example_plans.py
+          category: field
+          identifier: provider
+          occurrence: 0
+          reason: 'No longer matches any field in this file.'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, allowlist=allowlist, check=True)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    assert len(payload["stale_allowlist_entries"]) == 1
+
+
+def test_vacuous_zero_site_scan_fails_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A --check run that finds zero sites anywhere is far more likely a
+    broken scanner (wrong root, exclusion regression) than a fully retired
+    vocabulary -- the bead's own AC requires the tool prove it is "wired to
+    real code, not vacuous"."""
+    _write(
+        tmp_path,
+        "polylogue/api/example_unrelated.py",
+        """
+        def noop() -> None:
+            return None
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, check=True)
+
+    assert payload["sites_scanned"] == 0
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+
+
+def test_real_repo_allowlist_is_internally_consistent(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed docs/plans/provider-vocabulary-exclusions.yaml must
+    currently match the real repo: no stale entries, and a non-zero,
+    non-vacuous scan. This is the gate a CI wiring of --check would run."""
+    rc = census_provider_vocabulary.main(["--json", "--check"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["stale_allowlist_entries"] == []
+    assert payload["sites_scanned"] > 0
+    # Sanity: the census should surface all four categories on the real repo,
+    # and the documented Axis-2 exclusion classes should show up allowlisted.
+    assert all(count > 0 for count in payload["counts_by_category"].values())
+    assert payload["allowlisted"] >= 9


### PR DESCRIPTION
## Summary
Phase 1 of the polylogue-9e5.8 Provider->Origin retirement plan: dedupes
three independently drifted provider-for-origin mappings and adds the
plan's Step 0 census tooling.

## Problem
A prior research pass (polylogue-9e5.8's design field, ~22KB inventory)
found three independently hand-copied `_provider_for_origin` dicts in
archive/query/archive_execution.py, storage/sqlite/archive_tiers/archive.py,
and storage/sqlite/queries/tool_usage.py -- all three already silently
drifted, missing a grok-export entry and silently falling back to
Provider.UNKNOWN instead of Provider.GROK.

## Solution
- All three now delegate to the canonical `provider_from_origin` in
  core/sources.py instead of hand-copied dicts, making future drift
  structurally impossible.
- New `devtools lab census provider-vocabulary`: AST-level census of
  provider/origin vocabulary leak sites (parameters, dataclass/Pydantic/
  TypedDict fields, dict/set string-literal keys, CLI-flag/HTTP-route
  literals), replacing the manual rg census two adversarial falsification
  rounds proved missed the identifier-vocabulary leak axis. `--check`
  only fails on allowlist rot, not the large expected unallowlisted
  retirement backlog -- rerun after each later phase to watch it shrink.
- Investigation refined the earlier "aistudio-drive -> Provider.GEMINI
  silent collapse" framing from the research phase: on closer inspection
  this is a deliberate, documented non-injective design choice in
  core/sources.py (not a bug) -- left unchanged, with the delegating
  function's docstring explaining why rather than "fixing" intentional
  behavior.

## Scope
This is Phase 1 only (small independent dedup + census tooling). The
larger bottom-up coordinated flip of the protocols.py->api->
storage/repository->storage/sqlite filter-vocabulary contract (the plan's
PR-4 onward) remains for follow-up phases. polylogue-9e5.8 stays open.

## Verification
- devtools test tests/unit/core/test_provider_origin_dedup.py
  tests/unit/devtools/test_census_provider_vocabulary.py -> 25 passed.
- devtools test tests/unit/mcp/ -k insight -> 12 passed (server_insight_tools.py consumer).
- devtools verify --quick -> 15/15 steps green.
- devtools lab census provider-vocabulary run live: 239 sites found
  (param/field/key/literal categories), matching the research phase's
  estimate.
- GitHub Actions CI blocked repo-wide by an account billing lock
  (unrelated to this diff; operator-confirmed to keep merging through it
  this session); GitGuardian will be checked before merge.

Ref polylogue-9e5.8

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer verification command to scan for provider-related vocabulary and report allowlisted or stale matches.
  * Added JSON output and validation mode for automated checks.
  * Centralized origin-to-provider resolution for more consistent behavior across archive, storage, and insight tools.

* **Documentation**
  * Documented the new verification command and added its vocabulary exclusions list.

* **Tests**
  * Added coverage for vocabulary scanning, allowlist validation, and origin/provider mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->