### PR TITLE
chore(tools): fanout lane launcher + live-bead prompt generator

### DIFF
--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -49,7 +49,7 @@ if [[ "${1:-}" == "resume-headless" ]]; then
   for lane in "${lanes[@]}"; do
     sid=$(python3 -c "import json;print(json.load(open('$MAN')).get('$lane',{}).get('sid',''))")
     wt="/realm/worktrees/$lane"
-    [[ -z "$sid" || ! -d "$wt" ]] && { echo "skip $lane (sid='$sid')"; continue }
+    [[ -z "$sid" || ! -d "$wt" ]] && { echo "skip $lane (sid='$sid')"; continue; }
     rm -f "$OUTPUT_DIR/$lane.exit"
     n=1; while [[ -e "$OUTPUT_DIR/$lane.headless-$n.log" ]]; do n=$((n+1)); done
     hlog="$OUTPUT_DIR/$lane.headless-$n.log"

--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# fanout-launch.sh — polylogue defaults for the canonical fanout launcher.
+#
+# The real implementation is permanent in sinnix:
+#   dots/_ai/skills/agent-orchestration/scripts/launch_agent_tabs.sh
+#   (sinnix commit 1a26aff: --persist-windows, --per-task-workdir-base,
+#    --job-prefix, --status)
+# The deployed skill copy under ~/.claude/skills resolves into the nix store
+# and only refreshes on `switch`; this wrapper prefers the sinnix working-tree
+# copy so improvements are usable immediately.
+#
+# Usage:
+#   .agent/tools/fanout-launch.sh <lane...>              # launch on workspace 6
+#   .agent/tools/fanout-launch.sh --status               # completion table
+# Naming convention (lane name = worktree dir name = prompt basename):
+#   lane "polylogue-hermes-wedge" ->
+#     worktree /realm/worktrees/polylogue-hermes-wedge
+#     prompt   .agent/scratch/fanout-prompts/polylogue-hermes-wedge.prompt
+set -euo pipefail
+
+CANONICAL="/realm/project/sinnix/dots/_ai/skills/agent-orchestration/scripts/launch_agent_tabs.sh"
+DEPLOYED="$HOME/.claude/skills/agent-orchestration/scripts/launch_agent_tabs.sh"
+LAUNCHER="$CANONICAL"
+[[ -x "$LAUNCHER" ]] || LAUNCHER="$DEPLOYED"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+PROMPT_DIR="$REPO_ROOT/.agent/scratch/fanout-prompts"
+OUTPUT_DIR="/realm/tmp/fanout-$(date +%Y-%m)/out"
+
+if [[ "${1:-}" == "--status" ]]; then
+  exec bash "$LAUNCHER" --status --output-dir "$OUTPUT_DIR"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+exec bash "$LAUNCHER" \
+  --agent codex \
+  --mode kitty \
+  --launch-type os-window \
+  --workspace 6 \
+  --persist-windows \
+  --per-task-workdir-base /realm/worktrees \
+  --job-prefix fanout- \
+  --model "${FANOUT_MODEL:-gpt-5.6-terra}" \
+  --reasoning-effort "${FANOUT_EFFORT:-high}" \
+  --prompt-dir "$PROMPT_DIR" \
+  --output-dir "$OUTPUT_DIR" \
+  "$@"

--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -31,6 +31,38 @@ if [[ "${1:-}" == "--status" ]]; then
   exec bash "$LAUNCHER" --status --output-dir "$OUTPUT_DIR"
 fi
 
+# resume-headless <lane...|--all>: relaunch lanes HEADLESS on codex-lean
+# (lean MCP profile, hooks disabled) resuming their persisted sessions from
+# .agent/scratch/fanout-sessions.json. Survives kitty/desktop death; use
+# after an auth cutoff or when visibility isn't needed. Logs/exit markers in
+# the output dir; monitor with --status.
+if [[ "${1:-}" == "resume-headless" ]]; then
+  shift
+  MAN="$REPO_ROOT/.agent/scratch/fanout-sessions.json"
+  lanes=()
+  if [[ "${1:-}" == "--all" ]]; then
+    lanes=($(python3 -c "import json;print('\n'.join(json.load(open('$MAN'))))"))
+  else
+    lanes=("$@")
+  fi
+  mkdir -p "$OUTPUT_DIR"
+  for lane in "${lanes[@]}"; do
+    sid=$(python3 -c "import json;print(json.load(open('$MAN')).get('$lane',{}).get('sid',''))")
+    wt="/realm/worktrees/$lane"
+    [[ -z "$sid" || ! -d "$wt" ]] && { echo "skip $lane (sid='$sid')"; continue }
+    rm -f "$OUTPUT_DIR/$lane.exit"
+    n=1; while [[ -e "$OUTPUT_DIR/$lane.headless-$n.log" ]]; do n=$((n+1)); done
+    hlog="$OUTPUT_DIR/$lane.headless-$n.log"
+    cont="Coordinator: resumed headless after interruption. Run git status && git log --oneline -5 first; continue your mission from where you left off (re-read your bead list with bd show; your PR may already exist — continue on the same branch). Commit and push every chunk. Do not merge."
+    scope=(); command -v sinnix-scope >/dev/null && scope=(sinnix-scope background --)
+    contq=$(printf '%q' "$cont")
+    nohup zsh -c "cd $wt && printf '%s' $contq | ${scope[*]} $HOME/.local/bin/codex-lean exec resume $sid --model ${FANOUT_MODEL:-gpt-5.6-terra} -c 'model_reasoning_effort=\"${FANOUT_EFFORT:-high}\"' -c 'features.hooks=false' --output-last-message $OUTPUT_DIR/$lane.last.md - ; ec=\$?; echo \$ec > $OUTPUT_DIR/$lane.exit" >"$hlog" 2>&1 &
+    echo "headless-resumed $lane (sid $sid) log=$hlog pid=$!"
+    sleep "${FANOUT_STAGGER:-8}"
+  done
+  exit 0
+fi
+
 # resume <lane...> [--workspace N]: continue a dead lane's PERSISTED codex
 # session (context intact) instead of paying fresh re-orientation. Extracts
 # the exact session id from the lane's launch receipt in the log — never

--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -22,6 +22,7 @@ CANONICAL="/realm/project/sinnix/dots/_ai/skills/agent-orchestration/scripts/lau
 DEPLOYED="$HOME/.claude/skills/agent-orchestration/scripts/launch_agent_tabs.sh"
 LAUNCHER="$CANONICAL"
 [[ -x "$LAUNCHER" ]] || LAUNCHER="$DEPLOYED"
+[[ -x "$LAUNCHER" ]] || { echo "fanout-launch: no launcher at $CANONICAL or $DEPLOYED" >&2; exit 1; }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 PROMPT_DIR="$REPO_ROOT/.agent/scratch/fanout-prompts"

--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -31,6 +31,15 @@ if [[ "${1:-}" == "--status" ]]; then
   exec bash "$LAUNCHER" --status --output-dir "$OUTPUT_DIR"
 fi
 
+# --tails [n] [--tails-all] [lane...]: colored per-lane log tails with
+# run/idle timings (running lanes by default; DONE lanes show last.md).
+if [[ "${1:-}" == "--tails" || "${1:-}" == "tails" ]]; then
+  shift
+  # --output-dir must precede positional lane names: the launcher's flag
+  # parser stops at the first non-flag argument.
+  exec bash "$LAUNCHER" --output-dir "$OUTPUT_DIR" --tails "$@"
+fi
+
 # resume-headless <lane...|--all>: relaunch lanes HEADLESS on codex-lean
 # (lean MCP profile, hooks disabled) resuming their persisted sessions from
 # .agent/scratch/fanout-sessions.json. Survives kitty/desktop death; use
@@ -58,6 +67,38 @@ if [[ "${1:-}" == "resume-headless" ]]; then
     contq=$(printf '%q' "$cont")
     nohup zsh -c "cd $wt && printf '%s' $contq | ${scope[*]} $HOME/.local/bin/codex-lean exec resume $sid --model ${FANOUT_MODEL:-gpt-5.6-terra} -c 'model_reasoning_effort=\"${FANOUT_EFFORT:-high}\"' -c 'features.hooks=false' --output-last-message $OUTPUT_DIR/$lane.last.md - ; ec=\$?; echo \$ec > $OUTPUT_DIR/$lane.exit" >"$hlog" 2>&1 &
     echo "headless-resumed $lane (sid $sid) log=$hlog pid=$!"
+    sleep "${FANOUT_STAGGER:-8}"
+  done
+  exit 0
+fi
+
+# review <lane...|--all>: relaunch finished lanes HEADLESS on codex-lean into
+# an ADVERSARIAL SELF-REVIEW fixpoint loop — hostile re-review of their own
+# branch diff + beads AC, fix/verify/commit/push every finding, repeat until
+# a full iteration finds nothing new. Use after lanes report "done": an open
+# PR is a checkpoint, not completion.
+if [[ "${1:-}" == "review" ]]; then
+  shift
+  MAN="$REPO_ROOT/.agent/scratch/fanout-sessions.json"
+  lanes=()
+  if [[ "${1:-}" == "--all" ]]; then
+    lanes=($(python3 -c "import json;print('\n'.join(json.load(open('$MAN'))))"))
+  else
+    lanes=("$@")
+  fi
+  mkdir -p "$OUTPUT_DIR"
+  cont='Coordinator directive: adversarial self-review fixpoint loop. Your PR being open does NOT mean you are done. Each iteration: (1) git fetch origin and review your full branch diff (git diff origin/master...HEAD) as a hostile reviewer — hunt vacuous tests, unwired runtime paths, missed or quietly-dropped acceptance criteria, edge cases, contract violations, dishonest claims in the PR body; (2) re-read each of your beads (bd show <id> --json) including notes and AC — beads are fast now, use them freely; (3) check your PR for new review comments (gh pr view --comments) and address substantive ones; (4) for EVERY finding: fix, verify with focused devtools tests, commit, push; (5) append an iteration summary to the PR (gh pr comment): findings, fixes, what survived scrutiny. REPEAT until one full iteration yields ZERO new findings, then post a final honest per-AC matrix comment (satisfied / deferred-to-bead / misframed) and stop. Do not merge. Do not close beads. Known infra, not yours to fix: GitHub Actions currently fails ALL jobs at init with no steps (account billing) — ignore that pattern. Keep pytest temp under /realm/tmp, never host /tmp (small tmpfs).'
+  contq=$(printf '%q' "$cont")
+  for lane in "${lanes[@]}"; do
+    sid=$(python3 -c "import json;print(json.load(open('$MAN')).get('$lane',{}).get('sid',''))")
+    wt="/realm/worktrees/$lane"
+    [[ -z "$sid" || ! -d "$wt" ]] && { echo "skip $lane (sid='$sid')"; continue; }
+    rm -f "$OUTPUT_DIR/$lane.exit"
+    n=1; while [[ -e "$OUTPUT_DIR/$lane.review-$n.log" ]]; do n=$((n+1)); done
+    hlog="$OUTPUT_DIR/$lane.review-$n.log"
+    scope=(); command -v sinnix-scope >/dev/null && scope=(sinnix-scope background --)
+    nohup zsh -c "cd $wt && printf '%s' $contq | ${scope[*]} $HOME/.local/bin/codex-lean exec resume $sid --model ${FANOUT_MODEL:-gpt-5.6-terra} -c 'model_reasoning_effort=\"${FANOUT_EFFORT:-high}\"' -c 'features.hooks=false' --output-last-message $OUTPUT_DIR/$lane.last.md - ; ec=\$?; echo \$ec > $OUTPUT_DIR/$lane.exit" >"$hlog" 2>&1 &
+    echo "review-loop $lane (sid $sid) log=$hlog pid=$!"
     sleep "${FANOUT_STAGGER:-8}"
   done
   exit 0

--- a/.agent/tools/fanout-launch.sh
+++ b/.agent/tools/fanout-launch.sh
@@ -31,6 +31,47 @@ if [[ "${1:-}" == "--status" ]]; then
   exec bash "$LAUNCHER" --status --output-dir "$OUTPUT_DIR"
 fi
 
+# resume <lane...> [--workspace N]: continue a dead lane's PERSISTED codex
+# session (context intact) instead of paying fresh re-orientation. Extracts
+# the exact session id from the lane's launch receipt in the log — never
+# `resume --last` (25+ concurrent sessions make it ambiguous).
+if [[ "${1:-}" == "resume" ]]; then
+  shift
+  ws=66
+  lanes=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --workspace) ws="$2"; shift 2 ;;
+      *) lanes+=("$1"); shift ;;
+    esac
+  done
+  for lane in "${lanes[@]}"; do
+    log="$OUTPUT_DIR/$lane.log"
+    sid="$(grep -m1 -oE 'session id: [0-9a-f-]+' "$log" 2>/dev/null | awk '{print $3}')"
+    wt="/realm/worktrees/$lane"
+    if [[ -z "$sid" || ! -d "$wt" ]]; then
+      echo "cannot resume $lane: sid='$sid' wt='$wt'" >&2
+      continue
+    fi
+    rm -f "$OUTPUT_DIR/$lane.exit"
+    n=1; while [[ -e "$OUTPUT_DIR/$lane.resume-$n.log" ]]; do n=$((n+1)); done
+    rlog="$OUTPUT_DIR/$lane.resume-$n.log"
+    cont="Your previous run was interrupted (process died; RAM or quota). First run: git status && git log --oneline -5 to see what you already committed in this worktree. Then continue your mission exactly where you left off — the original brief is at $PROMPT_DIR/$lane.prompt (re-read it). All the same rules apply: commit every chunk, report AC status, open a PR, do not merge."
+    scope=(); command -v sinnix-scope >/dev/null && scope=(sinnix-scope background --)
+    # NOTE: the `codex` command on this host is a wrapper that already injects
+    # --profile; do NOT pass --profile here (double-flag is a hard error).
+    # zsh pipestatus is 1-based: printf=[1], codex=[2], tee=[3].
+    inner="cd $(printf '%q' "$wt") && { command -v direnv >/dev/null && direnv allow . 2>/dev/null; }; printf '%s' $(printf '%q' "$cont") | ${scope[*]} codex exec resume $(printf '%q' "$sid") --model ${FANOUT_MODEL:-gpt-5.6-terra} -c 'model_reasoning_effort=\"${FANOUT_EFFORT:-high}\"' --output-last-message $(printf '%q' "$OUTPUT_DIR/$lane.last.md") - 2>&1 | tee $(printf '%q' "$rlog"); ec=\${pipestatus[2]:-\$?}; echo \$ec > $(printf '%q' "$OUTPUT_DIR/$lane.exit"); print \"[resume $lane exit=\$ec]\"; exec zsh -i"
+    kitty @ launch --keep-focus --type=os-window --title "agent-$lane" --cwd "$wt" -- zsh -lc "$inner" >/dev/null
+    for _ in {1..40}; do
+      sinnix-hypr-control dispatch movetoworkspacesilent "$ws,title:^(agent-$lane)\$" >/dev/null 2>&1 && break
+      sleep 0.05
+    done
+    echo "resumed $lane (session $sid) -> workspace $ws, log $rlog"
+  done
+  exit 0
+fi
+
 mkdir -p "$OUTPUT_DIR"
 exec bash "$LAUNCHER" \
   --agent codex \

--- a/.agent/tools/fanout_gen_prompts.py
+++ b/.agent/tools/fanout_gen_prompts.py
@@ -509,7 +509,10 @@ def load_beads() -> dict[str, dict]:
             d = json.loads(line)
         except json.JSONDecodeError:
             continue
-        out[d["id"].removeprefix("polylogue-")] = d
+        bead_id = d.get("id")
+        if not isinstance(bead_id, str):
+            continue
+        out[bead_id.removeprefix("polylogue-")] = d
     return out
 
 
@@ -564,7 +567,12 @@ def main() -> int:
     for e in errors:
         print(f"ERROR {e}")
     if not args.check:
-        print(f"\nwrote {len(LANES)} prompts to {OUT}")
+        if errors:
+            print(
+                f"\nwrote {len(LANES)} prompts to {OUT} — {len(errors)} error(s) above; roster needs fixing before launch"
+            )
+        else:
+            print(f"\nwrote {len(LANES)} prompts to {OUT}")
         sol = [name for name, s in LANES.items() if s.get("model") == "gpt-5.6-sol"]
         if sol:
             print(f"SOL lanes (launch separately with FANOUT_MODEL=gpt-5.6-sol): {', '.join(sol)}")

--- a/.agent/tools/fanout_gen_prompts.py
+++ b/.agent/tools/fanout_gen_prompts.py
@@ -42,7 +42,12 @@ LANES: dict[str, dict] = {
             "descriptive Fable delegation packet, only if 1+2 land cleanly."
         ),
         "own": ["polylogue/archive/query/", "polylogue/insights/", "tests/unit/archive/", "tests/unit/insights/"],
-        "avoid": ["polylogue/storage/sqlite/", "polylogue/daemon/", "browser-extension/"],
+        "avoid": [
+            "polylogue/storage/sqlite/",
+            "polylogue/daemon/",
+            "browser-extension/",
+            "insights rigor/field contracts (rigor-contracts lane owns them; you CREATE new packet modules)",
+        ],
         "verify": "devtools test tests/unit/archive tests/unit/insights -k 'aggregate or cohort or manifest' (narrow further per change)",
     },
     "polylogue-hermes-wedge": {
@@ -57,20 +62,24 @@ LANES: dict[str, dict] = {
         ),
         "own": [
             "polylogue/sources/parsers/hermes_state.py",
-            "polylogue/mcp/",
+            "polylogue/mcp/ (recall/context tools only)",
             "polylogue/daemon/recall*",
             "tests/unit/sources/",
             "tests/unit/mcp/",
         ],
-        "avoid": ["polylogue/storage/sqlite/archive_tiers/", "browser-extension/"],
+        "avoid": [
+            "polylogue/storage/sqlite/archive_tiers/",
+            "browser-extension/",
+            "mcp response envelope/pagination plumbing (mcp-ergonomics lane)",
+        ],
         "verify": "devtools test tests/unit/sources/test_hermes* tests/unit/mcp -k 'hermes or recall or manifest'",
     },
     "polylogue-extension-redesign": {
-        "beads": [],  # ids assigned by the design-pack import in the beads pass
+        "beads": ["r4no", "bkff", "r2kb", "4g3n"],
         "goal": (
-            "Extension redesign per docs/design/browser-capture-redesign/ and "
-            "the handoff pack (coordinator files beads before launch; read "
-            "them via bd ready --json | grep redesign). Order: silent-capture "
+            "Extension redesign first slice (epic polylogue-yyvg; in-page "
+            "layers ys30/wvji/bj5h are follow-ups, NOT this lane). Order: "
+            "r4no silent-capture "
             "P1 bug (auto-capture trigger never fires — 160 GETs, 0 POSTs) "
             "first; then popup mission-control; operator status vocabulary; "
             "'What Polylogue did here' timeline (doing-nothing must be a "
@@ -111,12 +120,13 @@ LANES: dict[str, dict] = {
         "verify": "devtools test tests/unit/daemon -k 'web or shell' + playwright smoke if route shapes change",
     },
     "polylogue-distribution": {
-        "beads": ["y8s5"],
+        "beads": ["y8s5", "6rvt"],
         "goal": (
             "Distribution/legibility: everything y8s5 unblocks — PyPI/pipx "
             "publishable package, Homebrew/GHCR smoke lanes, install matrix "
             "doc, extension packaging for store submission. v0.2.0 is tagged; "
-            "wire the release artifacts, don't re-cut."
+            "wire the release artifacts, don't re-cut. Include 6rvt: packaged "
+            "runtimes must expose the full build revision."
         ),
         "own": [
             "pyproject.toml",
@@ -210,6 +220,7 @@ LANES: dict[str, dict] = {
         "verify": "devtools verify --quick + testmon-affected; zero behavior diffs expected",
     },
     "polylogue-origin-interop": {
+        "wave2_after": "polylogue-provider-origin",
         "beads": ["2ilz"],
         "goal": (
             "Origin identity hygiene: 2ilz durable capture-mode field "
@@ -224,7 +235,7 @@ LANES: dict[str, dict] = {
         "verify": "devtools test tests/unit/core -k 'source or origin'",
     },
     "polylogue-demo-corpus": {
-        "beads": ["212.11"],
+        "beads": ["212.11", "67ac"],
         "goal": (
             "Demo construct validity: 212.11 shared deterministic proof "
             "world for flagship demos; PLUS the measured-result experiment — "
@@ -239,20 +250,183 @@ LANES: dict[str, dict] = {
         "verify": "polylogue demo seed && polylogue demo verify && polylogue demo receipts (deterministic, CI-green)",
     },
     "polylogue-fastforward-mech": {
-        "beads": [],  # bead filed in the beads pass; informed by the live v35 run
+        "beads": ["9rw0", "ma2"],
         "goal": (
-            "Productize derived-tier fast-forward plans (bead filed by "
-            "coordinator; read it + the fanout-prep doc section 'v35 "
-            "rebuild'). Each index bump declares a delta class (constraint/"
+            "Productize derived-tier fast-forward plans (polylogue-9rw0; read "
+            "it + the fanout-prep doc section 'v35 rebuild'). Each index bump declares a delta class (constraint/"
             "view/index-only vs semantic-reparse); non-semantic deltas get a "
             "generated SQL fast-forward validated by equivalence sampling "
             "on a reflink clone. Codify what the live v32->v35 fast-forward "
             "just did manually; add the policy lint so bumps without a "
-            "declared class fail devtools lab policy schema-versioning."
+            "declared class fail devtools lab policy schema-versioning. "
+            "Live exercise: ma2 (FK-supporting index for web_content_constructs "
+            "cleanup) is an index-only delta — ship it THROUGH the new "
+            "mechanism as its first proof."
         ),
         "own": ["polylogue/storage/sqlite/lifecycle*", "devtools/ (policy)", "tests/unit/storage/"],
         "avoid": ["archive_tiers DDL semantics"],
         "verify": "devtools lab policy schema-versioning + focused lifecycle tests",
+    },
+    "polylogue-search-coverage": {
+        "beads": ["013x"],
+        "goal": (
+            "Close the search_text coverage gap: Write-tool file bodies "
+            "(tool_input.$.content) are excluded from search_text — decide "
+            "and implement the documented contract (include with bounds, or "
+            "document exclusion + expose via a dedicated lane). Bead notes "
+            "carry the #2740 documentation groundwork."
+        ),
+        "own": ["polylogue/pipeline/", "docs/search.md", "tests/unit/pipeline/"],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/", "polylogue/archive/query/"],
+        "verify": "devtools test tests/unit/pipeline -k 'search_text or tool_body'",
+    },
+    "polylogue-docs-ia": {
+        "beads": ["ttu"],
+        "goal": (
+            "Docs information architecture: tiered index, orphan sweep, "
+            "stale-doc triage. Hand-written docs only — generated surfaces "
+            "(cli-reference.md, mcp-reference.md, topology-status.md) are "
+            "off-limits; fix their generators only if an orphan points there."
+        ),
+        "own": ["docs/ (hand-written)", "README.md cross-links"],
+        "avoid": ["docs/cli-reference.md", "docs/mcp-reference.md", "docs/topology-status.md", "polylogue/"],
+        "verify": "devtools render all --check (grep output for 'out of sync' — exit code alone lies)",
+    },
+    "polylogue-coverage-triage": {
+        "beads": ["kp4q"],
+        "goal": (
+            "Triage the 4 zero-coverage files: classify each as dead/unwired "
+            "(delete or file removal bead) vs untested-but-live (add focused "
+            "real-route tests). Deletion needs the safe-delete evidence "
+            "standard: no dynamic imports, no CLI/MCP registration reach."
+        ),
+        "own": ["tests/", "the 4 files named in the bead (delete-only changes)"],
+        "avoid": ["any behavior change to live code"],
+        "verify": "devtools test <new tests> + devtools verify --quick",
+    },
+    "polylogue-eqp-census": {
+        "beads": ["20d.7"],
+        "goal": (
+            "READ-ONLY analysis lane: EQP sweep + dbstat census against the "
+            "live archive opened strictly read-only "
+            "(file:...index.db?mode=ro URI; never set POLYLOGUE_ARCHIVE_ROOT "
+            "to the live root for write commands). Deliverables: a report in "
+            "your worktree .agent/reports/eqp-census-2026-07.md ranking "
+            "missing-index/scan hotspots with measured timings, plus "
+            "follow-up bead proposals (list them in the PR body; do NOT "
+            "create beads yourself). Note the archive may transition "
+            "v32->v35 mid-run; record which generation you measured."
+        ),
+        "own": [".agent/reports/ (new file in your worktree only)"],
+        "avoid": ["ALL code; this lane ships a report PR only"],
+        "verify": "every claim in the report carries the exact query + timing; no code changes to test",
+    },
+    "polylogue-test-harness": {
+        "beads": ["th0"],
+        "goal": (
+            "Interactive-surface test harness: pty flows, completion menus, "
+            "fuzzy pickers — the untested interactive tier. Build on "
+            "tests/infra patterns; harness first, then 2-3 exemplar tests "
+            "proving real interactive routes (not toy replicas)."
+        ),
+        "own": ["tests/infra/", "tests/unit/cli/ (new interactive tests)"],
+        "avoid": ["polylogue/ (harness may not change production code)"],
+        "verify": "devtools test <new harness tests>; anti-vacuity statement mandatory",
+    },
+    "polylogue-cost-honesty": {
+        "beads": ["d3xj", "w8et", "w379"],
+        "goal": (
+            "Cost/usage honesty cluster: d3xj Codex per-message fallback path "
+            "still double-bills cached input (token-lane divergence — the "
+            "7.7x-inflation bug class); w8et reconciliation probe for state_5 "
+            "sentinel/stale/cross-thread tokens_used; w379 price catalog_hash "
+            "computed but never compared — wire or delete."
+        ),
+        "own": ["polylogue/archive/semantic/ (pricing/costs)", "polylogue/costs*", "tests/unit/costs/"],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/", "polylogue/insights/"],
+        "verify": "devtools test -k 'cost or pricing or token_lane' with cross-provider control cases",
+    },
+    "polylogue-hooks-capture": {
+        "beads": ["qqyg"],
+        "goal": (
+            "Comprehensive hook-event capture for Claude Code, Codex, and "
+            "Hermes (epic-shaped bead — read notes for the staged plan; ship "
+            "the Claude Code + Codex stages, leave Hermes for the "
+            "hermes-wedge lane's spool work if absent). Durable local spool, "
+            "receiver-ack semantics per the browser-capture pattern."
+        ),
+        "own": ["polylogue/sources/hooks*", "polylogue/sources/live/", "tests/unit/sources/hooks/"],
+        "avoid": ["polylogue/sources/parsers/hermes_state.py", "browser-extension/"],
+        "verify": "devtools test tests/unit/sources -k hook",
+    },
+    "polylogue-rigor-contracts": {
+        "beads": ["uwk3", "jph5"],
+        "goal": (
+            "A-trust-floor frontier: uwk3 extend RigorFieldContract coverage "
+            "to remaining quantitative insight fields; jph5 verify/implement "
+            "n_min coverage refusal in the claim-vs-evidence generator. "
+            "Boundary: you own the rigor/field-contract modules; the "
+            "fable-demo lane CREATES new packet modules — do not edit its "
+            "new files, it does not edit yours."
+        ),
+        "own": [
+            "polylogue/insights/ (rigor/field contracts + claim-vs-evidence generator)",
+            "tests/unit/insights/rigor*",
+        ],
+        "avoid": ["polylogue/archive/query/", "new delegation-packet modules"],
+        "verify": "devtools test -k 'rigor or n_min or claim' + insight_rigor_audit output before/after",
+    },
+    "polylogue-api-parity": {
+        "beads": ["9e5.16"],
+        "goal": (
+            "A-trust-floor frontier: audit the Python API (Polylogue facade + "
+            "SessionRepository) against CLI/MCP capabilities; produce the "
+            "parity matrix, then close the tractable gaps in-lane and file "
+            "follow-up proposals (PR body) for the rest."
+        ),
+        "own": ["polylogue/api/", "tests/unit/api/"],
+        "avoid": ["polylogue/cli/", "polylogue/mcp/", "polylogue/storage/"],
+        "verify": "devtools test tests/unit/api + the parity matrix as a PR artifact",
+    },
+    "polylogue-test-hardening": {
+        "beads": ["n4hb", "c52g", "znwj"],
+        "goal": (
+            "Test-quality cluster (tests-only lane): n4hb convert the 3 "
+            "cleanest mock-depth offenders to infra-backed tests; c52g harden "
+            "cli/query_verbs.py + commands/status.py coverage; znwj harden "
+            "daemon/cli.py + status.py (highest fix-churn file). You may NOT "
+            "change production code — if a test exposes a real bug, document "
+            "it in the PR body as a proposed bead."
+        ),
+        "own": ["tests/ only"],
+        "avoid": ["polylogue/ entirely"],
+        "verify": "devtools test <new/changed tests>; anti-vacuity statement per test",
+    },
+    "polylogue-mcp-ergonomics": {
+        "beads": ["rsad"],
+        "goal": (
+            "MCP agent ergonomics (ac-patched, execution-ready): oversized "
+            "responses, boilerplate affordances, metadata-only summaries. "
+            "Boundary: you own response envelope/pagination plumbing; the "
+            "hermes-wedge lane owns recall/context tools — coordinate via "
+            "PR if a tool needs both."
+        ),
+        "own": ["polylogue/mcp/ (envelope/pagination/summaries)", "tests/unit/mcp/"],
+        "avoid": ["recall/context/compile tools (hermes-wedge lane)", "polylogue/daemon/"],
+        "verify": "devtools test tests/unit/mcp -k 'envelope or pagination or summary'; EXPECTED_TOOL_NAMES untouched unless a tool is added",
+    },
+    "polylogue-temporal-provenance": {
+        "beads": ["cuxz"],
+        "goal": (
+            "Design + implement the time_confidence/degraded-provenance "
+            "signal for timeless rows (cpf.5/.6 landed the propagation "
+            "substrate; this is the consumer-visible signal). Weakest-source "
+            "propagation rules apply; no fabricated timestamps — unknown "
+            "renders as unknown."
+        ),
+        "own": ["polylogue/core/temporal*", "polylogue/insights/temporal*", "tests/unit/core/"],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/"],
+        "verify": "devtools test -k 'temporal or time_confidence'",
     },
     # ---- wave 2: launch only after the named lane's PR merges ----
     "polylogue-query-polish": {

--- a/.agent/tools/fanout_gen_prompts.py
+++ b/.agent/tools/fanout_gen_prompts.py
@@ -133,9 +133,11 @@ LANES: dict[str, dict] = {
         "model": "gpt-5.6-sol",
         "goal": (
             "Execute the next sequenced phase of the provider->origin "
-            "retirement per 9e5.8's plan (read the bead notes FIRST — the "
-            "plan is the deliverable of the in-progress work; coordinator "
-            "confirms claim state before launch). GEMINI+DRIVE collapse to "
+            "retirement per 9e5.8's plan (read the bead notes FIRST). If the "
+            "plan in the bead is incomplete or ambiguous about the phase you "
+            "would execute, STOP and report — planning the vocabulary "
+            "semantics is coordinator/operator work, not lane work. "
+            "GEMINI+DRIVE collapse to "
             "AISTUDIO_DRIVE is non-injective — use the Source-family "
             "disambiguator (#2737, 4rrv). STRICT no-drive-by rule: touch "
             "only the files the phase names."

--- a/.agent/tools/fanout_gen_prompts.py
+++ b/.agent/tools/fanout_gen_prompts.py
@@ -130,7 +130,6 @@ LANES: dict[str, dict] = {
     },
     "polylogue-provider-origin": {
         "beads": ["9e5.8"],
-        "model": "gpt-5.6-sol",
         "goal": (
             "Execute the next sequenced phase of the provider->origin "
             "retirement per 9e5.8's plan (read the bead notes FIRST). If the "

--- a/.agent/tools/fanout_gen_prompts.py
+++ b/.agent/tools/fanout_gen_prompts.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Generate execution-grade fanout lane prompts from the live beads file.
+
+Permanent tool: lane specs live here; bead titles/status are pulled from
+.beads/issues.jsonl at generation time so prompts never embed stale scope.
+Regenerate after any beads-adjustment pass:
+
+    python3 .agent/tools/fanout_gen_prompts.py            # writes prompts
+    python3 .agent/tools/fanout_gen_prompts.py --check    # roster health only
+
+Output: .agent/scratch/fanout-prompts/<lane>.prompt  (lane name == worktree
+dir name under /realm/worktrees/, launched via .agent/tools/fanout-launch.sh).
+
+Roster health rules enforced at generation:
+  - a bead assigned to a lane that is CLOSED -> error (roster stale)
+  - a bead IN_PROGRESS -> warning (possible stale claim from a killed agent;
+    coordinator must confirm ownership before launch)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BEADS = REPO / ".beads/issues.jsonl"
+OUT = REPO / ".agent/scratch/fanout-prompts"
+
+# wave 2 lanes conflict with a wave-1 lane's footprint; launch them only after
+# the named lane's PR merges.
+LANES: dict[str, dict] = {
+    "polylogue-fable-demo": {
+        "beads": ["xiyv", "fnm.1", "212.9.1"],
+        "goal": (
+            "Fable-delegation demo enablers, in order: (1) xiyv deterministic "
+            "cohort/sample manifests; (2) fnm.1 NARROWED first slice — "
+            "multi-field group-by + count/proportion aggregates with explicit "
+            "denominator, n, and unknown/missing counts (percentiles/time "
+            "buckets stay in-bead but later); (3) 212.9.1 the private "
+            "descriptive Fable delegation packet, only if 1+2 land cleanly."
+        ),
+        "own": ["polylogue/archive/query/", "polylogue/insights/", "tests/unit/archive/", "tests/unit/insights/"],
+        "avoid": ["polylogue/storage/sqlite/", "polylogue/daemon/", "browser-extension/"],
+        "verify": "devtools test tests/unit/archive tests/unit/insights -k 'aggregate or cohort or manifest' (narrow further per change)",
+    },
+    "polylogue-hermes-wedge": {
+        "beads": ["fs1.3", "fs1.11", "fs1.12"],
+        "goal": (
+            "Hermes integration critical path, strictly in order: fs1.3 "
+            "per-source coverage/fidelity declaration; fs1.11 bounded "
+            "read-only recall + effective-context audit (exact delivery "
+            "manifests); fs1.12 the compact evidence-and-continuity demo "
+            "composing fs1.1/fs1.3/fs1.11 — NO parallel importer/manifest/"
+            "report machinery (epic note 2026-07-10)."
+        ),
+        "own": [
+            "polylogue/sources/parsers/hermes_state.py",
+            "polylogue/mcp/",
+            "polylogue/daemon/recall*",
+            "tests/unit/sources/",
+            "tests/unit/mcp/",
+        ],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/", "browser-extension/"],
+        "verify": "devtools test tests/unit/sources/test_hermes* tests/unit/mcp -k 'hermes or recall or manifest'",
+    },
+    "polylogue-extension-redesign": {
+        "beads": [],  # ids assigned by the design-pack import in the beads pass
+        "goal": (
+            "Extension redesign per docs/design/browser-capture-redesign/ and "
+            "the handoff pack (coordinator files beads before launch; read "
+            "them via bd ready --json | grep redesign). Order: silent-capture "
+            "P1 bug (auto-capture trigger never fires — 160 GETs, 0 POSTs) "
+            "first; then popup mission-control; operator status vocabulary; "
+            "'What Polylogue did here' timeline (doing-nothing must be a "
+            "logged visible event). Pixel specs: project/Polylogue "
+            "Redesign.dc.html in the design dir."
+        ),
+        "own": ["browser-extension/"],
+        "avoid": ["polylogue/", "webui/"],
+        "verify": "cd browser-extension && npm test (vitest suite; 143 tests baseline must not regress)",
+    },
+    "polylogue-capture-hardening": {
+        "beads": ["57rp", "5k5l", "3v1.1"],
+        "goal": (
+            "Capture-path raw-authority + asset hardening: 57rp reacquire "
+            "replaced browser-capture snapshots under typed raw authority; "
+            "5k5l asset acquisition (sandbox + file-service bytes) — check "
+            "5k5l.1 state first, another agent may have finished it; 3v1.1 "
+            "concurrent-instance attribution/dedup/spool safety."
+        ),
+        "own": [
+            "browser-extension/src/background.js",
+            "polylogue/daemon/receiver*",
+            "polylogue/browser_capture/",
+            "tests/unit/daemon/",
+        ],
+        "avoid": ["browser-extension/src/popup*", "browser-extension/src/content/"],
+        "verify": "devtools test tests/unit/daemon -k 'receiver or capture' + extension tests for background.js changes",
+    },
+    "polylogue-web-cockpit": {
+        "beads": ["bby.17", "nhjs"],
+        "goal": (
+            "Web cockpit depth: bby.17 privacy-safe overview + evidence "
+            "aggregates API; nhjs bounded web reader shapes for long sessions "
+            "and aggregates (no unbounded payloads)."
+        ),
+        "own": ["polylogue/daemon/web_shell_*.py", "polylogue/daemon/http.py (web routes only)", "webui/tests/"],
+        "avoid": ["polylogue/daemon/convergence*", "polylogue/storage/"],
+        "verify": "devtools test tests/unit/daemon -k 'web or shell' + playwright smoke if route shapes change",
+    },
+    "polylogue-distribution": {
+        "beads": ["y8s5"],
+        "goal": (
+            "Distribution/legibility: everything y8s5 unblocks — PyPI/pipx "
+            "publishable package, Homebrew/GHCR smoke lanes, install matrix "
+            "doc, extension packaging for store submission. v0.2.0 is tagged; "
+            "wire the release artifacts, don't re-cut."
+        ),
+        "own": [
+            "pyproject.toml",
+            ".github/workflows/",
+            "packaging/",
+            "docs/install*",
+            "browser-extension/package.json",
+        ],
+        "avoid": ["polylogue/ (runtime code)"],
+        "verify": "wheel/sdist build + install smoke in a clean venv; CI workflow dry runs",
+    },
+    "polylogue-provider-origin": {
+        "beads": ["9e5.8"],
+        "model": "gpt-5.6-sol",
+        "goal": (
+            "Execute the next sequenced phase of the provider->origin "
+            "retirement per 9e5.8's plan (read the bead notes FIRST — the "
+            "plan is the deliverable of the in-progress work; coordinator "
+            "confirms claim state before launch). GEMINI+DRIVE collapse to "
+            "AISTUDIO_DRIVE is non-injective — use the Source-family "
+            "disambiguator (#2737, 4rrv). STRICT no-drive-by rule: touch "
+            "only the files the phase names."
+        ),
+        "own": ["polylogue/core/enums.py", "polylogue/core/sources.py", "projection shims named by the plan"],
+        "avoid": ["everything else — repo-wide renames are FORBIDDEN in this lane"],
+        "verify": "mypy --strict via devtools verify --quick + testmon-affected set; census tool from #2737",
+    },
+    "polylogue-embeddings-hygiene": {
+        "beads": ["1dk1", "egm8"],
+        "goal": (
+            "Embedding lifecycle honesty: 1dk1 reconcile orphan embedding "
+            "rows across index rebuild generations (coordinate with the v35 "
+            "transition — the authoritative generation may have just "
+            "changed); egm8 make terminal embedding failures inspectable and "
+            "resolvable."
+        ),
+        "own": [
+            "polylogue/storage/sqlite/archive_tiers/embeddings.py",
+            "polylogue/archive/semantic/",
+            "tests/unit/storage/",
+        ],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/index.py"],
+        "verify": "devtools test tests/unit/storage -k embedding",
+    },
+    "polylogue-annotation-judgment": {
+        "beads": ["mrxt", "37t.12", "p5g", "rxdo.4"],
+        "goal": (
+            "Close the assertion flywheel loop: mrxt first assertion row via "
+            "auto-mark/auto-promote; 37t.12 operator bulk judgment queue; "
+            "p5g `polylogue judge` interactive terminal triage; rxdo.4 "
+            "AssertionKind.FINDING reusing the candidate->judge lifecycle "
+            "verbatim. Substrate (rxdo.7 schemas/batches, kmts joins) is "
+            "merged — build on it, do not extend it."
+        ),
+        "own": [
+            "polylogue/storage/sqlite/archive_tiers/user*",
+            "polylogue/cli/judge*",
+            "polylogue/mcp/ (assertion tools)",
+            "tests/unit/user/",
+        ],
+        "avoid": ["polylogue/archive/query/"],
+        "verify": "devtools test -k 'assertion or judge or annotation' + user_audit every-kind invariant",
+    },
+    "polylogue-live-performance": {
+        "beads": ["s7ae.8", "20d.2", "20d.4", "oxz"],
+        "goal": (
+            "Interactive-latency cluster: s7ae.8 budget+reduce coordination "
+            "status latency; 20d.2 defer heavy imports off CLI startup; "
+            "20d.4 CLI structured-query routing parity with daemon; oxz "
+            "instrumentation doctrine (slow-query log, phase timings). "
+            "Measure before/after — perf claims need numbers."
+        ),
+        "own": ["polylogue/cli/ (startup+routing)", "polylogue/daemon/ (status paths)", "tests/benchmarks/"],
+        "avoid": ["polylogue/storage/sqlite/archive_tiers/", "polylogue/archive/query/expression.py"],
+        "verify": "devtools test -k 'startup or routing or status_latency' + benchmark deltas quoted in PR",
+    },
+    "polylogue-consolidation": {
+        "beads": ["a7xr.9", "a7xr.15", "a7xr.16", "a7xr.11"],
+        "goal": (
+            "Mechanical consolidation sweep (one PR): a7xr.9 helper dedup "
+            "(scalar coercion quadruplet, _table_exists x40, provenance "
+            "vocab x6); a7xr.15 generic from_row for payloads.py's 74 "
+            "identical copy lines; a7xr.16 table-drive the hand-aligned "
+            "column triplicates in archive_tiers; a7xr.11 prune "
+            "zero-consumer protocols. Behavior-preserving; mypy --strict is "
+            "the net."
+        ),
+        "own": ["cross-cutting textual dedup — everything, which is why this lane launches LAST in the merge train"],
+        "avoid": ["any semantic change; any file another active lane has open PRs against — rebase late"],
+        "verify": "devtools verify --quick + testmon-affected; zero behavior diffs expected",
+    },
+    "polylogue-origin-interop": {
+        "beads": ["2ilz"],
+        "goal": (
+            "Origin identity hygiene: 2ilz durable capture-mode field "
+            "splitting GEMINI export vs live-Drive AISTUDIO_DRIVE; fold in "
+            "4rrv completion only if its claim is stale (coordinator "
+            "confirms). Classify the schema change per the durability "
+            "regime before touching DDL; if it needs an index bump, declare "
+            "the delta class for the fast-forward mechanism."
+        ),
+        "own": ["polylogue/core/sources.py (capture-mode)", "polylogue/schemas/", "tests/unit/core/"],
+        "avoid": ["polylogue/core/enums.py (provider-origin lane owns it)"],
+        "verify": "devtools test tests/unit/core -k 'source or origin'",
+    },
+    "polylogue-demo-corpus": {
+        "beads": ["212.11"],
+        "goal": (
+            "Demo construct validity: 212.11 shared deterministic proof "
+            "world for flagship demos; PLUS the measured-result experiment — "
+            "sample N assistant completion claims from the live archive, "
+            "compare against structural tool evidence, produce the honest "
+            "headline number (X% unsupported / Y% contradicted-then-"
+            "repaired) with full population/sample manifest, packaged so "
+            "`demo receipts` and the README can cite it."
+        ),
+        "own": [".agent/demos/", "polylogue/cli/demo*", "tests/unit/demo/"],
+        "avoid": ["polylogue/storage/", "polylogue/archive/query/"],
+        "verify": "polylogue demo seed && polylogue demo verify && polylogue demo receipts (deterministic, CI-green)",
+    },
+    "polylogue-fastforward-mech": {
+        "beads": [],  # bead filed in the beads pass; informed by the live v35 run
+        "goal": (
+            "Productize derived-tier fast-forward plans (bead filed by "
+            "coordinator; read it + the fanout-prep doc section 'v35 "
+            "rebuild'). Each index bump declares a delta class (constraint/"
+            "view/index-only vs semantic-reparse); non-semantic deltas get a "
+            "generated SQL fast-forward validated by equivalence sampling "
+            "on a reflink clone. Codify what the live v32->v35 fast-forward "
+            "just did manually; add the policy lint so bumps without a "
+            "declared class fail devtools lab policy schema-versioning."
+        ),
+        "own": ["polylogue/storage/sqlite/lifecycle*", "devtools/ (policy)", "tests/unit/storage/"],
+        "avoid": ["archive_tiers DDL semantics"],
+        "verify": "devtools lab policy schema-versioning + focused lifecycle tests",
+    },
+    # ---- wave 2: launch only after the named lane's PR merges ----
+    "polylogue-query-polish": {
+        "wave2_after": "polylogue-fable-demo",
+        "beads": ["9srm", "fnm.6"],
+        "goal": (
+            "DSL polish (WAVE 2 — launch after polylogue-fable-demo merges; "
+            "shared footprint on the query executor): 9srm terminal `| "
+            "count` stage consistency across unit types (confirm claim "
+            "state; may be stale from a killed agent); fnm.6 wire the "
+            "terminal stage to projections (| read / | context-image)."
+        ),
+        "own": ["polylogue/archive/query/", "tests/unit/archive/"],
+        "avoid": ["polylogue/insights/"],
+        "verify": "devtools test tests/unit/archive -k 'pipeline or stage or count'",
+    },
+    "polylogue-webui-2": {
+        "wave2_after": "polylogue-web-cockpit",
+        "beads": ["t67b", "9l5.5"],
+        "goal": (
+            "Web workbench second slice (WAVE 2 — after polylogue-web-cockpit "
+            "merges): t67b compile browser proof obligations from workflow "
+            "claims; 9l5.5 ship opinionated saved views as product defaults."
+        ),
+        "own": ["polylogue/daemon/web_shell_*.py", "polylogue/product/workflows.py", "webui/tests/"],
+        "avoid": ["polylogue/storage/"],
+        "verify": "devtools test -k 'workflow or saved_view or proof'",
+    },
+}
+
+PROMPT_TEMPLATE = """You are lane {lane} of a parallel fanout on the Polylogue repo.
+Worktree = your root: /realm/worktrees/{lane}. NEVER cd to /realm/project/polylogue
+(a hook will abort commits; the canonical checkout belongs to the coordinator).
+Branch: you are already on a dedicated feature branch; confirm with
+`git branch --show-current` before the first commit.
+
+MISSION
+{goal}
+
+BEADS (read each with `bd show polylogue-<id>` INCLUDING notes before coding;
+prework packets under .agent/scratch/corpus-gpt-pro-2026-07-07/ are
+accelerators, not authority — anchors are from 2026-07-06, re-verify against
+your checkout):
+{bead_lines}
+
+FILE OWNERSHIP
+OWN (you may modify): {own}
+AVOID (another lane owns these; do not touch): {avoid}
+Generated surfaces (docs/cli-reference.md, docs/plans/topology-target.yaml,
+openapi/cli-output schemas, EXPECTED_TOOL_NAMES): regenerate ONLY if your
+change requires it, in a separate commit, and expect the coordinator to
+re-run regeneration at merge time.
+
+VERIFICATION (worker-owned — coordinator runs broad gates, you run these):
+{verify}
+Anti-vacuity requirement: for every test you add, state in the PR body which
+production dependency it exercises and which implementation mutation or
+removal would make it fail. Toy replicas, test-only validators, and mocks
+that only prove their own wrapping will be rejected.
+
+DISCIPLINE
+- Commit every logical chunk immediately (worktree cleanup discards
+  uncommitted work). Push after each commit.
+- Do NOT run `bd close`/`bd update --claim`; report per-bead AC status
+  (satisfied / deferred / misframed) in your final message AND the PR body.
+- Do NOT merge your PR; open it with Summary/Problem/Solution/Verification
+  sections and `Ref polylogue-<id>` lines, then stop.
+- If a bead turns out to be already-done, stale-claimed, or blocked by
+  missing substrate, say so explicitly and move to the next bead rather
+  than improvising scope.
+- Archive safety: never export POLYLOGUE_ARCHIVE_ROOT to the live archive
+  (/home/sinity/.local/share/polylogue); tests use isolated roots.
+"""
+
+
+def load_beads() -> dict[str, dict]:
+    out = {}
+    for line in BEADS.read_text().splitlines():
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        out[d["id"].removeprefix("polylogue-")] = d
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="roster health only")
+    args = ap.parse_args()
+
+    beads = load_beads()
+    errors, warnings = [], []
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    for lane, spec in LANES.items():
+        bead_lines = []
+        for bid in spec["beads"]:
+            b = beads.get(bid)
+            if b is None:
+                errors.append(f"{lane}: bead {bid} not found")
+                continue
+            status = b.get("status")
+            title = (b.get("title") or "").strip()
+            if status == "closed":
+                errors.append(f"{lane}: bead {bid} is CLOSED — roster stale")
+            elif status == "in_progress":
+                warnings.append(
+                    f"{lane}: bead {bid} is in_progress — confirm the claim is not stale (killed agent) before launch"
+                )
+            bead_lines.append(f"- polylogue-{bid} [{status}]: {title}")
+        if not spec["beads"]:
+            bead_lines.append(
+                "- (bead ids assigned by the coordinator's beads pass — ask for them / check bd ready before starting)"
+            )
+        if args.check:
+            continue
+        prompt = PROMPT_TEMPLATE.format(
+            lane=lane,
+            goal=spec["goal"],
+            bead_lines="\n".join(bead_lines),
+            own="; ".join(spec["own"]),
+            avoid="; ".join(spec["avoid"]),
+            verify=spec["verify"],
+        )
+        if spec.get("wave2_after"):
+            prompt = (
+                f"## WAVE 2 LANE — do not launch before {spec['wave2_after']} "
+                "has merged (shared footprint).\n\n" + prompt
+            )
+        (OUT / f"{lane}.prompt").write_text(prompt)
+
+    for w in warnings:
+        print(f"WARN  {w}")
+    for e in errors:
+        print(f"ERROR {e}")
+    if not args.check:
+        print(f"\nwrote {len(LANES)} prompts to {OUT}")
+        sol = [name for name, s in LANES.items() if s.get("model") == "gpt-5.6-sol"]
+        if sol:
+            print(f"SOL lanes (launch separately with FANOUT_MODEL=gpt-5.6-sol): {', '.join(sol)}")
+        wave2 = [name for name, s in LANES.items() if s.get("wave2_after")]
+        if wave2:
+            print(f"WAVE-2 lanes (hold): {', '.join(wave2)}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Tooling for the planned 14+2-lane parallel agent fanout: a prompt generator that derives execution-grade lane prompts from live bead state, and a launcher wrapper over the upstreamed kitty fanout mode.

## Problem
Lane rosters go stale within hours at current merge velocity (two stale-claim warnings were caught on first generation), and kitty-mode launches previously lost scrollback and had no completion accounting.

## Solution
`fanout_gen_prompts.py` embeds the lane specs (footprint ownership, wave-2 ordering, per-lane model overrides) and pulls bead titles/status at generation time, failing on closed beads and warning on in_progress claims. `fanout-launch.sh` wraps the canonical sinnix launcher (commit 1a26aff) with polylogue defaults (workspace 6, terra/high, per-lane worktrees).

## Verification
`python3 .agent/tools/fanout_gen_prompts.py` — 16 prompts written, expected WARNs for in_progress beads; `bash -n` + dry-run over two lanes + `--status` table against mixed marker dirs; ruff format/check clean.

Ref polylogue-212.9. Fanout prep doc: `.agent/scratch/fanout-prep-2026-07-12.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooling to launch parallel agent tasks with configurable model and reasoning settings.
  * Added automatic generation of lane-specific execution prompts from current task metadata.
  * Added support for status checks, dated output directories, workspace persistence, and per-task working directories.
  * Added wave-based launch gating to prevent dependent tasks from starting prematurely.

* **Bug Fixes**
  * Added roster validation that flags completed or already-active tasks before prompt generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->