### PR TITLE
feat(browser): run resumable provider-aware backfills (#2771)

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,7 +1,8 @@
 # Polylogue Browser Capture
 
 Local-first Manifest V3 extension for capturing ChatGPT and Claude.ai
-sessions into Polylogue.
+sessions into Polylogue, including resumable inventory-driven background
+backfills.
 
 ## Install
 
@@ -164,7 +165,11 @@ pages the badge shows grey and no data is sent.
 - **Stale archive**: the receiver spool is newer than the indexed archive. Keep
   the daemon running; live convergence should advance this to **Archived**
   automatically.
-- **No background collection**: the extension only reads the DOM when you are actively on a supported page
+- **Explicit background collection only**: ordinary page capture reads content
+  only on an explicit capture action. A backfill runs in the service worker
+  only after **Start** is pressed with a provider and cutoff; it uses the
+  authenticated provider inventory/API, never activates foreground tabs, and
+  can be paused or cancelled from the popup.
 - **Local only**: content is posted to the configured `127.0.0.1` receiver and never leaves your machine
 - **Privacy diagnostics**: the popup shows capture counts and timestamps, never message content
 
@@ -198,6 +203,33 @@ polylogue browser-capture serve (Python)
     ▼
 polylogued daemon → ingests → FTS index
 ```
+
+## Resumable background backfill
+
+The popup's **Background backfill** panel starts a provider-native inventory
+delta from a user-selected cutoff. Jobs and queue entries live in IndexedDB,
+so MV3 service-worker suspension or a browser restart does not lose the cursor,
+captured artifact, retry deadline, or receiver receipt. `chrome.alarms` wakes
+the next eligible item; expired leases are recovered and only one extension
+instance may own an item at a time.
+
+The scheduler uses concurrency one per provider, a conservative learned
+request cadence, daily and per-wake budgets, `Retry-After`, exponential
+full-jitter backoff, and a circuit breaker. A 403/auth/challenge pauses for
+operator action; repeated 429s or transport failures pause the provider job.
+Native-empty conversations, authorization failures, bounded retry exhaustion,
+receiver outages, and successful durable ACKs remain distinct in the exported
+diagnostic ledger. Receiver-down artifacts remain queued and are retried
+without refetching provider data.
+
+Completion means the loopback receiver atomically wrote the artifact and
+returned both a request id and the exact submitted JSON-byte SHA-256. The
+deduplication identity is provider native id plus content hash. It does **not**
+mean the provider inventory was historically complete: Polylogue honors the
+provider's authentication, inventory visibility, rate limits, challenges, and
+deletion semantics and cannot prove completeness beyond what that authenticated
+inventory exposes. It does not bypass anti-bot controls or scrape records the
+provider does not enumerate.
 
 ## Development
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -222,6 +222,16 @@ receiver outages, and successful durable ACKs remain distinct in the exported
 diagnostic ledger. Receiver-down artifacts remain queued and are retried
 without refetching provider data.
 
+Execution itself is leased in IndexedDB, not only the queue item. Request
+budget is reserved atomically before a provider call, and pause/cancel bumps a
+generation checked by every asynchronous continuation, so two service workers
+cannot spend the same token or resurrect cancelled work. Provider requests
+time out before the execution lease can expire. Exact provider revision
+timestamps are recorded in a durable native-id ledger; a later job skips only
+an exact known revision, while missing/untrusted revisions are fetched again.
+Receiver retries and stored native envelopes are bounded and fail-paused on
+attempt, byte, or IndexedDB quota exhaustion.
+
 Completion means the loopback receiver atomically wrote the artifact and
 returned both a request id and the exact submitted JSON-byte SHA-256. The
 deduplication identity is provider native id plus content hash. It does **not**

--- a/browser-extension/eslint.config.js
+++ b/browser-extension/eslint.config.js
@@ -19,11 +19,18 @@ export default [
         URLSearchParams: "readonly",
         fetch: "readonly",
         TextEncoder: "readonly",
+        structuredClone: "readonly",
       },
     },
     rules: {
       "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
       "no-undef": "error",
+    },
+  },
+  {
+    files: ["src/background.js", "src/backfill/**/*.js"],
+    languageOptions: {
+      sourceType: "module",
     },
   },
   {
@@ -40,6 +47,8 @@ export default [
         afterEach: "readonly",
         URL: "readonly",
         URLSearchParams: "readonly",
+        document: "readonly",
+        structuredClone: "readonly",
       },
     },
   },

--- a/browser-extension/eslint.config.js
+++ b/browser-extension/eslint.config.js
@@ -19,6 +19,7 @@ export default [
         URLSearchParams: "readonly",
         fetch: "readonly",
         TextEncoder: "readonly",
+        AbortController: "readonly",
         structuredClone: "readonly",
       },
     },

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0",
+    "fake-indexeddb": "^6.2.4",
     "jsdom": "^25.0.0",
     "vitest": "^3.0.0"
   }

--- a/browser-extension/scripts/build.mjs
+++ b/browser-extension/scripts/build.mjs
@@ -28,7 +28,7 @@ const REPO_ROOT = resolve(EXT_ROOT, "..");
 const FIREFOX_GECKO_ID = "polylogue-browser-capture@sinity.dev";
 
 function parseArgs(argv) {
-  const args = { version: null, out: join(EXT_ROOT, "dist"), syncOnly: false };
+  const args = { version: null, out: join(EXT_ROOT, "dist"), syncOnly: false, syncSource: true };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--version") {
@@ -37,9 +37,11 @@ function parseArgs(argv) {
       args.out = resolve(argv[++i]);
     } else if (a === "--sync-only") {
       args.syncOnly = true;
+    } else if (a === "--no-source-sync") {
+      args.syncSource = false;
     } else if (a === "--help" || a === "-h") {
       process.stdout.write(
-        "Usage: build.mjs [--version X.Y.Z] [--out DIR] [--sync-only]\n",
+        "Usage: build.mjs [--version X.Y.Z] [--out DIR] [--sync-only] [--no-source-sync]\n",
       );
       process.exit(0);
     } else {
@@ -170,8 +172,10 @@ function main() {
 
   const manifestPath = join(EXT_ROOT, "manifest.json");
   const packagePath = join(EXT_ROOT, "package.json");
-  syncJsonVersion(manifestPath, version);
-  syncJsonVersion(packagePath, version);
+  if (args.syncSource) {
+    syncJsonVersion(manifestPath, version);
+    syncJsonVersion(packagePath, version);
+  }
 
   if (args.syncOnly) {
     process.stdout.write("sync-only mode — skipping archive build\n");
@@ -186,6 +190,8 @@ function main() {
     const chromeDir = join(stageRoot, "chrome");
     mkdirSync(chromeDir);
     copyTree(EXT_ROOT, chromeDir);
+    syncJsonVersion(join(chromeDir, "manifest.json"), version);
+    syncJsonVersion(join(chromeDir, "package.json"), version);
     const chromeArchive = join(args.out, `polylogue-browser-capture-${version}-chrome.zip`);
     if (existsSync(chromeArchive)) rmSync(chromeArchive);
     makeArchive(chromeDir, chromeArchive, "chrome zip");
@@ -194,7 +200,9 @@ function main() {
     const firefoxDir = join(stageRoot, "firefox");
     mkdirSync(firefoxDir);
     copyTree(EXT_ROOT, firefoxDir);
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    syncJsonVersion(join(firefoxDir, "manifest.json"), version);
+    syncJsonVersion(join(firefoxDir, "package.json"), version);
+    const manifest = JSON.parse(readFileSync(join(firefoxDir, "manifest.json"), "utf8"));
     const fxManifest = buildFirefoxManifest(manifest);
     writeFileSync(join(firefoxDir, "manifest.json"), JSON.stringify(fxManifest, null, 2) + "\n");
     const firefoxArchive = join(args.out, `polylogue-browser-capture-${version}-firefox.xpi`);

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -13,7 +13,11 @@ function nowIso(nowMs) { return new Date(nowMs).toISOString(); }
 
 function queueId(jobId, provider, nativeId) { return `${jobId}:${provider}:${nativeId}`; }
 
-function mergePolicy(patch = {}) { return { ...DEFAULT_BACKFILL_POLICY, ...patch }; }
+function mergePolicy(patch = {}) {
+  const policy = { ...DEFAULT_BACKFILL_POLICY, ...patch };
+  if (policy.leaseMs <= policy.providerRequestTimeoutMs * 2) throw new Error("backfill_lease_must_exceed_request_timeout");
+  return policy;
+}
 
 export class BackfillCoordinator {
   constructor({ store, adapters, receiver, alarms, clock = () => Date.now(), random = Math.random, instanceId = "extension-instance" }) {
@@ -28,11 +32,8 @@ export class BackfillCoordinator {
 
   async start({ provider, cutoff, policy = {}, provider_options = {} }) {
     if (!this.adapters[provider]) throw new Error(`unsupported_backfill_provider:${provider}`);
-    const existing = (await this.store.listJobs()).find(
-      (job) => job.provider === provider && ["running", "paused"].includes(job.status),
-    );
-    if (existing) throw new Error(`backfill_job_already_active:${provider}:${existing.id}`);
     const now = this.clock();
+    const resolvedPolicy = mergePolicy(policy);
     const id = `backfill-${provider}-${now}-${Math.floor(this.random() * 1e9).toString(36)}`;
     const job = {
       id,
@@ -42,8 +43,8 @@ export class BackfillCoordinator {
       status: "running",
       inventory_cursor: "0",
       inventory_complete: false,
-      policy: mergePolicy(policy),
-      learned_cadence_ms: mergePolicy(policy).baseCadenceMs,
+      policy: resolvedPolicy,
+      learned_cadence_ms: resolvedPolicy.baseCadenceMs,
       next_request_at_ms: now,
       cooldown_until_ms: null,
       cooldown_reason: null,
@@ -55,31 +56,25 @@ export class BackfillCoordinator {
       last_ack: null,
       created_at: nowIso(now),
       updated_at: nowIso(now),
+      execution_generation: 0,
+      execution_owner: null,
+      execution_expires_at_ms: null,
     };
-    await this.store.putJob(job);
+    await this.store.createJob(job);
     await this.schedule(id, now);
     return job;
   }
 
   async control(jobId, action) {
-    const job = await this.requireJob(jobId);
     const now = this.clock();
     const status = action === "start" || action === "resume" ? "running" : action === "pause" ? "paused" : action === "cancel" ? "cancelled" : null;
     if (!status) throw new Error(`unknown_backfill_action:${action}`);
-    const next = {
-      ...job,
-      status,
-      cooldown_until_ms: action === "resume" ? null : job.cooldown_until_ms,
-      cooldown_reason: action === "resume" ? null : job.cooldown_reason,
-      throttle_count: action === "resume" ? 0 : job.throttle_count,
-      updated_at: nowIso(now),
-    };
-    await this.store.putJob(next);
-    if (status === "cancelled") {
-      for (const item of await this.store.listQueue(jobId)) {
-        if (!item.state || !["complete", "no_turns"].includes(item.state)) await this.store.putQueue({ ...item, state: "cancelled" });
-      }
-    } else if (status === "running") {
+    await this.store.controlJob(jobId, status, nowIso(now), action === "resume" ? {
+      cooldown_until_ms: null,
+      cooldown_reason: null,
+      throttle_count: 0,
+    } : {});
+    if (status === "running") {
       await this.schedule(jobId, now);
     }
     return this.status(jobId);
@@ -105,10 +100,25 @@ export class BackfillCoordinator {
   }
 
   async runJob(jobId) {
-    let job = await this.requireJob(jobId);
     const now = this.clock();
+    const current = await this.requireJob(jobId);
+    const job = await this.store.acquireJobExecution(jobId, this.instanceId, now, current.policy.leaseMs);
+    if (!job) return this.status(jobId);
+    const generation = job.execution_generation;
+    try {
+      return await this.runLeasedJob(job, now);
+    } catch (error) {
+      if (String(error?.message || error).startsWith("stale_backfill_execution:")) return this.status(jobId);
+      throw error;
+    } finally {
+      await this.store.releaseJobExecution(jobId, this.instanceId, generation);
+    }
+  }
+
+  async runLeasedJob(initialJob, now) {
+    let job = initialJob;
+    const jobId = job.id;
     await this.store.recoverExpiredLeases(jobId, now);
-    if (job.status !== "running") return this.status(jobId);
     await this.schedule(jobId, now + job.policy.leaseMs);
     const receiverItem = await this.store.acquireNextLease(jobId, this.instanceId, now, job.policy.leaseMs, true);
     if (receiverItem) {
@@ -135,7 +145,7 @@ export class BackfillCoordinator {
     let processed = 0;
     while (processed < job.policy.maxCapturesPerWake) {
       const currentNow = this.clock();
-      job = await this.requireJob(jobId);
+      job = await this.store.assertJobExecution(jobId, this.instanceId, job.execution_generation);
       if (job.next_request_at_ms > currentNow || job.daily_requests >= job.policy.maxDailyRequests) break;
       const adapter = this.adapters[job.provider];
       adapter.configure?.(job.provider_options || {});
@@ -152,10 +162,17 @@ export class BackfillCoordinator {
     }
     const queue = await this.store.listQueue(jobId);
     if (job.inventory_complete && jobFinished(queue)) {
-      await this.store.putJob({ ...job, status: "complete", updated_at: nowIso(this.clock()) });
+      await this.saveJob({ ...job, status: "complete", updated_at: nowIso(this.clock()) });
     } else if (job.status === "running") {
-      const candidates = queue.filter((item) => ["eligible", "retry_wait", "captured_waiting_receiver", "leased"].includes(item.state));
-      const next = Math.max(job.next_request_at_ms || 0, Math.min(...candidates.map((item) => item.next_eligible_at_ms || 0).filter(Boolean), Infinity));
+      const receiverDue = Math.min(
+        ...queue.filter((item) => item.state === "captured_waiting_receiver").map((item) => item.next_eligible_at_ms || this.clock()),
+        Infinity,
+      );
+      const providerEligible = queue.filter((item) => ["eligible", "retry_wait", "leased"].includes(item.state));
+      const providerDue = providerEligible.length
+        ? Math.max(job.next_request_at_ms || 0, Math.min(...providerEligible.map((item) => item.next_eligible_at_ms || 0)))
+        : Infinity;
+      const next = Math.min(receiverDue, providerDue);
       await this.schedule(jobId, Number.isFinite(next) ? Math.max(this.clock() + 1000, next) : this.clock() + 60000);
     }
     return this.status(jobId);
@@ -168,78 +185,84 @@ export class BackfillCoordinator {
     const adapter = this.adapters[job.provider];
     adapter.configure?.(job.provider_options || {});
     const requestCost = adapter.requestCost?.("enumerate") || 1;
-    if (job.daily_requests + requestCost > job.policy.maxDailyRequests) {
-      return this.pauseJob(job, "daily_request_budget_exhausted", now);
-    }
+    const reserved = await this.reserveProviderRequests(job, now, requestCost);
+    if (!reserved) return this.pauseJob(job, "daily_request_budget_exhausted", now);
+    job = reserved;
     try {
       result = await adapter.enumerate(job.inventory_cursor, job.cutoff);
     } catch (error) {
-      const accounted = await this.recordProviderRequests(job, now, requestCost);
-      return this.handleJobTransport(accounted, error, now);
+      job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
+      return this.handleJobTransport(job, error, now);
     }
-    const accounted = await this.recordProviderRequests(job, now, requestCost);
-    if (result.classification !== "success") return this.handleProviderBlock(accounted, result.response, result.classification, now);
+    job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
+    if (result.classification !== "success") return this.handleProviderBlock(job, result.response, result.classification, now);
     const room = job.policy.maxQueueSize - queue.length;
-    if (result.items.length > room) return this.pauseJob(accounted, "queue_budget_exhausted", now);
+    if (result.items.length > room) return this.pauseJob(job, "queue_budget_exhausted", now);
     for (const item of result.items) {
-      await this.store.upsertDiscovered({
+      const revision = item.updated_at ? await this.store.getRevision(job.provider, item.native_id) : null;
+      const unchanged = revision?.provider_updated_at === item.updated_at;
+      await this.store.upsertDiscoveredCas(job.id, this.instanceId, job.execution_generation, {
         id: queueId(job.id, job.provider, item.native_id),
         job_id: job.id,
         provider: job.provider,
         native_id: item.native_id,
         title: item.title || null,
         provider_updated_at: item.updated_at || null,
-        state: "eligible",
+        state: unchanged ? "unchanged" : "eligible",
         attempt_count: 0,
         next_eligible_at_ms: now,
         lease_owner: null,
         lease_expires_at_ms: null,
-        last_response_class: "discovered",
+        last_response_class: unchanged ? "known_revision" : "discovered",
         capture_fidelity: null,
         receiver_receipt: null,
         content_hash: null,
       });
     }
     const next = {
-      ...accounted,
-      provider_options: { ...accounted.provider_options, ...(result.provider_options || {}) },
+      ...job,
+      provider_options: { ...job.provider_options, ...(result.provider_options || {}) },
       inventory_cursor: result.next_cursor,
       inventory_complete: Boolean(result.done),
       updated_at: nowIso(now),
     };
-    await this.store.putJob(next);
+    await this.saveJob(next);
     return next;
   }
 
   async processItem(job, item, now, requestCost = 1) {
     if (item.resume_state === "captured_waiting_receiver" && item.envelope) return this.submitReceiver(job, item, item.envelope, now);
+    const reserved = await this.reserveProviderRequests(job, now, requestCost);
+    if (!reserved) return this.pauseJob(job, "daily_request_budget_exhausted", now);
+    job = reserved;
     let response;
     try {
       response = await this.adapters[job.provider].fetchNative(item.native_id);
     } catch (error) {
-      const accounted = await this.recordProviderRequests(job, now, requestCost);
-      return this.retryTransport(accounted, item, error, now);
+      job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
+      return this.retryTransport(job, item, error, now);
     }
-    job = await this.recordProviderRequests(job, now, requestCost);
+    job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
     const classification = this.adapters[job.provider].classifyResponse(response);
     if (classification !== "success") {
       if (classification === "rate_limited" || classification === "auth_or_challenge") {
-        await this.store.putQueue({ ...item, state: classification === "auth_or_challenge" ? "auth_required" : "retry_wait", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, next_eligible_at_ms: now });
+        await this.saveQueue(job, { ...item, state: classification === "auth_or_challenge" ? "auth_required" : "retry_wait", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, next_eligible_at_ms: now });
         return this.handleProviderBlock(job, response, classification, now);
       }
       if (classification === "transport") return this.retryTransport(job, item, new Error(`provider_http_${response.status}`), now);
-      await this.store.putQueue({ ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, last_error: `provider_http_${response.status}` });
+      await this.saveQueue(job, { ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, last_error: `provider_http_${response.status}` });
       return job;
     }
     let capture;
     try {
       capture = await this.adapters[job.provider].normalizeCapture(response, item, { job_id: job.id, queue_id: item.id, instance_id: this.instanceId });
+      job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
     } catch (error) {
-      await this.store.putQueue({ ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: "contract_drift", last_error: String(error.message || error) });
+      await this.saveQueue(job, { ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: "contract_drift", last_error: String(error.message || error) });
       return job;
     }
     if (!capture.session?.turns?.length) {
-      await this.store.putQueue({ ...item, state: "no_turns", lease_owner: null, lease_expires_at_ms: null, last_response_class: "native_empty", capture_fidelity: "native_full" });
+      await this.saveQueue(job, { ...item, state: "no_turns", lease_owner: null, lease_expires_at_ms: null, last_response_class: "native_empty", capture_fidelity: "native_full" });
       return job;
     }
     return this.submitReceiver(job, item, capture, now);
@@ -248,19 +271,59 @@ export class BackfillCoordinator {
   async submitReceiver(job, item, capture, now) {
     const serialized = serializedJson(capture);
     const hash = await serializedContentHash(serialized);
-    await this.store.putQueue({ ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "captured" });
+    const firstPersistence = item.resume_state !== "captured_waiting_receiver" || !item.envelope;
+    if (firstPersistence) {
+      const projectedBytes = await this.store.storedBytes(job.id) + new TextEncoder().encode(serialized).length;
+      if (projectedBytes > job.policy.maxStoredBytes) {
+        await this.saveQueue(job, { ...item, state: "failed", envelope: null, lease_owner: null, lease_expires_at_ms: null, last_response_class: "storage_budget_exhausted", last_error: "storage_budget_exhausted" });
+        return this.pauseJob(job, "storage_budget_exhausted", now);
+      }
+      try {
+        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "captured" });
+      } catch (error) {
+        if (error?.name !== "QuotaExceededError") throw error;
+        return this.pauseJob({ ...job, last_error: "indexeddb_quota_exceeded" }, "indexeddb_quota_exceeded", now);
+      }
+    }
     try {
       const receipt = await this.receiver(capture, serialized);
+      job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
       if (!receipt?.receiver_request_id || receipt.content_hash !== hash) throw new Error("receiver_ack_hash_mismatch");
-      await this.store.putQueue({ ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: "native_full", receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) });
-      const next = { ...job, last_ack: { receiver_request_id: receipt.receiver_request_id, content_hash: hash, at: nowIso(now) }, last_error: null };
-      await this.store.putJob(next);
+      const completeItem = { ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: "native_full", receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) };
+      const revision = item.provider_updated_at
+        ? {
+          id: `${item.provider}:${item.native_id}`,
+          provider: item.provider,
+          native_id: item.native_id,
+          provider_updated_at: item.provider_updated_at,
+          receiver_content_hash: hash,
+          receiver_request_id: receipt.receiver_request_id,
+          completed_at: nowIso(now),
+        }
+        : null;
+      const lastAck = { receiver_request_id: receipt.receiver_request_id, content_hash: hash, at: nowIso(now) };
+      const next = await this.store.finalizeCaptureCas(
+        job,
+        this.instanceId,
+        job.execution_generation,
+        completeItem,
+        revision,
+        lastAck,
+      );
       return next;
     } catch (error) {
+      if (String(error?.message || error).startsWith("stale_backfill_execution:")) throw error;
       const attempt = (item.attempt_count || 0) + 1;
-      await this.store.putQueue({ ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
-      const next = { ...job, last_error: String(error.message || error), updated_at: nowIso(now) };
-      await this.store.putJob(next);
+      await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
+      const exhausted = attempt >= job.policy.maxReceiverAttempts;
+      const next = {
+        ...job,
+        status: exhausted ? "paused" : job.status,
+        cooldown_reason: exhausted ? "receiver_retry_budget_exhausted" : job.cooldown_reason,
+        last_error: String(error.message || error),
+        updated_at: nowIso(now),
+      };
+      await this.saveJob(next);
       return next;
     }
   }
@@ -268,11 +331,11 @@ export class BackfillCoordinator {
   async retryTransport(job, item, error, now) {
     const attempt = (item.attempt_count || 0) + 1;
     const terminal = attempt >= job.policy.maxTransportAttempts;
-    await this.store.putQueue({ ...item, state: terminal ? "failed" : "retry_wait", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "transport", last_error: String(error.message || error) });
+    await this.saveQueue(job, { ...item, state: terminal ? "failed" : "retry_wait", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "transport", last_error: String(error.message || error) });
     const failures = (job.transport_failures || 0) + 1;
     const next = { ...job, transport_failures: failures, last_error: String(error.message || error) };
     if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);
-    await this.store.putJob(next);
+    await this.saveJob(next);
     return next;
   }
 
@@ -284,7 +347,7 @@ export class BackfillCoordinator {
     const delay = Math.max(retryAfterMs(response?.headers, now) || 0, fullJitterDelay(count, learned, job.policy.maxCadenceMs, this.random));
     const next = { ...job, throttle_count: count, learned_cadence_ms: learned, cooldown_until_ms: now + delay, cooldown_reason: "provider_rate_limited", last_error: `provider_http_${response?.status || 429}`, updated_at: nowIso(now) };
     if (count >= job.policy.breakerThreshold) next.status = "paused";
-    await this.store.putJob(next);
+    await this.saveJob(next);
     await this.schedule(job.id, next.cooldown_until_ms);
     return next;
   }
@@ -294,32 +357,44 @@ export class BackfillCoordinator {
     const next = { ...job, transport_failures: failures, last_error: String(error.message || error) };
     if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);
     const deadline = now + fullJitterDelay(failures, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random);
-    await this.store.putJob({ ...next, cooldown_until_ms: deadline, cooldown_reason: "transport_backoff", updated_at: nowIso(now) });
+    await this.saveJob({ ...next, cooldown_until_ms: deadline, cooldown_reason: "transport_backoff", updated_at: nowIso(now) });
     await this.schedule(job.id, deadline);
     return { ...next, cooldown_until_ms: deadline, cooldown_reason: "transport_backoff" };
   }
 
-  async recordProviderRequests(job, now, count) {
+  async reserveProviderRequests(job, now, count) {
     const currentDay = dayKey(now);
-    const requests = job.daily_key === currentDay ? (job.daily_requests || 0) + count : count;
     const jitter = Math.floor(this.random() * Math.max(1, job.learned_cadence_ms / 4));
-    const next = { ...job, daily_key: currentDay, daily_requests: requests, next_request_at_ms: now + job.learned_cadence_ms + jitter, updated_at: nowIso(now) };
-    await this.store.putJob(next);
-    return next;
+    return this.store.reserveProviderRequests(
+      job.id,
+      this.instanceId,
+      job.execution_generation,
+      count,
+      currentDay,
+      now + job.learned_cadence_ms + jitter,
+    );
   }
 
   async resetDailyBudget(job, now) {
     const key = dayKey(now);
     if (job.daily_key === key) return job;
     const next = { ...job, daily_key: key, daily_requests: 0 };
-    await this.store.putJob(next);
+    await this.saveJob(next);
     return next;
   }
 
   async pauseJob(job, reason, now) {
     const next = { ...job, status: "paused", cooldown_reason: reason, last_error: job.last_error || reason, updated_at: nowIso(now) };
-    await this.store.putJob(next);
+    await this.saveJob(next);
     return next;
+  }
+
+  async saveJob(job) {
+    return this.store.putJobCas(job, this.instanceId, job.execution_generation);
+  }
+
+  async saveQueue(job, item) {
+    return this.store.putQueueCas(job.id, this.instanceId, job.execution_generation, item);
   }
 
   async requireJob(jobId) {

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -74,7 +74,8 @@ export class BackfillCoordinator {
       cooldown_until_ms: null,
       cooldown_reason: null,
       throttle_count: 0,
-    } : {});
+      last_error: null,
+    } : {}, action === "resume" ? now : null);
     if (status === "running") {
       await this.schedule(jobId, now);
     }
@@ -162,7 +163,7 @@ export class BackfillCoordinator {
       if (job.status !== "running" || (job.cooldown_until_ms && currentNow < job.cooldown_until_ms)) break;
     }
     const queue = await this.store.listQueue(jobId);
-    if (job.inventory_complete && jobFinished(queue)) {
+    if (job.status === "running" && job.inventory_complete && jobFinished(queue)) {
       await this.saveJob({ ...job, status: "complete", updated_at: nowIso(this.clock()) });
     } else if (job.status === "running") {
       const receiverDue = Math.min(

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -1,5 +1,6 @@
 import {
   DEFAULT_BACKFILL_POLICY,
+  PROVIDER_REQUEST_TIMEOUT_MS,
   backfillAlarmName,
   dayKey,
   fullJitterDelay,
@@ -15,7 +16,7 @@ function queueId(jobId, provider, nativeId) { return `${jobId}:${provider}:${nat
 
 function mergePolicy(patch = {}) {
   const policy = { ...DEFAULT_BACKFILL_POLICY, ...patch };
-  if (policy.leaseMs <= policy.providerRequestTimeoutMs * 2) throw new Error("backfill_lease_must_exceed_request_timeout");
+  if (policy.leaseMs <= PROVIDER_REQUEST_TIMEOUT_MS * 2) throw new Error("backfill_lease_must_exceed_request_timeout");
   return policy;
 }
 
@@ -279,7 +280,7 @@ export class BackfillCoordinator {
         return this.pauseJob(job, "storage_budget_exhausted", now);
       }
       try {
-        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "captured" });
+        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: this.instanceId, lease_expires_at_ms: now + job.policy.leaseMs, last_response_class: "captured" });
       } catch (error) {
         if (error?.name !== "QuotaExceededError") throw error;
         return this.pauseJob({ ...job, last_error: "indexeddb_quota_exceeded" }, "indexeddb_quota_exceeded", now);

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -1,0 +1,335 @@
+import {
+  DEFAULT_BACKFILL_POLICY,
+  backfillAlarmName,
+  dayKey,
+  fullJitterDelay,
+  retryAfterMs,
+  serializedContentHash,
+  serializedJson,
+} from "./models.js";
+import { jobFinished, progressBuckets } from "./storage.js";
+
+function nowIso(nowMs) { return new Date(nowMs).toISOString(); }
+
+function queueId(jobId, provider, nativeId) { return `${jobId}:${provider}:${nativeId}`; }
+
+function mergePolicy(patch = {}) { return { ...DEFAULT_BACKFILL_POLICY, ...patch }; }
+
+export class BackfillCoordinator {
+  constructor({ store, adapters, receiver, alarms, clock = () => Date.now(), random = Math.random, instanceId = "extension-instance" }) {
+    this.store = store;
+    this.adapters = adapters;
+    this.receiver = receiver;
+    this.alarms = alarms;
+    this.clock = clock;
+    this.random = random;
+    this.instanceId = instanceId;
+  }
+
+  async start({ provider, cutoff, policy = {}, provider_options = {} }) {
+    if (!this.adapters[provider]) throw new Error(`unsupported_backfill_provider:${provider}`);
+    const existing = (await this.store.listJobs()).find(
+      (job) => job.provider === provider && ["running", "paused"].includes(job.status),
+    );
+    if (existing) throw new Error(`backfill_job_already_active:${provider}:${existing.id}`);
+    const now = this.clock();
+    const id = `backfill-${provider}-${now}-${Math.floor(this.random() * 1e9).toString(36)}`;
+    const job = {
+      id,
+      provider,
+      cutoff,
+      provider_options,
+      status: "running",
+      inventory_cursor: "0",
+      inventory_complete: false,
+      policy: mergePolicy(policy),
+      learned_cadence_ms: mergePolicy(policy).baseCadenceMs,
+      next_request_at_ms: now,
+      cooldown_until_ms: null,
+      cooldown_reason: null,
+      throttle_count: 0,
+      transport_failures: 0,
+      daily_key: dayKey(now),
+      daily_requests: 0,
+      last_error: null,
+      last_ack: null,
+      created_at: nowIso(now),
+      updated_at: nowIso(now),
+    };
+    await this.store.putJob(job);
+    await this.schedule(id, now);
+    return job;
+  }
+
+  async control(jobId, action) {
+    const job = await this.requireJob(jobId);
+    const now = this.clock();
+    const status = action === "start" || action === "resume" ? "running" : action === "pause" ? "paused" : action === "cancel" ? "cancelled" : null;
+    if (!status) throw new Error(`unknown_backfill_action:${action}`);
+    const next = {
+      ...job,
+      status,
+      cooldown_until_ms: action === "resume" ? null : job.cooldown_until_ms,
+      cooldown_reason: action === "resume" ? null : job.cooldown_reason,
+      throttle_count: action === "resume" ? 0 : job.throttle_count,
+      updated_at: nowIso(now),
+    };
+    await this.store.putJob(next);
+    if (status === "cancelled") {
+      for (const item of await this.store.listQueue(jobId)) {
+        if (!item.state || !["complete", "no_turns"].includes(item.state)) await this.store.putQueue({ ...item, state: "cancelled" });
+      }
+    } else if (status === "running") {
+      await this.schedule(jobId, now);
+    }
+    return this.status(jobId);
+  }
+
+  async status(jobId) {
+    const job = await this.requireJob(jobId);
+    const queue = await this.store.listQueue(jobId);
+    return { ...job, progress: progressBuckets(queue) };
+  }
+
+  async listStatus() {
+    return Promise.all((await this.store.listJobs()).map((job) => this.status(job.id)));
+  }
+
+  async exportLedger(jobId) {
+    return { job: await this.requireJob(jobId), queue: await this.store.listQueue(jobId) };
+  }
+
+  async wake(jobId = null) {
+    const jobs = jobId ? [await this.requireJob(jobId)] : await this.store.listJobs();
+    for (const job of jobs.filter((candidate) => candidate.status === "running")) await this.runJob(job.id);
+  }
+
+  async runJob(jobId) {
+    let job = await this.requireJob(jobId);
+    const now = this.clock();
+    await this.store.recoverExpiredLeases(jobId, now);
+    if (job.status !== "running") return this.status(jobId);
+    await this.schedule(jobId, now + job.policy.leaseMs);
+    const receiverItem = await this.store.acquireNextLease(jobId, this.instanceId, now, job.policy.leaseMs, true);
+    if (receiverItem) {
+      job = await this.submitReceiver(job, receiverItem, receiverItem.envelope, now);
+    }
+    if (job.cooldown_until_ms && now < job.cooldown_until_ms) {
+      await this.schedule(jobId, job.cooldown_until_ms);
+      return this.status(jobId);
+    }
+    job = await this.resetDailyBudget(job, now);
+    if (job.daily_requests >= job.policy.maxDailyRequests) {
+      job = await this.pauseJob(job, "daily_request_budget_exhausted", now);
+      return this.status(jobId);
+    }
+    if (job.next_request_at_ms > now) {
+      await this.schedule(jobId, job.next_request_at_ms);
+      return this.status(jobId);
+    }
+    if (!job.inventory_complete) {
+      job = await this.enumerate(job, now);
+      if (job.status === "running") await this.schedule(jobId, job.next_request_at_ms);
+      return this.status(jobId);
+    }
+    let processed = 0;
+    while (processed < job.policy.maxCapturesPerWake) {
+      const currentNow = this.clock();
+      job = await this.requireJob(jobId);
+      if (job.next_request_at_ms > currentNow || job.daily_requests >= job.policy.maxDailyRequests) break;
+      const adapter = this.adapters[job.provider];
+      adapter.configure?.(job.provider_options || {});
+      const requestCost = adapter.requestCost?.("fetch") || 1;
+      if (job.daily_requests + requestCost > job.policy.maxDailyRequests) {
+        job = await this.pauseJob(job, "daily_request_budget_exhausted", currentNow);
+        break;
+      }
+      const item = await this.store.acquireNextLease(jobId, this.instanceId, currentNow, job.policy.leaseMs, false);
+      if (!item) break;
+      job = await this.processItem(job, item, currentNow, requestCost);
+      processed += 1;
+      if (job.status !== "running" || (job.cooldown_until_ms && currentNow < job.cooldown_until_ms)) break;
+    }
+    const queue = await this.store.listQueue(jobId);
+    if (job.inventory_complete && jobFinished(queue)) {
+      await this.store.putJob({ ...job, status: "complete", updated_at: nowIso(this.clock()) });
+    } else if (job.status === "running") {
+      const candidates = queue.filter((item) => ["eligible", "retry_wait", "captured_waiting_receiver", "leased"].includes(item.state));
+      const next = Math.max(job.next_request_at_ms || 0, Math.min(...candidates.map((item) => item.next_eligible_at_ms || 0).filter(Boolean), Infinity));
+      await this.schedule(jobId, Number.isFinite(next) ? Math.max(this.clock() + 1000, next) : this.clock() + 60000);
+    }
+    return this.status(jobId);
+  }
+
+  async enumerate(job, now) {
+    const queue = await this.store.listQueue(job.id);
+    if (queue.length >= job.policy.maxQueueSize) return this.pauseJob(job, "queue_budget_exhausted", now);
+    let result;
+    const adapter = this.adapters[job.provider];
+    adapter.configure?.(job.provider_options || {});
+    const requestCost = adapter.requestCost?.("enumerate") || 1;
+    if (job.daily_requests + requestCost > job.policy.maxDailyRequests) {
+      return this.pauseJob(job, "daily_request_budget_exhausted", now);
+    }
+    try {
+      result = await adapter.enumerate(job.inventory_cursor, job.cutoff);
+    } catch (error) {
+      const accounted = await this.recordProviderRequests(job, now, requestCost);
+      return this.handleJobTransport(accounted, error, now);
+    }
+    const accounted = await this.recordProviderRequests(job, now, requestCost);
+    if (result.classification !== "success") return this.handleProviderBlock(accounted, result.response, result.classification, now);
+    const room = job.policy.maxQueueSize - queue.length;
+    if (result.items.length > room) return this.pauseJob(accounted, "queue_budget_exhausted", now);
+    for (const item of result.items) {
+      await this.store.upsertDiscovered({
+        id: queueId(job.id, job.provider, item.native_id),
+        job_id: job.id,
+        provider: job.provider,
+        native_id: item.native_id,
+        title: item.title || null,
+        provider_updated_at: item.updated_at || null,
+        state: "eligible",
+        attempt_count: 0,
+        next_eligible_at_ms: now,
+        lease_owner: null,
+        lease_expires_at_ms: null,
+        last_response_class: "discovered",
+        capture_fidelity: null,
+        receiver_receipt: null,
+        content_hash: null,
+      });
+    }
+    const next = {
+      ...accounted,
+      provider_options: { ...accounted.provider_options, ...(result.provider_options || {}) },
+      inventory_cursor: result.next_cursor,
+      inventory_complete: Boolean(result.done),
+      updated_at: nowIso(now),
+    };
+    await this.store.putJob(next);
+    return next;
+  }
+
+  async processItem(job, item, now, requestCost = 1) {
+    if (item.resume_state === "captured_waiting_receiver" && item.envelope) return this.submitReceiver(job, item, item.envelope, now);
+    let response;
+    try {
+      response = await this.adapters[job.provider].fetchNative(item.native_id);
+    } catch (error) {
+      const accounted = await this.recordProviderRequests(job, now, requestCost);
+      return this.retryTransport(accounted, item, error, now);
+    }
+    job = await this.recordProviderRequests(job, now, requestCost);
+    const classification = this.adapters[job.provider].classifyResponse(response);
+    if (classification !== "success") {
+      if (classification === "rate_limited" || classification === "auth_or_challenge") {
+        await this.store.putQueue({ ...item, state: classification === "auth_or_challenge" ? "auth_required" : "retry_wait", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, next_eligible_at_ms: now });
+        return this.handleProviderBlock(job, response, classification, now);
+      }
+      if (classification === "transport") return this.retryTransport(job, item, new Error(`provider_http_${response.status}`), now);
+      await this.store.putQueue({ ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: classification, last_error: `provider_http_${response.status}` });
+      return job;
+    }
+    let capture;
+    try {
+      capture = await this.adapters[job.provider].normalizeCapture(response, item, { job_id: job.id, queue_id: item.id, instance_id: this.instanceId });
+    } catch (error) {
+      await this.store.putQueue({ ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: "contract_drift", last_error: String(error.message || error) });
+      return job;
+    }
+    if (!capture.session?.turns?.length) {
+      await this.store.putQueue({ ...item, state: "no_turns", lease_owner: null, lease_expires_at_ms: null, last_response_class: "native_empty", capture_fidelity: "native_full" });
+      return job;
+    }
+    return this.submitReceiver(job, item, capture, now);
+  }
+
+  async submitReceiver(job, item, capture, now) {
+    const serialized = serializedJson(capture);
+    const hash = await serializedContentHash(serialized);
+    await this.store.putQueue({ ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "captured" });
+    try {
+      const receipt = await this.receiver(capture, serialized);
+      if (!receipt?.receiver_request_id || receipt.content_hash !== hash) throw new Error("receiver_ack_hash_mismatch");
+      await this.store.putQueue({ ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: "native_full", receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) });
+      const next = { ...job, last_ack: { receiver_request_id: receipt.receiver_request_id, content_hash: hash, at: nowIso(now) }, last_error: null };
+      await this.store.putJob(next);
+      return next;
+    } catch (error) {
+      const attempt = (item.attempt_count || 0) + 1;
+      await this.store.putQueue({ ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
+      const next = { ...job, last_error: String(error.message || error), updated_at: nowIso(now) };
+      await this.store.putJob(next);
+      return next;
+    }
+  }
+
+  async retryTransport(job, item, error, now) {
+    const attempt = (item.attempt_count || 0) + 1;
+    const terminal = attempt >= job.policy.maxTransportAttempts;
+    await this.store.putQueue({ ...item, state: terminal ? "failed" : "retry_wait", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "transport", last_error: String(error.message || error) });
+    const failures = (job.transport_failures || 0) + 1;
+    const next = { ...job, transport_failures: failures, last_error: String(error.message || error) };
+    if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);
+    await this.store.putJob(next);
+    return next;
+  }
+
+  async handleProviderBlock(job, response, classification, now) {
+    if (classification === "auth_or_challenge") return this.pauseJob({ ...job, last_error: "provider_auth_or_challenge" }, "provider_auth_or_challenge", now);
+    if (classification !== "rate_limited") return this.handleJobTransport(job, new Error(`provider_${classification}`), now);
+    const count = (job.throttle_count || 0) + 1;
+    const learned = Math.min(job.policy.maxCadenceMs, Math.max(job.learned_cadence_ms * 2, job.policy.baseCadenceMs));
+    const delay = Math.max(retryAfterMs(response?.headers, now) || 0, fullJitterDelay(count, learned, job.policy.maxCadenceMs, this.random));
+    const next = { ...job, throttle_count: count, learned_cadence_ms: learned, cooldown_until_ms: now + delay, cooldown_reason: "provider_rate_limited", last_error: `provider_http_${response?.status || 429}`, updated_at: nowIso(now) };
+    if (count >= job.policy.breakerThreshold) next.status = "paused";
+    await this.store.putJob(next);
+    await this.schedule(job.id, next.cooldown_until_ms);
+    return next;
+  }
+
+  async handleJobTransport(job, error, now) {
+    const failures = (job.transport_failures || 0) + 1;
+    const next = { ...job, transport_failures: failures, last_error: String(error.message || error) };
+    if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);
+    const deadline = now + fullJitterDelay(failures, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random);
+    await this.store.putJob({ ...next, cooldown_until_ms: deadline, cooldown_reason: "transport_backoff", updated_at: nowIso(now) });
+    await this.schedule(job.id, deadline);
+    return { ...next, cooldown_until_ms: deadline, cooldown_reason: "transport_backoff" };
+  }
+
+  async recordProviderRequests(job, now, count) {
+    const currentDay = dayKey(now);
+    const requests = job.daily_key === currentDay ? (job.daily_requests || 0) + count : count;
+    const jitter = Math.floor(this.random() * Math.max(1, job.learned_cadence_ms / 4));
+    const next = { ...job, daily_key: currentDay, daily_requests: requests, next_request_at_ms: now + job.learned_cadence_ms + jitter, updated_at: nowIso(now) };
+    await this.store.putJob(next);
+    return next;
+  }
+
+  async resetDailyBudget(job, now) {
+    const key = dayKey(now);
+    if (job.daily_key === key) return job;
+    const next = { ...job, daily_key: key, daily_requests: 0 };
+    await this.store.putJob(next);
+    return next;
+  }
+
+  async pauseJob(job, reason, now) {
+    const next = { ...job, status: "paused", cooldown_reason: reason, last_error: job.last_error || reason, updated_at: nowIso(now) };
+    await this.store.putJob(next);
+    return next;
+  }
+
+  async requireJob(jobId) {
+    const job = await this.store.getJob(jobId);
+    if (!job) throw new Error(`backfill_job_not_found:${jobId}`);
+    return job;
+  }
+
+  async schedule(jobId, whenMs) {
+    if (!this.alarms?.create) return;
+    await this.alarms.create(backfillAlarmName(jobId), { when: Math.max(this.clock() + 1000, whenMs) });
+  }
+}

--- a/browser-extension/src/backfill/models.js
+++ b/browser-extension/src/backfill/models.js
@@ -1,0 +1,48 @@
+export const BACKFILL_ALARM = "polylogueBackfillWake";
+export const BACKFILL_DB_NAME = "polylogue-browser-backfill";
+export const BACKFILL_DB_VERSION = 1;
+
+export const DEFAULT_BACKFILL_POLICY = Object.freeze({
+  maxQueueSize: 10000,
+  maxCapturesPerWake: 5,
+  maxDailyRequests: 250,
+  leaseMs: 120000,
+  baseCadenceMs: 15000,
+  maxCadenceMs: 15 * 60 * 1000,
+  maxTransportAttempts: 5,
+  breakerThreshold: 2,
+});
+
+export const TERMINAL_QUEUE_STATES = new Set(["complete", "no_turns", "auth_required", "failed", "cancelled"]);
+
+export function backfillAlarmName(jobId) {
+  return `${BACKFILL_ALARM}:${jobId}`;
+}
+
+export function serializedJson(value) {
+  return JSON.stringify(value);
+}
+
+export async function serializedContentHash(serialized) {
+  const bytes = new TextEncoder().encode(serialized);
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function retryAfterMs(headers, nowMs) {
+  const value = headers?.get?.("Retry-After");
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+  const deadline = Date.parse(value);
+  return Number.isFinite(deadline) ? Math.max(0, deadline - nowMs) : null;
+}
+
+export function fullJitterDelay(attempt, baseMs, maxMs, random = Math.random) {
+  const ceiling = Math.min(maxMs, baseMs * 2 ** Math.max(0, attempt));
+  return Math.floor(random() * ceiling);
+}
+
+export function dayKey(nowMs) {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}

--- a/browser-extension/src/backfill/models.js
+++ b/browser-extension/src/backfill/models.js
@@ -1,19 +1,23 @@
 export const BACKFILL_ALARM = "polylogueBackfillWake";
 export const BACKFILL_DB_NAME = "polylogue-browser-backfill";
-export const BACKFILL_DB_VERSION = 1;
+export const BACKFILL_DB_VERSION = 2;
+export const PROVIDER_REQUEST_TIMEOUT_MS = 60000;
 
 export const DEFAULT_BACKFILL_POLICY = Object.freeze({
   maxQueueSize: 10000,
   maxCapturesPerWake: 5,
   maxDailyRequests: 250,
-  leaseMs: 120000,
+  leaseMs: 180000,
+  providerRequestTimeoutMs: PROVIDER_REQUEST_TIMEOUT_MS,
   baseCadenceMs: 15000,
   maxCadenceMs: 15 * 60 * 1000,
   maxTransportAttempts: 5,
+  maxReceiverAttempts: 20,
+  maxStoredBytes: 100 * 1024 * 1024,
   breakerThreshold: 2,
 });
 
-export const TERMINAL_QUEUE_STATES = new Set(["complete", "no_turns", "auth_required", "failed", "cancelled"]);
+export const TERMINAL_QUEUE_STATES = new Set(["complete", "unchanged", "no_turns", "auth_required", "failed", "cancelled"]);
 
 export function backfillAlarmName(jobId) {
   return `${BACKFILL_ALARM}:${jobId}`;

--- a/browser-extension/src/backfill/models.js
+++ b/browser-extension/src/backfill/models.js
@@ -8,7 +8,6 @@ export const DEFAULT_BACKFILL_POLICY = Object.freeze({
   maxCapturesPerWake: 5,
   maxDailyRequests: 250,
   leaseMs: 180000,
-  providerRequestTimeoutMs: PROVIDER_REQUEST_TIMEOUT_MS,
   baseCadenceMs: 15000,
   maxCadenceMs: 15 * 60 * 1000,
   maxTransportAttempts: 5,

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -111,14 +111,17 @@ export class ChatGptBackfillAdapter {
     const response = await providerRequest(this.fetchImpl, `https://chatgpt.com/backend-api/conversations?offset=${offset}&limit=100&order=updated`);
     if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: 1 };
     const body = await jsonResponse(response, "chatgpt_inventory");
-    const items = requireArray(body.items, "chatgpt_inventory.items").map((item, index) => ({
+    const records = requireArray(body.items, "chatgpt_inventory.items");
+    const projected = records.map((item, index) => ({
       native_id: requireString(item.id, `chatgpt_inventory.items[${index}].id`),
       title: typeof item.title === "string" ? item.title : null,
       updated_at: isoTimestamp(item.update_time),
-    })).filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
-    const total = Number.isFinite(body.total) ? body.total : offset + items.length;
-    const nextOffset = offset + requireArray(body.items, "chatgpt_inventory.items").length;
-    return { response, classification: "success", items, next_cursor: String(nextOffset), done: nextOffset >= total, request_count: 1 };
+    }));
+    const items = projected.filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
+    const crossedCutoff = Boolean(cutoff && projected.some((item) => item.updated_at && item.updated_at < cutoff));
+    const total = Number.isFinite(body.total) ? body.total : offset + records.length;
+    const nextOffset = offset + records.length;
+    return { response, classification: "success", items, next_cursor: String(nextOffset), done: nextOffset >= total || crossedCutoff, request_count: 1 };
   }
   async fetchNative(nativeId) { return providerRequest(this.fetchImpl, `https://chatgpt.com/backend-api/conversation/${encodeURIComponent(nativeId)}`); }
   classifyResponse(response) { return responseClass(response); }
@@ -176,12 +179,14 @@ export class ClaudeBackfillAdapter {
     if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
     const body = await response.json();
     const records = requireArray(body, "claude_inventory");
-    const items = records.map((item, index) => ({
+    const projected = records.map((item, index) => ({
       native_id: requireString(item.uuid, `claude_inventory[${index}].uuid`),
       title: typeof item.name === "string" ? item.name : null,
       updated_at: isoTimestamp(item.updated_at),
-    })).filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
-    return { response, classification: "success", items, next_cursor: String(offset + records.length), done: records.length < 100, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
+    }));
+    const items = projected.filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
+    const crossedCutoff = Boolean(cutoff && projected.some((item) => item.updated_at && item.updated_at < cutoff));
+    return { response, classification: "success", items, next_cursor: String(offset + records.length), done: records.length < 100 || crossedCutoff, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
   }
   async fetchNative(nativeId) {
     const organization = await this.organization();

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -185,8 +185,7 @@ export class ClaudeBackfillAdapter {
       updated_at: isoTimestamp(item.updated_at),
     }));
     const items = projected.filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
-    const crossedCutoff = Boolean(cutoff && projected.some((item) => item.updated_at && item.updated_at < cutoff));
-    return { response, classification: "success", items, next_cursor: String(offset + records.length), done: records.length < 100 || crossedCutoff, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
+    return { response, classification: "success", items, next_cursor: String(offset + records.length), done: records.length < 100, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
   }
   async fetchNative(nativeId) {
     const organization = await this.organization();

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -1,0 +1,210 @@
+function requireArray(value, path) {
+  if (!Array.isArray(value)) throw new Error(`provider_contract_drift:${path}_must_be_array`);
+  return value;
+}
+
+function requireString(value, path) {
+  if (typeof value !== "string" || !value) throw new Error(`provider_contract_drift:${path}_must_be_string`);
+  return value;
+}
+
+function responseClass(response) {
+  if (response.ok) return "success";
+  if (response.status === 429) return "rate_limited";
+  if (response.status === 401 || response.status === 403) return "auth_or_challenge";
+  if (response.status >= 500) return "transport";
+  return "fatal";
+}
+
+async function jsonResponse(response, label) {
+  const body = await response.json().catch(() => null);
+  if (!body || typeof body !== "object") throw new Error(`provider_contract_drift:${label}_not_json_object`);
+  return body;
+}
+
+function isoTimestamp(value) {
+  if (typeof value === "number") return new Date(value < 10_000_000_000 ? value * 1000 : value).toISOString();
+  return typeof value === "string" && value ? value : null;
+}
+
+const REQUEST_OPTIONS = Object.freeze({ credentials: "include", cache: "no-store" });
+
+function chatGptText(content) {
+  if (Array.isArray(content?.parts)) {
+    const parts = content.parts.flatMap((part) => {
+      if (typeof part === "string" && part) return [part];
+      if (part && typeof part === "object" && typeof part.text === "string" && part.text) return [part.text];
+      return [];
+    });
+    if (parts.length) return parts.join("\n");
+  }
+  if (typeof content?.text === "string" && content.text) return content.text;
+  if (typeof content?.result === "string" && content.result) return content.result;
+  return "";
+}
+
+function normalizedRole(raw) {
+  if (["user", "assistant", "system", "tool"].includes(raw)) return raw;
+  if (["function", "tool_use", "tool_result"].includes(raw)) return "tool";
+  if (raw === "human") return "user";
+  if (raw === "claude") return "assistant";
+  return "unknown";
+}
+
+function claudeText(message) {
+  if (typeof message?.text === "string" && message.text) return message.text;
+  if (typeof message?.content === "string" && message.content) return message.content;
+  if (!Array.isArray(message?.content)) return "";
+  return message.content.flatMap((part) => {
+    if (typeof part === "string") return [part];
+    if (part && typeof part === "object" && typeof part.text === "string") return [part.text];
+    return [];
+  }).filter(Boolean).join("\n");
+}
+
+function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawPayload, adapterName, sourceUrl, attribution }) {
+  return {
+    polylogue_capture_kind: "browser_llm_session",
+    schema_version: 1,
+    capture_id: `${provider}:${nativeId}`,
+    source: "browser-extension",
+    provenance: {
+      source_url: sourceUrl,
+      page_title: title || null,
+      captured_at: new Date().toISOString(),
+      extension_id: globalThis.chrome?.runtime?.id || null,
+      adapter_name: adapterName,
+      adapter_version: globalThis.chrome?.runtime?.getManifest?.().version || null,
+      capture_mode: "snapshot",
+      provider_meta: { backfill: attribution },
+    },
+    session: {
+      provider,
+      provider_session_id: nativeId,
+      title: title || nativeId,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      provider_meta: { capture_fidelity: "native_full", backfill: attribution },
+      turns: turns.map((turn, ordinal) => ({ ...turn, ordinal })),
+    },
+    provider_meta: { backfill: attribution },
+    raw_provider_payload: rawPayload,
+  };
+}
+
+export class ChatGptBackfillAdapter {
+  constructor(fetchImpl = globalThis.fetch) { this.fetchImpl = fetchImpl; this.provider = "chatgpt"; }
+  configure() {}
+  requestCost() { return 1; }
+  async enumerate(cursor = "0", cutoff = null) {
+    const offset = Number.parseInt(cursor || "0", 10) || 0;
+    const response = await this.fetchImpl(`https://chatgpt.com/backend-api/conversations?offset=${offset}&limit=100&order=updated`, REQUEST_OPTIONS);
+    if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: 1 };
+    const body = await jsonResponse(response, "chatgpt_inventory");
+    const items = requireArray(body.items, "chatgpt_inventory.items").map((item, index) => ({
+      native_id: requireString(item.id, `chatgpt_inventory.items[${index}].id`),
+      title: typeof item.title === "string" ? item.title : null,
+      updated_at: isoTimestamp(item.update_time),
+    })).filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
+    const total = Number.isFinite(body.total) ? body.total : offset + items.length;
+    const nextOffset = offset + requireArray(body.items, "chatgpt_inventory.items").length;
+    return { response, classification: "success", items, next_cursor: String(nextOffset), done: nextOffset >= total, request_count: 1 };
+  }
+  async fetchNative(nativeId) { return this.fetchImpl(`https://chatgpt.com/backend-api/conversation/${encodeURIComponent(nativeId)}`, REQUEST_OPTIONS); }
+  classifyResponse(response) { return responseClass(response); }
+  async normalizeCapture(response, item, attribution) {
+    const body = await jsonResponse(response, "chatgpt_conversation");
+    const mapping = body.mapping && typeof body.mapping === "object" ? Object.entries(body.mapping) : null;
+    if (!mapping) throw new Error("provider_contract_drift:chatgpt_conversation.mapping_must_be_object");
+    const turns = mapping.flatMap(([nodeId, node]) => {
+      const message = node?.message;
+      if (!message || !message.author || !message.content) return [];
+      const text = chatGptText(message.content).trim();
+      if (!text) return [];
+      const metadata = message.metadata && typeof message.metadata === "object" ? message.metadata : {};
+      return [{
+        provider_turn_id: requireString(message.id || node.id || nodeId, "chatgpt_conversation.message.id"),
+        role: normalizedRole(message.author.role),
+        text,
+        timestamp: isoTimestamp(message.create_time),
+        parent_turn_id: node.parent || null,
+        provider_meta: {
+          node_id: nodeId,
+          content_type: message.content.content_type || "text",
+          status: message.status || null,
+          model_slug: metadata.model_slug || null,
+          capture_source: "chatgpt_backend_api",
+        },
+      }];
+    });
+    return envelope({ provider: "chatgpt", nativeId: item.native_id, title: body.title || item.title, createdAt: isoTimestamp(body.create_time), updatedAt: isoTimestamp(body.update_time) || item.updated_at, turns, rawPayload: body, adapterName: "chatgpt-backfill-native-v1", sourceUrl: `https://chatgpt.com/c/${item.native_id}`, attribution });
+  }
+}
+
+export class ClaudeBackfillAdapter {
+  constructor(fetchImpl = globalThis.fetch, organizationId = null) { this.fetchImpl = fetchImpl; this.organizationId = organizationId; this.provider = "claude-ai"; }
+  configure(options = {}) {
+    if (options.claudeOrganizationId) this.organizationId = options.claudeOrganizationId;
+  }
+  requestCost(operation) {
+    return operation === "enumerate" && !this.organizationId ? 2 : 1;
+  }
+  async organization() {
+    if (this.organizationId) return { id: this.organizationId, request_count: 0 };
+    const response = await this.fetchImpl("https://claude.ai/api/organizations", REQUEST_OPTIONS);
+    if (!response.ok) return { response, classification: responseClass(response), request_count: 1 };
+    const organizations = requireArray(await response.json(), "claude_organizations");
+    this.organizationId = requireString(organizations[0]?.uuid, "claude_organizations[0].uuid");
+    return { id: this.organizationId, request_count: 1 };
+  }
+  async enumerate(cursor = "0", cutoff = null) {
+    const organization = await this.organization();
+    if (!organization.id) return { ...organization, items: [], next_cursor: cursor, done: false };
+    const offset = Number.parseInt(cursor || "0", 10) || 0;
+    const response = await this.fetchImpl(`https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations?limit=100&offset=${offset}`, REQUEST_OPTIONS);
+    const requestCount = organization.request_count + 1;
+    if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
+    const body = await response.json();
+    const records = requireArray(body, "claude_inventory");
+    const items = records.map((item, index) => ({
+      native_id: requireString(item.uuid, `claude_inventory[${index}].uuid`),
+      title: typeof item.name === "string" ? item.name : null,
+      updated_at: isoTimestamp(item.updated_at),
+    })).filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
+    return { response, classification: "success", items, next_cursor: String(offset + records.length), done: records.length < 100, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
+  }
+  async fetchNative(nativeId) {
+    const organization = await this.organization();
+    if (!organization.id) return organization.response;
+    return this.fetchImpl(`https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations/${encodeURIComponent(nativeId)}`, REQUEST_OPTIONS);
+  }
+  classifyResponse(response) { return responseClass(response); }
+  async normalizeCapture(response, item, attribution) {
+    const body = await jsonResponse(response, "claude_conversation");
+    const messages = requireArray(body.chat_messages, "claude_conversation.chat_messages");
+    const turns = messages.flatMap((message, index) => {
+      const text = claudeText(message).trim();
+      if (!text) return [];
+      return [{
+        provider_turn_id: requireString(message.uuid || message.id, `claude_conversation.chat_messages[${index}].uuid`),
+        role: normalizedRole(message.sender || message.role || message.author),
+        text,
+        timestamp: isoTimestamp(message.created_at),
+        parent_turn_id: message.parent_message_uuid || message.parent_uuid || null,
+        provider_meta: {
+          model: message.model || null,
+          sender: message.sender || message.role || null,
+          capture_source: "claude_chat_conversations_api",
+        },
+      }];
+    });
+    return envelope({ provider: "claude-ai", nativeId: item.native_id, title: body.name || item.title, createdAt: isoTimestamp(body.created_at), updatedAt: isoTimestamp(body.updated_at) || item.updated_at, turns, rawPayload: body, adapterName: "claude-ai-backfill-native-v1", sourceUrl: `https://claude.ai/chat/${item.native_id}`, attribution });
+  }
+}
+
+export function providerAdapters(fetchImpl = globalThis.fetch, options = {}) {
+  return {
+    chatgpt: new ChatGptBackfillAdapter(fetchImpl),
+    "claude-ai": new ClaudeBackfillAdapter(fetchImpl, options.claudeOrganizationId || null),
+  };
+}

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -29,6 +29,16 @@ function isoTimestamp(value) {
 
 const REQUEST_OPTIONS = Object.freeze({ credentials: "include", cache: "no-store" });
 
+async function providerRequest(fetchImpl, url) {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort("provider_request_timeout"), PROVIDER_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetchImpl(url, { ...REQUEST_OPTIONS, signal: controller.signal });
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
+}
+
 function chatGptText(content) {
   if (Array.isArray(content?.parts)) {
     const parts = content.parts.flatMap((part) => {
@@ -98,7 +108,7 @@ export class ChatGptBackfillAdapter {
   requestCost() { return 1; }
   async enumerate(cursor = "0", cutoff = null) {
     const offset = Number.parseInt(cursor || "0", 10) || 0;
-    const response = await this.fetchImpl(`https://chatgpt.com/backend-api/conversations?offset=${offset}&limit=100&order=updated`, REQUEST_OPTIONS);
+    const response = await providerRequest(this.fetchImpl, `https://chatgpt.com/backend-api/conversations?offset=${offset}&limit=100&order=updated`);
     if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: 1 };
     const body = await jsonResponse(response, "chatgpt_inventory");
     const items = requireArray(body.items, "chatgpt_inventory.items").map((item, index) => ({
@@ -110,7 +120,7 @@ export class ChatGptBackfillAdapter {
     const nextOffset = offset + requireArray(body.items, "chatgpt_inventory.items").length;
     return { response, classification: "success", items, next_cursor: String(nextOffset), done: nextOffset >= total, request_count: 1 };
   }
-  async fetchNative(nativeId) { return this.fetchImpl(`https://chatgpt.com/backend-api/conversation/${encodeURIComponent(nativeId)}`, REQUEST_OPTIONS); }
+  async fetchNative(nativeId) { return providerRequest(this.fetchImpl, `https://chatgpt.com/backend-api/conversation/${encodeURIComponent(nativeId)}`); }
   classifyResponse(response) { return responseClass(response); }
   async normalizeCapture(response, item, attribution) {
     const body = await jsonResponse(response, "chatgpt_conversation");
@@ -151,7 +161,7 @@ export class ClaudeBackfillAdapter {
   }
   async organization() {
     if (this.organizationId) return { id: this.organizationId, request_count: 0 };
-    const response = await this.fetchImpl("https://claude.ai/api/organizations", REQUEST_OPTIONS);
+    const response = await providerRequest(this.fetchImpl, "https://claude.ai/api/organizations");
     if (!response.ok) return { response, classification: responseClass(response), request_count: 1 };
     const organizations = requireArray(await response.json(), "claude_organizations");
     this.organizationId = requireString(organizations[0]?.uuid, "claude_organizations[0].uuid");
@@ -161,7 +171,7 @@ export class ClaudeBackfillAdapter {
     const organization = await this.organization();
     if (!organization.id) return { ...organization, items: [], next_cursor: cursor, done: false };
     const offset = Number.parseInt(cursor || "0", 10) || 0;
-    const response = await this.fetchImpl(`https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations?limit=100&offset=${offset}`, REQUEST_OPTIONS);
+    const response = await providerRequest(this.fetchImpl, `https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations?limit=100&offset=${offset}`);
     const requestCount = organization.request_count + 1;
     if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: requestCount, provider_options: { claudeOrganizationId: organization.id } };
     const body = await response.json();
@@ -176,7 +186,16 @@ export class ClaudeBackfillAdapter {
   async fetchNative(nativeId) {
     const organization = await this.organization();
     if (!organization.id) return organization.response;
-    return this.fetchImpl(`https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations/${encodeURIComponent(nativeId)}`, REQUEST_OPTIONS);
+    const query = new URLSearchParams({
+      tree: "True",
+      rendering_mode: "messages",
+      render_all_tools: "true",
+      consistency: "strong",
+    });
+    return providerRequest(
+      this.fetchImpl,
+      `https://claude.ai/api/organizations/${encodeURIComponent(organization.id)}/chat_conversations/${encodeURIComponent(nativeId)}?${query}`,
+    );
   }
   classifyResponse(response) { return responseClass(response); }
   async normalizeCapture(response, item, attribution) {
@@ -208,3 +227,4 @@ export function providerAdapters(fetchImpl = globalThis.fetch, options = {}) {
     "claude-ai": new ClaudeBackfillAdapter(fetchImpl, options.claudeOrganizationId || null),
   };
 }
+import { PROVIDER_REQUEST_TIMEOUT_MS } from "./models.js";

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -149,7 +149,7 @@ export class IndexedDbBackfillStore {
     await transactionDone(tx);
   }
 
-  async controlJob(jobId, status, nowIsoValue, patch = {}) {
+  async controlJob(jobId, status, nowIsoValue, patch = {}, resumeQueueAtMs = null) {
     const db = await this.database();
     const tx = db.transaction(["jobs", "queue"], "readwrite");
     const store = tx.objectStore("jobs");
@@ -168,8 +168,25 @@ export class IndexedDbBackfillStore {
       updated_at: nowIsoValue,
     };
     store.put(next);
+    const queueStore = tx.objectStore("queue");
+    if (status === "running" && resumeQueueAtMs !== null) {
+      const items = await requestResult(queueStore.getAll());
+      for (const item of items) {
+        if (item.job_id === jobId && item.state === "auth_required") {
+          queueStore.put({
+            ...item,
+            state: "eligible",
+            resume_state: "eligible",
+            lease_owner: null,
+            lease_expires_at_ms: null,
+            next_eligible_at_ms: resumeQueueAtMs,
+            last_response_class: null,
+            last_error: null,
+          });
+        }
+      }
+    }
     if (status === "cancelled") {
-      const queueStore = tx.objectStore("queue");
       const items = await requestResult(queueStore.getAll());
       for (const item of items) {
         if (item.job_id === jobId && !["complete", "unchanged", "no_turns"].includes(item.state)) {
@@ -378,11 +395,27 @@ export class MemoryBackfillStore {
     const current = this.jobs.get(jobId);
     if (current?.execution_owner === owner && current.execution_generation === generation) this.jobs.set(jobId, { ...current, execution_owner: null, execution_expires_at_ms: null });
   }
-  async controlJob(jobId, status, nowIsoValue, patch = {}) {
+  async controlJob(jobId, status, nowIsoValue, patch = {}, resumeQueueAtMs = null) {
     const current = this.jobs.get(jobId);
     if (!current) throw new Error(`backfill_job_not_found:${jobId}`);
     const next = { ...current, ...patch, status, execution_owner: null, execution_expires_at_ms: null, execution_generation: (current.execution_generation || 0) + 1, updated_at: nowIsoValue };
     this.jobs.set(jobId, structuredClone(next));
+    if (status === "running" && resumeQueueAtMs !== null) {
+      for (const item of this.queue.values()) {
+        if (item.job_id === jobId && item.state === "auth_required") {
+          this.queue.set(item.id, {
+            ...item,
+            state: "eligible",
+            resume_state: "eligible",
+            lease_owner: null,
+            lease_expires_at_ms: null,
+            next_eligible_at_ms: resumeQueueAtMs,
+            last_response_class: null,
+            last_error: null,
+          });
+        }
+      }
+    }
     if (status === "cancelled") {
       for (const item of this.queue.values()) {
         if (item.job_id === jobId && !["complete", "unchanged", "no_turns"].includes(item.state)) {

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -88,7 +88,7 @@ export class IndexedDbBackfillStore {
       ...job,
       execution_owner: owner,
       execution_expires_at_ms: nowMs + leaseMs,
-      execution_generation: job.execution_generation || 0,
+      execution_generation: (job.execution_generation || 0) + 1,
     };
     store.put(leased);
     await transactionDone(tx);
@@ -310,6 +310,7 @@ export class IndexedDbBackfillStore {
       .filter((item) => item.job_id === jobId && (
         receiverOnly ? item.state === "captured_waiting_receiver" : ["eligible", "retry_wait"].includes(item.state)
       ))
+      .filter((item) => !item.lease_owner || item.lease_expires_at_ms <= nowMs)
       .filter((item) => (item.next_eligible_at_ms || 0) <= nowMs)
       .sort((left, right) => (left.next_eligible_at_ms || 0) - (right.next_eligible_at_ms || 0))[0];
     if (candidate) {
@@ -349,7 +350,7 @@ export class MemoryBackfillStore {
   async acquireJobExecution(jobId, owner, nowMs, leaseMs) {
     const job = this.jobs.get(jobId);
     if (!job || job.status !== "running" || (job.execution_owner && job.execution_expires_at_ms > nowMs)) return null;
-    const leased = { ...job, execution_owner: owner, execution_expires_at_ms: nowMs + leaseMs, execution_generation: job.execution_generation || 0 };
+    const leased = { ...job, execution_owner: owner, execution_expires_at_ms: nowMs + leaseMs, execution_generation: (job.execution_generation || 0) + 1 };
     this.jobs.set(jobId, structuredClone(leased));
     return structuredClone(leased);
   }
@@ -441,6 +442,7 @@ export class MemoryBackfillStore {
       .filter((item) => item.job_id === jobId && (
         receiverOnly ? item.state === "captured_waiting_receiver" : ["eligible", "retry_wait"].includes(item.state)
       ))
+      .filter((item) => !item.lease_owner || item.lease_expires_at_ms <= nowMs)
       .filter((item) => (item.next_eligible_at_ms || 0) <= nowMs)
       .sort((left, right) => (left.next_eligible_at_ms || 0) - (right.next_eligible_at_ms || 0))[0];
     if (!candidate) return null;

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -30,6 +30,7 @@ export class IndexedDbBackfillStore {
         request.onupgradeneeded = () => {
           const database = request.result;
           if (!database.objectStoreNames.contains("jobs")) database.createObjectStore("jobs", { keyPath: "id" });
+          if (!database.objectStoreNames.contains("revisions")) database.createObjectStore("revisions", { keyPath: "id" });
           if (!database.objectStoreNames.contains("queue")) {
             const queue = database.createObjectStore("queue", { keyPath: "id" });
             queue.createIndex("job_state_next", ["job_id", "state", "next_eligible_at_ms"], { unique: false });
@@ -57,6 +58,129 @@ export class IndexedDbBackfillStore {
     return job;
   }
 
+  async createJob(job) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    const store = tx.objectStore("jobs");
+    const jobs = await requestResult(store.getAll());
+    const existing = jobs.find(
+      (candidate) => candidate.provider === job.provider && ["running", "paused"].includes(candidate.status),
+    );
+    if (existing) {
+      tx.abort();
+      throw new Error(`backfill_job_already_active:${job.provider}:${existing.id}`);
+    }
+    store.add(structuredClone(job));
+    await transactionDone(tx);
+    return job;
+  }
+
+  async acquireJobExecution(jobId, owner, nowMs, leaseMs) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    const store = tx.objectStore("jobs");
+    const job = await requestResult(store.get(jobId));
+    if (!job || job.status !== "running" || (job.execution_owner && job.execution_expires_at_ms > nowMs)) {
+      await transactionDone(tx);
+      return null;
+    }
+    const leased = {
+      ...job,
+      execution_owner: owner,
+      execution_expires_at_ms: nowMs + leaseMs,
+      execution_generation: job.execution_generation || 0,
+    };
+    store.put(leased);
+    await transactionDone(tx);
+    return leased;
+  }
+
+  async assertJobExecution(jobId, owner, generation) {
+    const job = await this.getJob(jobId);
+    if (!job || job.execution_owner !== owner || job.execution_generation !== generation || job.status !== "running") {
+      throw new Error(`stale_backfill_execution:${jobId}`);
+    }
+    return job;
+  }
+
+  async putJobCas(job, owner, generation) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    const store = tx.objectStore("jobs");
+    const current = await requestResult(store.get(job.id));
+    if (!current || current.execution_owner !== owner || current.execution_generation !== generation) {
+      tx.abort();
+      throw new Error(`stale_backfill_execution:${job.id}`);
+    }
+    const next = { ...job, execution_owner: owner, execution_expires_at_ms: current.execution_expires_at_ms, execution_generation: generation };
+    store.put(structuredClone(next));
+    await transactionDone(tx);
+    return next;
+  }
+
+  async reserveProviderRequests(jobId, owner, generation, count, dailyKey, nextRequestAtMs) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    const store = tx.objectStore("jobs");
+    const current = await requestResult(store.get(jobId));
+    if (!current || current.execution_owner !== owner || current.execution_generation !== generation || current.status !== "running") {
+      tx.abort();
+      throw new Error(`stale_backfill_execution:${jobId}`);
+    }
+    const used = current.daily_key === dailyKey ? current.daily_requests || 0 : 0;
+    if (used + count > current.policy.maxDailyRequests) {
+      await transactionDone(tx);
+      return null;
+    }
+    const next = { ...current, daily_key: dailyKey, daily_requests: used + count, next_request_at_ms: nextRequestAtMs };
+    store.put(next);
+    await transactionDone(tx);
+    return next;
+  }
+
+  async releaseJobExecution(jobId, owner, generation) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    const store = tx.objectStore("jobs");
+    const current = await requestResult(store.get(jobId));
+    if (current?.execution_owner === owner && current.execution_generation === generation) {
+      store.put({ ...current, execution_owner: null, execution_expires_at_ms: null });
+    }
+    await transactionDone(tx);
+  }
+
+  async controlJob(jobId, status, nowIsoValue, patch = {}) {
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue"], "readwrite");
+    const store = tx.objectStore("jobs");
+    const current = await requestResult(store.get(jobId));
+    if (!current) {
+      tx.abort();
+      throw new Error(`backfill_job_not_found:${jobId}`);
+    }
+    const next = {
+      ...current,
+      ...patch,
+      status,
+      execution_owner: null,
+      execution_expires_at_ms: null,
+      execution_generation: (current.execution_generation || 0) + 1,
+      updated_at: nowIsoValue,
+    };
+    store.put(next);
+    if (status === "cancelled") {
+      const queueStore = tx.objectStore("queue");
+      const items = await requestResult(queueStore.getAll());
+      for (const item of items) {
+        if (item.job_id === jobId && !["complete", "unchanged", "no_turns"].includes(item.state)) {
+          queueStore.put({ ...item, state: "cancelled", lease_owner: null, lease_expires_at_ms: null });
+        }
+      }
+    }
+    await transactionDone(tx);
+    return next;
+  }
+
   async listJobs() {
     const db = await this.database();
     const tx = db.transaction("jobs", "readonly");
@@ -69,6 +193,51 @@ export class IndexedDbBackfillStore {
     tx.objectStore("queue").put(structuredClone(item));
     await transactionDone(tx);
     return item;
+  }
+
+  async putQueueCas(jobId, owner, generation, item) {
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue"], "readwrite");
+    const job = await requestResult(tx.objectStore("jobs").get(jobId));
+    if (!job || job.execution_owner !== owner || job.execution_generation !== generation || job.status !== "running") {
+      tx.abort();
+      throw new Error(`stale_backfill_execution:${jobId}`);
+    }
+    tx.objectStore("queue").put(structuredClone(item));
+    await transactionDone(tx);
+    return item;
+  }
+
+  async upsertDiscoveredCas(jobId, owner, generation, item) {
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue"], "readwrite");
+    const job = await requestResult(tx.objectStore("jobs").get(jobId));
+    if (!job || job.execution_owner !== owner || job.execution_generation !== generation || job.status !== "running") {
+      tx.abort();
+      throw new Error(`stale_backfill_execution:${jobId}`);
+    }
+    const queue = tx.objectStore("queue");
+    const existing = await requestResult(queue.index("job_native").get([item.job_id, item.provider, item.native_id]));
+    if (!existing) queue.add(structuredClone(item));
+    await transactionDone(tx);
+    return existing || item;
+  }
+
+  async finalizeCaptureCas(job, owner, generation, item, revision, lastAck) {
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue", "revisions"], "readwrite");
+    const jobs = tx.objectStore("jobs");
+    const current = await requestResult(jobs.get(job.id));
+    if (!current || current.execution_owner !== owner || current.execution_generation !== generation || current.status !== "running") {
+      tx.abort();
+      throw new Error(`stale_backfill_execution:${job.id}`);
+    }
+    tx.objectStore("queue").put(structuredClone(item));
+    if (revision) tx.objectStore("revisions").put(structuredClone(revision));
+    const next = { ...current, last_ack: structuredClone(lastAck), last_error: null };
+    jobs.put(next);
+    await transactionDone(tx);
+    return next;
   }
 
   async upsertDiscovered(item) {
@@ -87,6 +256,25 @@ export class IndexedDbBackfillStore {
     const tx = db.transaction("queue", "readonly");
     const all = await requestResult(tx.objectStore("queue").getAll());
     return all.filter((item) => item.job_id === jobId);
+  }
+
+  async getRevision(provider, nativeId) {
+    const db = await this.database();
+    const tx = db.transaction("revisions", "readonly");
+    return requestResult(tx.objectStore("revisions").get(`${provider}:${nativeId}`));
+  }
+
+  async putRevision(revision) {
+    const db = await this.database();
+    const tx = db.transaction("revisions", "readwrite");
+    tx.objectStore("revisions").put(structuredClone(revision));
+    await transactionDone(tx);
+    return revision;
+  }
+
+  async storedBytes(jobId) {
+    const items = await this.listQueue(jobId);
+    return new TextEncoder().encode(JSON.stringify(items)).length;
   }
 
   async recoverExpiredLeases(jobId, nowMs) {
@@ -145,12 +333,84 @@ export class MemoryBackfillStore {
   constructor() {
     this.jobs = new Map();
     this.queue = new Map();
+    this.revisions = new Map();
   }
 
   async getJob(id) { return structuredClone(this.jobs.get(id)); }
   async putJob(job) { this.jobs.set(job.id, structuredClone(job)); return job; }
+  async createJob(job) {
+    const existing = [...this.jobs.values()].find(
+      (candidate) => candidate.provider === job.provider && ["running", "paused"].includes(candidate.status),
+    );
+    if (existing) throw new Error(`backfill_job_already_active:${job.provider}:${existing.id}`);
+    this.jobs.set(job.id, structuredClone(job));
+    return job;
+  }
+  async acquireJobExecution(jobId, owner, nowMs, leaseMs) {
+    const job = this.jobs.get(jobId);
+    if (!job || job.status !== "running" || (job.execution_owner && job.execution_expires_at_ms > nowMs)) return null;
+    const leased = { ...job, execution_owner: owner, execution_expires_at_ms: nowMs + leaseMs, execution_generation: job.execution_generation || 0 };
+    this.jobs.set(jobId, structuredClone(leased));
+    return structuredClone(leased);
+  }
+  async assertJobExecution(jobId, owner, generation) {
+    const job = this.jobs.get(jobId);
+    if (!job || job.execution_owner !== owner || job.execution_generation !== generation || job.status !== "running") throw new Error(`stale_backfill_execution:${jobId}`);
+    return structuredClone(job);
+  }
+  async putJobCas(job, owner, generation) {
+    const current = this.jobs.get(job.id);
+    if (!current || current.execution_owner !== owner || current.execution_generation !== generation) throw new Error(`stale_backfill_execution:${job.id}`);
+    const next = { ...job, execution_owner: owner, execution_expires_at_ms: current.execution_expires_at_ms, execution_generation: generation };
+    this.jobs.set(job.id, structuredClone(next));
+    return next;
+  }
+  async reserveProviderRequests(jobId, owner, generation, count, dailyKeyValue, nextRequestAtMs) {
+    const current = await this.assertJobExecution(jobId, owner, generation);
+    const used = current.daily_key === dailyKeyValue ? current.daily_requests || 0 : 0;
+    if (used + count > current.policy.maxDailyRequests) return null;
+    const next = { ...current, daily_key: dailyKeyValue, daily_requests: used + count, next_request_at_ms: nextRequestAtMs };
+    this.jobs.set(jobId, structuredClone(next));
+    return next;
+  }
+  async releaseJobExecution(jobId, owner, generation) {
+    const current = this.jobs.get(jobId);
+    if (current?.execution_owner === owner && current.execution_generation === generation) this.jobs.set(jobId, { ...current, execution_owner: null, execution_expires_at_ms: null });
+  }
+  async controlJob(jobId, status, nowIsoValue, patch = {}) {
+    const current = this.jobs.get(jobId);
+    if (!current) throw new Error(`backfill_job_not_found:${jobId}`);
+    const next = { ...current, ...patch, status, execution_owner: null, execution_expires_at_ms: null, execution_generation: (current.execution_generation || 0) + 1, updated_at: nowIsoValue };
+    this.jobs.set(jobId, structuredClone(next));
+    if (status === "cancelled") {
+      for (const item of this.queue.values()) {
+        if (item.job_id === jobId && !["complete", "unchanged", "no_turns"].includes(item.state)) {
+          this.queue.set(item.id, { ...item, state: "cancelled", lease_owner: null, lease_expires_at_ms: null });
+        }
+      }
+    }
+    return next;
+  }
   async listJobs() { return [...this.jobs.values()].map((job) => structuredClone(job)); }
   async putQueue(item) { this.queue.set(item.id, structuredClone(item)); return item; }
+  async putQueueCas(jobId, owner, generation, item) {
+    await this.assertJobExecution(jobId, owner, generation);
+    this.queue.set(item.id, structuredClone(item));
+    return item;
+  }
+  async upsertDiscoveredCas(jobId, owner, generation, item) {
+    await this.assertJobExecution(jobId, owner, generation);
+    return this.upsertDiscovered(item);
+  }
+  async finalizeCaptureCas(job, owner, generation, item, revision, lastAck) {
+    await this.assertJobExecution(job.id, owner, generation);
+    this.queue.set(item.id, structuredClone(item));
+    if (revision) this.revisions.set(revision.id, structuredClone(revision));
+    const current = this.jobs.get(job.id);
+    const next = { ...current, last_ack: structuredClone(lastAck), last_error: null };
+    this.jobs.set(job.id, next);
+    return structuredClone(next);
+  }
   async upsertDiscovered(item) {
     const found = [...this.queue.values()].find(
       (candidate) => candidate.job_id === item.job_id && candidate.provider === item.provider && candidate.native_id === item.native_id,
@@ -159,6 +419,9 @@ export class MemoryBackfillStore {
     return structuredClone(found || item);
   }
   async listQueue(jobId) { return [...this.queue.values()].filter((item) => item.job_id === jobId).map((item) => structuredClone(item)); }
+  async getRevision(provider, nativeId) { return structuredClone(this.revisions.get(`${provider}:${nativeId}`)); }
+  async putRevision(revision) { this.revisions.set(revision.id, structuredClone(revision)); return revision; }
+  async storedBytes(jobId) { return new TextEncoder().encode(JSON.stringify(await this.listQueue(jobId))).length; }
   async recoverExpiredLeases(jobId, nowMs) {
     let recovered = 0;
     for (const item of this.queue.values()) {
@@ -191,7 +454,7 @@ export function progressBuckets(items) {
   const buckets = { total: items.length, eligible: 0, complete: 0, no_turns: 0, retry: 0, error: 0, operator_action: 0 };
   for (const item of items) {
     if (["discovered", "eligible", "leased"].includes(item.state)) buckets.eligible += 1;
-    if (item.state === "complete") buckets.complete += 1;
+    if (["complete", "unchanged"].includes(item.state)) buckets.complete += 1;
     if (item.state === "no_turns") buckets.no_turns += 1;
     if (["retry_wait", "captured_waiting_receiver"].includes(item.state)) buckets.retry += 1;
     if (item.state === "auth_required") buckets.operator_action += 1;

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -1,0 +1,205 @@
+import { BACKFILL_DB_NAME, BACKFILL_DB_VERSION, TERMINAL_QUEUE_STATES } from "./models.js";
+
+function requestResult(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error("indexeddb_request_failed"));
+  });
+}
+
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error || new Error("indexeddb_transaction_aborted"));
+    transaction.onerror = () => reject(transaction.error || new Error("indexeddb_transaction_failed"));
+  });
+}
+
+export class IndexedDbBackfillStore {
+  constructor(indexedDb = globalThis.indexedDB, databaseName = BACKFILL_DB_NAME) {
+    this.indexedDb = indexedDb;
+    this.databaseName = databaseName;
+    this.databasePromise = null;
+  }
+
+  async database() {
+    if (!this.indexedDb) throw new Error("indexeddb_unavailable");
+    if (!this.databasePromise) {
+      this.databasePromise = new Promise((resolve, reject) => {
+        const request = this.indexedDb.open(this.databaseName, BACKFILL_DB_VERSION);
+        request.onupgradeneeded = () => {
+          const database = request.result;
+          if (!database.objectStoreNames.contains("jobs")) database.createObjectStore("jobs", { keyPath: "id" });
+          if (!database.objectStoreNames.contains("queue")) {
+            const queue = database.createObjectStore("queue", { keyPath: "id" });
+            queue.createIndex("job_state_next", ["job_id", "state", "next_eligible_at_ms"], { unique: false });
+            queue.createIndex("job_native", ["job_id", "provider", "native_id"], { unique: true });
+          }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error || new Error("indexeddb_open_failed"));
+      });
+    }
+    return this.databasePromise;
+  }
+
+  async getJob(id) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readonly");
+    return requestResult(tx.objectStore("jobs").get(id));
+  }
+
+  async putJob(job) {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readwrite");
+    tx.objectStore("jobs").put(structuredClone(job));
+    await transactionDone(tx);
+    return job;
+  }
+
+  async listJobs() {
+    const db = await this.database();
+    const tx = db.transaction("jobs", "readonly");
+    return requestResult(tx.objectStore("jobs").getAll());
+  }
+
+  async putQueue(item) {
+    const db = await this.database();
+    const tx = db.transaction("queue", "readwrite");
+    tx.objectStore("queue").put(structuredClone(item));
+    await transactionDone(tx);
+    return item;
+  }
+
+  async upsertDiscovered(item) {
+    const db = await this.database();
+    const tx = db.transaction("queue", "readwrite");
+    const store = tx.objectStore("queue");
+    const index = store.index("job_native");
+    const existing = await requestResult(index.get([item.job_id, item.provider, item.native_id]));
+    if (!existing) store.add(structuredClone(item));
+    await transactionDone(tx);
+    return existing || item;
+  }
+
+  async listQueue(jobId) {
+    const db = await this.database();
+    const tx = db.transaction("queue", "readonly");
+    const all = await requestResult(tx.objectStore("queue").getAll());
+    return all.filter((item) => item.job_id === jobId);
+  }
+
+  async recoverExpiredLeases(jobId, nowMs) {
+    const db = await this.database();
+    const tx = db.transaction("queue", "readwrite");
+    const store = tx.objectStore("queue");
+    const all = await requestResult(store.getAll());
+    let recovered = 0;
+    for (const item of all) {
+      if (item.job_id === jobId && item.state === "leased" && item.lease_expires_at_ms <= nowMs) {
+        store.put({ ...item, state: item.resume_state || "eligible", lease_owner: null, lease_expires_at_ms: null });
+        recovered += 1;
+      }
+    }
+    await transactionDone(tx);
+    return recovered;
+  }
+
+  async acquireNextLease(jobId, owner, nowMs, leaseMs, receiverOnly = false) {
+    const db = await this.database();
+    const tx = db.transaction("queue", "readwrite");
+    const store = tx.objectStore("queue");
+    const all = await requestResult(store.getAll());
+    const targetProvider = all.find((item) => item.job_id === jobId)?.provider;
+    const providerBusy = targetProvider && all.some(
+      (item) => item.provider === targetProvider && item.state === "leased" && item.lease_expires_at_ms > nowMs,
+    );
+    if (providerBusy) {
+      await transactionDone(tx);
+      return null;
+    }
+    const candidate = all
+      .filter((item) => item.job_id === jobId && (
+        receiverOnly ? item.state === "captured_waiting_receiver" : ["eligible", "retry_wait"].includes(item.state)
+      ))
+      .filter((item) => (item.next_eligible_at_ms || 0) <= nowMs)
+      .sort((left, right) => (left.next_eligible_at_ms || 0) - (right.next_eligible_at_ms || 0))[0];
+    if (candidate) {
+      const leased = {
+        ...candidate,
+        resume_state: candidate.state,
+        state: "leased",
+        lease_owner: owner,
+        lease_expires_at_ms: nowMs + leaseMs,
+      };
+      store.put(leased);
+      await transactionDone(tx);
+      return leased;
+    }
+    await transactionDone(tx);
+    return null;
+  }
+}
+
+export class MemoryBackfillStore {
+  constructor() {
+    this.jobs = new Map();
+    this.queue = new Map();
+  }
+
+  async getJob(id) { return structuredClone(this.jobs.get(id)); }
+  async putJob(job) { this.jobs.set(job.id, structuredClone(job)); return job; }
+  async listJobs() { return [...this.jobs.values()].map((job) => structuredClone(job)); }
+  async putQueue(item) { this.queue.set(item.id, structuredClone(item)); return item; }
+  async upsertDiscovered(item) {
+    const found = [...this.queue.values()].find(
+      (candidate) => candidate.job_id === item.job_id && candidate.provider === item.provider && candidate.native_id === item.native_id,
+    );
+    if (!found) this.queue.set(item.id, structuredClone(item));
+    return structuredClone(found || item);
+  }
+  async listQueue(jobId) { return [...this.queue.values()].filter((item) => item.job_id === jobId).map((item) => structuredClone(item)); }
+  async recoverExpiredLeases(jobId, nowMs) {
+    let recovered = 0;
+    for (const item of this.queue.values()) {
+      if (item.job_id === jobId && item.state === "leased" && item.lease_expires_at_ms <= nowMs) {
+        this.queue.set(item.id, { ...item, state: item.resume_state || "eligible", lease_owner: null, lease_expires_at_ms: null });
+        recovered += 1;
+      }
+    }
+    return recovered;
+  }
+  async acquireNextLease(jobId, owner, nowMs, leaseMs, receiverOnly = false) {
+    const targetProvider = [...this.queue.values()].find((item) => item.job_id === jobId)?.provider;
+    if (targetProvider && [...this.queue.values()].some(
+      (item) => item.provider === targetProvider && item.state === "leased" && item.lease_expires_at_ms > nowMs,
+    )) return null;
+    const candidate = [...this.queue.values()]
+      .filter((item) => item.job_id === jobId && (
+        receiverOnly ? item.state === "captured_waiting_receiver" : ["eligible", "retry_wait"].includes(item.state)
+      ))
+      .filter((item) => (item.next_eligible_at_ms || 0) <= nowMs)
+      .sort((left, right) => (left.next_eligible_at_ms || 0) - (right.next_eligible_at_ms || 0))[0];
+    if (!candidate) return null;
+    const leased = { ...candidate, resume_state: candidate.state, state: "leased", lease_owner: owner, lease_expires_at_ms: nowMs + leaseMs };
+    this.queue.set(leased.id, structuredClone(leased));
+    return structuredClone(leased);
+  }
+}
+
+export function progressBuckets(items) {
+  const buckets = { total: items.length, eligible: 0, complete: 0, no_turns: 0, retry: 0, error: 0, operator_action: 0 };
+  for (const item of items) {
+    if (["discovered", "eligible", "leased"].includes(item.state)) buckets.eligible += 1;
+    if (item.state === "complete") buckets.complete += 1;
+    if (item.state === "no_turns") buckets.no_turns += 1;
+    if (["retry_wait", "captured_waiting_receiver"].includes(item.state)) buckets.retry += 1;
+    if (item.state === "auth_required") buckets.operator_action += 1;
+    if (item.state === "failed") buckets.error += 1;
+  }
+  return buckets;
+}
+
+export function jobFinished(items) {
+  return items.every((item) => TERMINAL_QUEUE_STATES.has(item.state));
+}

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,5 +1,5 @@
 import { BackfillCoordinator } from "./backfill/coordinator.js";
-import { BACKFILL_ALARM } from "./backfill/models.js";
+import { BACKFILL_ALARM, PROVIDER_REQUEST_TIMEOUT_MS } from "./backfill/models.js";
 import { providerAdapters } from "./backfill/providers.js";
 import { IndexedDbBackfillStore } from "./backfill/storage.js";
 
@@ -33,7 +33,12 @@ async function backfillCoordinator() {
     backfillCoordinatorPromise = extensionInstanceId().then((instanceId) => new BackfillCoordinator({
       store: new IndexedDbBackfillStore(),
       adapters: providerAdapters(globalThis.fetch.bind(globalThis)),
-      receiver: (envelope, serialized) => postJson("/v1/browser-captures", envelope, serialized),
+      receiver: (envelope, serialized) => postJson(
+        "/v1/browser-captures",
+        envelope,
+        serialized,
+        PROVIDER_REQUEST_TIMEOUT_MS,
+      ),
       alarms: chrome.alarms,
       instanceId,
     }));
@@ -453,15 +458,18 @@ async function requestHeaders({ hasBody = false, requestId = "" } = {}) {
   return headers;
 }
 
-async function postJson(path, payload, serializedBody = null) {
+async function postJson(path, payload, serializedBody = null, timeoutMs = null) {
   const settings = await receiverSettings();
   const requestId = buildReceiverRequestId();
   await appendDebugLog({ stage: "receiver_request", method: "POST", path, request_id: requestId, has_body: true });
+  const controller = timeoutMs ? new AbortController() : null;
+  const timeout = timeoutMs ? globalThis.setTimeout(() => controller.abort("receiver_request_timeout"), timeoutMs) : 0;
   try {
     const response = await fetch(`${settings.baseUrl}${path}`, {
       method: "POST",
       headers: await requestHeaders({ hasBody: true, requestId }),
-      body: serializedBody || JSON.stringify(payload)
+      body: serializedBody || JSON.stringify(payload),
+      signal: controller?.signal,
     });
     const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
     const body = await response.json().catch(() => ({}));
@@ -495,6 +503,8 @@ async function postJson(path, payload, serializedBody = null) {
       error: String(error.message || error),
     });
     throw error;
+  } finally {
+    if (timeout) globalThis.clearTimeout(timeout);
   }
 }
 

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,3 +1,8 @@
+import { BackfillCoordinator } from "./backfill/coordinator.js";
+import { BACKFILL_ALARM } from "./backfill/models.js";
+import { providerAdapters } from "./backfill/providers.js";
+import { IndexedDbBackfillStore } from "./backfill/storage.js";
+
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const BACKGROUND_CAPTURE_MIN_INTERVAL_MS = 30000;
 const ACTIVE_TAB_STATE_MIN_INTERVAL_MS = 4000;
@@ -12,6 +17,29 @@ const recentActiveTabStateChecks = new Map();
 const inFlightPostCommands = new Set();
 const pendingPostCommandAcks = new Map();
 let postPollTimer = 0;
+let backfillCoordinatorPromise = null;
+
+async function extensionInstanceId() {
+  const key = "polylogueExtensionInstanceId";
+  const stored = await chrome.storage.local.get({ [key]: "" });
+  if (stored[key]) return stored[key];
+  const created = globalThis.crypto?.randomUUID?.() || `instance-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await chrome.storage.local.set({ [key]: created });
+  return created;
+}
+
+async function backfillCoordinator() {
+  if (!backfillCoordinatorPromise) {
+    backfillCoordinatorPromise = extensionInstanceId().then((instanceId) => new BackfillCoordinator({
+      store: new IndexedDbBackfillStore(),
+      adapters: providerAdapters(globalThis.fetch.bind(globalThis)),
+      receiver: (envelope, serialized) => postJson("/v1/browser-captures", envelope, serialized),
+      alarms: chrome.alarms,
+      instanceId,
+    }));
+  }
+  return backfillCoordinatorPromise;
+}
 
 // ---- Capture retry queue --------------------------------------------------
 //
@@ -425,7 +453,7 @@ async function requestHeaders({ hasBody = false, requestId = "" } = {}) {
   return headers;
 }
 
-async function postJson(path, payload) {
+async function postJson(path, payload, serializedBody = null) {
   const settings = await receiverSettings();
   const requestId = buildReceiverRequestId();
   await appendDebugLog({ stage: "receiver_request", method: "POST", path, request_id: requestId, has_body: true });
@@ -433,7 +461,7 @@ async function postJson(path, payload) {
     const response = await fetch(`${settings.baseUrl}${path}`, {
       method: "POST",
       headers: await requestHeaders({ hasBody: true, requestId }),
-      body: JSON.stringify(payload)
+      body: serializedBody || JSON.stringify(payload)
     });
     const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
     const body = await response.json().catch(() => ({}));
@@ -895,6 +923,10 @@ chrome.alarms?.onAlarm?.addListener((alarm) => {
   if (alarm?.name === CAPTURE_RETRY_ALARM) {
     void drainCaptureQueue("alarm");
   }
+  if (alarm?.name?.startsWith(`${BACKFILL_ALARM}:`)) {
+    const jobId = alarm.name.slice(BACKFILL_ALARM.length + 1);
+    void backfillCoordinator().then((coordinator) => coordinator.wake(jobId));
+  }
 });
 
 chrome.runtime.onInstalled?.addListener(() => {
@@ -903,6 +935,7 @@ chrome.runtime.onInstalled?.addListener(() => {
 
 chrome.runtime.onStartup?.addListener(() => {
   void refreshCurrentActiveTab("browser_startup");
+  void backfillCoordinator().then((coordinator) => coordinator.wake());
 });
 
 chrome.tabs?.onActivated?.addListener((activeInfo) => {
@@ -924,6 +957,33 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type === "polylogue.configureReceiver") {
       const settings = await saveReceiverSettings(message.receiverBaseUrl || DEFAULT_RECEIVER, message.receiverAuthToken || "");
       sendResponse({ ok: true, receiverBaseUrl: settings.baseUrl, authConfigured: Boolean(settings.authToken) });
+      return;
+    }
+    if (message.type === "polylogue.backfill.start") {
+      const coordinator = await backfillCoordinator();
+      const job = await coordinator.start({
+        provider: message.provider,
+        cutoff: message.cutoff,
+        policy: message.policy || {},
+        provider_options: message.provider_options || {},
+      });
+      void coordinator.wake(job.id);
+      sendResponse({ ok: true, job });
+      return;
+    }
+    if (message.type === "polylogue.backfill.control") {
+      const coordinator = await backfillCoordinator();
+      sendResponse({ ok: true, job: await coordinator.control(message.job_id, message.action) });
+      return;
+    }
+    if (message.type === "polylogue.backfill.status") {
+      const coordinator = await backfillCoordinator();
+      sendResponse({ ok: true, jobs: await coordinator.listStatus() });
+      return;
+    }
+    if (message.type === "polylogue.backfill.export") {
+      const coordinator = await backfillCoordinator();
+      sendResponse({ ok: true, ledger: await coordinator.exportLedger(message.job_id) });
       return;
     }
     if (message.type === "polylogue.capture") {

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -189,7 +189,7 @@
       button.primary .button-status {
         color: #d8e6f2;
       }
-      input {
+      input, select {
         width: 100%;
         min-height: 40px;
         padding: 8px 10px;
@@ -318,6 +318,33 @@
 
       <section>
         <div class="row"><span class="label">Receiver health</span><span id="receiver-health" class="value">--</span></div>
+      </section>
+
+      <section id="backfill-panel">
+        <div class="section-head">
+          <strong>Background backfill</strong>
+          <span id="backfill-status" class="value">idle</span>
+        </div>
+        <select id="backfill-job" aria-label="Backfill job"><option value="">No jobs yet</option></select>
+        <div class="setting-row">
+          <select id="backfill-provider" aria-label="Backfill provider">
+            <option value="chatgpt">ChatGPT</option>
+            <option value="claude-ai">Claude.ai</option>
+          </select>
+          <input id="backfill-cutoff" type="date" aria-label="Capture conversations updated since">
+        </div>
+        <div class="row"><span class="label">Inventory cursor</span><span id="backfill-cursor" class="value">--</span></div>
+        <div class="row"><span class="label">Progress</span><span id="backfill-progress" class="value">--</span></div>
+        <div class="row"><span class="label">Cadence / cooldown</span><span id="backfill-rate" class="value">--</span></div>
+        <div class="row"><span class="label">Last ACK / error</span><span id="backfill-last" class="value">--</span></div>
+        <div class="controls">
+          <button id="backfill-start" class="primary"><span class="button-label">Start</span><span class="button-status"></span></button>
+          <button id="backfill-pause"><span class="button-label">Pause</span><span class="button-status"></span></button>
+          <button id="backfill-resume"><span class="button-label">Resume</span><span class="button-status"></span></button>
+          <button id="backfill-cancel"><span class="button-label">Cancel</span><span class="button-status"></span></button>
+          <button id="backfill-export"><span class="button-label">Export ledger</span><span class="button-status"></span></button>
+        </div>
+        <p class="log-meta">Runs against the authenticated provider inventory without activating foreground tabs. Provider controls and cooldowns are always honored.</p>
       </section>
 
       <section>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -337,6 +337,44 @@ function renderReceiverHealth(health) {
   node.title = health.detail || "";
 }
 
+let selectedBackfillJobId = null;
+
+function renderBackfill(jobs) {
+  const statusNode = document.getElementById("backfill-status");
+  if (!statusNode) return;
+  const list = Array.isArray(jobs) ? [...jobs].sort((left, right) => {
+    const leftActive = ["running", "paused"].includes(left.status) ? 1 : 0;
+    const rightActive = ["running", "paused"].includes(right.status) ? 1 : 0;
+    return rightActive - leftActive || String(right.updated_at || right.created_at || "").localeCompare(String(left.updated_at || left.created_at || ""));
+  }) : [];
+  const job = list.find((candidate) => candidate.id === selectedBackfillJobId) || list[0] || null;
+  const selector = document.getElementById("backfill-job");
+  if (selector) {
+    selector.innerHTML = list.length
+      ? list.map((candidate) => `<option value="${escapeHtml(candidate.id)}">${escapeHtml(`${candidate.provider} · ${candidate.status} · ${candidate.cutoff || "no cutoff"}`)}</option>`).join("")
+      : '<option value="">No jobs yet</option>';
+  }
+  if (!job) {
+    statusNode.textContent = "idle";
+    return;
+  }
+  selectedBackfillJobId = job.id;
+  if (selector) selector.value = job.id;
+  statusNode.textContent = `${job.provider} · ${job.status}`;
+  document.getElementById("backfill-cursor").textContent = job.inventory_complete ? `${job.inventory_cursor} · complete` : job.inventory_cursor || "--";
+  const progress = job.progress || {};
+  document.getElementById("backfill-progress").textContent = `${progress.complete || 0}/${progress.total || 0} · ${progress.retry || 0} retry · ${progress.no_turns || 0} empty · ${(progress.error || 0) + (progress.operator_action || 0)} attention`;
+  const cooldown = job.cooldown_until_ms ? new Date(job.cooldown_until_ms).toLocaleTimeString() : "none";
+  document.getElementById("backfill-rate").textContent = `${Math.round((job.learned_cadence_ms || 0) / 1000)}s · ${cooldown}`;
+  document.getElementById("backfill-last").textContent = job.last_ack?.receiver_request_id || job.last_error || "--";
+}
+
+async function refreshBackfills() {
+  const result = await chrome.runtime.sendMessage({ type: "polylogue.backfill.status" });
+  renderBackfill(result?.jobs || []);
+  return result;
+}
+
 function renderDebugLog(items) {
   const debug = document.getElementById("debug-log");
   const safeItems = Array.isArray(items) ? items.slice(0, 24) : [];
@@ -429,6 +467,7 @@ async function render() {
   document.getElementById("state").textContent = explanation.headline;
   document.getElementById("state-detail").textContent = explanation.detail;
   setBadge(badgeKind, badgeText);
+  await refreshBackfills().catch(() => renderBackfill([]));
 }
 
 async function refreshStatus(reason = "popup_manual") {
@@ -540,6 +579,50 @@ document.getElementById("debug-export").addEventListener("click", async () => {
     const link = document.createElement("a");
     link.href = url;
     link.download = `polylogue-browser-capture-debug-${Date.now()}.json`;
+    link.click();
+    globalThis.URL.revokeObjectURL(url);
+  }, { busy: "Exporting", ok: "Exported" });
+});
+
+document.getElementById("backfill-start")?.addEventListener("click", async () => {
+  await withAction("backfill-start", async () => {
+    const provider = document.getElementById("backfill-provider").value;
+    const cutoffValue = document.getElementById("backfill-cutoff").value;
+    if (!cutoffValue) throw new Error("backfill_cutoff_required");
+    const response = await chrome.runtime.sendMessage({
+      type: "polylogue.backfill.start",
+      provider,
+      cutoff: new Date(`${cutoffValue}T00:00:00Z`).toISOString(),
+    });
+    selectedBackfillJobId = response.job.id;
+    await refreshBackfills();
+  }, { busy: "Starting", ok: "Started" });
+});
+
+document.getElementById("backfill-job")?.addEventListener("change", async (event) => {
+  selectedBackfillJobId = event.target.value || null;
+  await refreshBackfills();
+});
+
+for (const action of ["pause", "resume", "cancel"]) {
+  document.getElementById(`backfill-${action}`)?.addEventListener("click", async () => {
+    if (!selectedBackfillJobId) return;
+    await withAction(`backfill-${action}`, async () => {
+      await chrome.runtime.sendMessage({ type: "polylogue.backfill.control", job_id: selectedBackfillJobId, action });
+      await refreshBackfills();
+    }, { busy: `${action}…`, ok: action });
+  });
+}
+
+document.getElementById("backfill-export")?.addEventListener("click", async () => {
+  if (!selectedBackfillJobId) return;
+  await withAction("backfill-export", async () => {
+    const response = await chrome.runtime.sendMessage({ type: "polylogue.backfill.export", job_id: selectedBackfillJobId });
+    const blob = new globalThis.Blob([`${JSON.stringify(response.ledger, null, 2)}\n`], { type: "application/json" });
+    const url = globalThis.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `polylogue-backfill-${selectedBackfillJobId}.json`;
     link.click();
     globalThis.URL.revokeObjectURL(url);
   }, { busy: "Exporting", ok: "Exported" });

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -1,11 +1,12 @@
 import { createHash } from "node:crypto";
 
+import { indexedDB } from "fake-indexeddb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BackfillCoordinator } from "../src/backfill/coordinator.js";
 import { backfillAlarmName, serializedContentHash, serializedJson } from "../src/backfill/models.js";
 import { ChatGptBackfillAdapter, ClaudeBackfillAdapter } from "../src/backfill/providers.js";
-import { MemoryBackfillStore, progressBuckets } from "../src/backfill/storage.js";
+import { IndexedDbBackfillStore, MemoryBackfillStore, progressBuckets } from "../src/backfill/storage.js";
 
 function response(body, { status = 200, retryAfter = null } = {}) {
   return {
@@ -224,6 +225,79 @@ describe("background backfill coordinator", () => {
     await expect(startJob(h)).rejects.toThrow("backfill_job_already_active:chatgpt");
   });
 
+  it("serializes concurrent wakes and request reservation in real IndexedDB", async () => {
+    const databaseName = `polylogue-test-${globalThis.crypto.randomUUID()}`;
+    const store = new IndexedDbBackfillStore(indexedDB, databaseName);
+    let releaseInventory;
+    const inventoryGate = new Promise((resolve) => { releaseInventory = resolve; });
+    const adapter = new FixtureAdapter(["one"]);
+    adapter.enumerate = vi.fn(async () => {
+      await inventoryGate;
+      return { classification: "success", items: [{ native_id: "one", updated_at: "2026-07-01T00:00:00Z" }], next_cursor: "1", done: true, request_count: 1 };
+    });
+    const coordinator = new BackfillCoordinator({ store, adapters: { chatgpt: adapter }, receiver: vi.fn(), alarms: { create: vi.fn() }, clock: () => 1000, random: () => 0, instanceId: "idb-instance" });
+    const job = await coordinator.start({ provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z" });
+    const wakes = [coordinator.wake(job.id), coordinator.wake(job.id)];
+    await vi.waitFor(() => expect(adapter.enumerate).toHaveBeenCalledTimes(1));
+    releaseInventory();
+    await Promise.all(wakes);
+    expect(adapter.enumerate).toHaveBeenCalledTimes(1);
+    expect((await coordinator.status(job.id)).daily_requests).toBe(1);
+    indexedDB.deleteDatabase(databaseName);
+  });
+
+  it("invalidates an in-flight fetch on cancel without resurrecting queue state", async () => {
+    const adapter = new FixtureAdapter(["one"]);
+    let releaseFetch;
+    const fetchGate = new Promise((resolve) => { releaseFetch = resolve; });
+    adapter.fetchNative = vi.fn(async () => fetchGate);
+    const h = harness({ adapter });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    const wake = h.coordinator.wake(job.id);
+    await vi.waitFor(() => expect(adapter.fetchNative).toHaveBeenCalledTimes(1));
+    await h.coordinator.control(job.id, "cancel");
+    releaseFetch(response(chatGptNative("one")));
+    await wake;
+    expect((await h.coordinator.status(job.id)).status).toBe("cancelled");
+    expect((await h.store.listQueue(job.id))[0].state).toBe("cancelled");
+    expect(h.receiver).not.toHaveBeenCalled();
+  });
+
+  it("skips an unchanged native revision in a later job", async () => {
+    const adapter = new FixtureAdapter(["one"]);
+    const h = harness({ adapter });
+    const first = await startJob(h);
+    await enumerateThenAdvance(h, first);
+    await h.coordinator.wake(first.id);
+    expect(h.receiver).toHaveBeenCalledTimes(1);
+    h.advance(1000);
+    const second = await startJob(h);
+    await enumerateThenAdvance(h, second);
+    await h.coordinator.wake(second.id);
+    expect((await h.store.listQueue(second.id))[0].state).toBe("unchanged");
+    expect(adapter.fetchCalls).toEqual(["one"]);
+    expect(h.receiver).toHaveBeenCalledTimes(1);
+  });
+
+  it("fail-pauses receiver retries and stored envelope bytes at configured bounds", async () => {
+    const receiverDown = vi.fn(async () => { throw new Error("receiver_down"); });
+    const receiverHarness = harness({ adapter: new FixtureAdapter(["one"]), receiver: receiverDown, policy: { maxReceiverAttempts: 1 } });
+    const receiverJob = await startJob(receiverHarness);
+    await enumerateThenAdvance(receiverHarness, receiverJob);
+    await receiverHarness.coordinator.wake(receiverJob.id);
+    expect((await receiverHarness.coordinator.status(receiverJob.id)).cooldown_reason).toBe("receiver_retry_budget_exhausted");
+    expect((await receiverHarness.store.listQueue(receiverJob.id))[0].state).toBe("captured_waiting_receiver");
+
+    const byteHarness = harness({ adapter: new FixtureAdapter(["one"]), policy: { maxStoredBytes: 64 } });
+    const byteJob = await startJob(byteHarness);
+    await enumerateThenAdvance(byteHarness, byteJob);
+    await byteHarness.coordinator.wake(byteJob.id);
+    expect((await byteHarness.coordinator.status(byteJob.id)).cooldown_reason).toBe("storage_budget_exhausted");
+    expect((await byteHarness.store.listQueue(byteJob.id))[0].last_response_class).toBe("storage_budget_exhausted");
+    expect(byteHarness.receiver).not.toHaveBeenCalled();
+  });
+
   it("persists Claude organization identity across restart and hard-reserves its request budget", async () => {
     let now = 1000;
     const store = new MemoryBackfillStore();
@@ -291,6 +365,9 @@ describe("provider adapter contracts", () => {
     expect(capture.session.turns[0].role).toBe("assistant");
     expect(capture.session.turns[0].parent_turn_id).toBe("parent");
     expect(capture.session.turns[0].provider_meta.model).toBe("claude-opus");
+    expect(fetchImpl.mock.calls[2][0]).toContain("tree=True");
+    expect(fetchImpl.mock.calls[2][0]).toContain("render_all_tools=true");
+    expect(fetchImpl.mock.calls[2][0]).toContain("consistency=strong");
 
     await expect(adapter.normalizeCapture(response({ messages: [] }), inventory.items[0], {})).rejects.toThrow("provider_contract_drift:claude_conversation.chat_messages_must_be_array");
   });

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -192,6 +192,15 @@ describe("background backfill coordinator", () => {
     expect(await store.acquireNextLease("j2", "instance-right", 100, 1000)).toBeNull();
   });
 
+  it("invalidates an expired execution even when the stable instance id reacquires it", async () => {
+    const store = new MemoryBackfillStore();
+    await store.createJob({ id: "j1", provider: "chatgpt", status: "running", policy: { maxDailyRequests: 10 }, execution_generation: 0 });
+    const first = await store.acquireJobExecution("j1", "stable-instance", 0, 10);
+    const second = await store.acquireJobExecution("j1", "stable-instance", 11, 10);
+    expect(second.execution_generation).toBe(first.execution_generation + 1);
+    await expect(store.putQueueCas("j1", "stable-instance", first.execution_generation, { id: "q", job_id: "j1" })).rejects.toThrow("stale_backfill_execution:j1");
+  });
+
   it("accounts inventory cadence and budget before any native fetch", async () => {
     const h = harness({ adapter: new FixtureAdapter(["one"]), policy: { maxDailyRequests: 1 } });
     const job = await startJob(h);
@@ -351,6 +360,19 @@ describe("provider adapter contracts", () => {
 
     const drifted = new ChatGptBackfillAdapter(vi.fn(async () => response({ conversations: [] })));
     await expect(drifted.enumerate()).rejects.toThrow("provider_contract_drift:chatgpt_inventory.items_must_be_array");
+  });
+
+  it("stops descending inventory pagination when a page crosses the cutoff", async () => {
+    const adapter = new ChatGptBackfillAdapter(vi.fn(async () => response({
+      items: [
+        { id: "new", update_time: 1780000000 },
+        { id: "old", update_time: 1600000000 },
+      ],
+      total: 5000,
+    })));
+    const inventory = await adapter.enumerate("0", "2026-01-01T00:00:00Z");
+    expect(inventory.items.map((item) => item.native_id)).toEqual(["new"]);
+    expect(inventory.done).toBe(true);
   });
 
   it("normalizes Claude inventory/native fixtures and rejects message drift", async () => {

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -59,9 +59,8 @@ class FixtureAdapter {
   }
 }
 
-function harness({ adapter = new FixtureAdapter(), receiver = null, start = 100000, instanceId = "instance-a", policy = {} } = {}) {
+function harness({ adapter = new FixtureAdapter(), receiver = null, start = 100000, instanceId = "instance-a", policy = {}, store = new MemoryBackfillStore() } = {}) {
   let now = start;
-  const store = new MemoryBackfillStore();
   const alarms = { create: vi.fn(async () => undefined) };
   const durableReceiver = receiver || vi.fn(async (envelope, serialized) => ({ receiver_request_id: `ack-${envelope.session.provider_session_id}`, content_hash: await serializedContentHash(serialized) }));
   const coordinator = new BackfillCoordinator({
@@ -171,6 +170,42 @@ describe("background backfill coordinator", () => {
       expect((await h.store.listQueue(job.id))[0].state).toBe(scenario.expected);
       expect((await h.coordinator.status(job.id)).daily_requests).toBe(2);
     }
+  });
+
+  it.each([
+    ["memory storage", () => new MemoryBackfillStore()],
+    ["IndexedDB", () => new IndexedDbBackfillStore(indexedDB, `polylogue-test-${globalThis.crypto.randomUUID()}`)],
+  ])("atomically requeues auth-required work when resuming with %s", async (_label, makeStore) => {
+    const adapter = new FixtureAdapter(["one"]);
+    adapter.responses = [response({}, { status: 403 }), response(chatGptNative("one"))];
+    const store = makeStore();
+    const h = harness({ adapter, store });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+
+    expect((await h.coordinator.status(job.id)).status).toBe("paused");
+    expect((await store.listQueue(job.id))[0].state).toBe("auth_required");
+
+    await h.coordinator.control(job.id, "resume");
+    const resumed = (await store.listQueue(job.id))[0];
+    expect(resumed).toMatchObject({
+      state: "eligible",
+      resume_state: "eligible",
+      lease_owner: null,
+      lease_expires_at_ms: null,
+      next_eligible_at_ms: h.now(),
+      last_response_class: null,
+      last_error: null,
+    });
+
+    h.advance(h.policy.baseCadenceMs);
+    await h.coordinator.wake(job.id);
+    const status = await h.coordinator.status(job.id);
+    expect(status.status).toBe("complete");
+    expect(status.progress).toMatchObject({ complete: 1, operator_action: 0 });
+    expect(adapter.fetchCalls).toEqual(["one", "one"]);
+    expect(h.receiver).toHaveBeenCalledTimes(1);
   });
 
   it("grants only one lease across simultaneous extension instances", async () => {

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -1,0 +1,297 @@
+import { createHash } from "node:crypto";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BackfillCoordinator } from "../src/backfill/coordinator.js";
+import { backfillAlarmName, serializedContentHash, serializedJson } from "../src/backfill/models.js";
+import { ChatGptBackfillAdapter, ClaudeBackfillAdapter } from "../src/backfill/providers.js";
+import { MemoryBackfillStore, progressBuckets } from "../src/backfill/storage.js";
+
+function response(body, { status = 200, retryAfter = null } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => (name === "Retry-After" ? retryAfter : null) },
+    json: vi.fn(async () => structuredClone(body)),
+  };
+}
+
+function chatGptNative(id, turns = true) {
+  return {
+    id,
+    title: `Conversation ${id}`,
+    create_time: 1710000000,
+    update_time: 1710000100,
+    mapping: turns
+      ? {
+          first: { parent: null, message: { id: `${id}-u`, author: { role: "user" }, content: { parts: [{ text: "hello" }] }, create_time: 1710000000 } },
+          second: { parent: "first", message: { id: `${id}-a`, author: { role: "function" }, content: { result: "world", content_type: "tool_result" }, create_time: 1710000001, metadata: { model_slug: "tool-model" } } },
+        }
+      : {},
+  };
+}
+
+class FixtureAdapter {
+  constructor(ids = ["one", "two"]) {
+    this.ids = ids;
+    this.fetchCalls = [];
+    this.responses = [];
+    this.enumerateCalls = 0;
+  }
+  async enumerate() {
+    this.enumerateCalls += 1;
+    return { classification: "success", items: this.ids.map((native_id) => ({ native_id, updated_at: "2026-07-01T00:00:00Z" })), next_cursor: String(this.ids.length), done: true, request_count: 1 };
+  }
+  async fetchNative(nativeId) {
+    this.fetchCalls.push(nativeId);
+    return this.responses.shift() || response(chatGptNative(nativeId));
+  }
+  classifyResponse(result) {
+    if (result.ok) return "success";
+    if (result.status === 429) return "rate_limited";
+    if (result.status === 403) return "auth_or_challenge";
+    if (result.status >= 500) return "transport";
+    return "fatal";
+  }
+  async normalizeCapture(result, item, attribution) {
+    return new ChatGptBackfillAdapter().normalizeCapture(result, item, attribution);
+  }
+}
+
+function harness({ adapter = new FixtureAdapter(), receiver = null, start = 100000, instanceId = "instance-a", policy = {} } = {}) {
+  let now = start;
+  const store = new MemoryBackfillStore();
+  const alarms = { create: vi.fn(async () => undefined) };
+  const durableReceiver = receiver || vi.fn(async (envelope, serialized) => ({ receiver_request_id: `ack-${envelope.session.provider_session_id}`, content_hash: await serializedContentHash(serialized) }));
+  const coordinator = new BackfillCoordinator({
+    store,
+    adapters: { chatgpt: adapter },
+    receiver: durableReceiver,
+    alarms,
+    clock: () => now,
+    random: () => 0,
+    instanceId,
+  });
+  return { adapter, store, alarms, receiver: durableReceiver, coordinator, now: () => now, advance: (ms) => { now += ms; }, policy: { baseCadenceMs: 1000, ...policy } };
+}
+
+async function startJob(h, patch = {}) {
+  return h.coordinator.start({ provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", policy: { ...h.policy, ...patch } });
+}
+
+async function enumerateThenAdvance(h, job) {
+  await h.coordinator.wake(job.id);
+  h.advance(h.policy.baseCadenceMs);
+}
+
+describe("background backfill coordinator", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("survives a service-worker restart and completes each native capture once", async () => {
+    const h = harness();
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+    expect(progressBuckets(await h.store.listQueue(job.id)).complete).toBe(1);
+
+    h.advance(1000);
+    const restarted = new BackfillCoordinator({ store: h.store, adapters: { chatgpt: h.adapter }, receiver: h.receiver, alarms: h.alarms, clock: h.now, random: () => 0, instanceId: "instance-b" });
+    await restarted.wake(job.id);
+
+    const status = await restarted.status(job.id);
+    expect(status.status).toBe("complete");
+    expect(status.progress.complete).toBe(2);
+    expect(h.adapter.fetchCalls).toEqual(["one", "two"]);
+    expect(h.receiver).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a receiver-down capture durable and retries the ACK without refetching provider data", async () => {
+    let calls = 0;
+    const receiver = vi.fn(async (_envelope, serialized) => {
+      calls += 1;
+      if (calls === 1) throw new Error("receiver_down");
+      return { receiver_request_id: "ack-recovered", content_hash: await serializedContentHash(serialized) };
+    });
+    const h = harness({ adapter: new FixtureAdapter(["one"]), receiver });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+    expect((await h.store.listQueue(job.id))[0].state).toBe("captured_waiting_receiver");
+    expect(h.adapter.fetchCalls).toHaveLength(1);
+    const providerRequests = (await h.coordinator.status(job.id)).daily_requests;
+
+    h.advance(1000);
+    await h.coordinator.wake(job.id);
+    const item = (await h.store.listQueue(job.id))[0];
+    expect(item.state).toBe("complete");
+    expect(item.receiver_receipt.content_hash).toBe(item.content_hash);
+    expect(h.adapter.fetchCalls).toHaveLength(1);
+    expect((await h.coordinator.status(job.id)).daily_requests).toBe(providerRequests);
+  });
+
+  it("honors Retry-After exactly and opens a circuit after repeated 429s", async () => {
+    const adapter = new FixtureAdapter(["one"]);
+    adapter.responses = [response({}, { status: 429, retryAfter: "60" }), response({}, { status: 429, retryAfter: "60" })];
+    const h = harness({ adapter, policy: { breakerThreshold: 2 } });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+    let status = await h.coordinator.status(job.id);
+    expect(status.cooldown_reason).toBe("provider_rate_limited");
+    expect(status.cooldown_until_ms).toBe(h.now() + 60000);
+
+    h.advance(59999);
+    await h.coordinator.wake(job.id);
+    expect(adapter.fetchCalls).toHaveLength(1);
+    h.advance(1);
+    await h.coordinator.wake(job.id);
+    status = await h.coordinator.status(job.id);
+    expect(adapter.fetchCalls).toHaveLength(2);
+    expect(status.status).toBe("paused");
+    expect(status.learned_cadence_ms).toBeGreaterThan(status.policy.baseCadenceMs);
+    expect(status.daily_requests).toBe(3);
+  });
+
+  it("persists auth, native-empty, bounded transport, and durable ACK as distinct outcomes", async () => {
+    const cases = [
+      { result: response({}, { status: 403 }), expected: "auth_required" },
+      { result: response(chatGptNative("one", false)), expected: "no_turns" },
+      { result: response({}, { status: 503 }), expected: "failed", policy: { maxTransportAttempts: 1, breakerThreshold: 5 } },
+      { result: response({}, { status: 400 }), expected: "failed" },
+      { result: response(chatGptNative("one")), expected: "complete" },
+    ];
+    for (const scenario of cases) {
+      const adapter = new FixtureAdapter(["one"]);
+      adapter.responses = [scenario.result];
+      const h = harness({ adapter, policy: scenario.policy });
+      const job = await startJob(h);
+      await enumerateThenAdvance(h, job);
+      await h.coordinator.wake(job.id);
+      expect((await h.store.listQueue(job.id))[0].state).toBe(scenario.expected);
+      expect((await h.coordinator.status(job.id)).daily_requests).toBe(2);
+    }
+  });
+
+  it("grants only one lease across simultaneous extension instances", async () => {
+    const store = new MemoryBackfillStore();
+    await store.putQueue({ id: "q1", job_id: "j1", provider: "chatgpt", native_id: "one", state: "eligible", next_eligible_at_ms: 0 });
+    const [left, right] = await Promise.all([
+      store.acquireNextLease("j1", "instance-left", 100, 1000),
+      store.acquireNextLease("j1", "instance-right", 100, 1000),
+    ]);
+    expect([left, right].filter(Boolean)).toHaveLength(1);
+    expect((await store.listQueue("j1"))[0].state).toBe("leased");
+  });
+
+  it("serializes leases across separate jobs for the same provider", async () => {
+    const store = new MemoryBackfillStore();
+    await store.putQueue({ id: "q1", job_id: "j1", provider: "chatgpt", native_id: "one", state: "eligible", next_eligible_at_ms: 0 });
+    await store.putQueue({ id: "q2", job_id: "j2", provider: "chatgpt", native_id: "two", state: "eligible", next_eligible_at_ms: 0 });
+    expect(await store.acquireNextLease("j1", "instance-left", 100, 1000)).not.toBeNull();
+    expect(await store.acquireNextLease("j2", "instance-right", 100, 1000)).toBeNull();
+  });
+
+  it("accounts inventory cadence and budget before any native fetch", async () => {
+    const h = harness({ adapter: new FixtureAdapter(["one"]), policy: { maxDailyRequests: 1 } });
+    const job = await startJob(h);
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.enumerateCalls).toBe(1);
+    expect((await h.coordinator.status(job.id)).daily_requests).toBe(1);
+
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.fetchCalls).toHaveLength(0);
+    h.advance(1000);
+    await h.coordinator.wake(job.id);
+    expect((await h.coordinator.status(job.id)).status).toBe("paused");
+    expect(h.adapter.fetchCalls).toHaveLength(0);
+  });
+
+  it("uses per-job alarms so a later deadline cannot replace earlier work", async () => {
+    const h = harness();
+    const first = await startJob(h);
+    await h.store.putJob({ ...(await h.store.getJob(first.id)), status: "complete" });
+    h.advance(10);
+    const second = await startJob(h);
+    const names = h.alarms.create.mock.calls.map(([name]) => name);
+    expect(names).toContain(backfillAlarmName(first.id));
+    expect(names).toContain(backfillAlarmName(second.id));
+    expect(new Set(names).size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("rejects a second active crawl for the same provider", async () => {
+    const h = harness();
+    await startJob(h);
+    await expect(startJob(h)).rejects.toThrow("backfill_job_already_active:chatgpt");
+  });
+
+  it("persists Claude organization identity across restart and hard-reserves its request budget", async () => {
+    let now = 1000;
+    const store = new MemoryBackfillStore();
+    const alarms = { create: vi.fn(async () => undefined) };
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response([{ uuid: "org-1" }]))
+      .mockResolvedValueOnce(response([{ uuid: "claude-1", updated_at: "2026-01-02T00:00:00Z" }]))
+      .mockResolvedValueOnce(response({ uuid: "claude-1", chat_messages: [{ uuid: "m1", sender: "human", text: "hello" }] }));
+    const receiver = vi.fn(async (_envelope, serialized) => ({ receiver_request_id: "ack", content_hash: await serializedContentHash(serialized) }));
+    const first = new BackfillCoordinator({ store, adapters: { "claude-ai": new ClaudeBackfillAdapter(fetchImpl) }, receiver, alarms, clock: () => now, random: () => 0 });
+    const job = await first.start({ provider: "claude-ai", cutoff: "2026-01-01T00:00:00Z", policy: { baseCadenceMs: 1000, maxDailyRequests: 3 } });
+    await first.wake(job.id);
+    expect((await first.status(job.id)).daily_requests).toBe(2);
+    expect((await first.status(job.id)).provider_options.claudeOrganizationId).toBe("org-1");
+
+    now += 1000;
+    const restarted = new BackfillCoordinator({ store, adapters: { "claude-ai": new ClaudeBackfillAdapter(fetchImpl) }, receiver, alarms, clock: () => now, random: () => 0 });
+    await restarted.wake(job.id);
+    expect((await restarted.status(job.id)).daily_requests).toBe(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls[2][0]).toContain("/organizations/org-1/chat_conversations/claude-1");
+
+    const cappedFetch = vi.fn();
+    const capped = new BackfillCoordinator({ store: new MemoryBackfillStore(), adapters: { "claude-ai": new ClaudeBackfillAdapter(cappedFetch) }, receiver, alarms, clock: () => now, random: () => 0 });
+    const cappedJob = await capped.start({ provider: "claude-ai", cutoff: "2026-01-01T00:00:00Z", policy: { maxDailyRequests: 1 } });
+    await capped.wake(cappedJob.id);
+    expect((await capped.status(cappedJob.id)).status).toBe("paused");
+    expect(cappedFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("provider adapter contracts", () => {
+  it("hashes the exact UTF-8 JSON request bytes used by the receiver contract", async () => {
+    const payload = { z: "żółć 😀", number: 1.25, nested: { b: 2, a: 1 } };
+    const serialized = serializedJson(payload);
+    expect(await serializedContentHash(serialized)).toBe(createHash("sha256").update(serialized, "utf8").digest("hex"));
+  });
+
+  it("normalizes ChatGPT and rejects inventory drift loudly", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ items: [{ id: "gpt-1", title: "GPT", update_time: 1710000100 }], total: 1 }))
+      .mockResolvedValueOnce(response(chatGptNative("gpt-1")));
+    const adapter = new ChatGptBackfillAdapter(fetchImpl);
+    const inventory = await adapter.enumerate("0", "2020-01-01T00:00:00Z");
+    const capture = await adapter.normalizeCapture(await adapter.fetchNative("gpt-1"), inventory.items[0], { job_id: "j", queue_id: "q", instance_id: "i" });
+    expect(capture.session.turns).toHaveLength(2);
+    expect(capture.session.turns[0].text).toBe("hello");
+    expect(capture.session.turns[1].role).toBe("tool");
+    expect(capture.session.turns[1].provider_meta.model_slug).toBe("tool-model");
+    expect(capture.session.provider_meta.backfill.instance_id).toBe("i");
+
+    const drifted = new ChatGptBackfillAdapter(vi.fn(async () => response({ conversations: [] })));
+    await expect(drifted.enumerate()).rejects.toThrow("provider_contract_drift:chatgpt_inventory.items_must_be_array");
+  });
+
+  it("normalizes Claude inventory/native fixtures and rejects message drift", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response([{ uuid: "org-1" }]))
+      .mockResolvedValueOnce(response([{ uuid: "claude-1", name: "Claude", updated_at: "2026-01-02T00:00:00Z" }]))
+      .mockResolvedValueOnce(response({ uuid: "claude-1", name: "Claude", chat_messages: [{ uuid: "m1", sender: "claude", content: [{ type: "text", text: "hello" }], parent_message_uuid: "parent", model: "claude-opus" }] }));
+    const adapter = new ClaudeBackfillAdapter(fetchImpl);
+    const inventory = await adapter.enumerate("0", "2026-01-01T00:00:00Z");
+    const capture = await adapter.normalizeCapture(await adapter.fetchNative("claude-1"), inventory.items[0], { job_id: "j" });
+    expect(capture.session.provider).toBe("claude-ai");
+    expect(capture.session.turns[0].role).toBe("assistant");
+    expect(capture.session.turns[0].parent_turn_id).toBe("parent");
+    expect(capture.session.turns[0].provider_meta.model).toBe("claude-opus");
+
+    await expect(adapter.normalizeCapture(response({ messages: [] }), inventory.items[0], {})).rejects.toThrow("provider_contract_drift:claude_conversation.chat_messages_must_be_array");
+  });
+});

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -375,6 +375,20 @@ describe("provider adapter contracts", () => {
     expect(inventory.done).toBe(true);
   });
 
+  it("does not assume Claude inventory order when filtering a full page", async () => {
+    const records = Array.from({ length: 100 }, (_, index) => ({
+      uuid: `claude-${index}`,
+      updated_at: index === 1 ? "2020-01-01T00:00:00Z" : "2026-02-01T00:00:00Z",
+    }));
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response([{ uuid: "org-1" }]))
+      .mockResolvedValueOnce(response(records));
+    const adapter = new ClaudeBackfillAdapter(fetchImpl);
+    const inventory = await adapter.enumerate("0", "2026-01-01T00:00:00Z");
+    expect(inventory.done).toBe(false);
+    expect(inventory.items.at(-1).native_id).toBe("claude-99");
+  });
+
   it("normalizes Claude inventory/native fixtures and rejects message drift", async () => {
     const fetchImpl = vi.fn()
       .mockResolvedValueOnce(response([{ uuid: "org-1" }]))

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -4,13 +4,16 @@
 // emission so a future change to the build pipeline cannot silently break
 // the release artifact shape.
 
+import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { indexedDB } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXT_ROOT = resolve(__dirname, "..");
@@ -81,7 +84,7 @@ describe("build.mjs full archive emission", () => {
   });
 
   it("emits chrome zip + firefox xpi with build-manifest.json", () => {
-    execFileSync("node", [BUILD, "--version", "0.9.0", "--out", outDir], { stdio: "pipe" });
+    execFileSync("node", [BUILD, "--version", "0.9.0", "--out", outDir, "--no-source-sync"], { stdio: "pipe" });
     expect(existsSync(join(outDir, "build-manifest.json"))).toBe(true);
     expect(existsSync(join(outDir, "polylogue-browser-capture-0.9.0-chrome.zip"))).toBe(true);
     expect(existsSync(join(outDir, "polylogue-browser-capture-0.9.0-firefox.xpi"))).toBe(true);
@@ -96,5 +99,62 @@ describe("build.mjs full archive emission", () => {
     expect(listing).toContain("src/backfill/coordinator.js");
     expect(listing).toContain("src/backfill/providers.js");
     expect(listing).toContain("src/backfill/storage.js");
+  });
+
+  it("executes the packaged service worker fixture without foreground tab activation", async () => {
+    const smokeRoot = join(EXT_ROOT, ".cache", `packaged-smoke-${Date.now()}`);
+    mkdirSync(smokeRoot, { recursive: true });
+    const sourceHashBefore = createHash("sha256").update(readFileSync(MANIFEST_PATH)).update(readFileSync(PACKAGE_PATH)).digest("hex");
+    execFileSync("node", [BUILD, "--version", "0.9.0", "--out", smokeRoot, "--no-source-sync"], { stdio: "pipe" });
+    const sourceHashAfter = createHash("sha256").update(readFileSync(MANIFEST_PATH)).update(readFileSync(PACKAGE_PATH)).digest("hex");
+    expect(sourceHashAfter).toBe(sourceHashBefore);
+    const archive = join(smokeRoot, "polylogue-browser-capture-0.9.0-chrome.zip");
+    const unpacked = join(smokeRoot, "unpacked");
+    execFileSync("python3", ["-c", "import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])", archive, unpacked]);
+    let messageListener;
+    let alarmListener;
+    let stored = { receiverBaseUrl: "http://127.0.0.1:8765", receiverAuthToken: "token" };
+    const tabs = { create: vi.fn(), update: vi.fn(), sendMessage: vi.fn(), query: vi.fn(async () => []) };
+    globalThis.indexedDB = indexedDB;
+    globalThis.chrome = {
+      action: { setBadgeText: vi.fn(), setBadgeBackgroundColor: vi.fn() },
+      alarms: { create: vi.fn(), clear: vi.fn(), onAlarm: { addListener: vi.fn((listener) => { alarmListener = listener; }) } },
+      runtime: {
+        id: "packaged-extension",
+        getManifest: () => ({ version: "0.9.0" }),
+        onInstalled: { addListener: vi.fn() },
+        onStartup: { addListener: vi.fn() },
+        onMessage: { addListener: vi.fn((listener) => { messageListener = listener; }) },
+      },
+      scripting: { executeScript: vi.fn() },
+      storage: { local: {
+        get: vi.fn(async (defaults) => ({ ...defaults, ...stored })),
+        set: vi.fn(async (patch) => { stored = { ...stored, ...patch }; }),
+      } },
+      tabs: { ...tabs, get: vi.fn(), onActivated: { addListener: vi.fn() }, onUpdated: { addListener: vi.fn() } },
+    };
+    const fetchCalls = [];
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      let body;
+      if (String(url).includes("/backend-api/conversations?")) body = { items: [{ id: "fixture-1", update_time: 1780000000 }], total: 1 };
+      else if (String(url).includes("/backend-api/conversation/fixture-1")) body = { id: "fixture-1", mapping: { one: { message: { id: "m1", author: { role: "user" }, content: { parts: ["fixture"] } } } } };
+      else {
+        const contentHash = createHash("sha256").update(options.body, "utf8").digest("hex");
+        body = { ok: true, provider: "chatgpt", provider_session_id: "fixture-1", content_hash: contentHash };
+      }
+      return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-ack" : null }, json: async () => body };
+    });
+    const packagedWorkerUrl = `${pathToFileURL(join(unpacked, "src", "background.js")).href}?smoke=${Date.now()}`;
+    await import(/* @vite-ignore */ packagedWorkerUrl);
+    const send = (message) => new Promise((resolve) => messageListener(message, {}, resolve));
+    const started = await send({ type: "polylogue.backfill.start", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", policy: { baseCadenceMs: 0 } });
+    await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).includes("/backend-api/conversations?"))).toBe(true));
+    alarmListener({ name: `polylogueBackfillWake:${started.job.id}` });
+    await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).includes("/v1/browser-captures"))).toBe(true));
+    expect(tabs.create).not.toHaveBeenCalled();
+    expect(tabs.update).not.toHaveBeenCalled();
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    rmSync(smokeRoot, { recursive: true, force: true });
   });
 });

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -88,5 +88,13 @@ describe("build.mjs full archive emission", () => {
     const summary = JSON.parse(readFileSync(join(outDir, "build-manifest.json"), "utf8"));
     expect(summary.version).toBe("0.9.0");
     expect(summary.firefox_gecko_id).toMatch(/@/);
+    const listing = execFileSync(
+      "python3",
+      ["-c", "import sys,zipfile; print('\\n'.join(zipfile.ZipFile(sys.argv[1]).namelist()))", join(outDir, "polylogue-browser-capture-0.9.0-chrome.zip")],
+      { encoding: "utf8" },
+    );
+    expect(listing).toContain("src/backfill/coordinator.js");
+    expect(listing).toContain("src/backfill/providers.js");
+    expect(listing).toContain("src/backfill/storage.js");
   });
 });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -29,6 +29,19 @@ function installDom() {
       <button id="check-receiver"><span class="button-status"></span></button>
       <button id="debug-toggle"><span class="button-status"></span></button>
       <button id="debug-export"><span class="button-status"></span></button>
+      <select id="backfill-provider"><option value="chatgpt">ChatGPT</option></select>
+      <select id="backfill-job"></select>
+      <input id="backfill-cutoff" />
+      <span id="backfill-status"></span>
+      <span id="backfill-cursor"></span>
+      <span id="backfill-progress"></span>
+      <span id="backfill-rate"></span>
+      <span id="backfill-last"></span>
+      <button id="backfill-start"><span class="button-status"></span></button>
+      <button id="backfill-pause"><span class="button-status"></span></button>
+      <button id="backfill-resume"><span class="button-status"></span></button>
+      <button id="backfill-cancel"><span class="button-status"></span></button>
+      <button id="backfill-export"><span class="button-status"></span></button>
       <span id="mode"></span>
       <span id="fidelity"></span>
       <span id="turns"></span>
@@ -316,6 +329,40 @@ describe("popup capture", () => {
 
     expect(globalThis.document.getElementById("queue-count").textContent).toBe("0");
     expect(globalThis.document.getElementById("queue-log").textContent).toContain("No captures queued for retry.");
+  });
+
+  it("starts and controls a background backfill while rendering rate and progress", async () => {
+    let status = "running";
+    const job = () => ({
+      id: "backfill-1",
+      provider: "chatgpt",
+      status,
+      inventory_cursor: "144",
+      inventory_complete: false,
+      learned_cadence_ms: 30000,
+      cooldown_until_ms: Date.now() + 60000,
+      last_error: "provider_http_429",
+      progress: { total: 462, complete: 144, retry: 1, no_turns: 0, error: 0, operator_action: 0 },
+    });
+    globalThis.chrome.runtime.sendMessage.mockImplementation(async (message) => {
+      if (message.type === "polylogue.backfill.status") return { ok: true, jobs: [job()] };
+      if (message.type === "polylogue.backfill.start") return { ok: true, job: job() };
+      if (message.type === "polylogue.backfill.control") { status = message.action === "pause" ? "paused" : message.action; return { ok: true, job: job() }; }
+      return { ok: true };
+    });
+    document.getElementById("backfill-cutoff").value = "2026-04-23";
+
+    document.getElementById("backfill-start").click();
+    await vi.waitFor(() => expect(document.getElementById("backfill-progress").textContent).toContain("144/462"));
+    expect(document.getElementById("backfill-rate").textContent).toContain("30s");
+    expect(globalThis.chrome.runtime.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: "polylogue.backfill.start",
+      provider: "chatgpt",
+      cutoff: "2026-04-23T00:00:00.000Z",
+    }));
+
+    document.getElementById("backfill-pause").click();
+    await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("paused"));
   });
 
   it("checks receiver health and shows a reachable-but-unauthorized result", async () => {

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -121,6 +121,17 @@ request count are bounded. Receiver downtime never marks an item complete and
 does not force a second provider fetch: the native-full envelope waits durably
 for an idempotent receiver ACK.
 
+An IndexedDB execution lease serializes inventory and native-fetch requests as
+well as queue ownership. The coordinator atomically reserves provider budget
+before network I/O; request timeouts are shorter than the lease. Pause/cancel
+increments the job generation and transactionally cancels queue entries, so a
+late response cannot restore stale running state. Successful ACK finalization
+atomically updates job, queue, and the provider-native revision ledger. A later
+job skips only an exact trusted `(provider, native id, updated_at)` revision;
+records without a revision are fetched. Stored-envelope bytes, receiver retry
+attempts, and actual IndexedDB quota errors all fail paused rather than growing
+without bound.
+
 This workflow repairs gaps relative to an immutable export/GDPR baseline and a
 user-selected cutoff. It honors provider authentication and controls and cannot
 prove completeness beyond the authenticated inventory returned by the provider.

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -70,6 +70,10 @@ The filename is deterministic from provider and provider session id, so repeated
 observation of the same web session replaces the same source artifact. Receiver
 responses expose this artifact as an `artifact_ref` relative to the spool root;
 absolute filesystem paths stay inside the receiver process.
+An accepted response also carries `content_hash`, the SHA-256 of the exact
+UTF-8 JSON request bytes. The receiver returns it only after the atomic spool
+write succeeds. Background backfill therefore treats a response as a durable
+ACK only when both `X-Request-ID` and the expected content hash match.
 
 Every receiver response carries `X-Request-ID`. If the extension or a local
 debug probe sends a safe `X-Request-ID` header, the receiver echoes its
@@ -99,6 +103,29 @@ archive-state feedback. Provider adapters should prefer provider-native
 structured page/app payloads where available and use DOM text extraction only
 as a compatibility fallback. The shared envelope carries session, turn,
 attachment, provenance, and provider metadata semantics.
+
+### Background inventory delta
+
+An explicitly started background job uses a ChatGPT or Claude.ai provider
+adapter with four operations: inventory enumeration, native fetch, response
+classification, and normalized capture. IndexedDB stores the inventory cursor,
+queue state, attempts, eligibility deadline, lease owner/expiry, fidelity,
+submitted envelope, and receiver receipt. MV3 alarms resume eligible work after
+service-worker termination; expired leases return to their prior state.
+
+The default provider concurrency is one. Token cadence is conservative and
+learned upward after throttling. `Retry-After` is authoritative, retry delays
+use exponential full jitter, and repeated 429/403/challenge or transport
+failures open a fail-paused circuit. Queue size, captures per wake, and daily
+request count are bounded. Receiver downtime never marks an item complete and
+does not force a second provider fetch: the native-full envelope waits durably
+for an idempotent receiver ACK.
+
+This workflow repairs gaps relative to an immutable export/GDPR baseline and a
+user-selected cutoff. It honors provider authentication and controls and cannot
+prove completeness beyond the authenticated inventory returned by the provider.
+It never bypasses anti-bot checks, discovers deleted/ephemeral records absent
+from inventory, or activates an operator foreground tab.
 
 ## Dataflow and boundary
 

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -234,6 +234,7 @@ class BrowserCaptureAcceptedPayload(BaseModel):
     provider: str
     provider_session_id: str
     artifact_ref: str
+    content_hash: str
     bytes_written: int
     replaced: bool
 

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
@@ -154,7 +153,6 @@ class BrowserCaptureWriteResult:
     provider_session_id: str
     path: Path
     artifact_ref: str
-    content_hash: str
     bytes_written: int
     replaced: bool
 
@@ -483,7 +481,6 @@ def write_capture_envelope(
             _check_spool_quota(root, max_files=SPOOL_MAX_FILES, max_bytes=SPOOL_MAX_BYTES)
         target.parent.mkdir(parents=True, exist_ok=True)
         payload = envelope.model_dump(mode="json", exclude_none=True)
-        canonical = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
         raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
         with tempfile.NamedTemporaryFile("wb", dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
             temp_path = Path(handle.name)
@@ -495,7 +492,6 @@ def write_capture_envelope(
         provider_session_id=envelope.provider_session_id,
         path=target,
         artifact_ref=capture_artifact_ref(envelope, spool_path),
-        content_hash=hashlib.sha256(canonical).hexdigest(),
         bytes_written=target.stat().st_size,
         replaced=replaced,
     )

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -153,6 +154,7 @@ class BrowserCaptureWriteResult:
     provider_session_id: str
     path: Path
     artifact_ref: str
+    content_hash: str
     bytes_written: int
     replaced: bool
 
@@ -481,6 +483,7 @@ def write_capture_envelope(
             _check_spool_quota(root, max_files=SPOOL_MAX_FILES, max_bytes=SPOOL_MAX_BYTES)
         target.parent.mkdir(parents=True, exist_ok=True)
         payload = envelope.model_dump(mode="json", exclude_none=True)
+        canonical = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
         raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
         with tempfile.NamedTemporaryFile("wb", dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
             temp_path = Path(handle.name)
@@ -492,6 +495,7 @@ def write_capture_envelope(
         provider_session_id=envelope.provider_session_id,
         path=target,
         artifact_ref=capture_artifact_ref(envelope, spool_path),
+        content_hash=hashlib.sha256(canonical).hexdigest(),
         bytes_written=target.stat().st_size,
         replaced=replaced,
     )

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import json
 import time
@@ -250,12 +251,14 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         if length <= 0 or length > MAX_BROWSER_CAPTURE_BODY_BYTES:
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_body_size")
             return None
+        raw = self.rfile.read(length)
         try:
-            parsed: object = json.loads(self.rfile.read(length))
+            parsed: object = json.loads(raw)
         except json.JSONDecodeError:
             logger.warning("browser_capture.invalid_json", request_id=self._request_id())
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_json")
             return None
+        self._request_content_hash = hashlib.sha256(raw).hexdigest()
         return parsed
 
     def _do_post(self) -> None:
@@ -307,6 +310,7 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 provider=result.provider,
                 provider_session_id=result.provider_session_id,
                 artifact_ref=result.artifact_ref,
+                content_hash=self._request_content_hash,
                 bytes_written=result.bytes_written,
                 replaced=result.replaced,
             ).model_dump(mode="json"),

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from collections.abc import Iterator
@@ -135,12 +136,12 @@ def _seed_browser_capture_archive(
 
 
 def _request(
-    host: str, port: int, method: str, path: str, *, body: object | str | None = None, origin: str
+    host: str, port: int, method: str, path: str, *, body: object | str | bytes | None = None, origin: str
 ) -> HTTPResponse:
     conn = HTTPConnection(host, port)
     headers = {"Origin": origin}
-    payload: str | None
-    if isinstance(body, str):
+    payload: str | bytes | None
+    if isinstance(body, (bytes, str)):
         payload = body
         headers["Content-Type"] = "application/json"
     elif body is not None:
@@ -423,8 +424,33 @@ def test_receiver_accepts_extension_capture_and_reports_typed_dto(tmp_path: Path
     assert body.schema_version == 1
     assert body.capture_id == "chatgpt:conv-123"
     assert body.artifact_ref == capture_artifact_ref(BrowserCaptureEnvelope.model_validate(_payload()), tmp_path)
+    request_body = json.dumps(_payload()).encode()
+    assert body.content_hash == hashlib.sha256(request_body).hexdigest()
     assert Path(body.artifact_ref).is_absolute() is False
     assert (tmp_path / body.artifact_ref).exists()
+
+
+def test_receiver_ack_hashes_exact_javascript_request_bytes(tmp_path: Path) -> None:
+    request_body = (
+        '{"polylogue_capture_kind":"browser_llm_session","schema_version":1,'
+        '"provenance":{"source_url":"https://chatgpt.com/c/conv-123",'
+        '"captured_at":"2026-04-24T00:00:00.000Z","adapter_name":"chatgpt-backfill-native-v1"},'
+        '"session":{"provider":"chatgpt","provider_session_id":"conv-123",'
+        '"turns":[{"provider_turn_id":"u1","role":"user","text":"żółć 😀"}]},'
+        '"provider_meta":{"number":1.25,"nested":{"b":2,"a":1}}}'
+    ).encode()
+    with _running_receiver(tmp_path) as (host, port):
+        response = _request(
+            host,
+            port,
+            "POST",
+            "/v1/browser-captures",
+            body=request_body,
+            origin=_EXTENSION_ORIGIN,
+        )
+        accepted = BrowserCaptureAcceptedPayload.model_validate(json.loads(response.read()))
+
+    assert accepted.content_hash == hashlib.sha256(request_body).hexdigest()
 
 
 def test_receiver_returns_429_without_writing_when_spool_quota_exceeded(


### PR DESCRIPTION
## Summary

Add a provider-aware background backfill engine to the MV3 browser extension. ChatGPT and Claude.ai inventory deltas run as durable IndexedDB jobs with restart recovery, atomic execution leases, hard request reservation, stable revision deduplication, learned cadence, explicit terminal states, and receiver-content acknowledgements.

## Problem

The 2026-07-12 ChatGPT delta crawl reached 144/462 candidates before provider throttling. It depended on a foreground agent, an external checkpoint, and fixed pacing. Receiver downtime, MV3 suspension, concurrent extension instances, stale async continuations, and provider challenges could not be handled autonomously or audited from the popup.

## Solution

- Add strict ChatGPT and Claude.ai adapters for authenticated inventory and full-tree native capture endpoints, including structured/tool normalization and drift-loud fixtures.
- Persist jobs, queue items, attempts, native artifacts, receipts, exact provider revisions, and atomic provider-wide leases in IndexedDB.
- Atomically lease each execution and reserve provider budget before network I/O. Every reacquisition/control change increments a generation checked by job and queue transactions, so concurrent wakes cannot double-spend and late responses cannot resurrect cancellation.
- Enforce one active crawl per provider, hard daily reservation, per-wake and stored-byte limits, Retry-After, full-jitter backoff, learned cadence, bounded receiver retries, and circuit breaking.
- Keep fixed 60-second provider and receiver request timeouts below a non-overridable 180-second execution lease; retain queue ownership until ACK.
- Use per-job MV3 alarms and expired-lease recovery across service-worker/browser restart without activating foreground tabs.
- Skip only exact trusted `(provider, native id, updated_at)` revisions across later jobs. Missing revisions fetch again. ChatGPT stops ordered pagination at the cutoff; Claude makes no ordering assumption.
- Atomically finalize queue completion, revision ledger, and job ACK after the receiver writes the spool artifact and echoes the exact POST-byte SHA-256.
- Add popup start/pause/resume/cancel, historical-job selection, progress/rate/cooldown/ACK state, and diagnostic ledger export.
- Document provider-control and authenticated-inventory completeness limits.

Ref polylogue-jlme.1

## Acceptance criteria

1. Satisfied: synthetic ChatGPT inventory survives coordinator restart and captures each native id once.
2. Satisfied: fake-clock Retry-After blocks early requests and repeated 429s pause the provider circuit.
3. Satisfied: auth/challenge, transport exhaustion, native-empty, receiver-down, fatal response, and durable ACK remain distinct persisted states.
4. Satisfied: receiver-only recovery reuses the stored envelope, preserves provider counters, bounds attempts/bytes, and verifies the exact content hash.
5. Satisfied: popup controls and all requested status fields are rendered; historical jobs remain selectable.
6. Satisfied: real IndexedDB Promise-all proof grants one execution/request reservation; queue CAS and generation tests prevent stale/cancelled writes.
7. Satisfied: an extracted packaged extension imports and executes the service worker against fake IndexedDB/provider/receiver fixtures with zero foreground tab activation; source manifest/package hashes remain unchanged.
8. Satisfied: docs state provider controls are honored and completeness cannot exceed authenticated inventory.

## Verification

- `cd browser-extension && npm test`
  - 8 files passed; 145 tests passed.
- `cd browser-extension && npm run lint && npm run validate`
  - ESLint clean; `manifest ok`.
- `devtools test tests/unit/browser_capture/test_receiver.py tests/unit/browser_capture/test_receiver_contract.py`
  - 59 passed on the receiver boundary after final review repairs.
- Pre-push `devtools verify --quick`
  - 15/15 steps passed; latest run `20260712T192227Z-quick-3812364-11b62839`.

## Anti-vacuity

- Real fake-indexeddb concurrency exercises production job transactions; removing the execution lease/reservation makes two inventory calls or loses a daily charge.
- Deferred cancellation exercises production generation and jobs+queue CAS; removing either leaves the final queue resurrected instead of cancelled.
- Expired stable-instance reacquisition exercises the monotonic execution token; reusing a generation permits the old continuation to write.
- Revision replay exercises production atomic jobs+queue+revisions finalization; removing the ledger causes a second unchanged job to refetch/repost.
- Rate-limit and budget proofs exercise pre-call reservation, `next_request_at`, Retry-After, circuit state, receiver attempts, and byte limits; removing a bound permits an early request or exceeds the hard cap.
- Python receiver proof sends representative JavaScript JSON bytes with Unicode, floats, and nested key order and asserts the post-write ACK equals SHA-256 of those exact bytes.
- Package proof imports the extracted built `background.js`, runs a fixture backfill, observes a durable receiver POST, asserts no tab activation, and verifies source manifest/package bytes did not change.

No live ChatGPT or Claude request was made, and the paused checkpoint at `/realm/tmp/polylogue-chatgpt-backfill-progress-20260712.json` was not read or modified.
