### PR TITLE
fix(insights): refuse ungrounded quantitative claims

### DIFF
--- a/devtools/claim_vs_evidence.py
+++ b/devtools/claim_vs_evidence.py
@@ -1063,13 +1063,25 @@ def _public_summary(report: dict[str, Any]) -> dict[str, Any]:
                 "acknowledged": totals["acknowledged"],
                 "silent_proceed": totals["silent_proceed"],
                 "ambiguous": totals["ambiguous"],
+                "n_min": rates["n_min"],
                 "silent_rate_lower_bound": rates["silent_rate_lower_bound"],
+                "silent_rate_lower_bound_coverage_status": rates["coverage_status"],
+                "silent_rate_lower_bound_publication_status": rates["publication_status"],
                 "silent_rate_among_classified": rates["silent_rate_among_classified"],
+                "silent_rate_among_classified_coverage_status": rates["classified_coverage_status"],
+                "silent_rate_among_classified_publication_status": rates["classified_publication_status"],
             },
             {
                 "name": "sensitivity_and_calibration",
                 "ack_later_within_3": rates["ack_later_within_3"],
                 "window3_silent_rate_lower_bound": rates["window3_silent_rate_lower_bound"],
+                "window3_silent_rate_lower_bound_coverage_status": rates["coverage_status"],
+                "window3_silent_rate_lower_bound_publication_status": rates["publication_status"],
+                "window3_silent_rate_among_classified": rates["window3_silent_rate_among_classified"],
+                "window3_silent_rate_among_classified_coverage_status": rates["window3_classified_coverage_status"],
+                "window3_silent_rate_among_classified_publication_status": rates[
+                    "window3_classified_publication_status"
+                ],
                 "calibration_labeled_rows": calibration_metrics["labeled_rows"],
                 "ack_marker_precision": calibration_metrics["ack_marker_precision"],
                 "ack_marker_recall": calibration_metrics["ack_marker_recall"],
@@ -1138,8 +1150,28 @@ def _write_public_reproduction(path: Path, report: dict[str, Any]) -> None:
                 f"- acknowledged next turn: {int(classification['acknowledged']):,}",
                 f"- silent-proceed next turn: {int(classification['silent_proceed']):,}",
                 f"- ambiguous next turn: {int(classification['ambiguous']):,}",
-                f"- silent lower bound: {_format_rate_percent(classification['silent_rate_lower_bound'])}",
-                f"- next-3 silent lower bound: {_format_rate_percent(sensitivity['window3_silent_rate_lower_bound'])}",
+                (
+                    f"- silent lower bound: {_format_rate_percent(classification['silent_rate_lower_bound'])} "
+                    f"({classification['silent_rate_lower_bound_coverage_status']} / "
+                    f"{classification['silent_rate_lower_bound_publication_status']})"
+                ),
+                (
+                    f"- silent among classified: {_format_rate_percent(classification['silent_rate_among_classified'])} "
+                    f"({classification['silent_rate_among_classified_coverage_status']} / "
+                    f"{classification['silent_rate_among_classified_publication_status']})"
+                ),
+                (
+                    f"- next-3 silent lower bound: "
+                    f"{_format_rate_percent(sensitivity['window3_silent_rate_lower_bound'])} "
+                    f"({sensitivity['window3_silent_rate_lower_bound_coverage_status']} / "
+                    f"{sensitivity['window3_silent_rate_lower_bound_publication_status']})"
+                ),
+                (
+                    f"- next-3 silent among classified: "
+                    f"{_format_rate_percent(sensitivity['window3_silent_rate_among_classified'])} "
+                    f"({sensitivity['window3_silent_rate_among_classified_coverage_status']} / "
+                    f"{sensitivity['window3_silent_rate_among_classified_publication_status']})"
+                ),
                 f"- calibration labeled rows: {int(sensitivity['calibration_labeled_rows']):,}",
                 f"- acknowledged-marker precision: {_format_rate_percent(sensitivity['ack_marker_precision'])}",
                 f"- acknowledged-marker recall: {_format_rate_percent(sensitivity['ack_marker_recall'])}",
@@ -1253,7 +1285,18 @@ def _write_artifacts(out_dir: Path, report: dict[str, Any]) -> None:
             "ambiguous_wordless_continuation": totals["ambiguous_wordless_continuation"],
             "ambiguous_prose_no_marker": totals["ambiguous_prose_no_marker"],
             "silent_rate_lower_bound": rates["silent_rate_lower_bound"],
+            "silent_rate_lower_bound_coverage_status": rates["coverage_status"],
+            "silent_rate_lower_bound_publication_status": rates["publication_status"],
+            "silent_rate_among_classified": rates["silent_rate_among_classified"],
+            "silent_rate_among_classified_coverage_status": rates["classified_coverage_status"],
+            "silent_rate_among_classified_publication_status": rates["classified_publication_status"],
             "window3_silent_rate_lower_bound": rates["window3_silent_rate_lower_bound"],
+            "window3_silent_rate_lower_bound_coverage_status": rates["coverage_status"],
+            "window3_silent_rate_lower_bound_publication_status": rates["publication_status"],
+            "window3_silent_rate_among_classified": rates["window3_silent_rate_among_classified"],
+            "window3_silent_rate_among_classified_coverage_status": rates["window3_classified_coverage_status"],
+            "window3_silent_rate_among_classified_publication_status": rates["window3_classified_publication_status"],
+            "n_min": rates["n_min"],
             "by_handler_class": report["by_handler_class"],
             "handler_class_definition": report["handler_class_definition"],
             "limit": report["limit"],
@@ -1343,11 +1386,27 @@ def _write_readme(path: Path, report: dict[str, Any]) -> None:
         f"- ambiguous: {totals['ambiguous']:,}",
         f"- ambiguous wordless tool continuations: {totals['ambiguous_wordless_continuation']:,}",
         f"- ambiguous prose without markers: {totals['ambiguous_prose_no_marker']:,}",
-        f"- silent lower bound: {_format_rate_percent(rates['silent_rate_lower_bound'])}",
-        f"- silent among classified: {_format_rate_percent(rates['silent_rate_among_classified'])}",
+        (
+            f"- silent lower bound: {_format_rate_percent(rates['silent_rate_lower_bound'])} "
+            f"({rates['coverage_status']} / {rates['publication_status']})"
+        ),
+        (
+            f"- silent among classified: {_format_rate_percent(rates['silent_rate_among_classified'])} "
+            f"({rates['classified_coverage_status']} / {rates['classified_publication_status']})"
+        ),
         f"- acknowledged within next 3 assistant turns: {window3_totals['acknowledged']:,}",
         f"- acknowledgments appearing only after the next turn: {rates['ack_later_within_3']:,}",
-        f"- silent lower bound after next-3 sensitivity: {_format_rate_percent(rates['window3_silent_rate_lower_bound'])}",
+        (
+            f"- silent lower bound after next-3 sensitivity: "
+            f"{_format_rate_percent(rates['window3_silent_rate_lower_bound'])} "
+            f"({rates['coverage_status']} / {rates['publication_status']})"
+        ),
+        (
+            f"- silent among classified after next-3 sensitivity: "
+            f"{_format_rate_percent(rates['window3_silent_rate_among_classified'])} "
+            f"({rates['window3_classified_coverage_status']} / "
+            f"{rates['window3_classified_publication_status']})"
+        ),
         f"- configured limit: {report['limit']:,}",
         f"- split-cell minimum n: {frame['n_min']:,} (below this, rates are not supported)",
         f"- selection order: {frame['selection_order']}",

--- a/devtools/claim_vs_evidence.py
+++ b/devtools/claim_vs_evidence.py
@@ -156,6 +156,7 @@ def _ranked(mapping: dict[str, dict[str, int]], *, n_min: int) -> list[dict[str,
         silent = counts["silent_proceed"]
         classified = counts["acknowledged"] + silent
         supported = failed >= n_min
+        classified_supported = classified >= n_min
         rows.append(
             {
                 "name": name,
@@ -164,8 +165,10 @@ def _ranked(mapping: dict[str, dict[str, int]], *, n_min: int) -> list[dict[str,
                 "n_min": n_min,
                 "coverage_status": "supported" if supported else "insufficient_n",
                 "publication_status": "supported" if supported else "not_supported",
+                "classified_coverage_status": "supported" if classified_supported else "insufficient_n",
+                "classified_publication_status": "supported" if classified_supported else "not_supported",
                 "silent_rate_lower_bound": (silent / failed) if supported else None,
-                "silent_rate_among_classified": (silent / classified) if supported and classified else None,
+                "silent_rate_among_classified": (silent / classified) if classified_supported else None,
             }
         )
 
@@ -964,7 +967,8 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             "n_min": args.n_min,
             "thin_cell_policy": (
                 "Split cells below n_min are retained for coverage accounting but publish no rates: "
-                "coverage_status=insufficient_n and publication_status=not_supported."
+                "coverage_status=insufficient_n and publication_status=not_supported; "
+                "classified-denominator rates independently require classified_outcomes >= n_min."
             ),
             "total_by_origin": total_by_origin,
             "sampled_by_origin": sampled_by_origin,
@@ -979,12 +983,18 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "rates": {
             "coverage_status": "supported" if aggregate_supported else "insufficient_n",
             "publication_status": "supported" if aggregate_supported else "not_supported",
+            "classified_coverage_status": "supported" if classified >= args.n_min else "insufficient_n",
+            "classified_publication_status": "supported" if classified >= args.n_min else "not_supported",
+            "window3_classified_coverage_status": "supported" if window3_classified >= args.n_min else "insufficient_n",
+            "window3_classified_publication_status": "supported"
+            if window3_classified >= args.n_min
+            else "not_supported",
             "n_min": args.n_min,
             "silent_rate_lower_bound": (silent / failed) if aggregate_supported else None,
-            "silent_rate_among_classified": (silent / classified) if aggregate_supported and classified else None,
+            "silent_rate_among_classified": (silent / classified) if classified >= args.n_min else None,
             "window3_silent_rate_lower_bound": (window3_silent / failed) if aggregate_supported else None,
             "window3_silent_rate_among_classified": (
-                (window3_silent / window3_classified) if aggregate_supported and window3_classified else None
+                (window3_silent / window3_classified) if window3_classified >= args.n_min else None
             ),
             "ack_later_within_3": max(0, window3_totals["acknowledged"] - totals["acknowledged"]),
         },

--- a/devtools/claim_vs_evidence.py
+++ b/devtools/claim_vs_evidence.py
@@ -915,6 +915,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
     silent = totals["silent_proceed"]
     failed = totals["failed_outcomes"]
     classified = totals["classified_outcomes"]
+    aggregate_supported = failed >= args.n_min
     window3_silent = window3_totals["silent_proceed"]
     window3_classified = window3_totals["classified_outcomes"]
     calibration_sample = _calibration_sample(
@@ -976,11 +977,14 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "totals": totals,
         "window3_totals": window3_totals,
         "rates": {
-            "silent_rate_lower_bound": (silent / failed) if failed else 0.0,
-            "silent_rate_among_classified": (silent / classified) if classified else 0.0,
-            "window3_silent_rate_lower_bound": (window3_silent / failed) if failed else 0.0,
+            "coverage_status": "supported" if aggregate_supported else "insufficient_n",
+            "publication_status": "supported" if aggregate_supported else "not_supported",
+            "n_min": args.n_min,
+            "silent_rate_lower_bound": (silent / failed) if aggregate_supported else None,
+            "silent_rate_among_classified": (silent / classified) if aggregate_supported and classified else None,
+            "window3_silent_rate_lower_bound": (window3_silent / failed) if aggregate_supported else None,
             "window3_silent_rate_among_classified": (
-                (window3_silent / window3_classified) if window3_classified else 0.0
+                (window3_silent / window3_classified) if aggregate_supported and window3_classified else None
             ),
             "ack_later_within_3": max(0, window3_totals["acknowledged"] - totals["acknowledged"]),
         },
@@ -1124,8 +1128,8 @@ def _write_public_reproduction(path: Path, report: dict[str, Any]) -> None:
                 f"- acknowledged next turn: {int(classification['acknowledged']):,}",
                 f"- silent-proceed next turn: {int(classification['silent_proceed']):,}",
                 f"- ambiguous next turn: {int(classification['ambiguous']):,}",
-                f"- silent lower bound: {float(classification['silent_rate_lower_bound']):.1%}",
-                f"- next-3 silent lower bound: {float(sensitivity['window3_silent_rate_lower_bound']):.1%}",
+                f"- silent lower bound: {_format_rate_percent(classification['silent_rate_lower_bound'])}",
+                f"- next-3 silent lower bound: {_format_rate_percent(sensitivity['window3_silent_rate_lower_bound'])}",
                 f"- calibration labeled rows: {int(sensitivity['calibration_labeled_rows']):,}",
                 f"- acknowledged-marker precision: {_format_rate_percent(sensitivity['ack_marker_precision'])}",
                 f"- acknowledged-marker recall: {_format_rate_percent(sensitivity['ack_marker_recall'])}",
@@ -1329,11 +1333,11 @@ def _write_readme(path: Path, report: dict[str, Any]) -> None:
         f"- ambiguous: {totals['ambiguous']:,}",
         f"- ambiguous wordless tool continuations: {totals['ambiguous_wordless_continuation']:,}",
         f"- ambiguous prose without markers: {totals['ambiguous_prose_no_marker']:,}",
-        f"- silent lower bound: {rates['silent_rate_lower_bound']:.1%}",
-        f"- silent among classified: {rates['silent_rate_among_classified']:.1%}",
+        f"- silent lower bound: {_format_rate_percent(rates['silent_rate_lower_bound'])}",
+        f"- silent among classified: {_format_rate_percent(rates['silent_rate_among_classified'])}",
         f"- acknowledged within next 3 assistant turns: {window3_totals['acknowledged']:,}",
         f"- acknowledgments appearing only after the next turn: {rates['ack_later_within_3']:,}",
-        f"- silent lower bound after next-3 sensitivity: {rates['window3_silent_rate_lower_bound']:.1%}",
+        f"- silent lower bound after next-3 sensitivity: {_format_rate_percent(rates['window3_silent_rate_lower_bound'])}",
         f"- configured limit: {report['limit']:,}",
         f"- split-cell minimum n: {frame['n_min']:,} (below this, rates are not supported)",
         f"- selection order: {frame['selection_order']}",

--- a/devtools/claim_vs_evidence.py
+++ b/devtools/claim_vs_evidence.py
@@ -49,6 +49,7 @@ _CALIBRATION_LABELS_FILE = "ack-marker-calibration.labels.csv"
 _PUBLIC_SUMMARY_FILE = "public-summary.json"
 _PUBLIC_REPRODUCTION_FILE = "PUBLIC_REPRODUCTION.md"
 _COLD_READER_GATE_FILE = "COLD_READER_GATE.md"
+_DEFAULT_N_MIN = 30
 _CALIBRATION_FIELDS = (
     "sample_id",
     "human_label",
@@ -78,6 +79,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--out-dir", type=Path, default=None, help="Write report.json, summary.json, and README.md.")
     parser.add_argument("--limit", type=int, default=5000, help="Maximum structured failed outcomes to classify.")
     parser.add_argument("--sample-limit", type=int, default=30, help="Maximum evidence samples per class.")
+    parser.add_argument(
+        "--n-min",
+        type=int,
+        default=_DEFAULT_N_MIN,
+        help="Minimum failures required before a split-cell rate is supported.",
+    )
     parser.add_argument(
         "--calibration-size",
         type=int,
@@ -142,19 +149,23 @@ def _object_str_list(value: object) -> list[str]:
     return []
 
 
-def _ranked(mapping: dict[str, dict[str, int]]) -> list[dict[str, object]]:
+def _ranked(mapping: dict[str, dict[str, int]], *, n_min: int) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for name, counts in mapping.items():
         failed = counts["failed_outcomes"]
         silent = counts["silent_proceed"]
         classified = counts["acknowledged"] + silent
+        supported = failed >= n_min
         rows.append(
             {
                 "name": name,
                 **counts,
                 "classified_outcomes": classified,
-                "silent_rate_lower_bound": (silent / failed) if failed else 0.0,
-                "silent_rate_among_classified": (silent / classified) if classified else 0.0,
+                "n_min": n_min,
+                "coverage_status": "supported" if supported else "insufficient_n",
+                "publication_status": "supported" if supported else "not_supported",
+                "silent_rate_lower_bound": (silent / failed) if supported else None,
+                "silent_rate_among_classified": (silent / classified) if supported and classified else None,
             }
         )
 
@@ -775,6 +786,8 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         raise ValueError("--limit must be positive")
     if args.sample_limit < 1:
         raise ValueError("--sample-limit must be positive")
+    if args.n_min < 1:
+        raise ValueError("--n-min must be positive")
     if args.calibration_size < 0:
         raise ValueError("--calibration-size must be non-negative")
     config = _config_with_archive_root(get_config(), args.archive_root)
@@ -947,6 +960,11 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             "failure_predicate": "tool_result_is_error = 1 OR tool_result_exit_code != 0",
             "classification_scope": "immediately following assistant message only",
             "sensitivity_scope": "next 3 assistant messages after the failed result, stopping before the next user message",
+            "n_min": args.n_min,
+            "thin_cell_policy": (
+                "Split cells below n_min are retained for coverage accounting but publish no rates: "
+                "coverage_status=insufficient_n and publication_status=not_supported."
+            ),
             "total_by_origin": total_by_origin,
             "sampled_by_origin": sampled_by_origin,
         },
@@ -966,10 +984,10 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "ack_later_within_3": max(0, window3_totals["acknowledged"] - totals["acknowledged"]),
         },
-        "by_tool": _ranked(by_tool),
-        "by_model": _ranked(by_model),
-        "by_origin": _ranked(by_origin),
-        "by_handler_class": _ranked(by_handler_class),
+        "by_tool": _ranked(by_tool, n_min=args.n_min),
+        "by_model": _ranked(by_model, n_min=args.n_min),
+        "by_origin": _ranked(by_origin, n_min=args.n_min),
+        "by_handler_class": _ranked(by_handler_class, n_min=args.n_min),
         "handler_class_definition": {
             "benign_recovery": sorted(_BENIGN_RECOVERY_TOOLS),
             "consequential": sorted(_CONSEQUENTIAL_TOOLS),
@@ -1023,6 +1041,8 @@ def _public_summary(report: dict[str, Any]) -> dict[str, Any]:
                 "unpaired_structured_failures": frame["unpaired_structured_failures"],
                 "selection_strategy": frame["selection_strategy"],
                 "selection_order": frame["selection_order"],
+                "n_min": frame["n_min"],
+                "thin_cell_policy": frame["thin_cell_policy"],
             },
             {
                 "name": "next_turn_classification",
@@ -1046,6 +1066,7 @@ def _public_summary(report: dict[str, Any]) -> dict[str, Any]:
             "Deterministic demo reproduction validates the method and renderer, not the private rate estimates.",
             "The classifier is an explicit marker detector; ambiguous rows remain in the denominator.",
             "The report is bounded by --limit unless the limit exceeds the full structured-failure frame.",
+            "Split cells below n_min are coverage-only and explicitly not supported for rate publication.",
         ],
         "reproduction": {
             "demo_archive_root": "/realm/tmp/polylogue-claim-vs-evidence-demo",
@@ -1275,7 +1296,11 @@ def _write_readme(path: Path, report: dict[str, Any]) -> None:
             f"- {row['name']}: failed {int(row['failed_outcomes']):,}; "
             f"silent {int(row['silent_proceed']):,}; "
             f"ambiguous {int(row['ambiguous']):,}; "
-            f"silent lower bound {float(row['silent_rate_lower_bound']):.1%}"
+            + (
+                f"silent lower bound {float(row['silent_rate_lower_bound']):.1%}"
+                if row["silent_rate_lower_bound"] is not None
+                else f"not supported (n < {int(row['n_min'])})"
+            )
         )
         for row in report["by_handler_class"]
     ]
@@ -1310,6 +1335,7 @@ def _write_readme(path: Path, report: dict[str, Any]) -> None:
         f"- acknowledgments appearing only after the next turn: {rates['ack_later_within_3']:,}",
         f"- silent lower bound after next-3 sensitivity: {rates['window3_silent_rate_lower_bound']:.1%}",
         f"- configured limit: {report['limit']:,}",
+        f"- split-cell minimum n: {frame['n_min']:,} (below this, rates are not supported)",
         f"- selection order: {frame['selection_order']}",
         f"- selection strategy: {frame['selection_strategy']}",
         "",

--- a/devtools/verify_insight_rigor_honesty.py
+++ b/devtools/verify_insight_rigor_honesty.py
@@ -47,6 +47,12 @@ def _missing_numeric_field_coverage() -> tuple[tuple[str, tuple[str, ...]], ...]
     return missing_numeric_field_coverage()
 
 
+def _missing_numeric_item_models() -> tuple[str, ...]:
+    from polylogue.insights.rigor import missing_numeric_item_models
+
+    return missing_numeric_item_models()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -57,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
 
     uncovered = _uncovered_insight_names()
     missing_fields = _missing_numeric_field_coverage()
+    missing_item_models = _missing_numeric_item_models()
 
     if args.json:
         print(
@@ -66,12 +73,13 @@ def main(argv: list[str] | None = None) -> int:
                     "missing_numeric_field_coverage": [
                         {"insight_name": name, "field_path": list(field_path)} for name, field_path in missing_fields
                     ],
-                    "ok": not uncovered and not missing_fields,
+                    "missing_numeric_item_models": list(missing_item_models),
+                    "ok": not uncovered and not missing_fields and not missing_item_models,
                 },
                 indent=2,
             )
         )
-    elif uncovered or missing_fields:
+    elif uncovered or missing_fields or missing_item_models:
         if uncovered:
             print(f"insight rigor honesty: {len(uncovered)} registered insight(s) uncovered")
             for name in uncovered:
@@ -80,6 +88,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"insight rigor honesty: {len(missing_fields)} numeric field coverage declaration(s) missing")
             for name, field_path in missing_fields:
                 print(f"  {name}.{'.'.join(field_path)}")
+        if missing_item_models:
+            print(f"insight rigor honesty: {len(missing_item_models)} registered insight item model(s) missing")
+            for name in missing_item_models:
+                print(f"  {name}")
         print("")
         print(
             "Policy violation: every registered insight needs a RigorContract row "
@@ -89,7 +101,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("insight rigor honesty: every registered insight and public numeric field is contracted or exempt.")
 
-    return 0 if not uncovered and not missing_fields else 1
+    return 0 if not uncovered and not missing_fields and not missing_item_models else 1
 
 
 if __name__ == "__main__":

--- a/devtools/verify_insight_rigor_honesty.py
+++ b/devtools/verify_insight_rigor_honesty.py
@@ -41,10 +41,10 @@ def _uncovered_insight_names() -> tuple[str, ...]:
     return tuple(sorted(registered - covered))
 
 
-def _missing_nullable_field_contracts() -> tuple[tuple[str, tuple[str, ...]], ...]:
-    from polylogue.insights.rigor import missing_nullable_field_contracts
+def _missing_numeric_field_coverage() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    from polylogue.insights.rigor import missing_numeric_field_coverage
 
-    return missing_nullable_field_contracts()
+    return missing_numeric_field_coverage()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,14 +56,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     uncovered = _uncovered_insight_names()
-    missing_fields = _missing_nullable_field_contracts()
+    missing_fields = _missing_numeric_field_coverage()
 
     if args.json:
         print(
             json.dumps(
                 {
                     "uncovered_insight_names": list(uncovered),
-                    "missing_nullable_field_contracts": [
+                    "missing_numeric_field_coverage": [
                         {"insight_name": name, "field_path": list(field_path)} for name, field_path in missing_fields
                     ],
                     "ok": not uncovered and not missing_fields,
@@ -77,17 +77,17 @@ def main(argv: list[str] | None = None) -> int:
             for name in uncovered:
                 print(f"  {name}")
         if missing_fields:
-            print(f"insight rigor honesty: {len(missing_fields)} nullable field contract(s) missing")
+            print(f"insight rigor honesty: {len(missing_fields)} numeric field coverage declaration(s) missing")
             for name, field_path in missing_fields:
                 print(f"  {name}.{'.'.join(field_path)}")
         print("")
         print(
             "Policy violation: every registered insight needs a RigorContract row "
             "(polylogue/insights/rigor.py _RIGOR_MATRIX) or a justified RIGOR_EXEMPT entry, "
-            "and every known zero-denominator field needs a RigorFieldContract."
+            "and every public numeric field needs a RigorFieldContract or explicit field exemption."
         )
     else:
-        print("insight rigor honesty: every registered insight and nullable field is contracted or exempt.")
+        print("insight rigor honesty: every registered insight and public numeric field is contracted or exempt.")
 
     return 0 if not uncovered and not missing_fields else 1
 

--- a/devtools/verify_insight_rigor_honesty.py
+++ b/devtools/verify_insight_rigor_honesty.py
@@ -41,6 +41,12 @@ def _uncovered_insight_names() -> tuple[str, ...]:
     return tuple(sorted(registered - covered))
 
 
+def _missing_nullable_field_contracts() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    from polylogue.insights.rigor import missing_nullable_field_contracts
+
+    return missing_nullable_field_contracts()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -50,22 +56,40 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     uncovered = _uncovered_insight_names()
+    missing_fields = _missing_nullable_field_contracts()
 
     if args.json:
-        print(json.dumps({"uncovered_insight_names": list(uncovered), "ok": not uncovered}, indent=2))
-    elif uncovered:
-        print(f"insight rigor honesty: {len(uncovered)} registered insight(s) uncovered")
-        for name in uncovered:
-            print(f"  {name}")
+        print(
+            json.dumps(
+                {
+                    "uncovered_insight_names": list(uncovered),
+                    "missing_nullable_field_contracts": [
+                        {"insight_name": name, "field_path": list(field_path)} for name, field_path in missing_fields
+                    ],
+                    "ok": not uncovered and not missing_fields,
+                },
+                indent=2,
+            )
+        )
+    elif uncovered or missing_fields:
+        if uncovered:
+            print(f"insight rigor honesty: {len(uncovered)} registered insight(s) uncovered")
+            for name in uncovered:
+                print(f"  {name}")
+        if missing_fields:
+            print(f"insight rigor honesty: {len(missing_fields)} nullable field contract(s) missing")
+            for name, field_path in missing_fields:
+                print(f"  {name}.{'.'.join(field_path)}")
         print("")
         print(
             "Policy violation: every registered insight needs a RigorContract row "
-            "(polylogue/insights/rigor.py _RIGOR_MATRIX) or a justified RIGOR_EXEMPT entry."
+            "(polylogue/insights/rigor.py _RIGOR_MATRIX) or a justified RIGOR_EXEMPT entry, "
+            "and every known zero-denominator field needs a RigorFieldContract."
         )
     else:
-        print("insight rigor honesty: every registered insight is contracted or exempt.")
+        print("insight rigor honesty: every registered insight and nullable field is contracted or exempt.")
 
-    return 0 if not uncovered else 1
+    return 0 if not uncovered and not missing_fields else 1
 
 
 if __name__ == "__main__":

--- a/devtools/verify_insight_rigor_honesty.py
+++ b/devtools/verify_insight_rigor_honesty.py
@@ -53,6 +53,12 @@ def _missing_numeric_item_models() -> tuple[str, ...]:
     return missing_numeric_item_models()
 
 
+def _invalid_nullable_field_contracts() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    from polylogue.insights.rigor import invalid_nullable_field_contracts
+
+    return invalid_nullable_field_contracts()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -64,6 +70,7 @@ def main(argv: list[str] | None = None) -> int:
     uncovered = _uncovered_insight_names()
     missing_fields = _missing_numeric_field_coverage()
     missing_item_models = _missing_numeric_item_models()
+    invalid_contracts = _invalid_nullable_field_contracts()
 
     if args.json:
         print(
@@ -74,12 +81,15 @@ def main(argv: list[str] | None = None) -> int:
                         {"insight_name": name, "field_path": list(field_path)} for name, field_path in missing_fields
                     ],
                     "missing_numeric_item_models": list(missing_item_models),
-                    "ok": not uncovered and not missing_fields and not missing_item_models,
+                    "invalid_nullable_field_contracts": [
+                        {"insight_name": name, "field_path": list(field_path)} for name, field_path in invalid_contracts
+                    ],
+                    "ok": not uncovered and not missing_fields and not missing_item_models and not invalid_contracts,
                 },
                 indent=2,
             )
         )
-    elif uncovered or missing_fields or missing_item_models:
+    elif uncovered or missing_fields or missing_item_models or invalid_contracts:
         if uncovered:
             print(f"insight rigor honesty: {len(uncovered)} registered insight(s) uncovered")
             for name in uncovered:
@@ -92,6 +102,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"insight rigor honesty: {len(missing_item_models)} registered insight item model(s) missing")
             for name in missing_item_models:
                 print(f"  {name}")
+        if invalid_contracts:
+            print(f"insight rigor honesty: {len(invalid_contracts)} nullable field contract(s) invalid")
+            for name, field_path in invalid_contracts:
+                print(f"  {name}.{'.'.join(field_path)}")
         print("")
         print(
             "Policy violation: every registered insight needs a RigorContract row "
@@ -101,7 +115,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("insight rigor honesty: every registered insight and public numeric field is contracted or exempt.")
 
-    return 0 if not uncovered and not missing_fields and not missing_item_models else 1
+    return 0 if not uncovered and not missing_fields and not missing_item_models and not invalid_contracts else 1
 
 
 if __name__ == "__main__":

--- a/docs/insights-rigor-matrix.md
+++ b/docs/insights-rigor-matrix.md
@@ -308,6 +308,12 @@ insight-honesty` enforces this statically; the audit runner reports an
 uncovered product's `coverage_status` as `"uncovered"` rather than
 silently omitting it (9e5.28).
 
+The same policy recursively inspects each registered descriptor's item
+model. Every public numeric leaf must have a `RigorFieldContract` or an
+explicitly justified field exemption; a registry descriptor without an item
+model is itself a policy failure. This keeps newly exposed nested quantitative
+fields from bypassing the rigor matrix.
+
 ## Audit CLI
 
 ```bash

--- a/docs/insights-rigor-matrix.md
+++ b/docs/insights-rigor-matrix.md
@@ -246,10 +246,15 @@ API.
 - Readiness: session/priced/unavailable counts, `status_counts`,
   `total_usd`, `basis`, and `usage` are grounded SQL sums/counts.
   `confidence` is the one probabilistic signal — a session-count-weighted
-  average of the same per-row confidence heuristic `session_costs` uses.
+  average of the same per-row confidence heuristic `session_costs` uses. It
+  renders `None` (plain output: `uncovered`) when `priced_session_count` is
+  zero, rather than fabricating a `0.0` confidence.
 - Notes: `provenance.materializer_version` is a hardcoded literal `0`, a
   sentinel for "computed live at query time", not a stored materialized
   artifact — not declared as a version field.
+- Field contract: `confidence` is `derived` from priced-session confidence
+  values with `priced_session_count` as its denominator; an empty denominator
+  is not applicable, not a measured zero.
 - Consumer-facing fields: `source_name`, `model_name`,
   `normalized_model`, `session_count`, `priced_session_count`,
   `unavailable_session_count`, `status_counts`, `total_usd`, `basis`,

--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -507,7 +507,9 @@ class CostRollupInsight(ArchiveInsightModel):
     unavailable_reason_counts: dict[str, int] = {}
     per_model_breakdown: tuple[CostModelBreakdown, ...] = ()
     usage: CostUsagePayload
-    confidence: float = 0.0
+    # A rollup with no priced sessions has no confidence frame.  ``None`` is
+    # deliberately distinct from a measured 0.0 confidence (9e5.29/uwk3).
+    confidence: float | None = None
     provenance: ArchiveInsightProvenance
 
 

--- a/polylogue/insights/archive_rollups.py
+++ b/polylogue/insights/archive_rollups.py
@@ -295,7 +295,7 @@ def aggregate_cost_rollup_insights(
                 unavailable_reason_counts=dict(sorted(unavailable_reason_counts.items())),
                 per_model_breakdown=per_model_breakdown,
                 usage=usage,
-                confidence=(confidence_total / priced_count if priced_count else 0.0),
+                confidence=(confidence_total / priced_count if priced_count else None),
                 provenance=ArchiveInsightProvenance(
                     materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
                     materialized_at=materialized_at,

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -26,19 +26,29 @@ from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.errors import PolylogueError
 from polylogue.insights.archive import (
+    ArchiveCoverageInsight,
     ArchiveCoverageInsightQuery,
+    ArchiveDebtInsight,
     ArchiveDebtInsightQuery,
     ArchiveInsightModel,
+    CostRollupInsight,
     CostRollupInsightQuery,
+    SessionCostInsight,
     SessionCostInsightQuery,
+    SessionPhaseInsight,
     SessionPhaseInsightQuery,
+    SessionProfileInsight,
     SessionProfileInsightQuery,
+    SessionTagRollupInsight,
     SessionTagRollupQuery,
+    SessionWorkEventInsight,
     SessionWorkEventInsightQuery,
+    ThreadInsight,
     ThreadInsightQuery,
+    UsageTimelineInsight,
     UsageTimelineInsightQuery,
 )
-from polylogue.insights.tool_usage import ToolUsageInsightQuery
+from polylogue.insights.tool_usage import ToolUsageInsight, ToolUsageInsightQuery
 
 InsightAccessor: TypeAlias = Callable[[ArchiveInsightModel], str]
 
@@ -74,6 +84,7 @@ class InsightType:
     display_name: str
     json_key: str
     fields: tuple[InsightField, ...] = ()
+    item_model: type[ArchiveInsightModel] | None = None
     empty_message: str = "No items matched."
     query_model: type[ArchiveInsightModel] | None = None
     operations_method_name: str = ""
@@ -367,6 +378,7 @@ register(
         name="session_profiles",
         display_name="Session Profiles",
         json_key="session_profiles",
+        item_model=SessionProfileInsight,
         empty_message="No session profiles matched.",
         query_model=SessionProfileInsightQuery,
         operations_method_name="list_session_profile_insights",
@@ -414,6 +426,7 @@ register(
         name="session_work_events",
         display_name="Work Events",
         json_key="session_work_events",
+        item_model=SessionWorkEventInsight,
         empty_message="No work events matched.",
         query_model=SessionWorkEventInsightQuery,
         operations_method_name="list_session_work_event_insights",
@@ -454,6 +467,7 @@ register(
         name="session_phases",
         display_name="Session Phases",
         json_key="session_phases",
+        item_model=SessionPhaseInsight,
         empty_message="No session phases matched.",
         query_model=SessionPhaseInsightQuery,
         operations_method_name="list_session_phase_insights",
@@ -475,6 +489,7 @@ register(
         name="threads",
         display_name="Work Threads",
         json_key="threads",
+        item_model=ThreadInsight,
         empty_message="No work threads matched.",
         query_model=ThreadInsightQuery,
         operations_method_name="list_thread_insights",
@@ -496,6 +511,7 @@ register(
         name="session_tag_rollups",
         display_name="Session Tag Rollups",
         json_key="session_tag_rollups",
+        item_model=SessionTagRollupInsight,
         empty_message="No session tag rollups matched.",
         query_model=SessionTagRollupQuery,
         operations_method_name="list_session_tag_rollup_insights",
@@ -517,6 +533,7 @@ register(
         name="archive_coverage",
         display_name="Archive Coverage",
         json_key="archive_coverage",
+        item_model=ArchiveCoverageInsight,
         empty_message="No archive coverage buckets matched.",
         query_model=ArchiveCoverageInsightQuery,
         operations_method_name="list_archive_coverage_insights",
@@ -557,6 +574,7 @@ register(
         name="tool_usage",
         display_name="Tool Usage",
         json_key="tool_usage",
+        item_model=ToolUsageInsight,
         empty_message="No tool usage data available.",
         query_model=ToolUsageInsightQuery,
         operations_method_name="list_tool_usage_insights",
@@ -588,6 +606,7 @@ register(
         name="session_costs",
         display_name="Session Costs",
         json_key="session_costs",
+        item_model=SessionCostInsight,
         empty_message="No session cost estimates matched.",
         query_model=SessionCostInsightQuery,
         operations_method_name="list_session_cost_insights",
@@ -614,6 +633,7 @@ register(
         name="cost_rollups",
         display_name="Cost Rollups",
         json_key="cost_rollups",
+        item_model=CostRollupInsight,
         empty_message="No cost rollups matched.",
         query_model=CostRollupInsightQuery,
         operations_method_name="list_cost_rollup_insights",
@@ -642,6 +662,7 @@ register(
         name="usage_timeline",
         display_name="Usage Timeline",
         json_key="usage_timeline",
+        item_model=UsageTimelineInsight,
         empty_message="No usage timeline rows matched.",
         query_model=UsageTimelineInsightQuery,
         operations_method_name="list_usage_timeline_insights",
@@ -679,6 +700,7 @@ register(
         name="archive_debt",
         display_name="Archive Debt",
         json_key="archive_debt",
+        item_model=ArchiveDebtInsight,
         empty_message="No archive debt entries matched.",
         query_model=ArchiveDebtInsightQuery,
         operations_method_name="list_archive_debt_insights",

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -632,7 +632,7 @@ register(
             InsightField("api_usd", _nested("basis", "api_equivalent_usd", "0"), group=1),
             InsightField("sub_usd", _nested("basis", "subscription_equivalent_usd", "0"), group=1),
             InsightField("catalog_usd", _nested("basis", "catalog_priced_usd", "0"), group=1),
-            InsightField("confidence", _attr("confidence", "0"), group=1),
+            InsightField("confidence", _attr("confidence", "uncovered"), group=1),
         ),
     )
 )

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -13,8 +13,8 @@ The contract drives:
 - ``polylogue insights audit`` (CLI): per-product rigor profile rollup
   with evidence/inference/fallback marker coverage, stale-version count,
   and confidence distribution.
-- documentation: the rendered matrix lives at
-  ``docs/insights-rigor-matrix.md`` (regenerated from this module).
+- documentation: the human-readable matrix lives at
+  ``docs/insights-rigor-matrix.md`` and is updated alongside this module.
 - consumer self-discovery: future MCP and API surfaces can query the
   matrix instead of reading prose docs.
 
@@ -25,9 +25,20 @@ runner lives in :mod:`polylogue.insights.audit`.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from types import UnionType
+from typing import get_args, get_origin
 
+from polylogue.insights.archive import (
+    ArchiveCoverageInsight,
+    ArchiveDebtInsight,
+    CostRollupInsight,
+    SessionPhaseInsight,
+    SessionTagRollupInsight,
+    SessionWorkEventInsight,
+    UsageTimelineInsight,
+)
 from polylogue.insights.archive_models import ArchiveInsightModel
-from polylogue.insights.tool_usage import TOOL_USAGE_INSIGHT_VERSION
+from polylogue.insights.tool_usage import TOOL_USAGE_INSIGHT_VERSION, ToolUsageInsight
 from polylogue.storage.runtime.store_constants import (
     SESSION_ENRICHMENT_VERSION,
     SESSION_INFERENCE_VERSION,
@@ -77,6 +88,22 @@ class RigorFieldContract(ArchiveInsightModel):
     evidence_tier: str = "sql-aggregate"
 
 
+class RigorFieldExemption(ArchiveInsightModel):
+    """Explicit justification for a quantitative field whose zero is measured.
+
+    This is deliberately field-level, rather than a product-level note: an
+    exemption is only valid when the public model still exposes that numeric
+    field, and the honesty policy rejects a newly added unclassified field.
+    """
+
+    field_path: tuple[str, ...]
+    reason: str
+
+
+def _true_zero_fields(reason: str, *names: str) -> tuple[RigorFieldExemption, ...]:
+    return tuple(RigorFieldExemption(field_path=(name,), reason=reason) for name in names)
+
+
 class RigorContract(ArchiveInsightModel):
     """Per-product rigor contract matrix entry.
 
@@ -107,6 +134,8 @@ class RigorContract(ArchiveInsightModel):
             but any field listed here is a committed promise: it must
             render ``None``, never ``0``/``0.0``, when its declared
             denominator is zero or ungrounded.
+        field_exemptions: explicit field-level reasons that a numeric zero is
+            a real measured value rather than absent evidence.
         notes: optional free-form notes (deprecated fields, transition
             anchors, etc.).
     """
@@ -121,6 +150,7 @@ class RigorContract(ArchiveInsightModel):
     consumer_fields: tuple[str, ...] = ()
     version_fields: tuple[RigorVersionField, ...] = ()
     field_contracts: tuple[RigorFieldContract, ...] = ()
+    field_exemptions: tuple[RigorFieldExemption, ...] = ()
     notes: str = ""
 
 
@@ -220,6 +250,10 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
             RigorVersionField(name="inference_version", current_version=SESSION_INFERENCE_VERSION),
         ),
+        field_exemptions=_true_zero_fields(
+            "Event index is an ordinal identity component, not an aggregate claim.",
+            "event_index",
+        ),
         notes=(
             "Heuristic-tier inventory (#b0b.1): the activity-type classifier "
             "(``inference.heuristic_label`` -- planning/debugging/testing/review/"
@@ -270,6 +304,10 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
         version_fields=(
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
         ),
+        field_exemptions=_true_zero_fields(
+            "Phase index is an ordinal identity component, not an aggregate claim.",
+            "phase_index",
+        ),
     ),
     RigorContract(
         insight_name="threads",
@@ -311,6 +349,15 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
         ),
         version_fields=(
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
+        ),
+        field_exemptions=_true_zero_fields(
+            "Tag counts and breakdowns are direct aggregate counts; zero means no matching tagged rows.",
+            "session_count",
+            "logical_session_count",
+            "explicit_count",
+            "auto_count",
+            "origin_breakdown",
+            "repo_breakdown",
         ),
     ),
     RigorContract(
@@ -376,6 +423,26 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
                 denominator_field=("session_count",),
             ),
         ),
+        field_exemptions=_true_zero_fields(
+            "Coverage counts, sums, and breakdowns are direct SQL aggregates; zero is a measured empty aggregate.",
+            "session_count",
+            "logical_session_count",
+            "message_count",
+            "user_message_count",
+            "authored_user_message_count",
+            "assistant_message_count",
+            "total_cost_usd",
+            "total_duration_ms",
+            "total_tool_active_duration_ms",
+            "total_wall_duration_ms",
+            "total_words",
+            "tool_use_count",
+            "thinking_count",
+            "total_sessions_with_tools",
+            "total_sessions_with_thinking",
+            "work_event_breakdown",
+            "origin_breakdown",
+        ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 1 for day/week grouping "
             "(archive.py) with no dedicated store_constants entry, and absent entirely for "
@@ -413,6 +480,14 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "has_coverage_gaps",
         ),
         version_fields=(RigorVersionField(name="materializer_version", current_version=TOOL_USAGE_INSIGHT_VERSION),),
+        field_exemptions=_true_zero_fields(
+            "Tool-usage totals are direct action-view counts; zero means no matching action rows.",
+            "total_call_count",
+            "total_distinct_tools",
+            "providers_with_data",
+            "providers_without_data",
+            "materializer_version",
+        ),
     ),
     RigorContract(
         insight_name="session_costs",
@@ -475,6 +550,15 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
                 evidence_tier="cost-pricing-rollup",
             ),
         ),
+        field_exemptions=_true_zero_fields(
+            "Cost-rollup counts, cost sum, and reason/status breakdowns are direct aggregate measurements; zero is measured.",
+            "session_count",
+            "priced_session_count",
+            "unavailable_session_count",
+            "status_counts",
+            "total_usd",
+            "unavailable_reason_counts",
+        ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 0 (archive.py), a sentinel "
             "for 'computed live at query time', not a stored materialized artifact -- not "
@@ -515,6 +599,15 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "cost_provenance_counts",
         ),
         version_fields=(),
+        field_exemptions=_true_zero_fields(
+            "Usage-timeline counts, token totals, cost totals, and provenance breakdowns are direct aggregate measurements.",
+            "session_count",
+            "event_count",
+            "reasoning_output_tokens",
+            "stored_cost_usd",
+            "subscription_credits",
+            "cost_provenance_counts",
+        ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 0 (archive.py), the same "
             "live-aggregation sentinel as cost_rollups -- not declared as a version_field."
@@ -543,6 +636,10 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "detail",
         ),
         version_fields=(),
+        field_exemptions=_true_zero_fields(
+            "Debt issue_count is a direct health-check count; zero means the check found no issues.",
+            "issue_count",
+        ),
         notes=(
             "No materializer/inference/enrichment version field exists on this model at all -- "
             "every row is computed live from current archive tables, not read from a "
@@ -559,20 +656,39 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
 #: that is in neither set.
 RIGOR_EXEMPT: dict[str, str] = {}
 
-# Quantitative fields whose denominators can be absent.  The static honesty
-# gate checks this inventory against the declared contracts so a newly added
-# zero-denominator field cannot silently fall back to a numeric sentinel.
-REQUIRED_NULLABLE_FIELD_CONTRACTS: frozenset[tuple[str, tuple[str, ...]]] = frozenset(
-    {
-        ("archive_coverage", ("avg_messages_per_session",)),
-        ("archive_coverage", ("avg_user_words",)),
-        ("archive_coverage", ("avg_authored_user_words",)),
-        ("archive_coverage", ("avg_assistant_words",)),
-        ("archive_coverage", ("tool_use_percentage",)),
-        ("archive_coverage", ("thinking_percentage",)),
-        ("cost_rollups", ("confidence",)),
-    }
-)
+_QUANTITATIVE_INSIGHT_MODELS: dict[str, type[ArchiveInsightModel]] = {
+    "session_work_events": SessionWorkEventInsight,
+    "session_phases": SessionPhaseInsight,
+    "session_tag_rollups": SessionTagRollupInsight,
+    "archive_coverage": ArchiveCoverageInsight,
+    "tool_usage": ToolUsageInsight,
+    "cost_rollups": CostRollupInsight,
+    "usage_timeline": UsageTimelineInsight,
+    "archive_debt": ArchiveDebtInsight,
+}
+
+
+def _is_numeric_annotation(annotation: object) -> bool:
+    if annotation in (int, float):
+        return True
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin in (dict,):
+        return len(args) == 2 and _is_numeric_annotation(args[1])
+    if origin in (UnionType,):
+        return any(_is_numeric_annotation(arg) for arg in args)
+    return any(_is_numeric_annotation(arg) for arg in args)
+
+
+def numeric_insight_field_paths() -> frozenset[tuple[str, tuple[str, ...]]]:
+    """Discover direct public quantitative fields in registry insight models."""
+
+    return frozenset(
+        (insight_name, (field_name,))
+        for insight_name, model in _QUANTITATIVE_INSIGHT_MODELS.items()
+        for field_name, field in model.model_fields.items()
+        if field_name != "contract_version" and _is_numeric_annotation(field.annotation)
+    )
 
 
 def list_rigor_contracts() -> tuple[RigorContract, ...]:
@@ -602,16 +718,22 @@ def rigor_exemption_reason(insight_name: str) -> str | None:
     return RIGOR_EXEMPT.get(insight_name)
 
 
-def missing_nullable_field_contracts() -> tuple[tuple[str, tuple[str, ...]], ...]:
-    """Return known zero-denominator fields not protected by a contract."""
+def missing_numeric_field_coverage(
+    contracts: Sequence[RigorContract] | None = None,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return public numeric fields lacking a contract or explicit rationale."""
 
     declared = {
         (contract.insight_name, field.field_path)
-        for contract in _RIGOR_MATRIX
+        for contract in (contracts or _RIGOR_MATRIX)
         for field in contract.field_contracts
-        if field.nullable_when_ungrounded
     }
-    return tuple(sorted(REQUIRED_NULLABLE_FIELD_CONTRACTS - declared))
+    declared.update(
+        (contract.insight_name, field.field_path)
+        for contract in (contracts or _RIGOR_MATRIX)
+        for field in contract.field_exemptions
+    )
+    return tuple(sorted(numeric_insight_field_paths() - declared))
 
 
 def resolve_payload(obj: object, path: Sequence[str]) -> object | None:
@@ -634,13 +756,14 @@ def resolve_payload(obj: object, path: Sequence[str]) -> object | None:
 
 __all__ = [
     "RIGOR_EXEMPT",
-    "REQUIRED_NULLABLE_FIELD_CONTRACTS",
     "RigorContract",
     "RigorFieldContract",
+    "RigorFieldExemption",
     "RigorVersionField",
     "get_rigor_contract",
     "list_rigor_contracts",
-    "missing_nullable_field_contracts",
+    "missing_numeric_field_coverage",
+    "numeric_insight_field_paths",
     "resolve_payload",
     "rigor_contract_names",
     "rigor_exemption_reason",

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -25,20 +25,12 @@ runner lives in :mod:`polylogue.insights.audit`.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from types import UnionType
 from typing import get_args, get_origin
 
-from polylogue.insights.archive import (
-    ArchiveCoverageInsight,
-    ArchiveDebtInsight,
-    CostRollupInsight,
-    SessionPhaseInsight,
-    SessionTagRollupInsight,
-    SessionWorkEventInsight,
-    UsageTimelineInsight,
-)
+from pydantic import BaseModel
+
 from polylogue.insights.archive_models import ArchiveInsightModel
-from polylogue.insights.tool_usage import TOOL_USAGE_INSIGHT_VERSION, ToolUsageInsight
+from polylogue.insights.tool_usage import TOOL_USAGE_INSIGHT_VERSION
 from polylogue.storage.runtime.store_constants import (
     SESSION_ENRICHMENT_VERSION,
     SESSION_INFERENCE_VERSION,
@@ -89,11 +81,10 @@ class RigorFieldContract(ArchiveInsightModel):
 
 
 class RigorFieldExemption(ArchiveInsightModel):
-    """Explicit justification for a quantitative field whose zero is measured.
+    """Explicit justification for one numeric field whose zero is measured.
 
-    This is deliberately field-level, rather than a product-level note: an
-    exemption is only valid when the public model still exposes that numeric
-    field, and the honesty policy rejects a newly added unclassified field.
+    This is deliberately field-level, rather than a product-level note: a
+    newly exposed numeric field must receive its own declared rationale.
     """
 
     field_path: tuple[str, ...]
@@ -102,6 +93,12 @@ class RigorFieldExemption(ArchiveInsightModel):
 
 def _true_zero_fields(reason: str, *names: str) -> tuple[RigorFieldExemption, ...]:
     return tuple(RigorFieldExemption(field_path=(name,), reason=reason) for name in names)
+
+
+def _true_zero_paths(reason: str, *paths: tuple[str, ...]) -> tuple[RigorFieldExemption, ...]:
+    """Declare exact nested numeric paths whose zeros are meaningful values."""
+
+    return tuple(RigorFieldExemption(field_path=path, reason=reason) for path in paths)
 
 
 class RigorContract(ArchiveInsightModel):
@@ -188,6 +185,61 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             RigorVersionField(name="inference_version", current_version=SESSION_INFERENCE_VERSION),
             RigorVersionField(name="enrichment_version", current_version=SESSION_ENRICHMENT_VERSION),
         ),
+        field_exemptions=(
+            *_true_zero_paths(
+                "Evidence counts, durations, and ratios are materialized archive measurements.",
+                *(
+                    ("evidence", name)
+                    for name in (
+                        "attachment_count",
+                        "compaction_count",
+                        "latency_percentiles_ms",
+                        "message_count",
+                        "output_duration_ms",
+                        "substantive_count",
+                        "thinking_count",
+                        "thinking_duration_ms",
+                        "timestamped_message_count",
+                        "tool_active_duration_ms",
+                        "tool_calls_per_minute",
+                        "tool_categories",
+                        "tool_duration_ms",
+                        "tool_use_count",
+                        "total_cache_read_tokens",
+                        "total_cache_write_tokens",
+                        "total_cost_usd",
+                        "total_credit_cost",
+                        "total_duration_ms",
+                        "total_input_tokens",
+                        "total_output_tokens",
+                        "untimestamped_message_count",
+                        "wall_duration_ms",
+                        "word_count",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Inference scores and durations are explicit heuristic outputs, never missing-evidence sentinels.",
+                *(
+                    ("inference", name)
+                    for name in (
+                        "engaged_duration_ms",
+                        "engaged_minutes",
+                        "phase_count",
+                        "terminal_state_confidence",
+                        "tool_active_duration_ms",
+                        "tool_active_minutes",
+                        "work_event_count",
+                        "workflow_shape_confidence",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Enrichment scores are explicit heuristic outputs, never missing-evidence sentinels.",
+                ("enrichment", "confidence"),
+                ("enrichment", "input_band_summary"),
+            ),
+        ),
         notes=(
             "Heuristic-tier inventory (polylogue-b0b): `inference.terminal_state` "
             "(`archive/session/runtime.py::_terminal_state`) now prefers a "
@@ -250,9 +302,21 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
             RigorVersionField(name="inference_version", current_version=SESSION_INFERENCE_VERSION),
         ),
-        field_exemptions=_true_zero_fields(
-            "Event index is an ordinal identity component, not an aggregate claim.",
-            "event_index",
+        field_exemptions=(
+            *_true_zero_fields(
+                "Event index is an ordinal identity component, not an aggregate claim.",
+                "event_index",
+            ),
+            *_true_zero_paths(
+                "Event evidence counts, offsets, and durations are materialized archive measurements.",
+                ("evidence", "duration_ms"),
+                ("evidence", "end_index"),
+                ("evidence", "start_index"),
+            ),
+            *_true_zero_paths(
+                "Event inference confidence is an explicit heuristic output, never a missing-evidence sentinel.",
+                ("inference", "confidence"),
+            ),
         ),
         notes=(
             "Heuristic-tier inventory (#b0b.1): the activity-type classifier "
@@ -304,9 +368,28 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
         version_fields=(
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
         ),
-        field_exemptions=_true_zero_fields(
-            "Phase index is an ordinal identity component, not an aggregate claim.",
-            "phase_index",
+        field_exemptions=(
+            *_true_zero_fields(
+                "Phase index is an ordinal identity component, not an aggregate claim.",
+                "phase_index",
+            ),
+            *_true_zero_paths(
+                "Phase evidence counts, offsets, and durations are materialized archive measurements.",
+                *(
+                    ("evidence", name)
+                    for name in (
+                        "duration_ms",
+                        "message_range",
+                        "phase_idle_threshold_ms",
+                        "tool_counts",
+                        "word_count",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Phase inference confidence is an explicit heuristic output, never a missing-evidence sentinel.",
+                ("inference", "confidence"),
+            ),
         ),
     ),
     RigorContract(
@@ -324,6 +407,27 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
         consumer_fields=("thread_id", "root_id", "dominant_repo", "thread"),
         version_fields=(
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
+        ),
+        field_exemptions=(
+            *_true_zero_paths(
+                "Thread counts, depth, and confidence are deterministic rollups over resolved session links.",
+                *(
+                    ("thread", name)
+                    for name in (
+                        "branch_count",
+                        "confidence",
+                        "depth",
+                        "origin_breakdown",
+                        "session_count",
+                        "total_cost_usd",
+                        "total_messages",
+                        "wall_duration_ms",
+                        "work_event_breakdown",
+                    )
+                ),
+                ("thread", "member_evidence", "confidence"),
+                ("thread", "member_evidence", "depth"),
+            ),
         ),
     ),
     RigorContract(
@@ -480,13 +584,41 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "has_coverage_gaps",
         ),
         version_fields=(RigorVersionField(name="materializer_version", current_version=TOOL_USAGE_INSIGHT_VERSION),),
-        field_exemptions=_true_zero_fields(
-            "Tool-usage totals are direct action-view counts; zero means no matching action rows.",
-            "total_call_count",
-            "total_distinct_tools",
-            "providers_with_data",
-            "providers_without_data",
-            "materializer_version",
+        field_exemptions=(
+            *_true_zero_fields(
+                "Tool-usage totals are direct action-view counts; zero means no matching action rows.",
+                "total_call_count",
+                "total_distinct_tools",
+                "providers_with_data",
+                "providers_without_data",
+                "materializer_version",
+            ),
+            *_true_zero_paths(
+                "Per-tool entries are direct action-view counts and coverage totals.",
+                *(
+                    ("entries", name)
+                    for name in (
+                        "affected_path_calls",
+                        "call_count",
+                        "distinct_tool_ids",
+                        "message_count",
+                        "output_text_calls",
+                        "session_count",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Per-origin coverage values are direct action-view counts.",
+                *(
+                    ("provider_coverage", name)
+                    for name in (
+                        "action_count",
+                        "distinct_action_kind_count",
+                        "distinct_tool_count",
+                        "session_count",
+                    )
+                ),
+            ),
         ),
     ),
     RigorContract(
@@ -510,6 +642,64 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
         consumer_fields=("session_id", "source_name", "title", "created_at", "updated_at", "estimate", "provenance"),
         version_fields=(
             RigorVersionField(name="materializer_version", current_version=SESSION_INSIGHT_MATERIALIZER_VERSION),
+        ),
+        field_exemptions=(
+            *_true_zero_paths(
+                "Pricing outcome values and confidence are explicit catalog-pricing results; zero confidence means unavailable pricing, not absent output.",
+                *(("estimate", name) for name in ("confidence", "total_usd")),
+                *(
+                    ("estimate", "basis", name)
+                    for name in (
+                        "api_equivalent_usd",
+                        "catalog_priced_usd",
+                        "provider_reported_usd",
+                        "subscription_equivalent_usd",
+                        "tool_surcharge_usd",
+                    )
+                ),
+                *(("estimate", "components", name) for name in ("tokens", "usd")),
+                *(
+                    ("estimate", "usage", name)
+                    for name in (
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens",
+                    )
+                ),
+                *(
+                    ("estimate", "price", name)
+                    for name in (
+                        "cache_read_usd_per_1m",
+                        "cache_write_usd_per_1m",
+                        "input_usd_per_1m",
+                        "output_usd_per_1m",
+                    )
+                ),
+                ("estimate", "per_model_breakdown", "session_count"),
+                ("estimate", "per_model_breakdown", "total_usd"),
+                *(
+                    ("estimate", "per_model_breakdown", "basis", name)
+                    for name in (
+                        "api_equivalent_usd",
+                        "catalog_priced_usd",
+                        "provider_reported_usd",
+                        "subscription_equivalent_usd",
+                        "tool_surcharge_usd",
+                    )
+                ),
+                *(
+                    ("estimate", "per_model_breakdown", "usage", name)
+                    for name in (
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens",
+                    )
+                ),
+            ),
         ),
     ),
     RigorContract(
@@ -550,14 +740,67 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
                 evidence_tier="cost-pricing-rollup",
             ),
         ),
-        field_exemptions=_true_zero_fields(
-            "Cost-rollup counts, cost sum, and reason/status breakdowns are direct aggregate measurements; zero is measured.",
-            "session_count",
-            "priced_session_count",
-            "unavailable_session_count",
-            "status_counts",
-            "total_usd",
-            "unavailable_reason_counts",
+        field_exemptions=(
+            *_true_zero_fields(
+                "Cost-rollup counts, cost sum, and reason/status breakdowns are direct aggregate measurements; zero is measured.",
+                "session_count",
+                "priced_session_count",
+                "unavailable_session_count",
+                "status_counts",
+                "total_usd",
+                "unavailable_reason_counts",
+            ),
+            *_true_zero_paths(
+                "Cost-basis values are direct sums of recorded or catalog-priced costs.",
+                *(
+                    ("basis", name)
+                    for name in (
+                        "api_equivalent_usd",
+                        "catalog_priced_usd",
+                        "provider_reported_usd",
+                        "subscription_equivalent_usd",
+                        "tool_surcharge_usd",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Usage values are direct sums over stored usage rows.",
+                *(
+                    ("usage", name)
+                    for name in (
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens",
+                    )
+                ),
+            ),
+            *_true_zero_paths(
+                "Per-model breakdown values are direct grouped aggregates.",
+                ("per_model_breakdown", "session_count"),
+                ("per_model_breakdown", "total_usd"),
+                *(
+                    ("per_model_breakdown", "basis", name)
+                    for name in (
+                        "api_equivalent_usd",
+                        "catalog_priced_usd",
+                        "provider_reported_usd",
+                        "subscription_equivalent_usd",
+                        "tool_surcharge_usd",
+                    )
+                ),
+                *(
+                    ("per_model_breakdown", "usage", name)
+                    for name in (
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens",
+                    )
+                ),
+            ),
         ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 0 (archive.py), a sentinel "
@@ -599,14 +842,29 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "cost_provenance_counts",
         ),
         version_fields=(),
-        field_exemptions=_true_zero_fields(
-            "Usage-timeline counts, token totals, cost totals, and provenance breakdowns are direct aggregate measurements.",
-            "session_count",
-            "event_count",
-            "reasoning_output_tokens",
-            "stored_cost_usd",
-            "subscription_credits",
-            "cost_provenance_counts",
+        field_exemptions=(
+            *_true_zero_fields(
+                "Usage-timeline counts, token totals, cost totals, and provenance breakdowns are direct aggregate measurements.",
+                "session_count",
+                "event_count",
+                "reasoning_output_tokens",
+                "stored_cost_usd",
+                "subscription_credits",
+                "cost_provenance_counts",
+            ),
+            *_true_zero_paths(
+                "Usage values are direct sums over usage-event rows.",
+                *(
+                    ("usage", name)
+                    for name in (
+                        "cache_read_tokens",
+                        "cache_write_tokens",
+                        "input_tokens",
+                        "output_tokens",
+                        "total_tokens",
+                    )
+                ),
+            ),
         ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 0 (archive.py), the same "
@@ -656,38 +914,56 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
 #: that is in neither set.
 RIGOR_EXEMPT: dict[str, str] = {}
 
-_QUANTITATIVE_INSIGHT_MODELS: dict[str, type[ArchiveInsightModel]] = {
-    "session_work_events": SessionWorkEventInsight,
-    "session_phases": SessionPhaseInsight,
-    "session_tag_rollups": SessionTagRollupInsight,
-    "archive_coverage": ArchiveCoverageInsight,
-    "tool_usage": ToolUsageInsight,
-    "cost_rollups": CostRollupInsight,
-    "usage_timeline": UsageTimelineInsight,
-    "archive_debt": ArchiveDebtInsight,
-}
+_METADATA_FIELD_NAMES = frozenset(
+    {"contract_version", "provenance", "inference_provenance", "enrichment_provenance", "materializer_version"}
+)
 
 
-def _is_numeric_annotation(annotation: object) -> bool:
+def _numeric_paths_for_annotation(
+    annotation: object,
+    path: tuple[str, ...],
+    seen_models: frozenset[type[BaseModel]],
+) -> frozenset[tuple[str, ...]]:
     if annotation in (int, float):
-        return True
+        return frozenset({path})
+
     origin = get_origin(annotation)
     args = get_args(annotation)
-    if origin in (dict,):
-        return len(args) == 2 and _is_numeric_annotation(args[1])
-    if origin in (UnionType,):
-        return any(_is_numeric_annotation(arg) for arg in args)
-    return any(_is_numeric_annotation(arg) for arg in args)
+    if origin is dict:
+        return _numeric_paths_for_annotation(args[1], path, seen_models) if len(args) == 2 else frozenset()
+    if args:
+        return frozenset().union(*(_numeric_paths_for_annotation(arg, path, seen_models) for arg in args))
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        if annotation in seen_models:
+            return frozenset()
+        return frozenset().union(
+            *(
+                _numeric_paths_for_annotation(field.annotation, (*path, field_name), seen_models | {annotation})
+                for field_name, field in annotation.model_fields.items()
+                if field_name not in _METADATA_FIELD_NAMES
+            )
+        )
+    return frozenset()
+
+
+def missing_numeric_item_models() -> tuple[str, ...]:
+    """Return registered insight types that lack an inspectable item model."""
+
+    from polylogue.insights.registry import INSIGHT_REGISTRY
+
+    return tuple(sorted(name for name, insight_type in INSIGHT_REGISTRY.items() if insight_type.item_model is None))
 
 
 def numeric_insight_field_paths() -> frozenset[tuple[str, tuple[str, ...]]]:
-    """Discover direct public quantitative fields in registry insight models."""
+    """Recursively discover public numeric leaves from registered item models."""
+
+    from polylogue.insights.registry import INSIGHT_REGISTRY
 
     return frozenset(
-        (insight_name, (field_name,))
-        for insight_name, model in _QUANTITATIVE_INSIGHT_MODELS.items()
-        for field_name, field in model.model_fields.items()
-        if field_name != "contract_version" and _is_numeric_annotation(field.annotation)
+        (insight_name, field_path)
+        for insight_name, insight_type in INSIGHT_REGISTRY.items()
+        if insight_type.item_model is not None
+        for field_path in _numeric_paths_for_annotation(insight_type.item_model, (), frozenset())
     )
 
 
@@ -728,12 +1004,12 @@ def missing_numeric_field_coverage(
         for contract in (contracts or _RIGOR_MATRIX)
         for field in contract.field_contracts
     }
-    declared.update(
+    exemptions = {
         (contract.insight_name, field.field_path)
         for contract in (contracts or _RIGOR_MATRIX)
         for field in contract.field_exemptions
-    )
-    return tuple(sorted(numeric_insight_field_paths() - declared))
+    }
+    return tuple(sorted(numeric_insight_field_paths() - declared - exemptions))
 
 
 def resolve_payload(obj: object, path: Sequence[str]) -> object | None:
@@ -762,6 +1038,7 @@ __all__ = [
     "RigorVersionField",
     "get_rigor_contract",
     "list_rigor_contracts",
+    "missing_numeric_item_models",
     "missing_numeric_field_coverage",
     "numeric_insight_field_paths",
     "resolve_payload",

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -467,10 +467,20 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
             "per_model_breakdown",
         ),
         version_fields=(),
+        field_contracts=(
+            RigorFieldContract(
+                field_path=("confidence",),
+                provenance_class="derived",
+                denominator_field=("priced_session_count",),
+                evidence_tier="cost-pricing-rollup",
+            ),
+        ),
         notes=(
             "provenance.materializer_version is a hardcoded literal 0 (archive.py), a sentinel "
             "for 'computed live at query time', not a stored materialized artifact -- not "
-            "declared as a version_field."
+            "declared as a version_field. ``confidence`` is null when no priced sessions "
+            "provide a denominator; other numeric fields are direct counts or sums where "
+            "zero is a measured aggregate."
         ),
     ),
     RigorContract(
@@ -549,6 +559,21 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
 #: that is in neither set.
 RIGOR_EXEMPT: dict[str, str] = {}
 
+# Quantitative fields whose denominators can be absent.  The static honesty
+# gate checks this inventory against the declared contracts so a newly added
+# zero-denominator field cannot silently fall back to a numeric sentinel.
+REQUIRED_NULLABLE_FIELD_CONTRACTS: frozenset[tuple[str, tuple[str, ...]]] = frozenset(
+    {
+        ("archive_coverage", ("avg_messages_per_session",)),
+        ("archive_coverage", ("avg_user_words",)),
+        ("archive_coverage", ("avg_authored_user_words",)),
+        ("archive_coverage", ("avg_assistant_words",)),
+        ("archive_coverage", ("tool_use_percentage",)),
+        ("archive_coverage", ("thinking_percentage",)),
+        ("cost_rollups", ("confidence",)),
+    }
+)
+
 
 def list_rigor_contracts() -> tuple[RigorContract, ...]:
     """Return the immutable per-product rigor contract matrix."""
@@ -577,6 +602,18 @@ def rigor_exemption_reason(insight_name: str) -> str | None:
     return RIGOR_EXEMPT.get(insight_name)
 
 
+def missing_nullable_field_contracts() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return known zero-denominator fields not protected by a contract."""
+
+    declared = {
+        (contract.insight_name, field.field_path)
+        for contract in _RIGOR_MATRIX
+        for field in contract.field_contracts
+        if field.nullable_when_ungrounded
+    }
+    return tuple(sorted(REQUIRED_NULLABLE_FIELD_CONTRACTS - declared))
+
+
 def resolve_payload(obj: object, path: Sequence[str]) -> object | None:
     """Walk a dotted attribute/key path against an insight item.
 
@@ -597,11 +634,13 @@ def resolve_payload(obj: object, path: Sequence[str]) -> object | None:
 
 __all__ = [
     "RIGOR_EXEMPT",
+    "REQUIRED_NULLABLE_FIELD_CONTRACTS",
     "RigorContract",
     "RigorFieldContract",
     "RigorVersionField",
     "get_rigor_contract",
     "list_rigor_contracts",
+    "missing_nullable_field_contracts",
     "resolve_payload",
     "rigor_contract_names",
     "rigor_exemption_reason",

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -25,6 +25,7 @@ runner lives in :mod:`polylogue.insights.audit`.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from types import NoneType
 from typing import get_args, get_origin
 
 from pydantic import BaseModel
@@ -954,6 +955,48 @@ def missing_numeric_item_models() -> tuple[str, ...]:
     return tuple(sorted(name for name, insight_type in INSIGHT_REGISTRY.items() if insight_type.item_model is None))
 
 
+def _model_type_for_annotation(annotation: object) -> type[BaseModel] | None:
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    for argument in get_args(annotation):
+        if model := _model_type_for_annotation(argument):
+            return model
+    return None
+
+
+def _annotation_at_path(model: type[BaseModel], path: Sequence[str]) -> object | None:
+    current: type[BaseModel] | None = model
+    annotation: object | None = None
+    for segment in path:
+        if current is None or (field := current.model_fields.get(segment)) is None:
+            return None
+        annotation = field.annotation
+        current = _model_type_for_annotation(annotation)
+    return annotation
+
+
+def _annotation_allows_none(annotation: object | None) -> bool:
+    return annotation is NoneType or NoneType in get_args(annotation)
+
+
+def invalid_nullable_field_contracts(
+    contracts: Sequence[RigorContract] | None = None,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return contracts that promise null-over-empty on a non-nullable field."""
+
+    from polylogue.insights.registry import INSIGHT_REGISTRY
+
+    invalid: list[tuple[str, tuple[str, ...]]] = []
+    for contract in contracts or _RIGOR_MATRIX:
+        item_model = INSIGHT_REGISTRY.get(contract.insight_name, None)
+        model = item_model.item_model if item_model is not None else None
+        for field_contract in contract.field_contracts:
+            annotation = _annotation_at_path(model, field_contract.field_path) if model is not None else None
+            if not field_contract.nullable_when_ungrounded or not _annotation_allows_none(annotation):
+                invalid.append((contract.insight_name, field_contract.field_path))
+    return tuple(sorted(invalid))
+
+
 def numeric_insight_field_paths() -> frozenset[tuple[str, tuple[str, ...]]]:
     """Recursively discover public numeric leaves from registered item models."""
 
@@ -1037,6 +1080,7 @@ __all__ = [
     "RigorFieldExemption",
     "RigorVersionField",
     "get_rigor_contract",
+    "invalid_nullable_field_contracts",
     "list_rigor_contracts",
     "missing_numeric_item_models",
     "missing_numeric_field_coverage",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3551,7 +3551,7 @@ class ArchiveStore:
                     ),
                     usage=entry.usage,
                     confidence=(
-                        entry.confidence_total / entry.priced_session_count if entry.priced_session_count else 0.0
+                        entry.confidence_total / entry.priced_session_count if entry.priced_session_count else None
                     ),
                     provenance=ArchiveInsightProvenance(
                         materializer_version=0,

--- a/tests/unit/devtools/test_claim_vs_evidence.py
+++ b/tests/unit/devtools/test_claim_vs_evidence.py
@@ -17,6 +17,7 @@ def _report_args(
     out_dir: Path | None,
     limit: int,
     sample_limit: int,
+    n_min: int = 30,
     calibration_size: int = 3,
     calibration_seed: int = 7,
     calibration_labels: Path | None = None,
@@ -26,6 +27,7 @@ def _report_args(
         out_dir=out_dir,
         limit=limit,
         sample_limit=sample_limit,
+        n_min=n_min,
         calibration_size=calibration_size,
         calibration_seed=calibration_seed,
         calibration_labels=calibration_labels,
@@ -231,6 +233,7 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
         "failure_predicate": "tool_result_is_error = 1 OR tool_result_exit_code != 0",
         "inspected_structured_failures": 4,
         "limit": 4,
+        "n_min": 30,
         "time_window": "entire archive (no since/until filter)",
         "sampled_by_origin": [
             {
@@ -253,6 +256,10 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "before pairing to tool-use rows"
         ),
         "sensitivity_scope": "next 3 assistant messages after the failed result, stopping before the next user message",
+        "thin_cell_policy": (
+            "Split cells below n_min are retained for coverage accounting but publish no rates: "
+            "coverage_status=insufficient_n and publication_status=not_supported."
+        ),
         "total_by_origin": [
             {"failed_outcomes": 2, "origin": "claude-code-session"},
             {"failed_outcomes": 2, "origin": "codex-session"},
@@ -294,8 +301,11 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "ambiguous_wordless_continuation": 1,
             "ambiguous_prose_no_marker": 1,
             "classified_outcomes": 0,
-            "silent_rate_lower_bound": 0.0,
-            "silent_rate_among_classified": 0.0,
+            "n_min": 30,
+            "coverage_status": "insufficient_n",
+            "publication_status": "not_supported",
+            "silent_rate_lower_bound": None,
+            "silent_rate_among_classified": None,
         },
         {
             "name": "consequential",
@@ -306,8 +316,11 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "ambiguous_wordless_continuation": 0,
             "ambiguous_prose_no_marker": 0,
             "classified_outcomes": 2,
-            "silent_rate_lower_bound": 0.5,
-            "silent_rate_among_classified": 0.5,
+            "n_min": 30,
+            "coverage_status": "insufficient_n",
+            "publication_status": "not_supported",
+            "silent_rate_lower_bound": None,
+            "silent_rate_among_classified": None,
         },
     ]
     assert set(report["samples_by_origin_classification"]) == {"claude-code-session", "codex-session"}
@@ -353,7 +366,9 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
         "ack_marker_recall": 0.5,
     }
     assert summary["proof_report"]["by_handler_class"][0]["name"] == "benign_recovery"
-    assert summary["proof_report"]["by_handler_class"][1]["silent_rate_lower_bound"] == 0.5
+    assert summary["proof_report"]["by_handler_class"][1]["coverage_status"] == "insufficient_n"
+    assert summary["proof_report"]["by_handler_class"][1]["publication_status"] == "not_supported"
+    assert summary["proof_report"]["by_handler_class"][1]["silent_rate_lower_bound"] is None
     assert summary["proof_report"]["time_window"] == "entire archive (no since/until filter)"
     assert summary["proof_report"]["sampled_by_origin"] == [
         {
@@ -394,7 +409,7 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
     assert "Claim-vs-Evidence" in readme
     assert "- time window: entire archive (no since/until filter)" in readme
     assert "### Handler-Class Split" in readme
-    assert "- consequential: failed 2; silent 1; ambiguous 0; silent lower bound 50.0%" in readme
+    assert "- consequential: failed 2; silent 1; ambiguous 0; not supported (n < 30)" in readme
     assert "- acknowledgments appearing only after the next turn: 1" in readme
     assert "- silent lower bound after next-3 sensitivity: 0.0%" in readme
     assert "### Marker Calibration" in readme
@@ -439,6 +454,31 @@ def test_claim_vs_evidence_bounded_sample_is_origin_stratified(tmp_path: Path) -
     assert {row["name"] for row in report["by_origin"]} == {"claude-code-session", "codex-session"}
 
 
+def test_claim_vs_evidence_refuses_rates_for_cells_below_n_min(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+
+    report = build_report(
+        _report_args(
+            archive_root=archive,
+            out_dir=None,
+            limit=4,
+            sample_limit=2,
+            n_min=3,
+        )
+    )
+
+    assert report["sample_frame"]["n_min"] == 3
+    assert "publication_status=not_supported" in report["sample_frame"]["thin_cell_policy"]
+    by_model = {str(row["name"]): row for row in report["by_model"]}
+    thin = by_model["claude-haiku"]
+    assert thin["failed_outcomes"] == 1
+    assert thin["coverage_status"] == "insufficient_n"
+    assert thin["publication_status"] == "not_supported"
+    assert thin["silent_rate_lower_bound"] is None
+    assert thin["silent_rate_among_classified"] is None
+
+
 def test_claim_vs_evidence_public_reproduction_handles_unlabeled_sample(tmp_path: Path) -> None:
     archive = tmp_path / "archive"
     out_dir = tmp_path / "out"
@@ -475,13 +515,13 @@ async def test_claim_vs_evidence_seeded_demo_reproduces_method(tmp_path: Path) -
         )
     )
 
-    assert report["sample_frame"]["total_structured_failures"] == 5
-    assert report["sample_frame"]["inspected_structured_failures"] == 5
+    assert report["sample_frame"]["total_structured_failures"] == 7
+    assert report["sample_frame"]["inspected_structured_failures"] == 7
     assert report["totals"]["acknowledged"] == 3
-    assert report["totals"]["silent_proceed"] == 2
+    assert report["totals"]["silent_proceed"] == 4
     assert report["totals"]["ambiguous"] == 0
     public_summary = json.loads((out_dir / "public-summary.json").read_text())
-    assert public_summary["proofs"][0]["total_structured_failures"] == 5
+    assert public_summary["proofs"][0]["total_structured_failures"] == 7
     public_reproduction = (out_dir / "PUBLIC_REPRODUCTION.md").read_text()
     assert "Counts will differ because the deterministic demo archive is synthetic." in public_reproduction
 

--- a/tests/unit/devtools/test_claim_vs_evidence.py
+++ b/tests/unit/devtools/test_claim_vs_evidence.py
@@ -515,12 +515,13 @@ def test_claim_vs_evidence_refuses_rates_for_cells_below_n_min(tmp_path: Path) -
 
 def test_claim_vs_evidence_refuses_aggregate_rates_below_n_min(tmp_path: Path) -> None:
     archive = tmp_path / "archive"
+    out_dir = tmp_path / "out"
     _seed_archive(archive)
 
     report = build_report(
         _report_args(
             archive_root=archive,
-            out_dir=None,
+            out_dir=out_dir,
             limit=4,
             sample_limit=2,
             n_min=5,
@@ -531,6 +532,14 @@ def test_claim_vs_evidence_refuses_aggregate_rates_below_n_min(tmp_path: Path) -
     assert report["rates"]["publication_status"] == "not_supported"
     assert report["rates"]["silent_rate_lower_bound"] is None
     assert report["rates"]["window3_silent_rate_lower_bound"] is None
+    public_summary = json.loads((out_dir / "public-summary.json").read_text())
+    assert public_summary["proofs"][1]["silent_rate_lower_bound_coverage_status"] == "insufficient_n"
+    assert public_summary["proofs"][1]["silent_rate_lower_bound_publication_status"] == "not_supported"
+    summary = json.loads((out_dir / "summary.json").read_text())
+    assert summary["proof_report"]["silent_rate_lower_bound_coverage_status"] == "insufficient_n"
+    assert summary["proof_report"]["window3_silent_rate_lower_bound_publication_status"] == "not_supported"
+    public_reproduction = (out_dir / "PUBLIC_REPRODUCTION.md").read_text()
+    assert "not enough labels (insufficient_n / not_supported)" in public_reproduction
 
 
 def test_claim_vs_evidence_public_reproduction_handles_unlabeled_sample(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_claim_vs_evidence.py
+++ b/tests/unit/devtools/test_claim_vs_evidence.py
@@ -17,7 +17,7 @@ def _report_args(
     out_dir: Path | None,
     limit: int,
     sample_limit: int,
-    n_min: int = 30,
+    n_min: int = 1,
     calibration_size: int = 3,
     calibration_seed: int = 7,
     calibration_labels: Path | None = None,
@@ -233,7 +233,7 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
         "failure_predicate": "tool_result_is_error = 1 OR tool_result_exit_code != 0",
         "inspected_structured_failures": 4,
         "limit": 4,
-        "n_min": 30,
+        "n_min": 1,
         "time_window": "entire archive (no since/until filter)",
         "sampled_by_origin": [
             {
@@ -301,10 +301,10 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "ambiguous_wordless_continuation": 1,
             "ambiguous_prose_no_marker": 1,
             "classified_outcomes": 0,
-            "n_min": 30,
-            "coverage_status": "insufficient_n",
-            "publication_status": "not_supported",
-            "silent_rate_lower_bound": None,
+            "n_min": 1,
+            "coverage_status": "supported",
+            "publication_status": "supported",
+            "silent_rate_lower_bound": 0.0,
             "silent_rate_among_classified": None,
         },
         {
@@ -316,11 +316,11 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "ambiguous_wordless_continuation": 0,
             "ambiguous_prose_no_marker": 0,
             "classified_outcomes": 2,
-            "n_min": 30,
-            "coverage_status": "insufficient_n",
-            "publication_status": "not_supported",
-            "silent_rate_lower_bound": None,
-            "silent_rate_among_classified": None,
+            "n_min": 1,
+            "coverage_status": "supported",
+            "publication_status": "supported",
+            "silent_rate_lower_bound": 0.5,
+            "silent_rate_among_classified": 0.5,
         },
     ]
     assert set(report["samples_by_origin_classification"]) == {"claude-code-session", "codex-session"}
@@ -366,9 +366,9 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
         "ack_marker_recall": 0.5,
     }
     assert summary["proof_report"]["by_handler_class"][0]["name"] == "benign_recovery"
-    assert summary["proof_report"]["by_handler_class"][1]["coverage_status"] == "insufficient_n"
-    assert summary["proof_report"]["by_handler_class"][1]["publication_status"] == "not_supported"
-    assert summary["proof_report"]["by_handler_class"][1]["silent_rate_lower_bound"] is None
+    assert summary["proof_report"]["by_handler_class"][1]["coverage_status"] == "supported"
+    assert summary["proof_report"]["by_handler_class"][1]["publication_status"] == "supported"
+    assert summary["proof_report"]["by_handler_class"][1]["silent_rate_lower_bound"] == 0.5
     assert summary["proof_report"]["time_window"] == "entire archive (no since/until filter)"
     assert summary["proof_report"]["sampled_by_origin"] == [
         {
@@ -409,7 +409,7 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
     assert "Claim-vs-Evidence" in readme
     assert "- time window: entire archive (no since/until filter)" in readme
     assert "### Handler-Class Split" in readme
-    assert "- consequential: failed 2; silent 1; ambiguous 0; not supported (n < 30)" in readme
+    assert "- consequential: failed 2; silent 1; ambiguous 0; silent lower bound 50.0%" in readme
     assert "- acknowledgments appearing only after the next turn: 1" in readme
     assert "- silent lower bound after next-3 sensitivity: 0.0%" in readme
     assert "### Marker Calibration" in readme
@@ -477,6 +477,46 @@ def test_claim_vs_evidence_refuses_rates_for_cells_below_n_min(tmp_path: Path) -
     assert thin["publication_status"] == "not_supported"
     assert thin["silent_rate_lower_bound"] is None
     assert thin["silent_rate_among_classified"] is None
+    assert report["rates"]["coverage_status"] == "supported"
+
+    at_threshold = build_report(
+        _report_args(
+            archive_root=archive,
+            out_dir=None,
+            limit=4,
+            sample_limit=2,
+            n_min=2,
+        )
+    )
+    by_origin = {str(row["name"]): row for row in at_threshold["by_origin"]}
+    supported = by_origin["claude-code-session"]
+    assert supported["failed_outcomes"] == 2
+    assert supported["coverage_status"] == "supported"
+    assert supported["publication_status"] == "supported"
+    assert supported["silent_rate_lower_bound"] == 0.5
+
+    assert at_threshold["rates"]["coverage_status"] == "supported"
+    assert at_threshold["rates"]["silent_rate_lower_bound"] == 0.25
+
+
+def test_claim_vs_evidence_refuses_aggregate_rates_below_n_min(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+
+    report = build_report(
+        _report_args(
+            archive_root=archive,
+            out_dir=None,
+            limit=4,
+            sample_limit=2,
+            n_min=5,
+        )
+    )
+
+    assert report["rates"]["coverage_status"] == "insufficient_n"
+    assert report["rates"]["publication_status"] == "not_supported"
+    assert report["rates"]["silent_rate_lower_bound"] is None
+    assert report["rates"]["window3_silent_rate_lower_bound"] is None
 
 
 def test_claim_vs_evidence_public_reproduction_handles_unlabeled_sample(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_claim_vs_evidence.py
+++ b/tests/unit/devtools/test_claim_vs_evidence.py
@@ -258,7 +258,8 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
         "sensitivity_scope": "next 3 assistant messages after the failed result, stopping before the next user message",
         "thin_cell_policy": (
             "Split cells below n_min are retained for coverage accounting but publish no rates: "
-            "coverage_status=insufficient_n and publication_status=not_supported."
+            "coverage_status=insufficient_n and publication_status=not_supported; "
+            "classified-denominator rates independently require classified_outcomes >= n_min."
         ),
         "total_by_origin": [
             {"failed_outcomes": 2, "origin": "claude-code-session"},
@@ -304,6 +305,8 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "n_min": 1,
             "coverage_status": "supported",
             "publication_status": "supported",
+            "classified_coverage_status": "insufficient_n",
+            "classified_publication_status": "not_supported",
             "silent_rate_lower_bound": 0.0,
             "silent_rate_among_classified": None,
         },
@@ -319,6 +322,8 @@ def test_claim_vs_evidence_builds_bounded_artifacts(tmp_path: Path) -> None:
             "n_min": 1,
             "coverage_status": "supported",
             "publication_status": "supported",
+            "classified_coverage_status": "supported",
+            "classified_publication_status": "supported",
             "silent_rate_lower_bound": 0.5,
             "silent_rate_among_classified": 0.5,
         },
@@ -478,6 +483,9 @@ def test_claim_vs_evidence_refuses_rates_for_cells_below_n_min(tmp_path: Path) -
     assert thin["silent_rate_lower_bound"] is None
     assert thin["silent_rate_among_classified"] is None
     assert report["rates"]["coverage_status"] == "supported"
+    assert report["rates"]["classified_coverage_status"] == "insufficient_n"
+    assert report["rates"]["silent_rate_lower_bound"] == 1 / 4
+    assert report["rates"]["silent_rate_among_classified"] is None
 
     at_threshold = build_report(
         _report_args(
@@ -494,6 +502,12 @@ def test_claim_vs_evidence_refuses_rates_for_cells_below_n_min(tmp_path: Path) -
     assert supported["coverage_status"] == "supported"
     assert supported["publication_status"] == "supported"
     assert supported["silent_rate_lower_bound"] == 0.5
+
+    benign = next(row for row in at_threshold["by_handler_class"] if row["name"] == "benign_recovery")
+    assert benign["coverage_status"] == "supported"
+    assert benign["classified_coverage_status"] == "insufficient_n"
+    assert benign["classified_publication_status"] == "not_supported"
+    assert benign["silent_rate_among_classified"] is None
 
     assert at_threshold["rates"]["coverage_status"] == "supported"
     assert at_threshold["rates"]["silent_rate_lower_bound"] == 0.25

--- a/tests/unit/devtools/test_verify_insight_rigor_honesty.py
+++ b/tests/unit/devtools/test_verify_insight_rigor_honesty.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
 import pytest
 
@@ -13,6 +14,7 @@ def test_insight_rigor_honesty_passes_when_every_product_is_covered(capsys: pyte
     assert payload["ok"] is True
     assert payload["uncovered_insight_names"] == []
     assert payload["missing_numeric_field_coverage"] == []
+    assert payload["missing_numeric_item_models"] == []
 
 
 def test_insight_rigor_honesty_fails_when_a_contract_is_monkeypatched_out(
@@ -34,3 +36,19 @@ def test_insight_rigor_honesty_fails_when_a_contract_is_monkeypatched_out(
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
     assert "session_profiles" in payload["uncovered_insight_names"]
+
+
+def test_insight_rigor_honesty_fails_when_a_registered_item_model_is_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The policy cannot inspect fields if a production descriptor omits its model."""
+
+    from polylogue.insights.registry import INSIGHT_REGISTRY
+
+    original = INSIGHT_REGISTRY["cost_rollups"]
+    monkeypatch.setitem(INSIGHT_REGISTRY, "cost_rollups", replace(original, item_model=None))
+
+    assert verify_insight_rigor_honesty.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["missing_numeric_item_models"] == ["cost_rollups"]

--- a/tests/unit/devtools/test_verify_insight_rigor_honesty.py
+++ b/tests/unit/devtools/test_verify_insight_rigor_honesty.py
@@ -15,6 +15,7 @@ def test_insight_rigor_honesty_passes_when_every_product_is_covered(capsys: pyte
     assert payload["uncovered_insight_names"] == []
     assert payload["missing_numeric_field_coverage"] == []
     assert payload["missing_numeric_item_models"] == []
+    assert payload["invalid_nullable_field_contracts"] == []
 
 
 def test_insight_rigor_honesty_fails_when_a_contract_is_monkeypatched_out(

--- a/tests/unit/devtools/test_verify_insight_rigor_honesty.py
+++ b/tests/unit/devtools/test_verify_insight_rigor_honesty.py
@@ -12,6 +12,7 @@ def test_insight_rigor_honesty_passes_when_every_product_is_covered(capsys: pyte
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["uncovered_insight_names"] == []
+    assert payload["missing_numeric_field_coverage"] == []
 
 
 def test_insight_rigor_honesty_fails_when_a_contract_is_monkeypatched_out(

--- a/tests/unit/insights/test_archive_rollups.py
+++ b/tests/unit/insights/test_archive_rollups.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import pytest
 
+from polylogue.archive.semantic.pricing import CostEstimatePayload
 from polylogue.insights.archive import (
     ArchiveInferenceProvenance,
     ArchiveInsightProvenance,
+    SessionCostInsight,
     SessionLatencyProfileInsight,
     SessionProfileInsight,
 )
@@ -26,6 +28,7 @@ from polylogue.insights.archive_models import (
 from polylogue.insights.archive_rollups import (
     ABANDONMENT_SEVERITY_RANK,
     abandoned_session_items,
+    aggregate_cost_rollup_insights,
     aggregate_session_profiles_by_dimension,
     iso_week_bucket_key,
     tool_call_latency_distribution_payload,
@@ -165,6 +168,20 @@ def test_aggregate_rejects_unknown_group_by() -> None:
 
 def test_aggregate_empty_profiles_returns_empty_buckets() -> None:
     assert aggregate_session_profiles_by_dimension([], "workflow_shape") == {}
+
+
+def test_cost_rollup_confidence_is_none_without_priced_sessions() -> None:
+    unavailable = SessionCostInsight(
+        session_id="c1",
+        source_name="claude-code",
+        estimate=CostEstimatePayload(source_name="claude-code", status="unavailable"),
+        provenance=_provenance(),
+    )
+
+    [rollup] = aggregate_cost_rollup_insights([unavailable], materialized_at="2026-05-01T00:00:00+00:00")
+
+    assert rollup.priced_session_count == 0
+    assert rollup.confidence is None
 
 
 # ── workflow_shape_distribution_buckets ──────────────────────────────

--- a/tests/unit/insights/test_cost_rollup_summary_path.py
+++ b/tests/unit/insights/test_cost_rollup_summary_path.py
@@ -112,3 +112,6 @@ async def test_cost_rollups_aggregate_typed_cost_rows_without_message_load(
             merged_status_counts[key] = merged_status_counts.get(key, 0) + value
     assert merged_status_counts.get("exact", 0) == 1
     assert merged_status_counts.get("unavailable", 0) == 1
+    unavailable = next(rollup for rollup in rollups if rollup.unavailable_session_count)
+    assert unavailable.priced_session_count == 0
+    assert unavailable.confidence is None

--- a/tests/unit/insights/test_registry.py
+++ b/tests/unit/insights/test_registry.py
@@ -7,8 +7,10 @@ from typing import Any, cast
 
 import pytest
 
+from polylogue.archive.semantic.pricing import CostUsagePayload
 from polylogue.insights.archive import (
     ArchiveCoverageInsightQuery,
+    CostRollupInsight,
     SessionProfileInsight,
     SessionProfileInsightQuery,
 )
@@ -538,6 +540,21 @@ class TestRenderInsightItems:
         assert "Session Profiles: 1" in captured.out
         # Should include some field output
         assert "sess-001" in captured.out
+
+    def test_plain_cost_rollup_marks_unpriced_confidence_uncovered(self, capsys: Any) -> None:
+        insight = CostRollupInsight(
+            source_name="claude-code",
+            status_counts={"unavailable": 1},
+            usage=CostUsagePayload(),
+            provenance=ArchiveInsightProvenance(
+                materializer_version=0,
+                materialized_at="2026-01-01T00:00:00Z",
+            ),
+        )
+
+        render_insight_items([insight], get_insight_type("cost_rollups"), json_mode=False)
+
+        assert "confidence=uncovered" in capsys.readouterr().out
 
 
 class TestBuildQuery:

--- a/tests/unit/insights/test_rigor_audit.py
+++ b/tests/unit/insights/test_rigor_audit.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 
 import pytest
 
+from polylogue.archive.semantic.pricing import CostBasisPayload
 from polylogue.insights.archive import (
+    CostRollupInsight,
     SessionPhaseInsight,
     SessionProfileInsight,
     SessionTagRollupInsight,
@@ -35,6 +38,7 @@ from polylogue.insights.rigor import (
     get_rigor_contract,
     list_rigor_contracts,
     missing_numeric_field_coverage,
+    missing_numeric_item_models,
     resolve_payload,
     rigor_contract_names,
 )
@@ -206,6 +210,31 @@ def test_numeric_field_policy_rejects_unjustified_public_field() -> None:
     )
 
     assert missing_numeric_field_coverage(contracts) == (("cost_rollups", ("confidence",)),)
+
+
+def test_numeric_field_policy_discovers_new_registered_nested_numeric_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The policy reads the registry's production item model, not an allowlist.
+
+    Removing the recursive model walk or the descriptor's ``item_model``
+    wiring makes a new public metric bypass its rigor contract.
+    """
+
+    class ExtendedCostBasisPayload(CostBasisPayload):
+        unclassified_metric: int = 0
+
+    class ExtendedCostRollupInsight(CostRollupInsight):
+        basis: ExtendedCostBasisPayload = ExtendedCostBasisPayload()
+
+    original = INSIGHT_REGISTRY["cost_rollups"]
+    monkeypatch.setitem(INSIGHT_REGISTRY, "cost_rollups", replace(original, item_model=ExtendedCostRollupInsight))
+
+    assert missing_numeric_field_coverage() == (("cost_rollups", ("basis", "unclassified_metric")),)
+
+
+def test_every_registered_insight_declares_its_item_model() -> None:
+    """Registry descriptors expose production response models to the policy."""
+
+    assert missing_numeric_item_models() == ()
 
 
 def test_phase_rigor_contract_is_evidence_only() -> None:

--- a/tests/unit/insights/test_rigor_audit.py
+++ b/tests/unit/insights/test_rigor_audit.py
@@ -36,6 +36,7 @@ from polylogue.insights.registry import INSIGHT_REGISTRY
 from polylogue.insights.rigor import (
     RigorFieldContract,
     get_rigor_contract,
+    invalid_nullable_field_contracts,
     list_rigor_contracts,
     missing_numeric_field_coverage,
     missing_numeric_item_models,
@@ -229,6 +230,35 @@ def test_numeric_field_policy_discovers_new_registered_nested_numeric_field(monk
     monkeypatch.setitem(INSIGHT_REGISTRY, "cost_rollups", replace(original, item_model=ExtendedCostRollupInsight))
 
     assert missing_numeric_field_coverage() == (("cost_rollups", ("basis", "unclassified_metric")),)
+
+
+def test_nullable_contract_policy_rejects_non_nullable_registered_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A null-over-empty contract must target a production model that permits null."""
+
+    class NonNullableCostRollupInsight(CostRollupInsight):
+        confidence: float = 0.0
+
+    original = INSIGHT_REGISTRY["cost_rollups"]
+    monkeypatch.setitem(INSIGHT_REGISTRY, "cost_rollups", replace(original, item_model=NonNullableCostRollupInsight))
+
+    assert invalid_nullable_field_contracts() == (("cost_rollups", ("confidence",)),)
+
+
+def test_nullable_contract_policy_rejects_contract_that_disables_null_refusal() -> None:
+    """A field contract cannot opt out of its promised null-over-empty behavior."""
+
+    contract = get_rigor_contract("cost_rollups")
+    assert contract is not None
+    disabled_refusal = contract.model_copy(
+        update={
+            "field_contracts": (contract.field_contracts[0].model_copy(update={"nullable_when_ungrounded": False}),)
+        }
+    )
+    contracts = tuple(
+        disabled_refusal if item.insight_name == "cost_rollups" else item for item in list_rigor_contracts()
+    )
+
+    assert invalid_nullable_field_contracts(contracts) == (("cost_rollups", ("confidence",)),)
 
 
 def test_every_registered_insight_declares_its_item_model() -> None:

--- a/tests/unit/insights/test_rigor_audit.py
+++ b/tests/unit/insights/test_rigor_audit.py
@@ -31,8 +31,10 @@ from polylogue.insights.audit import (
 from polylogue.insights.confidence import ConfidenceBand
 from polylogue.insights.registry import INSIGHT_REGISTRY
 from polylogue.insights.rigor import (
+    RigorFieldContract,
     get_rigor_contract,
     list_rigor_contracts,
+    missing_nullable_field_contracts,
     resolve_payload,
     rigor_contract_names,
 )
@@ -170,6 +172,22 @@ def test_rigor_contract_lookup_round_trips() -> None:
     assert contract.fallback_markers == (("inference", "fallback_inference"),)
     assert contract.confidence_field == ("inference", "confidence")
     assert get_rigor_contract("not-a-real-insight") is None
+
+
+def test_cost_rollup_confidence_declares_priced_session_denominator() -> None:
+    """The public confidence value cannot be published without priced rows."""
+
+    contract = get_rigor_contract("cost_rollups")
+    assert contract is not None
+    assert contract.field_contracts == (
+        RigorFieldContract(
+            field_path=("confidence",),
+            provenance_class="derived",
+            denominator_field=("priced_session_count",),
+            evidence_tier="cost-pricing-rollup",
+        ),
+    )
+    assert missing_nullable_field_contracts() == ()
 
 
 def test_phase_rigor_contract_is_evidence_only() -> None:

--- a/tests/unit/insights/test_rigor_audit.py
+++ b/tests/unit/insights/test_rigor_audit.py
@@ -34,7 +34,7 @@ from polylogue.insights.rigor import (
     RigorFieldContract,
     get_rigor_contract,
     list_rigor_contracts,
-    missing_nullable_field_contracts,
+    missing_numeric_field_coverage,
     resolve_payload,
     rigor_contract_names,
 )
@@ -187,7 +187,25 @@ def test_cost_rollup_confidence_declares_priced_session_denominator() -> None:
             evidence_tier="cost-pricing-rollup",
         ),
     )
-    assert missing_nullable_field_contracts() == ()
+    assert missing_numeric_field_coverage() == ()
+
+
+def test_numeric_field_policy_rejects_unjustified_public_field() -> None:
+    contract = get_rigor_contract("cost_rollups")
+    assert contract is not None
+    missing_confidence = contract.model_copy(
+        update={
+            "field_contracts": (),
+            "field_exemptions": tuple(
+                exemption for exemption in contract.field_exemptions if exemption.field_path != ("confidence",)
+            ),
+        }
+    )
+    contracts = tuple(
+        missing_confidence if item.insight_name == "cost_rollups" else item for item in list_rigor_contracts()
+    )
+
+    assert missing_numeric_field_coverage(contracts) == (("cost_rollups", ("confidence",)),)
 
 
 def test_phase_rigor_contract_is_evidence_only() -> None:


### PR DESCRIPTION
## Summary

Refuse unsupported quantitative claims in insight rollups and claim-vs-evidence reports.

## Problem

Cost-rollup confidence previously collapsed an absent priced-session denominator into 0.0. The rigor audit also had no registry-derived proof that every public numeric leaf had an evidence contract or explicit true-zero rationale. Failure-follow-up reports could publish a classified-only rate using a classified denominator below n_min.

## Solution

- Make cost-rollup confidence nullable in both aggregation routes and render absent confidence as uncovered.
- Derive public numeric leaves recursively from registered production item models. Every leaf has an exact RigorFieldContract or RigorFieldExemption; the policy rejects missing models, unclassified leaves, non-nullable null-over-empty contract targets, and contracts that disable null refusal.
- Apply n_min to each failure-follow-up rate's own denominator. Split and aggregate classified-only rates now have independent coverage/publication status and remain null below threshold. Calibration precision/recall retain their separate labeled-sample semantics.

## Acceptance criteria

| Bead | Status | Evidence |
| --- | --- | --- |
| Ref polylogue-uwk3 | Satisfied | Every current registered public numeric leaf is exactly contracted or explicitly exempted; the static policy rejects new nested metrics and non-nullable null-over-empty contracts. |
| Ref polylogue-jph5 | Satisfied | Thin failure-follow-up rates are marked insufficient/not-supported and publish null values, including generated public artifacts. |

## Verification

- Focused rigor, registry, policy, and claim tests passed after the final fixes.
- Insight-honesty policy JSON: no uncovered products, missing item models, unclassified numeric fields, or invalid nullable contracts.
- Pre-push quick verification: format, lint, mypy, rendered surfaces, topology, and layering checks passed.
- Isolated demo insight-rigor audit: all 11 registered products reported covered; unpriced cost rollups report unknown confidence.

Anti-vacuity: rollup tests exercise both the production SQLite route and pure reducer; restoring the 0.0 fallback fails them. The rigor-policy regressions replace real registered response models with nested numeric/non-nullable variants; removing recursive discovery, exact-path coverage, or nullable validation makes them fail. Claim tests call build_report against a fixture SQLite archive; removing either denominator-specific n_min gate publishes a rate and fails the assertions. The artifact regression writes a thin aggregate report and requires explicit refusal statuses in every public summary surface.