### PR TITLE
feat(browser): add capture mission control (#2780)

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -831,7 +831,18 @@ async function cleanupBackfillTransportTab(alarmName) {
   }
 }
 
-async function captureTab(tab, reason = "background") {
+async function captureTab(tab, reason = "background", expectedConversation = null) {
+  if (expectedConversation && tab?.id && chrome.tabs?.get) {
+    const currentTab = await chrome.tabs.get(tab.id);
+    const currentUrl = currentTab?.url || currentTab?.pendingUrl || "";
+    if (
+      !currentTab
+      || currentUrl !== expectedConversation.url
+      || archiveProviderForUrl(currentUrl) !== expectedConversation.provider
+      || conversationIdForUrl(currentUrl) !== expectedConversation.providerSessionId
+    ) return { ok: false, skipped: true, reason: "tab_navigation_changed" };
+    tab = currentTab;
+  }
   if (!tab?.id || !injectionPlanForUrl(tab.url || tab.pendingUrl || "").length) return null;
   const now = Date.now();
   const lastCaptureAt = recentBackgroundCaptures.get(tab.id) || 0;
@@ -1017,7 +1028,16 @@ function conversationIdForUrl(url) {
       return parts[0] === "chat" && parts[1] ? parts[1] : null;
     }
     if (provider === "grok") {
-      return parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok") || null;
+      const pathId = parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok");
+      if (pathId) return pathId;
+      const queryId = parsed.searchParams.get("conversation") || parsed.searchParams.get("conversationId");
+      if (queryId) return queryId;
+      let hash = 0x811c9dc5;
+      for (const char of `${parsed.origin}${parsed.pathname}${parsed.search}`) {
+        hash ^= char.charCodeAt(0);
+        hash = Math.imul(hash, 0x01000193);
+      }
+      return `dom:${(hash >>> 0).toString(16).padStart(8, "0")}`;
     }
   } catch {
     return null;
@@ -1078,7 +1098,11 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
           detail: "archive_state_missing",
           tabId: tab?.id || null,
         });
-        const captureResult = await captureTab(tab, "auto_capture_missing");
+        const captureResult = await captureTab(tab, "auto_capture_missing", {
+          provider,
+          providerSessionId,
+          url,
+        });
         if (!captureResult || captureResult.skipped) {
           await appendConversationTimeline({
             provider,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -9,6 +9,9 @@ const BACKGROUND_CAPTURE_MIN_INTERVAL_MS = 30000;
 const ACTIVE_TAB_STATE_MIN_INTERVAL_MS = 4000;
 const CAPTURE_LOG_LIMIT = 80;
 const DEBUG_LOG_LIMIT = 160;
+const CONVERSATION_TIMELINE_KEY = "polylogueConversationTimeline";
+const CONVERSATION_TIMELINE_EVENT_LIMIT = 24;
+const CONVERSATION_TIMELINE_CONVERSATION_LIMIT = 80;
 const POST_POLL_INTERVAL_MS = 5000;
 const CAPTURE_MESSAGE_TIMEOUT_MS = 15000;
 const BACKFILL_PAGE_REQUEST_TIMEOUT_MS = 58000;
@@ -455,6 +458,35 @@ async function updateSessionLedger({ provider, providerSessionId, patch }) {
   return next;
 }
 
+async function appendConversationTimeline({ provider, providerSessionId, event, reason = null, detail = null, tabId = null }) {
+  if (!provider || !providerSessionId) return null;
+  const stored = await chrome.storage.local.get({ [CONVERSATION_TIMELINE_KEY]: {} });
+  const timelines = stored[CONVERSATION_TIMELINE_KEY] && typeof stored[CONVERSATION_TIMELINE_KEY] === "object"
+    ? stored[CONVERSATION_TIMELINE_KEY]
+    : {};
+  const key = sessionKey(provider, providerSessionId);
+  const entry = {
+    at: new Date().toISOString(),
+    event,
+    reason,
+    detail,
+    tab_id: tabId,
+  };
+  const next = {
+    ...timelines,
+    [key]: [entry, ...(Array.isArray(timelines[key]) ? timelines[key] : [])].slice(0, CONVERSATION_TIMELINE_EVENT_LIMIT),
+  };
+  const keys = Object.keys(next);
+  if (keys.length > CONVERSATION_TIMELINE_CONVERSATION_LIMIT) {
+    keys
+      .sort((left, right) => Date.parse(next[left]?.[0]?.at || "") - Date.parse(next[right]?.[0]?.at || ""))
+      .slice(0, keys.length - CONVERSATION_TIMELINE_CONVERSATION_LIMIT)
+      .forEach((oldKey) => delete next[oldKey]);
+  }
+  await chrome.storage.local.set({ [CONVERSATION_TIMELINE_KEY]: next });
+  return entry;
+}
+
 function badgeForState(state) {
   if (cachedQueueLength > 0) {
     return { text: cachedQueueLength > 99 ? "99+" : String(cachedQueueLength), color: "#9a5b00" };
@@ -774,6 +806,8 @@ async function captureTab(tab, reason = "background") {
       const envelopeSession = resultWithTimeout.envelope?.session || {};
       const provider = resultWithTimeout.captureResult?.provider || envelopeSession.provider;
       const providerSessionId = resultWithTimeout.captureResult?.provider_session_id || envelopeSession.provider_session_id;
+      const timelineProvider = archiveProviderForUrl(tab.url || tab.pendingUrl || "") || provider;
+      const timelineSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "") || providerSessionId;
       await updateSessionLedger({
         provider,
         providerSessionId,
@@ -800,9 +834,20 @@ async function captureTab(tab, reason = "background") {
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
       });
+      await appendConversationTimeline({
+        provider: timelineProvider,
+        providerSessionId: timelineSessionId,
+        event: "captured",
+        reason,
+        detail: resultWithTimeout.archiveState?.state || "capture_accepted",
+        tabId: tab.id,
+      });
       await setState({
         online: true,
         captured: true,
+        active_page_state: "conversation",
+        active_tab_id: tab.id,
+        passive_reason: reason,
         last_capture: resultWithTimeout.captureResult || resultWithTimeout,
         archive_state: resultWithTimeout.archiveState || null,
         provider,
@@ -823,6 +868,17 @@ async function captureTab(tab, reason = "background") {
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
       });
+    } else {
+      const provider = archiveProviderForUrl(tab.url || tab.pendingUrl || "");
+      const providerSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "");
+      await appendConversationTimeline({
+        provider,
+        providerSessionId,
+        event: "held_with_reason",
+        reason,
+        detail: "capture_not_confirmed",
+        tabId: tab.id,
+      });
     }
     return resultWithTimeout;
   } catch (error) {
@@ -839,6 +895,14 @@ async function captureTab(tab, reason = "background") {
       reason,
       tab_id: tab.id,
       error: String(error.message || error),
+    });
+    await appendConversationTimeline({
+      provider: archiveProviderForUrl(tab.url || tab.pendingUrl || ""),
+      providerSessionId: conversationIdForUrl(tab.url || tab.pendingUrl || ""),
+      event: "held_with_reason",
+      reason,
+      detail: String(error.message || error),
+      tabId: tab.id,
     });
     return { ok: false, error: String(error.message || error) };
   }
@@ -947,6 +1011,27 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
         passive_reason: reason,
         last_receiver_request_id: state.receiver_request_id || null,
       });
+      if (state.state === "missing") {
+        await appendConversationTimeline({
+          provider,
+          providerSessionId,
+          event: "detected_new",
+          reason,
+          detail: "archive_state_missing",
+          tabId: tab?.id || null,
+        });
+        const captureResult = await captureTab(tab, "auto_capture_missing");
+        if (!captureResult || captureResult.skipped) {
+          await appendConversationTimeline({
+            provider,
+            providerSessionId,
+            event: "held_with_reason",
+            reason: "auto_capture_missing",
+            detail: captureResult?.reason || "capture_not_available",
+            tabId: tab?.id || null,
+          });
+        }
+      }
       return;
     }
 

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -238,11 +238,13 @@ function isRetryableCaptureError(error) {
   return true;
 }
 
-async function enqueueCaptureForRetry({ envelope, reason, error }) {
+async function enqueueCaptureForRetry({ envelope, reason, error, tab = null }) {
   const entry = {
     id: buildReceiverRequestId(),
     envelope,
     reason: reason || "content_script_capture",
+    tab_id: tab?.id || null,
+    tab_url: tab?.url || tab?.pendingUrl || null,
     enqueued_at: new Date().toISOString(),
     attempts: 0,
     next_attempt_at: new Date(Date.now() + retryDelayForAttempt(0)).toISOString(),
@@ -301,6 +303,7 @@ async function drainCaptureQueue(trigger = "alarm") {
     try {
       const result = await postJson("/v1/browser-captures", envelope);
       drained += 1;
+      const archiveState = { state: result.state || "spooled_only" };
       await updateSessionLedger({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,
@@ -313,6 +316,7 @@ async function drainCaptureQueue(trigger = "alarm") {
           artifact_ref: result.artifact_ref || null,
           extension_instance_id: result.capture_instance_id || null,
           deduplicated: Boolean(result.deduplicated),
+          archive_state: archiveState,
           last_error: null,
         },
       });
@@ -327,7 +331,6 @@ async function drainCaptureQueue(trigger = "alarm") {
         queued_id: entry.id,
         attempts: entry.attempts,
       });
-      const archiveState = { state: result.state || "spooled_only" };
       await appendConversationTimeline({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,
@@ -335,7 +338,7 @@ async function drainCaptureQueue(trigger = "alarm") {
         reason: "capture_retry_drained",
         detail: archiveState.state,
       });
-      await setState({
+      if (entry.tab_id) await setStateForTab(entry.tab_id, {
         online: true,
         captured: true,
         last_capture: result,
@@ -533,8 +536,21 @@ async function setState(state) {
 async function setStateForTab(tabId, state) {
   if (!tabId || !chrome.tabs?.query) return setState(state);
   const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!activeTab || activeTab.id === tabId) return setState(state);
-  return null;
+  if (!activeTab || activeTab.id !== tabId) return null;
+  const expectedProvider = state.provider || null;
+  const expectedSessionId = state.provider_session_id || null;
+  const activeProvider = archiveProviderForUrl(activeTab.url || activeTab.pendingUrl || "");
+  const activeSessionId = conversationIdForUrl(activeTab.url || activeTab.pendingUrl || "");
+  if (
+    expectedProvider
+    && expectedSessionId
+    && activeSessionId
+    && (
+      activeProvider !== expectedProvider
+      || activeSessionId !== expectedSessionId
+    )
+  ) return null;
+  return setState(state);
 }
 
 function buildReceiverRequestId() {
@@ -835,6 +851,8 @@ async function captureTab(tab, reason = "background") {
       const envelopeSession = resultWithTimeout.envelope?.session || {};
       const provider = resultWithTimeout.captureResult?.provider || envelopeSession.provider;
       const providerSessionId = resultWithTimeout.captureResult?.provider_session_id || envelopeSession.provider_session_id;
+      const pageProvider = archiveProviderForUrl(tab.url || tab.pendingUrl || "") || provider;
+      const pageSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "") || providerSessionId;
       await updateSessionLedger({
         provider,
         providerSessionId,
@@ -855,8 +873,8 @@ async function captureTab(tab, reason = "background") {
       await appendCaptureLog({
         ok: true,
         reason,
-        provider,
-        provider_session_id: providerSessionId,
+        provider: pageProvider,
+        provider_session_id: pageSessionId,
         tab_id: tab.id,
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
@@ -869,8 +887,8 @@ async function captureTab(tab, reason = "background") {
         passive_reason: reason,
         last_capture: resultWithTimeout.captureResult || resultWithTimeout,
         archive_state: resultWithTimeout.archiveState || null,
-        provider,
-        provider_session_id: providerSessionId,
+        provider: pageProvider,
+        provider_session_id: pageSessionId,
         capture_mode: envelopeSession.provider_meta?.capture_fidelity || null,
         asset_acquisition: envelopeSession.provider_meta?.asset_acquisition || null,
         turn_count: Array.isArray(envelopeSession.turns) ? envelopeSession.turns.length : null,
@@ -1305,7 +1323,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         result = await postJson("/v1/browser-captures", envelope);
       } catch (error) {
         if (isRetryableCaptureError(error)) {
-          await enqueueCaptureForRetry({ envelope, reason: message.reason, error });
+          await enqueueCaptureForRetry({ envelope, reason: message.reason, error, tab: sender.tab });
           await appendConversationTimeline({
             provider: summary.provider,
             providerSessionId: summary.providerSessionId,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -494,9 +494,9 @@ function badgeForState(state) {
   }
   if (!state.online) return { text: "off", color: "#9b2c2c" };
   const archiveState = state.archive_state?.state;
-  if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
   if (archiveState === "failed" || state.error) return { text: "err", color: "#ad2f2f" };
   if (archiveState === "spooled_only" || archiveState === "ingest_pending") return { text: "…", color: "#9a5b00" };
+  if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
   if (state.capture_mode === "dom_degraded") return { text: "dom", color: "#8a5a00" };
   return { text: "on", color: "#325d8f" };
 }
@@ -1235,7 +1235,7 @@ chrome.tabs?.onUpdated?.addListener((tabId, changeInfo, tab) => {
   })();
 });
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   (async () => {
     if (message.type === "polylogue.configureReceiver") {
       const settings = await saveReceiverSettings(message.receiverBaseUrl || DEFAULT_RECEIVER, message.receiverAuthToken || "");
@@ -1320,10 +1320,20 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         receiver_request_id: result.receiver_request_id || null,
         artifact_ref: result.artifact_ref || null,
       });
+      const archiveState = result.state ? { state: result.state } : null;
+      await appendConversationTimeline({
+        provider: summary.provider || result.provider,
+        providerSessionId: summary.providerSessionId || result.provider_session_id,
+        event: "captured",
+        reason: message.reason || "content_script_capture",
+        detail: result.state || "capture_accepted",
+        tabId: sender.tab?.id || null,
+      });
       await setState({
         online: true,
         captured: true,
         last_capture: result,
+        archive_state: archiveState,
         provider: summary.provider || result.provider,
         provider_session_id: summary.providerSessionId || result.provider_session_id,
         capture_mode: summary.captureMode,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -515,7 +515,7 @@ function badgeForState(state) {
   if (!state.online) return { text: "off", color: "#9b2c2c" };
   const archiveState = state.archive_state?.state;
   if (archiveState === "failed" || state.error) return { text: "err", color: "#ad2f2f" };
-  if (archiveState === "spooled_only" || archiveState === "ingest_pending") return { text: "…", color: "#9a5b00" };
+  if (["spooled_only", "ingest_pending", "stale"].includes(archiveState)) return { text: "…", color: "#9a5b00" };
   if (archiveState === "missing") return { text: "on", color: "#325d8f" };
   if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
   if (state.capture_mode === "dom_degraded") return { text: "dom", color: "#8a5a00" };
@@ -1420,6 +1420,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         provider: message.provider,
         provider_session_id: message.provider_session_id,
         last_receiver_request_id: state.receiver_request_id || null
+      });
+      await updateSessionLedger({
+        provider: message.provider,
+        providerSessionId: message.provider_session_id,
+        patch: {
+          archive_state: state,
+          tab_id: sender.tab?.id || null,
+          tab_url: sender.tab?.url || null,
+          last_error: null,
+        },
       });
       sendResponse(state);
       return;

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -320,10 +320,19 @@ async function drainCaptureQueue(trigger = "alarm") {
         queued_id: entry.id,
         attempts: entry.attempts,
       });
+      const archiveState = result.state ? { state: result.state } : null;
+      await appendConversationTimeline({
+        provider: summary.provider || result.provider,
+        providerSessionId: summary.providerSessionId || result.provider_session_id,
+        event: "captured",
+        reason: "capture_retry_drained",
+        detail: result.state || "capture_accepted",
+      });
       await setState({
         online: true,
         captured: true,
         last_capture: result,
+        archive_state: archiveState,
         provider: summary.provider || result.provider,
         provider_session_id: summary.providerSessionId || result.provider_session_id,
         capture_mode: summary.captureMode,
@@ -1278,6 +1287,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       } catch (error) {
         if (isRetryableCaptureError(error)) {
           await enqueueCaptureForRetry({ envelope, reason: message.reason, error });
+          await appendConversationTimeline({
+            provider: summary.provider,
+            providerSessionId: summary.providerSessionId,
+            event: "held_with_reason",
+            reason: message.reason || "content_script_capture",
+            detail: "capture_queued_for_retry",
+            tabId: sender.tab?.id || null,
+          });
           await setState({
             online: false,
             captured: false,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -352,7 +352,7 @@ async function drainCaptureQueue(trigger = "alarm") {
         extension_instance_id: result.capture_instance_id || null,
         deduplicated: Boolean(result.deduplicated),
         last_receiver_request_id: result.receiver_request_id || null,
-      });
+      }, entry.tab_url);
     } catch (error) {
       const attempts = entry.attempts + 1;
       remaining.push({
@@ -533,14 +533,16 @@ async function setState(state) {
   await chrome.action.setBadgeBackgroundColor({ color: badge.color });
 }
 
-async function setStateForTab(tabId, state) {
+async function setStateForTab(tabId, state, expectedTabUrl = null) {
   if (!tabId || !chrome.tabs?.query) return setState(state);
   const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!activeTab || activeTab.id !== tabId) return null;
+  const activeUrl = activeTab.url || activeTab.pendingUrl || "";
+  if (expectedTabUrl && activeUrl && activeUrl !== expectedTabUrl) return null;
   const expectedProvider = state.provider || null;
   const expectedSessionId = state.provider_session_id || null;
-  const activeProvider = archiveProviderForUrl(activeTab.url || activeTab.pendingUrl || "");
-  const activeSessionId = conversationIdForUrl(activeTab.url || activeTab.pendingUrl || "");
+  const activeProvider = archiveProviderForUrl(activeUrl);
+  const activeSessionId = conversationIdForUrl(activeUrl);
   if (
     expectedProvider
     && expectedSessionId
@@ -894,7 +896,7 @@ async function captureTab(tab, reason = "background") {
         turn_count: Array.isArray(envelopeSession.turns) ? envelopeSession.turns.length : null,
         last_receiver_request_id:
           resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null
-      });
+      }, tab.url || tab.pendingUrl || null);
       await appendDebugLog({
         stage: "capture_result",
         ok: true,
@@ -1056,7 +1058,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
         active_tab_id: tab?.id || null,
         passive_reason: reason,
         last_receiver_request_id: state.receiver_request_id || null,
-      });
+      }, url);
       await updateSessionLedger({
         provider,
         providerSessionId,
@@ -1102,7 +1104,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
       active_tab_id: tab?.id || null,
       passive_reason: reason,
       last_receiver_request_id: status.receiver_request_id || null,
-    });
+    }, url);
   } catch (error) {
     await setStateForTab(tab?.id || null, {
       online: false,
@@ -1114,7 +1116,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
       passive_reason: reason,
       error: String(error.message || error),
       last_receiver_request_id: error.receiverRequestId || null,
-    });
+    }, url);
   }
 }
 
@@ -1339,7 +1341,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             provider_session_id: summary.providerSessionId,
             error: String(error.message || error),
             last_receiver_request_id: error.receiverRequestId || null,
-          });
+          }, sender.tab?.url || sender.tab?.pendingUrl || null);
           sendResponse({
             ok: false,
             queued: true,
@@ -1397,7 +1399,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         extension_instance_id: result.capture_instance_id || null,
         deduplicated: Boolean(result.deduplicated),
         last_receiver_request_id: result.receiver_request_id || null
-      });
+      }, sender.tab?.url || sender.tab?.pendingUrl || null);
       // Receiver just proved reachable — flush anything queued from earlier
       // outages before returning this capture's result.
       void drainCaptureQueue("post_success");
@@ -1457,7 +1459,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         provider: message.provider,
         provider_session_id: message.provider_session_id,
         last_receiver_request_id: state.receiver_request_id || null
-      });
+      }, sender.tab?.url || sender.tab?.pendingUrl || null);
       await updateSessionLedger({
         provider: message.provider,
         providerSessionId: message.provider_session_id,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -269,12 +269,14 @@ async function enqueueCaptureForRetry({ envelope, reason, error, tab = null }) {
       reason: "capture_queue_entry_over_budget",
       error: entry.last_error,
     });
-    return getCaptureQueue();
+    return { queue: await getCaptureQueue(), accepted: false, evicted: [entry] };
   }
   const queue = await getCaptureQueue();
   let entries = [...queue.entries, entry];
   let droppedCount = queue.dropped_count || 0;
+  const evicted = [];
   while (entries.length > CAPTURE_QUEUE_MAX_ENTRIES || byteLength(entries) > CAPTURE_QUEUE_MAX_BYTES) {
+    evicted.push(entries[0]);
     entries = entries.slice(1);
     droppedCount += 1;
   }
@@ -288,7 +290,7 @@ async function enqueueCaptureForRetry({ envelope, reason, error, tab = null }) {
     error: entry.last_error,
     queue_length: entries.length,
   });
-  return nextQueue;
+  return { queue: nextQueue, accepted: true, evicted };
   });
 }
 
@@ -1066,6 +1068,7 @@ function conversationIdForUrl(url) {
       if (pathId) return pathId;
       const queryId = parsed.searchParams.get("conversation") || parsed.searchParams.get("conversationId");
       if (queryId) return queryId;
+      if (!(parts[0] === "i" && parts[1] === "grok")) return null;
       let hash = 0x811c9dc5;
       for (const char of `${parsed.origin}${parsed.pathname}${parsed.search}`) {
         hash ^= char.charCodeAt(0);
@@ -1391,13 +1394,24 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         result = await postJson("/v1/browser-captures", envelope);
       } catch (error) {
         if (isRetryableCaptureError(error)) {
-          await enqueueCaptureForRetry({ envelope, reason: message.reason, error, tab: sender.tab });
+          const queued = await enqueueCaptureForRetry({ envelope, reason: message.reason, error, tab: sender.tab });
+          for (const evicted of queued.accepted ? queued.evicted : []) {
+            const evictedSummary = envelopeSessionSummary(evicted.envelope);
+            await appendConversationTimeline({
+              provider: evictedSummary.provider,
+              providerSessionId: evictedSummary.providerSessionId,
+              event: "held_with_reason",
+              reason: evicted.reason,
+              detail: queued.accepted ? "capture_queue_evicted" : "capture_queue_entry_over_budget",
+              tabId: evicted.tab_id || null,
+            });
+          }
           await appendConversationTimeline({
             provider: summary.provider,
             providerSessionId: summary.providerSessionId,
             event: "held_with_reason",
             reason: message.reason || "content_script_capture",
-            detail: "capture_queued_for_retry",
+            detail: queued.accepted ? "capture_queued_for_retry" : "capture_queue_entry_over_budget",
             tabId: sender.tab?.id || null,
           });
           await setStateForTab(sender.tab?.id || null, {
@@ -1410,7 +1424,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }, sender.tab?.url || sender.tab?.pendingUrl || null);
           sendResponse({
             ok: false,
-            queued: true,
+            queued: queued.accepted,
             error: String(error.message || error),
             receiver_request_id: error.receiverRequestId || null,
           });
@@ -1566,6 +1580,30 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return;
       }
       sendResponse(state.archive_state || state.status || state);
+      return;
+    }
+    if (message.type === "polylogue.capturePageFailed") {
+      const tab = sender.tab || (message.tab_url ? { id: message.tab_id || null, url: message.tab_url } : null);
+      const url = tab?.url || tab?.pendingUrl || "";
+      const provider = archiveProviderForUrl(url);
+      const providerSessionId = conversationIdForUrl(url);
+      await appendConversationTimeline({
+        provider,
+        providerSessionId,
+        event: "held_with_reason",
+        reason: "popup_capture",
+        detail: "content_capture_failed",
+        tabId: tab?.id || null,
+      });
+      await setStateForTab(tab?.id || null, {
+        online: true,
+        captured: false,
+        provider,
+        provider_session_id: providerSessionId,
+        active_page_state: providerSessionId ? "conversation" : "supported_no_session",
+        error: message.error || "capture_page_failed",
+      }, url || null);
+      sendResponse({ ok: false });
       return;
     }
     if (message.type === "polylogue.captureSupportedTabs") {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1106,6 +1106,14 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
       last_receiver_request_id: status.receiver_request_id || null,
     }, url);
   } catch (error) {
+    await appendConversationTimeline({
+      provider,
+      providerSessionId,
+      event: "held_with_reason",
+      reason,
+      detail: "archive_state_check_failed",
+      tabId: tab?.id || null,
+    });
     await setStateForTab(tab?.id || null, {
       online: false,
       captured: false,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -458,13 +458,14 @@ async function updateSessionLedger({ provider, providerSessionId, patch }) {
   return next;
 }
 
-async function appendConversationTimeline({ provider, providerSessionId, event, reason = null, detail = null, tabId = null }) {
+async function appendConversationTimeline({ provider, providerSessionId, event, reason = null, detail = null, tabId = null, onlyIfEmpty = false }) {
   if (!provider || !providerSessionId) return null;
   const stored = await chrome.storage.local.get({ [CONVERSATION_TIMELINE_KEY]: {} });
   const timelines = stored[CONVERSATION_TIMELINE_KEY] && typeof stored[CONVERSATION_TIMELINE_KEY] === "object"
     ? stored[CONVERSATION_TIMELINE_KEY]
     : {};
   const key = sessionKey(provider, providerSessionId);
+  if (onlyIfEmpty && Array.isArray(timelines[key]) && timelines[key].length) return null;
   const entry = {
     at: new Date().toISOString(),
     event,
@@ -1000,6 +1001,15 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
     if (provider && providerSessionId) {
       const query = new URLSearchParams({ provider, provider_session_id: providerSessionId });
       const state = await getJson(`/v1/archive-state?${query.toString()}`);
+      await appendConversationTimeline({
+        provider,
+        providerSessionId,
+        event: "first_seen",
+        reason,
+        detail: "archive_state_checked",
+        tabId: tab?.id || null,
+        onlyIfEmpty: true,
+      });
       await setState({
         online: true,
         captured: Boolean(state.captured),

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -918,7 +918,7 @@ async function captureTab(tab, reason = "background", expectedConversation = nul
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
       });
-    } else {
+    } else if (!resultWithTimeout?.timelineRecorded) {
       const provider = archiveProviderForUrl(tab.url || tab.pendingUrl || "");
       const providerSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "");
       await appendConversationTimeline({
@@ -1382,6 +1382,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           });
           return;
         }
+        await updateSessionLedger({
+          provider: summary.provider,
+          providerSessionId: summary.providerSessionId,
+          patch: { last_error: String(error.message || error) },
+        });
+        await appendConversationTimeline({
+          provider: summary.provider,
+          providerSessionId: summary.providerSessionId,
+          event: "held_with_reason",
+          reason: message.reason || "content_script_capture",
+          detail: "capture_rejected",
+          tabId: sender.tab?.id || null,
+        });
         throw error;
       }
       const archiveState = { state: result.state || "spooled_only" };
@@ -1436,7 +1449,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       // Receiver just proved reachable — flush anything queued from earlier
       // outages before returning this capture's result.
       void drainCaptureQueue("post_success");
-      sendResponse(result);
+      sendResponse({ ok: true, ...result });
       return;
     }
     if (message.type === "polylogue.getCaptureQueue") {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -26,6 +26,13 @@ const pendingPostCommandAcks = new Map();
 let postPollTimer = 0;
 let backfillCoordinatorPromise = null;
 let extensionInstanceIdPromise = null;
+let storageMutationQueue = Promise.resolve();
+
+function serializeStorageMutation(mutation) {
+  const result = storageMutationQueue.then(mutation, mutation);
+  storageMutationQueue = result.then(() => undefined, () => undefined);
+  return result;
+}
 
 function extensionInstanceId() {
   if (!extensionInstanceIdPromise) {
@@ -450,51 +457,55 @@ async function appendDebugLog(entry) {
 
 async function updateSessionLedger({ provider, providerSessionId, patch }) {
   if (!provider || !providerSessionId) return null;
-  const stored = await chrome.storage.local.get({ polylogueSessionLedger: {} });
-  const ledger =
-    stored.polylogueSessionLedger && typeof stored.polylogueSessionLedger === "object"
-      ? stored.polylogueSessionLedger
-      : {};
-  const key = sessionKey(provider, providerSessionId);
-  const next = {
-    ...(ledger[key] || {}),
-    provider,
-    provider_session_id: providerSessionId,
-    updated_at: new Date().toISOString(),
-    ...patch,
-  };
-  await chrome.storage.local.set({ polylogueSessionLedger: { ...ledger, [key]: next } });
-  return next;
+  return serializeStorageMutation(async () => {
+    const stored = await chrome.storage.local.get({ polylogueSessionLedger: {} });
+    const ledger =
+      stored.polylogueSessionLedger && typeof stored.polylogueSessionLedger === "object"
+        ? stored.polylogueSessionLedger
+        : {};
+    const key = sessionKey(provider, providerSessionId);
+    const next = {
+      ...(ledger[key] || {}),
+      provider,
+      provider_session_id: providerSessionId,
+      updated_at: new Date().toISOString(),
+      ...patch,
+    };
+    await chrome.storage.local.set({ polylogueSessionLedger: { ...ledger, [key]: next } });
+    return next;
+  });
 }
 
 async function appendConversationTimeline({ provider, providerSessionId, event, reason = null, detail = null, tabId = null, onlyIfEmpty = false }) {
   if (!provider || !providerSessionId) return null;
-  const stored = await chrome.storage.local.get({ [CONVERSATION_TIMELINE_KEY]: {} });
-  const timelines = stored[CONVERSATION_TIMELINE_KEY] && typeof stored[CONVERSATION_TIMELINE_KEY] === "object"
-    ? stored[CONVERSATION_TIMELINE_KEY]
-    : {};
-  const key = sessionKey(provider, providerSessionId);
-  if (onlyIfEmpty && Array.isArray(timelines[key]) && timelines[key].length) return null;
-  const entry = {
-    at: new Date().toISOString(),
-    event,
-    reason,
-    detail,
-    tab_id: tabId,
-  };
-  const next = {
-    ...timelines,
-    [key]: [entry, ...(Array.isArray(timelines[key]) ? timelines[key] : [])].slice(0, CONVERSATION_TIMELINE_EVENT_LIMIT),
-  };
-  const keys = Object.keys(next);
-  if (keys.length > CONVERSATION_TIMELINE_CONVERSATION_LIMIT) {
-    keys
-      .sort((left, right) => Date.parse(next[left]?.[0]?.at || "") - Date.parse(next[right]?.[0]?.at || ""))
-      .slice(0, keys.length - CONVERSATION_TIMELINE_CONVERSATION_LIMIT)
-      .forEach((oldKey) => delete next[oldKey]);
-  }
-  await chrome.storage.local.set({ [CONVERSATION_TIMELINE_KEY]: next });
-  return entry;
+  return serializeStorageMutation(async () => {
+    const stored = await chrome.storage.local.get({ [CONVERSATION_TIMELINE_KEY]: {} });
+    const timelines = stored[CONVERSATION_TIMELINE_KEY] && typeof stored[CONVERSATION_TIMELINE_KEY] === "object"
+      ? stored[CONVERSATION_TIMELINE_KEY]
+      : {};
+    const key = sessionKey(provider, providerSessionId);
+    if (onlyIfEmpty && Array.isArray(timelines[key]) && timelines[key].length) return null;
+    const entry = {
+      at: new Date().toISOString(),
+      event,
+      reason,
+      detail,
+      tab_id: tabId,
+    };
+    const next = {
+      ...timelines,
+      [key]: [entry, ...(Array.isArray(timelines[key]) ? timelines[key] : [])].slice(0, CONVERSATION_TIMELINE_EVENT_LIMIT),
+    };
+    const keys = Object.keys(next);
+    if (keys.length > CONVERSATION_TIMELINE_CONVERSATION_LIMIT) {
+      keys
+        .sort((left, right) => Date.parse(next[left]?.[0]?.at || "") - Date.parse(next[right]?.[0]?.at || ""))
+        .slice(0, keys.length - CONVERSATION_TIMELINE_CONVERSATION_LIMIT)
+        .forEach((oldKey) => delete next[oldKey]);
+    }
+    await chrome.storage.local.set({ [CONVERSATION_TIMELINE_KEY]: next });
+    return entry;
+  });
 }
 
 function badgeForState(state) {
@@ -505,6 +516,7 @@ function badgeForState(state) {
   const archiveState = state.archive_state?.state;
   if (archiveState === "failed" || state.error) return { text: "err", color: "#ad2f2f" };
   if (archiveState === "spooled_only" || archiveState === "ingest_pending") return { text: "…", color: "#9a5b00" };
+  if (archiveState === "missing") return { text: "on", color: "#325d8f" };
   if (archiveState === "archived" || state.captured) return { text: "ok", color: "#14764e" };
   if (state.capture_mode === "dom_degraded") return { text: "dom", color: "#8a5a00" };
   return { text: "on", color: "#325d8f" };
@@ -816,8 +828,6 @@ async function captureTab(tab, reason = "background") {
       const envelopeSession = resultWithTimeout.envelope?.session || {};
       const provider = resultWithTimeout.captureResult?.provider || envelopeSession.provider;
       const providerSessionId = resultWithTimeout.captureResult?.provider_session_id || envelopeSession.provider_session_id;
-      const timelineProvider = archiveProviderForUrl(tab.url || tab.pendingUrl || "") || provider;
-      const timelineSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "") || providerSessionId;
       await updateSessionLedger({
         provider,
         providerSessionId,
@@ -843,14 +853,6 @@ async function captureTab(tab, reason = "background") {
         tab_id: tab.id,
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
-      });
-      await appendConversationTimeline({
-        provider: timelineProvider,
-        providerSessionId: timelineSessionId,
-        event: "captured",
-        reason,
-        detail: resultWithTimeout.archiveState?.state || "capture_accepted",
-        tabId: tab.id,
       });
       await setState({
         online: true,
@@ -1029,6 +1031,16 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
         active_tab_id: tab?.id || null,
         passive_reason: reason,
         last_receiver_request_id: state.receiver_request_id || null,
+      });
+      await updateSessionLedger({
+        provider,
+        providerSessionId,
+        patch: {
+          archive_state: state,
+          tab_id: tab?.id || null,
+          tab_url: url || null,
+          last_error: null,
+        },
       });
       if (state.state === "missing") {
         await appendConversationTimeline({
@@ -1413,14 +1425,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return;
     }
     if (message.type === "polylogue.status") {
-      const status = await getJson("/v1/status");
-      await setState({
-        online: true,
-        captured: false,
-        status,
-        last_receiver_request_id: status.receiver_request_id || null
-      });
-      sendResponse(status);
+      await refreshCurrentActiveTab(message.reason || "status");
+      const stored = await chrome.storage.local.get({ polylogueState: null });
+      const state = stored.polylogueState || {};
+      if (!state.online) {
+        sendResponse({
+          ok: false,
+          error: state.error || "receiver_unavailable",
+          receiver_request_id: state.last_receiver_request_id || null,
+        });
+        return;
+      }
+      sendResponse(state.archive_state || state.status || state);
       return;
     }
     if (message.type === "polylogue.captureSupportedTabs") {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -27,10 +27,17 @@ let postPollTimer = 0;
 let backfillCoordinatorPromise = null;
 let extensionInstanceIdPromise = null;
 let storageMutationQueue = Promise.resolve();
+let captureQueueMutationQueue = Promise.resolve();
 
 function serializeStorageMutation(mutation) {
   const result = storageMutationQueue.then(mutation, mutation);
   storageMutationQueue = result.then(() => undefined, () => undefined);
+  return result;
+}
+
+function serializeCaptureQueueMutation(mutation) {
+  const result = captureQueueMutationQueue.then(mutation, mutation);
+  captureQueueMutationQueue = result.then(() => undefined, () => undefined);
   return result;
 }
 
@@ -239,6 +246,7 @@ function isRetryableCaptureError(error) {
 }
 
 async function enqueueCaptureForRetry({ envelope, reason, error, tab = null }) {
+  return serializeCaptureQueueMutation(async () => {
   const entry = {
     id: buildReceiverRequestId(),
     envelope,
@@ -281,9 +289,11 @@ async function enqueueCaptureForRetry({ envelope, reason, error, tab = null }) {
     queue_length: entries.length,
   });
   return nextQueue;
+  });
 }
 
 async function drainCaptureQueue(trigger = "alarm") {
+  return serializeCaptureQueueMutation(async () => {
   const queue = await getCaptureQueue();
   if (!queue.entries.length) {
     await clearRetryAlarm();
@@ -354,6 +364,29 @@ async function drainCaptureQueue(trigger = "alarm") {
         last_receiver_request_id: result.receiver_request_id || null,
       }, entry.tab_url);
     } catch (error) {
+      if (!isRetryableCaptureError(error)) {
+        await updateSessionLedger({
+          provider: summary.provider,
+          providerSessionId: summary.providerSessionId,
+          patch: { last_error: String(error.message || error) },
+        });
+        await appendCaptureLog({
+          ok: false,
+          reason: "capture_retry_rejected",
+          queued_id: entry.id,
+          attempts: entry.attempts,
+          error: String(error.message || error),
+        });
+        await appendConversationTimeline({
+          provider: summary.provider,
+          providerSessionId: summary.providerSessionId,
+          event: "held_with_reason",
+          reason: "capture_retry_drained",
+          detail: "capture_rejected",
+          tabId: entry.tab_id || null,
+        });
+        continue;
+      }
       const attempts = entry.attempts + 1;
       remaining.push({
         ...entry,
@@ -378,6 +411,7 @@ async function drainCaptureQueue(trigger = "alarm") {
     await appendDebugLog({ stage: "capture_retry_drain", drained, remaining: remaining.length });
   }
   return { drained, remaining: remaining.length };
+  });
 }
 
 async function loadCaptureQueueIntoCache() {
@@ -1563,12 +1597,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       receiver_request_id: error.receiverRequestId || null,
       error: String(error.message || error),
     });
-    await setState({
+    const captureSummary = message.type === "polylogue.capture"
+      ? envelopeSessionSummary(message.envelope)
+      : null;
+    await setStateForTab(sender.tab?.id || null, {
       online: false,
       captured: false,
       error: String(error.message || error),
-      last_receiver_request_id: error.receiverRequestId || null
-    });
+      provider: captureSummary?.provider || null,
+      provider_session_id: captureSummary?.providerSessionId || null,
+      last_receiver_request_id: error.receiverRequestId || null,
+    }, sender.tab?.url || sender.tab?.pendingUrl || null);
     sendResponse({
       ok: false,
       error: String(error.message || error),

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1352,6 +1352,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
         throw error;
       }
+      const archiveState = { state: result.state || "spooled_only" };
       await updateSessionLedger({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,
@@ -1364,6 +1365,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           artifact_ref: result.artifact_ref || null,
           extension_instance_id: result.capture_instance_id || null,
           deduplicated: Boolean(result.deduplicated),
+          archive_state: archiveState,
           last_error: null,
         },
       });
@@ -1376,7 +1378,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         receiver_request_id: result.receiver_request_id || null,
         artifact_ref: result.artifact_ref || null,
       });
-      const archiveState = { state: result.state || "spooled_only" };
       await appendConversationTimeline({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -327,13 +327,13 @@ async function drainCaptureQueue(trigger = "alarm") {
         queued_id: entry.id,
         attempts: entry.attempts,
       });
-      const archiveState = result.state ? { state: result.state } : null;
+      const archiveState = { state: result.state || "spooled_only" };
       await appendConversationTimeline({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,
         event: "captured",
         reason: "capture_retry_drained",
-        detail: result.state || "capture_accepted",
+        detail: archiveState.state,
       });
       await setState({
         online: true,
@@ -528,6 +528,13 @@ async function setState(state) {
   const badge = badgeForState(nextState);
   await chrome.action.setBadgeText({ text: badge.text });
   await chrome.action.setBadgeBackgroundColor({ color: badge.color });
+}
+
+async function setStateForTab(tabId, state) {
+  if (!tabId || !chrome.tabs?.query) return setState(state);
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!activeTab || activeTab.id === tabId) return setState(state);
+  return null;
 }
 
 function buildReceiverRequestId() {
@@ -854,7 +861,7 @@ async function captureTab(tab, reason = "background") {
         archive_state: resultWithTimeout.archiveState?.state || null,
         receiver_request_id: resultWithTimeout.captureResult?.receiver_request_id || resultWithTimeout.archiveState?.receiver_request_id || null,
       });
-      await setState({
+      await setStateForTab(tab?.id || null, {
         online: true,
         captured: true,
         active_page_state: "conversation",
@@ -1021,7 +1028,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
         tabId: tab?.id || null,
         onlyIfEmpty: true,
       });
-      await setState({
+      await setStateForTab(tab?.id || null, {
         online: true,
         captured: Boolean(state.captured),
         archive_state: state,
@@ -1067,7 +1074,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
     }
 
     const status = await getJson("/v1/status");
-    await setState({
+    await setStateForTab(tab?.id || null, {
       online: true,
       captured: false,
       status,
@@ -1079,7 +1086,7 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state") {
       last_receiver_request_id: status.receiver_request_id || null,
     });
   } catch (error) {
-    await setState({
+    await setStateForTab(tab?.id || null, {
       online: false,
       captured: false,
       provider,
@@ -1307,7 +1314,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             detail: "capture_queued_for_retry",
             tabId: sender.tab?.id || null,
           });
-          await setState({
+          await setStateForTab(sender.tab?.id || null, {
             online: false,
             captured: false,
             provider: summary.provider,
@@ -1349,16 +1356,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         receiver_request_id: result.receiver_request_id || null,
         artifact_ref: result.artifact_ref || null,
       });
-      const archiveState = result.state ? { state: result.state } : null;
+      const archiveState = { state: result.state || "spooled_only" };
       await appendConversationTimeline({
         provider: summary.provider || result.provider,
         providerSessionId: summary.providerSessionId || result.provider_session_id,
         event: "captured",
         reason: message.reason || "content_script_capture",
-        detail: result.state || "capture_accepted",
+        detail: archiveState.state,
         tabId: sender.tab?.id || null,
       });
-      await setState({
+      await setStateForTab(sender.tab?.id || null, {
         online: true,
         captured: true,
         last_capture: result,
@@ -1413,7 +1420,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         provider_session_id: message.provider_session_id
       });
       const state = await getJson(`/v1/archive-state?${query.toString()}`);
-      await setState({
+      const stored = await chrome.storage.local.get({ polylogueState: null });
+      const previous = stored.polylogueState;
+      const sameSession = previous?.provider === message.provider
+        && previous?.provider_session_id === message.provider_session_id;
+      const preservedCaptureMetadata = sameSession ? {
+        last_capture: previous.last_capture,
+        capture_mode: previous.capture_mode,
+        asset_acquisition: previous.asset_acquisition,
+        turn_count: previous.turn_count,
+        attachment_count: previous.attachment_count,
+      } : {};
+      await setStateForTab(sender.tab?.id || null, {
+        ...preservedCaptureMetadata,
         online: true,
         captured: Boolean(state.captured),
         archive_state: state,

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -143,8 +143,10 @@
     return envelope;
   }
 
-  async function sendCapture(envelope) {
-    const response = await chrome.runtime.sendMessage({ type: "polylogue.capture", envelope });
+  async function sendCapture(envelope, reason = null) {
+    const message = { type: "polylogue.capture", envelope };
+    if (reason) message.reason = reason;
+    const response = await chrome.runtime.sendMessage(message);
     return response;
   }
 

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -619,7 +619,7 @@
     });
   }
 
-  async function capture() {
+  async function capture(reason = null) {
     const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
     let assetAcquisition = null;
     if (nativePayload) {
@@ -667,7 +667,7 @@
     };
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
-    const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope);
+    const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "chatgpt",
       finalEnvelope.session.provider_session_id
@@ -678,7 +678,7 @@
   window.polylogueCapture.capturePage = capture;
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
-    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
   // Outbound posting (reverse channel). Selectors target the ChatGPT composer

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -668,6 +668,13 @@
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
+    if (!captureResult?.ok) return {
+      ok: false,
+      envelope: finalEnvelope,
+      captureResult,
+      error: captureResult?.error || "capture_rejected",
+      timelineRecorded: true,
+    };
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "chatgpt",
       finalEnvelope.session.provider_session_id

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -212,7 +212,7 @@
     });
   }
 
-  async function capture() {
+  async function capture(reason = null) {
     const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
     const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
     const fallbackEnvelope = () => {
@@ -230,7 +230,7 @@
     };
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
-    const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope);
+    const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "claude-ai",
       finalEnvelope.session.provider_session_id
@@ -241,7 +241,7 @@
   window.polylogueCapture.capturePage = capture;
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
-    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
   // Outbound posting (reverse channel). Selectors target the Claude.ai composer

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -231,6 +231,13 @@
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
+    if (!captureResult?.ok) return {
+      ok: false,
+      envelope: finalEnvelope,
+      captureResult,
+      error: captureResult?.error || "capture_rejected",
+      timelineRecorded: true,
+    };
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "claude-ai",
       finalEnvelope.session.provider_session_id

--- a/browser-extension/src/content/grok.js
+++ b/browser-extension/src/content/grok.js
@@ -109,6 +109,13 @@
       },
     });
     const captureResult = await window.polylogueCapture.sendCapture(envelope, reason);
+    if (!captureResult?.ok) return {
+      ok: false,
+      envelope,
+      captureResult,
+      error: captureResult?.error || "capture_rejected",
+      timelineRecorded: true,
+    };
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "grok",
       envelope.session.provider_session_id,

--- a/browser-extension/src/content/grok.js
+++ b/browser-extension/src/content/grok.js
@@ -95,7 +95,7 @@
       .filter(Boolean);
   }
 
-  async function capture() {
+  async function capture(reason = null) {
     const turns = collectTurns();
     if (!turns.length) return { ok: false, error: "no_turns" };
     const envelope = window.polylogueCapture.buildEnvelope({
@@ -108,7 +108,7 @@
         native_attempts: [],
       },
     });
-    const captureResult = await window.polylogueCapture.sendCapture(envelope);
+    const captureResult = await window.polylogueCapture.sendCapture(envelope, reason);
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "grok",
       envelope.session.provider_session_id,
@@ -119,7 +119,7 @@
   window.polylogueCapture.capturePage = capture;
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
-    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
 })();

--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -1,0 +1,35 @@
+const OPERATOR_STATUS = Object.freeze({
+  safe: { label: "Safe", tone: "ok", detail: "This conversation is saved and available in Polylogue." },
+  catching_up: { label: "Catching up", tone: "warn", detail: "Polylogue has the capture and is making it queryable." },
+  needs_attention: { label: "Needs attention", tone: "warn", detail: "Polylogue needs a concrete conversation or a receiver check before it can save this page." },
+  failed: { label: "Failed", tone: "bad", detail: "The capture was rejected or could not be parsed." },
+  not_saved: { label: "Not saved", tone: "warn", detail: "This conversation has not been saved yet." },
+});
+
+function operatorStatusForState(state = {}) {
+  if (state.error === "unauthorized") {
+    return { ...OPERATOR_STATUS.needs_attention, tone: "bad" };
+  }
+  if (state.online === false) {
+    return { ...OPERATOR_STATUS.failed };
+  }
+  const archiveState = state.archive_state?.state;
+  let status;
+  if (archiveState === "archived" || state.captured) status = OPERATOR_STATUS.safe;
+  else if (["spooled_only", "ingest_pending", "stale"].includes(archiveState)) status = OPERATOR_STATUS.catching_up;
+  else if (archiveState === "failed" || state.error) status = OPERATOR_STATUS.failed;
+  else if (archiveState === "missing") status = OPERATOR_STATUS.not_saved;
+  else status = OPERATOR_STATUS.needs_attention;
+
+  return {
+    ...status,
+    partialFidelity: state.capture_mode === "dom_degraded",
+  };
+}
+
+function operatorStatusLabel(state = {}) {
+  const status = operatorStatusForState(state);
+  return status.partialFidelity ? `${status.label} · Partial fidelity` : status.label;
+}
+
+globalThis.PolylogueOperatorStatus = Object.freeze({ operatorStatusForState, operatorStatusLabel });

--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -32,4 +32,65 @@ function operatorStatusLabel(state = {}) {
   return status.partialFidelity ? `${status.label} · Partial fidelity` : status.label;
 }
 
-globalThis.PolylogueOperatorStatus = Object.freeze({ operatorStatusForState, operatorStatusLabel });
+function operatorPresentationForState(state) {
+  if (!state) return {
+    badge: ["warn", "idle"], archive: "Not checked", headline: "No receiver state yet.",
+    detail: "The popup refreshes automatically on open. If this stays idle, the service worker has not returned a status payload.",
+  };
+  if (state.active_page_state === "unsupported") return {
+    badge: ["warn", "idle"], archive: "Unsupported", headline: "This page is not a supported conversation.",
+    detail: "Open a ChatGPT, Claude.ai, or Grok/X conversation tab. The extension will update this state when the active tab changes.",
+  };
+  if (!state.online) {
+    if (state.error === "unauthorized") return {
+      badge: ["bad", "offline"], archive: "Unauthorized", headline: "Receiver requires a pairing token.",
+      detail: 'Run `polylogued browser-capture token show` and paste the value into "Receiver token" below, then Save.',
+    };
+    return {
+      badge: ["bad", "offline"], archive: "Offline", headline: "Receiver offline.",
+      detail: `Start the local receiver, then refresh. ${state.error || ""}`.trim(),
+    };
+  }
+  const archiveState = state.archive_state?.state || null;
+  if (archiveState === "failed" || state.error) return {
+    badge: ["bad", "failed"], archive: "Failed", headline: OPERATOR_STATUS.failed.detail,
+    detail: state.archive_state?.latest_failure || state.error || "Open the debug log and match the request id in the receiver log.",
+  };
+  if (archiveState === "stale") return {
+    badge: ["warn", "stale"], archive: "Stale", headline: "Receiver spool is newer than the indexed archive.",
+    detail: "The daemon has not caught up to the latest browser capture yet. Keep the daemon running; this should converge without a manual repair step.",
+  };
+  if (archiveState === "ingest_pending") return {
+    badge: ["warn", "pending"], archive: "Ingest pending", headline: "Capture reached source.db but is not queryable yet.",
+    detail: "The daemon still needs to materialize the indexed session and messages.",
+  };
+  if (archiveState === "spooled_only") return {
+    badge: ["warn", "spooled"], archive: "Spooled", headline: "Receiver wrote the capture artifact.",
+    detail: "The daemon has not acquired the spool artifact into source.db yet.",
+  };
+  if (archiveState === "missing") return {
+    badge: ["warn", "missing"], archive: "Not archived", headline: OPERATOR_STATUS.not_saved.detail,
+    detail: "Use Capture page for the active conversation. The extension checks archive state automatically when tabs activate or finish loading.",
+  };
+  if (archiveState === "archived" || state.captured) return {
+    badge: ["ok", "captured"], archive: "Archived",
+    headline: state.last_capture
+      ? `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`
+      : "The latest capture is visible in the archive.",
+    detail: "Archive evidence includes receiver spool, source raw row, indexed session, and indexed messages.",
+  };
+  if (state.capture_mode === "dom_degraded") return {
+    badge: ["warn", "dom"], archive: "DOM fallback", headline: "Captured from visible DOM, not provider-native app data.",
+    detail: "DOM fallback is useful but is not provider-native app data; it may omit branches, provider ids, timestamps, or attachments. Reload the page, wait for the conversation API response, then capture again.",
+  };
+  if (state.active_page_state === "supported_no_session") return {
+    badge: ["warn", "ready"], archive: "Ready", headline: "Supported site open, but no conversation id is visible.",
+    detail: "Open or select a concrete conversation. The extension does not read page content until Capture page or Sync open tabs is used.",
+  };
+  return {
+    badge: ["warn", "online"], archive: "Receiver online", headline: "Receiver online. Open a supported conversation to capture.",
+    detail: "Supported pages are ChatGPT, Claude.ai, and Grok/X conversation routes.",
+  };
+}
+
+globalThis.PolylogueOperatorStatus = Object.freeze({ operatorStatusForState, operatorStatusLabel, operatorPresentationForState });

--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -17,8 +17,8 @@ function operatorStatusForState(state = {}) {
   let status;
   if (archiveState === "failed" || state.error) status = OPERATOR_STATUS.failed;
   else if (["spooled_only", "ingest_pending", "stale"].includes(archiveState)) status = OPERATOR_STATUS.catching_up;
-  else if (archiveState === "archived" || state.captured) status = OPERATOR_STATUS.safe;
   else if (archiveState === "missing") status = OPERATOR_STATUS.not_saved;
+  else if (archiveState === "archived" || state.captured) status = OPERATOR_STATUS.safe;
   else status = OPERATOR_STATUS.needs_attention;
 
   return {

--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -15,9 +15,9 @@ function operatorStatusForState(state = {}) {
   }
   const archiveState = state.archive_state?.state;
   let status;
-  if (archiveState === "archived" || state.captured) status = OPERATOR_STATUS.safe;
+  if (archiveState === "failed" || state.error) status = OPERATOR_STATUS.failed;
   else if (["spooled_only", "ingest_pending", "stale"].includes(archiveState)) status = OPERATOR_STATUS.catching_up;
-  else if (archiveState === "failed" || state.error) status = OPERATOR_STATUS.failed;
+  else if (archiveState === "archived" || state.captured) status = OPERATOR_STATUS.safe;
   else if (archiveState === "missing") status = OPERATOR_STATUS.not_saved;
   else status = OPERATOR_STATUS.needs_attention;
 

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -329,6 +329,7 @@
         <p id="state-detail"></p>
         <div class="row"><span class="label">Fidelity</span><span id="fidelity" class="value">--</span></div>
         <div class="row"><span class="label">Captured / visible</span><span id="turns" class="value">--</span></div>
+        <div class="row"><span class="label">Cost / tokens</span><span id="cost-tokens" class="value">Unavailable</span></div>
         <div class="row"><span class="label">Assets</span><span id="assets" class="value">--</span></div>
         <div id="asset-failures" class="log-meta"></div>
       </section>

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -102,6 +102,33 @@
       .provider-logo.claude-ai { background: var(--claude); }
       .provider-logo.grok { background: var(--grok); }
       .provider-logo.unknown { background: var(--muted); }
+      .state-chip {
+        display: inline-flex;
+        align-items: center;
+        width: fit-content;
+        padding: 3px 8px;
+        border-radius: 999px;
+        color: #fff;
+        background: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+      }
+      .state-chip.ok { background: var(--ok); }
+      .state-chip.warn { background: var(--warn); }
+      .state-chip.bad { background: var(--bad); }
+      .tab-list { display: grid; gap: 7px; }
+      .tab-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 9px;
+        border: 1px solid var(--line);
+        border-radius: 7px;
+      }
+      .tab-item.active { border-color: var(--accent); background: #eaf1f8; }
+      .active-card { padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); }
+      #fidelity-flag { margin-left: 6px; }
       section {
         padding: 14px 0;
         border-bottom: 1px solid var(--line);
@@ -291,21 +318,22 @@
       </header>
 
       <section>
-        <div class="row"><span class="label">Page</span><span id="page" class="value provider-chip">Unknown</span></div>
-        <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
-        <div class="row"><span class="label">Archive</span><span id="archive" class="value">Not checked</span></div>
-        <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
-        <div class="row"><span class="label">Fidelity</span><span id="fidelity" class="value">--</span></div>
-        <div class="row"><span class="label">Turns</span><span id="turns" class="value">--</span></div>
-        <div class="row"><span class="label">Assets</span><span id="assets" class="value">--</span></div>
-        <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
-        <div class="row"><span class="label">Updated</span><span id="updated" class="value">--</span></div>
+        <div class="section-head"><strong>Open conversations</strong><span id="open-tab-count" class="value">0</span></div>
+        <div id="open-tabs" class="tab-list"></div>
       </section>
-      <div id="asset-failures" class="log-meta"></div>
 
-      <section>
+      <section class="active-card">
+        <div class="section-head"><strong>Active conversation</strong><span id="operator-state" class="state-chip">Checking</span></div>
+        <div class="row"><span id="page" class="value provider-chip">Unknown</span><span id="fidelity-flag" class="state-chip warn" hidden>Partial fidelity</span></div>
         <p id="state">Checking receiver...</p>
         <p id="state-detail"></p>
+        <div class="row"><span class="label">Fidelity</span><span id="fidelity" class="value">--</span></div>
+        <div class="row"><span class="label">Captured / visible</span><span id="turns" class="value">--</span></div>
+        <div class="row"><span class="label">Assets</span><span id="assets" class="value">--</span></div>
+        <div id="asset-failures" class="log-meta"></div>
+      </section>
+
+      <section>
         <div class="controls">
           <button id="capture" class="primary"><span class="button-label">Capture page</span><span class="button-status"></span></button>
           <button id="check"><span class="button-label">Check status</span><span class="button-status"></span></button>
@@ -314,6 +342,11 @@
           <button id="open-polylogue"><span class="button-label">Open in Polylogue</span><span class="button-status"></span></button>
           <button id="check-receiver"><span class="button-label">Check receiver</span><span class="button-status"></span></button>
         </div>
+      </section>
+
+      <section>
+        <div class="section-head"><strong>What Polylogue did here</strong></div>
+        <div id="timeline" class="log"></div>
       </section>
 
       <section>
@@ -373,6 +406,11 @@
           <button id="debug-export" class="link-button"><span class="button-label">Export JSON</span><span class="button-status"></span></button>
         </div>
         <div id="debug-panel" hidden>
+          <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
+          <div class="row"><span class="label">Archive state</span><span id="archive" class="value">Not checked</span></div>
+          <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
+          <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
+          <div class="row"><span class="label">Updated</span><span id="updated" class="value">--</span></div>
           <div id="debug-log" class="log"></div>
         </div>
       </section>
@@ -387,6 +425,7 @@
         <input id="receiver-token" type="password" autocomplete="off" placeholder="Only needed when receiver auth is enabled">
       </section>
     </main>
+    <script src="operator_status.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -177,6 +177,7 @@ function tabState(tab, ledger) {
         if (pathId) return pathId;
         const queryId = url.searchParams.get("conversation") || url.searchParams.get("conversationId");
         if (queryId) return queryId;
+        if (!(parts[0] === "i" && parts[1] === "grok")) return null;
         let hash = 0x811c9dc5;
         for (const char of `${url.origin}${url.pathname}${url.search}`) {
           hash ^= char.charCodeAt(0);
@@ -578,13 +579,11 @@ document.getElementById("capture").addEventListener("click", async () => {
       }));
     }
     if (!result?.ok) {
-      await chrome.storage.local.set({
-        polylogueState: {
-          online: false,
-          captured: false,
-          error: result?.error || "This page is not supported.",
-          updated_at: new Date().toISOString()
-        }
+      await chrome.runtime.sendMessage({
+        type: "polylogue.capturePageFailed",
+        error: result?.error || "capture_page_failed",
+        tab_id: tab.id,
+        tab_url: tab.url || tab.pendingUrl || null,
       });
     }
     await render();

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -169,7 +169,18 @@ function tabState(tab, ledger) {
       const parts = url.pathname.split("/").filter(Boolean);
       if (provider === "chatgpt") return parts[parts.indexOf("c") + 1] || null;
       if (provider === "claude-ai") return parts[0] === "chat" ? parts[1] || null : null;
-      if (provider === "grok") return parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok") || null;
+      if (provider === "grok") {
+        const pathId = parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok");
+        if (pathId) return pathId;
+        const queryId = url.searchParams.get("conversation") || url.searchParams.get("conversationId");
+        if (queryId) return queryId;
+        let hash = 0x811c9dc5;
+        for (const char of `${url.origin}${url.pathname}${url.search}`) {
+          hash ^= char.charCodeAt(0);
+          hash = Math.imul(hash, 0x01000193);
+        }
+        return `dom:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+      }
     } catch {
       return null;
     }

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -172,16 +172,6 @@ function stateExplanation(state) {
       detail: state.archive_state?.latest_failure || state.error || "Open the debug log and match the request id in the receiver log.",
     };
   }
-  if (archiveState === "archived" || state.captured) {
-    return {
-      badge: ["ok", "captured"],
-      archive: "Archived",
-      headline: state.last_capture
-        ? `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`
-        : "The latest capture is visible in the archive.",
-      detail: "Archive evidence includes receiver spool, source raw row, indexed session, and indexed messages.",
-    };
-  }
   if (archiveState === "stale") {
     return {
       badge: ["warn", "stale"],
@@ -204,6 +194,16 @@ function stateExplanation(state) {
       archive: "Spooled",
       headline: "Receiver wrote the capture artifact.",
       detail: "The daemon has not acquired the spool artifact into source.db yet.",
+    };
+  }
+  if (archiveState === "archived" || state.captured) {
+    return {
+      badge: ["ok", "captured"],
+      archive: "Archived",
+      headline: state.last_capture
+        ? `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`
+        : "The latest capture is visible in the archive.",
+      detail: "Archive evidence includes receiver spool, source raw row, indexed session, and indexed messages.",
     };
   }
   if (archiveState === "missing") {

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -1,7 +1,7 @@
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const AUTO_REFRESH_MS = 8000;
 const CAPTURE_MESSAGE_TIMEOUT_MS = 15000;
-const { operatorStatusForState } = globalThis.PolylogueOperatorStatus;
+const { operatorPresentationForState, operatorStatusForState } = globalThis.PolylogueOperatorStatus;
 
 function escapeHtml(value) {
   return String(value ?? "")
@@ -130,112 +130,7 @@ function relativeAge(iso) {
 }
 
 function stateExplanation(state) {
-  if (!state) {
-    return {
-      badge: ["warn", "idle"],
-      archive: "Not checked",
-      headline: "No receiver state yet.",
-      detail: "The popup refreshes automatically on open. If this stays idle, the service worker has not returned a status payload.",
-    };
-  }
-  if (state.active_page_state === "unsupported") {
-    return {
-      badge: ["warn", "idle"],
-      archive: "Unsupported",
-      headline: "This page is not a supported conversation.",
-      detail: "Open a ChatGPT, Claude.ai, or Grok/X conversation tab. The extension will update this state when the active tab changes.",
-    };
-  }
-  if (!state.online) {
-    if (state.error === "unauthorized") {
-      return {
-        badge: ["bad", "offline"],
-        archive: "Unauthorized",
-        headline: "Receiver requires a pairing token.",
-        detail:
-          'Run `polylogued browser-capture token show` and paste the value into "Receiver token" below, then Save.',
-      };
-    }
-    return {
-      badge: ["bad", "offline"],
-      archive: "Offline",
-      headline: "Receiver offline.",
-      detail: `Start the local receiver, then refresh. ${state.error || ""}`.trim(),
-    };
-  }
-  const archiveState = state.archive_state?.state || null;
-  if (archiveState === "failed" || state.error) {
-    return {
-      badge: ["bad", "failed"],
-      archive: "Failed",
-      headline: "Capture was rejected or could not be parsed.",
-      detail: state.archive_state?.latest_failure || state.error || "Open the debug log and match the request id in the receiver log.",
-    };
-  }
-  if (archiveState === "stale") {
-    return {
-      badge: ["warn", "stale"],
-      archive: "Stale",
-      headline: "Receiver spool is newer than the indexed archive.",
-      detail: "The daemon has not caught up to the latest browser capture yet. Keep the daemon running; this should converge without a manual repair step.",
-    };
-  }
-  if (archiveState === "ingest_pending") {
-    return {
-      badge: ["warn", "pending"],
-      archive: "Ingest pending",
-      headline: "Capture reached source.db but is not queryable yet.",
-      detail: "The daemon still needs to materialize the indexed session and messages.",
-    };
-  }
-  if (archiveState === "spooled_only") {
-    return {
-      badge: ["warn", "spooled"],
-      archive: "Spooled",
-      headline: "Receiver wrote the capture artifact.",
-      detail: "The daemon has not acquired the spool artifact into source.db yet.",
-    };
-  }
-  if (archiveState === "missing") {
-    return {
-      badge: ["warn", "missing"],
-      archive: "Not archived",
-      headline: "No capture exists for this conversation yet.",
-      detail: "Use Capture page for the active conversation. The extension checks archive state automatically when tabs activate or finish loading.",
-    };
-  }
-  if (archiveState === "archived" || state.captured) {
-    return {
-      badge: ["ok", "captured"],
-      archive: "Archived",
-      headline: state.last_capture
-        ? `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`
-        : "The latest capture is visible in the archive.",
-      detail: "Archive evidence includes receiver spool, source raw row, indexed session, and indexed messages.",
-    };
-  }
-  if (state.capture_mode === "dom_degraded") {
-    return {
-      badge: ["warn", "dom"],
-      archive: "DOM fallback",
-      headline: "Captured from visible DOM, not provider-native app data.",
-      detail: "DOM fallback is useful but is not provider-native app data; it may omit branches, provider ids, timestamps, or attachments. Reload the page, wait for the conversation API response, then capture again.",
-    };
-  }
-  if (state.active_page_state === "supported_no_session") {
-    return {
-      badge: ["warn", "ready"],
-      archive: "Ready",
-      headline: "Supported site open, but no conversation id is visible.",
-      detail: "Open or select a concrete conversation. The extension does not read page content until Capture page or Sync open tabs is used.",
-    };
-  }
-  return {
-    badge: ["warn", "online"],
-    archive: "Receiver online",
-    headline: "Receiver online. Open a supported conversation to capture.",
-    detail: "Supported pages are ChatGPT, Claude.ai, and Grok/X conversation routes.",
-  };
+  return operatorPresentationForState(state);
 }
 
 function conversationKey(provider, providerSessionId) {

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -222,7 +222,7 @@ function renderOpenTabs(tabs, ledger, activeTabId) {
   const node = document.getElementById("open-tabs");
   if (!node) return;
   const supported = (Array.isArray(tabs) ? tabs : []).map((tab) => ({ tab, ...tabState(tab, ledger) }))
-    .filter(({ provider }) => provider !== "unknown");
+    .filter(({ provider, sessionId }) => provider !== "unknown" && Boolean(sessionId));
   document.getElementById("open-tab-count").textContent = String(supported.length);
   if (!supported.length) {
     node.innerHTML = '<div class="log-meta">No supported conversation tabs are open.</div>';
@@ -506,6 +506,14 @@ async function refreshStatus(reason = "popup_manual") {
   await render();
 }
 
+async function currentActiveConversationState() {
+  const [stored, tab] = await Promise.all([
+    chrome.storage.local.get({ polylogueState: null, polylogueSessionLedger: {} }),
+    activeTab(),
+  ]);
+  return activeConversationState(tab, stored.polylogueState, stored.polylogueSessionLedger || {});
+}
+
 document.getElementById("check").addEventListener("click", async () => {
   await withAction("check", () => refreshStatus("popup_manual"), { busy: "Checking" });
 });
@@ -519,8 +527,7 @@ document.getElementById("sync-open-tabs").addEventListener("click", async () => 
 
 document.getElementById("copy-ref").addEventListener("click", async () => {
   await withAction("copy-ref", async () => {
-    const stored = await chrome.storage.local.get({ polylogueState: null });
-    const state = stored.polylogueState || {};
+    const state = await currentActiveConversationState();
     const provider = state.provider || state.last_capture?.provider;
     const providerSessionId = state.provider_session_id || state.last_capture?.provider_session_id;
     const ref = provider && providerSessionId ? `${provider}:${providerSessionId}` : "";
@@ -530,8 +537,11 @@ document.getElementById("copy-ref").addEventListener("click", async () => {
 
 document.getElementById("open-polylogue").addEventListener("click", async () => {
   await withAction("open-polylogue", async () => {
-    const stored = await chrome.storage.local.get({ polylogueState: null, receiverBaseUrl: DEFAULT_RECEIVER });
-    const providerSessionId = stored.polylogueState?.provider_session_id || stored.polylogueState?.last_capture?.provider_session_id;
+    const [stored, state] = await Promise.all([
+      chrome.storage.local.get({ receiverBaseUrl: DEFAULT_RECEIVER }),
+      currentActiveConversationState(),
+    ]);
+    const providerSessionId = state.provider_session_id || state.last_capture?.provider_session_id;
     const url = `${String(stored.receiverBaseUrl || DEFAULT_RECEIVER).replace(/\/+$/, "")}/?q=${encodeURIComponent(providerSessionId || "")}`;
     await chrome.tabs.create({ url });
   }, { busy: "Opening" });

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -196,6 +196,14 @@ function stateExplanation(state) {
       detail: "The daemon has not acquired the spool artifact into source.db yet.",
     };
   }
+  if (archiveState === "missing") {
+    return {
+      badge: ["warn", "missing"],
+      archive: "Not archived",
+      headline: "No capture exists for this conversation yet.",
+      detail: "Use Capture page for the active conversation. The extension checks archive state automatically when tabs activate or finish loading.",
+    };
+  }
   if (archiveState === "archived" || state.captured) {
     return {
       badge: ["ok", "captured"],
@@ -204,14 +212,6 @@ function stateExplanation(state) {
         ? `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`
         : "The latest capture is visible in the archive.",
       detail: "Archive evidence includes receiver spool, source raw row, indexed session, and indexed messages.",
-    };
-  }
-  if (archiveState === "missing") {
-    return {
-      badge: ["warn", "missing"],
-      archive: "Not archived",
-      headline: "No capture exists for this conversation yet.",
-      detail: "Use Capture page for the active conversation. The extension checks archive state automatically when tabs activate or finish loading.",
     };
   }
   if (state.capture_mode === "dom_degraded") {
@@ -529,8 +529,8 @@ async function render() {
   document.getElementById("fidelity").textContent = fidelityLabel(state?.capture_mode);
   renderAssetAcquisition(state?.asset_acquisition);
   const lastSession = state?.last_capture || {};
-  const capturedCount = state?.archive_state?.indexed_message_count ?? state?.turn_count ?? lastSession.turn_count ?? null;
-  const visibleCount = state?.turn_count ?? lastSession.turn_count ?? null;
+  const capturedCount = state?.turn_count ?? lastSession.turn_count ?? null;
+  const visibleCount = state?.archive_state?.indexed_message_count ?? null;
   turnsNode.textContent = capturedCount === null && visibleCount === null
     ? "--"
     : `${capturedCount ?? "--"} captured / ${visibleCount ?? "--"} visible`;

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -283,6 +283,31 @@ function tabState(tab, ledger) {
   return { provider, sessionId, ledger: ledger[conversationKey(provider, sessionId)] || {} };
 }
 
+function activeConversationState(tab, globalState, ledger) {
+  const context = tabState(tab, ledger);
+  if (!globalState?.provider || !globalState?.provider_session_id) return globalState || {};
+  if (!context.provider || !context.sessionId) return globalState || {};
+  if (
+    globalState?.provider === context.provider
+    && globalState?.provider_session_id === context.sessionId
+  ) return globalState;
+
+  const item = context.ledger;
+  return {
+    online: globalState?.online ?? true,
+    provider: context.provider,
+    provider_session_id: context.sessionId,
+    active_page_state: "conversation",
+    archive_state: item.archive_state || null,
+    capture_mode: item.capture_mode || null,
+    asset_acquisition: item.asset_acquisition || null,
+    turn_count: item.turn_count ?? null,
+    attachment_count: item.attachment_count ?? null,
+    last_receiver_request_id: item.receiver_request_id || null,
+    updated_at: item.updated_at || null,
+  };
+}
+
 function renderOpenTabs(tabs, ledger, activeTabId) {
   const node = document.getElementById("open-tabs");
   if (!node) return;
@@ -527,7 +552,7 @@ async function render() {
   const openTabs = await chrome.tabs.query({});
   const currentProvider = providerFromUrl(tab?.url || "");
   document.getElementById("page").innerHTML = `${providerLogo(currentProvider)} <span>${escapeHtml(hostLabel(tab?.url || ""))}</span>`;
-  const state = stored.polylogueState;
+  const state = activeConversationState(tab, stored.polylogueState, stored.polylogueSessionLedger || {});
   const status = operatorStatusForState(state || {});
   const requestNode = document.getElementById("receiver-request");
   const modeNode = document.getElementById("mode");

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -1,6 +1,7 @@
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const AUTO_REFRESH_MS = 8000;
 const CAPTURE_MESSAGE_TIMEOUT_MS = 15000;
+const { operatorStatusForState } = globalThis.PolylogueOperatorStatus;
 
 function escapeHtml(value) {
   return String(value ?? "")
@@ -237,6 +238,74 @@ function stateExplanation(state) {
   };
 }
 
+function conversationKey(provider, providerSessionId) {
+  return provider && providerSessionId ? `${provider}:${providerSessionId}` : null;
+}
+
+function timelineLabel(entry) {
+  const labels = {
+    captured: "Captured",
+    detected_new: "New conversation detected",
+    held_with_reason: "Held",
+    first_seen: "First seen",
+  };
+  return labels[entry?.event] || entry?.event || "Observed";
+}
+
+function renderTimeline(items) {
+  const node = document.getElementById("timeline");
+  if (!node) return;
+  const events = Array.isArray(items) ? items.slice(0, 8) : [];
+  if (!events.length) {
+    node.innerHTML = '<div class="log-meta">No decisions recorded for this conversation yet.</div>';
+    return;
+  }
+  node.innerHTML = events.map((entry) => {
+    const detail = [entry.reason, entry.detail].filter(Boolean).join(" · ");
+    return `<div class="log-item"><div class="log-time">${escapeHtml(relativeAge(entry.at))}</div><div><div class="log-title">${escapeHtml(timelineLabel(entry))}</div><div class="log-meta">${escapeHtml(detail)}</div></div></div>`;
+  }).join("");
+}
+
+function tabState(tab, ledger) {
+  const provider = providerFromUrl(tab?.url || tab?.pendingUrl || "");
+  const sessionId = (() => {
+    try {
+      const url = new URL(tab?.url || tab?.pendingUrl || "");
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (provider === "chatgpt") return parts[parts.indexOf("c") + 1] || null;
+      if (provider === "claude-ai") return parts[0] === "chat" ? parts[1] || null : null;
+      if (provider === "grok") return parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok") || null;
+    } catch {
+      return null;
+    }
+    return null;
+  })();
+  return { provider, sessionId, ledger: ledger[conversationKey(provider, sessionId)] || {} };
+}
+
+function renderOpenTabs(tabs, ledger, activeTabId) {
+  const node = document.getElementById("open-tabs");
+  if (!node) return;
+  const supported = (Array.isArray(tabs) ? tabs : []).map((tab) => ({ tab, ...tabState(tab, ledger) }))
+    .filter(({ provider }) => provider !== "unknown");
+  document.getElementById("open-tab-count").textContent = String(supported.length);
+  if (!supported.length) {
+    node.innerHTML = '<div class="log-meta">No supported conversation tabs are open.</div>';
+    return;
+  }
+  node.innerHTML = supported.map(({ tab, provider, sessionId, ledger: item }) => {
+    const status = operatorStatusForState({
+      online: true,
+      captured: item.archive_state?.state === "archived" || Boolean(item.receiver_request_id),
+      archive_state: item.archive_state,
+      capture_mode: item.capture_mode,
+    });
+    const active = tab.id === activeTabId ? " active" : "";
+    const title = tab.title || sessionId || "Untitled conversation";
+    return `<div class="tab-item${active}"><div>${providerLogo(provider)} <strong>${escapeHtml(title)}</strong></div><span class="state-chip ${escapeHtml(status.tone)}">${escapeHtml(status.label)}</span></div>`;
+  }).join("");
+}
+
 function renderLog(items) {
   const log = document.getElementById("log");
   const safeItems = Array.isArray(items) ? items.slice(0, 8) : [];
@@ -434,6 +503,8 @@ async function render() {
     polylogueDebugLog: [],
     polylogueCaptureQueue: { entries: [], dropped_count: 0 },
     polylogueState: null,
+    polylogueSessionLedger: {},
+    polylogueConversationTimeline: {},
     receiverAuthToken: "",
     receiverBaseUrl: DEFAULT_RECEIVER
   });
@@ -444,9 +515,11 @@ async function render() {
   document.getElementById("receiver-token").value = stored.receiverAuthToken || "";
   document.getElementById("receiver").textContent = stored.receiverBaseUrl;
   const tab = await activeTab();
+  const openTabs = await chrome.tabs.query({});
   const currentProvider = providerFromUrl(tab?.url || "");
   document.getElementById("page").innerHTML = `${providerLogo(currentProvider)} <span>${escapeHtml(hostLabel(tab?.url || ""))}</span>`;
   const state = stored.polylogueState;
+  const status = operatorStatusForState(state || {});
   const requestNode = document.getElementById("receiver-request");
   const modeNode = document.getElementById("mode");
   const turnsNode = document.getElementById("turns");
@@ -456,9 +529,11 @@ async function render() {
   document.getElementById("fidelity").textContent = fidelityLabel(state?.capture_mode);
   renderAssetAcquisition(state?.asset_acquisition);
   const lastSession = state?.last_capture || {};
-  const turnCount = state?.archive_state?.indexed_message_count ?? state?.turn_count ?? lastSession.turn_count ?? "--";
-  const attachmentCount = state?.archive_state?.attachment_count ?? state?.attachment_count ?? lastSession.attachment_count ?? null;
-  turnsNode.textContent = attachmentCount === null ? String(turnCount) : `${turnCount} / ${attachmentCount} files`;
+  const capturedCount = state?.archive_state?.indexed_message_count ?? state?.turn_count ?? lastSession.turn_count ?? null;
+  const visibleCount = state?.turn_count ?? lastSession.turn_count ?? null;
+  turnsNode.textContent = capturedCount === null && visibleCount === null
+    ? "--"
+    : `${capturedCount ?? "--"} captured / ${visibleCount ?? "--"} visible`;
   updatedNode.textContent = state?.updated_at ? `${relativeAge(state.updated_at)} ago` : "--";
 
   const explanation = stateExplanation(state);
@@ -467,6 +542,17 @@ async function render() {
   document.getElementById("state").textContent = explanation.headline;
   document.getElementById("state-detail").textContent = explanation.detail;
   setBadge(badgeKind, badgeText);
+  const operatorState = document.getElementById("operator-state");
+  if (operatorState) {
+    operatorState.textContent = status.label;
+    operatorState.className = `state-chip ${status.tone}`;
+  }
+  const fidelityFlag = document.getElementById("fidelity-flag");
+  if (fidelityFlag) fidelityFlag.hidden = !status.partialFidelity;
+  const activeProvider = state?.provider || providerFromUrl(tab?.url || "");
+  const activeSessionId = state?.provider_session_id || tabState(tab, stored.polylogueSessionLedger || {}).sessionId;
+  renderTimeline(stored.polylogueConversationTimeline?.[conversationKey(activeProvider, activeSessionId)] || []);
+  renderOpenTabs(openTabs, stored.polylogueSessionLedger || {}, tab?.id);
   await refreshBackfills().catch(() => renderBackfill([]));
 }
 

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -332,6 +332,15 @@ function fidelityLabel(captureMode) {
   return captureMode || "--";
 }
 
+function costTokensLabel(state) {
+  const totalTokens = state?.usage?.total_tokens ?? state?.total_tokens ?? null;
+  const costUsd = state?.cost_usd ?? state?.cost?.usd ?? null;
+  const parts = [];
+  if (Number.isFinite(costUsd)) parts.push(`$${Number(costUsd).toFixed(3)}`);
+  if (Number.isFinite(totalTokens)) parts.push(`${totalTokens} tokens`);
+  return parts.length ? parts.join(" · ") : "Unavailable";
+}
+
 function truncateForDisplay(value, limit = 200) {
   const text = String(value ?? "");
   return text.length > limit ? `${text.slice(0, limit - 3)}...` : text;
@@ -527,6 +536,7 @@ async function render() {
   requestNode.textContent = state?.last_receiver_request_id || "--";
   modeNode.textContent = state?.capture_mode || state?.archive_state?.state || "--";
   document.getElementById("fidelity").textContent = fidelityLabel(state?.capture_mode);
+  document.getElementById("cost-tokens").textContent = costTokensLabel(state);
   renderAssetAcquisition(state?.asset_acquisition);
   const lastSession = state?.last_capture || {};
   const capturedCount = state?.turn_count ?? lastSession.turn_count ?? null;

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -3,6 +3,10 @@ const AUTO_REFRESH_MS = 8000;
 const CAPTURE_MESSAGE_TIMEOUT_MS = 15000;
 const { operatorPresentationForState, operatorStatusForState } = globalThis.PolylogueOperatorStatus;
 
+function hostMatches(hostname, domain) {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
 function escapeHtml(value) {
   return String(value ?? "")
     .replaceAll("&", "&amp;")
@@ -14,11 +18,10 @@ function escapeHtml(value) {
 function hostLabel(url) {
   try {
     const parsed = new URL(url);
-    if (parsed.hostname.includes("chatgpt.com")) return "ChatGPT";
-    if (parsed.hostname.includes("claude.ai")) return "Claude.ai";
-    if (parsed.hostname.includes("grok.com")) return "Grok";
-    if (parsed.hostname === "x.com" || parsed.hostname.endsWith(".x.com")) return "Grok / X";
-    if (parsed.hostname === "twitter.com" || parsed.hostname.endsWith(".twitter.com")) return "Grok / X";
+    if (hostMatches(parsed.hostname, "chatgpt.com")) return "ChatGPT";
+    if (hostMatches(parsed.hostname, "claude.ai")) return "Claude.ai";
+    if (hostMatches(parsed.hostname, "grok.com")) return "Grok";
+    if (hostMatches(parsed.hostname, "x.com") || hostMatches(parsed.hostname, "twitter.com")) return "Grok / X";
     return parsed.hostname;
   } catch {
     return "Unknown";
@@ -28,9 +31,9 @@ function hostLabel(url) {
 function providerFromUrl(url) {
   try {
     const parsed = new URL(url || "");
-    if (parsed.hostname.includes("chatgpt.com")) return "chatgpt";
-    if (parsed.hostname.includes("claude.ai")) return "claude-ai";
-    if (parsed.hostname.includes("grok.com") || parsed.hostname.includes("x.com") || parsed.hostname.includes("twitter.com")) {
+    if (hostMatches(parsed.hostname, "chatgpt.com")) return "chatgpt";
+    if (hostMatches(parsed.hostname, "claude.ai")) return "claude-ai";
+    if (hostMatches(parsed.hostname, "grok.com") || hostMatches(parsed.hostname, "x.com") || hostMatches(parsed.hostname, "twitter.com")) {
       return "grok";
     }
   } catch {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -476,6 +476,38 @@ describe("background receiver diagnostics", () => {
     expect(fetchCalls[0].url).toContain("provider=grok&provider_session_id=query-77");
   });
 
+  it("does not invent a conversation identity for the X home timeline", async () => {
+    tabs = [{ id: 78, url: "https://x.com/home", title: "Home", active: true }];
+    globalThis.fetch = vi.fn(async (url) => {
+      fetchCalls.push({ url });
+      return responseJson({ ok: true });
+    });
+
+    activatedListener({ tabId: 78 });
+
+    await vi.waitFor(() => expect(fetchCalls).toHaveLength(1));
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:8875/v1/status");
+    expect(stored.polylogueSessionLedger).toBeUndefined();
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("records a local popup capture failure as a held decision without offline state", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-local-failure", title: "ChatGPT", active: true }];
+
+    await sendRuntimeMessage({
+      type: "polylogue.capturePageFailed",
+      tab_id: 42,
+      tab_url: tabs[0].url,
+      error: "no_turns",
+    });
+
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-local-failure"][0]).toMatchObject({
+      event: "held_with_reason",
+      detail: "content_capture_failed",
+    });
+    expect(stored.polylogueState).toMatchObject({ online: true, error: "no_turns" });
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));
@@ -863,6 +895,22 @@ describe("capture retry queue", () => {
       "conv-concurrent-a",
       "conv-concurrent-b",
     ]);
+  });
+
+  it("reports an oversized retry capture as dropped instead of queued", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const response = await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: {
+        session: { provider: "chatgpt", provider_session_id: "conv-oversized", turns: [{ text: "x".repeat(43_000_000) }] },
+      },
+    });
+
+    expect(response.queued).toBe(false);
+    expect(stored.polylogueCaptureQueue.entries).toHaveLength(0);
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-oversized"][0].detail).toBe("capture_queue_entry_over_budget");
   });
 
   it("drops a retry after a later non-retryable receiver rejection", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -264,6 +264,23 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueSessionLedger["chatgpt:conv-rejected"].last_error).toBe("invalid capture");
   });
 
+  it("does not let an inactive rejection replace the active conversation card", async () => {
+    tabs = [
+      { id: 1, url: "https://chatgpt.com/c/conv-active", active: true },
+      { id: 2, url: "https://chatgpt.com/c/conv-rejected", active: false },
+    ];
+    stored.polylogueState = { online: true, provider: "chatgpt", provider_session_id: "conv-active", archive_state: { state: "archived" } };
+    globalThis.fetch = vi.fn(async () => responseJson({ error: "invalid capture" }, { ok: false, status: 400 }));
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-rejected", turns: [] } },
+    }, { tab: tabs[1] });
+
+    expect(stored.polylogueState.provider_session_id).toBe("conv-active");
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-rejected"][0].detail).toBe("capture_rejected");
+  });
+
   it("keeps receiver request id on error state", async () => {
     globalThis.fetch = vi.fn(async () =>
       responseJson({ error: "unauthorized" }, { ok: false, status: 401, requestId: "reject-42" }),
@@ -829,6 +846,46 @@ describe("capture retry queue", () => {
       reason: "capture_retry_drained",
       detail: "spooled_only",
     });
+  });
+
+  it("keeps concurrent retry enqueues instead of overwriting one capture", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const capture = (sessionId) => sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: sessionId, turns: [] } },
+    });
+
+    await Promise.all([capture("conv-concurrent-a"), capture("conv-concurrent-b")]);
+
+    expect(stored.polylogueCaptureQueue.entries.map((entry) => entry.envelope.session.provider_session_id)).toEqual([
+      "conv-concurrent-a",
+      "conv-concurrent-b",
+    ]);
+  });
+
+  it("drops a retry after a later non-retryable receiver rejection", async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) throw new TypeError("Failed to fetch");
+      return responseJson({ error: "invalid capture" }, { ok: false, status: 400 });
+    });
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-retry-rejected", turns: [] } },
+    });
+    stored.polylogueCaptureQueue.entries[0].next_attempt_at = new Date(Date.now() - 1000).toISOString();
+
+    alarmListener({ name: "polylogueCaptureRetry" });
+
+    await vi.waitFor(() => expect(stored.polylogueCaptureQueue.entries).toHaveLength(0));
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-retry-rejected"][0]).toMatchObject({
+      event: "held_with_reason",
+      detail: "capture_rejected",
+    });
+    expect(stored.polylogueCaptureLog[0].reason).toBe("capture_retry_rejected");
   });
 
   it("does not queue a capture rejected with a client error", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -223,6 +223,27 @@ describe("background receiver diagnostics", () => {
       reason: "content_script_capture",
       detail: "spooled_only",
     });
+    expect(stored.polylogueSessionLedger["chatgpt:conv-manual"].archive_state).toEqual({ state: "spooled_only" });
+  });
+
+  it("records an inactive direct capture as catching up in its ledger", async () => {
+    tabs = [
+      { id: 1, url: "https://chatgpt.com/c/conv-active", active: true },
+      { id: 2, url: "https://chatgpt.com/c/conv-inactive", active: false },
+    ];
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-inactive",
+      state: "spooled_only",
+    }));
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-inactive", turns: [] } },
+    }, { tab: tabs[1] });
+
+    expect(stored.polylogueSessionLedger["chatgpt:conv-inactive"].archive_state).toEqual({ state: "spooled_only" });
+    expect(stored.polylogueState).toBeUndefined();
   });
 
   it("keeps receiver request id on error state", async () => {
@@ -496,6 +517,14 @@ describe("background receiver diagnostics", () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-123", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async (url, options) => {
       fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/browser-captures")) {
+        return responseJson({
+          provider: "chatgpt",
+          provider_session_id: "conv-123",
+          state: "spooled_only",
+          receiver_request_id: "capture-request-1",
+        }, { requestId: "capture-request-1" });
+      }
       return responseJson(
         {
           provider: "chatgpt",
@@ -508,6 +537,24 @@ describe("background receiver diagnostics", () => {
         },
         { requestId: "archive-state-1" },
       );
+    });
+    globalThis.chrome.tabs.sendMessage = vi.fn(async (tabId, message) => {
+      if (message.type !== "polylogue.capturePage") return null;
+      const envelope = {
+        session: {
+          provider: "chatgpt",
+          provider_session_id: "conv-123",
+          turns: [{ role: "user" }],
+        },
+      };
+      const captureResult = await new Promise((resolve) => {
+        messageListener(
+          { type: "polylogue.capture", envelope, reason: message.reason },
+          { tab: { id: tabId, url: "https://chatgpt.com/c/conv-123" } },
+          resolve,
+        );
+      });
+      return { ok: true, envelope, captureResult, archiveState: { state: "spooled_only" } };
     });
 
     activatedListener({ tabId: 42 });
@@ -522,8 +569,10 @@ describe("background receiver diagnostics", () => {
       type: "polylogue.capturePage",
       reason: "auto_capture_missing",
     });
+    expect(fetchCalls.map((call) => call.url)).toContain("http://127.0.0.1:8875/v1/browser-captures");
     const timeline = stored.polylogueConversationTimeline["chatgpt:conv-123"];
-    expect(timeline.map((entry) => entry.event)).toEqual(["detected_new", "first_seen"]);
+    expect(timeline.map((entry) => entry.event)).toEqual(["captured", "detected_new", "first_seen"]);
+    expect(timeline[0]).toMatchObject({ reason: "auto_capture_missing", detail: "spooled_only" });
   });
 
   it("serializes concurrent captures without losing either ledger or timeline entry", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -354,6 +354,26 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.provider_session_id).toBe("conv-b");
   });
 
+  it("does not restore a delayed conversation after same-tab navigation to a new page", async () => {
+    tabs = [{ id: 1, url: "https://chatgpt.com/c/conv-a", title: "A", active: true }];
+    let resolveA;
+    let fetchCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      fetchCount += 1;
+      if (fetchCount === 1) return new Promise((resolve) => { resolveA = resolve; });
+      return new Promise(() => {});
+    });
+
+    updatedListener(1, { status: "complete" }, tabs[0]);
+    tabs[0] = { id: 1, url: "https://chatgpt.com/new", title: "New", active: true };
+    updatedListener(1, { url: "https://chatgpt.com/new" }, tabs[0]);
+
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+    resolveA(responseJson({ provider: "chatgpt", provider_session_id: "conv-a", state: "archived", captured: true }));
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["chatgpt:conv-a"]?.archive_state?.state).toBe("archived"));
+    expect(stored.polylogueState?.provider_session_id).not.toBe("conv-a");
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -330,7 +330,7 @@ describe("background receiver diagnostics", () => {
     expect(status.inventory_complete).toBe(false);
   });
 
-  it("refreshes active conversation archive state on tab activation without capturing page content", async () => {
+  it("captures an automatically detected missing conversation and records the decision timeline", async () => {
     expect(activatedListener).toBeTypeOf("function");
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-123", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async (url, options) => {
@@ -353,10 +353,16 @@ describe("background receiver diagnostics", () => {
 
     await vi.waitFor(() => expect(stored.polylogueState?.active_page_state).toBe("conversation"));
     expect(fetchCalls[0].url).toBe("http://127.0.0.1:8875/v1/archive-state?provider=chatgpt&provider_session_id=conv-123");
-    expect(stored.polylogueState.archive_state.state).toBe("missing");
-    expect(stored.polylogueState.last_receiver_request_id).toBe("archive-state-1");
-    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
-    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    expect(stored.polylogueState.captured).toBe(true);
+    expect(stored.polylogueState.last_receiver_request_id).toBe("capture-request-1");
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalled();
+    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      type: "polylogue.capturePage",
+      reason: "auto_capture_missing",
+    });
+    const timeline = stored.polylogueConversationTimeline["chatgpt:conv-123"];
+    expect(timeline.map((entry) => entry.event)).toEqual(["captured", "detected_new"]);
+    expect(timeline[0].reason).toBe("auto_capture_missing");
   });
 
   it("refreshes receiver status for supported pages without a conversation id", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -279,6 +279,63 @@ describe("background receiver diagnostics", () => {
     expect(globalThis.chrome.action.setBadgeText.mock.calls.at(-1)[0]).toEqual({ text: "…" });
   });
 
+  it("preserves capture metadata when content refreshes its archive state", async () => {
+    let request = 0;
+    globalThis.fetch = vi.fn(async () => {
+      request += 1;
+      return responseJson(request === 1
+        ? { provider: "chatgpt", provider_session_id: "conv-metadata" }
+        : { provider: "chatgpt", provider_session_id: "conv-metadata", state: "spooled_only", captured: false });
+    });
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: {
+        session: {
+          provider: "chatgpt",
+          provider_session_id: "conv-metadata",
+          provider_meta: { capture_fidelity: "dom_degraded" },
+          turns: [{ role: "user" }, { role: "assistant" }],
+        },
+      },
+    });
+    await sendRuntimeMessage({
+      type: "polylogue.archiveState",
+      provider: "chatgpt",
+      provider_session_id: "conv-metadata",
+    });
+
+    expect(stored.polylogueState).toMatchObject({
+      capture_mode: "dom_degraded",
+      turn_count: 2,
+      archive_state: { state: "spooled_only" },
+    });
+  });
+
+  it("does not let an inactive tab update replace the active conversation card state", async () => {
+    tabs = [
+      { id: 1, url: "https://chatgpt.com/c/conv-active", title: "Active", active: true },
+      { id: 2, url: "https://chatgpt.com/c/conv-inactive", title: "Inactive", active: false },
+    ];
+    stored.polylogueState = {
+      online: true,
+      provider: "chatgpt",
+      provider_session_id: "conv-active",
+      archive_state: { state: "archived" },
+    };
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-inactive",
+      state: "archived",
+      captured: true,
+    }));
+
+    updatedListener(2, { status: "complete" }, tabs[1]);
+
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["chatgpt:conv-inactive"]?.archive_state?.state).toBe("archived"));
+    expect(stored.polylogueState.provider_session_id).toBe("conv-active");
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -197,6 +197,34 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueExtensionInstanceId).toBe(first.provenance.extension_instance_id);
   });
 
+  it("records a direct manual capture as pending timeline evidence", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-manual",
+      state: "spooled_only",
+      artifact_ref: "chatgpt/conv-manual.json",
+    }));
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      reason: "content_script_capture",
+      envelope: {
+        session: {
+          provider: "chatgpt",
+          provider_session_id: "conv-manual",
+          turns: [{ role: "user" }],
+        },
+      },
+    });
+
+    expect(stored.polylogueState.archive_state).toEqual({ state: "spooled_only" });
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-manual"][0]).toMatchObject({
+      event: "captured",
+      reason: "content_script_capture",
+      detail: "spooled_only",
+    });
+  });
+
   it("keeps receiver request id on error state", async () => {
     globalThis.fetch = vi.fn(async () =>
       responseJson({ error: "unauthorized" }, { ok: false, status: 401, requestId: "reject-42" }),

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -365,6 +365,30 @@ describe("background receiver diagnostics", () => {
     expect(timeline[0].reason).toBe("auto_capture_missing");
   });
 
+  it("records a held decision when automatic capture is throttled", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-123", title: "ChatGPT" }];
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(100000);
+    await sendRuntimeMessage({ type: "polylogue.captureSupportedTabs", reason: "popup_sync_open_tabs" });
+    now.mockReturnValue(105000);
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-123",
+      state: "missing",
+      captured: false,
+    }));
+
+    activatedListener({ tabId: 42 });
+
+    await vi.waitFor(() => expect(stored.polylogueState?.active_page_state).toBe("conversation"));
+    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(stored.polylogueConversationTimeline["chatgpt:conv-123"]?.[0]).toMatchObject({
+      event: "held_with_reason",
+      reason: "auto_capture_missing",
+      detail: "background_capture_throttled",
+    }));
+  });
+
   it("refreshes receiver status for supported pages without a conversation id", async () => {
     expect(updatedListener).toBeTypeOf("function");
     tabs = [{ id: 42, url: "https://chatgpt.com/", title: "ChatGPT" }];

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -510,6 +510,7 @@ describe("capture retry queue", () => {
         ok: true,
         provider: "chatgpt",
         provider_session_id: "conv-9",
+        state: "spooled_only",
         artifact_ref: "chatgpt/conv-9.json",
       });
     });
@@ -529,6 +530,10 @@ describe("capture retry queue", () => {
     expect(stored.polylogueCaptureQueue.entries).toHaveLength(1);
     expect(stored.polylogueCaptureQueue.entries[0].envelope.session.provider_session_id).toBe("conv-9");
     expect(stored.polylogueCaptureQueue.entries[0].attempts).toBe(0);
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-9"][0]).toMatchObject({
+      event: "held_with_reason",
+      detail: "capture_queued_for_retry",
+    });
     expect(globalThis.chrome.alarms.create).toHaveBeenCalledWith(
       "polylogueCaptureRetry",
       expect.objectContaining({ periodInMinutes: 1 }),
@@ -548,6 +553,12 @@ describe("capture retry queue", () => {
     expect(stored.polylogueCaptureLog[0].reason).toBe("capture_retry_drained");
     expect(stored.polylogueState.captured).toBe(true);
     expect(stored.polylogueState.provider_session_id).toBe("conv-9");
+    expect(stored.polylogueState.archive_state).toEqual({ state: "spooled_only" });
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-9"][0]).toMatchObject({
+      event: "captured",
+      reason: "capture_retry_drained",
+      detail: "spooled_only",
+    });
   });
 
   it("does not queue a capture rejected with a client error", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -241,6 +241,26 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.last_receiver_request_id).toBe("reject-42");
   });
 
+  it("refreshes the active conversation instead of discarding its archive identity", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-status", title: "ChatGPT" }];
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-status",
+      state: "spooled_only",
+      captured: false,
+    }));
+
+    const response = await sendRuntimeMessage({ type: "polylogue.status", reason: "popup_open" });
+
+    expect(response.state).toBe("spooled_only");
+    expect(stored.polylogueState).toMatchObject({
+      provider: "chatgpt",
+      provider_session_id: "conv-status",
+      archive_state: { state: "spooled_only" },
+    });
+    expect(stored.polylogueSessionLedger["chatgpt:conv-status"].archive_state.state).toBe("spooled_only");
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));
@@ -389,8 +409,22 @@ describe("background receiver diagnostics", () => {
       reason: "auto_capture_missing",
     });
     const timeline = stored.polylogueConversationTimeline["chatgpt:conv-123"];
-    expect(timeline.map((entry) => entry.event)).toEqual(["captured", "detected_new", "first_seen"]);
-    expect(timeline[0].reason).toBe("auto_capture_missing");
+    expect(timeline.map((entry) => entry.event)).toEqual(["detected_new", "first_seen"]);
+  });
+
+  it("serializes concurrent captures without losing either ledger or timeline entry", async () => {
+    globalThis.fetch = vi.fn(async (_url, options) => {
+      const session = JSON.parse(options.body).session;
+      return responseJson({ provider: session.provider, provider_session_id: session.provider_session_id });
+    });
+
+    await Promise.all(["conv-a", "conv-b"].map((providerSessionId) => sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: providerSessionId } },
+    })));
+
+    expect(Object.keys(stored.polylogueSessionLedger).sort()).toEqual(["chatgpt:conv-a", "chatgpt:conv-b"]);
+    expect(Object.keys(stored.polylogueConversationTimeline).sort()).toEqual(["chatgpt:conv-a", "chatgpt:conv-b"]);
   });
 
   it("records a held decision when automatic capture is throttled", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -411,6 +411,36 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState?.provider_session_id).not.toBe("conv-a");
   });
 
+  it("holds a missing conversation when the tab navigates before auto-capture", async () => {
+    tabs = [{ id: 1, url: "https://chatgpt.com/c/conv-a", title: "A", active: true }];
+    let resolveArchiveState;
+    globalThis.fetch = vi.fn(async () => new Promise((resolve) => { resolveArchiveState = resolve; }));
+
+    updatedListener(1, { status: "complete" }, tabs[0]);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    tabs[0] = { id: 1, url: "https://chatgpt.com/c/conv-b", title: "B", active: true };
+    resolveArchiveState(responseJson({ provider: "chatgpt", provider_session_id: "conv-a", state: "missing", captured: false }));
+
+    await vi.waitFor(() => expect(stored.polylogueConversationTimeline["chatgpt:conv-a"]?.[0]).toMatchObject({
+      event: "held_with_reason",
+      detail: "tab_navigation_changed",
+    }));
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses Grok query conversation identity for archive polling and the ledger", async () => {
+    tabs = [{ id: 77, url: "https://grok.com/?conversation=query-77", title: "Grok", active: true }];
+    globalThis.fetch = vi.fn(async (url) => {
+      fetchCalls.push({ url });
+      return responseJson({ provider: "grok", provider_session_id: "query-77", state: "archived", captured: true });
+    });
+
+    activatedListener({ tabId: 77 });
+
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["grok:query-77"]?.archive_state?.state).toBe("archived"));
+    expect(fetchCalls[0].url).toContain("provider=grok&provider_session_id=query-77");
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -361,7 +361,7 @@ describe("background receiver diagnostics", () => {
       reason: "auto_capture_missing",
     });
     const timeline = stored.polylogueConversationTimeline["chatgpt:conv-123"];
-    expect(timeline.map((entry) => entry.event)).toEqual(["captured", "detected_new"]);
+    expect(timeline.map((entry) => entry.event)).toEqual(["captured", "detected_new", "first_seen"]);
     expect(timeline[0].reason).toBe("auto_capture_missing");
   });
 

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -246,6 +246,24 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState).toBeUndefined();
   });
 
+  it("records a non-retryable capture rejection as a held decision", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({ error: "invalid capture" }, { ok: false, status: 400 }));
+
+    const response = await sendRuntimeMessage({
+      type: "polylogue.capture",
+      reason: "auto_capture_missing",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-rejected", turns: [] } },
+    });
+
+    expect(response).toMatchObject({ ok: false, error: "invalid capture" });
+    expect(stored.polylogueConversationTimeline["chatgpt:conv-rejected"][0]).toMatchObject({
+      event: "held_with_reason",
+      reason: "auto_capture_missing",
+      detail: "capture_rejected",
+    });
+    expect(stored.polylogueSessionLedger["chatgpt:conv-rejected"].last_error).toBe("invalid capture");
+  });
+
   it("keeps receiver request id on error state", async () => {
     globalThis.fetch = vi.fn(async () =>
       responseJson({ error: "unauthorized" }, { ok: false, status: 401, requestId: "reject-42" }),

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -116,9 +116,9 @@ async function loadBackground() {
   expect(messageListener).toBeTypeOf("function");
 }
 
-async function sendRuntimeMessage(message) {
+async function sendRuntimeMessage(message, sender = {}) {
   let response;
-  const keepAlive = messageListener(message, {}, (payload) => {
+  const keepAlive = messageListener(message, sender, (payload) => {
     response = payload;
   });
   await vi.waitFor(() => expect(response).toBeDefined());
@@ -336,6 +336,24 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.provider_session_id).toBe("conv-active");
   });
 
+  it("does not let a delayed prior conversation overwrite same-tab navigation", async () => {
+    tabs = [{ id: 1, url: "https://chatgpt.com/c/conv-a", title: "A", active: true }];
+    let resolveA;
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).includes("conv-a")) return new Promise((resolve) => { resolveA = resolve; });
+      return responseJson({ provider: "chatgpt", provider_session_id: "conv-b", state: "archived", captured: true });
+    });
+
+    updatedListener(1, { status: "complete" }, { id: 1, url: "https://chatgpt.com/c/conv-a", title: "A" });
+    tabs[0] = { id: 1, url: "https://chatgpt.com/c/conv-b", title: "B", active: true };
+    updatedListener(1, { url: "https://chatgpt.com/c/conv-b" }, tabs[0]);
+
+    await vi.waitFor(() => expect(stored.polylogueState?.provider_session_id).toBe("conv-b"));
+    resolveA(responseJson({ provider: "chatgpt", provider_session_id: "conv-a", state: "archived", captured: true }));
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["chatgpt:conv-a"]?.archive_state?.state).toBe("archived"));
+    expect(stored.polylogueState.provider_session_id).toBe("conv-b");
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));
@@ -475,6 +493,7 @@ describe("background receiver diagnostics", () => {
     activatedListener({ tabId: 42 });
 
     await vi.waitFor(() => expect(stored.polylogueState?.active_page_state).toBe("conversation"));
+    await vi.waitFor(() => expect(stored.polylogueState?.captured).toBe(true));
     expect(fetchCalls[0].url).toBe("http://127.0.0.1:8875/v1/archive-state?provider=chatgpt&provider_session_id=conv-123");
     expect(stored.polylogueState.captured).toBe(true);
     expect(stored.polylogueState.last_receiver_request_id).toBe("capture-request-1");
@@ -633,7 +652,15 @@ describe("capture retry queue", () => {
       },
     };
 
-    const response = await sendRuntimeMessage({ type: "polylogue.capture", envelope, reason: "content_script_capture" });
+    tabs = [
+      { id: 1, url: "https://chatgpt.com/c/conv-active", active: true },
+      { id: 2, url: "https://chatgpt.com/c/conv-9", active: false },
+    ];
+    stored.polylogueState = { online: true, provider: "chatgpt", provider_session_id: "conv-active", archive_state: { state: "archived" } };
+    const response = await sendRuntimeMessage(
+      { type: "polylogue.capture", envelope, reason: "content_script_capture" },
+      { tab: tabs[1] },
+    );
 
     expect(response).toEqual({ ok: false, queued: true, error: "Failed to fetch", receiver_request_id: null });
     expect(stored.polylogueCaptureQueue.entries).toHaveLength(1);
@@ -660,9 +687,10 @@ describe("capture retry queue", () => {
     expect(callCount).toBe(2);
     expect(globalThis.chrome.alarms.clear).toHaveBeenCalledWith("polylogueCaptureRetry");
     expect(stored.polylogueCaptureLog[0].reason).toBe("capture_retry_drained");
-    expect(stored.polylogueState.captured).toBe(true);
-    expect(stored.polylogueState.provider_session_id).toBe("conv-9");
-    expect(stored.polylogueState.archive_state).toEqual({ state: "spooled_only" });
+    expect(stored.polylogueState.captured).toBeUndefined();
+    expect(stored.polylogueState.provider_session_id).toBe("conv-active");
+    expect(stored.polylogueState.archive_state).toEqual({ state: "archived" });
+    expect(stored.polylogueSessionLedger["chatgpt:conv-9"].archive_state).toEqual({ state: "spooled_only" });
     expect(stored.polylogueConversationTimeline["chatgpt:conv-9"][0]).toMatchObject({
       event: "captured",
       reason: "capture_retry_drained",

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -262,6 +262,22 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.last_receiver_request_id).toBe("reject-42");
   });
 
+  it("records a held decision when archive-state cannot be checked", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-offline", title: "ChatGPT" }];
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    activatedListener({ tabId: 42 });
+
+    await vi.waitFor(() => expect(stored.polylogueConversationTimeline["chatgpt:conv-offline"]?.[0]).toMatchObject({
+      event: "held_with_reason",
+      reason: "tab_activated",
+      detail: "archive_state_check_failed",
+    }));
+    expect(stored.polylogueState.active_page_state).toBe("receiver_error");
+  });
+
   it("refreshes the active conversation instead of discarding its archive identity", async () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-status", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async () => responseJson({

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -261,6 +261,24 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueSessionLedger["chatgpt:conv-status"].archive_state.state).toBe("spooled_only");
   });
 
+  it("propagates content-script archive state into the multi-tab ledger", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-content",
+      state: "stale",
+      captured: false,
+    }));
+
+    await sendRuntimeMessage({
+      type: "polylogue.archiveState",
+      provider: "chatgpt",
+      provider_session_id: "conv-content",
+    });
+
+    expect(stored.polylogueSessionLedger["chatgpt:conv-content"].archive_state.state).toBe("stale");
+    expect(globalThis.chrome.action.setBadgeText.mock.calls.at(-1)[0]).toEqual({ text: "…" });
+  });
+
   it("does not capture existing provider tabs on extension update", async () => {
     expect(installedListener).toBeTypeOf("function");
     globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));

--- a/browser-extension/tests/content/grok.test.js
+++ b/browser-extension/tests/content/grok.test.js
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+
+import { JSDOM } from "jsdom";
+import { expect, it, vi } from "vitest";
+
+const commonSource = readFileSync("src/common.js", "utf8");
+const grokSource = readFileSync("src/content/grok.js", "utf8");
+
+it("forwards an automatic capture reason through the Grok content handler", async () => {
+  const dom = new JSDOM('<article data-message-author-role="user">Capture this</article>', {
+    runScripts: "outside-only",
+    url: "https://grok.com/chat/conversation-1",
+  });
+  const runtimeListener = vi.fn();
+  const sendMessage = vi.fn(async (message) => {
+    if (message.type === "polylogue.capture") return { state: "spooled_only" };
+    if (message.type === "polylogue.archiveState") return { state: "spooled_only" };
+    return null;
+  });
+  dom.window.chrome = {
+    runtime: {
+      getManifest: () => ({ version: "0.1.0" }),
+      onMessage: { addListener: runtimeListener },
+      sendMessage,
+    },
+  };
+
+  dom.window.eval(commonSource);
+  dom.window.eval(grokSource);
+  const listener = runtimeListener.mock.calls[0][0];
+  const response = await new Promise((resolve) => {
+    expect(listener({ type: "polylogue.capturePage", reason: "auto_capture_missing" }, {}, resolve)).toBe(true);
+  });
+
+  expect(response).toEqual({ ok: true, envelope: expect.any(Object), captureResult: expect.any(Object), archiveState: expect.any(Object) });
+  expect(sendMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+    type: "polylogue.capture",
+    reason: "auto_capture_missing",
+  }));
+});

--- a/browser-extension/tests/content/grok.test.js
+++ b/browser-extension/tests/content/grok.test.js
@@ -13,7 +13,7 @@ it("forwards an automatic capture reason through the Grok content handler", asyn
   });
   const runtimeListener = vi.fn();
   const sendMessage = vi.fn(async (message) => {
-    if (message.type === "polylogue.capture") return { state: "spooled_only" };
+    if (message.type === "polylogue.capture") return { ok: true, state: "spooled_only" };
     if (message.type === "polylogue.archiveState") return { state: "spooled_only" };
     return null;
   });
@@ -37,4 +37,30 @@ it("forwards an automatic capture reason through the Grok content handler", asyn
     type: "polylogue.capture",
     reason: "auto_capture_missing",
   }));
+});
+
+it("reports a rejected runtime capture without refreshing archive state", async () => {
+  const dom = new JSDOM('<article data-message-author-role="user">Capture this</article>', {
+    runScripts: "outside-only",
+    url: "https://grok.com/chat/conversation-1",
+  });
+  const runtimeListener = vi.fn();
+  const sendMessage = vi.fn(async () => ({ ok: false, error: "capture_rejected" }));
+  dom.window.chrome = {
+    runtime: {
+      getManifest: () => ({ version: "0.1.0" }),
+      onMessage: { addListener: runtimeListener },
+      sendMessage,
+    },
+  };
+
+  dom.window.eval(commonSource);
+  dom.window.eval(grokSource);
+  const listener = runtimeListener.mock.calls[0][0];
+  const response = await new Promise((resolve) => {
+    listener({ type: "polylogue.capturePage", reason: "auto_capture_missing" }, {}, resolve);
+  });
+
+  expect(response).toMatchObject({ ok: false, timelineRecorded: true, error: "capture_rejected" });
+  expect(sendMessage).toHaveBeenCalledTimes(1);
 });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -243,6 +243,39 @@ describe("popup capture", () => {
     expect(document.getElementById("timeline").textContent).toContain("background_capture_throttled");
   });
 
+  it("binds the active card and timeline to the current tab instead of stale global state", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        provider: "chatgpt",
+        provider_session_id: "previous-conversation",
+        captured: true,
+        archive_state: { state: "archived" },
+        updated_at: new Date().toISOString(),
+      },
+      polylogueSessionLedger: {
+        "chatgpt:test-conversation": {
+          archive_state: { state: "spooled_only" },
+          receiver_request_id: "pending-active",
+        },
+      },
+      polylogueConversationTimeline: {
+        "chatgpt:previous-conversation": [
+          { at: new Date().toISOString(), event: "captured", detail: "old capture" },
+        ],
+        "chatgpt:test-conversation": [
+          { at: new Date().toISOString(), event: "held_with_reason", detail: "active pending" },
+        ],
+      },
+    });
+
+    expect(document.getElementById("operator-state").textContent).toBe("Catching up");
+    expect(document.getElementById("archive").textContent).toBe("Spooled");
+    expect(document.getElementById("timeline").textContent).toContain("active pending");
+    expect(document.getElementById("timeline").textContent).not.toContain("old capture");
+    expect(document.getElementById("open-tabs").textContent).toContain("Catching up");
+  });
+
   it("marks DOM-derived captures as partial fidelity in the operator vocabulary", async () => {
     await loadPopup({
       polylogueState: {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -257,6 +257,20 @@ describe("popup capture", () => {
     expect(document.getElementById("fidelity-flag").hidden).toBe(false);
   });
 
+  it("maps every archive pipeline state through the shared operator vocabulary", async () => {
+    await loadPopup();
+
+    const { operatorStatusForState } = globalThis.PolylogueOperatorStatus;
+    expect(operatorStatusForState({ online: true, archive_state: { state: "missing" } }).label).toBe("Not saved");
+    expect(operatorStatusForState({ online: true, archive_state: { state: "spooled_only" } }).label).toBe("Catching up");
+    expect(operatorStatusForState({ online: true, archive_state: { state: "ingest_pending" } }).label).toBe("Catching up");
+    expect(operatorStatusForState({ online: true, archive_state: { state: "stale" } }).label).toBe("Catching up");
+    expect(operatorStatusForState({ online: true, archive_state: { state: "archived" } }).label).toBe("Safe");
+    expect(operatorStatusForState({ online: true, archive_state: { state: "failed" } }).label).toBe("Failed");
+    expect(operatorStatusForState({ online: true }).label).toBe("Needs attention");
+    expect(operatorStatusForState({ online: true, capture_mode: "dom_degraded" }).partialFidelity).toBe(true);
+  });
+
   it("renders supported pages without a conversation id without implying capture happened", async () => {
     await loadPopup({
       polylogueState: {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -302,6 +302,13 @@ describe("popup capture", () => {
     expect(document.getElementById("open-tabs").textContent).toContain("Catching up");
   });
 
+  it("does not list unrelated lookalike hosts as supported providers", async () => {
+    await loadPopup({}, [{ id: 88, title: "Lookalike", url: "https://notx.com/chat/anything" }]);
+
+    expect(document.getElementById("open-tab-count").textContent).toBe("0");
+    expect(document.getElementById("open-tabs").textContent).toContain("No supported conversation tabs");
+  });
+
   it("marks DOM-derived captures as partial fidelity in the operator vocabulary", async () => {
     await loadPopup({
       polylogueState: {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -268,6 +268,7 @@ describe("popup capture", () => {
     expect(operatorStatusForState({ online: true, archive_state: { state: "archived" } }).label).toBe("Safe");
     expect(operatorStatusForState({ online: true, archive_state: { state: "failed" } }).label).toBe("Failed");
     expect(operatorStatusForState({ online: true, captured: true, archive_state: { state: "spooled_only" } }).label).toBe("Catching up");
+    expect(operatorStatusForState({ online: true, captured: true, archive_state: { state: "missing" } }).label).toBe("Not saved");
     expect(operatorStatusForState({ online: true }).label).toBe("Needs attention");
     expect(operatorStatusForState({ online: true, capture_mode: "dom_degraded" }).partialFidelity).toBe(true);
   });
@@ -284,6 +285,20 @@ describe("popup capture", () => {
 
     expect(document.getElementById("operator-state").textContent).toBe("Catching up");
     expect(document.getElementById("archive").textContent).toBe("Ingest pending");
+  });
+
+  it("labels envelope turns as captured and indexed messages as visible", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: true,
+        turn_count: 12,
+        archive_state: { state: "archived", indexed_message_count: 5 },
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(document.getElementById("turns").textContent).toBe("12 captured / 5 visible");
   });
 
   it("renders supported pages without a conversation id without implying capture happened", async () => {
@@ -359,7 +374,7 @@ describe("popup capture", () => {
     });
 
     expect(globalThis.document.getElementById("fidelity").textContent).toBe("Native");
-    expect(globalThis.document.getElementById("turns").textContent).toBe("12 captured / 12 visible");
+    expect(globalThis.document.getElementById("turns").textContent).toBe("12 captured / -- visible");
     expect(globalThis.document.getElementById("assets").textContent).toBe("2 acquired · 1 failed");
     expect(globalThis.document.getElementById("asset-failures").textContent).toContain("file-abc: timeout");
   });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -11,6 +11,9 @@ function installDom() {
   const dom = new JSDOM(`<!doctype html>
     <body>
       <span id="badge"></span>
+      <span id="operator-state"></span>
+      <span id="fidelity-flag" hidden></span>
+      <span id="open-tab-count"></span>
       <span id="state"></span>
       <span id="receiver-request"></span>
       <span id="updated"></span>
@@ -53,6 +56,8 @@ function installDom() {
       <span id="log-count"></span>
       <span id="debug-count"></span>
       <div id="log"></div>
+      <div id="timeline"></div>
+      <div id="open-tabs"></div>
       <div id="debug-panel" hidden><div id="debug-log"></div></div>
     </body>`);
   globalThis.window = dom.window;
@@ -108,6 +113,7 @@ async function loadPopup(storagePatch = {}) {
   vi.resetModules();
   installDom();
   installChromeMock(storagePatch);
+  await import("../src/operator_status.js");
   await import("../src/popup.js");
   await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).toContain("ChatGPT"));
 }
@@ -148,7 +154,7 @@ describe("popup capture", () => {
     }));
   });
 
-  it("renders stale archive state with operator-facing explanation", async () => {
+  it("renders stale archive state as catching up", async () => {
     await loadPopup({
       polylogueState: {
         online: true,
@@ -160,6 +166,7 @@ describe("popup capture", () => {
 
     expect(globalThis.document.getElementById("badge").textContent).toBe("stale");
     expect(globalThis.document.getElementById("archive").textContent).toBe("Stale");
+    expect(globalThis.document.getElementById("operator-state").textContent).toBe("Catching up");
     expect(globalThis.document.getElementById("state-detail").textContent).toContain("daemon has not caught up");
   });
 
@@ -205,6 +212,49 @@ describe("popup capture", () => {
     expect(globalThis.document.getElementById("badge").textContent).toBe("missing");
     expect(globalThis.document.getElementById("archive").textContent).toBe("Not archived");
     expect(globalThis.document.getElementById("state").textContent).toContain("No capture exists");
+  });
+
+  it("renders mission-control status, open tabs, and the active decision timeline", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: false,
+        provider: "chatgpt",
+        provider_session_id: "test-conversation",
+        archive_state: { state: "missing" },
+        updated_at: new Date().toISOString(),
+      },
+      polylogueSessionLedger: {
+        "chatgpt:test-conversation": { archive_state: { state: "missing" } },
+      },
+      polylogueConversationTimeline: {
+        "chatgpt:test-conversation": [
+          { at: new Date().toISOString(), event: "held_with_reason", reason: "auto_capture_missing", detail: "background_capture_throttled" },
+          { at: new Date().toISOString(), event: "detected_new", detail: "archive_state_missing" },
+        ],
+      },
+    });
+
+    expect(document.getElementById("operator-state").textContent).toBe("Not saved");
+    expect(document.getElementById("open-tab-count").textContent).toBe("1");
+    expect(document.getElementById("open-tabs").textContent).toContain("Not saved");
+    expect(document.getElementById("timeline").textContent).toContain("Held");
+    expect(document.getElementById("timeline").textContent).toContain("background_capture_throttled");
+  });
+
+  it("marks DOM-derived captures as partial fidelity in the operator vocabulary", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: true,
+        capture_mode: "dom_degraded",
+        archive_state: { state: "archived" },
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(document.getElementById("operator-state").textContent).toBe("Safe");
+    expect(document.getElementById("fidelity-flag").hidden).toBe(false);
   });
 
   it("renders supported pages without a conversation id without implying capture happened", async () => {
@@ -280,7 +330,7 @@ describe("popup capture", () => {
     });
 
     expect(globalThis.document.getElementById("fidelity").textContent).toBe("Native");
-    expect(globalThis.document.getElementById("turns").textContent).toBe("12");
+    expect(globalThis.document.getElementById("turns").textContent).toBe("12 captured / 12 visible");
     expect(globalThis.document.getElementById("assets").textContent).toBe("2 acquired · 1 failed");
     expect(globalThis.document.getElementById("asset-failures").textContent).toContain("file-abc: timeout");
   });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -212,7 +212,7 @@ describe("popup capture", () => {
 
     expect(globalThis.document.getElementById("badge").textContent).toBe("missing");
     expect(globalThis.document.getElementById("archive").textContent).toBe("Not archived");
-    expect(globalThis.document.getElementById("state").textContent).toContain("No capture exists");
+    expect(globalThis.document.getElementById("state").textContent).toContain("not been saved");
   });
 
   it("renders mission-control status, open tabs, and the active decision timeline", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -48,6 +48,7 @@ function installDom() {
       <span id="mode"></span>
       <span id="fidelity"></span>
       <span id="turns"></span>
+      <span id="cost-tokens"></span>
       <span id="assets"></span>
       <div id="asset-failures"></div>
       <span id="receiver-health"></span>
@@ -299,6 +300,19 @@ describe("popup capture", () => {
     });
 
     expect(document.getElementById("turns").textContent).toBe("12 captured / 5 visible");
+  });
+
+  it("renders known cost and token data or an explicit unavailable state", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        usage: { total_tokens: 17 },
+        cost_usd: 0.012,
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(document.getElementById("cost-tokens").textContent).toBe("$0.012 · 17 tokens");
   });
 
   it("renders supported pages without a conversation id without implying capture happened", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -267,8 +267,23 @@ describe("popup capture", () => {
     expect(operatorStatusForState({ online: true, archive_state: { state: "stale" } }).label).toBe("Catching up");
     expect(operatorStatusForState({ online: true, archive_state: { state: "archived" } }).label).toBe("Safe");
     expect(operatorStatusForState({ online: true, archive_state: { state: "failed" } }).label).toBe("Failed");
+    expect(operatorStatusForState({ online: true, captured: true, archive_state: { state: "spooled_only" } }).label).toBe("Catching up");
     expect(operatorStatusForState({ online: true }).label).toBe("Needs attention");
     expect(operatorStatusForState({ online: true, capture_mode: "dom_degraded" }).partialFidelity).toBe(true);
+  });
+
+  it("keeps a pending capture out of the safe operator state", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        captured: true,
+        archive_state: { state: "ingest_pending" },
+        updated_at: new Date().toISOString(),
+      },
+    });
+
+    expect(document.getElementById("operator-state").textContent).toBe("Catching up");
+    expect(document.getElementById("archive").textContent).toBe("Ingest pending");
   });
 
   it("renders supported pages without a conversation id without implying capture happened", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -6,6 +6,11 @@ const CHATGPT_TAB = {
   title: "ChatGPT conversation",
   url: "https://chatgpt.com/c/test-conversation",
 };
+const GROK_QUERY_TAB = {
+  id: 77,
+  title: "Grok query conversation",
+  url: "https://grok.com/?conversation=query-77",
+};
 
 function installDom() {
   const dom = new JSDOM(`<!doctype html>
@@ -70,7 +75,7 @@ function installDom() {
   dom.window.HTMLAnchorElement.prototype.click = vi.fn();
 }
 
-function installChromeMock(storagePatch = {}) {
+function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB]) {
   let captureAttempts = 0;
   const defaults = {
     polylogueCaptureLog: [],
@@ -94,7 +99,7 @@ function installChromeMock(storagePatch = {}) {
       },
     },
     tabs: {
-      query: vi.fn(async () => [CHATGPT_TAB]),
+      query: vi.fn(async () => tabs),
       sendMessage: vi.fn(async () => {
         captureAttempts += 1;
         if (captureAttempts === 1) {
@@ -110,13 +115,13 @@ function installChromeMock(storagePatch = {}) {
   };
 }
 
-async function loadPopup(storagePatch = {}) {
+async function loadPopup(storagePatch = {}, tabs = [CHATGPT_TAB]) {
   vi.resetModules();
   installDom();
-  installChromeMock(storagePatch);
+  installChromeMock(storagePatch, tabs);
   await import("../src/operator_status.js");
   await import("../src/popup.js");
-  await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).toContain("ChatGPT"));
+  await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).not.toContain("Unknown"));
 }
 
 describe("popup capture", () => {
@@ -273,6 +278,27 @@ describe("popup capture", () => {
     expect(document.getElementById("archive").textContent).toBe("Spooled");
     expect(document.getElementById("timeline").textContent).toContain("active pending");
     expect(document.getElementById("timeline").textContent).not.toContain("old capture");
+    expect(document.getElementById("open-tabs").textContent).toContain("Catching up");
+  });
+
+  it("renders the ledger and timeline for a Grok query conversation", async () => {
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        provider: "grok",
+        provider_session_id: "query-77",
+        archive_state: { state: "spooled_only" },
+      },
+      polylogueSessionLedger: {
+        "grok:query-77": { archive_state: { state: "spooled_only" } },
+      },
+      polylogueConversationTimeline: {
+        "grok:query-77": [{ at: new Date().toISOString(), event: "first_seen", detail: "query route" }],
+      },
+    }, [GROK_QUERY_TAB]);
+
+    expect(document.getElementById("operator-state").textContent).toBe("Catching up");
+    expect(document.getElementById("timeline").textContent).toContain("query route");
     expect(document.getElementById("open-tabs").textContent).toContain("Catching up");
   });
 


### PR DESCRIPTION
## Summary

Adds the browser-extension mission-control slice: automatic capture when a conversation is newly reported missing, a bounded per-conversation decision timeline, a multi-tab popup, and a shared operator status vocabulary.

## Problem

Archive-state polling could repeatedly identify a missing conversation without dispatching the existing capture route. The operator then saw no POST, no explanation of the non-action, and only a single-tab fact table.

## Solution

- src/background.js records first-seen, detected, captured, and held-with-reason events in bounded chrome.storage.local timelines, dispatches `polylogue.capturePage` for newly missing conversations, and retains decisions for receiver-check failures.
- src/common.js and the provider content handlers propagate the automatic-capture reason into the production runtime POST.
- src/operator_status.js maps archive pipeline state to Safe, Catching up, Needs attention, Failed, or Not saved, with a partial-fidelity flag and the active-card copy in one shared module.
- src/popup.html and src/popup.js render the open supported tabs, active conversation, capture-versus-visible counts, retained quick actions, and What Polylogue did here. Raw state/request fields are collapsed under Debug.

### Acceptance matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-r4no | Satisfied | A missing archive state records detection and dispatches the content-to-runtime capture POST in the same activation cycle; throttling records held-with-reason instead. |
| polylogue-bkff | Satisfied | Popup has a supported-tab list, active conversation card, truthful unavailable cost/tokens, and existing quick actions. |
| polylogue-r2kb | Satisfied | One shared mapper/presentation provides every requested status and partial-fidelity flag; popup list and card consume it. |
| polylogue-4g3n | Partially satisfied | Local reverse-chron first-seen, detected, captured, and held decision timeline is persisted and displayed. Remaining polylogue-4g3n scope: mirror it to a daemon-queryable event trail in the substrate-owning lane. |

## Verification

- `cd browser-extension && npm test -- tests/content/grok.test.js tests/background.test.js tests/popup.test.js` — 57 tests passed.
- `cd browser-extension && npm run lint` — ESLint passed.
- `cd browser-extension && npm test` — 173 tests passed; two unrelated package-build tests failed because the local ignored `.venv` exposes a pre-1980 symlink timestamp that Python ZIP rejects.

Anti-vacuity: the activation regression drives the production activation → capturePage → runtime `polylogue.capture` → receiver POST route; removing the missing-state dispatch, runtime post handoff, or timeline append fails it. The Grok handler test evaluates the actual common and provider scripts; removing automatic reason propagation fails it. Popup tests import the actual renderer and shared operator module with tab/ledger/timeline inputs; removing the mapper, presentation consumer, timeline renderer, or tab-list rendering fails their visible assertions.

Ref polylogue-r4no
Ref polylogue-bkff
Ref polylogue-r2kb
Ref polylogue-4g3n