### PR TITLE
fix(nix): embed full git revision in packaged build identity

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -317,6 +317,64 @@ through the existing periodic-loop catch boundary in
 `polylogue/daemon/cli.py`; it does not crash the daemon. Dedup and
 rate-limiting are out of scope for this backend.
 
+## Build Identity & Deployment Attestation
+
+Every runtime (Nix package, `pip`/`uv` install from a git checkout, or an
+sdist) embeds the exact git commit it was built from and reports it through
+two channels, distinct on purpose:
+
+- **Concise human version** — `polylogue --version` / `polylogued --version`
+  and `polylogue.version.POLYLOGUE_VERSION`: `<pyproject-version>+<8-char
+  commit prefix>[-dirty]`, e.g. `0.1.0+d8194234`. Meant for logs and
+  `--version` banners, not for exact identity comparison — an 8-character
+  prefix is not collision-proof.
+- **Full machine-readable revision** — the same build's *complete* 40-character
+  commit hash, for attestation:
+  - `polylogue.version.VERSION_INFO.commit` (Python) — always the full hash,
+    never truncated.
+  - `polylogued status --json` → `archive_storage.identity.build_commit`
+    (also `.build_dirty`), from `ArchiveIdentity.as_dict()`
+    (`polylogue/storage/archive_identity.py`).
+  - `GET /metrics` → `polylogue_daemon_build_info{version="...",
+    revision="...", dirty="true|false"} 1` — `revision` is the full hash,
+    `version` is the concise human string above.
+
+For Nix-packaged deployments, the embedded commit comes from the flake's
+`self.rev` (or `self.dirtyRev` with the `-dirty` suffix stripped and tracked
+separately as `BUILD_DIRTY`, when the source tree was dirty at build time —
+see `flake.nix`'s `buildRevision`/`buildDirty` and the `checks.build-info`
+package-level proof that the embedded value matches `self`).
+
+**Joining runtime identity to deployment evidence.** A consuming flake (e.g.
+`sinnix`) pins Polylogue as a flake input and records its exact provenance in
+that flake's own `flake.lock`, under `nodes.polylogue.locked`:
+
+```json
+{
+  "rev": "d81942345…",       // full 40-char commit — compare directly to
+                              // polylogue_daemon_build_info{revision=…}
+  "narHash": "sha256-…"      // content hash of the fetched source tree
+}
+```
+
+To confirm a running daemon matches what was actually deployed:
+
+1. Read the running build's revision: `curl -s
+   http://127.0.0.1:8766/metrics | grep polylogue_daemon_build_info` (or
+   `polylogued status --json | jq .archive_storage.identity.build_commit`).
+2. Read the deploying flake's locked revision: `jq
+   .nodes.polylogue.locked.rev flake.lock` in the consuming repo (`sinnix`).
+3. The two full hashes must match exactly. A mismatch means the running
+   binary was built from a different commit than the one the deployment
+   flake currently locks — e.g. a `nixos-rebuild switch` that hasn't picked
+   up a `nix flake update` yet, or a manually-built/side-loaded package.
+   `narHash` corroborates that the fetched source tree content itself was
+   not tampered with in transit, independent of the `rev` string.
+4. `build_dirty` / `dirty="true"` means the build was taken from an
+   uncommitted working tree — there is no `rev` to join against a lockfile
+   at all for that build; treat it as unattested and rebuild from a clean
+   commit before trusting the comparison.
+
 ## Maintenance
 
 Maintenance tasks are split between daemon-owned (fast, inline) and

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,25 @@
       # directly (see tests/unit/devtools/test_cli_wrapper.py).
       devtoolsCli = pkgs.writeShellScriptBin "devtools" (builtins.readFile ./nix/devtools-wrapper.sh);
 
+      # Full immutable git revision embedded at build time (polylogue-6rvt).
+      #
+      # `self.rev`/`self.dirtyRev` (not `self.shortRev`/`self.dirtyShortRev`)
+      # so the packaged runtime can independently attest its exact source
+      # identity against a consuming flake's `flake.lock` `rev`/`narHash`
+      # entry for this input, not just a truncated, collision-prone prefix.
+      # `self.dirtyRev` carries a literal "-dirty" suffix baked into the
+      # string; strip it so `buildRevision` is always either a clean
+      # 40-character hex commit or the explicit sentinel "unknown", with
+      # dirtiness tracked separately in `buildDirty`.
+      buildDirty = self ? dirtyRev;
+      buildRevision =
+        if self ? rev then
+          self.rev
+        else if self ? dirtyRev then
+          pkgs.lib.removeSuffix "-dirty" self.dirtyRev
+        else
+          "unknown";
+
       polylogue = pkgs.python313Packages.buildPythonPackage {
         pname = "polylogue";
         version = "0.1.0";
@@ -29,8 +48,8 @@
 
         postPatch = ''
           cat > polylogue/_build_info.py << BUILDEOF
-          BUILD_COMMIT = "${self.shortRev or self.dirtyShortRev or "unknown"}"
-          BUILD_DIRTY = ${if self ? dirtyShortRev then "True" else "False"}
+          BUILD_COMMIT = "${buildRevision}"
+          BUILD_DIRTY = ${if buildDirty then "True" else "False"}
           BUILDEOF
         '';
 
@@ -251,6 +270,46 @@
             polylogue --help >/dev/null
             polylogued --help >/dev/null
             polylogue-mcp --help >/dev/null
+            touch $out
+          '';
+
+        # Package-level proof (polylogue-6rvt) that the full revision the
+        # running artifact reports actually matches this flake's `self`
+        # input, not just a plausible-looking string. Fails loudly if a
+        # future edit reintroduces truncation (e.g. reverting to
+        # `self.shortRev`) or drops the embedded metadata module.
+        build-info = pkgs.runCommand "polylogue-build-info"
+          {
+            nativeBuildInputs = [
+              polylogue
+            ];
+          }
+          ''
+            build_info="${polylogue}/${python.sitePackages}/polylogue/_build_info.py"
+            echo "checking $build_info" >&2
+            grep -qxF 'BUILD_COMMIT = "${buildRevision}"' "$build_info" || {
+              echo "embedded BUILD_COMMIT does not match flake self.rev/self.dirtyRev (${buildRevision})" >&2
+              cat "$build_info" >&2
+              exit 1
+            }
+            grep -qxF 'BUILD_DIRTY = ${if buildDirty then "True" else "False"}' "$build_info" || {
+              echo "embedded BUILD_DIRTY does not match flake dirty state (${if buildDirty then "True" else "False"})" >&2
+              cat "$build_info" >&2
+              exit 1
+            }
+            ${if buildRevision != "unknown" then ''
+              revision_len=$(printf '%s' "${buildRevision}" | wc -c)
+              [ "$revision_len" -eq 40 ] || {
+                echo "flake revision is not a full 40-character commit hash: ${buildRevision}" >&2
+                exit 1
+              }
+            '' else ""}
+            export HOME=$TMPDIR
+            polylogue --version | grep -qF "${builtins.substring 0 8 buildRevision}" || {
+              echo "polylogue --version does not surface the short prefix of the embedded revision" >&2
+              polylogue --version >&2
+              exit 1
+            }
             touch $out
           '';
 

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -33,7 +33,12 @@ Exposed series (label policy: use labels only when a series naturally
 varies on a known-bounded dimension):
 
 - ``polylogue_daemon_uptime_seconds`` (gauge) — process uptime
-- ``polylogue_daemon_build_info`` (gauge, value 1) — labels: version
+- ``polylogue_daemon_build_info`` (gauge, value 1) — labels: version,
+  revision, dirty. ``revision`` is the full (not truncated) git commit
+  the running build was compiled from — join it against a consuming
+  flake's ``flake.lock`` ``rev``/``narHash`` entry for the ``polylogue``
+  input to attest that the deployed runtime matches the locked source
+  (polylogue-6rvt).
 - ``polylogue_status_snapshot_age_seconds`` (gauge) — cached status age
 - ``polylogue_status_snapshot_state`` (gauge) — labels: state
 - ``polylogue_live_ingest_attempts_total`` (counter) — labels: status
@@ -943,17 +948,34 @@ def format_metrics(
         samples=[(None, uptime_s)],
     )
 
-    # Build info — version label so dashboards can break out per-release.
+    # Build info — version/revision/dirty labels so dashboards can break out
+    # per-release and operators can attest a running daemon against a
+    # consuming flake's locked `rev`/`narHash` for this input (polylogue-6rvt).
     try:
-        from polylogue import __version__ as polylogue_version
+        from polylogue.version import VERSION_INFO
+
+        build_version = VERSION_INFO.version
+        build_revision = VERSION_INFO.commit or "unknown"
+        build_dirty = VERSION_INFO.dirty
     except Exception:
-        polylogue_version = "unknown"
+        build_version = "unknown"
+        build_revision = "unknown"
+        build_dirty = False
     _emit_metric(
         lines,
         name="polylogue_daemon_build_info",
         help_text="Constant 1 gauge labelled with daemon build identity.",
         metric_type="gauge",
-        samples=[({"version": str(polylogue_version)}, 1)],
+        samples=[
+            (
+                {
+                    "version": str(build_version),
+                    "revision": str(build_revision),
+                    "dirty": "true" if build_dirty else "false",
+                },
+                1,
+            )
+        ],
     )
     _emit_archive_storage_metrics(lines, db)
     _emit_hook_flow_metrics(lines, db)

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -139,7 +139,26 @@ class TestFormatMetricsExpositionShape:
 
     def test_build_info_exposes_version_label(self, tmp_path: Path) -> None:
         body = format_metrics(tmp_path / "missing.db")
-        assert "polylogue_daemon_build_info{version=" in body
+        assert re.search(r'polylogue_daemon_build_info\{[^}]*\bversion="[^"]+"', body)
+
+    def test_build_info_exposes_full_revision_and_dirty_labels(self, tmp_path: Path) -> None:
+        """polylogue-6rvt: the metric must carry the full (untruncated) build
+        revision plus an explicit dirty flag, not just the human version
+        string — dashboards/attestation join on ``revision``, not
+        ``version``."""
+        from polylogue.version import VERSION_INFO
+
+        body = format_metrics(tmp_path / "missing.db")
+        match = re.search(r"polylogue_daemon_build_info\{([^}]*)\} 1", body)
+        assert match is not None, body
+        labels = dict(re.findall(r'(\w+)="([^"]*)"', match.group(1)))
+        assert labels["version"] == VERSION_INFO.version
+        assert labels["revision"] == (VERSION_INFO.commit or "unknown")
+        assert labels["dirty"] in {"true", "false"}
+        assert labels["dirty"] == ("true" if VERSION_INFO.dirty else "false")
+        # Never truncated to a short/collision-prone prefix.
+        if labels["revision"] != "unknown":
+            assert len(labels["revision"]) == 40
 
     def test_archive_storage_metrics_report_archive_file_sets(self, tmp_path: Path) -> None:
         from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database


### PR DESCRIPTION
## Summary

Nix-packaged Polylogue runtimes (`polylogue`/`polylogued`/`polylogue-mcp`) now embed the full 40-character git commit instead of a 7-character short revision, and the daemon's `polylogue_daemon_build_info` Prometheus metric now correctly exposes that full revision (it previously always reported `version="unknown"` due to a broken import).

## Problem

`flake.nix` wrote `BUILD_COMMIT` from `self.shortRev` (7 hex chars), so every packaged runtime — `polylogue --version`, `polylogued --version`, `ArchiveIdentity.build_commit` (daemon status JSON), and the daemon build-info metric — could only ever report a truncated, collision-prone prefix. The Nix build/flake.lock retain the full revision, but nothing embedded it into the artifact, so a running artifact couldn't independently attest its exact source identity against a consuming flake's `flake.lock` `rev`/`narHash` during schema-sensitive rollouts.

Separately, `polylogue_daemon_build_info` always reported `version="unknown"` because it imported the nonexistent `polylogue.__version__` (no such attribute on the package) inside a bare `try/except`.

Verified before fixing: building the package at HEAD (`d81942345…`) embedded `BUILD_COMMIT = "d819423"` (shortRev) into `_build_info.py`.

## Solution

- `flake.nix`: derive `buildRevision` from `self.rev` (falling back to `self.dirtyRev` with the literal `"-dirty"` suffix stripped, then `"unknown"`), and `buildDirty` from `self ? dirtyRev`; embed both into `polylogue/_build_info.py`. Added a `checks.build-info` derivation that builds the package and asserts the installed `_build_info.py`'s `BUILD_COMMIT`/`BUILD_DIRTY` literally match `self.rev`/`self.dirtyRev`, and that `polylogue --version` surfaces the matching short prefix — a package-level proof the reported revision matches the flake input.
- `polylogue/daemon/metrics.py`: fixed `polylogue_daemon_build_info` to source `version`/`revision`/`dirty` from `polylogue.version.VERSION_INFO` (the real API) instead of the broken `__version__` import, and added `revision` (full commit) and `dirty` labels alongside the existing concise `version` label.
- `docs/daemon.md`: new "Build Identity & Deployment Attestation" section documenting the concise-version vs. full-revision fields and how to join a running daemon's revision against a consuming flake's `flake.lock` `rev`/`narHash`.
- `tests/unit/daemon/test_metrics_endpoint.py`: replaced the substring-order-dependent version-label assertion (labels are emitted alphabetically sorted, so `{version=` no longer prefixes the label set once `dirty`/`revision` are added) with an order-independent check, plus a new test pinning the `revision`/`dirty` labels and the full 40-char length.

`polylogue/version.py` and the `storage/archive_identity.py` / `insights/export_bundles.py` read paths already exposed `VERSION_INFO.commit` as a full, untruncated field for source checkouts and PyPI/hatch builds (`git rev-parse HEAD` is already full there) — only the Nix packaging path and the metrics label were truncated/broken. No schema change.

## Acceptance criteria

- **Nix builds embed the full immutable revision when available** — done (`buildRevision`/`buildDirty` in `flake.nix`).
- **CLI and daemon observability expose it in a stable machine-readable field while retaining a concise human version** — done: `VERSION_INFO.commit` / `archive_storage.identity.build_commit` (daemon status JSON) / `polylogue_daemon_build_info{revision=...}` (Prometheus) are full; `polylogue --version` / `POLYLOGUE_VERSION` remain the concise 8-char-prefix human form.
- **Dirty/source-checkout behavior remains explicit** — done: `BUILD_DIRTY`/`VERSION_INFO.dirty`/`dirty="true|false"` label, derived from `self ? dirtyRev` in Nix.
- **A package-level test proves the reported full revision matches the flake input** — done: `checks.x86_64-linux.build-info` in `flake.nix`.
- **Document how operators join runtime identity to deployment lock/NAR evidence** — done: new `docs/daemon.md` section.

## Verification

- `nix flake check --no-build`: all checks pass.
- `nix build .#checks.x86_64-linux.build-info --no-link --print-out-paths`: passes; inspected the built store path directly — `_build_info.py` now contains `BUILD_COMMIT = "d819423459dc1fdf3c2a249a5182d8d3970df3dd"` (full 40 hex) and `BUILD_DIRTY = True` (dirty worktree at build time), vs. the prior `BUILD_COMMIT = "d819423"` on the same build.
- `devtools test tests/unit/daemon/test_metrics_endpoint.py tests/unit/core/test_version.py`: 59 passed.
- `mypy --strict polylogue/daemon/metrics.py`: no issues.
- Pre-push hook ran `devtools verify --quick` (format + lint + mypy + `render all --check`): exit 0.
- Not run: the full/heavy `devtools test`/`devtools verify --all` suite (per operator lean-verification directive for this session — the coordinator runs consolidated verification before merging).

Note: per the task instructions, GitHub CI is currently blocked by an account billing lock unrelated to this diff.

Ref polylogue-6rvt

🤖 Generated with [Claude Code](https://claude.com/claude-code)