### PR TITLE
feat(refs): add delegation ObjectRef kind and ingest-shaped fixtures

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -31,7 +31,7 @@ from polylogue.context.compiler import (
 )
 from polylogue.core.enums import AssertionKind, AssertionStatus, MaterialOrigin, Origin, Provider
 from polylogue.core.json import JSONDocument
-from polylogue.core.refs import EvidenceRef, ObjectRef, parse_public_ref
+from polylogue.core.refs import EvidenceRef, ObjectRef, parse_delegation_edge_object_id, parse_public_ref
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.core.timestamps import parse_archive_datetime
 from polylogue.core.user_state_targets import TARGET_MESSAGE, TARGET_SESSION
@@ -2755,6 +2755,8 @@ class PolylogueArchiveMixin:
                 return self._resolve_block_object_ref(archive, ref, normalized_ref, object_ref, evidence_ref)
             if object_ref.kind == "assertion":
                 return self._resolve_assertion_object_ref(archive_root, ref, normalized_ref, object_ref)
+            if object_ref.kind == "delegation":
+                return self._resolve_delegation_object_ref(archive, ref, normalized_ref, object_ref)
             if object_ref.kind in {"run", "observed-event", "context-snapshot"}:
                 return self._resolve_runtime_object_ref(archive, ref, normalized_ref, object_ref)
             if object_ref.kind in _PENDING_OBJECT_REF_KINDS:
@@ -2972,6 +2974,77 @@ class PolylogueArchiveMixin:
             object_refs=(normalized_ref, payload.target_ref),
             evidence_refs=payload.evidence_refs,
             actions=(_resolution_action("list assertion target", f"polylogue find {payload.target_ref} then read"),),
+        )
+
+    def _resolve_delegation_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        object_ref: ObjectRef,
+    ) -> PublicRefResolutionPayload:
+        """Resolve a ``delegation:`` ref against the polylogue-y964 `delegations`
+        view. Two id shapes share one lookup: action-observed refs carry an
+        ``instruction_tool_use_block_id`` verbatim; edge-only refs carry the
+        deterministic ``edge:<parent>::<child>`` relation identity (no
+        parent-side dispatch action exists to key off for edge_only/
+        quarantined attempts). Missing, ambiguous, edge_only, and quarantined
+        states are returned as typed payloads, never silently guessed."""
+
+        from polylogue.surfaces.payloads import (
+            DELEGATION_STATE_CAVEATS,
+            DelegationAttemptPayload,
+            PublicRefResolutionPayload,
+            model_json_document,
+        )
+
+        edge_identity = parse_delegation_edge_object_id(object_ref.object_id)
+        if edge_identity is not None:
+            parent_session_id, child_session_id = edge_identity
+            row = archive.get_delegation_attempt(parent_session_id=parent_session_id, child_session_id=child_session_id)
+        else:
+            row = archive.get_delegation_attempt(instruction_tool_use_block_id=object_ref.object_id)
+
+        if row is None:
+            return PublicRefResolutionPayload(
+                ref=ref,
+                normalized_ref=normalized_ref,
+                kind="delegation",
+                resolved=False,
+                payload_kind="missing",
+                caveats=("delegation attempt not found for this identity",),
+            )
+
+        payload = DelegationAttemptPayload.from_row(row)
+        object_refs = [f"session:{payload.parent_session_id}"]
+        if payload.child_session_id is not None:
+            object_refs.append(f"session:{payload.child_session_id}")
+        evidence_refs: list[str] = []
+        if payload.instruction_tool_use_block_id is not None:
+            evidence_refs.append(f"block:{payload.instruction_tool_use_block_id}")
+        elif payload.instruction_message_id is not None:
+            evidence_refs.append(f"message:{payload.instruction_message_id}")
+        if payload.artifact_block_id is not None:
+            evidence_refs.append(f"block:{payload.artifact_block_id}")
+        caveats: tuple[str, ...] = ()
+        state_caveat = DELEGATION_STATE_CAVEATS.get(payload.mapping_state)
+        if state_caveat is not None:
+            caveats = (state_caveat,)
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="delegation",
+            resolved=True,
+            payload_kind="delegation-attempt",
+            payload=model_json_document(payload),
+            title=f"delegation attempt ({payload.mapping_state})",
+            summary=payload.instruction_payload,
+            object_refs=tuple(object_refs),
+            evidence_refs=tuple(evidence_refs),
+            caveats=caveats,
+            actions=(
+                _resolution_action("read parent session", f"polylogue find id:{payload.parent_session_id} then read"),
+            ),
         )
 
     def _resolve_runtime_object_ref(

--- a/polylogue/core/refs.py
+++ b/polylogue/core/refs.py
@@ -47,6 +47,19 @@ ObjectRefKind: TypeAlias = Literal[
     "cohort",
     "analysis",
     "annotation-batch",
+    # polylogue-lph4: delegation attempt identity, reusing the polylogue-y964
+    # `delegations` view vocabulary. Two id shapes share this one kind:
+    #   - action-observed (resolved/unresolved/ambiguous): object_id is the
+    #     parent-side dispatch `instruction_tool_use_block_id` verbatim. That
+    #     block id already embeds its owning session_id as a structural
+    #     prefix, so (parent_session_id, instruction_tool_use_block_id) is
+    #     fully recoverable from the id alone -- no extra encoding needed.
+    #   - edge-only (edge_only/quarantined, no parent-side dispatch action
+    #     to key off): object_id is ``edge:<parent_session_id>::<child_session_id>``,
+    #     a deterministic relation identity over the resolved session_links
+    #     pair. ``::`` is used as the internal separator (matching
+    #     EvidenceRef) because session ids themselves may contain ``:``.
+    "delegation",
 ]
 
 EvidenceRefKind: TypeAlias = Literal["session", "message", "block"]
@@ -89,6 +102,7 @@ _OBJECT_REF_KINDS: Final[dict[str, ObjectRefKind]] = {
     "cohort": "cohort",
     "analysis": "analysis",
     "annotation-batch": "annotation-batch",
+    "delegation": "delegation",
 }
 
 
@@ -232,13 +246,50 @@ def _parse_object_ref_kind(value: str) -> ObjectRefKind:
         raise ValueError(f"unsupported object ref kind: {value!r}") from exc
 
 
+_DELEGATION_EDGE_PREFIX: Final[str] = "edge:"
+
+
+def delegation_edge_object_id(parent_session_id: str, child_session_id: str) -> str:
+    """Return the deterministic edge-only delegation object id.
+
+    Used when a resolved child has no discoverable parent-side dispatch
+    action to key off (``mapping_state`` ``edge_only``/``quarantined`` in
+    the ``delegations`` view) -- there is no ``instruction_tool_use_block_id``
+    to anchor identity on, so identity falls back to the resolved
+    ``session_links`` relation itself.
+    """
+
+    if not parent_session_id or not child_session_id:
+        raise ValueError("delegation edge identity requires non-empty parent and child session ids")
+    return f"{_DELEGATION_EDGE_PREFIX}{parent_session_id}::{child_session_id}"
+
+
+def parse_delegation_edge_object_id(object_id: str) -> tuple[str, str] | None:
+    """Split a delegation object id into ``(parent_session_id, child_session_id)``.
+
+    Returns ``None`` when ``object_id`` is not the edge-only shape -- callers
+    should then treat it as an action-observed
+    ``instruction_tool_use_block_id`` instead.
+    """
+
+    if not object_id.startswith(_DELEGATION_EDGE_PREFIX):
+        return None
+    remainder = object_id[len(_DELEGATION_EDGE_PREFIX) :]
+    parent_session_id, separator, child_session_id = remainder.partition("::")
+    if not separator or not parent_session_id or not child_session_id:
+        return None
+    return parent_session_id, child_session_id
+
+
 __all__ = [
     "EvidenceRef",
     "EvidenceRefKind",
     "ObjectRef",
     "ObjectRefKind",
     "PublicRef",
+    "delegation_edge_object_id",
     "normalize_object_ref_text",
     "normalize_public_ref_text",
+    "parse_delegation_edge_object_id",
     "parse_public_ref",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -407,6 +407,102 @@ def _archive_action_query_row(row: sqlite3.Row) -> ArchiveActionQueryRow:
     )
 
 
+DelegationMappingState = Literal["resolved", "unresolved", "ambiguous", "edge_only", "quarantined"]
+DelegationResultStatus = Literal["ok", "error", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveDelegationQueryRow:
+    """Terminal query projection over one `delegations` view row
+    (polylogue-y964). ``mapping_state`` is the view's own vocabulary --
+    resolved/unresolved/ambiguous/edge_only/quarantined -- never
+    reinterpreted here. Action-observed rows (resolved/unresolved/ambiguous)
+    always carry ``instruction_tool_use_block_id``; edge-only rows
+    (edge_only/quarantined) never fabricate one."""
+
+    parent_session_id: str
+    child_session_id: str | None
+    mapping_state: DelegationMappingState
+    link_confidence: float | None
+    link_method: str | None
+    inheritance: str | None
+    branch_point_message_id: str | None
+    instruction_message_id: str | None
+    instruction_tool_use_block_id: str | None
+    instruction_payload: str | None
+    dispatch_turn_model: str | None
+    requested_model: str | None
+    artifact_block_id: str | None
+    artifact_text: str | None
+    result_is_error: int | None
+    result_exit_code: int | None
+    result_status: DelegationResultStatus
+    parent_origin: str
+    parent_session_dominant_model: str | None
+    parent_session_dominant_model_family: str | None
+    parent_terminal_state: str | None
+    child_session_dominant_model: str | None
+    child_session_dominant_model_family: str | None
+    child_cost_usd: float | None
+    child_cost_is_estimated: int | None
+    child_tokens: int | None
+    child_wall_ms: int | None
+    child_terminal_state: str | None
+
+
+def _archive_delegation_query_row(row: sqlite3.Row) -> ArchiveDelegationQueryRow:
+    return ArchiveDelegationQueryRow(
+        parent_session_id=str(row["parent_session_id"]),
+        child_session_id=str(row["child_session_id"]) if row["child_session_id"] is not None else None,
+        mapping_state=cast(DelegationMappingState, str(row["mapping_state"])),
+        link_confidence=float(row["link_confidence"]) if row["link_confidence"] is not None else None,
+        link_method=str(row["link_method"]) if row["link_method"] is not None else None,
+        inheritance=str(row["inheritance"]) if row["inheritance"] is not None else None,
+        branch_point_message_id=(
+            str(row["branch_point_message_id"]) if row["branch_point_message_id"] is not None else None
+        ),
+        instruction_message_id=(
+            str(row["instruction_message_id"]) if row["instruction_message_id"] is not None else None
+        ),
+        instruction_tool_use_block_id=(
+            str(row["instruction_tool_use_block_id"]) if row["instruction_tool_use_block_id"] is not None else None
+        ),
+        instruction_payload=str(row["instruction_payload"]) if row["instruction_payload"] is not None else None,
+        dispatch_turn_model=str(row["dispatch_turn_model"]) if row["dispatch_turn_model"] is not None else None,
+        requested_model=str(row["requested_model"]) if row["requested_model"] is not None else None,
+        artifact_block_id=str(row["artifact_block_id"]) if row["artifact_block_id"] is not None else None,
+        artifact_text=str(row["artifact_text"]) if row["artifact_text"] is not None else None,
+        result_is_error=int(row["result_is_error"]) if row["result_is_error"] is not None else None,
+        result_exit_code=int(row["result_exit_code"]) if row["result_exit_code"] is not None else None,
+        result_status=cast(DelegationResultStatus, str(row["result_status"])),
+        parent_origin=str(row["parent_origin"]),
+        parent_session_dominant_model=(
+            str(row["parent_session_dominant_model"]) if row["parent_session_dominant_model"] is not None else None
+        ),
+        parent_session_dominant_model_family=(
+            str(row["parent_session_dominant_model_family"])
+            if row["parent_session_dominant_model_family"] is not None
+            else None
+        ),
+        parent_terminal_state=(str(row["parent_terminal_state"]) if row["parent_terminal_state"] is not None else None),
+        child_session_dominant_model=(
+            str(row["child_session_dominant_model"]) if row["child_session_dominant_model"] is not None else None
+        ),
+        child_session_dominant_model_family=(
+            str(row["child_session_dominant_model_family"])
+            if row["child_session_dominant_model_family"] is not None
+            else None
+        ),
+        child_cost_usd=float(row["child_cost_usd"]) if row["child_cost_usd"] is not None else None,
+        child_cost_is_estimated=(
+            int(row["child_cost_is_estimated"]) if row["child_cost_is_estimated"] is not None else None
+        ),
+        child_tokens=int(row["child_tokens"]) if row["child_tokens"] is not None else None,
+        child_wall_ms=int(row["child_wall_ms"]) if row["child_wall_ms"] is not None else None,
+        child_terminal_state=str(row["child_terminal_state"]) if row["child_terminal_state"] is not None else None,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ArchiveFileQueryRow:
     """Terminal query projection over affected file-path evidence."""
@@ -6973,6 +7069,45 @@ class ArchiveStore:
             [*normalized_session_ids, normalized_limit, normalized_offset],
         ).fetchall()
         return [_archive_action_query_row(row) for row in rows]
+
+    def get_delegation_attempt(
+        self,
+        *,
+        instruction_tool_use_block_id: str | None = None,
+        parent_session_id: str | None = None,
+        child_session_id: str | None = None,
+    ) -> ArchiveDelegationQueryRow | None:
+        """Resolve one `delegations` row (polylogue-y964) by its ref identity.
+
+        Action-observed identity (resolved/unresolved/ambiguous): pass only
+        ``instruction_tool_use_block_id``. Edge-only identity (edge_only/
+        quarantined -- no parent-side dispatch action to key off): pass both
+        ``parent_session_id`` and ``child_session_id``; only rows with no
+        instruction (the edge-only mapping states) are eligible so this path
+        never shadows an action-observed row for the same pair.
+        """
+
+        if instruction_tool_use_block_id is not None:
+            row = self._conn.execute(
+                "SELECT * FROM delegations WHERE instruction_tool_use_block_id = ? LIMIT 1",
+                (instruction_tool_use_block_id,),
+            ).fetchone()
+        elif parent_session_id is not None and child_session_id is not None:
+            row = self._conn.execute(
+                """
+                SELECT * FROM delegations
+                WHERE parent_session_id = ? AND child_session_id = ?
+                  AND mapping_state IN ('edge_only', 'quarantined')
+                LIMIT 1
+                """,
+                (parent_session_id, child_session_id),
+            ).fetchone()
+        else:
+            raise ValueError(
+                "get_delegation_attempt requires either instruction_tool_use_block_id or both "
+                "parent_session_id and child_session_id"
+            )
+        return None if row is None else _archive_delegation_query_row(row)
 
     def query_files(
         self,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
         ArchiveAssertionQueryRow,
         ArchiveBlockQueryRow,
         ArchiveContextSnapshotQueryRow,
+        ArchiveDelegationQueryRow,
         ArchiveFileQueryRow,
         ArchiveMessageQueryRow,
         ArchiveObservedEventQueryRow,
@@ -1788,6 +1789,116 @@ class PendingObjectRefPayload(SurfacePayloadModel):
     unit: Literal["pending"] = "pending"
     kind: str
     reason: Literal["substrate-pending"] = "substrate-pending"
+
+
+_DELEGATION_TEXT_BOUND = 2000
+
+
+def _bounded_delegation_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if len(value) <= _DELEGATION_TEXT_BOUND:
+        return value
+    return value[:_DELEGATION_TEXT_BOUND] + "…[truncated]"
+
+
+DelegationMappingState: TypeAlias = Literal["resolved", "unresolved", "ambiguous", "edge_only", "quarantined"]
+DelegationResultStatus: TypeAlias = Literal["ok", "error", "unknown"]
+
+
+class DelegationAttemptPayload(SurfacePayloadModel):
+    """Bounded read payload for one delegation attempt (polylogue-y964
+    `delegations` view, polylogue-lph4 ObjectRef normalization).
+
+    ``mapping_state`` mirrors the view's own vocabulary exactly --
+    resolved/unresolved/ambiguous/edge_only/quarantined -- never
+    reinterpreted here. Action-observed rows (resolved/unresolved/ambiguous)
+    always carry a non-null ``instruction_tool_use_block_id``; edge-only rows
+    (edge_only/quarantined) never fabricate one. Instruction/artifact text is
+    length-bounded (never full-session content) to keep this a citable
+    evidence pointer, not a transcript dump.
+    """
+
+    unit: Literal["delegation-attempt"] = "delegation-attempt"
+    parent_session_id: str
+    child_session_id: str | None = None
+    mapping_state: DelegationMappingState
+    link_confidence: float | None = None
+    link_method: str | None = None
+    inheritance: str | None = None
+    branch_point_message_id: str | None = None
+    instruction_message_id: str | None = None
+    instruction_tool_use_block_id: str | None = None
+    instruction_payload: str | None = None
+    dispatch_turn_model: str | None = None
+    requested_model: str | None = None
+    artifact_block_id: str | None = None
+    artifact_text: str | None = None
+    result_is_error: bool | None = None
+    result_exit_code: int | None = None
+    result_status: DelegationResultStatus
+    parent_origin: str
+    parent_session_dominant_model: str | None = None
+    parent_session_dominant_model_family: str | None = None
+    parent_terminal_state: str | None = None
+    child_session_dominant_model: str | None = None
+    child_session_dominant_model_family: str | None = None
+    child_cost_usd: float | None = None
+    child_cost_is_estimated: bool | None = None
+    child_tokens: int | None = None
+    child_wall_ms: int | None = None
+    child_terminal_state: str | None = None
+
+    @classmethod
+    def from_row(cls, row: ArchiveDelegationQueryRow) -> DelegationAttemptPayload:
+        return cls(
+            parent_session_id=row.parent_session_id,
+            child_session_id=row.child_session_id,
+            mapping_state=row.mapping_state,
+            link_confidence=row.link_confidence,
+            link_method=row.link_method,
+            inheritance=row.inheritance,
+            branch_point_message_id=row.branch_point_message_id,
+            instruction_message_id=row.instruction_message_id,
+            instruction_tool_use_block_id=row.instruction_tool_use_block_id,
+            instruction_payload=_bounded_delegation_text(row.instruction_payload),
+            dispatch_turn_model=row.dispatch_turn_model,
+            requested_model=row.requested_model,
+            artifact_block_id=row.artifact_block_id,
+            artifact_text=_bounded_delegation_text(row.artifact_text),
+            result_is_error=None if row.result_is_error is None else bool(row.result_is_error),
+            result_exit_code=row.result_exit_code,
+            result_status=row.result_status,
+            parent_origin=row.parent_origin,
+            parent_session_dominant_model=row.parent_session_dominant_model,
+            parent_session_dominant_model_family=row.parent_session_dominant_model_family,
+            parent_terminal_state=row.parent_terminal_state,
+            child_session_dominant_model=row.child_session_dominant_model,
+            child_session_dominant_model_family=row.child_session_dominant_model_family,
+            child_cost_usd=row.child_cost_usd,
+            child_cost_is_estimated=None if row.child_cost_is_estimated is None else bool(row.child_cost_is_estimated),
+            child_tokens=row.child_tokens,
+            child_wall_ms=row.child_wall_ms,
+            child_terminal_state=row.child_terminal_state,
+        )
+
+
+#: Caveats surfaced for delegation attempt states that structurally cannot
+#: (or must not) claim a fully resolved child -- keeps `resolve_ref` honest
+#: about what each `mapping_state` does and does not know (polylogue-y964
+#: vocabulary, polylogue-lph4 ObjectRef surface).
+DELEGATION_STATE_CAVEATS: dict[str, str] = {
+    "unresolved": "dispatch action observed but no child session resolved yet (mapping_state=unresolved)",
+    "ambiguous": (
+        "dispatch and resolved-child counts disagree for this parent; the real instruction is known but the "
+        "child cannot be attributed without guessing (mapping_state=ambiguous)"
+    ),
+    "edge_only": (
+        "resolved child session with no discoverable parent-side dispatch action "
+        "(mapping_state=edge_only) -- instruction is never fabricated"
+    ),
+    "quarantined": "session link quarantined as a lineage cycle-break (mapping_state=quarantined)",
+}
 
 
 class SessionReadViewEnvelope(SurfacePayloadModel):

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -37,7 +37,8 @@ import pytest
 from polylogue import Polylogue
 from polylogue.api.archive import SessionNotFoundError
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import AssertionKind, AssertionStatus, BlockType, MaterialOrigin, Origin, Provider
+from polylogue.core.enums import AssertionKind, AssertionStatus, BlockType, BranchType, MaterialOrigin, Origin, Provider
+from polylogue.core.refs import delegation_edge_object_id
 from polylogue.errors import DatabaseError, PolylogueError
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
@@ -2319,6 +2320,219 @@ async def test_resolve_ref_returns_assertion_payload(tmp_path: Path) -> None:
         assert payload.payload is not None
         assert payload.payload["assertion_id"] == "assertion-ref-resolution"
         assert payload.evidence_refs == ("codex-session:ref-resolution-v1",)
+    finally:
+        await archive.close()
+
+
+def _delegation_parent_session(*, provider_session_id: str, with_dispatch: bool) -> ParsedSession:
+    """Ingest-shaped parent fixture: writes real session/message/block rows
+    through the live archive writer (``ArchiveStore.write_parsed`` ->
+    ``write_parsed_session_to_archive``), the same seam the daemon uses --
+    not a hand-inserted SQL row. A Task ``tool_use``/``tool_result`` pair
+    gets classified ``semantic_type='subagent'`` at write time
+    (``polylogue/storage/sqlite/archive_tiers/write.py:_semantic_type``),
+    which is what the polylogue-y964 `delegations` view spines on."""
+
+    messages = [
+        ParsedMessage(
+            provider_message_id="turn-0",
+            role=Role.USER,
+            text="please look into this",
+            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="please look into this")],
+        )
+    ]
+    if with_dispatch:
+        messages.append(
+            ParsedMessage(
+                provider_message_id="dispatch",
+                role=Role.ASSISTANT,
+                model_name="claude-opus-4-8",
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Task",
+                        tool_id="task-1",
+                        tool_input={"prompt": "audit the thing", "subagent_type": "general-purpose"},
+                    )
+                ],
+            )
+        )
+        messages.append(
+            ParsedMessage(
+                provider_message_id="dispatch-result",
+                role=Role.USER,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_RESULT,
+                        tool_id="task-1",
+                        text="3 gaps found",
+                        is_error=False,
+                        exit_code=0,
+                    )
+                ],
+            )
+        )
+    return ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id=provider_session_id,
+        title="Delegation parent fixture",
+        messages=messages,
+    )
+
+
+async def test_resolve_ref_returns_resolved_delegation_attempt_payload(tmp_path: Path) -> None:
+    """polylogue-lph4: action-observed delegation identity is
+    (parent_session_id, instruction_tool_use_block_id) -- the ref carries
+    only the block id since it already embeds the parent session id
+    structurally (block_id = message_id:position, message_id =
+    session_id:native_id)."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            parent_session_id = archive_db.write_parsed(
+                _delegation_parent_session(provider_session_id="delegation-parent-v1", with_dispatch=True)
+            )
+            child_session_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-child-v1",
+                    title="Delegation child fixture",
+                    messages=[
+                        ParsedMessage(provider_message_id="c1", role=Role.ASSISTANT, text="on it"),
+                    ],
+                    parent_session_provider_id="delegation-parent-v1",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+
+        instruction_block_id = f"{parent_session_id}:dispatch:0"
+        payload = await archive.resolve_ref(f"delegation:{instruction_block_id}")
+
+        assert payload.resolved is True
+        assert payload.kind == "delegation"
+        assert payload.payload_kind == "delegation-attempt"
+        assert payload.payload is not None
+        assert payload.payload["mapping_state"] == "resolved"
+        assert payload.payload["parent_session_id"] == parent_session_id
+        assert payload.payload["child_session_id"] == child_session_id
+        assert payload.payload["instruction_tool_use_block_id"] == instruction_block_id
+        assert payload.payload["dispatch_turn_model"] == "claude-opus-4-8"
+        assert payload.object_refs == (f"session:{parent_session_id}", f"session:{child_session_id}")
+        assert f"block:{instruction_block_id}" in payload.evidence_refs
+        assert payload.caveats == ()
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_edge_only_delegation_attempt_payload(tmp_path: Path) -> None:
+    """A resolved child with no parent-side dispatch action (e.g. a Codex
+    async subagent) resolves through the deterministic edge identity and is
+    typed edge_only -- never given a fabricated instruction."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            parent_session_id = archive_db.write_parsed(
+                _delegation_parent_session(provider_session_id="delegation-edge-parent-v1", with_dispatch=False)
+            )
+            child_session_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-edge-child-v1",
+                    title="Delegation edge-only child fixture",
+                    messages=[ParsedMessage(provider_message_id="c1", role=Role.ASSISTANT, text="on it")],
+                    parent_session_provider_id="delegation-edge-parent-v1",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+
+        edge_ref = f"delegation:{delegation_edge_object_id(parent_session_id, child_session_id)}"
+        payload = await archive.resolve_ref(edge_ref)
+
+        assert payload.resolved is True
+        assert payload.payload_kind == "delegation-attempt"
+        assert payload.payload is not None
+        assert payload.payload["mapping_state"] == "edge_only"
+        assert payload.payload["parent_session_id"] == parent_session_id
+        assert payload.payload["child_session_id"] == child_session_id
+        assert payload.payload["instruction_tool_use_block_id"] is None
+        assert payload.payload["instruction_payload"] is None
+        assert any("edge_only" in caveat for caveat in payload.caveats)
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_ambiguous_delegation_attempt_payload(tmp_path: Path) -> None:
+    """Two dispatch actions but only one resolved child: rank-pairing would
+    have to guess, so both dispatch rows surface as ambiguous with a real
+    instruction but no fabricated child (polylogue-y964)."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            parent_session_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-ambiguous-parent-v1",
+                    title="Delegation ambiguous fixture",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="dispatch-a",
+                            role=Role.ASSISTANT,
+                            blocks=[
+                                ParsedContentBlock(
+                                    type=BlockType.TOOL_USE, tool_name="Task", tool_id="task-a", tool_input={}
+                                )
+                            ],
+                        ),
+                        ParsedMessage(
+                            provider_message_id="dispatch-b",
+                            role=Role.ASSISTANT,
+                            blocks=[
+                                ParsedContentBlock(
+                                    type=BlockType.TOOL_USE, tool_name="Task", tool_id="task-b", tool_input={}
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            )
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-ambiguous-child-v1",
+                    title="Delegation ambiguous child fixture",
+                    messages=[ParsedMessage(provider_message_id="c1", role=Role.ASSISTANT, text="on it")],
+                    parent_session_provider_id="delegation-ambiguous-parent-v1",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+
+        instruction_block_id = f"{parent_session_id}:dispatch-a:0"
+        payload = await archive.resolve_ref(f"delegation:{instruction_block_id}")
+
+        assert payload.resolved is True
+        assert payload.payload is not None
+        assert payload.payload["mapping_state"] == "ambiguous"
+        assert payload.payload["child_session_id"] is None
+        assert payload.payload["instruction_tool_use_block_id"] == instruction_block_id
+        assert any("ambiguous" in caveat for caveat in payload.caveats)
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_missing_payload_for_unknown_delegation_identity(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    try:
+        block_missing = await archive.resolve_ref("delegation:claude-code-session:no-such-parent:dispatch:0")
+        assert block_missing.resolved is False
+        assert block_missing.kind == "delegation"
+        assert block_missing.payload_kind == "missing"
+        assert block_missing.payload is None
+
+        edge_missing = await archive.resolve_ref(
+            f"delegation:{delegation_edge_object_id('claude-code-session:no-parent', 'claude-code-session:no-child')}"
+        )
+        assert edge_missing.resolved is False
+        assert edge_missing.payload_kind == "missing"
     finally:
         await archive.close()
 

--- a/tests/unit/core/test_refs.py
+++ b/tests/unit/core/test_refs.py
@@ -5,8 +5,10 @@ import pytest
 from polylogue.core.refs import (
     EvidenceRef,
     ObjectRef,
+    delegation_edge_object_id,
     normalize_object_ref_text,
     normalize_public_ref_text,
+    parse_delegation_edge_object_id,
     parse_public_ref,
 )
 
@@ -51,6 +53,23 @@ from polylogue.core.refs import (
         ("cohort:cohort-1", "cohort", "cohort-1", ()),
         ("analysis:analysis-1", "analysis", "analysis-1", ()),
         ("annotation-batch:batch-1", "annotation-batch", "batch-1", ()),
+        # polylogue-lph4: delegation attempt identity. Action-observed rows
+        # key off the instruction tool-use block id verbatim (already
+        # colon-bearing, opaque); edge-only rows use the deterministic
+        # edge:<parent>::<child> relation identity (polylogue-y964 states
+        # with no parent-side dispatch action to key off).
+        (
+            "delegation:claude-code-session:parent:dispatch:0",
+            "delegation",
+            "claude-code-session:parent:dispatch:0",
+            (),
+        ),
+        (
+            "delegation:edge:codex-session:parent::codex-session:child",
+            "delegation",
+            "edge:codex-session:parent::codex-session:child",
+            (),
+        ),
     ],
 )
 def test_object_ref_parses_and_formats_existing_assertion_ref_shapes(
@@ -160,3 +179,52 @@ def test_object_ref_rejects_empty_ids_for_analysis_provenance_kinds(raw: str) ->
     """New kinds reuse the shared empty-id guard; they don't weaken validation."""
     with pytest.raises(ValueError):
         normalize_object_ref_text(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "delegation:claude-code-session:parent:dispatch:0",
+        "delegation:edge:codex-session:parent::codex-session:child",
+    ],
+)
+def test_normalize_object_ref_text_accepts_delegation_kind(raw: str) -> None:
+    assert normalize_object_ref_text(raw) == raw
+    assert normalize_public_ref_text(raw) == raw
+
+
+def test_object_ref_rejects_empty_id_for_delegation_kind() -> None:
+    with pytest.raises(ValueError):
+        normalize_object_ref_text("delegation:")
+
+
+def test_delegation_edge_object_id_round_trips() -> None:
+    object_id = delegation_edge_object_id("claude-code-session:parent", "claude-code-session:child")
+
+    assert object_id == "edge:claude-code-session:parent::claude-code-session:child"
+    assert parse_delegation_edge_object_id(object_id) == ("claude-code-session:parent", "claude-code-session:child")
+
+    ref = ObjectRef(kind="delegation", object_id=object_id)
+    assert ref.format() == f"delegation:{object_id}"
+    assert ObjectRef.parse(ref.format()) == ref
+
+
+@pytest.mark.parametrize(
+    "object_id",
+    [
+        "claude-code-session:parent:dispatch:0",  # action-observed shape, no edge: prefix
+        "edge:only-one-segment",
+        "edge:",
+    ],
+)
+def test_parse_delegation_edge_object_id_returns_none_for_non_edge_shapes(object_id: str) -> None:
+    assert parse_delegation_edge_object_id(object_id) is None
+
+
+@pytest.mark.parametrize(
+    ("parent_session_id", "child_session_id"),
+    [("", "child"), ("parent", "")],
+)
+def test_delegation_edge_object_id_rejects_empty_segments(parent_session_id: str, child_session_id: str) -> None:
+    with pytest.raises(ValueError):
+        delegation_edge_object_id(parent_session_id, child_session_id)

--- a/tests/unit/pipeline/test_delegation_provider_fixtures.py
+++ b/tests/unit/pipeline/test_delegation_provider_fixtures.py
@@ -1,0 +1,360 @@
+"""polylogue-lph4: ingest-shaped delegation fixtures.
+
+The `delegations` view (polylogue-y964, `polylogue/storage/sqlite/archive_tiers/
+index.py`) spines on `actions.semantic_type='subagent'` (a parent-side Task
+tool_use) corroborated against resolved `session_links(link_type='subagent')`
+edges. `tests/unit/storage/test_delegations_view.py` proves the view's SQL
+contract by hand-inserting rows directly into `actions`/`session_links` --
+legitimate for exercising the view's join logic in isolation, but it does not
+prove that a REAL provider parser ever produces those rows in that shape.
+
+These tests drive real JSONL/dict-shaped payloads through the actual parser
+dispatch (`iter_source_sessions`, matching `tests/unit/pipeline/
+test_branching.py`'s pattern) and the real writer (`ingest_session` ->
+`write_parsed_session_to_archive`), then read the resulting `delegations`
+view back. Three things must hold under real ingestion, none of which the
+direct-SQL fixtures can prove on their own:
+
+  1. A Claude Code Task dispatch + its `agent-*.jsonl` subagent transcript
+     resolve to mapping_state='resolved' with real child-to-parent lineage
+     direction (not the pre-y964 reversed direction).
+  2. A Codex subagent spawn (`session_meta.source.subagent`, no parent-side
+     Task action observable) resolves to mapping_state='edge_only' -- never
+     a fabricated instruction.
+  3. Auto-compaction (`agent-acompact-*.jsonl`, BranchType.CONTINUATION) and
+     a plain Codex continuation never appear in `delegations` at all --
+     `link_type != 'subagent'` is excluded at the view's own WHERE clause,
+     and only a real parser round-trip proves the classifier actually
+     assigns CONTINUATION (not SUBAGENT) to these shapes.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.core.enums import Provider
+from polylogue.core.identity_law import session_id as archive_session_id
+from polylogue.core.sources import origin_from_provider
+from polylogue.sources import iter_source_sessions
+from polylogue.sources.parsers.base import ParsedSession
+from polylogue.storage.repository import SessionRepository
+from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+from tests.infra.live_ingest import ingest_session
+from tests.infra.storage_records import db_setup
+
+WorkspaceEnv = dict[str, Path]
+
+
+def _make_repository(db_path: Path) -> SessionRepository:
+    return SessionRepository(backend=SQLiteBackend(db_path=db_path))
+
+
+def _write_payload(tmp_path: Path, filename: str, payload: object) -> Path:
+    path = tmp_path / filename
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _parse_single(source_name: str, source_path: Path) -> ParsedSession:
+    sessions = list(iter_source_sessions(Source(name=source_name, path=source_path)))
+    assert len(sessions) == 1
+    return sessions[0]
+
+
+def _archive_session_id(provider: Provider, native_id: str) -> str:
+    return archive_session_id(origin_from_provider(provider).value, native_id)
+
+
+def _delegations_rows(db_path: Path, *, parent_session_id: str) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return list(
+            conn.execute(
+                "SELECT * FROM delegations WHERE parent_session_id = ? ORDER BY instruction_tool_use_block_id",
+                (parent_session_id,),
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+
+def _claude_code_task_dispatch_payload(*, session_id: str) -> list[dict[str, object]]:
+    """Real Claude Code JSONL shape: an assistant Task tool_use record
+    followed by the user tool_result record for the same tool_use id."""
+
+    return [
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": None,
+            "sessionId": session_id,
+            "timestamp": "2025-01-01T10:00:00Z",
+            "cwd": "/repo",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_task1",
+                        "name": "Task",
+                        "input": {"prompt": "Investigate X", "subagent_type": "general-purpose"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": "u1",
+            "parentUuid": "a1",
+            "sessionId": session_id,
+            "timestamp": "2025-01-01T10:00:05Z",
+            "cwd": "/repo",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "toolu_task1", "content": "Subagent finished."}],
+            },
+        },
+    ]
+
+
+def _claude_code_agent_child_payload(*, parent_session_id: str) -> list[dict[str, object]]:
+    """A subagent transcript's own records carry the PARENT's native session
+    id in `sessionId` -- `code_parser.py` reads `parent_session_id = session_id`
+    when the file's fallback_id (filename stem) starts with `agent-`."""
+
+    return [
+        {
+            "type": "user",
+            "uuid": "cu1",
+            "sessionId": parent_session_id,
+            "timestamp": "2025-01-01T10:00:01Z",
+            "message": {"role": "user", "content": "Subagent task"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "ca1",
+            "parentUuid": "cu1",
+            "sessionId": parent_session_id,
+            "timestamp": "2025-01-01T10:00:04Z",
+            "message": {"role": "assistant", "content": "Subagent reply"},
+        },
+    ]
+
+
+def _claude_code_plain_payload(*, session_id: str) -> list[dict[str, object]]:
+    return [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": session_id,
+            "timestamp": "2025-01-01T10:00:00Z",
+            "message": {"role": "user", "content": "hello"},
+        },
+    ]
+
+
+def _codex_subagent_spawn_payload(*, child_id: str, parent_id: str) -> list[dict[str, object]]:
+    """Real Codex shape for an edge-only subagent: the child's own
+    session_meta carries `source.subagent` and `forked_from_id`, with no
+    parent-side dispatch action observable at all (codex.py:766-770,
+    840-846)."""
+
+    return [
+        {
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "timestamp": "2025-01-02T10:00:00Z",
+                "forked_from_id": parent_id,
+                "source": {"subagent": {"thread_spawn": True}},
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": "msg-1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Working on it"}],
+            },
+        },
+    ]
+
+
+class TestDelegationIngestShapedFixtures:
+    @pytest.mark.asyncio
+    async def test_claude_code_task_dispatch_and_agent_child_resolve_through_real_parser(
+        self, workspace_env: WorkspaceEnv, tmp_path: Path
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            parent_path = _write_payload(
+                tmp_path, "claude_code_parent.json", _claude_code_task_dispatch_payload(session_id="delegation-parent")
+            )
+            parent_parsed = _parse_single("claude-code", parent_path)
+            parent_session_id = await ingest_session(parent_parsed, backend=repo.backend)
+            assert parent_session_id == _archive_session_id(Provider.CLAUDE_CODE, "delegation-parent")
+
+            # Real subagent filename shape: fallback_id (filename stem) must
+            # start with "agent-" for code_parser.py to classify it as a
+            # subagent transcript rather than a generic sidechain.
+            child_path = _write_payload(
+                tmp_path,
+                "agent-delegation-child.json",
+                _claude_code_agent_child_payload(parent_session_id="delegation-parent"),
+            )
+            child_parsed = _parse_single("claude-code", child_path)
+            await ingest_session(child_parsed, backend=repo.backend)
+
+        rows = _delegations_rows(db_path, parent_session_id=parent_session_id)
+        assert len(rows) == 1
+        row = rows[0]
+        # The load-bearing direction assertion (polylogue-y964): parent_session_id
+        # is the session that DISPATCHED, not the one dispatched to.
+        assert row["parent_session_id"] == parent_session_id
+        assert row["mapping_state"] == "resolved"
+        assert row["child_session_id"] is not None
+        assert row["instruction_tool_use_block_id"] is not None
+        assert "Investigate X" in (row["instruction_payload"] or "")
+        assert row["artifact_text"] == "Subagent finished."
+
+    @pytest.mark.asyncio
+    async def test_codex_subagent_spawn_resolves_edge_only_through_real_parser(
+        self, workspace_env: WorkspaceEnv, tmp_path: Path
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            parent_path = _write_payload(
+                tmp_path,
+                "codex_parent.json",
+                [
+                    {"type": "session_meta", "payload": {"id": "codex-parent", "timestamp": "2025-01-01T10:00:00Z"}},
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "id": "p-msg-1",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "Parent question"}],
+                        },
+                    },
+                ],
+            )
+            parent_session_id = await ingest_session(_parse_single("codex", parent_path), backend=repo.backend)
+            assert parent_session_id == _archive_session_id(Provider.CODEX, "codex-parent")
+
+            child_path = _write_payload(
+                tmp_path,
+                "codex_subagent_child.json",
+                _codex_subagent_spawn_payload(child_id="codex-subagent-child", parent_id="codex-parent"),
+            )
+            await ingest_session(_parse_single("codex", child_path), backend=repo.backend)
+
+        rows = _delegations_rows(db_path, parent_session_id=parent_session_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["mapping_state"] == "edge_only"
+        assert row["child_session_id"] is not None
+        # No parent-side dispatch action exists for this pair -- never fabricate one.
+        assert row["instruction_tool_use_block_id"] is None
+        assert row["instruction_payload"] is None
+
+    @pytest.mark.asyncio
+    async def test_claude_code_auto_compaction_child_excluded_from_delegations(
+        self, workspace_env: WorkspaceEnv, tmp_path: Path
+    ) -> None:
+        """agent-acompact-*.jsonl classifies as BranchType.CONTINUATION, not
+        SUBAGENT (code_parser.py's is_acompact check) -- it must never appear
+        in `delegations`, real dispatch action or not."""
+
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            parent_path = _write_payload(
+                tmp_path,
+                "claude_code_acompact_parent.json",
+                _claude_code_task_dispatch_payload(session_id="acompact-parent"),
+            )
+            parent_session_id = await ingest_session(_parse_single("claude-code", parent_path), backend=repo.backend)
+
+            acompact_path = _write_payload(
+                tmp_path,
+                "agent-acompact-1.json",
+                _claude_code_plain_payload(session_id="acompact-parent"),
+            )
+            acompact_parsed = _parse_single("claude-code", acompact_path)
+            assert acompact_parsed.branch_type == "continuation"
+            await ingest_session(acompact_parsed, backend=repo.backend)
+
+        rows = _delegations_rows(db_path, parent_session_id=parent_session_id)
+        # The real Task dispatch is still an unresolved attempt (its own row);
+        # the auto-compaction child must NOT be attached to it as a resolved
+        # subagent, and must not appear as any kind of delegation row itself.
+        assert len(rows) == 1
+        assert rows[0]["mapping_state"] == "unresolved"
+        assert rows[0]["child_session_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_codex_continuation_excluded_from_delegations(
+        self, workspace_env: WorkspaceEnv, tmp_path: Path
+    ) -> None:
+        """A plain Codex continuation (`forked_from_id` with no `source.subagent`
+        marker) is `link_type='continuation'`/unclassified branch_type, not a
+        delegation, even though the topology link resolves cleanly."""
+
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            parent_path = _write_payload(
+                tmp_path,
+                "codex_continuation_parent.json",
+                [
+                    {
+                        "type": "session_meta",
+                        "payload": {"id": "codex-cont-parent", "timestamp": "2025-01-01T10:00:00Z"},
+                    },
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "id": "p-msg-1",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "Parent question"}],
+                        },
+                    },
+                ],
+            )
+            parent_session_id = await ingest_session(_parse_single("codex", parent_path), backend=repo.backend)
+
+            child_path = _write_payload(
+                tmp_path,
+                "codex_continuation_child.json",
+                [
+                    {
+                        "type": "session_meta",
+                        "payload": {"id": "codex-cont-child", "timestamp": "2025-01-02T10:00:00Z"},
+                    },
+                    {
+                        "type": "session_meta",
+                        "payload": {"id": "codex-cont-parent", "timestamp": "2025-01-01T10:00:00Z"},
+                    },
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "id": "msg-1",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "Continue from parent"}],
+                        },
+                    },
+                ],
+            )
+            child_parsed = _parse_single("codex", child_path)
+            await ingest_session(child_parsed, backend=repo.backend)
+
+        rows = _delegations_rows(db_path, parent_session_id=parent_session_id)
+        assert rows == []

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -858,6 +858,12 @@ def test_assertion_targets_various_ref_shapes(tmp_path: Path) -> None:
             "message:abc-123:7",
             "block:abc-123:7:2",
             "github-issue:Sinity/polylogue#1883",
+            # polylogue-lph4: delegation attempts are a registered ObjectRef
+            # target -- candidate annotations/judgments can scope to a
+            # delegation the same way as any other object ref, action-observed
+            # (bare instruction block id) or edge-only (edge:<parent>::<child>).
+            "delegation:claude-code-session:parent:dispatch:0",
+            "delegation:edge:codex-session:parent::codex-session:child",
         ]
         for idx, ref in enumerate(refs):
             upsert_assertion(


### PR DESCRIPTION
## Summary

Registers `delegation` as a public `ObjectRefKind`, wires a real `resolve_ref` resolver against the polylogue-y964 `delegations` view, and adds ingest-shaped (real parser/writer, not hand-inserted SQL) fixtures proving Claude Code Task dispatch, Codex subagent spawn, and auto-compaction/continuation exclusion all produce the correct view state.

## Problem

polylogue-y964 shipped a corrected `delegations` view keyed on `(parent_session_id, instruction_tool_use_block_id)` for action-observed attempts and a deterministic `(parent, child)` relation for edge-only ones (edge_only/quarantined), but:

1. Nothing could address a delegation attempt as a public ref — it couldn't be an annotation/candidate/judgment target, and there was no way to look one up through the shared CLI/MCP/API `resolve_ref` seam.
2. Every existing delegation test fixture (`tests/unit/storage/test_delegations_view.py`) hand-inserts rows directly into `actions`/`session_links` — legitimate for exercising the view's join SQL in isolation, but it doesn't prove a real provider parser ever produces those rows in that shape. This is exactly the class of bug y964 itself fixed (a reversed-direction fixture matching a reversed-direction view).

## Solution

- `polylogue/core/refs.py`: add `delegation` to `ObjectRefKind` + `_OBJECT_REF_KINDS`, plus `delegation_edge_object_id`/`parse_delegation_edge_object_id` helpers. Action-observed refs carry the `instruction_tool_use_block_id` verbatim (it already embeds its owning session id structurally, so no extra encoding is needed). Edge-only refs use a deterministic `edge:<parent>::<child>` relation identity (`::` matches the existing `EvidenceRef` convention for colon-bearing session ids). Registering the kind in `_OBJECT_REF_KINDS` is also what makes it a valid assertion `scope_ref`/`target_ref` — that dict is the single enforcement point (`normalize_object_ref_text`), confirmed against how `polylogue-rxdo.1`'s analysis-provenance kinds worked; no separate registry to touch.
- `polylogue/storage/sqlite/archive_tiers/archive.py`: `ArchiveDelegationQueryRow` dataclass + `ArchiveStore.get_delegation_attempt(...)`, a typed lookup against the `delegations` view by either identity shape.
- `polylogue/surfaces/payloads.py`: `DelegationAttemptPayload` (bounded — instruction/artifact text truncated at 2000 chars, never a full transcript dump) plus a `DELEGATION_STATE_CAVEATS` map so unresolved/ambiguous/edge_only/quarantined states carry an explanatory caveat instead of silently looking like a full resolution.
- `polylogue/api/archive.py`: `resolve_ref` dispatches `delegation:` refs to a real resolver (not a `substrate-pending` stub — unlike `polylogue-rxdo.1`'s analysis-provenance kinds, the backing `delegations` view already exists), returning `resolved=False`/`payload_kind="missing"` when no row matches an identity, and the typed attempt payload with per-state caveats plus `object_refs`/`evidence_refs` otherwise.
- New `tests/unit/pipeline/test_delegation_provider_fixtures.py`: drives real JSONL/dict payloads through `iter_source_sessions` (real parser dispatch) and `write_parsed_session_to_archive` (real writer, via the `ingest_session` test helper) for:
  - a Claude Code Task dispatch + its `agent-*.jsonl` subagent transcript → `mapping_state='resolved'` with correct child-to-parent direction;
  - a Codex `session_meta.source.subagent` spawn with no parent-side Task action → `mapping_state='edge_only'`, no fabricated instruction;
  - an `agent-acompact-*.jsonl` auto-compaction child and a plain Codex continuation → both excluded from `delegations` entirely (`link_type != 'subagent'`), proven under real classification rather than by construction.
- Round-trip/registration tests in `tests/unit/core/test_refs.py`, resolver tests (resolved/edge_only/ambiguous/missing) in `tests/unit/api/test_facade_contracts.py`, and an assertion-scope-ref case in `tests/unit/storage/test_archive_tiers_assertions.py`.

### Deferred / intentionally out of scope

- `AssertionKind.FINDING` and the sequence/retry/redelegation relations are `polylogue-f3kd`'s scope (per the parent bead's own dependents list).
- No dedicated `fork`-branch-type exclusion fixture: it shares the identical `link_type != 'subagent'` WHERE-clause exclusion already proven by the continuation/auto-compaction fixtures, so it would be testing the same SQL predicate through a third provider shape.
- `quarantined` mapping_state is exercised at the SQL-view level in the pre-existing `test_delegations_view.py`; its resolver caveat path is byte-identical code to `edge_only` (same branch, different `mapping_state` string), so it wasn't duplicated as a separate ingest-shaped facade fixture.

## Verification

- `devtools test tests/unit/core/test_refs.py` → 75 passed
- `devtools test tests/unit/api/test_facade_contracts.py -k delegation` → 4 passed
- `devtools test tests/unit/pipeline/test_delegation_provider_fixtures.py` → 4 passed
- `devtools test tests/unit/storage/test_archive_tiers_assertions.py -k targets_various_ref_shapes` → 1 passed
- Combined run of all touched/new test files → 370 passed, 2 failed; both failures reproduce identically with this diff stashed (pre-existing on master, unrelated): `test_fresh_user_tier_has_no_legacy_overlay_tables` (unrelated `context_deliveries` table drift) and `test_archive_tiers_api_raw_artifacts_read_source_tier` (the `parsed_at` wall-clock hygiene bug already documented on `polylogue-rxdo.1`'s notes).
- `mypy --strict` on all touched files → `Success: no issues found in 7 source files`
- `devtools render all --check` → exit 0, no `out of sync` surfaces (no new module files added, so no topology-projection regen needed)
- `ruff format --check` / `ruff check` on all touched files → clean
- Pre-push hook ran `devtools verify --quick` automatically → exit 0

Not run: full `devtools verify`/broad `devtools test` (lean-verification directive for this session — the coordinator runs consolidated verification before merge).

Ref polylogue-lph4

🤖 Generated with [Claude Code](https://claude.com/claude-code)