### PR TITLE
test(cli): exercise interactive selector routes

### DIFF
--- a/tests/infra/pty_cli.py
+++ b/tests/infra/pty_cli.py
@@ -14,10 +14,13 @@ Key capabilities:
 
 from __future__ import annotations
 
+import fcntl
 import os
 import re
+import struct
 import subprocess
 import sys
+import termios
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -130,7 +133,15 @@ def run_in_pty(
 
     # Open PTY
     master_fd, slave_fd = os.openpty()
+    # ``openpty`` does not inherit the requested dimensions.  Set them before
+    # spawning so Rich, fzf, and any future full-screen route see the same
+    # terminal shape that pyte renders for assertions.
+    fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
     os.set_blocking(master_fd, False)
+
+    def _attach_controlling_terminal() -> None:
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
 
     start_time = time.time()
     output_chunks: list[bytes] = []
@@ -144,7 +155,7 @@ def run_in_pty(
             stderr=slave_fd,
             env=clean_env,
             cwd=project_root,
-            preexec_fn=os.setsid,  # Create new session so PTY works correctly
+            preexec_fn=_attach_controlling_terminal,
             start_new_session=False,
         )
 

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -240,6 +240,8 @@
       ops     Run operational archive and daemon commands.
       `polylogue status` is the root shortcut for `polylogue ops status`; deeper
       maintenance stays under `ops`.
+    Other commands:
+      annotations  Import typed annotation batches.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_narrow_width
@@ -312,188 +314,186 @@
         polylogue --diagnose <args>       # explain parser dec
   isions
   Options:
-    --help-markdown                 Emit the full --help tree
-  (root + every
-                                    subcommand) as Markdown an
-  d exit.
-    -i, --id TEXT                   Session ID (exact or prefi
-  x match)
-    -c, --contains TEXT             FTS term (repeatable = AND
-  )
+    --help-markdown                 Emit the full --help
+                                    tree (root + every
+                                    subcommand) as Markdown
+                                    and exit.
+    -i, --id TEXT                   Session ID (exact or
+                                    prefix match)
+    -c, --contains TEXT             FTS term (repeatable =
+                                    AND)
     --exclude-text TEXT             Exclude FTS term
-    --retrieval-lane LANE           Query lane: dialogue FTS,
-  action text, or
+    --retrieval-lane LANE           Query lane: dialogue
+                                    FTS, action text, or
                                     hybrid
     --lexical                       Force FTS-only search.
-    --semantic                      Treat the query as a simil
-  arity prompt
-                                    (vector-only; requires emb
-  eddings).
-    --origin TEXT                   Include origins (comma = O
-  R)
+    --semantic                      Treat the query as a
+                                    similarity prompt
+                                    (vector-only; requires
+                                    embeddings).
+    --origin TEXT                   Include origins (comma =
+                                    OR)
     --exclude-origin TEXT           Exclude origins
-    -r, --repo TEXT                 Filter by repository name
-  (comma = OR)
-    --project TEXT                  Filter by provider project
-   ref, e.g. ChatGPT
-                                    g-p-<id> (comma = OR)
-    -t, --tag TEXT                  Include tags (comma = OR,
-  supports
-                                    key:value)
+    -r, --repo TEXT                 Filter by repository
+                                    name (comma = OR)
+    --project TEXT                  Filter by provider
+                                    project ref, e.g.
+                                    ChatGPT g-p-<id> (comma
+                                    = OR)
+    -t, --tag TEXT                  Include tags (comma =
+                                    OR, supports key:value)
     --exclude-tag TEXT              Exclude tags
     --title TEXT                    Title contains
-    --referenced-path TEXT          Referenced file path conta
-  ins substring
+    --referenced-path TEXT          Referenced file path
+                                    contains substring
                                     (repeatable = AND)
-    --cwd-prefix TEXT               Filter sessions whose reco
-  rded working
-                                    directory starts with this
-   prefix
-    --action ACTION                 Require semantic action ca
-  tegory (repeatable
-                                    = AND)
-    --exclude-action ACTION         Exclude semantic action ca
-  tegory (repeatable
-                                    = AND)
-    --action-sequence TEXT          Require ordered semantic a
-  ction subsequence
+    --cwd-prefix TEXT               Filter sessions whose
+                                    recorded working
+                                    directory starts with
+                                    this prefix
+    --action ACTION                 Require semantic action
+                                    category (repeatable =
+                                    AND)
+    --exclude-action ACTION         Exclude semantic action
+                                    category (repeatable =
+                                    AND)
+    --action-sequence TEXT          Require ordered semantic
+                                    action subsequence
                                     (comma-separated)
-    --action-text TEXT              Require text within normal
-  ized action
-                                    evidence (repeatable = AND
-  )
-    --tool TEXT                     Require normalized tool na
-  me (repeatable =
+    --action-text TEXT              Require text within
+                                    normalized action
+                                    evidence (repeatable =
                                     AND)
-    --exclude-tool TEXT             Exclude normalized tool na
-  me (repeatable =
-                                    AND)
-    --similar TEXT                  Semantic similarity query
-  (requires
+    --tool TEXT                     Require normalized tool
+                                    name (repeatable = AND)
+    --exclude-tool TEXT             Exclude normalized tool
+                                    name (repeatable = AND)
+    --similar TEXT                  Semantic similarity
+                                    query (requires
                                     embeddings)
-    --has TEXT                      Filter by content: thinkin
-  g (reasoning),
-                                    tools (calls), summary, at
-  tachments
-    --has-tool-use                  Only sessions with tool us
-  e (SQL pushdown)
-    --has-thinking                  Only sessions with thinkin
-  g blocks (SQL
+    --has TEXT                      Filter by content:
+                                    thinking (reasoning),
+                                    tools (calls), summary,
+                                    attachments
+    --has-tool-use                  Only sessions with tool
+                                    use (SQL pushdown)
+    --has-thinking                  Only sessions with
+                                    thinking blocks (SQL
                                     pushdown)
-    --has-paste                     Only sessions with paste e
-  vidence (SQL
-                                    pushdown)
-    --typed-only                    Only sessions without past
-  e evidence (typed
+    --has-paste                     Only sessions with paste
+                                    evidence (SQL pushdown)
+    --typed-only                    Only sessions without
+                                    paste evidence (typed
                                     prose only)
     --min-messages INTEGER          Minimum message count
     --max-messages INTEGER          Maximum message count
     --min-words INTEGER             Minimum total word count
-    --since-session TEXT            Show sessions in same cwd
-  after this session
+    --since-session TEXT            Show sessions in same
+                                    cwd after this session
                                     ID
-    --since TEXT                    After date (ISO, 'yesterda
-  y', 'last week')
+    --since TEXT                    After date (ISO,
+                                    'yesterday', 'last
+                                    week')
     --until TEXT                    Before date
     -l, -n, --limit INTEGER         Max results
-    --offset INTEGER                Offset for paginated resul
-  ts
-    --cursor TEXT                   Opaque keyset cursor from
-  a previous
-                                    response's next_cursor. St
-  able across
-                                    archive growth for ranked
-  search (#1268).
-    --latest                        Most recent (= --sort date
-   --limit 1)
+    --offset INTEGER                Offset for paginated
+                                    results
+    --cursor TEXT                   Opaque keyset cursor
+                                    from a previous
+                                    response's next_cursor.
+                                    Stable across archive
+                                    growth for ranked search
+                                    (#1268).
+    --latest                        Most recent (= --sort
+                                    date --limit 1)
     --sort [date|tokens|messages|words|longest|random]
                                     Sort by field
     --reverse                       Reverse sort order
-    --sample INTEGER                Random sample of N session
-  s
-    -o, --output TEXT               Output destinations: brows
-  er, clipboard,
+    --sample INTEGER                Random sample of N
+                                    sessions
+    -o, --output TEXT               Output destinations:
+                                    browser, clipboard,
                                     stdout (comma-separated)
-    --json                          Shortcut for --format json
-  . Disables color
-                                    and progress for pipeable
-  output. (#1689)
+    --json                          Shortcut for --format
+                                    json. Disables color and
+                                    progress for pipeable
+                                    output. (#1689)
     -f, --format [markdown|json|ndjson|html|obsidian|org|yaml|
   plaintext|csv]
-                                    Output format (for --lates
-  t, --stream, or
-                                    verb output). `ndjson` emi
-  ts one JSON
-                                    document per line, streami
-  ng-friendly for
-                                    shell pipelines and LLM to
-  ol-use harnesses.
-    --explain                       Explain query DSL parsing
-  and lowering
-                                    instead of executing the q
-  uery.
-    --stream                        Stream output (low memory)
-  . Requires
+                                    Output format (for
+                                    --latest, --stream, or
+                                    verb output). `ndjson`
+                                    emits one JSON document
+                                    per line, streaming-
+                                    friendly for shell
+                                    pipelines and LLM tool-
+                                    use harnesses.
+    --explain                       Explain query DSL
+                                    parsing and lowering
+                                    instead of executing the
+                                    query.
+    --stream                        Stream output (low
+                                    memory). Requires
                                     --latest or -i ID.
     --set TEXT...                   Set metadata key value
-    --add-tag TEXT                  Add tags (comma-separated)
-    --plain                         Force non-interactive plai
-  n output
+    --add-tag TEXT                  Add tags (comma-
+                                    separated)
+    --plain                         Force non-interactive
+                                    plain output
     -v, --verbose                   Verbose output
-    --diagnose                      Explain CLI parser decisio
-  ns on stderr
-                                    before running. Useful whe
-  n query-first
-                                    dispatch surprises you: sh
-  ows whether tokens
-                                    were routed to a subcomman
-  d, an explicit
-                                    query, or the strict comma
-  nd floor.
-    --version                       Show the version and exit.
-    -h, --help                      Show this message and exit
-  .
+    --diagnose                      Explain CLI parser
+                                    decisions on stderr
+                                    before running. Useful
+                                    when query-first
+                                    dispatch surprises you:
+                                    shows whether tokens
+                                    were routed to a
+                                    subcommand, an explicit
+                                    query, or the strict
+                                    command floor.
+    --version                       Show the version and
+                                    exit.
+    -h, --help                      Show this message and
+                                    exit.
   Commands:
     Search, read, and action workflows:
       find      Search the archive, then optionally run an...
-      read      Read matched sessions (route to view<PATH>
-  on).
+      read      Read matched sessions (route to
+                view<PATH>).
       select    Select one matched session or print candidate
-  identities.
-      mark      Mark selected sessions; review candidates unde
-  r mark candidates.
-      analyze   Analyze matched sessions and named facet famil
-  ies.
+                identities.
+      mark      Mark selected sessions; review candidates
+                under mark candidates.
+      analyze   Analyze matched sessions and named facet
+                families.
       facets    Show global or scoped archive facet families.
       delete    Delete matched sessions.
       continue  Compile a successor-agent continuation report.
-      Use `find QUERY then ACTION`; `facets` is the direct arc
-  hive aggregate
-      command.
+      Use `find QUERY then ACTION`; `facets` is the direct
+      archive aggregate command.
     Setup, import, and evidence:
       config    Show resolved Polylogue configuration with...
-      init      Detect chat sources and write a starter polylo
-  gue.toml.
+      init      Detect chat sources and write a starter
+                polylogue.toml.
       hooks     Install and monitor harness capture hooks.
       import    Import sessions from configured sources.
-      demo      Seed and verify the deterministic demo archive
-  .
+      demo      Seed and verify the deterministic demo
+                archive.
       tutorial  Inspect first-run setup state.
-      Use these for first-run setup, hook wiring, source impor
-  t, demo archives,
-      and onboarding checks.
+      Use these for first-run setup, hook wiring, source
+      import, demo archives, and onboarding checks.
     Reader and local UI:
       agents     Inspect agent coordination state.
       dashboard  Launch the terminal dashboard TUI.
-      `agents` exposes JSON-first coordination views for agent
-   loops;
-      `dashboard` launches the terminal TUI.
+      `agents` exposes JSON-first coordination views for
+      agent loops; `dashboard` launches the terminal TUI.
     Operations and maintenance:
       status  Show daemon and archive status.
       ops     Run operational archive and daemon commands.
-      `polylogue status` is the root shortcut for `polylogue o
-  ps status`; deeper
-      maintenance stays under `ops`.
+      `polylogue status` is the root shortcut for `polylogue
+      ops status`; deeper maintenance stays under `ops`.
+    Other commands:
+      annotations  Import typed annotation batches.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_wide_width
@@ -661,5 +661,7 @@
       ops     Run operational archive and daemon commands.
       `polylogue status` is the root shortcut for `polylogue ops status`; deeper
       maintenance stays under `ops`.
+    Other commands:
+      annotations  Import typed annotation batches.
   '''
 # ---

--- a/tests/unit/cli/test_interactive_cli.py
+++ b/tests/unit/cli/test_interactive_cli.py
@@ -103,7 +103,8 @@ def test_click_bash_completion_protocol_runs_in_a_real_pty(
     )
 
     assert result.exit_code == 0
-    assert "--origin" in grid_to_text(result.grid)
+    completion_rows = result.raw_output.decode("utf-8").replace("\r\n", "\n").splitlines()
+    assert completion_rows == ["plain,--origin", "plain,origin:"]
 
 
 def test_select_uses_fzf_first_ranked_candidate_in_a_real_pty(

--- a/tests/unit/cli/test_interactive_cli.py
+++ b/tests/unit/cli/test_interactive_cli.py
@@ -1,0 +1,168 @@
+"""Real-process contracts for the CLI's interactive boundary.
+
+The unit tests for selection and completion cover their component logic.  This
+module deliberately crosses the process and PTY boundary so it catches
+regressions in TTY detection, external-picker invocation, and Click's shell
+completion protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from tests.infra.pty_cli import grid_to_text, run_in_pty
+from tests.infra.storage_records import DbFactory
+
+
+def _interactive_env(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+    *,
+    picker_dir: Path | None = None,
+) -> dict[str, str]:
+    """Return a process-isolated environment that keeps the CLI interactive."""
+    home = tmp_path / "interactive-home"
+    home.mkdir()
+    env = {
+        "HOME": str(home),
+        "XDG_DATA_HOME": str(cli_workspace["data_root"]),
+        "XDG_STATE_HOME": str(cli_workspace["state_dir"]),
+        "XDG_CONFIG_HOME": str(home / ".config"),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "POLYLOGUE_ARCHIVE_ROOT": str(cli_workspace["archive_root"]),
+        "POLYLOGUE_SITE_CONFIG": "",
+        "POLYLOGUE_DAEMON_URL": "http://127.0.0.1:1",
+        "POLYLOGUE_SCHEMA_VALIDATION": "off",
+    }
+    if picker_dir is not None:
+        env["PATH"] = f"{picker_dir}{os.pathsep}{os.environ.get('PATH', '/usr/bin:/bin')}"
+    return env
+
+
+def _install_first_row_fzf(
+    directory: Path,
+    trace_path: Path,
+    *,
+    size_path: Path | None = None,
+) -> None:
+    """Install a deterministic fzf stand-in that selects its first candidate.
+
+    The CLI still invokes its real external-process picker path.  Returning the
+    first input row makes result ordering observable: swapping candidate order
+    changes the selected session and fails the route test.
+    """
+    executable = directory / "fzf"
+    terminal_probe = "" if size_path is None else f"stty size < /dev/tty > {shlex.quote(str(size_path))}\n"
+    script = "".join(
+        (
+            "#!/bin/sh\n",
+            terminal_probe,
+            f"printf '%s\\n' \"$@\" > {shlex.quote(str(trace_path))}\n",
+            "IFS= read -r selection || exit 1\n",
+            "printf '%s\\n' \"$selection\"\n",
+        )
+    )
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+
+def _seed_picker_sessions(cli_workspace: dict[str, Path]) -> None:
+    factory = DbFactory(cli_workspace["db_path"])
+    now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    for native_id, title, updated_at in (
+        ("older", "Interactive picker candidate older", now - timedelta(days=1)),
+        ("newer", "Interactive picker candidate newer", now),
+    ):
+        factory.create_session(
+            id=native_id,
+            provider="chatgpt",
+            title=title,
+            messages=[{"id": f"{native_id}-message", "role": "user", "text": "picker route fixture"}],
+            created_at=updated_at,
+            updated_at=updated_at,
+        )
+
+
+def test_click_bash_completion_protocol_runs_in_a_real_pty(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The installed Click completion protocol emits root options in a PTY."""
+    result = run_in_pty(
+        [],
+        env={
+            **_interactive_env(cli_workspace, tmp_path),
+            "_POLYLOGUE_COMPLETE": "bash_complete",
+            "COMP_WORDS": "polylogue --ori",
+            "COMP_CWORD": "1",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert "--origin" in grid_to_text(result.grid)
+
+
+def test_select_uses_fzf_first_ranked_candidate_in_a_real_pty(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The real CLI hands ranked rows to fzf and prints fzf's chosen session."""
+    _seed_picker_sessions(cli_workspace)
+    picker_dir = tmp_path / "bin"
+    picker_dir.mkdir()
+    trace_path = tmp_path / "fzf-options.txt"
+    _install_first_row_fzf(picker_dir, trace_path)
+
+    result = run_in_pty(
+        ["--sort", "date", "--reverse", "find", "title:Interactive", "then", "select"],
+        env=_interactive_env(cli_workspace, tmp_path, picker_dir=picker_dir),
+    )
+
+    assert result.exit_code == 0
+    assert grid_to_text(result.grid).splitlines()[-1] == "chatgpt-export:ext-older"
+    assert trace_path.read_text(encoding="utf-8").splitlines() == [
+        "--delimiter",
+        "\t",
+        "--with-nth",
+        "2",
+        "--height",
+        "40%",
+        "--reverse",
+        "--preview",
+        "echo {} | cut -f3-",
+        "--preview-window",
+        "down:4:wrap",
+    ]
+
+
+def test_select_propagates_requested_pty_size_to_fzf(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The PTY harness gives the real selector route the requested terminal size."""
+    _seed_picker_sessions(cli_workspace)
+    picker_dir = tmp_path / "bin"
+    picker_dir.mkdir()
+    trace_path = tmp_path / "fzf-options.txt"
+    size_path = tmp_path / "fzf-terminal-size.txt"
+    _install_first_row_fzf(picker_dir, trace_path, size_path=size_path)
+
+    result = run_in_pty(
+        ["--sort", "date", "--reverse", "find", "title:Interactive", "then", "select"],
+        rows=41,
+        cols=137,
+        env={
+            **_interactive_env(cli_workspace, tmp_path, picker_dir=picker_dir),
+            "FZF_DEFAULT_OPTS": "",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert grid_to_text(result.grid).splitlines()[-1] == "chatgpt-export:ext-older"
+    # fzf receives its size through the controlling TTY, not through pyte's
+    # renderer; the stand-in reads that terminal directly.
+    assert size_path.read_text(encoding="utf-8").strip() == "41 137"


### PR DESCRIPTION
## Summary

Add a real PTY test boundary for the interactive CLI: Click shell completion, fzf selection, and terminal-size propagation.

## Problem

Existing terminal tests captured output but did not attach a controlling terminal, invoke the real external picker, or execute Click shell completion through its installed process protocol. Those gaps could let interactive-only regressions pass.

## Solution

The PTY harness now applies its requested window size and gives the child process a controlling terminal. Three process-route tests use an isolated archive and deterministic fzf stand-in to prove completion output, ranked picker selection, and picker-visible terminal dimensions. The child-width change also refreshes the affected terminal snapshots; that full fixture refresh records pre-existing annotations-command inventory drift at each tested width.

## Verification

- env POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest POLYLOGUE_PYTEST_WORKERS=1 nix develop --command devtools test tests/unit/cli/test_terminal_snapshots.py tests/unit/cli/test_interactive_cli.py
  - 12 passed in 35.64s
- Pre-push quick verification passed before each pushed commit.

## Acceptance criteria

Ref polylogue-th0

- Deferred to polylogue-th0: the five-plus golden-flow serial CI lane is not implemented in this PR.
- Deferred to polylogue-th0: this PR does not add the required registry-generated completion contract; the existing manually curated completion matrix does not satisfy that AC.
- Deferred to polylogue-th0: the first-row fzf test makes candidate-order regression observable, but this branch has no retained deliberate mutation-demonstration commit as required by the bead.

## Anti-vacuity

- test_click_bash_completion_protocol_runs_in_a_real_pty executes the CLI entrypoint and Click shell-complete dispatch. Removing root --origin completion or changing the bash completion records makes it fail.
- test_select_uses_fzf_first_ranked_candidate_in_a_real_pty executes query routing, selection, and the external fzf process. Skipping fzf, ignoring its result, or reordering candidates makes it fail.
- test_select_propagates_requested_pty_size_to_fzf executes the same selector route and reads its controlling terminal from fzf. Removing PTY size or controlling-terminal setup makes it fail.

## Adversarial review notes

- Iteration 1: refreshed terminal snapshots after the real PTY width became visible to the CLI, in 0ec19eb5a. Strengthened the completion oracle from a rendered substring to the exact Click bash protocol records in the same commit.
- Iteration 2: corrected the remaining fzf acceptance claim. The test is a real route and exposes reordering, but the deliberate mutation demonstration is not present in this branch and remains deferred to polylogue-th0.
- Iteration 3: no legitimate gaps found. The PR body and review-thread state accurately distinguish this shipped test slice from the open bead requirements.
- The five-flow serial lane and registry-generated completion matrix remain deferred to open bead polylogue-th0.