### PR TITLE
docs(testing): document testmon collection-time-import blind spot

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -170,6 +170,72 @@ For optional lane, mutation-campaign, and benchmark inventories, see
 secondary navigation over executable checks; the source of truth for behavior is
 pytest plus the concrete `polylogue`/`devtools` commands they invoke.
 
+### Known limitation: collection-time-only imports are invisible to testmon
+
+`pytest-testmon` only builds a file-to-test dependency edge while a specific
+test is *running* (its `pytest_runtest_protocol` hookwrapper opens the tracing
+window). Anything a test module or `conftest.py` executes at **collection
+time** — a bare `from polylogue.x import Y` at the top of a test file, before
+any test in that file has started — falls outside every test's tracing
+window and is never recorded, even though the coverage.py summary for a
+normal `--cov` run legitimately counts those lines as executed. The result:
+declarative-only modules (`TypedDict`/dataclass/`Protocol`/enum/Pydantic
+model definitions, no behavior beyond class/field statements) that are only
+ever referenced via a top-level import in test files show **zero** rows in
+`.cache/testmon/testmondata`'s `file_fp` table, no matter how much of the
+file's statements a full-suite coverage run reports as covered. This is
+inherent to how testmon (and coverage-context-based selective testing in
+general) works — it is **not** dependency-graph staleness, and running
+`devtools verify --seed-testmon` does not fix it.
+
+Confirmed reproducible (2026-07-12, polylogue-csg7) with an isolated,
+freshly-seeded testmon run scoped to exactly one test file: after
+`TESTMON_DATAFILE=<scratch> pytest --testmon --testmon-noselect
+tests/unit/devtools/test_verify_manifests.py`, `polylogue/verification/manifests/models.py`
+still has 0 `file_fp` rows even though a `--cov` run over the same test file
+reports 80% statement coverage on that module — all of it from Pydantic
+model/field declarations executed when `devtools.verify_manifests` is
+imported at module-collection time; every uncovered line is inside a
+`@field_validator`/`@model_validator` method body, which only runs when
+`validate_manifest()` is actually called (no test in that file calls it).
+
+Cross-referencing a full-suite `coverage.json` (`--cov=polylogue`) against
+`file_fp` filenames finds **95 files** under `polylogue/` with nonzero
+covered statements but zero testmon dependency rows — largely `*_models.py`,
+`types.py`, `protocols.py`, `enums.py`, and `api/contracts/*.py`, i.e. modules
+whose test-suite touch points are import-only. Query:
+
+```python
+import json, sqlite3
+cov = json.load(open(".cache/coverage/coverage.json"))["files"]
+tm = {r[0] for r in sqlite3.connect(".cache/testmon/testmondata")
+      .execute("SELECT DISTINCT filename FROM file_fp")}
+gaps = [(f, d["summary"]["covered_lines"]) for f, d in cov.items()
+        if d["summary"]["covered_lines"] > 0 and f not in tm]
+```
+
+**Blast radius:** the default `devtools verify` gate (`--testmon
+--testmon-forceselect`) is the only local pre-merge signal for a change
+scoped to one of these files — `devtools test <file>` forwards a literal
+pytest selection and is not testmon-aware, so it does not share this gap
+(point it at the file's *owning test module*, not the changed source file).
+A change confined to one of these 95 files can select zero tests locally and
+still report a clean `devtools verify`. The heavy full-suite `devtools verify
+coverage` CI job (`.github/workflows/ci.yml`) does not use testmon selection
+and still catches such a regression, but only **post-merge** (it is
+intentionally off the per-PR gate) — so the exposure window is "merged before
+caught," not "never caught."
+
+**Mitigation:** there is no testmon configuration knob for this — it is
+upstream tool behavior. When changing a file that is purely declarative
+(only type/model/protocol definitions, no function bodies with real logic),
+do not trust "0 tests selected" from the default `devtools verify` gate as
+proof of safety; run the file's owning test module directly with `devtools
+test <test-file>`, and rely on `mypy --strict` (already in the default gate)
+to catch structural regressions in `TypedDict`/protocol shapes. See
+polylogue-csg7 for the investigation and a follow-up tracking item for making
+this gap machine-checkable.
+
 ## Test Suite Layout
 
 ```text


### PR DESCRIPTION
## Summary
- Root-causes the testmon fingerprint-graph vs coverage discrepancy named in polylogue-csg7: `polylogue/verification/manifests/models.py` has zero `file_fp` rows in `.cache/testmon/testmondata` despite ~80% statement coverage in a full-suite run.
- Confirms this is a **structural, permanent limitation** of `pytest-testmon` (persists after a fresh `--seed-testmon` rebuild), not staleness.
- Documents the mechanism, an isolated repro, and the quantified blast radius (95 files under `polylogue/`) in `TESTING.md`.

## Problem
While cross-referencing testmon's dependency database against a fresh coverage run, `polylogue-9e5.11`'s follow-up work surfaced a file with zero recorded test dependents yet substantial real coverage. It was unclear whether this was one-off staleness or a systemic tracer blind spot — the answer determines whether `devtools verify`'s default testmon-narrowed inner loop can be trusted for files like this one.

## Solution
Built an isolated reproduction scoped to exactly the test file the bead named (`tests/unit/devtools/test_verify_manifests.py`), using a scratch `TESTMON_DATAFILE` and a fresh `--testmon --testmon-noselect` seed — the gap persists. Root cause: `pytest-testmon`'s coverage-context tracing window opens only inside `pytest_runtest_protocol` (i.e. only during an individual test's actual execution). A bare top-level `from X import Y` in a test module executes during pytest's *collection* phase, before any test in that file has run, so it falls outside every test's tracing window and never gets a `file_fp` row — even though a plain `--cov` run's session-wide tracer legitimately counts those lines as covered. For `models.py`, every "missing" (uncovered) line under `--cov` is inside a `@field_validator`/`@model_validator` method body; the ~80% that *is* covered is exactly the Pydantic class/field declarations executed when `devtools.verify_manifests` (imported at the top of the test file) transitively imports `models.py`. No test in that file ever calls `validate_manifest()`.

Cross-referenced the checked-out `.cache/coverage/coverage.json` (full-suite `--cov=polylogue`) against `.cache/testmon/testmondata`'s `file_fp` table and found 95 files under `polylogue/` with the same signature — mostly `*_models.py`, `types.py`, `protocols.py`, `enums.py`, `api/contracts/*.py`: declarative-only modules whose only test-suite touch point is an import. Spot-checked a second, only-partially-covered file (`polylogue/storage/sqlite/queries/tool_usage.py`) to rule out a different cause (e.g. subprocess/multiprocessing tracing) — same root cause confirmed.

`devtools test <file>` is **not** affected (it forwards a literal pytest selection, not testmon-aware). The exposure is specifically the default `devtools verify` gate (`--testmon --testmon-forceselect`): a change confined to one of these 95 files can select zero tests locally and still report clean. CI's heavy `devtools verify coverage` job is not testmon-selected and still catches such a regression, but only post-merge (intentionally off the per-PR path).

No code fix in this PR — this is upstream `pytest-testmon` behavior with no configuration knob to change it. `TESTING.md` gets a new "Known limitation: collection-time-only imports are invisible to testmon" section with the mechanism, repro, the reusable cross-reference query, and mitigation guidance. Filed polylogue-vyxq (discovered-from this bead) to build a periodic `devtools lab` audit that tracks the blind-spot set over time — scoped separately since it needs a real heuristic (declarative-only vs. real untested logic) rather than being a narrow fix.

## Verification
- `TESTMON_DATAFILE=<scratch> .venv/bin/python -m pytest --testmon --testmon-noselect tests/unit/devtools/test_verify_manifests.py` then `sqlite3 <scratch> "SELECT DISTINCT filename FROM file_fp WHERE filename LIKE '%manifests%'"` → `models.py` absent, `verify_manifests.py`/test file present.
- `.venv/bin/python -m pytest --cov=polylogue.verification.manifests.models tests/unit/devtools/test_verify_manifests.py --cov-report=term-missing` → 80% coverage, all missing lines inside validator method bodies.
- Python cross-reference script (in `TESTING.md`) against the main checkout's `.cache/coverage/coverage.json` + `.cache/testmon/testmondata` → 95-file blast radius.
- Pre-push `devtools verify --quick` (ruff format/check, mypy --strict, render all, layering/topology/manifests/ci-workflows/doc-commands/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly checks) — all green (`git push` hook output).
- Not run: broad `devtools verify`/`devtools test` — reserved for the coordinator per this session's lean-verification directive. GitHub CI is currently blocked by an unrelated account billing lock.

Ref polylogue-csg7