### PR TITLE
feat(core): add Source-family disambiguator for GEMINI/DRIVE reverse lookups

### DIFF
--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveMessageRow, ArchiveSessionEnvelope
 
 
-def _provider_for_origin(origin: str) -> Provider:
+def _provider_for_origin(origin: str, *, family_hint: Provider | str | None = None) -> Provider:
     """Return the canonical provider-wire ``Provider`` for an origin token.
 
     Delegates to :func:`polylogue.core.sources.provider_from_origin`, the
@@ -54,13 +54,23 @@ def _provider_for_origin(origin: str) -> Provider:
     (all three were missing a ``grok-export`` entry, falling back to
     ``Provider.UNKNOWN`` instead of ``Provider.GROK``). Delegating fixes that
     drift and makes future drift structurally impossible (polylogue-9e5.8).
+
     ``Origin.AISTUDIO_DRIVE`` still canonically resolves to ``Provider.GEMINI``
-    here -- that collapse is a deliberate, documented, non-injective design
-    choice (see ``core/sources.py``'s ``_ORIGIN_TO_PROVIDER`` comment), not a
-    bug this delegation fixes; un-collapsing it needs a Source-family
-    disambiguator (polylogue-9e5.8 Step 5), not a narrow fix here.
+    by default -- that collapse is a deliberate, documented, non-injective
+    design choice (see ``core/sources.py``'s ``_ORIGIN_TO_PROVIDER`` comment),
+    not a bug this delegation fixes on its own. ``family_hint`` threads
+    through to :func:`provider_from_origin`'s Source-family disambiguator
+    (polylogue-9e5.8 Step 5 / polylogue-4rrv) for callers that already know,
+    independently of the stored ``origin``, which fiber member (e.g.
+    ``Provider.DRIVE`` vs ``Provider.GEMINI``) applies. This module's own
+    call site (``_session_to_session``) currently has no such independent
+    knowledge -- ``ArchiveSessionEnvelope`` only carries the already-collapsed
+    ``origin`` column, so it omits the hint and gets the canonical default,
+    same as before. Recovering it there for good needs a durable
+    acquisition-time field on ``sessions``/``raw_sessions`` (tracked as a
+    follow-up bead), not something this reverse lookup can invent.
     """
-    return provider_from_origin(Origin.from_string(origin))
+    return provider_from_origin(Origin.from_string(origin), family_hint=family_hint)
 
 
 def _session_seed_scored(

--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -43,6 +43,7 @@ __all__ = [
     "SourceFamily",
     "lab_of_origin",
     "origin_from_provider",
+    "origin_provider_fiber",
     "provider_from_origin",
     "provider_to_source",
     "source_for_family",
@@ -296,15 +297,91 @@ _ORIGIN_TO_PROVIDER: Final[dict[Origin, Provider]] = {
 }
 
 
-def provider_from_origin(origin: Origin) -> Provider:
+def _build_origin_provider_fiber() -> dict[Origin, tuple[Provider, ...]]:
+    """Group every ``Provider`` by the ``Origin`` it collapses onto.
+
+    Built from :data:`_PROVIDER_TO_ORIGIN` (the total, authoritative forward
+    map) rather than re-declared by hand, so a newly added ``Provider`` can
+    never silently omit itself from its origin's fiber the way the three
+    independently hand-copied ``_provider_for_origin`` dicts drifted before
+    polylogue-9e5.8 Step 1 deduplicated them.
+    """
+
+    fiber: dict[Origin, list[Provider]] = {}
+    for provider in Provider:
+        fiber.setdefault(_PROVIDER_TO_ORIGIN[provider], []).append(provider)
+    return {origin: tuple(providers) for origin, providers in fiber.items()}
+
+
+_ORIGIN_PROVIDER_FIBER: Final[dict[Origin, tuple[Provider, ...]]] = _build_origin_provider_fiber()
+
+
+def origin_provider_fiber(origin: Origin) -> tuple[Provider, ...]:
+    """Return every ``Provider`` that collapses onto ``origin``.
+
+    Most origins have exactly one member and round-trip losslessly through
+    :func:`provider_from_origin`. ``Origin.AISTUDIO_DRIVE`` is the sole
+    multi-member fiber today: ``(Provider.GEMINI, Provider.DRIVE)`` --
+    Gemini/AI-Studio export bundles and Google-Drive-live-acquired AI-Studio
+    captures are the same public source-origin but different provider-wire
+    acquisition mechanisms (see ``docs/provider-origin-identity.md``'s
+    "Capture mode" row). Use this to test whether an origin is ambiguous
+    before trusting :func:`provider_from_origin`'s canonical fallback, or to
+    validate that a ``family_hint`` actually belongs to the fiber it claims
+    to disambiguate.
+    """
+
+    return _ORIGIN_PROVIDER_FIBER.get(origin, ())
+
+
+def _resolve_family_hint(hint: Provider | SourceFamily) -> Provider | None:
+    """Resolve a disambiguating hint to a ``Provider``, or ``None`` if it
+    does not name a recognized provider or source family."""
+
+    if isinstance(hint, Provider):
+        return hint
+    family_provider = _FAMILY_TO_PROVIDER.get(hint)
+    if family_provider is not None:
+        return family_provider
+    try:
+        return Provider.from_string(hint)
+    except ValueError:
+        return None
+
+
+def provider_from_origin(origin: Origin, *, family_hint: Provider | SourceFamily | None = None) -> Provider:
     """Return the canonical provider-wire ``Provider`` for an archive ``Origin``.
 
     Total over ``Origin``. Inverse of :func:`origin_from_provider` with a
     canonical choice for the non-injective ``Origin.AISTUDIO_DRIVE``
     (``Provider.GEMINI``). New code should consume ``Origin`` directly; this
     exists only for boundaries that still speak provider tokens.
+
+    ``family_hint`` disambiguates origins whose :func:`origin_provider_fiber`
+    has more than one member -- today only ``Origin.AISTUDIO_DRIVE``
+    (``{Provider.GEMINI, Provider.DRIVE}``). Pass a ``Source.family`` token
+    (e.g. ``"drive-takeout"``), a provider-wire string, or a ``Provider``
+    value that the caller already knows independently of the stored
+    ``Origin`` -- typically an explicit filter parameter or other
+    acquisition-time context -- to recover the correct fiber member instead
+    of the canonical default.
+
+    A hint that fails to resolve, or resolves to a ``Provider`` outside
+    ``origin``'s fiber, is ignored (falls back to the canonical choice)
+    rather than raising: disambiguation here is advisory, not authoritative.
+    No current storage tier persists the acquisition-time provider once a
+    session is written -- ``sessions``/``raw_sessions`` only carry the
+    already-collapsed ``origin`` column (polylogue-9e5.8 Step 5 investigation;
+    see polylogue-4rrv for the follow-up durable-field bead) -- so this
+    parameter only helps call sites that already have independent knowledge
+    of which fiber member applies, not ones trying to recover it from a
+    previously-persisted session alone.
     """
 
+    if family_hint is not None:
+        resolved = _resolve_family_hint(family_hint)
+        if resolved is not None and resolved in _ORIGIN_PROVIDER_FIBER.get(origin, ()):
+            return resolved
     return _ORIGIN_TO_PROVIDER[origin]
 
 

--- a/polylogue/insights/tag_rollups.py
+++ b/polylogue/insights/tag_rollups.py
@@ -46,6 +46,20 @@ def synthesize_provider_tag_rollups(
         until_ms=until_ms,
     )
     needle = query.strip().lower() if query else None
+    # Provider -> Origin, not the reverse: this direction is total and
+    # well-defined even for the non-injective Origin.AISTUDIO_DRIVE fiber --
+    # both "gemini" and "drive" forward-map to the same "aistudio-drive"
+    # origin_filter (polylogue-9e5.8 Step 5 investigation / polylogue-4rrv).
+    # There is nothing here for a Source-family disambiguator to recover:
+    # disambiguation only matters for the *reverse* Origin -> Provider
+    # lookup (see core/sources.py's provider_from_origin family_hint), which
+    # this function never performs. What *is* coarse is the resulting
+    # rollup: origin_filter can only select the whole "aistudio-drive"
+    # bucket, so provider="gemini" and provider="drive" return identical
+    # counts today (both fold into one origin-tag rollup, and per-origin
+    # ArchiveStore.stats_by("origin", ...) has no finer axis to group on --
+    # see polylogue-4rrv's follow-up bead for the durable capture-mode field
+    # that would be needed to split them).
     origin_filter = origin_from_provider(Provider.from_string(provider)).value if provider is not None else None
     rollups: list[SessionTagRollupInsight] = []
     for origin_value, count in counts.items():

--- a/tests/unit/archive/test_archive_execution_filters.py
+++ b/tests/unit/archive/test_archive_execution_filters.py
@@ -2,11 +2,48 @@
 
 from __future__ import annotations
 
-from polylogue.archive.query.archive_execution import _plan_filter_kwargs
+from polylogue.archive.query.archive_execution import _plan_filter_kwargs, _provider_for_origin
 from polylogue.archive.query.expression import compile_expression
+from polylogue.core.enums import Provider
 
 
 def test_archive_filter_kwargs_include_session_id() -> None:
     plan = compile_expression("id:abc123").to_plan()
 
     assert _plan_filter_kwargs(plan)["session_id"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# GEMINI/DRIVE reverse-lookup disambiguation (polylogue-4rrv,
+# polylogue-9e5.8 Step 5)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_for_origin_defaults_to_canonical_gemini() -> None:
+    """Unchanged default: no hint means the documented canonical choice."""
+    assert _provider_for_origin("aistudio-drive") is Provider.GEMINI
+
+
+def test_provider_for_origin_family_hint_disambiguates_drive() -> None:
+    """When a caller has independent knowledge of the acquisition mechanism
+    (e.g. Provider.DRIVE from live Google-Drive acquisition context), this
+    reverse lookup now correctly recovers it instead of always collapsing to
+    Provider.GEMINI."""
+    assert _provider_for_origin("aistudio-drive", family_hint=Provider.DRIVE) is Provider.DRIVE
+    assert _provider_for_origin("aistudio-drive", family_hint="drive-takeout") is Provider.DRIVE
+
+
+def test_provider_for_origin_family_hint_confirms_gemini() -> None:
+    assert _provider_for_origin("aistudio-drive", family_hint=Provider.GEMINI) is Provider.GEMINI
+    assert _provider_for_origin("aistudio-drive", family_hint="gemini-export") is Provider.GEMINI
+
+
+def test_provider_for_origin_unrelated_origin_ignores_hint() -> None:
+    """A hint outside the target origin's fiber is ignored, not honored."""
+    assert _provider_for_origin("codex-session", family_hint=Provider.GEMINI) is Provider.CODEX
+
+
+def test_provider_for_origin_grok_still_resolves_correctly() -> None:
+    """polylogue-9e5.8 Step 1 regression: grok-export must not silently fall
+    back to Provider.UNKNOWN (the bug the dedup fixed)."""
+    assert _provider_for_origin("grok-export") is Provider.GROK

--- a/tests/unit/core/test_sources.py
+++ b/tests/unit/core/test_sources.py
@@ -10,6 +10,8 @@ from polylogue.core.sources import (
     Source,
     lab_of_origin,
     origin_from_provider,
+    origin_provider_fiber,
+    provider_from_origin,
     provider_to_source,
     source_for_family,
     source_to_provider,
@@ -238,3 +240,72 @@ def test_lab_derivation_agrees_with_source_attribution() -> None:
     for provider in Provider:
         derived = lab_of_origin(origin_from_provider(provider))
         assert derived == provider_to_source(provider).originating_lab
+
+
+# ---------------------------------------------------------------------------
+# Origin -> Provider fiber + family_hint disambiguator (polylogue-4rrv,
+# polylogue-9e5.8 Step 5)
+# ---------------------------------------------------------------------------
+
+
+def test_origin_provider_fiber_is_total_and_singleton_for_most_origins() -> None:
+    """Every Origin has a non-empty fiber, and every Origin except
+    AISTUDIO_DRIVE has exactly one member (lossless round-trip)."""
+    for origin in Origin:
+        fiber = origin_provider_fiber(origin)
+        assert fiber, f"Origin {origin!r} has an empty provider fiber"
+        if origin is not Origin.AISTUDIO_DRIVE:
+            assert len(fiber) == 1, f"Origin {origin!r} unexpectedly has a multi-member fiber: {fiber}"
+            assert fiber[0] is provider_from_origin(origin)
+
+
+def test_aistudio_drive_fiber_has_exactly_gemini_and_drive() -> None:
+    """AISTUDIO_DRIVE is the sole multi-member fiber: {GEMINI, DRIVE}."""
+    assert set(origin_provider_fiber(Origin.AISTUDIO_DRIVE)) == {Provider.GEMINI, Provider.DRIVE}
+
+
+def test_provider_from_origin_default_is_canonical_gemini() -> None:
+    """Without a hint, AISTUDIO_DRIVE still resolves to the documented
+    canonical choice (Provider.GEMINI) -- unchanged default behavior."""
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE) is Provider.GEMINI
+
+
+def test_provider_from_origin_family_hint_recovers_drive() -> None:
+    """A caller that independently knows the session came from the live
+    Google-Drive acquisition path (Source.family == "drive-takeout") can
+    recover Provider.DRIVE instead of the canonical Provider.GEMINI default."""
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="drive-takeout") is Provider.DRIVE
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint=Provider.DRIVE) is Provider.DRIVE
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="drive") is Provider.DRIVE
+
+
+def test_provider_from_origin_family_hint_confirms_gemini() -> None:
+    """A hint naming the Gemini export family explicitly still resolves to
+    Provider.GEMINI (same as the default, but via the disambiguator path)."""
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="gemini-export") is Provider.GEMINI
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint=Provider.GEMINI) is Provider.GEMINI
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="gemini") is Provider.GEMINI
+
+
+def test_provider_from_origin_hint_outside_fiber_is_ignored() -> None:
+    """A hint that resolves to a real Provider, but one that does not belong
+    to the target origin's fiber, is ignored -- falls back to canonical,
+    does not raise and does not silently return the wrong provider."""
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint=Provider.CODEX) is Provider.GEMINI
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="codex-session") is Provider.GEMINI
+
+
+def test_provider_from_origin_unresolvable_hint_is_ignored() -> None:
+    """A hint that names neither a known Source family nor a provider-wire
+    token falls back to canonical rather than raising."""
+    assert provider_from_origin(Origin.AISTUDIO_DRIVE, family_hint="not-a-real-family") is Provider.GEMINI
+
+
+def test_provider_from_origin_hint_is_irrelevant_for_unambiguous_origins() -> None:
+    """A hint has nothing to disambiguate for a singleton fiber: the
+    canonical (and only) provider is returned regardless of the hint,
+    matching the origin's sole fiber member."""
+    assert provider_from_origin(Origin.CODEX_SESSION, family_hint="codex-session") is Provider.CODEX
+    # An irrelevant/mismatched hint is still ignored for a singleton fiber --
+    # it can never select a provider outside that fiber.
+    assert provider_from_origin(Origin.CODEX_SESSION, family_hint=Provider.GEMINI) is Provider.CODEX

--- a/tests/unit/insights/test_tag_rollups.py
+++ b/tests/unit/insights/test_tag_rollups.py
@@ -1,0 +1,98 @@
+"""Regression tests for ``synthesize_provider_tag_rollups`` (polylogue-4rrv).
+
+polylogue-9e5.8's Step 5 investigation into the non-injective
+``Origin.AISTUDIO_DRIVE`` collapse (``Provider.GEMINI`` and ``Provider.DRIVE``
+both produce it) named ``insights/tag_rollups.py:49`` as a candidate leak
+site. Reading it to ground truth shows it performs the *forward*
+``Provider -> Origin`` conversion (via ``origin_from_provider``), which is
+total and well-defined even for this fiber -- there is no reverse lookup here
+for a disambiguator to fix. These tests pin that: both ``provider="gemini"``
+and ``provider="drive"`` correctly resolve to the ``aistudio-drive`` origin
+filter (not silently falling back to ``unknown-export`` or raising), proving
+the site was already correct and is not blocked by the collapse.
+"""
+
+from __future__ import annotations
+
+from polylogue.insights.tag_rollups import synthesize_provider_tag_rollups
+
+
+class _FakeArchive:
+    """Minimal stand-in for ``ArchiveStore.stats_by`` used by tag rollups."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    def stats_by(
+        self,
+        group_by: str,
+        *,
+        since_ms: int | None = None,
+        until_ms: int | None = None,
+    ) -> dict[str, int]:
+        assert group_by == "origin"
+        return dict(self._counts)
+
+
+def _counts() -> dict[str, int]:
+    return {
+        "aistudio-drive": 7,
+        "codex-session": 3,
+        "claude-code-session": 5,
+    }
+
+
+def test_provider_gemini_filters_to_aistudio_drive_origin() -> None:
+    rollups = synthesize_provider_tag_rollups(
+        _FakeArchive(_counts()),  # type: ignore[arg-type]
+        provider="gemini",
+        materialized_at="2026-07-12T00:00:00+00:00",
+    )
+    assert [r.tag for r in rollups] == ["origin:aistudio-drive"]
+    assert rollups[0].session_count == 7
+
+
+def test_provider_drive_filters_to_the_same_aistudio_drive_origin() -> None:
+    """Provider.GEMINI and Provider.DRIVE both forward-map to
+    Origin.AISTUDIO_DRIVE (origin_from_provider is total, non-injective only
+    in the reverse direction) -- "drive" must resolve identically to
+    "gemini", not fall back to unknown-export or raise."""
+    rollups = synthesize_provider_tag_rollups(
+        _FakeArchive(_counts()),  # type: ignore[arg-type]
+        provider="drive",
+        materialized_at="2026-07-12T00:00:00+00:00",
+    )
+    assert [r.tag for r in rollups] == ["origin:aistudio-drive"]
+    assert rollups[0].session_count == 7
+
+
+def test_gemini_and_drive_provider_filters_agree() -> None:
+    """Documents the known coarseness (not a bug this bead fixes): since no
+    storage tier persists which acquisition mechanism produced an
+    aistudio-drive session, both provider filters necessarily return the
+    identical rollup. Splitting them needs a durable capture-mode field
+    (tracked as this bead's follow-up), not a smarter reverse lookup here."""
+    gemini_rollups = synthesize_provider_tag_rollups(
+        _FakeArchive(_counts()),  # type: ignore[arg-type]
+        provider="gemini",
+        materialized_at="2026-07-12T00:00:00+00:00",
+    )
+    drive_rollups = synthesize_provider_tag_rollups(
+        _FakeArchive(_counts()),  # type: ignore[arg-type]
+        provider="drive",
+        materialized_at="2026-07-12T00:00:00+00:00",
+    )
+    assert [r.tag for r in gemini_rollups] == [r.tag for r in drive_rollups]
+    assert [r.session_count for r in gemini_rollups] == [r.session_count for r in drive_rollups]
+
+
+def test_no_provider_filter_returns_every_origin() -> None:
+    rollups = synthesize_provider_tag_rollups(
+        _FakeArchive(_counts()),  # type: ignore[arg-type]
+        materialized_at="2026-07-12T00:00:00+00:00",
+    )
+    assert {r.tag for r in rollups} == {
+        "origin:aistudio-drive",
+        "origin:codex-session",
+        "origin:claude-code-session",
+    }


### PR DESCRIPTION
## Summary

Adds a genuine, hint-based Source-family disambiguator for the non-injective
`Origin.AISTUDIO_DRIVE -> Provider` reverse lookup, instead of silently
picking `Provider.GEMINI` with no way for a caller with independent context
to recover `Provider.DRIVE`.

## Problem

`Origin.AISTUDIO_DRIVE` is produced by both `Provider.GEMINI` (offline
AI-Studio export bundles) and `Provider.DRIVE` (live Google-Drive-API
acquisition of the same AI-Studio content) -- a deliberate, documented,
non-injective collapse (`core/sources.py`). `provider_from_origin` had no way
to recover which fiber member applied for a given caller, so every reverse
lookup silently returned the canonical `Provider.GEMINI`, even for
Drive-acquired sessions (polylogue-9e5.8 Step 5; the phase-1 dedup this PR
stacks on, PR #2737, explicitly deferred fixing this to a follow-up
disambiguator rather than picking arbitrarily).

## Solution

- `core/sources.py`: added `origin_provider_fiber(origin) -> tuple[Provider, ...]`,
  built from the existing total `_PROVIDER_TO_ORIGIN` map (so it can't
  independently drift). `provider_from_origin` gained an optional
  keyword-only `family_hint: Provider | SourceFamily | None` -- when the hint
  resolves to a `Provider` inside the target origin's fiber, it is honored
  instead of the canonical default; an unresolvable or out-of-fiber hint
  falls back to canonical rather than raising (disambiguation is advisory
  input from a caller with independent context, not an attempt to
  reconstruct lost data).
- `archive_execution.py:_provider_for_origin`: threads `family_hint` through.
  Its own call site (`_session_to_session`) still has no independent hint
  available today -- `ArchiveSessionEnvelope` only carries the already-
  collapsed `origin` column -- so behavior there is unchanged; the site is
  now disambiguator-ready for a caller that does have one.
- `tag_rollups.py:49`: investigated per the bead's AC and found **not**
  lossy -- it performs the forward `Provider -> Origin` conversion
  (`origin_from_provider`), which is total and well-defined for both
  `"gemini"` and `"drive"` (both correctly resolve to the `aistudio-drive`
  origin filter already). Documented this finding in place with a comment;
  added regression tests proving both filters agree and neither silently
  breaks. The bead's AC listing this as a site needing disambiguation was
  misframed by the originating audit -- there is no reverse lookup here.

**Investigation finding, tracked as follow-up polylogue-2ilz:** no current
storage tier persists which of GEMINI/DRIVE produced an already-ingested
`aistudio-drive` session. `sessions`/`raw_sessions` only store the collapsed
`origin` column, `session_profiles.source_name` is set directly from
`session.origin` (same collapse), and both providers share one parser
(`sources/parsers/drive.py`) producing structurally identical JSON regardless
of acquisition mechanism -- so re-parsing raw bytes cannot recover it either.
`family_hint` therefore only helps callers with independent, out-of-band
knowledge (e.g. an explicit filter parameter) of which fiber member applies.
True per-session disambiguation for already-ingested and future sessions
needs a durable additive column on `raw_sessions` (source.db) capturing the
acquisition-time provider before the Origin collapse -- filed as
polylogue-2ilz, out of scope here.

## Verification

```
devtools test tests/unit/core/test_sources.py \
  tests/unit/archive/test_archive_execution_filters.py \
  tests/unit/insights/test_tag_rollups.py \
  tests/unit/core/test_provider_origin_dedup.py
-> 53 passed

mypy --strict polylogue/core/sources.py \
  polylogue/archive/query/archive_execution.py \
  polylogue/insights/tag_rollups.py \
  tests/unit/core/test_sources.py \
  tests/unit/archive/test_archive_execution_filters.py \
  tests/unit/insights/test_tag_rollups.py
-> Success: no issues found in 6 source files
```

Pre-push `devtools verify --quick` (format/lint/mypy/render/layering/etc.)
also ran clean via the repo's own hook.

Not run: the full/testmon `devtools verify` suite -- per operator directive,
the coordinator runs consolidated verification before merging tonight's
parallel-agent batch. GitHub CI is currently blocked by an account billing
lock unrelated to this diff.

## Stacking note

This branch is based on the open `fix/origin-provider-phase1` (PR #2737,
polylogue-9e5.8 Step 1) because it directly builds on that PR's delegation of
`_provider_for_origin` to the canonical `provider_from_origin` -- merge order
is #2737 first, then this one (rebases cleanly once #2737 lands on master).

## Acceptance criteria

- `archive_execution.py:46-48` disambiguates GEMINI from DRIVE using the new
  `family_hint` field: **satisfied** -- wired through, tested with a real
  hint (currently advisory-only pending polylogue-2ilz's durable field for
  its one call site).
- `tag_rollups.py:49` disambiguates GEMINI from DRIVE: **misframed** -- this
  line performs the well-defined forward conversion, not a lossy reverse
  lookup; investigated and documented in place, regression-tested instead.
- Regression test for both origins: **satisfied** -- `tests/unit/core/test_sources.py`,
  `tests/unit/archive/test_archive_execution_filters.py`, and
  `tests/unit/insights/test_tag_rollups.py` all cover both GEMINI and DRIVE.

Ref polylogue-4rrv