### PR TITLE
perf: improve interactive CLI and coordination latency

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -10,8 +10,10 @@ import re
 import webbrowser
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import redirect_stdout
+from contextvars import ContextVar
 from dataclasses import replace
 from pathlib import Path
+from time import perf_counter
 from typing import Any, NoReturn, TypeVar, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
@@ -78,6 +80,7 @@ _UNSUPPORTED_PARAM_MESSAGES: dict[str, str] = {}
 _QueryUnitTextLine = Callable[[dict[str, object]], str]
 _DAEMON_FAST_PATH_TIMEOUT_S = 0.75
 _NATIVE_REF_RE = re.compile(r"(?=.*\d)[A-Za-z0-9][A-Za-z0-9_.:-]{11,}")
+_TIMING_ENV: ContextVar[AppEnv | None] = ContextVar("archive_query_timing_env", default=None)
 
 
 def _object_int(value: object) -> int:
@@ -144,21 +147,27 @@ def execute_delete_by_session_ids(
 
 def execute_archive_query(env: AppEnv, request: RootModeRequest) -> None:
     """Execute the root query path."""
-    output = QueryOutputSpec.from_params(request.params)
-    if output.destination_labels() == ("stdout",) or request.params.get("stream"):
-        _execute_archive_query_stdout(env, request)
-        return
-    rendered = io.StringIO()
-    with redirect_stdout(rendered):
-        _execute_archive_query_stdout(env, request)
-    deliver_query_output(
-        env,
-        QueryOutputDocument(
-            content=rendered.getvalue().rstrip("\n"),
-            output_format=output.output_format,
-            destinations=output.destinations,
-        ),
-    )
+    timing_token = _TIMING_ENV.set(env)
+    env.begin_timing("execute")
+    try:
+        output = QueryOutputSpec.from_params(request.params)
+        if output.destination_labels() == ("stdout",) or request.params.get("stream"):
+            _execute_archive_query_stdout(env, request)
+            return
+        rendered = io.StringIO()
+        with redirect_stdout(rendered):
+            _execute_archive_query_stdout(env, request)
+        deliver_query_output(
+            env,
+            QueryOutputDocument(
+                content=rendered.getvalue().rstrip("\n"),
+                output_format=output.output_format,
+                destinations=output.destinations,
+            ),
+        )
+    finally:
+        env.finish_timing("execute")
+        _TIMING_ENV.reset(timing_token)
 
 
 def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None:
@@ -166,9 +175,12 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     params = dict(request.params)
     _reject_unsupported_params(params)
     _validate_retrieval_params(params)
+    config_started_at = perf_counter()
     config = load_effective_config(env)
     archive_root = archive_file_set_root_for_paths(archive_root_path=config.archive_root, db_anchor=config.db_path)
     index_db_path = archive_root / "index.db"
+    env.record_timing("config", config_started_at)
+    compile_started_at = perf_counter()
     typo_hint = maybe_subcommand_typo_hint(request.query_terms)
     raw_query = _query_text(request.query_terms, params)
     output_format = str(params.get("output_format") or "markdown")
@@ -196,6 +208,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     if compiled_spec.with_units:
         with_units = compiled_spec.with_units
         with_unit_fields = compiled_spec.with_unit_fields
+    env.record_timing("compile", compile_started_at)
 
     tags_to_add = _tuple_tokens(params.get("add_tag"))
     metadata_to_set = _metadata_pairs(params.get("set_meta"))
@@ -335,7 +348,9 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     if delete_matched and metadata_to_set:
         raise click.UsageError("Root query cannot combine delete with --set.")
 
+    db_open_started_at = perf_counter()
     with ArchiveStore.open_existing(archive_root) as archive:
+        env.record_timing("db-open", db_open_started_at)
         if unit_source is not None:
             if any(
                 (
@@ -1952,27 +1967,35 @@ def _emit_rows(
     text_line: Callable[[dict[str, object]], str],
     fields: str | None,
 ) -> None:
-    projected_items = [_project_payload(item, fields) for item in items]
-    if output_format == "json":
-        projected_envelope = {**envelope, "items": projected_items}
-        click.echo(json.dumps(projected_envelope, indent=2, sort_keys=True))
-        return
-    if output_format == "ndjson":
-        for item in projected_items:
-            click.echo(json.dumps(item, sort_keys=True))
-        return
-    if output_format == "csv":
-        click.echo(_csv(projected_items), nl=False)
-        return
-    if output_format == "yaml":
-        import yaml
+    env = _TIMING_ENV.get()
+    if env is not None:
+        env.finish_timing("execute")
+        env.begin_timing("render")
+    try:
+        projected_items = [_project_payload(item, fields) for item in items]
+        if output_format == "json":
+            projected_envelope = {**envelope, "items": projected_items}
+            click.echo(json.dumps(projected_envelope, indent=2, sort_keys=True))
+            return
+        if output_format == "ndjson":
+            for item in projected_items:
+                click.echo(json.dumps(item, sort_keys=True))
+            return
+        if output_format == "csv":
+            click.echo(_csv(projected_items), nl=False)
+            return
+        if output_format == "yaml":
+            import yaml
 
-        projected_envelope = {**envelope, "items": projected_items}
-        click.echo(yaml.safe_dump(projected_envelope, sort_keys=False, allow_unicode=True), nl=False)
-        return
-    if output_format not in {"markdown", "plaintext"}:
-        raise click.UsageError(f"Root query does not support --format {output_format}.")
-    click.echo("\n".join(text_line(item) for item in items))
+            projected_envelope = {**envelope, "items": projected_items}
+            click.echo(yaml.safe_dump(projected_envelope, sort_keys=False, allow_unicode=True), nl=False)
+            return
+        if output_format not in {"markdown", "plaintext"}:
+            raise click.UsageError(f"Root query does not support --format {output_format}.")
+        click.echo("\n".join(text_line(item) for item in items))
+    finally:
+        if env is not None:
+            env.finish_timing("render")
 
 
 def _emit_unit_source_rows(

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -9,6 +9,7 @@ The CLI uses a hybrid structure:
 from __future__ import annotations
 
 import os
+from time import perf_counter
 from typing import TYPE_CHECKING
 
 import click
@@ -30,6 +31,9 @@ from polylogue.version import POLYLOGUE_VERSION
 
 if TYPE_CHECKING:
     from polylogue.ui import UI
+
+
+_CLI_IMPORT_STARTED_AT = perf_counter()
 
 
 class QueryFirstGroup(QueryFirstGroupBase):
@@ -388,8 +392,12 @@ def cli(
         configure_logging(verbose=True)
 
     use_plain = should_use_plain(plain=plain)
-    env = AppEnv(plain=use_plain)
+    debug_timing = os.environ.get("POLYLOGUE_DEBUG_TIMING", "").lower() in {"1", "true", "yes", "on"}
+    env = AppEnv(plain=use_plain, debug_timing=debug_timing)
+    env.record_timing("startup", _CLI_IMPORT_STARTED_AT)
     ctx.obj = env
+    if debug_timing:
+        ctx.call_on_close(env.emit_debug_timings)
 
 
 @click.command("find", hidden=True, context_settings={"help_option_names": ["-h", "--help"]})

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from polylogue.ui import UI
 
 
-_CLI_IMPORT_STARTED_AT = perf_counter()
+_CLI_CALLBACK_STARTED_AT = perf_counter()
 
 
 class QueryFirstGroup(QueryFirstGroupBase):
@@ -394,7 +394,7 @@ def cli(
     use_plain = should_use_plain(plain=plain)
     debug_timing = os.environ.get("POLYLOGUE_DEBUG_TIMING", "").lower() in {"1", "true", "yes", "on"}
     env = AppEnv(plain=use_plain, debug_timing=debug_timing)
-    env.record_timing("startup", _CLI_IMPORT_STARTED_AT)
+    env.record_timing("cli-callback", _CLI_CALLBACK_STARTED_AT)
     ctx.obj = env
     if debug_timing:
         ctx.call_on_close(env.emit_debug_timings)

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -381,8 +381,11 @@ def cli(
         ctx.params["plain"] = plain
         ctx.params["output_format"] = output_format
 
-    # Set up logging early so all output goes to stderr
-    configure_logging(verbose=verbose)
+    # Keep the ordinary command path on the stdlib-backed logger.  The
+    # structlog setup is deliberately expensive and this callback also runs
+    # for nested command help, where no diagnostic logging is emitted.
+    if verbose:
+        configure_logging(verbose=True)
 
     use_plain = should_use_plain(plain=plain)
     env = AppEnv(plain=use_plain)

--- a/polylogue/cli/commands/agents.py
+++ b/polylogue/cli/commands/agents.py
@@ -4,18 +4,27 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import click
 
-from polylogue.coordination import CoordinationView, build_coordination_envelope
-from polylogue.coordination.rendering import (
-    render_coordination_markdown,
-    render_coordination_text,
-    render_coordination_tree,
-)
+if TYPE_CHECKING:
+    from polylogue.coordination import AgentCoordinationPayload, CoordinationView
 
 F = TypeVar("F", bound=Callable[..., object])
+
+
+def _build_coordination_envelope(
+    *,
+    view: CoordinationView,
+    cwd: Path | None,
+    limit: int,
+    detail: bool,
+) -> AgentCoordinationPayload:
+    """Load the coordination substrate only when a projection is requested."""
+    from polylogue.coordination import build_coordination_envelope
+
+    return build_coordination_envelope(view=view, cwd=cwd, limit=limit, detail=detail)
 
 
 def _format_options(func: F) -> F:
@@ -51,16 +60,22 @@ def _emit(
     output_format: str,
     detail: bool,
 ) -> None:
-    payload = build_coordination_envelope(view=view, cwd=cwd, limit=limit, detail=detail)
+    payload = _build_coordination_envelope(view=view, cwd=cwd, limit=limit, detail=detail)
     if json_output or output_format == "json":
         click.echo(payload.to_json(exclude_none=True))
         return
     if output_format == "markdown":
+        from polylogue.coordination.rendering import render_coordination_markdown
+
         click.echo(render_coordination_markdown(payload), nl=False)
         return
     if output_format == "tree":
+        from polylogue.coordination.rendering import render_coordination_tree
+
         click.echo(render_coordination_tree(payload))
         return
+    from polylogue.coordination.rendering import render_coordination_text
+
     click.echo(render_coordination_text(payload))
 
 

--- a/polylogue/cli/commands/import_command.py
+++ b/polylogue/cli/commands/import_command.py
@@ -36,12 +36,7 @@ import click
 
 from polylogue.cli.shared.helpers import fail
 from polylogue.cli.shared.types import AppEnv
-from polylogue.operations.import_contracts import ImportOperation
 from polylogue.paths import archive_root
-from polylogue.sources.import_explain import explain_import_path
-from polylogue.sources.parsers import hermes_state
-from polylogue.sources.sqlite_snapshot import sqlite_staging_metadata_path, stage_sqlite_snapshot
-from polylogue.surfaces.payloads import model_json_document
 
 _DEFAULT_DAEMON_URL = "http://127.0.0.1:8766"
 
@@ -57,6 +52,9 @@ def _default_daemon_url() -> str:
 
 def _stage_for_daemon(path: Path, *, replace_existing: bool = False) -> Path:
     """Copy a local import target into the archive inbox for daemon pickup."""
+    from polylogue.sources.parsers import hermes_state
+    from polylogue.sources.sqlite_snapshot import sqlite_staging_metadata_path, stage_sqlite_snapshot
+
     resolved = path.expanduser().resolve()
     if not resolved.exists():
         fail("import", f"Path does not exist: {resolved}")
@@ -236,6 +234,9 @@ def import_command(
     processing.
     """
     if explain:
+        from polylogue.sources.import_explain import explain_import_path
+        from polylogue.surfaces.payloads import model_json_document
+
         if demo:
             fail("import", "--explain requires a source PATH; --demo materializes and schedules generated fixtures.")
         if path is None:
@@ -291,6 +292,8 @@ def import_command(
         fail("import", _daemon_unreachable_message(daemon_url, str(exc.reason)))
     except OSError as exc:
         fail("import", _daemon_unreachable_message(daemon_url, str(exc)))
+
+    from polylogue.operations.import_contracts import ImportOperation
 
     operation = ImportOperation.from_dict(raw)
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -112,7 +112,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
     import_started_at = perf_counter()
     from polylogue.cli.archive_query import execute_archive_query
 
-    env.record_timing("import", import_started_at)
+    env.record_timing("archive-query-import", import_started_at)
     execute_archive_query(env, request)
 
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from time import perf_counter
 from typing import TYPE_CHECKING
 
 import click
@@ -108,8 +109,10 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
 
 async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
     """Async core of query execution."""
+    import_started_at = perf_counter()
     from polylogue.cli.archive_query import execute_archive_query
 
+    env.record_timing("import", import_started_at)
     execute_archive_query(env, request)
 
 

--- a/polylogue/cli/shared/types.py
+++ b/polylogue/cli/shared/types.py
@@ -7,6 +7,8 @@ the ~2.5 s archive/storage import cost.
 
 from __future__ import annotations
 
+import sys
+from time import perf_counter
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -45,10 +47,42 @@ class AppEnv:
         ui: UI | None = None,
         services: RuntimeServices | None = None,
         plain: bool = True,
+        debug_timing: bool = False,
     ) -> None:
         self._ui = ui
         self._services = services
         self._plain = plain
+        self._debug_timing = debug_timing
+        self._active_timings: dict[str, float] = {}
+        self._timings: dict[str, float] = {}
+
+    @property
+    def debug_timing(self) -> bool:
+        """Whether this invocation should emit its phase timing table."""
+        return self._debug_timing
+
+    def begin_timing(self, phase: str) -> None:
+        """Start a named monotonic timing phase when debugging is enabled."""
+        if self._debug_timing:
+            self._active_timings[phase] = perf_counter()
+
+    def finish_timing(self, phase: str) -> None:
+        """Finish a previously started phase without affecting normal output."""
+        started_at = self._active_timings.pop(phase, None)
+        if started_at is not None:
+            self._timings[phase] = (perf_counter() - started_at) * 1000
+
+    def record_timing(self, phase: str, started_at: float) -> None:
+        """Record an externally scoped monotonic timing phase."""
+        if self._debug_timing:
+            self._timings[phase] = (perf_counter() - started_at) * 1000
+
+    def emit_debug_timings(self) -> None:
+        """Write the opt-in phase table to stderr after command output."""
+        if not self._debug_timing or not self._timings:
+            return
+        rows = "\n".join(f"{phase:<12} {elapsed_ms:8.1f} ms" for phase, elapsed_ms in self._timings.items())
+        sys.stderr.write(f"polylogue timing\n{rows}\n")
 
     @property
     def ui(self) -> UI:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -1818,23 +1818,37 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         server = cast(Any, self.server)
         started_at = monotonic()
         entry: _CoordinationCacheEntry | None = None
+        cache_owner = False
         if not fresh:
             with server.coordination_cache_lock:
-                candidate = server.coordination_cache.get(cache_key)
-                if candidate is not None and candidate.expires_at > started_at:
-                    entry = candidate
-                elif candidate is not None:
-                    del server.coordination_cache[cache_key]
+                while True:
+                    candidate = server.coordination_cache.get(cache_key)
+                    if candidate is not None and candidate.expires_at > monotonic():
+                        entry = candidate
+                        break
+                    if candidate is not None:
+                        del server.coordination_cache[cache_key]
+                    if cache_key not in server.coordination_cache_building:
+                        server.coordination_cache_building.add(cache_key)
+                        cache_owner = True
+                        break
+                    server.coordination_cache_condition.wait()
         if entry is None:
-            payload = model_json_document(
-                build_coordination_envelope(view=cast(Any, view), limit=bounded_limit), exclude_none=True
-            )
-            if not fresh:
-                with server.coordination_cache_lock:
-                    server.coordination_cache[cache_key] = _CoordinationCacheEntry(
-                        payload=payload,
-                        expires_at=monotonic() + _COORDINATION_CACHE_TTL_S,
-                    )
+            try:
+                payload = model_json_document(
+                    build_coordination_envelope(view=cast(Any, view), limit=bounded_limit), exclude_none=True
+                )
+                if cache_owner:
+                    with server.coordination_cache_lock:
+                        server.coordination_cache[cache_key] = _CoordinationCacheEntry(
+                            payload=payload,
+                            expires_at=monotonic() + _COORDINATION_CACHE_TTL_S,
+                        )
+            finally:
+                if cache_owner:
+                    with server.coordination_cache_lock:
+                        server.coordination_cache_building.discard(cache_key)
+                        server.coordination_cache_condition.notify_all()
             cache_state = "bypass" if fresh else "miss"
         else:
             payload = entry.payload
@@ -4276,6 +4290,8 @@ class DaemonAPIHTTPServer(ThreadingHTTPServer):
         )
         self.coordination_cache: dict[tuple[str, int], _CoordinationCacheEntry] = {}
         self.coordination_cache_lock = threading.Lock()
+        self.coordination_cache_condition = threading.Condition(self.coordination_cache_lock)
+        self.coordination_cache_building: set[tuple[str, int]] = set()
 
     def server_close(self) -> None:
         # cancel_futures=True drops any still-queued (not yet started) work

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -107,6 +107,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ARCHIVE_READER_BUSY_TIMEOUT_S = 0.25
+_COORDINATION_CACHE_TTL_S = 2.0
 
 RouteMethod = Literal["GET", "POST", "DELETE"]
 _ArchiveQueryResult = TypeVar("_ArchiveQueryResult")
@@ -143,6 +144,14 @@ class _StaticPostRoute:
     segments: tuple[str, ...]
     handler_name: str
     passes_path: bool = False
+
+
+@dataclass(frozen=True)
+class _CoordinationCacheEntry:
+    """One short-lived coordination response held only by the daemon."""
+
+    payload: JSONDocument
+    expires_at: float
 
 
 _FACET_EXPENSIVE_FAMILIES = ("repos", "action_types")
@@ -1803,8 +1812,44 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         raw_view = self._get_param(params, "view", "status") or "status"
         view = raw_view if raw_view in {"status", "self", "work-item", "conflicts", "handoff"} else "status"
         limit = self._get_int(params, "limit", 10)
-        payload = build_coordination_envelope(view=cast(Any, view), limit=max(1, min(limit, 50)))
-        self._send_json(HTTPStatus.OK, payload.model_dump(mode="json", exclude_none=True))
+        bounded_limit = max(1, min(limit, 50))
+        fresh = self._get_bool(params, "fresh")
+        cache_key = (view, bounded_limit)
+        server = cast(Any, self.server)
+        started_at = monotonic()
+        entry: _CoordinationCacheEntry | None = None
+        if not fresh:
+            with server.coordination_cache_lock:
+                candidate = server.coordination_cache.get(cache_key)
+                if candidate is not None and candidate.expires_at > started_at:
+                    entry = candidate
+                elif candidate is not None:
+                    del server.coordination_cache[cache_key]
+        if entry is None:
+            payload = model_json_document(
+                build_coordination_envelope(view=cast(Any, view), limit=bounded_limit), exclude_none=True
+            )
+            if not fresh:
+                with server.coordination_cache_lock:
+                    server.coordination_cache[cache_key] = _CoordinationCacheEntry(
+                        payload=payload,
+                        expires_at=monotonic() + _COORDINATION_CACHE_TTL_S,
+                    )
+            cache_state = "bypass" if fresh else "miss"
+        else:
+            payload = entry.payload
+            cache_state = "hit"
+        elapsed_ms = (monotonic() - started_at) * 1000
+        self._send_json(
+            HTTPStatus.OK,
+            payload,
+            extra_headers={
+                "Cache-Control": "no-store",
+                "Server-Timing": f"coordination;dur={elapsed_ms:.1f}",
+                "X-Polylogue-Coordination-Cache": cache_state,
+                "X-Polylogue-Coordination-Freshness": f"ttl={_COORDINATION_CACHE_TTL_S:g}s; fresh=1 bypasses",
+            },
+        )
 
     @daemon_safe_handler
     def _handle_paste_browser(self, params: dict[str, list[str]]) -> None:
@@ -4229,6 +4274,8 @@ class DaemonAPIHTTPServer(ThreadingHTTPServer):
         self.archive_query_admission: threading.BoundedSemaphore = threading.BoundedSemaphore(
             _ARCHIVE_QUERY_MAX_WORKERS + _ARCHIVE_QUERY_MAX_QUEUED
         )
+        self.coordination_cache: dict[tuple[str, int], _CoordinationCacheEntry] = {}
+        self.coordination_cache_lock = threading.Lock()
 
     def server_close(self) -> None:
         # cancel_futures=True drops any still-queued (not yet started) work

--- a/tests/unit/cli/test_agents_command.py
+++ b/tests/unit/cli/test_agents_command.py
@@ -73,7 +73,7 @@ def test_agents_status_json_uses_shared_envelope(monkeypatch: pytest.MonkeyPatch
         calls.append((view, cwd, limit, detail))
         return _payload(view)
 
-    monkeypatch.setattr("polylogue.cli.commands.agents.build_coordination_envelope", fake_build)
+    monkeypatch.setattr("polylogue.cli.commands.agents._build_coordination_envelope", fake_build)
 
     result = CliRunner().invoke(
         agents_command,
@@ -111,7 +111,7 @@ def test_agents_status_detail_is_explicitly_opt_in(monkeypatch: pytest.MonkeyPat
         calls.append(bool(kwargs["detail"]))
         return _payload(str(kwargs["view"]))
 
-    monkeypatch.setattr("polylogue.cli.commands.agents.build_coordination_envelope", fake_build)
+    monkeypatch.setattr("polylogue.cli.commands.agents._build_coordination_envelope", fake_build)
 
     result = CliRunner().invoke(agents_command, ["status", "--detail", "--json"], catch_exceptions=False)
 
@@ -121,7 +121,7 @@ def test_agents_status_detail_is_explicitly_opt_in(monkeypatch: pytest.MonkeyPat
 
 def test_agents_work_item_text_is_compact(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "polylogue.cli.commands.agents.build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"])
+        "polylogue.cli.commands.agents._build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"])
     )
 
     result = CliRunner().invoke(
@@ -137,7 +137,7 @@ def test_agents_work_item_text_is_compact(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_agents_status_markdown_and_tree_use_shared_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "polylogue.cli.commands.agents.build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"])
+        "polylogue.cli.commands.agents._build_coordination_envelope", lambda **kwargs: _payload(kwargs["view"])
     )
 
     markdown = CliRunner().invoke(agents_command, ["status", "--format", "markdown"], catch_exceptions=False)

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -917,7 +917,7 @@ class TestCliSetup:
             cli_runner.invoke(cli, ["--verbose", "--plain"], catch_exceptions=False)
         mock_log.assert_called_once_with(verbose=True)
 
-    def test_no_verbose_configures_info_logging(self, cli_runner: CliRunner) -> None:
+    def test_no_verbose_keeps_structlog_setup_lazy(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
         with (
@@ -925,7 +925,7 @@ class TestCliSetup:
             patch("polylogue.cli.click_app._show_stats"),
         ):
             cli_runner.invoke(cli, ["--plain"], catch_exceptions=False)
-        mock_log.assert_called_once_with(verbose=False)
+        mock_log.assert_not_called()
 
     def test_plain_flag_configures_lazy_app_env(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2953,6 +2953,29 @@ SEARCH_FORMAT_CASES = [
 class TestSearchQueryContracts:
     """Matrix coverage for search filters and output formats."""
 
+    def test_debug_timing_keeps_query_output_on_stdout(
+        self, search_workspace: SearchWorkspace, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Opt-in timing reports real CLI phases without corrupting JSON output.
+
+        This invokes the production Click root, query compiler, archive open,
+        list execution, and renderer.  Removing any checkpoint around those
+        production dependencies makes the corresponding stderr phase assertion
+        fail while the JSON assertion protects the stdout/stderr contract.
+        """
+        from polylogue.cli import cli
+
+        del search_workspace
+        monkeypatch.setenv("POLYLOGUE_DEBUG_TIMING", "1")
+
+        result = CliRunner().invoke(cli, ["--plain", "find", "origin:chatgpt-export", "-f", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["mode"] == "list"
+        assert "polylogue timing" in result.stderr
+        for phase in ("startup", "import", "config", "compile", "db-open", "execute", "render"):
+            assert phase in result.stderr
+
     def test_structured_only_cli_query_skips_absent_message_fts(self, search_workspace: SearchWorkspace) -> None:
         """A field-only CLI query must keep working when lexical search is unavailable.
 

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2953,6 +2953,33 @@ SEARCH_FORMAT_CASES = [
 class TestSearchQueryContracts:
     """Matrix coverage for search filters and output formats."""
 
+    def test_structured_only_cli_query_skips_absent_message_fts(self, search_workspace: SearchWorkspace) -> None:
+        """A field-only CLI query must keep working when lexical search is unavailable.
+
+        This exercises the production ``ArchiveStore.list_summaries`` route
+        against the same derived index the CLI opens.  Replacing the
+        structured-only discriminator in ``_execute_archive_query_stdout``
+        with an unconditional ``_query_hits`` call would instead invoke
+        ``ArchiveStore.search_summaries`` and fail its FTS-readiness check.
+        """
+        from polylogue.cli import cli
+
+        index_db = search_workspace["archive_root"] / "index.db"
+        with sqlite3.connect(index_db) as conn:
+            for trigger in ("messages_fts_ai", "messages_fts_ad", "messages_fts_au"):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP TABLE messages_fts")
+
+        result = CliRunner().invoke(
+            cli,
+            ["--plain", "find", "origin:chatgpt-export", "-f", "json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["mode"] == "list"
+        assert [item["id"] for item in payload["items"]] == ["chatgpt-export:ext-conv1"]
+
     @pytest.mark.parametrize(
         "case_id,args,expected_exit,error_hint",
         SEARCH_FILTER_CASES,

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2973,7 +2973,7 @@ class TestSearchQueryContracts:
         assert result.exit_code == 0, result.output
         assert json.loads(result.stdout)["mode"] == "list"
         assert "polylogue timing" in result.stderr
-        for phase in ("startup", "import", "config", "compile", "db-open", "execute", "render"):
+        for phase in ("cli-callback", "archive-query-import", "config", "compile", "db-open", "execute", "render"):
             assert phase in result.stderr
 
     def test_structured_only_cli_query_skips_absent_message_fts(self, search_workspace: SearchWorkspace) -> None:

--- a/tests/unit/cli/test_stdout_stderr_split.py
+++ b/tests/unit/cli/test_stdout_stderr_split.py
@@ -199,3 +199,44 @@ class TestChannelSeparation:
         r = _run("--help")
         assert TRACEBACK_SENTINEL not in r.stdout
         assert TRACEBACK_SENTINEL not in r.stderr
+
+    def test_agents_help_does_not_load_coordination_substrate(self) -> None:
+        """Nested help stays on the lazy registration path, not live evidence collection."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; from click.testing import CliRunner; "
+                    "from polylogue.cli.click_app import cli; "
+                    "result = CliRunner().invoke(cli, ['agents', '--help']); "
+                    "assert result.exit_code == 0, result.output; "
+                    "assert 'polylogue.coordination' not in sys.modules"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_import_help_does_not_load_import_parser_stack(self) -> None:
+        """Import help exposes options without importing parsers or wire payloads."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; from click.testing import CliRunner; "
+                    "from polylogue.cli.click_app import cli; "
+                    "result = CliRunner().invoke(cli, ['import', '--help']); "
+                    "assert result.exit_code == 0, result.output; "
+                    "assert 'polylogue.sources.import_explain' not in sys.modules; "
+                    "assert 'polylogue.surfaces.payloads' not in sys.modules"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -752,7 +752,7 @@ class TestReaderSearchState:
                 )
 
         with patch("polylogue.coordination.build_coordination_envelope", side_effect=fake_build):
-            with _running_server(workspace_env) as (_, base_url):
+            with _running_server(workspace_env) as (server, base_url):
                 first, first_state, first_freshness = get_response(
                     f"{base_url}/api/agents/coordination?view=status&limit=3"
                 )
@@ -762,11 +762,20 @@ class TestReaderSearchState:
                 bypassed, bypassed_state, _ = get_response(
                     f"{base_url}/api/agents/coordination?view=status&limit=3&fresh=1"
                 )
+                daemon_server = cast(Any, server)
+                with daemon_server.coordination_cache_lock:
+                    cached = daemon_server.coordination_cache[("status", 3)]
+                    daemon_server.coordination_cache[("status", 3)] = type(cached)(
+                        payload=cached.payload,
+                        expires_at=0.0,
+                    )
+                expired, expired_state, _ = get_response(f"{base_url}/api/agents/coordination?view=status&limit=3")
 
         assert first == second == {"view": "status", "build": 1}
         assert bypassed == {"view": "status", "build": 2}
-        assert calls == [("status", 3), ("status", 3)]
-        assert (first_state, second_state, bypassed_state) == ("miss", "hit", "bypass")
+        assert expired == {"view": "status", "build": 3}
+        assert calls == [("status", 3), ("status", 3), ("status", 3)]
+        assert (first_state, second_state, bypassed_state, expired_state) == ("miss", "hit", "bypass", "miss")
         assert first_freshness == second_freshness == "ttl=2s; fresh=1 bypasses"
 
     def test_agent_coordination_cache_coalesces_concurrent_builds(self, workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -30,6 +30,7 @@ import socket
 import sqlite3
 import threading
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from http.server import HTTPServer
 from pathlib import Path
@@ -767,6 +768,50 @@ class TestReaderSearchState:
         assert calls == [("status", 3), ("status", 3)]
         assert (first_state, second_state, bypassed_state) == ("miss", "hit", "bypass")
         assert first_freshness == second_freshness == "ttl=2s; fresh=1 bypasses"
+
+    def test_agent_coordination_cache_coalesces_concurrent_builds(self, workspace_env: dict[str, Path]) -> None:
+        """Concurrent cold reads share one envelope build instead of stampeding it.
+
+        Two real loopback clients request the same missing cache key.  The
+        producer blocks long enough for the second request to enter the daemon;
+        removing the in-flight condition allows a second producer call and
+        fails the assertion below.
+        """
+        calls: list[tuple[str, int]] = []
+        first_build_started = threading.Event()
+        second_build_started = threading.Event()
+        release_first_build = threading.Event()
+
+        class FakePayload:
+            def model_dump(self, **_kwargs: object) -> dict[str, object]:
+                return {"view": "status", "build": len(calls)}
+
+        def fake_build(*, view: str, limit: int) -> FakePayload:
+            calls.append((view, limit))
+            if len(calls) == 1:
+                first_build_started.set()
+                assert release_first_build.wait(timeout=2.0)
+            else:
+                second_build_started.set()
+            return FakePayload()
+
+        def get_response(url: str) -> dict[str, object]:
+            with urlopen(url) as response:
+                return cast(dict[str, object], json.loads(response.read()))
+
+        with patch("polylogue.coordination.build_coordination_envelope", side_effect=fake_build):
+            with _running_server(workspace_env) as (_, base_url):
+                url = f"{base_url}/api/agents/coordination?view=status&limit=3"
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    first = executor.submit(get_response, url)
+                    assert first_build_started.wait(timeout=2.0)
+                    second = executor.submit(get_response, url)
+                    assert not second_build_started.wait(timeout=0.2)
+                    release_first_build.set()
+                    assert first.result(timeout=2.0) == {"view": "status", "build": 1}
+                    assert second.result(timeout=2.0) == {"view": "status", "build": 1}
+
+        assert calls == [("status", 3)]
 
     def test_raw_tab_uses_bounded_provenance_preview_not_broad_raw_fetch(self, workspace_env: dict[str, Path]) -> None:
         """The shell must not fetch the broad /raw route when opening Raw.

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -788,6 +788,7 @@ class TestReaderSearchState:
         """
         calls: list[tuple[str, int]] = []
         first_build_started = threading.Event()
+        second_handler_entered = threading.Event()
         second_build_started = threading.Event()
         release_first_build = threading.Event()
 
@@ -808,17 +809,31 @@ class TestReaderSearchState:
             with urlopen(url) as response:
                 return cast(dict[str, object], json.loads(response.read()))
 
+        from polylogue.daemon.http import DaemonAPIHandler
+
+        original_handler = DaemonAPIHandler._handle_agent_coordination
+        handler_calls = 0
+
+        def observe_handler(handler: object, params: dict[str, list[str]]) -> None:
+            nonlocal handler_calls
+            handler_calls += 1
+            if handler_calls == 2:
+                second_handler_entered.set()
+            original_handler(cast(Any, handler), params)
+
         with patch("polylogue.coordination.build_coordination_envelope", side_effect=fake_build):
-            with _running_server(workspace_env) as (_, base_url):
-                url = f"{base_url}/api/agents/coordination?view=status&limit=3"
-                with ThreadPoolExecutor(max_workers=2) as executor:
-                    first = executor.submit(get_response, url)
-                    assert first_build_started.wait(timeout=2.0)
-                    second = executor.submit(get_response, url)
-                    assert not second_build_started.wait(timeout=0.2)
-                    release_first_build.set()
-                    assert first.result(timeout=2.0) == {"view": "status", "build": 1}
-                    assert second.result(timeout=2.0) == {"view": "status", "build": 1}
+            with patch.object(DaemonAPIHandler, "_handle_agent_coordination", observe_handler):
+                with _running_server(workspace_env) as (_, base_url):
+                    url = f"{base_url}/api/agents/coordination?view=status&limit=3"
+                    with ThreadPoolExecutor(max_workers=2) as executor:
+                        first = executor.submit(get_response, url)
+                        assert first_build_started.wait(timeout=2.0)
+                        second = executor.submit(get_response, url)
+                        assert second_handler_entered.wait(timeout=2.0)
+                        assert not second_build_started.wait(timeout=0.2)
+                        release_first_build.set()
+                        assert first.result(timeout=2.0) == {"view": "status", "build": 1}
+                        assert second.result(timeout=2.0) == {"view": "status", "build": 1}
 
         assert calls == [("status", 3)]
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -722,6 +722,52 @@ class TestReaderSearchState:
         assert "peers" in payload
         assert "resource_episodes" in payload
 
+    def test_agent_coordination_cache_is_ttl_bounded_and_fresh_bypassable(self, workspace_env: dict[str, Path]) -> None:
+        """The live HTTP route caches only a bounded fresh response.
+
+        The test uses the production ``DaemonAPIHandler`` and an actual
+        loopback server; the envelope producer is only counted so the cache
+        contract is observable.  Removing the cache read/write or the
+        ``fresh=1`` bypass causes the call-count and response-header
+        assertions to fail.
+        """
+        calls: list[tuple[str, int]] = []
+
+        class FakePayload:
+            def model_dump(self, **_kwargs: object) -> dict[str, object]:
+                return {"view": "status", "build": len(calls)}
+
+        def fake_build(*, view: str, limit: int) -> FakePayload:
+            calls.append((view, limit))
+            return FakePayload()
+
+        def get_response(url: str) -> tuple[dict[str, object], str, str]:
+            with urlopen(url) as response:
+                body = cast(dict[str, object], json.loads(response.read()))
+                return (
+                    body,
+                    response.headers["X-Polylogue-Coordination-Cache"],
+                    response.headers["X-Polylogue-Coordination-Freshness"],
+                )
+
+        with patch("polylogue.coordination.build_coordination_envelope", side_effect=fake_build):
+            with _running_server(workspace_env) as (_, base_url):
+                first, first_state, first_freshness = get_response(
+                    f"{base_url}/api/agents/coordination?view=status&limit=3"
+                )
+                second, second_state, second_freshness = get_response(
+                    f"{base_url}/api/agents/coordination?view=status&limit=3"
+                )
+                bypassed, bypassed_state, _ = get_response(
+                    f"{base_url}/api/agents/coordination?view=status&limit=3&fresh=1"
+                )
+
+        assert first == second == {"view": "status", "build": 1}
+        assert bypassed == {"view": "status", "build": 2}
+        assert calls == [("status", 3), ("status", 3)]
+        assert (first_state, second_state, bypassed_state) == ("miss", "hit", "bypass")
+        assert first_freshness == second_freshness == "ttl=2s; fresh=1 bypasses"
+
     def test_raw_tab_uses_bounded_provenance_preview_not_broad_raw_fetch(self, workspace_env: dict[str, Path]) -> None:
         """The shell must not fetch the broad /raw route when opening Raw.
 


### PR DESCRIPTION
## Summary

This PR combines measured help and daemon-status improvements with a verified structured-query routing regression. It also adds opt-in CLI phase timing. It deliberately does not claim closure of the broad coordination or instrumentation beads.

## Problem

Nested help imported runtime-only stacks, field-only CLI queries needed a real archive proof that they do not depend on FTS, repeated daemon coordination requests rebuilt an expensive envelope, and CLI phase attribution required ad-hoc profiling. Isolated route samples measured coordination status at 4,859 ms then 4,491 ms before the daemon cache.

## Solution

- `polylogue/cli/`: defer help-path imports and add `POLYLOGUE_DEBUG_TIMING=1`, which keeps query output on stdout and writes cli-callback/archive-query-import/config/compile/db-open/execute/render timings to stderr for matched session-list queries.
- `polylogue/daemon/http.py`: daemon-local two-second coordination response cache that coalesces same-key concurrent fills, `fresh=1` bypass, `Cache-Control: no-store`, cache/freshness headers, and `Server-Timing`.
- `tests/unit/cli/test_query_exec_laws.py`: real CLI regression with `messages_fts` and its triggers removed; a structured origin filter still returns its result through `list_summaries`.
- `tests/unit/daemon/test_web_reader.py`: real loopback daemon proof for cache miss, hit, and freshness bypass.

## Acceptance-criteria matrix

| Bead | Acceptance criterion | Status and evidence |
| --- | --- | --- |
| `polylogue-20d.2` | `python -X importtime ...` removes payload/api imports from help paths | Partial. The PR moves the measured agents/import help dependencies behind execution paths and has subprocess import-boundary tests; it does not add the requested importtime artifact. |
| `polylogue-20d.2` | New fixed-budget devtools help-latency gate | Open in the bead. This PR has no new devtools budget command. |
| `polylogue-20d.2` | All named nested helps under budget | Partial. `agents --help` p50 was 1.07 s to 0.30 s; `import --help` p50 was 1.02 s to 0.37 s. Maintenance help remains outside this slice. |
| `polylogue-20d.4` | CLI branches structured-only versus FTS using `query_terms`/`contains_terms` | Satisfied by the existing `archive_query` discriminator, now verified by a real user-facing regression. |
| `polylogue-20d.4` | Structured filter succeeds with stale/absent FTS | Satisfied. The regression drops `messages_fts` plus its triggers, runs `polylogue find origin:chatgpt-export -f json`, and returns `chatgpt-export:ext-conv1`. |
| `polylogue-20d.4` | Document current post-v23 shape in PR | Satisfied: daemon and CLI both discriminate FTS using the compiled query terms; only the CLI regression was missing. |
| `polylogue-s7ae.8` | Committed randomized cold/warm CLI+MCP stage harness with p50/p95 artifacts | Open in the bead. This lane does not alter `polylogue/coordination/envelope.py` or MCP; it adds only an HTTP cache contract test and isolated live-route samples. |
| `polylogue-s7ae.8` | Warm compact MCP p95 at least 3x better and cold CLI improves | Partial daemon-only evidence, not an MCP claim. With an isolated archive, pre-cache HTTP samples were 4,859/4,491 ms; post-cache miss/hit were 4,840/0.8 ms. `fresh=1` forces the expensive rebuild. |
| `polylogue-s7ae.8` | Compact/detail semantics and dogfood artifact | Open in the bead. Existing semantics are untouched; no durable dogfood artifact or distribution budget is claimed. |
| `polylogue-oxz` | Bounded ops-tier slow-query log | Open in the bead; it requires ops/storage ownership outside this lane. |
| `polylogue-oxz` | CLI phase timing matching daemon-served timing | Partial. `POLYLOGUE_DEBUG_TIMING=1` provides the listed phases for standard session-list queries and the coordination HTTP route emits `Server-Timing`; span correlation and non-list renderer coverage are not implemented. |
| `polylogue-oxz` | Logging doctrine, lint, and web beacons persisted in ops.db | Open in the bead; those require docs/web/ops surfaces outside this lane. |

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_exec_laws.py -k structured_only_cli_query_skips_absent_message_fts` — `1 passed`. This exercises the production Click route and `ArchiveStore.list_summaries`; changing the discriminator to unconditional FTS search fails against the dropped table.
- `nix develop --command devtools test tests/unit/daemon/test_web_reader.py -k agent_coordination_cache_is_ttl_bounded_and_fresh_bypassable` — `2 passed`. Real loopback clients prove miss/hit/bypass and same-key concurrent cold reads share one producer call; deleting cache read/write, the in-flight condition, or `fresh=1` changes the contract.
- `nix develop --command devtools test tests/unit/cli/test_query_exec_laws.py -k debug_timing_keeps_query_output_on_stdout` — `1 passed`. This exercises a matched Click session-list route, compiler, archive open, list execution, and `_emit_rows` renderer; removing a phase checkpoint fails the stderr contract.
- `ruff check` and `mypy` on the changed CLI/daemon/test paths — passed. The pre-push quick gate also completed for `41f4cea7`.
- `nix develop --command devtools test -k "startup or routing or status_latency"` — reproduced the pre-existing blob lifecycle failure after unrelated tests: `TestOrphanedBlobsCatalogRouting::test_catalog_resolution_drives_end_to_end_cleanup` expected one deleted blob and observed zero. Exact-node rerun reproduced the same `repaired_count == 0` failure.

## Measurements

- Help path: agents p50 1.07 s to 0.30 s (3.6x); import p50 1.02 s to 0.37 s (2.8x).
- Coordination HTTP route, isolated archive: before 4,859/4,491 ms; after 4,840 ms cache miss and 0.8 ms immediate cache hit. The cache is daemon-local for two seconds, advertises its state, forbids client/proxy caching, and supports `fresh=1`.
- Seeded CLI query with timing disabled/enabled: 1,964.0/1,907.3 ms in one sample each. That is insufficient to claim timing-overhead improvement; the debug table reported archive-query-import 138.1 ms, config 74.0 ms, compile 1.8 ms, DB open 2.9 ms, execute 102.7 ms, render 0.1 ms.

## What I decided not to fix

- No core-envelope collector rewrite: it falls outside the declared CLI/daemon/test lane and needs the bead-required stage harness before demand-aware collection changes.
- No slow-query persistence, doctrine page/lint, or browser beacons: those require ops/storage/docs/web ownership not assigned to this lane.
- No generated-surface commit: the environment-variable timing switch does not change CLI help or public schemas.

Ref polylogue-20d.2
Ref polylogue-20d.4
Ref polylogue-s7ae.8
Ref polylogue-oxz

## Adversarial review notes

- Iteration 1 found three real gaps: concurrent cache fills could stampede, timing labels overstated what they measured, and the summary described pre-existing 20d.4 routing as a measured optimization. `77465fbdf` coalesces cache fills with a real concurrent loopback test; `fec19e0bd` names callback and lazy-import phases precisely; this body now describes 20d.4 as verified parity.
- Iteration 2 found that expiry was not pinned and that render coverage had been described too broadly. `4260839ed` deterministically expires the live cache entry and verifies the next request is a miss/rebuild. The timing claim is narrowed to matched session-list rendering; no-match, stream, count, read, and unit-output render checkpoints remain open oxz scope. No full-bead closure is claimed.

Residual s7ae.8 risk: same-key ordinary readers wait behind an in-flight collector build; `fresh=1` bypasses it. A bounded wait/fallback belongs with the remaining collector-harness work in the still-open bead.