### PR TITLE
perf(storage): index message FK backreference + diagnose rebuild tail latency

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -22,7 +22,7 @@ over the `CREATE TABLE` statement.
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 7` |
-| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 32` |
+| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 34` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 1` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 5` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |
@@ -122,6 +122,14 @@ contract is visible in canonical DDL instead of hand-written per table.
 
 Recent index-tier versions:
 
+- version 34 (polylogue-rgbj) adds `idx_web_constructs_message` on
+  `web_content_constructs(message_id)` — the only `messages(message_id)` FK
+  child table that lacked a leading index on its foreign-key column. Without
+  it, SQLite's `ON DELETE CASCADE` enforcement fell back to a full table scan
+  of `web_content_constructs` per deleted message, making
+  `_replace_full_session_messages_and_blocks`'s session-scoped
+  `DELETE FROM messages` cost O(deleted_messages x web_content_constructs_rows)
+  — the dominant cost in a production 10+ minute full-session replacement;
 - version 9 adds typed `sessions.session_kind` for standard vs temporary
   sessions, so temporary chats are archive schema rather than only parser tags;
 - version 8 adds `web_content_constructs` for provider-native web/export

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -33,7 +33,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
     nullable_check,
 )
 
-INDEX_SCHEMA_VERSION = 33
+INDEX_SCHEMA_VERSION = 34
 
 FTS_FRESHNESS_STATE_DDL = """
 CREATE TABLE IF NOT EXISTS fts_freshness_state (
@@ -354,6 +354,25 @@ CREATE TABLE IF NOT EXISTS web_content_constructs (
 
 CREATE INDEX IF NOT EXISTS idx_web_constructs_session_type
 ON web_content_constructs(session_id, construct_type);
+
+-- polylogue-rgbj: the only messages(message_id) FK child table that lacked a
+-- leading index on its foreign key column. Every other referencing table
+-- (blocks, attachment_refs, paste_spans, session_events,
+-- session_agent_policies, session_provider_usage_events) already has one
+-- via its PRIMARY KEY or a dedicated index. Without this index, SQLite's FK
+-- `ON DELETE CASCADE` enforcement falls back to a full table scan of
+-- web_content_constructs for EVERY deleted message row (SQLite does not
+-- require a child-key index for FK enforcement, it just scans if one is
+-- missing). `_replace_full_session_messages_and_blocks`'s bare
+-- `DELETE FROM messages WHERE session_id = ?` therefore cost
+-- O(deleted_messages x web_content_constructs_rows): confirmed live at
+-- 132,796 web_content_constructs rows, `EXPLAIN QUERY PLAN` showed
+-- `SCAN web_content_constructs` before this index, `SEARCH ... USING INDEX`
+-- after. See tests/unit/storage/test_schema_safety.py and
+-- tests/benchmarks/test_full_session_replace.py for the query-plan and
+-- timing proof.
+CREATE INDEX IF NOT EXISTS idx_web_constructs_message
+ON web_content_constructs(message_id);
 
 CREATE INDEX IF NOT EXISTS idx_web_constructs_url
 ON web_content_constructs(url)

--- a/tests/benchmarks/test_full_session_replace.py
+++ b/tests/benchmarks/test_full_session_replace.py
@@ -1,0 +1,161 @@
+"""Regression benchmark for polylogue-rgbj: full-session message replacement.
+
+Covers the exact production hot path from the bead's py-spy evidence:
+``_replace_full_session_messages_and_blocks``'s bare
+``DELETE FROM messages WHERE session_id = ?``
+(``polylogue/storage/sqlite/archive_tiers/write.py``, near line 1795).
+
+Root cause: ``web_content_constructs`` was the only table with a FK to
+``messages(message_id)`` that lacked a leading index on the FK column.
+SQLite's ``ON DELETE CASCADE`` enforcement does not require a child-key
+index — without one it falls back to a full table scan of the child table
+for *every* deleted row. A session-scoped delete of N messages therefore
+cost O(N x web_content_constructs_rows) instead of O(N x log(rows)), which
+is what turned a 15k-message production Codex session replacement into a
+10+ minute stall while the writer held the transaction (live archive had
+132,796 ``web_content_constructs`` rows at the time).
+
+This test proves the fix at the SQL level: it builds two structurally
+identical index-tier databases from the canonical DDL, drops the new
+``idx_web_constructs_message`` index on one to reproduce the pre-fix shape,
+and asserts the with-index delete is dramatically faster.
+
+Run with:
+    pytest tests/benchmarks/test_full_session_replace.py --benchmark-enable -p no:xdist -v
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_INDEX_DDL = ARCHIVE_DDL_BY_TIER[ArchiveTier.INDEX]
+
+# Sized to reproduce the production shape (many unrelated web_content_constructs
+# rows scattered across other sessions) while keeping wall time bounded for a
+# benchmark test. The live archive ratio (132,796 web_content_constructs rows /
+# 4,525,143 messages) is not what matters here -- it's the absolute background
+# table size the FK-cascade scan must walk per deleted message.
+_TARGET_MESSAGES = 500
+_BACKGROUND_WEB_CONSTRUCTS = 30_000
+
+
+def _build_replace_fixture(db_path: Path, *, drop_leading_index: bool) -> tuple[sqlite3.Connection, str]:
+    """Seed a fresh index-tier DB with one large target session plus many
+    unrelated background sessions carrying web_content_constructs rows.
+
+    Uses raw SQL (not the production writer) because this test proves a
+    schema/query-plan property, not writer correctness -- the writer-level
+    behavior is already covered by tests/unit/storage/test_crud.py and
+    tests/unit/storage/test_archive_tiers_write.py.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(_INDEX_DDL)
+    if drop_leading_index:
+        conn.execute("DROP INDEX IF EXISTS idx_web_constructs_message")
+
+    target_session_id = "codex-session:target"
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, title, content_hash) VALUES ('codex-session', 'target', 't', ?)",
+        (b"t" * 32,),
+    )
+    conn.executemany(
+        "INSERT INTO messages (session_id, native_id, position, role, content_hash) VALUES (?, ?, ?, ?, ?)",
+        (
+            (target_session_id, f"m{i}", i, "user" if i % 2 == 0 else "assistant", bytes([i % 256]) * 32)
+            for i in range(_TARGET_MESSAGES)
+        ),
+    )
+
+    # Background sessions: 3 messages/blocks/web_content_constructs rows each,
+    # none related to the target session, simulating archive-wide footprint.
+    n_background_sessions = max(1, _BACKGROUND_WEB_CONSTRUCTS // 3)
+    background_messages = []
+    background_blocks = []
+    background_constructs = []
+    for session_index in range(n_background_sessions):
+        session_id = f"chatgpt-export:bg{session_index}"
+        conn.execute(
+            "INSERT INTO sessions (origin, native_id, title, content_hash) VALUES ('chatgpt-export', ?, 't', ?)",
+            (f"bg{session_index}", bytes([session_index % 256]) * 32),
+        )
+        for position in range(3):
+            native_id = f"m{position}"
+            message_id = f"{session_id}:{native_id}"
+            background_messages.append((session_id, native_id, position, "user", bytes([position]) * 32))
+            background_blocks.append((message_id, session_id, 0, "text", "hi"))
+            block_id = f"{message_id}:0"
+            background_constructs.append((session_id, message_id, block_id, 0, "chatgpt", "canvas"))
+    conn.executemany(
+        "INSERT INTO messages (session_id, native_id, position, role, content_hash) VALUES (?, ?, ?, ?, ?)",
+        background_messages,
+    )
+    conn.executemany(
+        "INSERT INTO blocks (message_id, session_id, position, block_type, text) VALUES (?, ?, ?, ?, ?)",
+        background_blocks,
+    )
+    conn.executemany(
+        "INSERT INTO web_content_constructs "
+        "(session_id, message_id, block_id, position, provider, construct_type) VALUES (?, ?, ?, ?, ?, ?)",
+        background_constructs,
+    )
+    conn.commit()
+    return conn, target_session_id
+
+
+@pytest.mark.benchmark
+def test_full_session_message_delete_uses_indexed_fk_cascade(tmp_path: Path) -> None:
+    """DELETE FROM messages WHERE session_id = ? must not full-scan
+    web_content_constructs (polylogue-rgbj).
+
+    Builds two identical fixtures (with/without the leading FK index) and
+    times the exact statement from
+    `_replace_full_session_messages_and_blocks` on each. The with-index
+    delete must be at least 20x faster -- comfortably below the ~300x
+    measured locally, leaving headroom for slower CI hardware while still
+    catching a regression if the index is ever dropped from canonical DDL.
+    """
+    without_index_conn, without_index_session_id = _build_replace_fixture(
+        tmp_path / "without_index.db", drop_leading_index=True
+    )
+    with_index_conn, with_index_session_id = _build_replace_fixture(
+        tmp_path / "with_index.db", drop_leading_index=False
+    )
+
+    try:
+        started_at = time.perf_counter()
+        without_index_conn.execute("DELETE FROM messages WHERE session_id = ?", (without_index_session_id,))
+        without_index_conn.commit()
+        without_index_seconds = time.perf_counter() - started_at
+
+        started_at = time.perf_counter()
+        with_index_conn.execute("DELETE FROM messages WHERE session_id = ?", (with_index_session_id,))
+        with_index_conn.commit()
+        with_index_seconds = time.perf_counter() - started_at
+    finally:
+        without_index_conn.close()
+        with_index_conn.close()
+
+    print(
+        f"\nfull-session DELETE FROM messages ({_TARGET_MESSAGES} messages, "
+        f"{_BACKGROUND_WEB_CONSTRUCTS} background web_content_constructs rows): "
+        f"without idx_web_constructs_message={without_index_seconds:.4f}s, "
+        f"with idx_web_constructs_message={with_index_seconds:.4f}s, "
+        f"speedup={without_index_seconds / max(with_index_seconds, 1e-9):.0f}x"
+    )
+
+    assert with_index_seconds * 20 < without_index_seconds, (
+        f"Expected the indexed delete to be at least 20x faster; got "
+        f"without_index={without_index_seconds:.4f}s with_index={with_index_seconds:.4f}s "
+        f"(only {without_index_seconds / max(with_index_seconds, 1e-9):.1f}x)"
+    )
+    # Absolute guard: catches a future regression even if the "before" fixture
+    # also regressed for an unrelated reason.
+    assert with_index_seconds < 1.0, f"Indexed delete took {with_index_seconds:.4f}s, expected well under 1s"

--- a/tests/benchmarks/test_graph_resolve_deferred_tail.py
+++ b/tests/benchmarks/test_graph_resolve_deferred_tail.py
@@ -1,0 +1,191 @@
+"""Diagnostic benchmark for polylogue-3wb: rebuild graph_resolve tail latency.
+
+Live evidence (2026-07-03, active v24 rebuild): batch 311 took 274s with 260s
+in ``append.index.graph_resolve`` for a single Codex session; batch 316 took
+427s. This reproduces the mechanism at controlled scale using
+``_resolve_session_graph``/``_reextract_prefix_tail_db`` directly
+(``polylogue/storage/sqlite/archive_tiers/write.py``).
+
+Root cause (traced via per-substage timings, see ``add_timing`` calls in
+``_reextract_prefix_tail_db``): when a session's *children* (resumes/forks)
+are ingested before the *parent* during a rebuild, each child is stored whole
+(#2467 deferred-tail workaround) rather than as a divergent tail. When the
+parent finally arrives, ``_resolve_session_graph`` walks every such orphaned
+child and normalizes it: deletes the child's own duplicate copy of the shared
+prefix, remaps the child's ``session_events`` refs onto the parent's rows, and
+deletes prefix-scoped dependents (blocks/attachment_refs/paste_spans/
+web_content_constructs). This is genuine row-mutation work proportional to
+``orphaned_children x shared_prefix_size`` -- not an accidental full scan.
+
+This benchmark exists to (a) prove the scaling is linear in child count, not
+quadratic (ruling out an accidental O(n^2) bug in the resolve path itself),
+and (b) give a concrete before/after harness for whatever mitigates the
+*frequency* of the expensive path (see polylogue-3wb bead notes for the
+proposed follow-up: rebuild replay currently processes logical sources in
+lexicographic ``sorted(logical_keys)`` order --
+``polylogue/sources/revision_backfill.py`` -- with no parent-before-child
+ordering, so this path triggers far more often during a cold rebuild than it
+would with lineage-aware scheduling).
+
+Every SQL statement on this hot path was audited via ``EXPLAIN QUERY PLAN``
+against the live archive and confirmed to already use an index (SEARCH, not
+SCAN) except ``web_content_constructs`` -- fixed by polylogue-rgbj's
+``idx_web_constructs_message``, which this benchmark's fixture does not
+exercise (Codex sessions have no ``web_content_constructs`` rows; that
+construct type is ChatGPT/browser-capture-specific). Restructuring the SQL
+here (batched vs. per-child statements, IN-list vs. range subqueries) was
+measured to change wall time by less than 10%, confirming the cost is real
+B-tree mutation work rather than query-shape/parameter-marshaling overhead.
+
+Run with:
+    pytest tests/benchmarks/test_graph_resolve_deferred_tail.py --benchmark-enable -p no:xdist -v
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
+from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_INDEX_DDL = ARCHIVE_DDL_BY_TIER[ArchiveTier.INDEX]
+
+_PARENT_MESSAGES = 3000
+_CHILD_TAIL_MESSAGES = 5
+
+
+def _build_deferred_tail_fixture(db_path: Path, *, n_children: int) -> tuple[sqlite3.Connection, str, str, str]:
+    """Seed a parent session plus N children stored whole with an unresolved
+    parent-link edge -- the exact on-disk shape #2467's deferred-tail
+    extraction repairs once the parent becomes known.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(_INDEX_DDL)
+
+    parent_native_id = "big"
+    parent_origin = "codex-session"
+    parent_session_id = f"{parent_origin}:{parent_native_id}"
+
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, title, content_hash) VALUES (?, ?, 't', ?)",
+        (parent_origin, parent_native_id, b"p" * 32),
+    )
+
+    parent_messages = []
+    parent_blocks = []
+    for position in range(_PARENT_MESSAGES):
+        native_id = f"m{position}"
+        message_id = f"{parent_session_id}:{native_id}"
+        role = "user" if position % 2 == 0 else "assistant"
+        parent_messages.append((parent_session_id, native_id, position, role, b"x" * 32))
+        parent_blocks.append((message_id, parent_session_id, 0, "text", f"text-{position}"))
+    conn.executemany(
+        "INSERT INTO messages (session_id, native_id, position, role, content_hash) VALUES (?, ?, ?, ?, ?)",
+        parent_messages,
+    )
+    conn.executemany(
+        "INSERT INTO blocks (message_id, session_id, position, block_type, text) VALUES (?, ?, ?, ?, ?)",
+        parent_blocks,
+    )
+
+    total_child_messages = _PARENT_MESSAGES + _CHILD_TAIL_MESSAGES
+    for child_index in range(n_children):
+        child_native_id = f"child{child_index}"
+        child_session_id = f"{parent_origin}:{child_native_id}"
+        conn.execute(
+            "INSERT INTO sessions (origin, native_id, title, content_hash) VALUES (?, ?, 't', ?)",
+            (parent_origin, child_native_id, bytes([child_index % 256]) * 32),
+        )
+        child_messages = []
+        child_blocks = []
+        child_events = []
+        for position in range(total_child_messages):
+            native_id = f"m{position}"
+            message_id = f"{child_session_id}:{native_id}"
+            role = "user" if position % 2 == 0 else "assistant"
+            # Shared-prefix positions reuse the parent's exact text so the
+            # composed-signature comparison walks the full shared prefix;
+            # tail positions diverge (this child's own new content).
+            text = f"text-{position}" if position < _PARENT_MESSAGES else f"child{child_index}-own-{position}"
+            child_messages.append((child_session_id, native_id, position, role, b"x" * 32))
+            child_blocks.append((message_id, child_session_id, 0, "text", text))
+            child_events.append((child_session_id, message_id, position, "message_event", "e"))
+        conn.executemany(
+            "INSERT INTO messages (session_id, native_id, position, role, content_hash) VALUES (?, ?, ?, ?, ?)",
+            child_messages,
+        )
+        conn.executemany(
+            "INSERT INTO blocks (message_id, session_id, position, block_type, text) VALUES (?, ?, ?, ?, ?)",
+            child_blocks,
+        )
+        conn.executemany(
+            "INSERT INTO session_events (session_id, source_message_id, position, event_type, summary, payload_json) "
+            "VALUES (?, ?, ?, ?, ?, '{}')",
+            child_events,
+        )
+        # Unresolved parent-link edge (inheritance IS NULL): the exact
+        # #2467 "child ingested before parent" state.
+        conn.execute(
+            """
+            INSERT INTO session_links (
+                src_session_id, dst_origin, dst_native_id, link_type,
+                branch_point_message_id, inheritance,
+                status, method, confidence, evidence_json, observed_at_ms
+            ) VALUES (?, ?, ?, 'resume', NULL, NULL, NULL, 'parser-parent', 1.0, '{}', 0)
+            """,
+            (child_session_id, parent_origin, parent_native_id),
+        )
+    conn.commit()
+    return conn, parent_session_id, parent_native_id, parent_origin
+
+
+def _time_graph_resolve(n_children: int, tmp_path: Path) -> float:
+    conn, session_id, native_id, origin = _build_deferred_tail_fixture(
+        tmp_path / f"deferred_tail_{n_children}.db", n_children=n_children
+    )
+    try:
+        started_at = time.perf_counter()
+        archive_tier_write._resolve_session_graph(conn, session_id, native_id, origin, cache={})
+        conn.commit()
+        return time.perf_counter() - started_at
+    finally:
+        conn.close()
+
+
+@pytest.mark.benchmark
+def test_graph_resolve_deferred_tail_scales_linearly_not_quadratically(tmp_path: Path) -> None:
+    """graph_resolve cost for N orphaned children must scale ~linearly in N.
+
+    Guards against a *new* accidental quadratic regression in
+    ``_resolve_session_graph``/``_reextract_prefix_tail_db`` (e.g. losing the
+    ``composed_cache`` sharing across siblings, or re-walking already-resolved
+    children). The existing linear cost (per-child O(shared_prefix_size) row
+    mutation) is a known, evidence-backed characteristic documented in
+    polylogue-3wb -- this test is not expected to make it fast, only to catch
+    it getting asymptotically worse.
+    """
+    small_seconds = _time_graph_resolve(5, tmp_path)
+    large_seconds = _time_graph_resolve(40, tmp_path)
+
+    # 8x the children at the same per-child prefix size. Linear cost implies
+    # ~8x wall time; quadratic implies ~64x. Allow generous headroom (20x)
+    # for fixed per-call overhead and host noise while still catching a
+    # genuine quadratic regression.
+    ratio = large_seconds / max(small_seconds, 1e-9)
+    print(
+        f"\ngraph_resolve deferred-tail scaling: 5 children={small_seconds:.4f}s, "
+        f"40 children={large_seconds:.4f}s, ratio={ratio:.1f}x (linear expects ~8x)"
+    )
+    assert ratio < 20, (
+        f"graph_resolve cost grew {ratio:.1f}x for 8x the orphaned children "
+        f"(5={small_seconds:.4f}s, 40={large_seconds:.4f}s) -- expected roughly linear "
+        "(~8x); this smells like a new quadratic regression in "
+        "_resolve_session_graph/_reextract_prefix_tail_db, not the known linear "
+        "per-child cost documented in polylogue-3wb."
+    )

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -608,6 +608,56 @@ def test_archive_tiers_blocks_have_tool_family_index(tmp_path: Path) -> None:
     assert columns[:2] == ["block_type", None]
 
 
+def test_archive_tiers_every_message_fk_backreference_has_leading_index(tmp_path: Path) -> None:
+    """Every FK to ``messages(message_id)`` must have a leading index on its
+    child column, or SQLite's ``ON DELETE`` cascade/set-null enforcement
+    silently falls back to a full table scan of that child table for *every*
+    deleted/updated message row (SQLite does not require a child-key index
+    for FK enforcement — it just scans if one is missing).
+
+    polylogue-rgbj: ``web_content_constructs`` was exactly this gap.
+    ``_replace_full_session_messages_and_blocks``'s session-scoped
+    ``DELETE FROM messages WHERE session_id = ?`` triggers SQLite's internal
+    FK cascade check against every table with a ``messages(message_id)`` FK,
+    once per deleted message row. With no leading index on
+    ``web_content_constructs.message_id``, that cascade check scanned the
+    *entire* table (all sessions, not just the one being replaced) for each
+    deleted message — confirmed live at 132,796 rows via
+    ``EXPLAIN QUERY PLAN`` (``SCAN web_content_constructs``), turning a
+    15k-message session replacement into a 10+ minute stall while the writer
+    held the transaction. This test makes that class of gap structural: any
+    future table with a FK to ``messages(message_id)`` must ship its leading
+    index in the same change, not be discovered via production py-spy
+    sampling. See ``tests/benchmarks/test_full_session_replace.py`` for the
+    timing proof.
+    """
+    conn = _connect(tmp_path / "index.db")
+    _apply_tier(conn, ArchiveTier.INDEX)
+
+    table_names = [
+        row["name"]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    ]
+
+    unindexed: list[str] = []
+    for table in table_names:
+        for fk in conn.execute(f"PRAGMA foreign_key_list('{table}')").fetchall():
+            if fk["table"] != "messages" or fk["to"] != "message_id":
+                continue
+            from_column = fk["from"]
+            plan_rows = conn.execute(f"EXPLAIN QUERY PLAN SELECT 1 FROM {table} WHERE {from_column} = 'x'").fetchall()
+            plan = " | ".join(str(row["detail"]) for row in plan_rows)
+            if "SEARCH" not in plan.upper():
+                unindexed.append(f"{table}.{from_column}: {plan}")
+
+    assert not unindexed, (
+        "Table(s) with a messages(message_id) FK lack a leading index on the FK "
+        f"column, forcing a full scan on every deleted/updated message: {unindexed}"
+    )
+
+
 def test_archive_tier_specs_capture_file_and_backup_policy() -> None:
     assert {tier: spec.filename for tier, spec in ARCHIVE_TIER_SPECS.items()} == {
         ArchiveTier.SOURCE: "source.db",


### PR DESCRIPTION
## Summary
Two production performance bugs found via py-spy profiling of live
rebuild/replace-heavy operations, per this repo's batch-execution
convention for overlapping-footprint beads.

## Problem
- polylogue-rgbj: production catch-up replacing a 15k-message Codex
  session spent 10+ minutes inside `_replace_full_session_messages_and_blocks`'s
  `DELETE FROM messages` while the writer held the transaction (py-spy:
  498/754 samples on that statement).
- polylogue-3wb: a live v24 rebuild exposed severe tail latency (batch 311:
  260s of 274s in `append.index.graph_resolve`; batch 316: 427s).

## Solution
- **rgbj (root cause, fixed):** `web_content_constructs` was the only table
  with an FK to `messages(message_id)` lacking a leading index -- SQLite's
  `ON DELETE CASCADE` doesn't require one for correctness, it silently
  full-table-scans the child table per deleted parent row when missing.
  Confirmed live against the active archive (132,796
  web_content_constructs rows) via `EXPLAIN QUERY PLAN`. Added
  `idx_web_constructs_message`, bumped `INDEX_SCHEMA_VERSION` 33->34
  (derived tier, rebuild-from-source per schema policy). New structural
  regression test walks every FK to `messages(message_id)` via
  `PRAGMA foreign_key_list` and asserts `EXPLAIN QUERY PLAN` uses an
  index, so a future missing-index table fails fast instead of waiting
  for production py-spy sampling.
- **3wb (diagnosed, real fix split out):** audited every SQL statement in
  the graph-resolve path -- all already indexed after the rgbj fix. The
  documented 15s->103s `full_replace.delete_messages` growth is explained
  by the SAME rgbj bug. The remaining `graph_resolve`-proper cost is a
  distinct mechanism (the #2467 deferred-tail-extraction path: orphaned
  children replayed before their parent get normalized with real
  O(shared_prefix_size) row mutation per child) -- confirmed linear, not
  quadratic, via a new benchmark, and empirically verified SQL-shape
  restructuring changes wall time by <10% (real B-tree work, not a fixable
  query-plan issue). The actual lever (replay ordering by lineage) is a
  higher-blast-radius change needing its own replay-outcome-parity proof,
  so it's split into polylogue-5q2u rather than rushed into this PR.

## Verification
- `tests/unit/storage/test_archive_tiers_ddl.py -k message_fk_backreference`
  passes with the index, fails (`web_content_constructs.message_id: SCAN
  web_content_constructs`) with it reverted (confirmed via stash).
- Benchmark (`tests/benchmarks/test_full_session_replace.py`): 2.2745s
  without index vs 0.0071s with (319x) for 500 target messages against
  30,000 background rows -- asserts at least 20x.
- `tests/benchmarks/test_graph_resolve_deferred_tail.py`: linear scaling
  confirmed (5 children=0.76s, 40 children=6.19s, ratio 8.1x for 8x
  children).
- Rebased onto current master and re-verified post-rebase: 30 tests
  passed, `devtools verify --quick` 15/15 green.
- GitHub Actions CI blocked repo-wide by an account billing lock
  (unrelated to this diff; operator-confirmed to keep merging through it
  this session); GitGuardian will be checked before merge.

Ref polylogue-rgbj, polylogue-3wb

Co-Authored-By: Claude <noreply@anthropic.com>