### PR TITLE
fix(release): recover artifacts from existing tags

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,8 @@ name: Container
 #                           corresponding -distroless variants
 #   - pull_request        → builds both variants on amd64 only as a smoke
 #                           test; does not push
-#   - workflow_dispatch   → manual build; `push=true` opt-in
+#   - workflow_dispatch   → manual build; `push=true` opt-in. Set
+#                           `release_tag` to replay an already-created tag.
 #
 # The release pipeline (release.yml) used to carry an inlined publish-container
 # job. That job has been removed in favour of this dedicated workflow so the
@@ -29,6 +30,10 @@ on:
       - polylogue/**
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Existing vX.Y.Z tag to build and publish (empty = selected workflow ref)"
+        required: false
+        default: ""
       push:
         description: "Push images to ghcr.io (default: false)"
         required: false
@@ -57,6 +62,32 @@ jobs:
         target: [runtime, distroless]
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve source identity
+        id: source
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          tag="${RELEASE_TAG}"
+          if [[ -z "${tag}" && "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+          fi
+          if [[ -n "${tag}" ]]; then
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::release_tag must be vX.Y.Z, got '${tag}'"
+              exit 1
+            fi
+            version="$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+            if [[ "${version}" != "${tag#v}" ]]; then
+              echo "::error::${tag} does not match pyproject.toml version ${version}"
+              exit 1
+            fi
+          fi
+          echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
@@ -97,7 +128,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
+            type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
             type=sha,prefix=master-,format=short,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build${{ steps.decide.outputs.push == 'true' && ' and push' || '' }}
@@ -110,7 +144,12 @@ jobs:
           push: ${{ steps.decide.outputs.push }}
           load: ${{ steps.decide.outputs.push != 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.revision=${{ steps.source.outputs.revision }}
+          build-args: |
+            POLYLOGUE_BUILD_COMMIT=${{ steps.source.outputs.revision }}
+            POLYLOGUE_BUILD_DIRTY=False
           # Attestations produce a manifest list even on single-platform builds,
           # which the classic docker image store cannot import via --load. Only
           # emit them on push paths (master / tag / opt-in workflow_dispatch),
@@ -120,6 +159,23 @@ jobs:
           sbom: ${{ steps.decide.outputs.push == 'true' }}
           cache-from: type=gha,scope=container-${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=container-${{ matrix.target }}
+
+      - name: Smoke published release image and revision
+        if: steps.decide.outputs.push == 'true' && (startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '')
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/polylogue:${{ inputs.release_tag || github.ref_name }}${{ matrix.target == 'distroless' && '-distroless' || '' }}
+          EXPECTED_REVISION: ${{ steps.source.outputs.revision }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE}"
+          docker pull --platform linux/amd64 "${IMAGE}"
+          if [[ "${{ matrix.target }}" == "runtime" ]]; then
+            version="$(docker run --rm --entrypoint polylogue "${IMAGE}" --version)"
+          else
+            version="$(docker run --rm --entrypoint /usr/local/bin/polylogue "${IMAGE}" --version)"
+          fi
+          printf '%s\n' "${version}"
+          grep -F -- "${EXPECTED_REVISION}" <<<"${version}"
 
       - name: Smoke test (amd64 image, --version)
         if: steps.decide.outputs.push != 'true'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -49,7 +49,10 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/polylogue
+  # OCI repository components are lowercase. Keep one canonical name for both
+  # metadata generation and post-push smoke pulls: github.repository_owner is
+  # currently "Sinity", which Docker rejects as a direct image reference.
+  IMAGE_NAME: sinity/polylogue
 
 jobs:
   build-and-push:
@@ -195,7 +198,7 @@ jobs:
       - name: Smoke published release image and revision
         if: steps.decide.outputs.push == 'true' && (startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '')
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/polylogue:${{ inputs.release_tag || github.ref_name }}${{ matrix.target == 'distroless' && '-distroless' || '' }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.release_tag || github.ref_name }}${{ matrix.target == 'distroless' && '-distroless' || '' }}
           EXPECTED_REVISION: ${{ steps.source.outputs.revision }}
         run: |
           set -euo pipefail

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -139,6 +139,10 @@ jobs:
           # The distroless build gets a `-distroless` suffix on every tag
           # so both variants share the same repository.
           flavor: |
+            # `docker/metadata-action` otherwise auto-emits latest for active
+            # semver tags. The explicit raw rule below is the only authority
+            # and stays disabled for manual recovery of an older release.
+            latest=false
             suffix=${{ matrix.target == 'distroless' && '-distroless' || '' }},onlatest=true
           tags: |
             type=ref,event=pr
@@ -150,6 +154,17 @@ jobs:
             type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha,prefix=master-,format=short,enable=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Assert recovery metadata preserves latest
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          if grep -Eq '(^|/)polylogue:latest(-distroless)?$' <<<"${TAGS}"; then
+            echo "::error::manual recovery must not retarget latest"
+            exit 1
+          fi
 
       - name: Build${{ steps.decide.outputs.push == 'true' && ' and push' || '' }}
         uses: docker/build-push-action@v7

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
           fetch-depth: 0
 
       - name: Resolve source identity
@@ -84,6 +84,11 @@ jobs:
             version="$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
             if [[ "${version}" != "${tag#v}" ]]; then
               echo "::error::${tag} does not match pyproject.toml version ${version}"
+              exit 1
+            fi
+            tag_revision="$(git rev-parse "refs/tags/${tag}^{commit}")"
+            if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
+              echo "::error::checked-out source does not match ${tag} target"
               exit 1
             fi
           fi
@@ -131,7 +136,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
             type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha,prefix=master-,format=short,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build${{ steps.decide.outputs.push == 'true' && ' and push' || '' }}
@@ -171,11 +176,14 @@ jobs:
           docker pull --platform linux/amd64 "${IMAGE}"
           if [[ "${{ matrix.target }}" == "runtime" ]]; then
             version="$(docker run --rm --entrypoint polylogue "${IMAGE}" --version)"
+            revision="$(docker run --rm --entrypoint python "${IMAGE}" -I -c 'from polylogue.version import VERSION_INFO; print(VERSION_INFO.commit)')"
           else
             version="$(docker run --rm --entrypoint /usr/local/bin/polylogue "${IMAGE}" --version)"
+            revision="$(docker run --rm --entrypoint /usr/local/bin/python "${IMAGE}" -I -c 'from polylogue.version import VERSION_INFO; print(VERSION_INFO.commit)')"
           fi
           printf '%s\n' "${version}"
-          grep -F -- "${EXPECTED_REVISION}" <<<"${version}"
+          grep -F -- "${EXPECTED_REVISION:0:8}" <<<"${version}"
+          test "${revision}" = "${EXPECTED_REVISION}"
 
       - name: Smoke test (amd64 image, --version)
         if: steps.decide.outputs.push != 'true'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -70,6 +70,7 @@ jobs:
         id: source
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${RELEASE_TAG}"
@@ -90,6 +91,17 @@ jobs:
             if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
               echo "::error::checked-out source does not match ${tag} target"
               exit 1
+            fi
+            if [[ -n "${RELEASE_TAG}" ]]; then
+              release_revision="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.target_commitish')"
+              if [[ ! "${release_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::GitHub Release ${tag} does not record an immutable commit SHA"
+                exit 1
+              fi
+              if [[ "${tag_revision}" != "${release_revision}" ]]; then
+                echo "::error::${tag} no longer matches its GitHub Release target"
+                exit 1
+              fi
             fi
           fi
           echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -54,6 +54,9 @@ jobs:
           # Recovery builds the extension sources that belong to the release,
           # not whatever code later reached the default branch.
           ref: ${{ inputs.release_tag || github.ref }}
+      - name: Record packaged source revision
+        id: source
+        run: echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -96,6 +99,42 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "Built artifacts for version ${version}:"
           ls -la dist/
+      - name: Write store-submission manifest
+        env:
+          VERSION: ${{ steps.summary.outputs.version }}
+          SOURCE_REVISION: ${{ steps.source.outputs.revision }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          dist = Path("dist")
+          version = os.environ["VERSION"]
+          artifacts = sorted(
+              [*dist.glob("polylogue-browser-capture-*-chrome.zip"), *dist.glob("polylogue-browser-capture-*-firefox.xpi")]
+          )
+          if len(artifacts) != 2:
+              raise SystemExit(f"expected one Chrome zip and one Firefox xpi, found: {artifacts}")
+          payload = {
+              "schema_version": 1,
+              "version": version,
+              "source_revision": os.environ["SOURCE_REVISION"],
+              "firefox_gecko_id": json.loads((dist / "build-manifest.json").read_text())["firefox_gecko_id"],
+              "artifacts": [
+                  {
+                      "name": path.name,
+                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                      "size_bytes": path.stat().st_size,
+                  }
+                  for path in artifacts
+              ],
+          }
+          target = dist / f"polylogue-browser-capture-{version}-store-submission.json"
+          target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          print(target.read_text(), end="")
+          PY
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -103,6 +142,7 @@ jobs:
           path: |
             browser-extension/dist/polylogue-browser-capture-*-chrome.zip
             browser-extension/dist/polylogue-browser-capture-*-firefox.xpi
+            browser-extension/dist/polylogue-browser-capture-*-store-submission.json
             browser-extension/dist/build-manifest.json
             browser-extension/dist/screenshots/**
           if-no-files-found: error
@@ -156,6 +196,7 @@ jobs:
           gh release upload "${TAG}" \
             artifacts/polylogue-browser-capture-*-chrome.zip \
             artifacts/polylogue-browser-capture-*-firefox.xpi \
+            artifacts/polylogue-browser-capture-*-store-submission.json \
             artifacts/build-manifest.json \
             --clobber --repo "${GITHUB_REPOSITORY}"
           # Screenshots are uploaded as a tar.gz so the release page does

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -58,6 +58,7 @@ jobs:
         id: source
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${RELEASE_TAG}"
@@ -73,6 +74,17 @@ jobs:
             if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
               echo "::error::checked-out source does not match ${tag} target"
               exit 1
+            fi
+            if [[ -n "${RELEASE_TAG}" ]]; then
+              release_revision="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.target_commitish')"
+              if [[ ! "${release_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::GitHub Release ${tag} does not record an immutable commit SHA"
+                exit 1
+              fi
+              if [[ "${tag_revision}" != "${release_revision}" ]]; then
+                echo "::error::${tag} no longer matches its GitHub Release target"
+                exit 1
+              fi
             fi
           fi
           echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -7,7 +7,7 @@ name: Extension Release
 #
 # Trigger surface:
 #   - tag push v*.*.*    → builds, lints, screenshots, attaches to release
-#   - workflow_dispatch  → dry-run build, uploads only as workflow artifacts
+#   - workflow_dispatch  → dry-run build, or backfills an existing release tag
 #   - pull_request paths → build + validate only (no upload), smoke gate
 #
 # Versioning: the build script reads `version` from the [project] table of
@@ -26,8 +26,8 @@ on:
       - .github/workflows/extension-release.yml
   workflow_dispatch:
     inputs:
-      upload-release:
-        description: "Upload artifacts to an existing release tag (e.g. v0.2.0)"
+      release_tag:
+        description: "Existing vX.Y.Z tag to build from and attach to (empty = dry-run)"
         required: false
         default: ""
 
@@ -50,6 +50,10 @@ jobs:
       version: ${{ steps.summary.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Recovery builds the extension sources that belong to the release,
+          # not whatever code later reached the default branch.
+          ref: ${{ inputs.release_tag || github.ref }}
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -106,7 +110,7 @@ jobs:
   attach-to-release:
     name: attach-to-release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.upload-release != ''
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -125,11 +129,19 @@ jobs:
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             tag="${GITHUB_REF_NAME}"
           else
-            tag="${{ github.event.inputs.upload-release }}"
+            tag="${{ inputs.release_tag }}"
           fi
           if [ -z "${tag}" ]; then
             echo "no target tag — skipping upload" >&2
             exit 0
+          fi
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release tag must be vX.Y.Z, got '${tag}'"
+            exit 1
+          fi
+          if [[ "${{ needs.build.outputs.version }}" != "${tag#v}" ]]; then
+            echo "::error::artifact version ${{ needs.build.outputs.version }} does not match ${tag}"
+            exit 1
           fi
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
       - name: Upload artifacts to release

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -53,10 +53,29 @@ jobs:
         with:
           # Recovery builds the extension sources that belong to the release,
           # not whatever code later reached the default branch.
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
       - name: Record packaged source revision
         id: source
-        run: echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          tag="${RELEASE_TAG}"
+          if [[ -z "${tag}" && "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+          fi
+          if [[ -n "${tag}" ]]; then
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::release_tag must be vX.Y.Z, got '${tag}'"
+              exit 1
+            fi
+            tag_revision="$(git rev-parse "refs/tags/${tag}^{commit}")"
+            if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
+              echo "::error::checked-out source does not match ${tag} target"
+              exit 1
+            fi
+          fi
+          echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -108,19 +127,29 @@ jobs:
           import hashlib
           import json
           import os
+          import re
           from pathlib import Path
 
           dist = Path("dist")
           version = os.environ["VERSION"]
-          artifacts = sorted(
-              [*dist.glob("polylogue-browser-capture-*-chrome.zip"), *dist.glob("polylogue-browser-capture-*-firefox.xpi")]
-          )
-          if len(artifacts) != 2:
-              raise SystemExit(f"expected one Chrome zip and one Firefox xpi, found: {artifacts}")
+          revision = os.environ["SOURCE_REVISION"]
+          chrome = sorted(dist.glob("polylogue-browser-capture-*-chrome.zip"))
+          firefox = sorted(dist.glob("polylogue-browser-capture-*-firefox.xpi"))
+          if len(chrome) != 1 or len(firefox) != 1:
+              raise SystemExit(f"expected one Chrome zip and one Firefox xpi, found chrome={chrome}, firefox={firefox}")
+          artifacts = [chrome[0], firefox[0]]
+          expected_names = {
+              f"polylogue-browser-capture-{version}-chrome.zip",
+              f"polylogue-browser-capture-{version}-firefox.xpi",
+          }
+          if {path.name for path in artifacts} != expected_names:
+              raise SystemExit(f"artifact names do not match version {version}: {artifacts}")
+          if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+              raise SystemExit(f"source revision is not a full immutable SHA: {revision!r}")
           payload = {
               "schema_version": 1,
               "version": version,
-              "source_revision": os.environ["SOURCE_REVISION"],
+              "source_revision": revision,
               "firefox_gecko_id": json.loads((dist / "build-manifest.json").read_text())["firefox_gecko_id"],
               "artifacts": [
                   {

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -9,7 +9,7 @@ name: Homebrew Bump
 #
 # Trigger surface:
 # - `push` on a `vX.Y.Z` tag                       — normal release path
-# - `workflow_dispatch` with a manual `version`    — recovery / backfill
+# - `workflow_dispatch` with an existing `release_tag` — recovery / backfill
 #
 # Required secrets:
 # - `HOMEBREW_TAP_TOKEN`: a GitHub fine-grained PAT with `contents: write`
@@ -23,8 +23,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to bump to (e.g. 0.2.3). Omit when triggered by a tag push."
+      release_tag:
+        description: "Existing vX.Y.Z release tag to backfill (empty = selected tag push)"
         required: false
         default: ""
 
@@ -41,30 +41,54 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Resolve target version
-        id: version
+      - name: Resolve target release tag
+        id: release
         env:
-          MANUAL_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          if [[ -n "${MANUAL_VERSION}" ]]; then
-            version="${MANUAL_VERSION}"
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            tag="${RELEASE_TAG}"
           else
-            # Tag refs look like `refs/tags/v0.2.3`; strip the leading `v`.
             tag="${GITHUB_REF_NAME}"
-            version="${tag#v}"
           fi
-          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version '${version}'. Expected X.Y.Z."
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag '${tag}'. Expected vX.Y.Z."
             exit 1
           fi
+          version="${tag#v}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "Bumping homebrew formula to polylogue ${version}"
+          echo "Bumping homebrew formula from ${tag}"
 
-      - name: Check out upstream repo (for the template + README links)
+      - name: Check out release source (for the formula template)
         uses: actions/checkout@v7
         with:
+          ref: refs/tags/${{ steps.release.outputs.tag }}
+          fetch-depth: 0
           path: upstream
+
+      - name: Verify manual recovery release identity
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag_revision="$(git -C upstream rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          if [[ "$(git -C upstream rev-parse HEAD)" != "${tag_revision}" ]]; then
+            echo "::error::checked-out source does not match ${RELEASE_TAG} target"
+            exit 1
+          fi
+          release_revision="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.target_commitish')"
+          if [[ ! "${release_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::GitHub Release ${RELEASE_TAG} does not record an immutable commit SHA"
+            exit 1
+          fi
+          if [[ "${tag_revision}" != "${release_revision}" ]]; then
+            echo "::error::${RELEASE_TAG} no longer matches its GitHub Release target"
+            exit 1
+          fi
 
       - name: Check out homebrew tap repo
         uses: actions/checkout@v7
@@ -73,10 +97,34 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 
+      - name: Reject formula downgrades
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          formula = Path("tap/Formula/polylogue.rb").read_text()
+          match = re.search(r"polylogue-(\d+\.\d+\.\d+)\.tar\.gz", formula)
+          if match is None:
+              raise SystemExit("could not determine current tap formula version")
+          current = tuple(map(int, match.group(1).split(".")))
+          requested = tuple(map(int, os.environ["VERSION"].split(".")))
+          if requested < current:
+              raise SystemExit(
+                  f"refusing to downgrade tap formula from {match.group(1)} to "
+                  f"{os.environ['VERSION']}"
+              )
+          print(f"tap formula {match.group(1)} -> {os.environ['VERSION']}")
+          PY
+
       - name: Wait for PyPI sdist availability and resolve sha256
         id: pypi
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           sdist="polylogue-${VERSION}.tar.gz"
@@ -105,7 +153,7 @@ jobs:
 
       - name: Rewrite formula placeholders
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
           URL: ${{ steps.pypi.outputs.url }}
           SHA256: ${{ steps.pypi.outputs.sha256 }}
         run: |
@@ -180,7 +228,7 @@ jobs:
       - name: Open / refresh tap PR
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           cd tap

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -165,6 +165,18 @@ jobs:
             brew audit --strict --online ./Formula/polylogue.rb
           )
 
+      - name: Install and smoke the generated formula
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_FROM_API: "1"
+        run: |
+          set -euo pipefail
+          # Audit only proves formula shape. Build the same resource-expanded
+          # formula that the tap PR will contain, then exercise its production
+          # `test do` block against the installed console scripts.
+          brew install --build-from-source tap/Formula/polylogue.rb
+          brew test --verbose polylogue
+
       - name: Open / refresh tap PR
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,29 @@ jobs:
         run: uv run devtools release verify-distribution --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
+      - name: Verify installed wheel exposes the exact build revision
+        env:
+          EXPECTED_REVISION: ${{ steps.source.outputs.revision }}
+        run: |
+          set -euo pipefail
+          uv venv "${RUNNER_TEMP}/build-info-venv"
+          uv pip install --python "${RUNNER_TEMP}/build-info-venv/bin/python" "${RUNNER_TEMP}/dist/dist"/*.whl
+          "${RUNNER_TEMP}/build-info-venv/bin/python" -I - <<'PY'
+          import json
+          import os
+
+          from polylogue.version import VERSION_INFO
+
+          payload = {
+              "version": VERSION_INFO.version,
+              "revision": VERSION_INFO.commit,
+              "dirty": VERSION_INFO.dirty,
+          }
+          print(json.dumps(payload, sort_keys=True))
+          assert payload["revision"] == os.environ["EXPECTED_REVISION"], payload
+          assert len(payload["revision"] or "") == 40, payload
+          assert payload["dirty"] is False, payload
+          PY
       - name: twine check (PyPI metadata long-description renderability)
         run: |
           uv run --with twine python -m twine check "${RUNNER_TEMP}/dist/dist"/*.whl "${RUNNER_TEMP}/dist/dist"/*.tar.gz
@@ -237,6 +260,41 @@ jobs:
             exit 1
           fi
 
+  pipx-smoke:
+    # pipx is the documented user-facing install route. Install the built
+    # wheel with pipx itself so console-script discovery is not accidentally
+    # relying on the repository's dev environment or a plain venv path.
+    name: pipx-smoke
+    needs: build
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts
+          path: dist/
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install built wheel through pipx and smoke every console script
+        shell: bash
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+          PIPX_HOME: ${{ runner.temp }}/pipx-home
+          PIPX_BIN_DIR: ${{ runner.temp }}/pipx-bin
+        run: |
+          set -euo pipefail
+          python -m pip install --user pipx
+          wheel=$(find dist -maxdepth 1 -type f -name '*.whl' | sort | head -n1)
+          python -m pipx install --suffix=-smoke "${wheel}"
+          archive_root="${RUNNER_TEMP}/polylogue-pipx-archive"
+          mkdir -p "${archive_root}"
+          export POLYLOGUE_ARCHIVE_ROOT="${archive_root}"
+          "${PIPX_BIN_DIR}/polylogue-smoke" --version
+          "${PIPX_BIN_DIR}/polylogue-smoke" --plain analyze --count
+          "${PIPX_BIN_DIR}/polylogued-smoke" --help > /dev/null
+          "${PIPX_BIN_DIR}/polylogue-mcp-smoke" --help > /dev/null
+
   installed-smoke-mcp:
     # polylogue-mcp is a thin wrapper that pins the matching polylogue release.
     # Install both wheels together and confirm the console script resolves
@@ -320,7 +378,7 @@ jobs:
 
   publish-pypi:
     name: publish-pypi
-    needs: [build, installed-smoke, installed-smoke-mcp, installed-smoke-hooks, sbom]
+    needs: [build, installed-smoke, installed-smoke-mcp, installed-smoke-hooks, pipx-smoke, sbom]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true' && inputs.release_tag != '')
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           # Manual recovery must package the immutable tag, not the workflow
           # branch that happens to contain this recovery machinery.
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
           fetch-depth: 0
       - name: Verify release source identity
         id: source
@@ -74,6 +74,11 @@ jobs:
             version="$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
             if [[ "${version}" != "${tag#v}" ]]; then
               echo "::error::${tag} does not match pyproject.toml version ${version}"
+              exit 1
+            fi
+            tag_revision="$(git rev-parse "refs/tags/${tag}^{commit}")"
+            if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
+              echo "::error::checked-out source does not match ${tag} target"
               exit 1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,9 @@ name: Release
 # The OCI image is built and published by `.github/workflows/container.yml`,
 # which fans out across slim + distroless variants and linux/amd64 + linux/arm64.
 #
-# A manual `workflow_dispatch` path exists to dry-run the build/smoke
-# pipeline against any ref without publishing.
+# A manual `workflow_dispatch` path can replay an already-created tag. This is
+# intentionally a release-artifact recovery path, not a way to publish the
+# current default branch under an older version number.
 #
 # PyPI Trusted Publishing must be configured once in the project on
 # pypi.org under "Publishing" → "Add a new pending publisher" with:
@@ -25,8 +26,12 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Existing vX.Y.Z tag whose exact source should be built (required to publish)"
+        required: false
+        default: ""
       publish:
-        description: "Publish to PyPI and GHCR (false = dry-run build/smoke only)"
+        description: "Publish to PyPI (false = dry-run build/smoke only)"
         required: false
         default: "false"
 
@@ -46,6 +51,33 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Manual recovery must package the immutable tag, not the workflow
+          # branch that happens to contain this recovery machinery.
+          ref: ${{ inputs.release_tag || github.ref }}
+          fetch-depth: 0
+      - name: Verify release source identity
+        id: source
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          tag="${RELEASE_TAG}"
+          if [[ -z "${tag}" && "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+          fi
+          if [[ -n "${tag}" ]]; then
+            if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::release_tag must be vX.Y.Z, got '${tag}'"
+              exit 1
+            fi
+            version="$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+            if [[ "${version}" != "${tag#v}" ]]; then
+              echo "::error::${tag} does not match pyproject.toml version ${version}"
+              exit 1
+            fi
+          fi
+          echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
       - uses: astral-sh/setup-uv@v8.3.0
         with:
           python-version: "3.13"
@@ -289,7 +321,7 @@ jobs:
   publish-pypi:
     name: publish-pypi
     needs: [build, installed-smoke, installed-smoke-mcp, installed-smoke-hooks, sbom]
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true' && inputs.release_tag != '')
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment:
@@ -333,7 +365,7 @@ jobs:
     # environment=pypi-mcp before the first tagged release reaches this job.
     name: publish-pypi-mcp
     needs: [build, installed-smoke-mcp, sbom]
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true' && inputs.release_tag != '')
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment:
@@ -372,7 +404,7 @@ jobs:
     # environment=pypi-hooks before the first tagged release reaches this job.
     name: publish-pypi-hooks
     needs: [build, installed-smoke-hooks, sbom]
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true' && inputs.release_tag != '')
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         id: source
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${RELEASE_TAG}"
@@ -80,6 +81,17 @@ jobs:
             if [[ "$(git rev-parse HEAD)" != "${tag_revision}" ]]; then
               echo "::error::checked-out source does not match ${tag} target"
               exit 1
+            fi
+            if [[ -n "${RELEASE_TAG}" ]]; then
+              release_revision="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.target_commitish')"
+              if [[ ! "${release_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error::GitHub Release ${tag} does not record an immutable commit SHA"
+                exit 1
+              fi
+              if [[ "${tag_revision}" != "${release_revision}" ]]; then
+                echo "::error::${tag} no longer matches its GitHub Release target"
+                exit 1
+              fi
             fi
           fi
           echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polylogue-browser-capture",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Polylogue browser extension for capturing web LLM sessions",
   "type": "module",

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polylogue-browser-capture",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Polylogue browser extension for capturing web LLM sessions",
   "type": "module",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -142,8 +142,9 @@ gh workflow run homebrew-bump.yml --ref master -f version=X.Y.Z
 ```
 
 The recovery workflows check out the named tag and reject version mismatches.
-The container lane additionally pulls each published image and checks that its
-`polylogue --version` output contains the tag's complete source revision.
+The container lane additionally pulls each published image, checks the concise
+`polylogue --version` prefix, and compares `VERSION_INFO.commit` to the tag's
+complete source revision.
 
 For local container or formula experiments before their artifacts exist, build
 from the checkout:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,17 +101,21 @@ polylogued --help
 polylogue-mcp --help
 ```
 
-For containers, prefer the immutable release tag and confirm the full runtime
-revision printed by `--version` matches the tag target before deploying:
+For containers, use `--version` for the concise human build identity and query
+the packaged runtime's `VERSION_INFO.commit` for the full revision before
+deploying:
 
 ```bash
 podman pull ghcr.io/sinity/polylogue:X.Y.Z
 podman run --rm --entrypoint polylogue ghcr.io/sinity/polylogue:X.Y.Z --version
+podman run --rm --entrypoint python ghcr.io/sinity/polylogue:X.Y.Z \
+  -I -c 'from polylogue.version import VERSION_INFO; print(VERSION_INFO.commit)'
 git ls-remote https://github.com/Sinity/polylogue refs/tags/vX.Y.Z
 ```
 
 The published workflow performs this smoke for both slim and distroless images;
-its package embeds the complete source revision rather than a short SHA.
+it requires the concise version to match the source prefix and the machine-
+readable runtime field to equal the complete source revision.
 
 For Homebrew, install only after the release-triggered tap PR has merged:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,25 +126,10 @@ brew test polylogue
 
 ### Recovering an already-created tag
 
-If a GitHub Release exists without its artifacts, do not re-cut its tag. After
-the recovery workflow changes are on `master`, dispatch the artifact lanes from
-the immutable release source instead:
-
-```bash
-gh workflow run release.yml --ref master \
-  -f release_tag=vX.Y.Z -f publish=true
-gh workflow run container.yml --ref master \
-  -f release_tag=vX.Y.Z -f push=true
-gh workflow run extension-release.yml --ref master \
-  -f release_tag=vX.Y.Z
-# Run after the PyPI sdist is visible and HOMEBREW_TAP_TOKEN is configured.
-gh workflow run homebrew-bump.yml --ref master -f version=X.Y.Z
-```
-
-The recovery workflows check out the named tag and reject version mismatches.
-The container lane additionally pulls each published image, checks the concise
-`polylogue --version` prefix, and compares `VERSION_INFO.commit` to the tag's
-complete source revision.
+If a GitHub Release exists without its artifacts, do not re-cut its tag. Follow
+the [release checklist recovery sequence](release.md#backfill-an-existing-tag-without-re-cutting-it),
+which requires the tag, checked-out source, and GitHub Release target commit to
+agree before publication.
 
 For local container or formula experiments before their artifacts exist, build
 from the checkout:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,15 +1,23 @@
 # Installation
 
-Polylogue is currently installed from the source checkout or the Nix flake.
-PyPI, Homebrew, container images, and browser-store extension packages are
-release-channel targets; do not treat them as available user install paths
-until the release workflow has published and smoke-tested those artifacts.
+Polylogue has source/Nix routes now and release-artifact routes once the
+corresponding tag artifacts have been published and smoke-tested. A GitHub tag
+or release page alone is not proof that PyPI, GHCR, Homebrew, or extension
+artifacts are available: use the linked verification for the channel you plan
+to install from.
 
-| Channel | Audience | Reference |
-| --- | --- | --- |
-| `nix develop` | Local development, source checkout, verification | [Contributing](../CONTRIBUTING.md) |
-| `nix run github:Sinity/polylogue` | NixOS / nix-darwin users | [`flake.nix`](../flake.nix) |
-| NixOS / Home Manager module | Managed local daemon deployment | see below |
+| Channel | Audience | Install after its artifact smoke passes | Verification |
+| --- | --- | --- | --- |
+| `nix develop` | Local development, source checkout, verification | `nix develop` | [Contributing](../CONTRIBUTING.md) |
+| Nix flake | NixOS / nix-darwin users | `nix run github:Sinity/polylogue -- --help` | [`flake.nix`](../flake.nix) |
+| PyPI / pipx | Python CLI users | `pipx install "polylogue==X.Y.Z"` | `polylogue --version`, `polylogued --help`, `polylogue-mcp --help` |
+| GHCR | Container deployments | `podman pull ghcr.io/sinity/polylogue:X.Y.Z` | `podman run --rm --entrypoint polylogue ghcr.io/sinity/polylogue:X.Y.Z --version` |
+| Homebrew | macOS/Linuxbrew users | `brew install sinity/tap/polylogue` | `brew test polylogue` |
+| Browser extension | Browser-capture users | Download the matching release `.zip` / `.xpi` | verify `build-manifest.json` version equals `X.Y.Z` |
+| NixOS / Home Manager module | Managed local daemon deployment | see below | `systemctl status polylogued.service` |
+
+For the release-channel recovery sequence and exact smoke matrix, see the
+[release checklist](release.md#backfill-an-existing-tag-without-re-cutting-it).
 
 The source and Nix paths expose the same three console scripts: `polylogue`,
 `polylogued`, and `polylogue-mcp`.
@@ -81,12 +89,60 @@ systemctl status polylogued.service
 polylogue ops status
 ```
 
-## Container image and Homebrew status
+## PyPI, containers, and Homebrew
 
-Container and Homebrew packaging files live in the repository, but those
-channels are not documented as current install routes until release artifacts
-exist and the release checklist verifies them. For local container experiments,
-build from the checkout:
+After the release workflow has published the matching version, `pipx` is the
+recommended isolated CLI install:
+
+```bash
+pipx install "polylogue==X.Y.Z"
+polylogue --version
+polylogued --help
+polylogue-mcp --help
+```
+
+For containers, prefer the immutable release tag and confirm the full runtime
+revision printed by `--version` matches the tag target before deploying:
+
+```bash
+podman pull ghcr.io/sinity/polylogue:X.Y.Z
+podman run --rm --entrypoint polylogue ghcr.io/sinity/polylogue:X.Y.Z --version
+git ls-remote https://github.com/Sinity/polylogue refs/tags/vX.Y.Z
+```
+
+The published workflow performs this smoke for both slim and distroless images;
+its package embeds the complete source revision rather than a short SHA.
+
+For Homebrew, install only after the release-triggered tap PR has merged:
+
+```bash
+brew install sinity/tap/polylogue
+brew test polylogue
+```
+
+### Recovering an already-created tag
+
+If a GitHub Release exists without its artifacts, do not re-cut its tag. After
+the recovery workflow changes are on `master`, dispatch the artifact lanes from
+the immutable release source instead:
+
+```bash
+gh workflow run release.yml --ref master \
+  -f release_tag=vX.Y.Z -f publish=true
+gh workflow run container.yml --ref master \
+  -f release_tag=vX.Y.Z -f push=true
+gh workflow run extension-release.yml --ref master \
+  -f release_tag=vX.Y.Z
+# Run after the PyPI sdist is visible and HOMEBREW_TAP_TOKEN is configured.
+gh workflow run homebrew-bump.yml --ref master -f version=X.Y.Z
+```
+
+The recovery workflows check out the named tag and reject version mismatches.
+The container lane additionally pulls each published image and checks that its
+`polylogue --version` output contains the tag's complete source revision.
+
+For local container or formula experiments before their artifacts exist, build
+from the checkout:
 
 ```bash
 docker buildx build -f packaging/Containerfile --target runtime    -t polylogue:slim       .
@@ -240,8 +296,8 @@ a glance:
 
 | Channel | Status | Tracking |
 | --- | --- | --- |
-| Packed `.zip` on GitHub Releases | shipped | this doc |
-| Packed `.xpi` on GitHub Releases | shipped | this doc |
+| Packed `.zip` on GitHub Releases | release-backed; verify the matching asset exists | this doc |
+| Packed `.xpi` on GitHub Releases | release-backed; verify the matching asset exists | this doc |
 | Chrome Web Store | not submitted (store sign-up + review have non-engineering blockers) | follow-up |
 | Mozilla AMO | not submitted (same blockers) | follow-up |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -266,6 +266,7 @@ attached to every GitHub release by
 | --- | --- | --- |
 | `polylogue-browser-capture-<version>-chrome.zip` | Chrome, Chromium, Edge, Brave, Vivaldi | Developer-mode unpacked install |
 | `polylogue-browser-capture-<version>-firefox.xpi` | Firefox | Temporary install via `about:debugging` |
+| `polylogue-browser-capture-<version>-store-submission.json` | Store operators | Version, source revision, Gecko ID, SHA-256, and size for both archives |
 | `store-screenshots-<tag>.tar.gz` | — | Submission media for store listings |
 
 Download the artifacts from the
@@ -273,7 +274,9 @@ Download the artifacts from the
 The version is locked to the polylogue Python project version on the same
 tag — the workflow rewrites `manifest.json` from `pyproject.toml` before
 packaging so the extension version always matches the daemon protocol it
-was built against.
+was built against. Before uploading to a store, verify each downloaded archive
+against the matching `store-submission.json`; it binds the pair to the release
+version and complete source revision.
 
 ### Install paths
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -137,8 +137,9 @@ recompute and open a new one on the next push to `master`.
 PyPI Trusted Publishing requires a one-time registration on pypi.org under
 "Publishing" → "Add a new pending publisher" with `owner = Sinity`,
 `repo = polylogue`, `workflow = release.yml`, `environment = pypi`. If this
-is missing the publish step fails with an OIDC error and the tag must be
-re-cut after re-running the workflow.
+is missing the publish step fails with an OIDC error. Configure the publisher,
+then use the [backfill procedure](#backfill-an-existing-tag-without-re-cutting-it)
+for the existing tag; do not move or re-cut it.
 
 The same release tag also publishes the wrapper distributions
 [`polylogue-mcp`](https://pypi.org/project/polylogue-mcp/) and
@@ -163,6 +164,34 @@ the public Sigstore transparency log. Consumers can verify the bundle with
 https://github.com/Sinity/polylogue/.github/workflows/release.yml@refs/tags/vX.Y.Z
 --cert-oidc-issuer https://token.actions.githubusercontent.com
 polylogue-X.Y.Z-py3-none-any.whl polylogue-X.Y.Z-py3-none-any.whl.sigstore`.
+
+## Backfill an existing tag without re-cutting it
+
+If a GitHub Release exists but its artifact workflows did not run, replay the
+artifacts from that release's recorded commit. Do not move, delete, or re-cut
+the tag. The recovery workflows require the explicit `vX.Y.Z` tag, check out
+`refs/tags/vX.Y.Z`, and reject it if either the checked-out commit or tag target
+differs from the immutable full SHA recorded on the GitHub Release.
+
+After the recovery workflow changes are on `master`, dispatch the lanes in this
+order:
+
+```bash
+gh workflow run release.yml --ref master \
+  -f release_tag=vX.Y.Z -f publish=true
+gh workflow run container.yml --ref master \
+  -f release_tag=vX.Y.Z -f push=true
+gh workflow run extension-release.yml --ref master \
+  -f release_tag=vX.Y.Z
+# Run after the PyPI sdist is visible and HOMEBREW_TAP_TOKEN is configured.
+gh workflow run homebrew-bump.yml --ref master -f version=X.Y.Z
+```
+
+Recovery publishes only the immutable versioned GHCR tags; it deliberately does
+not retarget `latest`. The container lane pulls slim and distroless images,
+checks the concise CLI version prefix, and compares the machine-readable full
+`VERSION_INFO.commit` to the recorded release commit. Finish with the post-cut
+checks below before treating any channel as available.
 
 ## Post
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -184,14 +184,16 @@ gh workflow run container.yml --ref master \
 gh workflow run extension-release.yml --ref master \
   -f release_tag=vX.Y.Z
 # Run after the PyPI sdist is visible and HOMEBREW_TAP_TOKEN is configured.
-gh workflow run homebrew-bump.yml --ref master -f version=X.Y.Z
+gh workflow run homebrew-bump.yml --ref master -f release_tag=vX.Y.Z
 ```
 
 Recovery publishes only the immutable versioned GHCR tags; it deliberately does
 not retarget `latest`. The container lane pulls slim and distroless images,
 checks the concise CLI version prefix, and compares the machine-readable full
 `VERSION_INFO.commit` to the recorded release commit. Finish with the post-cut
-checks below before treating any channel as available.
+checks below before treating any channel as available. The Homebrew lane also
+checks its manually selected tag against the GitHub Release target and refuses
+to downgrade the formula already in the tap.
 
 ## Post
 


### PR DESCRIPTION
## Summary

Completes the release-artifact recovery path for v0.2.0, makes every documented install channel exercise its production packaging route, and attaches verifiable browser-store submission metadata.

## Problem

v0.2.0 has a real GitHub tag/release but no release assets, no release/Homebrew tag workflow run, and no PyPI project. Rebuilding from current master could have published newer source under an older release version. The documented pipx and Homebrew install paths had not been exercised by their release workflows, and store archives were not bound to a full source revision.

## Solution

- Release, container, and extension workflows accept release_tag, resolve refs/tags/vX.Y.Z, and reject a checkout whose commit differs from the tag target. Manual PyPI publication requires it.
- PyPI release CI builds and installs the wheel through pipx, smokes CLI/daemon/MCP entrypoints, and requires installed VERSION_INFO to contain the full 40-character checked-out revision.
- GHCR builds embed the full checkout revision, publish it as an OCI label, then pull slim and distroless images and assert the concise CLI prefix plus the exact machine-readable VERSION_INFO.commit. Recovery never rewrites latest.
- Homebrew now audits, installs, and runs brew test on the generated resource-expanded formula before opening its tap PR.
- Extension releases attach a source-revision-and-SHA-256 store-submission manifest alongside exactly one version-matched Chrome archive, Firefox archive, and screenshot bundle. The installation matrix documents every route and the no-recut recovery sequence.

## Acceptance matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-y8s5 | implementation support satisfied; external publication deferred | Release, pipx, GHCR, Homebrew, and extension lanes now have recovery/publish/smoke wiring. The documented v0.2.0 dispatches still require operator-owned PyPI Trusted Publishing and Homebrew credentials. |
| polylogue-6rvt | satisfied/extended | PR #2743 supplied full revision for Nix. This PR proves it from the installed wheel and embeds/smokes the same full revision in GHCR runtimes. |

## Verification

- nix develop --command devtools release verify-distribution --work-dir /realm/tmp/polylogue-distribution-pipx — built wheel + sdist, installed each in isolated venvs, and exercised CLI, daemon, MCP, parser, and diagnostics entrypoints.
- pipx install --suffix=-smoke /realm/tmp/polylogue-distribution-pipx/dist/polylogue-0.2.0-py3-none-any.whl — installed the built wheel through real pipx; polylogue-smoke, polylogued-smoke, and polylogue-mcp-smoke all passed.
- node browser-extension/scripts/build.mjs --out /realm/tmp/polylogue-adversarial-store --no-source-sync — emitted one Chrome and one Firefox v0.2.0 archive; manifest checks verified version-matched names, a 40-character source revision, SHA-256, and sizes.
- nix develop --command devtools verify ci-workflows — verify ci-workflows: 17 workflow files checked, no errors.
- nix shell nixpkgs#actionlint -c actionlint on the changed workflows — exit 0.
- Pre-push devtools verify --quick — exit 0 after each commit.

The focused extension build suite has one reproducible unrelated failure: its pre-existing packaged-service-worker fixture expects two page requests and receives one. It does not cover any changed workflow/docs/package-metadata path; its archive-emission tests pass.

No tests were added. The release verifier exercises the production Hatch build configuration and installed console entrypoints; removing a runtime dependency or entrypoint would fail the isolated-wheel smoke. The pipx smoke exercises the documented installer rather than a test wrapper. The Homebrew smoke executes the formula test shipped to users. The extension build uses the production archive builder, and the submission-manifest validation would fail if a required archive or its integrity metadata were removed.