### PR TITLE
feat(api): expose annotation batch import

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -73,7 +73,10 @@ from polylogue.surfaces.temporal_evidence import (
 from polylogue.types import SessionId
 
 if TYPE_CHECKING:
+    from polylogue.annotations.importer import AnnotationBatchImportRequest, AnnotationBatchImportResult
     from polylogue.annotations.join import AnnotationStructuralJoinResult
+    from polylogue.annotations.schema import AnnotationSchemaRegistry
+    from polylogue.api import Polylogue
     from polylogue.archive.filter.filters import SessionFilter
     from polylogue.archive.message.models import Message
     from polylogue.archive.query.miss_diagnostics import QueryMissDiagnostics
@@ -1824,6 +1827,25 @@ class PolylogueArchiveMixin:
 
         @property
         def repository(self) -> SessionRepository: ...
+
+    async def import_annotation_batch(
+        self,
+        request: AnnotationBatchImportRequest,
+        *,
+        registry: AnnotationSchemaRegistry | None = None,
+    ) -> AnnotationBatchImportResult:
+        """Import bounded, provenance-stamped annotation candidates.
+
+        This is the library binding for the shared annotation-import product
+        operation used by the CLI and MCP surfaces. ``registry`` lets callers
+        use a deliberately constructed schema registry without bypassing the
+        facade.
+        """
+        from polylogue.annotations.importer import import_annotation_batch
+
+        if registry is None:
+            return await import_annotation_batch(cast("Polylogue", self), request)
+        return await import_annotation_batch(cast("Polylogue", self), request, registry=registry)
 
     async def get_session(
         self,

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1843,9 +1843,21 @@ class PolylogueArchiveMixin:
         """
         from polylogue.annotations.importer import import_annotation_batch
 
+        class _ActiveArchiveImportFacade:
+            @property
+            def archive_root(self) -> Path:
+                return _active_archive_root(self._archive.config)
+
+            def __init__(self, archive: PolylogueArchiveMixin) -> None:
+                self._archive = archive
+
+            async def resolve_ref(self, ref: str) -> PublicRefResolutionPayload:
+                return await self._archive.resolve_ref(ref)
+
+        import_facade = cast("Polylogue", _ActiveArchiveImportFacade(self))
         if registry is None:
-            return await import_annotation_batch(cast("Polylogue", self), request)
-        return await import_annotation_batch(cast("Polylogue", self), request, registry=registry)
+            return await import_annotation_batch(import_facade, request)
+        return await import_annotation_batch(import_facade, request, registry=registry)
 
     async def get_session(
         self,

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -36,6 +36,8 @@ from typing import Any, cast
 import pytest
 
 from polylogue import Polylogue
+from polylogue.annotations.importer import AnnotationBatchImportRequest
+from polylogue.annotations.schema import AnnotationField, AnnotationSchema, AnnotationSchemaRegistry
 from polylogue.api.archive import SessionNotFoundError
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import AssertionKind, AssertionStatus, BlockType, BranchType, MaterialOrigin, Origin, Provider
@@ -194,6 +196,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "list_sessions_for_spec",
         "search_session_hits",
         "diagnose_query_miss",
+        "import_annotation_batch",
         "storage_stats",
         "bulk_tag_sessions",
         "list_session_profile_insights",
@@ -4780,6 +4783,67 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
             ("saved_view:view-v1", "saved_query", "deleted"),
             ("workspace:workspace-v1", "workspace_note", "deleted"),
         ]
+    finally:
+        await archive.close()
+
+
+async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_path: Path) -> None:
+    """The facade reaches the bounded CLI/MCP annotation import operation.
+
+    Anti-vacuity: removing facade delegation, schema validation, live
+    reference resolution, or the user-tier write makes this test fail.
+    """
+    archive = _archive(tmp_path)
+    try:
+        session = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="annotation-facade-v1",
+            title="Annotation facade target",
+            messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text="evidence")],
+        )
+        with ArchiveStore(tmp_path) as archive_db:
+            session_id = archive_db.write_parsed(session)
+
+        registry = AnnotationSchemaRegistry()
+        registry.register(
+            AnnotationSchema(
+                schema_id="test.facade-import",
+                version=1,
+                title="Facade import fixture",
+                fields=(AnnotationField(name="label", value_type="enum", enum_values=("yes", "no")),),
+                target_ref_kinds=("session",),
+                evidence_policy="required",
+                status="active",
+            )
+        )
+        request = AnnotationBatchImportRequest(
+            jsonl=json.dumps(
+                {
+                    "row_key": "row-1",
+                    "value": {"label": "yes"},
+                    "evidence_refs": [str(session_id)],
+                }
+            ),
+            batch_id="facade-import",
+            schema_id="test.facade-import",
+            schema_version=1,
+            target_ref=f"session:{session_id}",
+            source_result_ref="result-set:facade-import",
+            actor_ref="agent:facade-test",
+            model_ref="agent:model",
+            prompt_ref="block:prompt:0",
+            created_at_ms=1_000,
+        )
+
+        result = await archive.import_annotation_batch(request, registry=registry)
+
+        assert result.status == "ok"
+        assert result.qualified_schema_id == "test.facade-import@v1"
+        assert result.valid_count == 1
+        assert result.rows[0].assertion_ref is not None
+        with sqlite3.connect(tmp_path / "user.db") as conn:
+            persisted = conn.execute("SELECT status, scope_ref FROM assertions WHERE key = 'row-1'").fetchone()
+        assert persisted == ("candidate", "annotation-batch:facade-import")
     finally:
         await archive.close()
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -4870,6 +4870,70 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
         await archive.close()
 
 
+async def test_facade_import_annotation_batch_uses_default_registry(tmp_path: Path) -> None:
+    """Omitting ``registry`` uses the registered production schema path.
+
+    Anti-vacuity: forwarding ``None`` to the importer instead of taking its
+    default registry causes this production-schema import to fail.
+    """
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            parent_session_id = archive_db.write_parsed(
+                _delegation_parent_session(provider_session_id="annotation-default-parent", with_dispatch=True)
+            )
+            archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="annotation-default-child",
+                    title="Default annotation registry child",
+                    messages=[ParsedMessage(provider_message_id="child-1", role=Role.ASSISTANT, text="on it")],
+                    parent_session_provider_id="annotation-default-parent",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+        delegation_ref = f"delegation:{parent_session_id}:dispatch:0"
+        request = AnnotationBatchImportRequest(
+            jsonl=json.dumps(
+                {
+                    "row_key": "production-schema-row",
+                    "value": {
+                        "directive_mode": "imperative",
+                        "prohibitions": "none",
+                        "autonomy": "bounded",
+                        "output_contract": "structured",
+                        "scope_control": "bounded",
+                        "verification_demand": "focused_tests",
+                        "checkpoint_escalation": "checkpoint",
+                        "relational_frame": "directive",
+                        "rationale_visibility": "explicit",
+                        "applicable": True,
+                        "confidence": 0.9,
+                    },
+                    "evidence_refs": [delegation_ref],
+                }
+            ),
+            batch_id="facade-default-registry",
+            schema_id="delegation.discourse",
+            schema_version=1,
+            target_ref=delegation_ref,
+            source_result_ref="result-set:facade-default-registry",
+            actor_ref="agent:facade-test",
+            model_ref="agent:model",
+            prompt_ref="block:prompt:0",
+            created_at_ms=2_000,
+        )
+
+        result = await archive.import_annotation_batch(request)
+
+        assert result.status == "ok"
+        assert result.qualified_schema_id == "delegation.discourse@v1"
+        assert result.valid_count == 1
+        assert result.rows[0].status == "imported"
+    finally:
+        await archive.close()
+
+
 async def test_archive_tiers_api_corrections_write_user_tier(tmp_path: Path) -> None:
     """Learning corrections use ``user.db``."""
     import sqlite3

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -4793,7 +4793,11 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
     Anti-vacuity: removing facade delegation, schema validation, live
     reference resolution, or the user-tier write makes this test fail.
     """
-    archive = _archive(tmp_path)
+    configured_root = tmp_path / "configured"
+    active_root = tmp_path / "active"
+    configured_root.mkdir()
+    active_root.mkdir()
+    archive = Polylogue(archive_root=configured_root, db_path=active_root / "index.db")
     try:
         session = ParsedSession(
             source_name=Provider.CODEX,
@@ -4801,7 +4805,7 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
             title="Annotation facade target",
             messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text="evidence")],
         )
-        with ArchiveStore(tmp_path) as archive_db:
+        with ArchiveStore(active_root) as archive_db:
             session_id = archive_db.write_parsed(session)
 
         registry = AnnotationSchemaRegistry()
@@ -4841,7 +4845,8 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
         assert result.qualified_schema_id == "test.facade-import@v1"
         assert result.valid_count == 1
         assert result.rows[0].assertion_ref is not None
-        with sqlite3.connect(tmp_path / "user.db") as conn:
+        assert not (configured_root / "user.db").exists()
+        with sqlite3.connect(active_root / "user.db") as conn:
             persisted = conn.execute("SELECT status, scope_ref FROM assertions WHERE key = 'row-1'").fetchone()
         assert persisted == ("candidate", "annotation-batch:facade-import")
     finally:

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -4821,12 +4821,23 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
             )
         )
         request = AnnotationBatchImportRequest(
-            jsonl=json.dumps(
-                {
-                    "row_key": "row-1",
-                    "value": {"label": "yes"},
-                    "evidence_refs": [str(session_id)],
-                }
+            jsonl="\n".join(
+                (
+                    json.dumps(
+                        {
+                            "row_key": "row-1",
+                            "value": {"label": "yes"},
+                            "evidence_refs": [str(session_id)],
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "row_key": "invalid-row",
+                            "value": {"label": "maybe"},
+                            "evidence_refs": ["missing-evidence"],
+                        }
+                    ),
+                )
             ),
             batch_id="facade-import",
             schema_id="test.facade-import",
@@ -4841,10 +4852,16 @@ async def test_facade_import_annotation_batch_persists_candidate_provenance(tmp_
 
         result = await archive.import_annotation_batch(request, registry=registry)
 
-        assert result.status == "ok"
+        assert result.status == "partial"
         assert result.qualified_schema_id == "test.facade-import@v1"
         assert result.valid_count == 1
+        assert result.invalid_count == 1
         assert result.rows[0].assertion_ref is not None
+        assert result.rows[1].status == "invalid"
+        assert result.rows[1].errors == (
+            "field 'label' must be one of ['no', 'yes'], got 'maybe'",
+            "evidence_ref 'missing-evidence' does not resolve in the live archive",
+        )
         assert not (configured_root / "user.db").exists()
         with sqlite3.connect(active_root / "user.db") as conn:
             persisted = conn.execute("SELECT status, scope_ref FROM assertions WHERE key = 'row-1'").fetchone()


### PR DESCRIPTION
## Summary

This PR audits the Python facade against the current CLI and MCP operation
surface, fixes the confirmed typed annotation-batch import gap, and records the
remaining work as proposals rather than claiming unimplemented governance.

## Problem

`Polylogue` lacked `import_annotation_batch`, although both CLI and MCP exposed
the bounded shared operation. The library therefore required callers to bypass
the promised facade. The audit also found that the existing parity manifest
cannot govern semantic operation bindings or API documentation drift.

## Solution

- Add `Polylogue.import_annotation_batch(request, *, registry=None)`.
- Use the active archive root for the shared importer, matching facade reads
  when `db_path` and configured `archive_root` differ.
- Add a real-route API test covering schema validation, evidence resolution,
  candidate persistence, and the split-root write boundary.

## Capability matrix

A dash means no equivalent implementation was found in that surface. It is not
an intention claim without a governed binding. Operation names are source-audit
identifiers; they must become a checked-in generated manifest in the follow-up.

### Shared archive/query/read

| Operation | CLI | MCP | Python API | Status |
| --- | --- | --- | --- | --- |
| session search/list/read | `find` / `read` | `search`, `list_sessions`, `archive_get_session` | `search`, `list_sessions`, `get_session` | aligned |
| messages | `read --view messages` | `get_messages` | `get_messages_paginated`, `bulk_get_messages` | aligned |
| raw artifacts | `read --view raw` | `raw_artifacts` | `get_raw_artifacts_for_session` | aligned |
| session tree/topology | — | `get_session_tree`, `get_session_topology` | same | MCP/API-only navigation reads |
| logical session | — | `get_logical_session` | same | MCP/API-only read pull |
| neighbors/correlation | `read --view neighbors/correlation` | `neighbor_candidates`, `correlate_*` | same | aligned |
| unit DSL / observed events | `find … then read` | `query_units` | `query_units` | aligned |
| explain/completions/facets | `find --explain`, `config query-completions`, `facets` | matching tools | matching methods | aligned |
| stats/readiness | `status`, `analyze`, `ops status` | `stats`, `readiness_check` | `stats`, `health_check` | domain-aligned; presentation differs |
| context image/preamble | `read --view context-image`, `continue` | `build_context_image`, `compose_context_preamble` | `context_image_payload`, `context_preamble_payload` | aligned |
| import explanation | `import --explain` | `explain_import` | `explain_import` | aligned |

### User state and annotations

| Operation family | CLI | MCP | Python API | Status |
| --- | --- | --- | --- | --- |
| tags / marks | `mark` | `list/add/remove`, `bulk_tag_sessions` | matching list/add/remove/bulk methods | aligned |
| annotations | `read`, `mark`, `delete` | `list_annotations`, `save_annotation`, `delete_annotation` | matching methods | aligned |
| typed annotation batch | `annotations import` | `import_annotation_batch` | `import_annotation_batch` | **fixed here** |
| typed annotation join | `annotations join` | `join_typed_annotations` | same | aligned |
| assertion candidates | `mark candidates *` | — | list/judge/review methods | CLI/API workflow; MCP excludes broad review writes |
| metadata / saved views | `read`, `mark`, `delete` | matching tools | matching methods | aligned |
| recall packs / workspaces | `continue`, `dashboard`, `delete` | matching tools | matching methods | aligned |
| corrections | — | record/list/clear tools | record/list/clear methods | intentional agent/API feedback path |
| blackboard | `agents *`, `agents handoff` | list/post tools | list/post methods | aligned |

### Insights, index, and maintenance

| Operation family | CLI | MCP | Python API | Status |
| --- | --- | --- | --- | --- |
| insight readers | `analyze insights *` | profiles, work-events, phases, threads, tags, coverage | matching get/list methods | aligned |
| costs / usage / debt | `analyze insights *`, `analyze usage` | costs, rollups, timeline, debt, usage | matching list/report methods | aligned |
| analysis | `analyze pace/turns`, `continue` | latency, stuck, workflow, abandoned, resume, postmortem, pathology | matching methods | aligned |
| insight rigor/rebuild/export | `ops insights *` | rigor audit, rebuild | audit/rebuild/export methods | CLI/API export is intentional |
| session tool timing | aggregate `analyze tools` | `session_tool_timing` | — | **deferred: split-tier typed contract required** |
| index / embeddings | `ops maintenance`, `ops embed *` | rebuild/update/status/preflight | matching methods | aligned where safely exposed |
| parse / configured sources | `import` | — | `parse_file`, `parse_sources` | intentional local/daemon API |
| guarded maintenance | `ops maintenance *` | maintenance wrappers | — | intentional operator-only guardrails |
| delete session | `delete` | `delete_session` | `delete_session_safe` | aligned; confirmation differs |

### Explicit surface-specific inventory

CLI-only interaction, credentials, lifecycle, backup, reset, GC, and destructive
maintenance commands remain terminal guardrails. MCP-only prompts/resources and
role-gated maintenance wrappers are agent-protocol concerns. Python lifecycle,
raw cursor/write primitives, repository vectors, and `SessionFilter` are
lower-level library mechanics rather than CLI/MCP capability promises.

## Bead acceptance-criteria status

- **Generated, committed capability matrix:** deferred. This PR body is a
  review artifact, not a rendered checked-in source of truth.
- **Every drifted row fixed or intentionally documented:** deferred. This PR
  fixes annotation-batch import; governed bindings and absences still need the
  follow-up manifest.
- **API-doc symbol check wired into verification:** deferred to the documentation
  and devtools proposal.
- **`docs/library-api.md` accurate against the facade:** deferred; it does not
  yet list this new method.

## Follow-up proposals

1. Govern semantic operation IDs in a manifest with per-surface bindings and
   explicit intentional absences; render and drift-check the matrix. Unknown or
   unbound live entries must fail.
2. Define a canonical typed, tier-safe `session-tool-timing` contract, then bind
   facade and MCP through it.
3. Add signature-, asyncness-, and section-aware library API documentation
   verification to the docs/devtools surface, including mutation-sensitive tests.
4. Consolidate MCP direct `ArchiveStore` reads behind the facade where DTO
   semantics already match.

## Verification

- `TMPDIR=/realm/tmp POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/api/test_facade_contracts.py::test_facade_import_annotation_batch_persists_candidate_provenance`
  - `1 passed in 11.11s`
- Push hook: `devtools verify --quick`
  - static/generated gate passed before the current test-only commit.

Anti-vacuity: the test drives the real facade, importer, custom schema registry,
live ref resolver, and `user.db` writer. Removing facade delegation, enum
validation, live evidence-ref resolution, or active-root persistence makes an
assertion fail.

Ref polylogue-9e5.16.
