### PR TITLE
fix(cost): preserve catalog pricing evidence

### DIFF
--- a/devtools/cost_reconciliation_probe.py
+++ b/devtools/cost_reconciliation_probe.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 ProbeStatus = Literal["pass", "fail", "skip"]
+_MAX_PLAUSIBLE_CODEX_THREAD_TOKENS = 2_000_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,6 +137,30 @@ def _counter_dict(counter: Counter[Any], *, limit: int = 10) -> list[dict[str, o
     return [{"value": value, "count": count} for value, count in counter.most_common(limit)]
 
 
+def _codex_external_state_unreliable(
+    external: dict[str, dict[str, object]],
+) -> dict[str, str]:
+    """Classify ``state_5`` counters that cannot support a token comparison.
+
+    ``threads.tokens_used`` is external runtime state, not archived evidence.
+    Exact zeroes are sentinels, repeated values across threads are stale
+    defaults, and values over any known Codex context window are inherited or
+    cumulative counters. None can establish archive accounting drift.
+    """
+
+    token_counts = Counter(_coerce_int(item["tokens_used"]) for item in external.values())
+    unreliable: dict[str, str] = {}
+    for thread_id, item in external.items():
+        tokens_used = _coerce_int(item["tokens_used"])
+        if tokens_used == 0:
+            unreliable[thread_id] = "zero_sentinel"
+        elif tokens_used > _MAX_PLAUSIBLE_CODEX_THREAD_TOKENS:
+            unreliable[thread_id] = "implausible_context_window"
+        elif token_counts[tokens_used] > 1:
+            unreliable[thread_id] = "repeated_cross_thread_value"
+    return unreliable
+
+
 def _codex_residual_classification(
     pairs: list[tuple[str, int, int, dict[str, object]]],
     *,
@@ -147,15 +172,10 @@ def _codex_residual_classification(
         for _, _, _, extra in outside
     )
     chain_size = Counter(_coerce_int(extra.get("archive_chain_session_count")) for _, _, _, extra in outside)
-    external_flags: Counter[str] = Counter()
-    for _, _, _, extra in outside:
-        external_flags[f"archived={extra.get('external_archived')}"] += 1
-        external_flags[f"has_user_event={extra.get('external_has_user_event')}"] += 1
     return {
         "outside_tolerance": len(outside),
         "replay_gap_classes": _counter_dict(replay_gap),
         "chain_session_counts": _counter_dict(chain_size),
-        "external_flag_counts": [{"flag": flag, "count": count} for flag, count in external_flags.most_common(10)],
         "external_token_values": [
             {"tokens_used": tokens, "count": count}
             for tokens, count in Counter(external for _, _, external, _ in outside).most_common(10)
@@ -345,11 +365,12 @@ def _probe_codex(
             details={"copied_path": str(copied), "error": str(exc)},
         )
 
+    external_unreliable = _codex_external_state_unreliable(external)
     pairs: list[tuple[str, int, int, dict[str, object]]] = []
     logical_pairs: list[tuple[str, int, int, dict[str, object]]] = []
     for thread_id, ext in external.items():
         ext_tokens = _coerce_int(ext["tokens_used"])
-        if thread_id in archive and ext_tokens > 0:
+        if thread_id in archive and thread_id not in external_unreliable:
             arch = archive[thread_id]
             pairs.append(
                 (
@@ -361,8 +382,6 @@ def _probe_codex(
                         "model": ext.get("model"),
                         "external_source": ext.get("source"),
                         "external_cli_version": ext.get("cli_version"),
-                        "external_archived": ext.get("archived"),
-                        "external_has_user_event": ext.get("has_user_event"),
                         "external_updated_at_ms": ext.get("updated_at_ms"),
                         "input_tokens": arch["input_tokens"],
                         "cached_input_tokens": arch["cached_input_tokens"],
@@ -375,7 +394,7 @@ def _probe_codex(
                     },
                 )
             )
-        if thread_id in logical_archive and ext_tokens > 0:
+        if thread_id in logical_archive and thread_id not in external_unreliable:
             logical = logical_archive[thread_id]
             logical_pairs.append(
                 (
@@ -387,8 +406,6 @@ def _probe_codex(
                         "model": ext.get("model"),
                         "external_source": ext.get("source"),
                         "external_cli_version": ext.get("cli_version"),
-                        "external_archived": ext.get("archived"),
-                        "external_has_user_event": ext.get("has_user_event"),
                         "external_updated_at_ms": ext.get("updated_at_ms"),
                         "archive_logical_native_id": logical.get("logical_native_id"),
                         "archive_logical_high_water_tokens": logical.get("total_tokens"),
@@ -427,11 +444,6 @@ def _probe_codex(
     outside_external_tokens = Counter(
         external_tokens for _, _, external_tokens, _ in _outside_pairs(pairs, tolerance=tolerance)
     )
-    outside_external_flags: Counter[str] = Counter()
-    for _, _, _, extra in _outside_pairs(pairs, tolerance=tolerance):
-        outside_external_flags[f"archived={extra.get('external_archived')}"] += 1
-        outside_external_flags[f"has_user_event={extra.get('external_has_user_event')}"] += 1
-        outside_external_flags[f"source={extra.get('external_source')}"] += 1
     status: ProbeStatus = "pass" if comparison.outside_tolerance == 0 else "fail"
     fewest_outside_grain = (
         "logical_session_model_high_water"
@@ -470,6 +482,19 @@ def _probe_codex(
             },
             "logical_comparison": logical_comparison.to_dict(),
             "logical_residual_classification": _codex_residual_classification(logical_pairs, tolerance=tolerance),
+            "external_state_unreliable": {
+                "count": len(external_unreliable),
+                "classes": _counter_dict(Counter(external_unreliable.values())),
+                "samples": [
+                    {
+                        "thread_id": thread_id,
+                        "tokens_used": _coerce_int(external[thread_id]["tokens_used"]),
+                        "classification": classification,
+                        "archive_present": thread_id in archive,
+                    }
+                    for thread_id, classification in sorted(external_unreliable.items())[:max_samples]
+                ],
+            },
             "outside_external_token_values": [
                 {"tokens_used": tokens, "count": count} for tokens, count in outside_external_tokens.most_common(10)
             ],
@@ -477,9 +502,6 @@ def _probe_codex(
                 {"tokens_used": tokens, "count": count}
                 for tokens, count in outside_external_tokens.most_common(10)
                 if count > 1
-            ],
-            "outside_external_flag_counts": [
-                {"flag": flag, "count": count} for flag, count in outside_external_flags.most_common(20)
             ],
             "lane_contract": (
                 "archive session_model_usage disjoint lanes and Codex threads.tokens_used both include cached input; "

--- a/devtools/cost_reconciliation_probe.py
+++ b/devtools/cost_reconciliation_probe.py
@@ -143,12 +143,19 @@ def _codex_external_state_unreliable(
     """Classify ``state_5`` counters that cannot support a token comparison.
 
     ``threads.tokens_used`` is external runtime state, not archived evidence.
-    Exact zeroes are sentinels, repeated values across threads are stale
+    Exact zeroes are sentinels, repeated complete state fingerprints are stale
     defaults, and values over any known Codex context window are inherited or
     cumulative counters. None can establish archive accounting drift.
     """
 
-    token_counts = Counter(_coerce_int(item["tokens_used"]) for item in external.values())
+    def stale_fingerprint(item: dict[str, object]) -> tuple[int, object, str] | None:
+        updated_at_ms = item.get("updated_at_ms")
+        rollout_path = item.get("rollout_path")
+        if updated_at_ms is None or not isinstance(rollout_path, str) or not rollout_path:
+            return None
+        return (_coerce_int(item["tokens_used"]), updated_at_ms, rollout_path)
+
+    fingerprints = Counter(fingerprint for item in external.values() if (fingerprint := stale_fingerprint(item)))
     unreliable: dict[str, str] = {}
     for thread_id, item in external.items():
         tokens_used = _coerce_int(item["tokens_used"])
@@ -156,8 +163,8 @@ def _codex_external_state_unreliable(
             unreliable[thread_id] = "zero_sentinel"
         elif tokens_used > _MAX_PLAUSIBLE_CODEX_THREAD_TOKENS:
             unreliable[thread_id] = "implausible_context_window"
-        elif token_counts[tokens_used] > 1:
-            unreliable[thread_id] = "repeated_cross_thread_value"
+        elif (fingerprint := stale_fingerprint(item)) is not None and fingerprints[fingerprint] > 1:
+            unreliable[thread_id] = "repeated_stale_state_fingerprint"
     return unreliable
 
 

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -191,6 +191,7 @@ def _token_usage(record: dict[str, object]) -> dict[str, int]:
     """
     usage = _dict_record(record.get("usage")) or _dict_record(record.get("tokens")) or record
     input_with_cached = _int_value(usage.get("input_tokens") or usage.get("inputTokenCount"))
+    explicit_uncached_input = _optional_int_field(usage, "uncached_input_tokens", "uncachedInputTokens")
     cache_read_tokens = _int_value(
         usage.get("cache_read_tokens")
         or usage.get("cache_read_input_tokens")
@@ -198,7 +199,11 @@ def _token_usage(record: dict[str, object]) -> dict[str, int]:
         or usage.get("cached_tokens")
     )
     return {
-        "input_tokens": max(input_with_cached - cache_read_tokens, 0),
+        "input_tokens": (
+            explicit_uncached_input
+            if explicit_uncached_input is not None
+            else max(input_with_cached - cache_read_tokens, 0)
+        ),
         "output_tokens": _int_value(usage.get("output_tokens") or usage.get("outputTokenCount")),
         "cache_read_tokens": cache_read_tokens,
         "cache_write_tokens": _int_value(

--- a/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
+++ b/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
@@ -8,9 +8,9 @@ the DB-backed rates match the in-memory estimates exactly.
 Design constraints:
 - The in-memory PRICING dict is the authoritative source.  This seeder
   populates the DB FROM it; rates are never duplicated by hand here.
-- The catalog_id is a deterministic slug so re-seeding is idempotent.
-- INSERT … ON CONFLICT DO NOTHING on both tables: re-running after a
-  schema-version bump (wipe-and-reinit) or daemon restart is safe.
+- A changed catalog hash creates a versioned catalog row, so existing usage
+  records retain the rates under which they were priced.
+- Re-seeding an unchanged catalog is idempotent.
 
 Writer module: index.
 """
@@ -29,7 +29,7 @@ def _catalog_id() -> str:
 
 
 def _catalog_hash() -> str:
-    """Stable hash of the current PRICING dict for change-detection."""
+    """Stable identity of the current PRICING dict."""
     from polylogue.archive.semantic.pricing import PRICING
 
     parts: list[str] = []
@@ -55,19 +55,67 @@ def _effective_at_ms() -> int | None:
         return None
 
 
+def _catalog_id_for_hash(conn: sqlite3.Connection, catalog_hash: str) -> str:
+    """Return the persisted version identity for the current catalog hash."""
+    from polylogue.archive.semantic.pricing import CATALOG_PROVENANCE
+
+    effective_at = _effective_at_ms()
+    matching = conn.execute(
+        """
+        SELECT catalog_id
+        FROM price_catalogs
+        WHERE catalog_hash = ?
+          AND source_name = ?
+          AND effective_at_ms IS ?
+        ORDER BY catalog_id
+        LIMIT 1
+        """,
+        (catalog_hash, CATALOG_PROVENANCE, effective_at),
+    ).fetchone()
+    if matching is not None:
+        return str(matching[0])
+
+    base_catalog_id = _catalog_id()
+    existing_base = conn.execute(
+        "SELECT catalog_hash FROM price_catalogs WHERE catalog_id = ?",
+        (base_catalog_id,),
+    ).fetchone()
+    if existing_base is None:
+        return base_catalog_id
+    return f"{base_catalog_id}-{catalog_hash}"
+
+
+def active_price_catalog_id(conn: sqlite3.Connection) -> str | None:
+    """Find the persisted catalog whose hash matches the active PRICING dict."""
+    from polylogue.archive.semantic.pricing import CATALOG_PROVENANCE
+
+    row = conn.execute(
+        """
+        SELECT catalog_id
+        FROM price_catalogs
+        WHERE catalog_hash = ?
+          AND source_name = ?
+          AND effective_at_ms IS ?
+        ORDER BY catalog_id
+        LIMIT 1
+        """,
+        (_catalog_hash(), CATALOG_PROVENANCE, _effective_at_ms()),
+    ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
 def seed_price_catalog(conn: sqlite3.Connection) -> str:
     """Seed price_catalogs + model_prices from the curated PRICING dict.
 
-    Idempotent: uses INSERT … ON CONFLICT DO NOTHING so calling this at
-    every archive-init or daemon-start has no effect when the catalog row
-    already exists.
+    A changed hash gets a new catalog ID and its own immutable price rows;
+    an unchanged hash reuses its existing catalog ID.
 
     Returns the catalog_id that was (or already was) seeded.
     """
     from polylogue.archive.semantic.pricing import CATALOG_PROVENANCE, PRICING
 
-    catalog_id = _catalog_id()
     catalog_hash = _catalog_hash()
+    catalog_id = _catalog_id_for_hash(conn, catalog_hash)
     effective_at = _effective_at_ms()
     loaded_at = int(time.time() * 1000)
 
@@ -106,5 +154,6 @@ def seed_price_catalog(conn: sqlite3.Connection) -> str:
 
 
 __all__ = [
+    "active_price_catalog_id",
     "seed_price_catalog",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -3381,11 +3381,11 @@ def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session
     if not token_rows:
         return
 
-    # Resolve the catalog by its current content hash, rather than choosing an
-    # arbitrary historical row after a pricing correction creates a revision.
-    from polylogue.storage.sqlite.archive_tiers.pricing_seed import active_price_catalog_id
+    # Seed or reuse the revision matching the current content hash before
+    # pricing, so an existing archive receives catalog corrections too.
+    from polylogue.storage.sqlite.archive_tiers.pricing_seed import seed_price_catalog
 
-    active_catalog_id = active_price_catalog_id(conn)
+    active_catalog_id = seed_price_catalog(conn)
     priced_at_ms = int(time.time() * 1000)
 
     for row in token_rows:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -3381,9 +3381,11 @@ def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session
     if not token_rows:
         return
 
-    # Look up the active catalog_id once so FK can be set when we have a price.
-    catalog_row = conn.execute("SELECT catalog_id FROM price_catalogs LIMIT 1").fetchone()
-    active_catalog_id: str | None = str(catalog_row[0]) if catalog_row is not None else None
+    # Resolve the catalog by its current content hash, rather than choosing an
+    # arbitrary historical row after a pricing correction creates a revision.
+    from polylogue.storage.sqlite.archive_tiers.pricing_seed import active_price_catalog_id
+
+    active_catalog_id = active_price_catalog_id(conn)
     priced_at_ms = int(time.time() * 1000)
 
     for row in token_rows:
@@ -3396,7 +3398,8 @@ def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session
 
         # Compute cost_usd from the curated catalog when a price entry exists.
         # estimate_cost() reads the in-memory PRICING dict so the result always
-        # matches the DB-backed model_prices rows seeded from the same source.
+        # matches the DB-backed model_prices rows selected by the same catalog
+        # hash as the active in-memory source.
         normalized = _normalize_model(model_name)
         billable = sum_input + sum_output + sum_cache_read + sum_cache_write
         if normalized in PRICING and billable > 0:

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -348,7 +348,8 @@ def test_disjoint_input_cache_lanes_survive_parse_write_and_pricing(
     )
     monkeypatch.setitem(pricing_mod.PRICING, "test-codex-like", codex_like)
 
-    raw_usage = {"input_tokens": 2500, "cached_input_tokens": 2400, "output_tokens": 50}
+    message_usage = {"uncached_input_tokens": 100, "cached_input_tokens": 2400, "output_tokens": 50}
+    provider_total_usage = {"input_tokens": 2500, "cached_input_tokens": 2400, "output_tokens": 50}
     raw = [
         {
             "type": "message",
@@ -356,7 +357,7 @@ def test_disjoint_input_cache_lanes_survive_parse_write_and_pricing(
             "role": "assistant",
             "model": "test-codex-like",
             "content": [{"type": "output_text", "text": "done"}],
-            "usage": raw_usage,
+            "usage": message_usage,
         },
         {
             "type": "event_msg",
@@ -364,7 +365,7 @@ def test_disjoint_input_cache_lanes_survive_parse_write_and_pricing(
                 "type": "token_count",
                 "info": {
                     "total_token_usage": {
-                        **raw_usage,
+                        **provider_total_usage,
                         "reasoning_output_tokens": 30,
                         "total_tokens": 2550,
                     },
@@ -419,7 +420,7 @@ def test_disjoint_input_cache_lanes_survive_parse_write_and_pricing(
         "total_reasoning_output_tokens": 30,
     }
     completion_output = event_usage["total_output_tokens"] - event_usage["total_reasoning_output_tokens"]
-    assert completion_output + event_usage["total_reasoning_output_tokens"] == raw_usage["output_tokens"]
+    assert completion_output + event_usage["total_reasoning_output_tokens"] == provider_total_usage["output_tokens"]
     # The model-cost tier keeps priced lanes additive: output is the provider's
     # inclusive total and reasoning stays event-tier evidence, never re-added.
     assert dict(model_usage) == dict(message_usage)
@@ -440,7 +441,29 @@ def test_disjoint_input_cache_lanes_survive_parse_write_and_pricing(
         provenance=("message_token_usage",),
     )
 
-    assert disjoint.usage.input_tokens + disjoint.usage.cache_read_tokens == raw_usage["input_tokens"]
+    assert disjoint.usage.input_tokens + disjoint.usage.cache_read_tokens == provider_total_usage["input_tokens"]
+    parsed_message = parsed.messages[0]
+    fallback_session = make_conv(
+        id="codex-message-fallback",
+        provider="codex",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="assistant-1",
+                    role="assistant",
+                    provider="codex",
+                    model_name=parsed_message.model_name,
+                    input_tokens=parsed_message.input_tokens,
+                    output_tokens=parsed_message.output_tokens,
+                    cache_read_tokens=parsed_message.cache_read_tokens,
+                    cache_write_tokens=parsed_message.cache_write_tokens,
+                )
+            ]
+        ),
+    )
+    fallback_estimate = estimate_session_cost(fallback_session)
+    assert fallback_estimate.usage == disjoint.usage
+    assert fallback_estimate.total_usd == pytest.approx(disjoint.total_usd)
     # Naive double-bills the entire cached lane at the full input rate on top
     # of the cache-read rate -- on this ~96%-cached ratio the guard requires
     # at least a 5x inflation (real corpus measured 7.69x; the exact multiple

--- a/tests/unit/devtools/test_cost_reconciliation_probe.py
+++ b/tests/unit/devtools/test_cost_reconciliation_probe.py
@@ -193,6 +193,8 @@ def test_codex_probe_excludes_unreliable_state_counters_from_drift(
             ("stale-one", 100),
             ("stale-two", 100),
             ("cross-thread", 100),
+            ("equal-total-one", 100),
+            ("equal-total-two", 100),
         ):
             _insert_session(
                 conn,
@@ -214,8 +216,13 @@ def test_codex_probe_excludes_unreliable_state_counters_from_drift(
             ("stale-one", 77),
             ("stale-two", 77),
             ("cross-thread", 2_000_001),
+            ("equal-total-one", 88),
+            ("equal-total-two", 88),
         ),
     )
+    with sqlite3.connect(codex_state) as conn:
+        conn.execute("UPDATE threads SET updated_at_ms = 2001 WHERE id = 'equal-total-one'")
+        conn.execute("UPDATE threads SET updated_at_ms = 2002 WHERE id = 'equal-total-two'")
 
     assert main(["--archive-root", str(archive), "--codex-state", str(codex_state), "--json", "--check"]) == 1
     payload = json.loads(capsys.readouterr().out)
@@ -223,13 +230,17 @@ def test_codex_probe_excludes_unreliable_state_counters_from_drift(
 
     # The one reliable disagreement remains a real failure; the three state_5
     # failure modes are reported separately and cannot inflate drift.
-    assert codex["comparison"]["compared"] == 1
-    assert codex["comparison"]["outside_tolerance"] == 1
-    assert codex["comparison"]["samples"][0]["key"] == "reliable-drift"
+    assert codex["comparison"]["compared"] == 3
+    assert codex["comparison"]["outside_tolerance"] == 3
+    assert {sample["key"] for sample in codex["comparison"]["samples"]} == {
+        "reliable-drift",
+        "equal-total-one",
+        "equal-total-two",
+    }
     assert codex["details"]["external_state_unreliable"] == {
         "count": 4,
         "classes": [
-            {"value": "repeated_cross_thread_value", "count": 2},
+            {"value": "repeated_stale_state_fingerprint", "count": 2},
             {"value": "zero_sentinel", "count": 1},
             {"value": "implausible_context_window", "count": 1},
         ],
@@ -243,13 +254,13 @@ def test_codex_probe_excludes_unreliable_state_counters_from_drift(
             {
                 "thread_id": "stale-one",
                 "tokens_used": 77,
-                "classification": "repeated_cross_thread_value",
+                "classification": "repeated_stale_state_fingerprint",
                 "archive_present": True,
             },
             {
                 "thread_id": "stale-two",
                 "tokens_used": 77,
-                "classification": "repeated_cross_thread_value",
+                "classification": "repeated_stale_state_fingerprint",
                 "archive_present": True,
             },
             {

--- a/tests/unit/devtools/test_cost_reconciliation_probe.py
+++ b/tests/unit/devtools/test_cost_reconciliation_probe.py
@@ -46,7 +46,13 @@ def _insert_session(
     return session_id
 
 
-def _write_codex_state(path: Path, *, tokens: int = 100, thread_id: str = "thread-1") -> None:
+def _write_codex_state(
+    path: Path,
+    *,
+    tokens: int = 100,
+    thread_id: str = "thread-1",
+    additional_threads: tuple[tuple[str, int], ...] = (),
+) -> None:
     with sqlite3.connect(path) as conn:
         conn.execute(
             """
@@ -71,6 +77,15 @@ def _write_codex_state(path: Path, *, tokens: int = 100, thread_id: str = "threa
             ) VALUES (?, ?, 'gpt-5-codex', 'cli', '0.test', 0, 0, 1234, '/x/rollout.jsonl')
             """,
             (thread_id, tokens),
+        )
+        conn.executemany(
+            """
+            INSERT INTO threads(
+                id, tokens_used, model, source, cli_version, archived,
+                has_user_event, updated_at_ms, rollout_path
+            ) VALUES (?, ?, 'gpt-5-codex', 'cli', '0.test', 0, 0, 1234, '/x/rollout.jsonl')
+            """,
+            additional_threads,
         )
 
 
@@ -159,12 +174,92 @@ def test_codex_probe_check_fails_outside_tolerance(tmp_path: Path, capsys: pytes
     assert payload["sections"][0]["comparison"]["outside_tolerance"] == 1
     assert payload["sections"][0]["comparison"]["samples"][0]["external_cli_version"] == "0.test"
     assert payload["sections"][0]["details"]["outside_external_token_values"] == [{"tokens_used": 100, "count": 1}]
-    assert {"flag": "archived=0", "count": 1} in payload["sections"][0]["details"]["outside_external_flag_counts"]
     residual = payload["sections"][0]["details"]["logical_residual_classification"]
     assert residual["outside_tolerance"] == 1
     assert {"value": "zero_replay_gap", "count": 1} in residual["replay_gap_classes"]
-    assert {"flag": "has_user_event=0", "count": 1} in residual["external_flag_counts"]
     assert residual["external_token_values"] == [{"tokens_used": 100, "count": 1}]
+
+
+def test_codex_probe_excludes_unreliable_state_counters_from_drift(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exercise the real state_5 reader and archive comparison, not a classifier stub."""
+
+    archive = _archive_root(tmp_path)
+    with sqlite3.connect(archive / "index.db") as conn:
+        for thread_id, archive_tokens in (
+            ("reliable-drift", 20),
+            ("zero-sentinel", 100),
+            ("stale-one", 100),
+            ("stale-two", 100),
+            ("cross-thread", 100),
+        ):
+            _insert_session(
+                conn,
+                origin="codex-session",
+                native_id=thread_id,
+                model="gpt-5-codex",
+                input_tokens=archive_tokens,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+            )
+    codex_state = tmp_path / "state_5.sqlite"
+    _write_codex_state(
+        codex_state,
+        tokens=100,
+        thread_id="reliable-drift",
+        additional_threads=(
+            ("zero-sentinel", 0),
+            ("stale-one", 77),
+            ("stale-two", 77),
+            ("cross-thread", 2_000_001),
+        ),
+    )
+
+    assert main(["--archive-root", str(archive), "--codex-state", str(codex_state), "--json", "--check"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    codex = payload["sections"][0]
+
+    # The one reliable disagreement remains a real failure; the three state_5
+    # failure modes are reported separately and cannot inflate drift.
+    assert codex["comparison"]["compared"] == 1
+    assert codex["comparison"]["outside_tolerance"] == 1
+    assert codex["comparison"]["samples"][0]["key"] == "reliable-drift"
+    assert codex["details"]["external_state_unreliable"] == {
+        "count": 4,
+        "classes": [
+            {"value": "repeated_cross_thread_value", "count": 2},
+            {"value": "zero_sentinel", "count": 1},
+            {"value": "implausible_context_window", "count": 1},
+        ],
+        "samples": [
+            {
+                "thread_id": "cross-thread",
+                "tokens_used": 2_000_001,
+                "classification": "implausible_context_window",
+                "archive_present": True,
+            },
+            {
+                "thread_id": "stale-one",
+                "tokens_used": 77,
+                "classification": "repeated_cross_thread_value",
+                "archive_present": True,
+            },
+            {
+                "thread_id": "stale-two",
+                "tokens_used": 77,
+                "classification": "repeated_cross_thread_value",
+                "archive_present": True,
+            },
+            {
+                "thread_id": "zero-sentinel",
+                "tokens_used": 0,
+                "classification": "zero_sentinel",
+                "archive_present": True,
+            },
+        ],
+    }
 
 
 def test_codex_probe_exposes_logical_chain_comparison(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/storage/test_pricing_chain_roundtrip.py
+++ b/tests/unit/storage/test_pricing_chain_roundtrip.py
@@ -12,6 +12,7 @@ Verifies that:
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -24,7 +25,12 @@ from polylogue.archive.semantic.pricing import (
 from polylogue.core.enums import Provider
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from polylogue.storage.sqlite.archive_tiers.pricing_seed import _catalog_id
+from polylogue.storage.sqlite.archive_tiers.pricing_seed import (
+    _catalog_hash,
+    _catalog_id,
+    active_price_catalog_id,
+    seed_price_catalog,
+)
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 
 
@@ -129,6 +135,61 @@ class TestPriceCatalogSeed:
         price_count = conn.execute("SELECT COUNT(*) FROM model_prices").fetchone()[0]
         assert catalog_count == 1
         assert price_count == len(PRICING)
+        conn.close()
+
+    def test_seed_versions_changed_pricing_and_writer_uses_new_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A catalog correction preserves old evidence and prices new usage by hash."""
+        conn = _make_archive(tmp_path)
+        original_catalog_id = _catalog_id()
+        model_name = "gpt-4o-mini"
+        original_pricing = PRICING[model_name]
+        monkeypatch.setitem(
+            PRICING,
+            model_name,
+            replace(original_pricing, input_usd_per_1m=original_pricing.input_usd_per_1m + 1.0),
+        )
+
+        with conn:
+            revised_catalog_id = seed_price_catalog(conn)
+            write_parsed_session_to_archive(
+                conn,
+                _session(
+                    provider_session_id="revised-pricing",
+                    messages=[_msg(provider_message_id="m1", model_name=model_name, input_tokens=100)],
+                ),
+            )
+
+        assert revised_catalog_id != original_catalog_id
+        assert active_price_catalog_id(conn) == revised_catalog_id
+        assert conn.execute("SELECT COUNT(*) FROM price_catalogs").fetchone()[0] == 2
+        assert (
+            conn.execute(
+                "SELECT catalog_hash FROM price_catalogs WHERE catalog_id = ?", (revised_catalog_id,)
+            ).fetchone()[0]
+            == _catalog_hash()
+        )
+        assert (
+            conn.execute(
+                "SELECT input_cost_per_million FROM model_prices WHERE catalog_id = ? AND model_name = ?",
+                (original_catalog_id, model_name),
+            ).fetchone()[0]
+            == original_pricing.input_usd_per_1m
+        )
+        assert (
+            conn.execute(
+                "SELECT input_cost_per_million FROM model_prices WHERE catalog_id = ? AND model_name = ?",
+                (revised_catalog_id, model_name),
+            ).fetchone()[0]
+            == PRICING[model_name].input_usd_per_1m
+        )
+        assert (
+            conn.execute(
+                "SELECT priced_with FROM session_model_usage WHERE session_id = 'claude-code-session:revised-pricing'"
+            ).fetchone()[0]
+            == revised_catalog_id
+        )
         conn.close()
 
 

--- a/tests/unit/storage/test_pricing_chain_roundtrip.py
+++ b/tests/unit/storage/test_pricing_chain_roundtrip.py
@@ -29,7 +29,6 @@ from polylogue.storage.sqlite.archive_tiers.pricing_seed import (
     _catalog_hash,
     _catalog_id,
     active_price_catalog_id,
-    seed_price_catalog,
 )
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 
@@ -152,7 +151,6 @@ class TestPriceCatalogSeed:
         )
 
         with conn:
-            revised_catalog_id = seed_price_catalog(conn)
             write_parsed_session_to_archive(
                 conn,
                 _session(
@@ -161,8 +159,9 @@ class TestPriceCatalogSeed:
                 ),
             )
 
+        revised_catalog_id = active_price_catalog_id(conn)
+        assert revised_catalog_id is not None
         assert revised_catalog_id != original_catalog_id
-        assert active_price_catalog_id(conn) == revised_catalog_id
         assert conn.execute("SELECT COUNT(*) FROM price_catalogs").fetchone()[0] == 2
         assert (
             conn.execute(


### PR DESCRIPTION
## Summary

Make Codex cost evidence honest at both reconciliation boundaries: unreliable `state_5.sqlite` counters are separated from archive drift, and pricing catalog revisions are versioned by their content hash.

## Problem

`threads.tokens_used` is external runtime state. Zero sentinels, stale repeated values, and inherited/cumulative counters were folded into outside-tolerance drift. Separately, `price_catalogs.catalog_hash` was write-only: a `PRICING` correction under the same effective date left DB price rows stale and new usage could select an arbitrary historical catalog.

## Solution

- Classify unreliable Codex state counters before physical or logical tolerance comparison, while retaining genuine mismatches as failures.
- Reuse a catalog only when its persisted hash matches the active in-memory prices; otherwise seed a hash-versioned immutable catalog.
- Resolve `session_model_usage.priced_with` from the catalog matching the current hash, preserving historical price evidence.

Acceptance matrix:

| Bead | Status | Evidence |
| --- | --- | --- |
| `polylogue-d3xj` | Satisfied before this branch | `8c9dfbb00` / PR #2647 normalizes Codex message input to disjoint fresh-input and cache-read lanes with a parser-to-storage-to-pricing fallback regression. |
| `polylogue-w8et` | Satisfied | `713a07fea` reports zero sentinel, repeated stale-state fingerprints, and over-2,000,000-token counters as external-state-unreliable rather than drift. |
| `polylogue-w379` | Satisfied | `292c4e84d` versions stored hashes; `831c7d970` seeds that revision during ordinary existing-archive writes and links new usage to it. |

Ref polylogue-d3xj

Ref polylogue-w8et

Ref polylogue-w379

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_cost_reconciliation_probe.py tests/unit/core/test_pricing.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_parsers_claude_code_artifacts.py -k 'cost or pricing or token_lane or unreliable_state'` — 29 passed, 77 deselected.
- `nix develop --command devtools test tests/unit/storage/test_pricing_chain_roundtrip.py tests/unit/core/test_pricing.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_parsers_claude_code_artifacts.py -k 'pricing or token_lane'` — 34 passed, 77 deselected.
- `nix develop --command devtools verify --quick` — 15 checks passed.

Anti-vacuity: the `w8et` regression drives the production CLI `main()` path against a real archive index and copied `state_5.sqlite`; removing classification/exclusion returns unreliable values to the tolerance comparison. The `w379` regression mutates the production `PRICING` dict, reseeds a real index, writes real usage, and fails if hash comparison, immutable revision seeding, or active-catalog linkage is removed.

## Adversarial review notes

- Iteration 1: two real gaps found and repaired—ordinary existing-archive writes did not seed a changed catalog revision (`831c7d970`), and direct messages could ignore explicit fresh-input lanes (`6b3ce5712`).
- Iteration 2: no real acceptance-criterion gaps found. Borderline dismissed: `external_total_tokens` includes excluded unreliable state rows, but it does not drive comparison/pass-fail and the response separately reports those rows.
