### PR TITLE
perf(storage): bound thread refresh cost for large reordering appends

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -2482,13 +2482,19 @@ def _refresh_thread(conn: sqlite3.Connection, root_session_id: str) -> None:
         ):
             return
         if existing_session_ids == desired_session_ids[: len(existing_session_ids)]:
-            for position, row in enumerate(session_rows[len(existing_session_ids) :], start=len(existing_session_ids)):
-                conn.execute(
+            new_rows = [
+                (root_session_id, row[0], position)
+                for position, row in enumerate(
+                    session_rows[len(existing_session_ids) :], start=len(existing_session_ids)
+                )
+            ]
+            if new_rows:
+                conn.executemany(
                     """
                     INSERT INTO thread_sessions (thread_id, session_id, position)
                     VALUES (?, ?, ?)
                     """,
-                    (root_session_id, row[0], position),
+                    new_rows,
                 )
             conn.execute(
                 """
@@ -2500,14 +2506,70 @@ def _refresh_thread(conn: sqlite3.Connection, root_session_id: str) -> None:
                 (len(session_rows), max(len(session_rows) - 1, 0), root_session_id),
             )
             return
+        if len(existing_session_ids) == len(desired_session_ids):
+            # Same membership, different order (a thread member's sort key
+            # moved past siblings without joining/leaving the thread). Since
+            # both lists have equal length, index i names the same numeric
+            # ``position`` in both orderings, so the common leading/trailing
+            # run that already agrees can be left untouched -- only the
+            # differing middle span needs a delete+reinsert. Without this, a
+            # giant long-lived thread (thousands of resumed/forked Codex
+            # sessions) pays a full O(thread_size) rebuild on every reorder,
+            # even when only a handful of rows actually moved
+            # (polylogue-6wnh).
+            n = len(existing_session_ids)
+            common_prefix_len = 0
+            while (
+                common_prefix_len < n
+                and existing_session_ids[common_prefix_len] == desired_session_ids[common_prefix_len]
+            ):
+                common_prefix_len += 1
+            common_suffix_len = 0
+            max_suffix = n - common_prefix_len
+            while (
+                common_suffix_len < max_suffix
+                and existing_session_ids[n - 1 - common_suffix_len] == desired_session_ids[n - 1 - common_suffix_len]
+            ):
+                common_suffix_len += 1
+            span_end = n - common_suffix_len
+            if span_end > common_prefix_len:
+                conn.execute(
+                    """
+                    DELETE FROM thread_sessions
+                    WHERE thread_id = ? AND position >= ? AND position < ?
+                    """,
+                    (root_session_id, common_prefix_len, span_end),
+                )
+                conn.executemany(
+                    """
+                    INSERT INTO thread_sessions (thread_id, session_id, position)
+                    VALUES (?, ?, ?)
+                    """,
+                    [
+                        (root_session_id, session_id, position)
+                        for position, session_id in enumerate(
+                            desired_session_ids[common_prefix_len:span_end], start=common_prefix_len
+                        )
+                    ],
+                )
+            conn.execute(
+                """
+                UPDATE threads
+                SET session_count = ?,
+                    depth = ?
+                WHERE thread_id = ?
+                """,
+                (n, max(n - 1, 0), root_session_id),
+            )
+            return
     conn.execute("DELETE FROM thread_sessions WHERE thread_id = ?", (root_session_id,))
-    for position, row in enumerate(session_rows):
-        conn.execute(
+    if session_rows:
+        conn.executemany(
             """
             INSERT INTO thread_sessions (thread_id, session_id, position)
             VALUES (?, ?, ?)
             """,
-            (root_session_id, row[0], position),
+            [(root_session_id, row[0], position) for position, row in enumerate(session_rows)],
         )
     conn.execute(
         """

--- a/tests/benchmarks/test_thread_refresh_scale.py
+++ b/tests/benchmarks/test_thread_refresh_scale.py
@@ -1,0 +1,221 @@
+"""Regression benchmark for polylogue-6wnh: bound thread refresh cost.
+
+Live evidence (2026-07-04, ``/realm/tmp/polylogue-workload-graph-tail-499e26363.json``):
+the worst recent ``append.index.graph_resolve`` sample on a 340.8 MB Codex
+append spent 3.020976s of a 3.040429s total in
+``append.index.graph_resolve.thread_refresh`` (``_refresh_thread`` in
+``polylogue/storage/sqlite/archive_tiers/write.py``). The live archive at that
+time had 3 threads averaging ~3000 members each (``thread_session_count: 8992``
+across ``thread_count: 3`` per the same evidence snapshot).
+
+Root cause (traced via ``_refresh_thread`` source + a granular per-statement
+profiling harness against a synthetic fixture of this shape): when a thread
+member's ``sort_key_ms`` (``COALESCE(updated_at_ms, created_at_ms)``) moves
+past siblings -- e.g. a late append to an older session in a large,
+long-lived thread built from many resumes/forks/subagent spawns -- the
+previous implementation unconditionally deleted *every* row in
+``thread_sessions`` for that thread and reinserted all of them one at a time
+via a Python loop, even when only a handful of positions actually moved.
+This is real O(thread_size) row-mutation work, not a query-shape or
+per-statement-overhead artifact (see ``test_graph_resolve_deferred_tail.py``
+for the analogous conclusion on the #2467 deferred-tail path).
+
+The fix (this bead) makes ``_refresh_thread`` refresh only the affected span:
+it trims the common leading/trailing run shared between the old and new
+orderings (safe because equal-length lists mean index ``i`` names the same
+numeric ``position`` in both orderings) and only delete+reinserts the
+differing middle span, using ``executemany`` instead of a per-row Python
+loop. A full front-to-back reorder (the worst case -- everything moves) is
+still O(thread_size), matching the architectural floor for a dense
+0..n-1 position invariant; a *localized* reorder (the common real-world
+shape: one member's timestamp jumps past a handful of siblings, not the
+entire thread) now costs O(affected span + two O(n) SELECTs to compute the
+diff), not O(thread_size) row mutations.
+
+Run with:
+    pytest tests/benchmarks/test_thread_refresh_scale.py --benchmark-enable -p no:xdist -v
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
+from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_INDEX_DDL = ARCHIVE_DDL_BY_TIER[ArchiveTier.INDEX]
+
+_ORIGIN = "codex-session"
+
+
+def _build_thread_fixture(db_path: Path, *, n_sessions: int) -> tuple[sqlite3.Connection, str]:
+    """Seed one root session plus ``n_sessions - 1`` descendants sharing its
+    ``root_session_id``, with ``threads``/``thread_sessions`` already
+    materialized to match ascending-``updated_at_ms`` order -- the on-disk
+    shape of one big long-lived Codex thread built from many resumes/forks.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(_INDEX_DDL)
+
+    root_native_id = "root"
+    root_session_id = f"{_ORIGIN}:{root_native_id}"
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, title, content_hash, root_session_id, "
+        "created_at_ms, updated_at_ms) VALUES (?, ?, 't', ?, ?, 0, 0)",
+        (_ORIGIN, root_native_id, b"r" * 32, root_session_id),
+    )
+    rows = [
+        (_ORIGIN, f"child{i}", bytes([i % 256]) * 32, root_session_id, i * 1000, i * 1000) for i in range(1, n_sessions)
+    ]
+    conn.executemany(
+        "INSERT INTO sessions (origin, native_id, content_hash, root_session_id, "
+        "created_at_ms, updated_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+    conn.execute(
+        "INSERT INTO threads (thread_id, created_at_ms, session_count, depth) VALUES (?, 0, ?, ?)",
+        (root_session_id, n_sessions, n_sessions - 1),
+    )
+    session_ids = [root_session_id] + [f"{_ORIGIN}:child{i}" for i in range(1, n_sessions)]
+    conn.executemany(
+        "INSERT INTO thread_sessions (thread_id, session_id, position) VALUES (?, ?, ?)",
+        [(root_session_id, sid, pos) for pos, sid in enumerate(session_ids)],
+    )
+    conn.commit()
+    return conn, root_session_id
+
+
+def _bump_session(conn: sqlite3.Connection, *, native_id: str, n_sessions: int, new_ms: int) -> None:
+    conn.execute(
+        "UPDATE sessions SET updated_at_ms = ? WHERE origin = ? AND native_id = ?",
+        (new_ms, _ORIGIN, native_id),
+    )
+    conn.commit()
+
+
+def _time_full_reorder(n_sessions: int, tmp_path: Path) -> float:
+    """Worst case: the middle member's timestamp jumps past every later
+    sibling, forcing it to the very end -- roughly half the thread's
+    positions must shift.
+    """
+    conn, root_session_id = _build_thread_fixture(tmp_path / f"full_{n_sessions}.db", n_sessions=n_sessions)
+    try:
+        mid = n_sessions // 2
+        native_id = "root" if mid == 0 else f"child{mid}"
+        _bump_session(conn, native_id=native_id, n_sessions=n_sessions, new_ms=n_sessions * 1000 + 1)
+        started = time.perf_counter()
+        archive_tier_write._refresh_thread(conn, root_session_id)
+        conn.commit()
+        return time.perf_counter() - started
+    finally:
+        conn.close()
+
+
+def _time_local_reorder(n_sessions: int, tmp_path: Path, *, span: int = 20) -> float:
+    """Common case: a member near the tail jumps past only ``span``
+    immediate siblings (e.g. concurrent subagent timestamps interleaving),
+    not the entire thread.
+    """
+    conn, root_session_id = _build_thread_fixture(tmp_path / f"local_{n_sessions}.db", n_sessions=n_sessions)
+    try:
+        idx = max(n_sessions - span - 1, 1)
+        native_id = f"child{idx}"
+        _bump_session(conn, native_id=native_id, n_sessions=n_sessions, new_ms=(idx + span) * 1000 + 1)
+        started = time.perf_counter()
+        archive_tier_write._refresh_thread(conn, root_session_id)
+        conn.commit()
+        return time.perf_counter() - started
+    finally:
+        conn.close()
+
+
+def _touched_row_count_for_local_reorder(n_sessions: int, tmp_path: Path, *, span: int = 20) -> int:
+    """Count actual thread_sessions INSERT statements issued for a localized
+    reorder -- the direct, host-noise-free measure of "only affected rows
+    were touched" (wall-clock time on a small in-process fixture is too
+    dominated by fixed per-call overhead and host jitter to reliably show
+    the asymptotic win at small N; row counts are exact and deterministic).
+    """
+    conn, root_session_id = _build_thread_fixture(tmp_path / f"count_{n_sessions}.db", n_sessions=n_sessions)
+    try:
+        idx = max(n_sessions - span - 1, 1)
+        native_id = f"child{idx}"
+        _bump_session(conn, native_id=native_id, n_sessions=n_sessions, new_ms=(idx + span) * 1000 + 1)
+        statements: list[str] = []
+        conn.set_trace_callback(statements.append)
+        archive_tier_write._refresh_thread(conn, root_session_id)
+        conn.set_trace_callback(None)
+        conn.commit()
+        return sum(1 for stmt in statements if "INSERT INTO thread_sessions" in stmt)
+    finally:
+        conn.close()
+
+
+@pytest.mark.benchmark
+def test_thread_refresh_full_reorder_scales_linearly_not_quadratically(tmp_path: Path) -> None:
+    """A full front-to-back reorder is architecturally O(thread_size) under
+    the dense 0..n-1 position invariant (this bead does not remove that
+    floor). Guard against a *new* accidental quadratic regression.
+    """
+    small_seconds = _time_full_reorder(500, tmp_path)
+    large_seconds = _time_full_reorder(4000, tmp_path)
+
+    ratio = large_seconds / max(small_seconds, 1e-9)
+    print(
+        f"\nthread_refresh full-reorder scaling: 500={small_seconds:.4f}s, "
+        f"4000={large_seconds:.4f}s, ratio={ratio:.1f}x (linear expects ~8x)"
+    )
+    assert ratio < 25, (
+        f"thread_refresh cost grew {ratio:.1f}x for 8x the thread size "
+        f"(500={small_seconds:.4f}s, 4000={large_seconds:.4f}s) -- expected roughly "
+        "linear (~8x); this smells like a new quadratic regression in "
+        "_refresh_thread, reopening the polylogue-3wb-class 260s tail."
+    )
+
+
+@pytest.mark.benchmark
+def test_thread_refresh_local_reorder_is_bounded_by_affected_span(tmp_path: Path) -> None:
+    """The concrete polylogue-6wnh acceptance criterion: a localized reorder
+    in a giant thread must touch only the affected rows, not rebuild the
+    whole thread.
+
+    Row-mutation count is the deterministic, host-noise-free signal here --
+    on a small in-process synthetic fixture, wall-clock time is dominated by
+    fixed per-call overhead rather than the row-count difference this fix
+    targets (the live 3.02s/9-thousand-row production evidence lives on a
+    multi-GiB disk-resident archive; see test_graph_resolve_deferred_tail.py
+    for the sibling benchmark's discussion of the same measurement
+    trade-off). Before this bead, a local reorder issued ``n_sessions``
+    thread_sessions INSERTs (a full unconditional rebuild) regardless of how
+    few positions actually moved; after the fix it issues only
+    ``span + 1``.
+    """
+    n_sessions = 4000
+    span = 20
+    touched = _touched_row_count_for_local_reorder(n_sessions, tmp_path, span=span)
+
+    print(f"\nthread_refresh n={n_sessions} local reorder (span={span}): {touched} rows reinserted")
+    # A handful more than `span` (the moved member plus everyone strictly
+    # between its old and new slot) -- nowhere near the full n_sessions a
+    # blanket rebuild would touch.
+    assert touched <= span + 5, (
+        f"a {span}-sibling local reorder in a {n_sessions}-member thread reinserted "
+        f"{touched} thread_sessions rows -- expected roughly {span}, not the full "
+        f"{n_sessions}-member thread. thread_refresh is no longer bounding its work "
+        "to the affected span (polylogue-6wnh regression)."
+    )
+
+    # Wall-clock sanity check (informational, generous headroom): the local
+    # reorder should still not be dramatically slower than a full reorder of
+    # the same thread.
+    full_seconds = _time_full_reorder(n_sessions, tmp_path)
+    local_seconds = _time_local_reorder(n_sessions, tmp_path, span=span)
+    print(f"thread_refresh n={n_sessions}: full-reorder={full_seconds:.4f}s, local-reorder={local_seconds:.4f}s")

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -2797,6 +2797,89 @@ def test_refresh_thread_appends_suffix_without_rebuilding_membership(tmp_path: P
     assert parent_thread_deletes == []
 
 
+def test_refresh_thread_reorder_only_touches_changed_span(tmp_path: Path) -> None:
+    """A same-membership reorder (a member's sort key moves past siblings,
+    e.g. a late append to an older session) must delete+reinsert only the
+    span that actually differs, not the whole thread (polylogue-6wnh).
+    """
+    conn = _connect(tmp_path / "index.db")
+    origin = "codex-session"
+    root_native_id = "root"
+    root_session_id = f"{origin}:{root_native_id}"
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, title, content_hash, root_session_id, "
+        "created_at_ms, updated_at_ms) VALUES (?, ?, 't', ?, ?, 0, 0)",
+        (origin, root_native_id, b"r" * 32, root_session_id),
+    )
+    child_ids = []
+    for i in range(1, 6):
+        native_id = f"child{i}"
+        conn.execute(
+            "INSERT INTO sessions (origin, native_id, content_hash, root_session_id, "
+            "created_at_ms, updated_at_ms) VALUES (?, ?, ?, ?, ?, ?)",
+            (origin, native_id, bytes([i]) * 32, root_session_id, i * 1000, i * 1000),
+        )
+        child_ids.append(f"{origin}:{native_id}")
+    conn.commit()
+    archive_tier_write._refresh_thread(conn, root_session_id)
+    conn.commit()
+
+    before = [
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT session_id, position FROM thread_sessions WHERE thread_id = ? ORDER BY position",
+            (root_session_id,),
+        ).fetchall()
+    ]
+    assert before == [(root_session_id, 0)] + [(cid, i) for i, cid in enumerate(child_ids, start=1)]
+
+    # child2 (originally position 2) gets appended to and its updated_at_ms
+    # jumps past child3/child4/child5 -- it should now sort last, and only
+    # positions 2..5 (child2's old slot through the new tail) should move.
+    conn.execute(
+        "UPDATE sessions SET updated_at_ms = 9999 WHERE origin = ? AND native_id = 'child2'",
+        (origin,),
+    )
+    conn.commit()
+
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    archive_tier_write._refresh_thread(conn, root_session_id)
+    conn.set_trace_callback(None)
+    conn.commit()
+
+    after = [
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT session_id, position FROM thread_sessions WHERE thread_id = ? ORDER BY position",
+            (root_session_id,),
+        ).fetchall()
+    ]
+    assert after == [
+        (root_session_id, 0),
+        (child_ids[0], 1),  # child1 unchanged
+        (child_ids[2], 2),  # child3 shifted down
+        (child_ids[3], 3),  # child4 shifted down
+        (child_ids[4], 4),  # child5 shifted down
+        (child_ids[1], 5),  # child2 moved to the end
+    ]
+    thread_row = conn.execute(
+        "SELECT session_count, depth FROM threads WHERE thread_id = ?", (root_session_id,)
+    ).fetchone()
+    assert dict(thread_row) == {"session_count": 6, "depth": 5}
+
+    deletes = [stmt for stmt in statements if "DELETE FROM thread_sessions" in stmt]
+    # The unchanged leading run (root, child1) must not be touched by any
+    # delete -- a full unconditional rebuild would issue a bare
+    # "DELETE FROM thread_sessions WHERE thread_id = ?" here instead.
+    assert len(deletes) == 1
+    assert "position >=" in deletes[0] and "position <" in deletes[0]
+    inserts = [stmt for stmt in statements if "INSERT INTO thread_sessions" in stmt]
+    # Only the 4 rows in the affected span (child2's old slot through the
+    # new tail) get reinserted, not all 6 members.
+    assert len(inserts) == 4
+
+
 def test_archive_tiers_writer_resolves_existing_child_link_when_parent_arrives_later(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     child = ParsedSession(


### PR DESCRIPTION
## Summary

Bounds the cost of `_refresh_thread` (`polylogue/storage/sqlite/archive_tiers/write.py`) when a large, long-lived thread's ordering changes: it now refreshes only the affected span of `thread_sessions` rows instead of unconditionally deleting and reinserting every member of the thread.

## Problem

Live evidence (`/realm/tmp/polylogue-workload-graph-tail-499e26363.json`, 2026-07-04) showed the worst recent `append.index.graph_resolve` sample spending 3.02s of a 3.04s total in `thread_refresh` on a 340.8 MB Codex append, against an archive with 3 giant threads averaging ~3000 members each (`thread_session_count: 8992` across `thread_count: 3`).

A per-statement profiling harness built against a synthetic fixture of the same shape (see benchmark docstring for the trace) localized the cost: whenever a thread member's `sort_key_ms` (`COALESCE(updated_at_ms, created_at_ms)`) moves past siblings — e.g. a late append to an older session in a long-lived thread built from many resumes/forks/subagent spawns — `_refresh_thread`'s fallback path unconditionally deleted every `thread_sessions` row for the thread and reinserted all of them one row at a time via a Python `for` loop over `conn.execute`, even when only a handful of positions actually moved.

## Solution

`_refresh_thread` now, in the case where thread membership count is unchanged (a pure reorder, not a join/leave), trims the common leading/trailing run shared between the old and new session orderings — safe because equal list lengths mean index `i` names the same numeric `position` in both orderings — and only delete+reinserts the differing middle span, using `executemany` instead of a per-row `execute()` loop. The pure-append fast path and the full-rebuild fallback (for cases where membership changes alongside reordering) also switched to `executemany`.

A full front-to-back reorder (every member moves) is still O(thread_size) — an unavoidable floor under the dense `0..n-1` position invariant that downstream readers (`ORDER BY position`) rely on — but a localized reorder now touches only the affected span. The live artifact established the large-thread cost and member count but did not record the affected span; the timestamp-jump shape is a synthetic common-case model, not a claim about that specific event.

Non-goals: did not change the `position` storage invariant (dense, contiguous integers) to a sort-key-derived scheme, which would make even a full front-to-back reorder O(1) — that's a larger, riskier change touching every reader of `thread_sessions.position`, out of scope for this bound-the-cost bead.

## Verification

- New regression benchmark `tests/benchmarks/test_thread_refresh_scale.py`:
  - `test_thread_refresh_full_reorder_scales_linearly_not_quadratically` — guards against a future quadratic regression (500 vs 4000-member thread, full front-to-back reorder).
  - `test_thread_refresh_local_reorder_is_bounded_by_affected_span` — asserts a 20-sibling local reorder in a 4000-member thread reinserts only ~20 rows, not the full 4000. Verified this benchmark actually fails against the pre-fix implementation via a `git stash` round-trip (4000 rows reinserted, assertion fails as expected).
  - Run: `pytest tests/benchmarks/test_thread_refresh_scale.py --benchmark-enable -p no:xdist -m benchmark -v` → 2 passed.
- New unit test `test_refresh_thread_reorder_only_touches_changed_span` in `tests/unit/storage/test_archive_tiers_write.py` — exact final positions plus a `conn.set_trace_callback` assertion that only one bounded-range `DELETE` and 4 `INSERT`s are issued for a 6-member thread reorder (not a full rebuild).
- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/benchmarks/test_thread_refresh_scale.py` → 65 passed (existing `_refresh_thread` fast-path tests unaffected).
- Coordinator rerun after independent audit: three focused production `_refresh_thread` tests -> `3 passed`; benchmark file with `--benchmark-enable -p no:xdist -p no:randomly -p no:random-order -m benchmark` -> `2 passed`.
- `mypy --strict polylogue/storage/sqlite/archive_tiers/write.py` → success.
- Manual before/after wall-clock comparison (via `git stash` on the same synthetic fixture, `PRAGMA cache_size` lowered to simulate a large real archive's page-cache pressure):
  - Localized reorder (span=20 of 9000 members), cache-pressured: baseline 0.309s → fixed 0.034s (~9x).
  - Full front-to-back reorder (9000 members), cache-pressured: baseline 0.493s → fixed 0.304s (~1.6x, matching the expected O(thread_size) floor since ~half the thread genuinely moves in that scenario).
- Not run: `devtools verify` (broad gate) — per this session's lean-verification directive, the coordinator runs consolidated verification before merging. Pre-push quick gate (`ruff format`/`check`, `mypy`, `render all`, topology/layering/manifest/closure-matrix/schema-roundtrip/doc-commands/test-infra-currency/clock-hygiene/pytest-timeout-overrides/degrade-loudly checks) passed locally on push.

Note: CI is currently blocked by an account billing lock unrelated to this diff.

Ref polylogue-6wnh