### PR TITLE
fix(query): name the unsupported shape for sessions pipeline count/group

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -119,6 +119,7 @@ from polylogue.archive.query.metadata import (
     query_unit_field_names,
     structural_query_fields,
     structural_query_units,
+    terminal_query_source_list,
     terminal_query_source_pairs,
     terminal_query_unit,
 )
@@ -1966,6 +1967,32 @@ def _parse_plain_unit_source_expression(expression: str) -> QueryUnitSource | No
     return QueryUnitSource(unit=unit, predicate=bound)
 
 
+#: Shape-only prefixes for terminal pipeline stage keywords (``sort by``,
+#: ``group by``, ``limit``, ``offset``). ``count`` has no trailing argument so
+#: it is matched by exact equality instead. Used only to *recognize* that a
+#: stage has the shape of a terminal pipeline action -- never to validate its
+#: contents, so this never raises.
+_PIPELINE_STAGE_KEYWORD_PREFIXES: tuple[str, ...] = ("sort by ", "group by ", "limit ", "offset ")
+
+
+def _pipeline_stage_keyword(stage: str) -> str | None:
+    """Return the terminal pipeline stage keyword ``stage`` looks like, if any.
+
+    Distinguishes "this stage has the shape of `count`/`group by`/`sort by`/
+    `limit`/`offset` but was misapplied" from "this stage is unrecognized
+    entirely", so callers can raise a specific, actionable error instead of a
+    generic one for the former.
+    """
+
+    normalized = " ".join(stage.split()).lower()
+    if normalized == "count":
+        return "count"
+    for prefix in _PIPELINE_STAGE_KEYWORD_PREFIXES:
+        if normalized.startswith(prefix):
+            return prefix.strip()
+    return None
+
+
 def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
     stages = _split_pipeline_stages(expression)
     if not stages:
@@ -1979,8 +2006,21 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
         session_predicate = _session_source_predicate(first_stage)
         terminal_source = _parse_plain_unit_source_expression(second_stage)
         if terminal_source is None:
+            keyword = _pipeline_stage_keyword(second_stage)
+            if keyword is not None:
+                raise ExpressionCompileError(
+                    f"pipeline `{keyword}` cannot follow `sessions where ...` directly; "
+                    "`sessions` has no terminal row/aggregate lowerer of its own, only a session-scoping "
+                    "stage. To count matching sessions, use `find <predicate> then analyze --count` instead "
+                    "of a pipeline `| count`. To count/group/sort/limit rows of a specific terminal unit "
+                    "scoped to these sessions, pipe into an executable `<unit>s where ...` terminal stage "
+                    "first, e.g. `sessions where ... | actions where ... | group by FIELD | count`. "
+                    f"Supported terminal units: {terminal_query_source_list()}.",
+                    field=None,
+                )
             raise ExpressionCompileError(
-                "pipeline terminal stage must be an executable `<unit>s where ...` query",
+                "pipeline terminal stage must be an executable `<unit>s where ...` query "
+                f"(got {second_stage!r}); supported terminal units: {terminal_query_source_list()}.",
                 field=None,
             )
         scoped_session_predicate = _bind_scoped_session_predicate(session_predicate, terminal_unit=terminal_source.unit)

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -938,6 +938,57 @@ class TestBooleanQueryExpression:
         with pytest.raises(ExpressionCompileError, match="unsupported pipeline stage"):
             parse_unit_source_expression("sessions where repo:polylogue | messages where role:assistant | sample 3")
 
+    def test_pipeline_sessions_count_names_the_unsupported_shape(self) -> None:
+        """`sessions where ... | count` (polylogue-9srm): sessions has no terminal
+        row/aggregate lowerer of its own, so this must fail with an error that
+        names `count` specifically and points at the working alternative
+        (`find ... then analyze --count`), not the generic
+        "must be an executable `<unit>s where ...` query" message.
+        """
+
+        with pytest.raises(ExpressionCompileError) as exc_info:
+            parse_unit_source_expression("sessions where repo:polylogue | count")
+
+        message = str(exc_info.value)
+        assert "`count` cannot follow `sessions where ...` directly" in message
+        assert "analyze --count" in message
+        assert "actions/blocks" in message  # supported terminal units are named
+
+    def test_pipeline_sessions_group_by_names_the_unsupported_shape(self) -> None:
+        """Same as above for `group by` directly on `sessions where ...`
+        (polylogue-9srm): previously raised the identical generic message even
+        though `group by` (not the missing terminal stage) is the actual
+        problem.
+        """
+
+        with pytest.raises(ExpressionCompileError) as exc_info:
+            parse_unit_source_expression("sessions where origin:codex-session | group by origin | count")
+
+        message = str(exc_info.value)
+        assert "`group by` cannot follow `sessions where ...` directly" in message
+        assert "analyze --count" in message
+
+    @pytest.mark.parametrize("stage", ["sort by time", "limit 10", "offset 5"])
+    def test_pipeline_sessions_other_terminal_keywords_name_the_unsupported_shape(self, stage: str) -> None:
+        with pytest.raises(ExpressionCompileError) as exc_info:
+            parse_unit_source_expression(f"sessions where repo:polylogue | {stage}")
+
+        message = str(exc_info.value)
+        assert "cannot follow `sessions where ...` directly" in message
+
+    def test_pipeline_sessions_unrecognized_second_stage_keeps_generic_message(self) -> None:
+        """A second stage that isn't a `<unit>s where ...` query AND doesn't
+        look like a known terminal pipeline keyword still falls back to the
+        original generic message (now naming supported terminal units too).
+        """
+
+        with pytest.raises(ExpressionCompileError) as exc_info:
+            parse_unit_source_expression("sessions where repo:polylogue | not a real stage")
+
+        message = str(exc_info.value)
+        assert "must be an executable `<unit>s where ...` query" in message
+        assert "cannot follow `sessions where ...` directly" not in message
+
     def test_pipeline_accepts_sort_by_time_on_sql_run_rows(self) -> None:
         source = parse_unit_source_expression(
             "sessions where repo:polylogue | runs where status:completed | sort by time desc"


### PR DESCRIPTION
## Summary

Fixes the misleading error when a `sessions where ...` pipeline is
piped directly into a terminal aggregate stage (`count`, `group by`,
`sort by`, `limit`, `offset`) instead of into an executable
`<unit>s where ...` terminal source.

## Problem

Prod smoke test 2026-07-09: `sessions where repo:polylogue | count`
failed with `Error: pipeline terminal stage must be an executable
<unit>s where ... query`, even though the input already had that
exact shape for the first stage. `sessions where origin:codex-session
| group by origin | count` failed with the identical message, even
with `group by` present. Meanwhile `actions where is_error:true |
group by followup_class | count` succeeds (the exact example cited in
this repo's own CLAUDE.md).

Root cause: `sessions` is not a terminal query unit in this
architecture -- there is no `session` entry in `QueryUnitName` /
`QUERY_UNIT_DESCRIPTORS`, and `query_unit_counts` has no row-alias
mapping for it (`docs/search.md` documents this as deliberate:
"session-selector surfaces reject piped queries... instead of
dropping those stages and widening the query"). `sessions where ...`
is only ever a *session-scoping* first stage that must be followed by
a distinct terminal `<unit>s where ...` clause (e.g. `actions
where ...`). `actions where ... | group by ... | count` works because
`actions` is parsed as a direct terminal source, not through the
sessions-scoping branch. When the second stage after `sessions
where ...` is `count`/`group by ...`/etc. instead of a nested
`<unit>s where ...` clause, `_parse_plain_unit_source_expression`
returns `None` and the code raised a generic, unhelpful message that
doesn't explain *why* the input (which looks correct on its face)
doesn't work.

## Solution

`polylogue/archive/query/expression.py`:

- Added `_pipeline_stage_keyword()`, a shape-only (non-raising) probe
  that recognizes when a stage looks like `count`/`group by ...`/
  `sort by ...`/`limit N`/`offset N`.
- In `_parse_pipeline_unit_source`, when the second stage after
  `sessions where ...` fails to parse as a terminal `<unit>s
  where ...` source, check whether it has the shape of a known
  terminal pipeline keyword. If so, raise a specific error that:
  - names the keyword that was misapplied,
  - explains `sessions` has no terminal row/aggregate lowerer of its
    own, only a session-scoping stage,
  - points at the existing working alternative for a plain session
    count (`find <predicate> then analyze --count`, confirmed live at
    `polylogue/cli/archive_query.py:428-467` / `query_verbs.py:1937`),
  - shows the correct scoped-pipeline pattern (`sessions where ... |
    actions where ... | group by FIELD | count`),
  - lists the supported terminal units via the existing
    `terminal_query_source_list()` helper.
  - Otherwise (a truly unrecognized second stage), the original
    generic message is kept, now also naming supported terminal
    units.

This satisfies the acceptance criteria's second, explicitly-permitted
branch ("if some unit types genuinely cannot support a terminal
count, the error names them explicitly instead of a generic 'must be
executable' message") rather than the first branch (making `sessions
where ... | count` itself succeed), because making `sessions` a
first-class terminal-count unit would mean adding a new
`QueryUnitDescriptor`, wiring a new SQL aggregate row-alias, and
reversing the documented "pipeline syntax is terminal-row syntax;
session-selector surfaces reject piped queries... by design" decision
in `docs/search.md` -- out of scope for a P2 error-message bug, and an
existing, already-wired surface (`analyze --count`) already answers
the "how many sessions match" question the smoke test was really
asking.

### Alternatives rejected

Wiring `sessions` itself into `QUERY_UNIT_DESCRIPTORS` /
`query_unit_counts` so `sessions where ... | count` succeeds directly:
rejected as a larger, riskier change than the bug's severity (P2,
error-message clarity) warrants, and it would silently reverse a
documented, deliberate architectural decision (`docs/search.md`
lines ~157-159) rather than a smaller, evidence-first fix. Left as a
possible follow-up if the operator wants `sessions` promoted to a
first-class terminal unit.

## Verification

- `devtools test tests/unit/cli/test_query_expression.py -k pipeline`
  → 44 passed, 1 skipped
- `devtools test tests/unit/api/test_facade_contracts.py -k "pipeline or count"`
  → 6 passed
- `mypy --strict polylogue/archive/query/expression.py tests/unit/cli/test_query_expression.py`
  → Success: no issues found in 2 source files
- Pre-push hook ran `devtools verify --quick` (format + lint + mypy +
  render-all-check) automatically → exit 0
- Not run: full `devtools verify`/broad `devtools test` (deferred to
  coordinator per operator directive for this session; GitHub CI is
  also currently blocked by an unrelated account billing lock)

Ref polylogue-9srm