### PR TITLE
feat(insights): emit boundary='resume' for continuation session snapshots

### DIFF
--- a/polylogue/insights/run_projection.py
+++ b/polylogue/insights/run_projection.py
@@ -218,12 +218,19 @@ def build_run_projection(
     tool_summaries: Sequence[_ToolSummaryLike],
     subagent_reports: Sequence[_SubagentReportLike],
     session_digest_events: Sequence[_SessionDigestEventLike],
+    is_resume: bool = False,
 ) -> RunProjection:
-    """Project digest evidence into bounded Run/ContextSnapshot/ObservedEvent DTOs."""
+    """Project digest evidence into bounded Run/ContextSnapshot/ObservedEvent DTOs.
+
+    ``is_resume`` marks a genuine continuation/resume session (see
+    ``Session.is_continuation``) — the main run's context-snapshot boundary is
+    then ``resume`` rather than a fresh ``session_start`` (polylogue-aoe5).
+    """
 
     session_evidence = _to_evidence_refs(session_raw_refs)
     main_run_ref = _run_ref(session_id)
-    main_snapshot_ref = _context_snapshot_ref(session_id, "session_start")
+    main_boundary: ContextBoundary = "resume" if is_resume else "session_start"
+    main_snapshot_ref = _context_snapshot_ref(session_id, main_boundary)
     harness = _harness_for_origin(source_origin)
     main_run = ProjectedRun(
         run_ref=main_run_ref,
@@ -246,7 +253,7 @@ def build_run_projection(
         ContextSnapshot(
             snapshot_ref=main_snapshot_ref,
             run_ref=main_run_ref,
-            boundary="session_start",
+            boundary=main_boundary,
             inheritance_mode="unknown",
             segment_refs=(ObjectRef(kind="session", object_id=session_id),),
             evidence_refs=session_evidence,

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -504,6 +504,7 @@ def compile_session_digest(
         tool_summaries=tool_summaries,
         subagent_reports=subagent_reports,
         session_digest_events=events,
+        is_resume=session.is_continuation,
     )
     role_counts = dict(Counter(_role_value(message) for message in messages))
     normal_read = _normal_read_text(messages)
@@ -602,6 +603,7 @@ def compile_session_run_projection(
         tool_summaries=tool_summaries,
         subagent_reports=subagent_reports,
         session_digest_events=events,
+        is_resume=session.is_continuation,
     )
 
 

--- a/polylogue/storage/sqlite/run_projection_relations.py
+++ b/polylogue/storage/sqlite/run_projection_relations.py
@@ -219,7 +219,8 @@ WITH source_runs AS (
         'raw' AS confidence,
         s0.session_id AS transcript_ref,
         json_array(s0.session_id) AS evidence_refs_json,
-        'context-snapshot:' || s0.session_id || ':session_start' AS context_snapshot_ref,
+        'context-snapshot:' || s0.session_id || ':' ||
+            CASE WHEN s0.branch_type = 'continuation' THEN 'resume' ELSE 'session_start' END AS context_snapshot_ref,
         trim(COALESCE(s0.title, '') || ' ' || COALESCE(s0.native_id, '') || ' ' || COALESCE(s0.git_branch, '')) AS search_text,
         NULL AS payload_json,
         1 AS materializer_version,
@@ -409,7 +410,12 @@ materialized_context_snapshots AS (
         c.materializer_version,
         c.materialized_at
     FROM session_context_snapshots c
-    WHERE c.boundary <> 'session_start'
+    -- 'session_start'/'resume' are the two boundaries the cheap source CTE below
+    -- can synthesize live from sessions.branch_type (polylogue-aoe5); excluding
+    -- both here (not just 'session_start') keeps the cheap path authoritative
+    -- for the main run's snapshot even if a materialized row predates a
+    -- branch_type backfill, avoiding a stale-boundary duplicate row.
+    WHERE c.boundary NOT IN ('session_start', 'resume')
         OR NOT EXISTS (
             SELECT 1
             FROM source_context_snapshots source
@@ -424,12 +430,13 @@ materialized_context_snapshots AS (
 WITH source_context_snapshots AS (
     SELECT
         'source' AS row_source,
-        'context-snapshot:' || s0.session_id || ':session_start' AS snapshot_ref,
+        'context-snapshot:' || s0.session_id || ':' ||
+            CASE WHEN s0.branch_type = 'continuation' THEN 'resume' ELSE 'session_start' END AS snapshot_ref,
         s0.session_id AS session_id,
         'run:' || s0.session_id AS run_ref,
         0 AS position,
         printf('%016d', COALESCE(s0.updated_at_ms, s0.created_at_ms, 0)) AS source_updated_at,
-        'session_start' AS boundary,
+        CASE WHEN s0.branch_type = 'continuation' THEN 'resume' ELSE 'session_start' END AS boundary,
         'unknown' AS inheritance_mode,
         json_array('session:' || s0.session_id) AS segment_refs_json,
         json_array(s0.session_id) AS evidence_refs_json,
@@ -503,7 +510,7 @@ def context_snapshot_from_row(row: RowLike) -> ContextSnapshot:
     return ContextSnapshot(
         snapshot_ref=ObjectRef.parse(str(row["snapshot_ref"])),
         run_ref=ObjectRef.parse(str(row["run_ref"])),
-        boundary="session_start",
+        boundary=str(row["boundary"]),  # type: ignore[arg-type]
         inheritance_mode="unknown",
         segment_refs=tuple(ObjectRef.parse(ref) for ref in _tuple_from_json_array(row["segment_refs_json"])),
         evidence_refs=tuple(EvidenceRef.parse(ref) for ref in _tuple_from_json_array(row["evidence_refs_json"])),

--- a/tests/unit/insights/test_run_projection_materialization.py
+++ b/tests/unit/insights/test_run_projection_materialization.py
@@ -16,6 +16,7 @@ import aiosqlite
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
 from polylogue.archive.message.roles import Role
+from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session
 from polylogue.core.enums import Origin
 from polylogue.insights.transforms import compile_session_digest
@@ -350,3 +351,99 @@ def test_subagent_and_child_main_runs_do_not_collide(tmp_path: Path) -> None:
         ("run:codex-session:parent:subagent:1:shared-tool", "codex-session:parent", "subagent"),
     ]
     conn.close()
+
+
+def test_continuation_session_projection_boundary_is_resume() -> None:
+    """polylogue-aoe5: a genuine continuation/resume session gets boundary='resume'."""
+    session = _session().model_copy(
+        update={
+            "id": SessionId("codex-session:demo-continuation"),
+            "parent_id": SessionId("codex-session:demo-root"),
+            "branch_type": BranchType.CONTINUATION,
+        }
+    )
+    assert session.is_continuation
+
+    projection = compile_session_digest(session, session_links=()).run_projection
+    main_snapshot = projection.context_snapshots[0]
+    main_run = projection.runs[0]
+
+    assert main_snapshot.boundary == "resume"
+    assert main_snapshot.snapshot_ref.object_id == "codex-session:demo-continuation:resume"
+    assert main_run.context_snapshot_ref == main_snapshot.snapshot_ref
+
+    # A fresh (non-continuation) session is unaffected.
+    fresh_projection = compile_session_digest(_session(), session_links=()).run_projection
+    assert fresh_projection.context_snapshots[0].boundary == "session_start"
+
+
+async def test_continuation_session_resume_boundary_read_through_source_and_materialized(tmp_path: Path) -> None:
+    """The SQL source fallback and the materializer agree on boundary='resume'.
+
+    The cheap ``sessions``-derived read path (``run_projection_relations.py``)
+    must reflect ``branch_type='continuation'`` without requiring the session
+    to be re-materialized, and materializing afterward must not produce a
+    duplicate context-snapshot row for the same run.
+    """
+    from tests.infra.storage_records import SessionBuilder
+
+    db_path = tmp_path / "index.db"
+    (
+        SessionBuilder(db_path, "resume-boundary-root")
+        .provider("claude-code")
+        .title("Resume Boundary Root")
+        .add_message("root-u1", role="user", text="Start the work.")
+        .save()
+    )
+    (
+        SessionBuilder(db_path, "resume-boundary-child")
+        .provider("claude-code")
+        .title("Resume Boundary Continuation")
+        .parent_session("ext-resume-boundary-root")
+        .branch_type("continuation")
+        .add_message("child-u1", role="user", text="Continue the work after a crash.")
+        .save()
+    )
+    session_id = "claude-code-session:ext-resume-boundary-child"
+
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+
+        # session_context_snapshots is populated by daemon convergence, not by
+        # SessionBuilder.save(); the source/cheap path must already carry the
+        # resume boundary before any materialization happens.
+        source_snapshots = await list_context_snapshots(conn, RunProjectionListQuery(session_id=session_id, limit=None))
+        assert [record.snapshot.boundary for record in source_snapshots] == ["resume"]
+        assert source_snapshots[0].snapshot.snapshot_ref.object_id == f"{session_id}:resume"
+
+        resume_filtered = await list_context_snapshots(
+            conn, RunProjectionListQuery(session_id=session_id, boundary="resume", limit=None)
+        )
+        assert [record.snapshot.snapshot_ref for record in resume_filtered] == [
+            source_snapshots[0].snapshot.snapshot_ref
+        ]
+
+        main_runs = await list_runs(conn, RunProjectionListQuery(session_id=session_id, role="main", limit=None))
+        assert main_runs[0].run.context_snapshot_ref == source_snapshots[0].snapshot.snapshot_ref
+
+        # Now materialize explicitly and confirm the read path still returns
+        # exactly one resume-boundary snapshot for this session (no duplicate
+        # row from the union of source + materialized rows).
+        session = Session(
+            id=SessionId(session_id),
+            origin=Origin.CLAUDE_CODE_SESSION,
+            title="Resume Boundary Continuation",
+            parent_id=SessionId("claude-code-session:ext-resume-boundary-root"),
+            branch_type=BranchType.CONTINUATION,
+            messages=MessageCollection(
+                messages=[Message(id="child-u1", role=Role.USER, text="Continue the work after a crash.")]
+            ),
+        )
+        projection = compile_session_digest(session, session_links=()).run_projection
+        snapshot_records = build_session_context_snapshot_records(projection, materialized_at=_MATERIALIZED_AT)
+        await replace_session_context_snapshots(conn, session_id, snapshot_records, 0)
+
+        after_materialize = await list_context_snapshots(
+            conn, RunProjectionListQuery(session_id=session_id, limit=None)
+        )
+        assert [record.snapshot.boundary for record in after_materialize] == ["resume"]


### PR DESCRIPTION
## Summary

Wires the run-projection materializer to emit `session_context_snapshots.boundary='resume'` for genuine continuation/resume sessions, instead of always hardcoding `session_start`, and keeps the SQL fallback read path in sync so reads are correct without waiting for re-materialization.

## Problem

`session_context_snapshots.boundary` has a valid `resume` CHECK member (schema already supports it — `literal_check("boundary", *get_args(ContextBoundary))`) that had never been written: 0/14422 rows, all `session_start` or `subagent_start`. `build_run_projection()` (`polylogue/insights/run_projection.py`) hardcoded the main run's `ContextSnapshot.boundary` to `"session_start"` regardless of whether the session was a fresh start or a genuine continuation (`session.branch_type == BranchType.CONTINUATION`, exposed as `Session.is_continuation`).

## Solution

- `polylogue/insights/run_projection.py`: `build_run_projection()` gains an `is_resume: bool = False` parameter; when set, the main run's `ContextSnapshot` (and its `snapshot_ref`) use boundary `"resume"` instead of `"session_start"`.
- `polylogue/insights/transforms.py`: both `compile_session_digest()` and `compile_session_run_projection()` pass `is_resume=session.is_continuation` through — no new inputs needed, `Session.branch_type`/`parent_id` are already denormalized onto the hydrated session row by `resolve_session_links_for_session`/`resolve_unresolved_links_for_child`.
- `polylogue/storage/sqlite/run_projection_relations.py`: the cheap SQL "source" read path — which the query surface always prefers over the materialized row for the *main* run/snapshot (see the existing `test_run_projection_materialization_parity` comment "cheap canonical rows are served from sessions/blocks") — now derives boundary live from `sessions.branch_type = 'continuation'` too, in both `source_runs.context_snapshot_ref` and `source_context_snapshots`. This means reads reflect the correct boundary immediately, without requiring a re-materialization pass after link resolution sets `branch_type`. The materialized-row union filter (`context_snapshot_relation_sql`) now excludes both `'session_start'` and `'resume'` boundaries (not just `'session_start'`), so a stale materialized row from before a `branch_type` backfill can't produce a duplicate context-snapshot row alongside the live-computed source row.
- `context_snapshot_from_row()`'s "source" fallback constructor now reads the actual computed `boundary` column instead of hardcoding `"session_start"`.

Non-goal: `inheritance_mode` is left as `"unknown"` for resume boundaries — the AC only asks for `boundary`, and `ContextInheritanceMode` semantics (`prefix` vs `snapshot` etc.) are a separate, unaudited decision better left to its own change.

## Verification

- `devtools test tests/unit/insights/test_run_projection_materialization.py` — 8 passed (2 new: a pure-projection boundary check, and a read-through parity test across the source/materialized SQL union, including a no-duplicate-row check after materializing).
- `devtools test tests/unit/insights/test_transforms.py` — 33 passed (unaffected fixtures, confirms no regression).
- `uv run mypy --strict polylogue/insights/run_projection.py polylogue/insights/transforms.py polylogue/storage/sqlite/run_projection_relations.py` — no issues.
- `devtools test tests/unit/storage/test_no_string_interpolated_sql.py` fails identically on a clean `master` checkout (unrelated pre-existing f-string SQL audit gaps in `raw_retention.py` / `archive_tiers/archive.py`, neither touched by this diff) — confirmed via `git stash`.
- Pre-push hook ran `devtools verify --quick` (format + lint + mypy + `render all --check`) — exit 0.

Ref polylogue-aoe5

Note: GitHub CI is currently blocked by an account billing lock unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)